### PR TITLE
Stop update_prefix from breaking hard links

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -176,7 +176,6 @@ def update_prefix(path, new_prefix):
     if new_data == data:
         return
     st = os.lstat(path)
-    os.unlink(path)
     with open(path, 'wb') as fo:
         fo.write(new_data)
     os.chmod(path, stat.S_IMODE(st.st_mode))


### PR DESCRIPTION
As we can see [here](https://github.com/conda/conda/blob/master/conda/install.py#L179), if a package has hard links that contain `prefix_placeholder`, the hard links will be broken because `os.unlink` is being explicitly called to wipe out the old version of the file. Opening the file with `wb` as the mode automatically truncates the file to zero bytes anyway, so this was unnecessary.

Without this fix, some packages (e.g., `automake`) failed to work in some cases because only one name for a given inode/file was being updated, and then the link was broken, leaving the other files with `/opt/anaconda1ananconda2anaconda3` in them.
