### PR TITLE
ENH : truncate venv name to basename

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -45,10 +45,11 @@ if (( $? == 0 )); then
     else
         export CONDA_DEFAULT_ENV="$@"
     fi
+    CONDA_PS_PREFIX=$(basename $CONDA_DEFAULT_ENV)
 
     if (( $("$_THIS_DIR/conda" ..changeps1) ));  then
             CONDA_OLD_PS1="$PS1"
-            PS1="($CONDA_DEFAULT_ENV)$PS1"
+            PS1="($CONDA_PS_PREFIX)$PS1"
     fi
 else
     return $?

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -25,6 +25,7 @@ if (( $? == 0 )); then
     if (( $($_THIS_DIR/conda ..changeps1) )); then
         PS1=$CONDA_OLD_PS1
         unset CONDA_OLD_PS1
+        usset CONDA_PS_PREFIX
     fi
 else
     return $?

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -25,7 +25,7 @@ if (( $? == 0 )); then
     if (( $($_THIS_DIR/conda ..changeps1) )); then
         PS1=$CONDA_OLD_PS1
         unset CONDA_OLD_PS1
-        usset CONDA_PS_PREFIX
+        unset CONDA_PS_PREFIX
     fi
 else
     return $?

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -309,7 +309,7 @@ def test_PS1():
             """).format(envs=envs, activate=activate)
 
             stdout, stderr = run_in(commands, shell)
-            assert stdout == '({envs}/test1)$'.format(envs=envs)
+            assert stdout == '(test1)$'
             assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test1/bin to PATH\n'.format(envs=envs, syspath=syspath)
 
             commands = (command_setup + """
@@ -319,7 +319,7 @@ def test_PS1():
             """).format(envs=envs, activate=activate)
 
             stdout, stderr = run_in(commands, shell)
-            assert stdout == '({envs}/test2)$'.format(envs=envs)
+            assert stdout == '(test2)$'
             assert stderr == 'discarding {envs}/test1/bin from PATH\nprepending {envs}/test2/bin to PATH\n'.format(envs=envs)
 
             commands = (command_setup + """
@@ -338,7 +338,7 @@ def test_PS1():
             """).format(envs=envs, activate=activate)
 
             stdout, stderr = run_in(commands, shell)
-            assert stdout == '({envs}/test1)$'.format(envs=envs)
+            assert stdout == '(test1)$'
             assert stderr == 'Error: no such directory: {envs}/test3/bin\n'.format(envs=envs)
 
             commands = (command_setup + """


### PR DESCRIPTION
When using environments not in (mini)conda/envs truncate the string inserted into PS1 to just be the base name.

Vauegly related to https://groups.google.com/a/continuum.io/forum/#!searchin/conda/activate/conda/c0DrrSdy1e8/x4q1V1iTXioJ