### PR TITLE
Don't error when generating icon URL if package is missing data

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -233,12 +233,14 @@ def launch(fn, prefix=config.root_dir, additional_args=None):
 
 
 def make_icon_url(info):
-    base_url = dirname(info['channel'].rstrip('/'))
-    icon_fn = info['icon']
-    #icon_cache_path = join(config.pkgs_dir, 'cache', icon_fn)
-    #if isfile(icon_cache_path):
-    #    return url_path(icon_cache_path)
-    return '%s/icons/%s' % (base_url, icon_fn)
+    if 'channel' in info and 'icon' in info:
+        base_url = dirname(info['channel'].rstrip('/'))
+        icon_fn = info['icon']
+        #icon_cache_path = join(config.pkgs_dir, 'cache', icon_fn)
+        #if isfile(icon_cache_path):
+        #    return url_path(icon_cache_path)
+        return '%s/icons/%s' % (base_url, icon_fn)
+    return ''
 
 
 def list_prefixes():


### PR DESCRIPTION
Something I just found when using `search --unknown` (channel isn't always defined for a package)
