### PR TITLE
* add ability to export multi-processor-build flags

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,7 +11,8 @@
   * conda search now shows the channel that the package comes from
   * conda search has a new --platform flag for searching for packages in other
     platforms.
-
+  * add ability to export multi-processor-build flags
+  
 
 2014-01-17   2.3.1:
 -------------------

--- a/conda/config.py
+++ b/conda/config.py
@@ -68,7 +68,8 @@ rc_bool_keys = [
 rc_other = [
     'proxy_servers',
     'root_dir',
-    'channel_alias'
+    'channel_alias',
+    'build_makeflags'
     ]
 
 user_rc_path = abspath(expanduser('~/.condarc'))
@@ -239,3 +240,5 @@ disallow = set(rc.get('disallow', []))
 # packages which are added to a newly created environment by default
 create_default_packages = list(rc.get('create_default_packages', []))
 track_features = set(rc.get('track_features', '').split())
+# --- only conda-build related
+build_makeflags = rc.get('build_makeflags', None)

--- a/condarc
+++ b/condarc
@@ -59,3 +59,10 @@ disallow:
 # enable certain features to be tracked by default
 track_features:
   - mkl
+
+
+# --- only conda-build related
+
+# MAKEFLAGS: e.g. multi-core enviroment option for build.sh
+#     gnu make multi-core compile option: -j [N], --jobs[=N]  
+build_makeflags: "-j 4"


### PR DESCRIPTION
https://github.com/conda/conda-build/issues/9
adds the ability to export multi-processor-build flags for simple configurable increased build speed without the need of changing the recipes.

this is the conda counter part from the conda-build change
P

<!---
@huboard:{"order":6.564505341220828e-21,"custom_state":""}
-->
