### PR TITLE
*  lchmod  issue #467, peter1000

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 2014-01-02   2.2.7:
 -------------------
   * fixed bug in conda build related to lchmod not being available on all
-    platforms
+    platforms (see issue #467, peter1000)
 
 
 2013-12-31   2.2.6:

--- a/conda/compat.py
+++ b/conda/compat.py
@@ -17,13 +17,7 @@ if PY3:
     text_type = str
     binary_type = bytes
     input = input
-    def lchmod(path, mode):
-        try:
-            os.chmod(path, mode, follow_symlinks=False)
-        except TypeError:
-            # On systems that don't allow permissions on symbolic links, skip
-            # this entirely.
-            pass
+
 else:
     string_types = basestring,
     integer_types = (int, long)
@@ -31,13 +25,6 @@ else:
     text_type = unicode
     binary_type = str
     input = raw_input
-    try:
-        lchmod = os.lchmod
-    except AttributeError:
-        def lchmod(*args):
-            # On systems that don't allow permissions on symbolic links, skip
-            # this entirely.
-            pass
 
 if PY3:
     _iterkeys = "keys"


### PR DESCRIPTION
https://github.com/pydata/conda/issues/467

I clean installed miniconda27 and also miniconda33 (linux debian 64)

building appdirs seems to work now on both: cached also an other error I got when building an other package

PermissionError: # e.g. /etc/mtab

tested it only on: only on linux debian 64 wheezy 
