### PR TITLE
* add ability to export autoremove .la files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@
   * conda search now shows the channel that the package comes from
   * conda search has a new --platform flag for searching for packages in other
     platforms.
+  * add ability to export autoremove .la files
 
 
 2014-01-17   2.3.1:

--- a/conda/config.py
+++ b/conda/config.py
@@ -62,6 +62,7 @@ rc_bool_keys = [
     'use_pip',
     'binstar_upload',
     'binstar_personal',
+    'build_remove_la_files'
     ]
 
 # Not supported by conda config yet
@@ -69,7 +70,6 @@ rc_other = [
     'proxy_servers',
     'root_dir',
     'channel_alias',
-    'build_remove_la_files'
     ]
 
 user_rc_path = abspath(expanduser('~/.condarc'))

--- a/conda/config.py
+++ b/conda/config.py
@@ -68,7 +68,8 @@ rc_bool_keys = [
 rc_other = [
     'proxy_servers',
     'root_dir',
-    'channel_alias'
+    'channel_alias',
+    'build_remove_la_files'
     ]
 
 user_rc_path = abspath(expanduser('~/.condarc'))
@@ -239,3 +240,5 @@ disallow = set(rc.get('disallow', []))
 # packages which are added to a newly created environment by default
 create_default_packages = list(rc.get('create_default_packages', []))
 track_features = set(rc.get('track_features', '').split())
+# --- only conda-build related
+build_remove_la_files = bool(rc.get('build_remove_la_files', False))

--- a/condarc
+++ b/condarc
@@ -59,3 +59,9 @@ disallow:
 # enable certain features to be tracked by default
 track_features:
   - mkl
+
+
+# --- only conda-build related
+
+#   if True: new .la files will be removed  before the conda package is done
+build_remove_la_files: True


### PR DESCRIPTION
https://github.com/conda/conda-build/issues/16
auto-remove linux .la files

This is the conda counter part: https://github.com/conda/conda-build/pull/17

if one builds more apps **within the conda framework** like gmp, mpfr, gcc, glibc and the whole essential development apps one might run into a number of issues
one of them might be: .la

example of conda build gmp .la

libgmp.la

```
...
...

# Directory that this library needs to be installed in:
libdir='/opt/anaconda1anaconda2anaconda3/lib'
```

one can read more for instance here: http://www.metastatic.org/text/libtool.html

to avoid removing them individually I did a small function in conda-build

<!---
@huboard:{"order":1.641126335305207e-21,"custom_state":""}
-->
