### PR TITLE
conda build doesn't work in Python 3

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -125,20 +125,20 @@ def yield_lines(path):
         yield line
 
 
-prefix_placeholder = ('/opt/anaconda1anaconda2'
+prefix_placeholder = (b'/opt/anaconda1anaconda2'
                       # this is intentionally split into parts,
                       # such that running this program on itself
                       # will leave it unchanged
-                      'anaconda3')
+                      b'anaconda3')
 def update_prefix(path, new_prefix):
-    with open(path) as fi:
+    with open(path, 'rb') as fi:
         data = fi.read()
-    new_data = data.replace(prefix_placeholder, new_prefix)
+    new_data = data.replace(prefix_placeholder, new_prefix.encode('utf-8'))
     if new_data == data:
         return
     st = os.stat(path)
     os.unlink(path)
-    with open(path, 'w') as fo:
+    with open(path, 'wb') as fo:
         fo.write(new_data)
     os.chmod(path, stat.S_IMODE(st.st_mode))
 


### PR DESCRIPTION
From the latest conda-recipes:

``` pytb
$conda build yt

The following packages will be linked:

    package                    |            build
    ---------------------------|-----------------
    cython-0.19.1              |           py33_0
    distribute-0.6.45          |           py33_0
    freetype-2.4.10            |                1
    hdf5-1.8.9                 |                1
    libpng-1.5.13              |                1
    numpy-1.7.1                |           py33_0
    python-3.3.2               |                1
    readline-6.2               |                1
    sqlite-3.7.13              |                1
    tk-8.5.13                  |                1
    zlib-1.2.7                 |                1

Linking packages ...
An unexpected error has occurred, please consider sending the#########                                                                                  |  36%
following traceback to the conda GitHub issue tracker at:

    https://github.com/ContinuumIO/conda/issues"


Traceback (most recent call last):
  File "/Users/aaronmeurer/anaconda3/bin/conda", line 7, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/aaronmeurer/Documents/Continuum/conda/bin/conda", line 5, in <module>
    sys.exit(main())
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/cli/main.py", line 148, in main
    args.func(args, p)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/cli/main_build.py", line 107, in execute
    build.build(m)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/builder/build.py", line 135, in build
    create_env(prefix, [ms.spec for ms in m.ms_depends('build')])
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/builder/build.py", line 119, in create_env
    plan.execute_actions(actions, index, verbose=True)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/plan.py", line 331, in execute_actions
    execute_plan(plan, index, verbose)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/plan.py", line 316, in execute_plan
    install.link(config.pkgs_dir, prefix, arg)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/install.py", line 307, in link
    update_prefix(join(prefix, f), prefix)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/install.py", line 135, in update_prefix
    data = fi.read()
  File "/Users/aaronmeurer/anaconda3/lib/python3.3/codecs.py", line 300, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcf in position 0: invalid continuation byte
```
