### PR TITLE
Workaround launch issue in Windows XP/Python 3

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -229,7 +229,7 @@ def launch(fn, prefix=config.root_dir, additional_args=None):
     cwd = abspath(expanduser('~'))
     if additional_args:
         args.extend(additional_args)
-    return subprocess.Popen(args, cwd=cwd , env=env)
+    return subprocess.Popen(args, cwd=cwd, env=env, close_fds=False)
 
 
 def make_icon_url(info):


### PR DESCRIPTION
Under Python 3.4 and Windows XP (32 or 64 bit), the spawned process does not inherit stdout/stderr. If the process then tries to spawn its own subprocess, this raises an exception when Python can't make a new file handle. This commit forces subprocess to spawn the new process with inherited file handles, avoiding the issue.

In Python 3 `subprocess.py` under Windows `close_fds` defaults to `True` unless you pass in at least one of `stdout`, `stderr`, or `stdin`. Presumably then this issue would apply to all Windows versions, but it does not - it happens only on XP (perhaps this is an interpreter issue or there was a change in win32 `CreateProcess` or something). In Python 2 this parameter defaulted to `False`.

In particular, this affected launching IPython-Qtconsole. For whatever reason, the behavior only exhibited itself under node-webkit. The exception it raised is: https://gist.github.com/lidavidm/5a05c4eb28ed1c9002d9
