### PR TITLE
ensure that the subversion revision field is a string

### DIFF
--- a/conda/builder/metadata.py
+++ b/conda/builder/metadata.py
@@ -92,7 +92,8 @@ def parse(data):
             res[section][key] = []
     # ensure those are strings
     for field in ('package/version',
-                  'source/git_tag', 'source/git_branch', 'source/md5'):
+                  'source/git_tag', 'source/git_branch', 'source/md5',
+                  'source/svn_rev'):
         section, key = field.split('/')
         if res.get(section) is None:
             res[section] = {}


### PR DESCRIPTION
pyaml automatially converts revision numbers to integers. This breaks subprocess.check_call which expects a list of string arguments.
This patch should fix this.
