### PR TITLE
conda build can no longer find binstar

### DIFF
--- a/conda/builder/external.py
+++ b/conda/builder/external.py
@@ -13,12 +13,11 @@ if sys.platform == 'win32':
     dir_paths = [join(build_prefix, 'Scripts'),
                  join(cc.root_dir, 'Scripts'),
                  'C:\cygwin\bin']
-    dir_paths.extend(os.environ['PATH'].split(os.pathsep))
 else:
     dir_paths = [join(build_prefix, 'bin'),
-                 join(cc.root_dir, 'bin'),
-                 '/usr/local/bin', '/bin', '/usr/bin']
+                 join(cc.root_dir, 'bin'),]
 
+dir_paths.extend(os.environ['PATH'].split(os.pathsep))
 
 def find_executable(executable):
     for dir_path in dir_paths:


### PR DESCRIPTION
I thought I opened an issue for this, but I couldn't find it. `conda build` no uploads to binstar. It just says

```
Error: cannot locate binstar (required for upload)
# Try:
# $ conda install binstar
```

This is because I don't have binstar installed in my root environment (because it doesn't support Python 3). `find_executable` only searches the root dir, the build dir, and `/usr/bin` and so on on unix, instead of searching PATH.  Is there a good reason for this?
