### PR TITLE
activateroot should not take arguments in the shell

### DIFF
--- a/bin/deactivate
+++ b/bin/deactivate
@@ -18,7 +18,7 @@ else
 fi
 _THIS_DIR=$(dirname "$_SCRIPT_LOCATION")
 
-_NEW_PATH=$("$_THIS_DIR/conda" ..activateroot "$@")
+_NEW_PATH=$("$_THIS_DIR/conda" ..activateroot)
 if (( $? == 0 )); then
     export PATH=$_NEW_PATH
     unset CONDA_DEFAULT_ENV


### PR DESCRIPTION
https://github.com/conda/conda/blob/master/conda/cli/activate.py#L71 raises if there's more than a single argument to conda thus the removal.
