### PR TITLE
Symbolic links in recipes

### DIFF
--- a/conda/builder/build.py
+++ b/conda/builder/build.py
@@ -57,6 +57,8 @@ def have_prefix_files(files):
             continue
         if is_obj(path):
             continue
+        if os.path.islink(path):
+            continue
         try:
             with open(path) as fi:
                 data = fi.read()

--- a/conda/builder/post.py
+++ b/conda/builder/post.py
@@ -175,8 +175,8 @@ def fix_permissions(files):
 
     for f in files:
         path = join(build_prefix, f)
-        st = os.stat(path)
-        os.chmod(path, stat.S_IMODE(st.st_mode) | stat.S_IWUSR) # chmod u+w
+        st = os.lstat(path)
+        os.lchmod(path, stat.S_IMODE(st.st_mode) | stat.S_IWUSR) # chmod u+w
 
 
 def post_build(files):

--- a/conda/install.py
+++ b/conda/install.py
@@ -170,7 +170,7 @@ def update_prefix(path, new_prefix):
                             new_prefix.encode('utf-8'))
     if new_data == data:
         return
-    st = os.stat(path)
+    st = os.lstat(path)
     os.unlink(path)
     with open(path, 'wb') as fo:
         fo.write(new_data)


### PR DESCRIPTION
I just tried to create a vagrant recipe, but there was an issue at the post stage

``` pytb
An unexpected error has occurred, please consider sending the
following traceback to the conda GitHub issue tracker at:

    https://github.com/ContinuumIO/conda/issues

Include the output of the command 'conda info' in your report.


Traceback (most recent call last):
  File "/Users/aaronmeurer/anaconda3/bin/conda", line 5, in <module>
    sys.exit(main())
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/cli/main.py", line 186, in main
    args.func(args, p)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/cli/main_build.py", line 169, in execute
    build.build(m, pypi=args.pypi)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/builder/build.py", line 180, in build
    post_build(sorted(files2 - files1))
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/builder/post.py", line 184, in post_build
    fix_permissions(files)
  File "/Users/aaronmeurer/Documents/Continuum/conda/conda/builder/post.py", line 178, in fix_permissions
    st = os.stat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/aaronmeurer/anaconda3/envs/_build/vagrant/embedded/include/ruby-1.9.1/x86_64-darwin12.2.1'
```

See https://github.com/ContinuumIO/conda-recipes/tree/master/vagrant
