### PR TITLE
Ensure env variable contain only utf8 strings.

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -237,7 +237,7 @@ def post_link(prefix, dist, unlink=False):
         args = ['/bin/bash', path]
     env = os.environ
     env['PREFIX'] = prefix
-    env['PKG_NAME'], env['PKG_VERSION'], unused_build = dist.rsplit('-', 2)
+    env['PKG_NAME'], env['PKG_VERSION'], unused_build = dist.encode('utf8').rsplit('-', 2)
     subprocess.call(args, env=env)
 
 


### PR DESCRIPTION
Fix problem where subprocess.call throws an exception if the env
variable contains unicode strings.
