### PR TITLE
Allow conda create with both --file and listed packages

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -143,10 +143,10 @@ def install(args, parser, command='install'):
     common.ensure_override_channels_requires_channel(args)
     channel_urls = args.channel or ()
 
+    specs = []
     if args.file:
-        specs = common.specs_from_url(args.file)
+        specs.extend(common.specs_from_url(args.file))
     elif getattr(args, 'all', False):
-        specs = []
         linked = ci.linked(prefix)
         for pkg in linked:
             name, ver, build = pkg.rsplit('-', 2)
@@ -155,8 +155,7 @@ def install(args, parser, command='install'):
                 specs.append('%s >=%s,<3' % (name, ver))
             else:
                 specs.append('%s >=%s' % (name, ver))
-    else:
-        specs = common.specs_from_args(args.packages)
+    specs.extend(common.specs_from_args(args.packages))
 
     if command == 'install' and args.revision:
         get_revision(args.revision)


### PR DESCRIPTION
Fixes #802

```
$ echo "scipy" > deps.txt
$ conda create -n testing2 --file deps.txt sympy        
Fetching package metadata: ..
Solving package specifications: .............
Package plan for installation in environment /home/lidavidm/miniconda3/envs/testing2:

The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    numpy-1.8.1                |           py34_0         7.2 MB
    scipy-0.14.0               |       np18py34_0        28.9 MB
    sympy-0.7.5                |           py34_0         5.8 MB
    ------------------------------------------------------------
                                           Total:        41.9 MB

The following NEW packages will be INSTALLED:

    numpy:    1.8.1-py34_0     
    openssl:  1.0.1h-0         
    python:   3.4.1-0          
    readline: 6.2-2            
    scipy:    0.14.0-np18py34_0
    sqlite:   3.8.4.1-0        
    sympy:    0.7.5-py34_0     
    system:   5.8-1            
    tk:       8.5.15-0         
    zlib:     1.2.7-0
```
