### PR TITLE
Correctly use soft-links when a package hasn't been downloaded yet

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -161,7 +161,7 @@ def ensure_linked_actions(dists, prefix):
                     lt = (install.LINK_SOFT if (config.allow_softlinks and
                                             sys.platform != 'win32') else
                       install.LINK_COPY)
-                actions[LINK].append('%s %s %d' % (dist, extracted_in, lt))
+                actions[LINK].append('%s %s %d' % (dist, config.pkgs_dirs[0], lt))
             except (OSError, IOError):
                 actions[LINK].append(dist)
             finally:


### PR DESCRIPTION
@ilanschnell does this look good to you? Previously, it would try to hard-link any package which wasn't downloaded yet, which would succeed without any errors (which is another issue), but only create the directories. 
