### PR TITLE
supports unix-style prefix paths in regular text files on windows

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -228,12 +228,12 @@ def binary_replace(data, a, b):
 
 def update_prefix(path, new_prefix, placeholder=prefix_placeholder,
                   mode='text'):
-    path = os.path.realpath(path)
-    if on_win and '/' in placeholder:
+    if on_win and (placeholder != prefix_placeholder) and ('/' in placeholder):
         # original prefix uses unix-style path separators
         # replace with unix-style path separators
         new_prefix = new_prefix.replace('\\', '/')
 
+    path = os.path.realpath(path)
     with open(path, 'rb') as fi:
         data = fi.read()
     if mode == 'text':


### PR DESCRIPTION
Some libraries (like Qt5) have text files with hard-coded prefix paths using unix-style path separators. This pull request allows such paths to be identified and properly replaced.
