### PR TITLE
Don't include python 3.3* in new specs in Python 3

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -228,6 +228,11 @@ def add_defaults_to_specs(r, linked, specs):
             specs.append(dist2spec3v(names_linked[name]))
             continue
 
+        if (name, def_ver) == ('python', '3.3'):
+            # Don't include Python 3 in the specs if this is the Python 3
+            # version of conda.
+            continue
+
         specs.append('%s %s*' % (name, def_ver))
     log.debug('HF specs=%r' % specs)
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -65,12 +65,12 @@ class TestAddDeaultsToSpec(unittest.TestCase):
 
     def test_4(self):
         self.linked = []
-        ps = 'python %s*' % default_python
+        ps = ['python 2.7*'] if default_python == '2.7' else []
         for specs, added in [
-            (['python'],     [ps]),
-            (['numpy'],      [ps]),
-            (['scipy'],      [ps]),
-            (['anaconda'],   [ps]),
+            (['python'],     ps),
+            (['numpy'],      ps),
+            (['scipy'],      ps),
+            (['anaconda'],   ps),
             (['anaconda 1.5.0 np17py27_0'], []),
             (['sympy 0.7.2 py27_0'], []),
             (['scipy 0.12.0 np16py27_0'], []),


### PR DESCRIPTION
This lets you create new environments in conda with packages that require 
Python 2 without explicitly specifying Python 2. Python 3 is still added if it 
is already installed into the environment (and the behavior for the Python 2 
version of conda is the same as it has always been).
