### PR TITLE
Test Python 3.4 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - sudo apt-get install zsh
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget http://repo.continuum.io/miniconda/Miniconda-3.5.2-Linux-x86_64.sh -O miniconda.sh;
-    else if [[ "$TRAVIS_PYTHON_VERSION" == "3.3" ]]; then
+    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.3" ]]; then
       wget http://repo.continuum.io/miniconda/Miniconda3-3.0.0-Linux-x86_64.sh -O miniconda.sh;
     else
       wget http://repo.continuum.io/miniconda/Miniconda3-3.5.2-Linux-x86_64.sh -O miniconda.sh;


### PR DESCRIPTION
We continue to test Python 3.3 using an old version of Miniconda (so that the
root Python is 3.3; testing against a non-root Python is not supported).
