### PR TITLE
conda.install.symlink_conda: Support 'pip install --user conda'

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -96,7 +96,7 @@ def main():
         binpath = binpath_from_arg(sys.argv[2])
         # Make sure an env always has the conda symlink
         try:
-            conda.install.symlink_conda(join(binpath, '..'), conda.config.root_dir)
+            conda.install.symlink_conda(prefix=join(binpath, '..'))
         except (IOError, OSError) as e:
             if e.errno == errno.EPERM or e.errno == errno.EACCES:
                 sys.exit("Cannot activate environment {}, do not have write access to write conda symlink".format(sys.argv[2]))

--- a/conda/install.py
+++ b/conda/install.py
@@ -359,20 +359,15 @@ def read_no_link(info_dir):
 
 # Should this be an API function?
 def symlink_conda(prefix, root_dir):
-    root_conda = join(root_dir, 'bin', 'conda')
-    root_activate = join(root_dir, 'bin', 'activate')
-    root_deactivate = join(root_dir, 'bin', 'deactivate')
-    prefix_conda = join(prefix, 'bin', 'conda')
-    prefix_activate = join(prefix, 'bin', 'activate')
-    prefix_deactivate = join(prefix, 'bin', 'deactivate')
     if not os.path.exists(join(prefix, 'bin')):
         os.makedirs(join(prefix, 'bin'))
-    if not os.path.exists(prefix_conda):
-        os.symlink(root_conda, prefix_conda)
-    if not os.path.exists(prefix_activate):
-        os.symlink(root_activate, prefix_activate)
-    if not os.path.exists(prefix_deactivate):
-        os.symlink(root_deactivate, prefix_deactivate)
+    for filename in ['conda', 'activate', 'deactivate']:
+        root_path = join(root_dir, 'bin', filename)
+        prefix_path = join(prefix, 'bin', filename)
+        if not os.path.exists(root_path):
+            raise FileNotFoundError(root_path)
+        if not os.path.exists(prefix_path):
+            os.symlink(root_path, prefix_path)
 
 # ========================== begin API functions =========================
 


### PR DESCRIPTION
Conda currently assumes a system-wide install:

    $ pip install --user conda
    $ command -v conda
    /home/me/.local/bin/conda
    $ conda create -n foo --yes python
    $ ls -l ~/envs/foo/bin/conda
    lrwxrwxrwx 1 ... /home/me/envs/foo/bin/conda -> /usr/bin/conda

This series adds a check for such broken symlinks, and sets up the symlinks to point to whatever versions of `conda` etc. it finds in the user's `PATH`.