### PR TITLE
Allow spaces to be contained inside conda run

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division, absolute_import
 
 import os
 import sys
+import shlex
 import shutil
 import subprocess
 from collections import defaultdict
@@ -259,7 +260,7 @@ def execute_in_environment(cmd, prefix=config.root_dir, additional_args=None,
     else:
         cmd = join(binpath, cmd)
 
-    args = [cmd]
+    args = shlex.split(cmd)
     if additional_args:
         args.extend(additional_args)
 


### PR DESCRIPTION
This fixes and issue where this will not run:

```
conda run --prefix=/path/to/env "python --version"
```

The issue is around the way arguments are passed to subprocess.Popen.  Popen can't handle `["python --version"]` as an argument, which is what we're passing in, but it can handle `["python", "--version"]`.  Using `shlex.split` gives us a shell-safe way of splitting a string so we can turn `python --version` from the command line into the second list.
