### PR TITLE
conda share doesn't work in Python 3

### DIFF
--- a/conda/builder/share.py
+++ b/conda/builder/share.py
@@ -31,9 +31,9 @@ def update_info(info):
     h = hashlib.new('sha1')
     for spec in info['depends']:
         assert MatchSpec(spec).strictness == 3
-        h.update(spec)
-        h.update('\x00')
-    h.update(info['file_hash'])
+        h.update(spec.encode('utf-8'))
+        h.update('\x00'.encode('utf-8'))
+    h.update(info['file_hash'].encode('utf-8'))
     info['version'] = h.hexdigest()
 
 def create_bundle(prefix):


### PR DESCRIPTION
``` pytb
$conda share
An unexpected error has occurred, please consider sending the
following traceback to the conda GitHub issue tracker at:

    https://github.com/ContinuumIO/conda/issues"


Traceback (most recent call last):
  File "/Users/aaronmeurer/anaconda3/bin/conda", line 7, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/aaronmeurer/Documents/Continuum/conda/bin/conda", line 5, in <module>
    sys.exit(main())
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/cli/main.py", line 148, in main
    args.func(args, p)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/cli/main_share.py", line 30, in execute
    path, warnings = create_bundle(prefix)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/builder/share.py", line 65, in create_bundle
    info, tmp_path, update_info)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/builder/packup.py", line 188, in create_conda_pkg
    update_info(info)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/builder/share.py", line 34, in update_info
    h.update(spec)
TypeError: Unicode-objects must be encoded before hashing
```
