### PR TITLE
Old way first

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -324,7 +324,6 @@ class Resolve(object):
         m = i + 1
 
         dotlog.debug("Solving using max dists only")
-        print(dists)
         clauses = self.gen_clauses(v, dists, specs, features)
         solutions = min_sat(clauses)
 


### PR DESCRIPTION
Tries installing things the "old way" first. This makes things faster in Python 2. 
