### PR TITLE
Typo in --known help text

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -77,7 +77,7 @@ def add_parser_known(p):
         default=True,
         dest='unknown',
         help="only use index metadata from the known remote channels, and not "
-             "the local package cache (which are of from unknown channels)",
+             "the local package cache (which are from unknown channels)",
     )
 
 def add_parser_use_index_cache(p):


### PR DESCRIPTION
@asmeurer  Fixed a small typo.  I'm not sure if it reads correctly, but "of from" didn't read right. 

Feel free to delete my branch whatever you decide.
