### PR TITLE
ENH: added env vars 

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -19,9 +19,9 @@ default_numpy = '1.7'
 
 # ----- constant paths -----
 
-root_dir = sys.prefix
-pkgs_dir = join(root_dir, 'pkgs')
-envs_dir = join(root_dir, 'envs')
+root_dir = os.environ.get('CONDA_ROOT', sys.prefix)
+pkgs_dir = os.environ.get('CONDA_PACKAGE_CACHE', join(root_dir, 'pkgs'))
+envs_dir = os.environ.get('CONDA_ENV_PATH', join(root_dir, 'envs'))
 
 # ----- default environment prefix -----
 


### PR DESCRIPTION
I think these variables are useful for a multi user or root install of conda.

```
CONDA_ROOT 
CONDA_ENV_PATH
CONDA_PACKAGE_CACHE
```

This PR adds them to config.py
