### PR TITLE
copy symlinks as symlinks

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -124,7 +124,12 @@ def _link(src, dst, linktype=LINK_HARD):
         else:
             os.symlink(src, dst)
     elif linktype == LINK_COPY:
-        shutil.copy2(src, dst)
+        # copy relative symlinks as symlinks
+        if not on_win and islink(src) and not os.readlink(src).startswith('/'):
+            target = os.readlink(src)
+            os.symlink(os.readlink(src), dst)
+        else:
+            shutil.copy2(src, dst)
     else:
         raise Exception("Did not expect linktype=%r" % linktype)
 
@@ -164,6 +169,7 @@ prefix_placeholder = ('/opt/anaconda1anaconda2'
                       # will leave it unchanged
                       'anaconda3')
 def update_prefix(path, new_prefix):
+    path = os.path.realpath(path)
     with open(path, 'rb') as fi:
         data = fi.read()
     new_data = data.replace(prefix_placeholder.encode('utf-8'),
@@ -376,7 +382,8 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
                 except OSError:
                     log.error('failed to unlink: %r' % dst)
             lt = (LINK_COPY if f in has_prefix_files or
-                  f.startswith('bin/python') else linktype)
+                  f.startswith('bin/python') or os.path.islink(src)
+                  else linktype)
             try:
                 _link(src, dst, lt)
             except OSError:


### PR DESCRIPTION
rather than copying file contents or hard linking.

I'm not convinced this is the right fix, but it does address an actual problem:

I was building a package for nodejs, and it's a trivial configure/make/make install. But the installed result doesn't work, and I tracked it down to copying `bin/npm`, which is a symlink to `lib/node_modules/npm/npm-cli.js` in the actual package.

node's insane module-loading mechanism actually depends on the location of the file, and hardlinking or copying will cause module loading to break.

This patch causes relative symlinks to be copied _as symlinks_, so that the structure of the resulting tree is preserved.

I'm especially unsure that fitting this behavior under LINK_COPY is the right thing to do, but a better choice was not immediately apparent.
