### PR TITLE
DOC: add example of using root_dir in condarc.

### DIFF
--- a/condarc
+++ b/condarc
@@ -13,6 +13,9 @@ proxy_servers:
     http: http://user:pass@corp.com:8080
     https: https://user:pass@corp.com:8080
 
+# directory in which conda root is located (used by `conda init`)
+root_dir: ~/.local/conda_root
+
 # directories in which environments are located
 envs_dirs:
   - ~/my-envs


### PR DESCRIPTION
Motivation: I had a hard time getting started with `conda init` after `pip install conda`. Init-ing in `sys.prefix` doesn't work on a normal Linux system due to permissions, and `sudo conda init` (besides not being desired) also doesn't work. Adding `root_dir` in condarc like `envs_dir` (i.e. a list) results in an incomprehensible error. So hopefully this helps someone.

A better solution would probably be to ask the user for a rootdir on `conda init`.
