### PR TITLE
Fixed link to conda builder docs

### DIFF
--- a/conda/builder/pypi.py
+++ b/conda/builder/pypi.py
@@ -73,7 +73,7 @@ about:
   license: {license}
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml
 """
 
@@ -85,7 +85,7 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.
 """
 
@@ -96,7 +96,7 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.
 """
 


### PR DESCRIPTION
Modified links to documentation, see ContinuumIO/conda-recipes#6.
