### PR TITLE
* add ability to disable build make relative path

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@
   * conda search now shows the channel that the package comes from
   * conda search has a new --platform flag for searching for packages in other
     platforms.
+  * add ability to disable build make relative path
 
 
 2014-01-17   2.3.1:

--- a/conda/config.py
+++ b/conda/config.py
@@ -62,6 +62,7 @@ rc_bool_keys = [
     'use_pip',
     'binstar_upload',
     'binstar_personal',
+    'build_no_rpath', 
     ]
 
 # Not supported by conda config yet
@@ -239,3 +240,5 @@ disallow = set(rc.get('disallow', []))
 # packages which are added to a newly created environment by default
 create_default_packages = list(rc.get('create_default_packages', []))
 track_features = set(rc.get('track_features', '').split())
+# --- only conda-build related
+build_no_rpath = bool(rc.get('build_no_rpath', False))

--- a/condarc
+++ b/condarc
@@ -63,6 +63,6 @@ track_features:
 
 # --- only conda-build related
 
-# this chould be set to False and only in special cases set to if True
+# this chould be set to False and only in special cases set to True
 #   if True: the automatic post: mk_relative: rpath is skipped  
 build_no_rpath: False

--- a/condarc
+++ b/condarc
@@ -59,3 +59,10 @@ disallow:
 # enable certain features to be tracked by default
 track_features:
   - mkl
+
+
+# --- only conda-build related
+
+# this chould be set to False and only in special cases set to if True
+#   if True: the automatic post: mk_relative: rpath is skipped  
+build_no_rpath: False


### PR DESCRIPTION
https://github.com/conda/conda-build/issues/14

**this is the conda part of the conda-build pull-request** https://github.com/conda/conda-build/pull/15



sometimes a package builder might want to set no rpath or a own one for internal usage.

it would be nice if one could have an option to disable the mk_relative rpath part.

build example something like
```
#CHECK: BUILD_NO_RPATH
if [ "${BUILD_NO_RPATH}" != "y" ]; then
    echo 'this recipes needs conda config: build_no_rpath: True'
    exit 1
fi

unset LD_RUN_PATH
./bootstrap.sh
LDFLAGS="-Wl,-rpath,${PREFIX}/usr" \
./configure --prefix=${PREFIX}
make
make install

```

<!---
@huboard:{"order":3.282252670610414e-21,"custom_state":""}
-->
