### PR TITLE
Add ssl_verify option to allow ignoring SSL certificate verification.

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -63,6 +63,7 @@ rc_bool_keys = [
     'binstar_personal',
     'show_channel_urls',
     'allow_other_channels',
+    'ssl_verify'
     ]
 
 # Not supported by conda config yet
@@ -271,6 +272,7 @@ show_channel_urls = bool(rc.get('show_channel_urls', False))
 disallow = set(rc.get('disallow', []))
 # packages which are added to a newly created environment by default
 create_default_packages = list(rc.get('create_default_packages', []))
+ssl_verify = bool(rc.get('ssl_verify', True))
 try:
     track_features = set(rc['track_features'].split())
 except KeyError:

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -171,7 +171,7 @@ def download(url, dst_path, session=None, md5=None, urlstxt=False):
 
     with Locked(dst_dir):
         try:
-            resp = session.get(url, stream=True)
+            resp = session.get(url, stream=True, verify=config.ssl_verify)
         except IOError:
             raise RuntimeError("Could not open '%s'" % url)
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
Makes everything that depends on `conda.fetch.download()` a lot more useful behind corporate proxies.

Default behaviour is unchanged: `ssl_verify = True`.
