### PR TITLE
Add explicit !!str tag for version field to avoid parsing it as float

### DIFF
--- a/conda/builder/pypi.py
+++ b/conda/builder/pypi.py
@@ -29,7 +29,7 @@ from conda.compat import input
 PYPI_META = """\
 package:
   name: {packagename}
-  version: {version}
+  version: !!str {version}
 
 source:
   fn: {filename}


### PR DESCRIPTION
Without this a skeleton for `memory_profiler` library (which is at version `0.30` a.t.m.) is being built as version `0.3` because yaml recognizes numbers during parsing according to its spec.
