### PR TITLE
Ensure hard links in archives are maintained during install

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -406,7 +406,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
 
         # Use while loop so we can modify file_set on the fly
         file_set = set(files)
-        while files:
+        while file_set:
             f = file_set.pop()
             src = join(source_dir, f)
             dst = join(prefix, f)

--- a/conda/install.py
+++ b/conda/install.py
@@ -398,11 +398,11 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
             no_softlink = set()
 
     with Locked(prefix), Locked(pkgs_dir):
-        if not on_win:
-            # Build mapping from inode to filenames to maintain hardlinks
-            inode_dict = defaultdict(list)
-            for f in files:
-                inode = os.lstat(os.path.realpath(join(source_dir, f))).st_ino
+        # Build mapping from inode to filenames to maintain hardlinks
+        inode_dict = defaultdict(list)
+        for f in files:
+            inode = os.lstat(os.path.realpath(join(source_dir, f))).st_ino
+            if inode:
                 inode_dict[inode].append(f)
 
         # Use while loop so we can modify file_set on the fly
@@ -432,8 +432,8 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
                           (src, dst, lt, e))
             # If this was a hard link in archive, make sure we maintain those
             # links even when link type is copy
-            if not on_win:
-                inode = os.lstat(os.path.realpath(src)).st_ino
+            inode = os.lstat(os.path.realpath(src)).st_ino
+            if inode:
                 link_src = dst
                 for link_file in inode_dict[inode]:
                     if link_file != f:

--- a/conda/install.py
+++ b/conda/install.py
@@ -431,14 +431,17 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
             # If this was a hard link in archive, make sure we maintain those
             # links even when link type is copy
             inode = os.lstat(os.path.realpath(src)).st_ino
+            link_src = dst
             for link_file in inode_dict[inode]:
                 if link_file != f:
+                    link_dst = join(prefix, link_file)
                     try:
                         # Hard link to newly created file
-                        _link(dst, join(prefix, link_file), LINK_HARD)
+                        _link(link_src, link_dst, LINK_HARD)
                     except OSError as e:
                         log.error(('failed to link (src=%r, dst=%r, type=%r, ' +
-                                   'error=%r)') % (src, dst, LINK_HARD, e))
+                                   'error=%r)') % (link_src, link_dst, 
+                                                   LINK_HARD, e))
                     files.remove(link_file)
 
         if name_dist(dist) == '_cache':

--- a/conda/install.py
+++ b/conda/install.py
@@ -384,7 +384,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
         sys.exit('Error: pre-link failed: %s' % dist)
 
     info_dir = join(source_dir, 'info')
-    files = set(yield_lines(join(info_dir, 'files')))
+    files = list(yield_lines(join(info_dir, 'files')))
 
     try:
         has_prefix_files = set(yield_lines(join(info_dir, 'has_prefix')))
@@ -404,7 +404,8 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
             inode = os.lstat(os.path.realpath(join(source_dir, f))).st_ino
             inode_dict[inode].append(f)
 
-        # Use while loop so we can modify files set on the fly
+        # Use while loop so we can modify file_set on the fly
+        file_set = set(files)
         while files:
             f = files.pop()
             src = join(source_dir, f)
@@ -459,7 +460,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
             return
 
         create_meta(prefix, dist, info_dir, {
-                'files': list(files),
+                'files': files,
                 'link': {'source': source_dir,
                          'type': link_name_map.get(linktype)},
                 })

--- a/conda/install.py
+++ b/conda/install.py
@@ -401,7 +401,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
         # Build mapping from inode to filenames to maintain hardlinks
         inode_dict = defaultdict(list)
         for f in files:
-            inode = os.lstat(os.path.realpath(join(source_dir, f))).st_ino
+            inode = os.lstat(join(source_dir, f)).st_ino
             if inode:
                 inode_dict[inode].append(f)
 
@@ -432,7 +432,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
                           (src, dst, lt, e))
             # If this was a hard link in archive, make sure we maintain those
             # links even when link type is copy
-            inode = os.lstat(os.path.realpath(src)).st_ino
+            inode = os.lstat(src).st_ino
             if inode:
                 link_src = dst
                 for link_file in inode_dict[inode]:
@@ -442,9 +442,9 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
                             # Hard link to newly created file
                             _link(link_src, link_dst, LINK_HARD)
                         except OSError as e:
-                            log.error(('failed to link (src=%r, dst=%r, ' + 
-                                       'type=%r, error=%r)') % (link_src, 
-                                                               link_dst, 
+                            log.error(('failed to link (src=%r, dst=%r, ' +
+                                       'type=%r, error=%r)') % (link_src,
+                                                               link_dst,
                                                                LINK_HARD, e))
                         file_set.remove(link_file)
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -407,7 +407,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
         # Use while loop so we can modify file_set on the fly
         file_set = set(files)
         while files:
-            f = files.pop()
+            f = file_set.pop()
             src = join(source_dir, f)
             dst = join(prefix, f)
             dst_dir = dirname(dst)
@@ -443,7 +443,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD):
                         log.error(('failed to link (src=%r, dst=%r, type=%r, ' +
                                    'error=%r)') % (link_src, link_dst, 
                                                    LINK_HARD, e))
-                    files.remove(link_file)
+                    file_set.remove(link_file)
 
         if name_dist(dist) == '_cache':
             return


### PR DESCRIPTION
Even if link type is copy, we still want to make sure that package-internal hard links are maintained.
For example, with `automake`, `aclocal` and `aclocal-1.14` are just different names for the same inode. If we copy both of them separately, the hard link will be lost. 

This patch makes sure that those links are recreated by:
1. Creating a dictionary that maps from inodes to lists of files/names for that inode.
2. Using that dictionary to make sure that after one file name for a given inode is copied/linked to the prefix directory, hard links with the other names are created in the prefix directory.

This fully addresses the problem that my previous PR, #622, tried to solve.

<!---
@huboard:{"order":3.0568360077314207e-30,"custom_state":""}
-->
