### PR TITLE
Fix that argcomplete can be empty.

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -136,6 +136,10 @@ In short:
         argcomplete.autocomplete(p)
     except ImportError:
         pass
+    except AttributeError:
+        # On Python 3.3, argcomplete can be an empty namespace package when 
+        # argcomplete is not installed. Not sure why, but this fixes it.
+        pass
 
     args = p.parse_args()
 


### PR DESCRIPTION
On my system (py33) I do not have argcomplete installed, but when I can actually import `argcomplete`, which gives me an empty namespace package. I don't know why, but anyway, here is a simple fix.
