### PR TITLE
Fix run environment

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -257,8 +257,6 @@ def execute_in_environment(cmd, prefix=config.root_dir, additional_args=None,
     if sys.platform == 'win32' and cmd == 'python':
         # python is located one directory up on Windows
         cmd = join(binpath, '..', cmd)
-    else:
-        cmd = join(binpath, cmd)
 
     args = shlex.split(cmd)
     if additional_args:

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -204,8 +204,7 @@ def environment_for_conda_environment(prefix=config.root_dir):
     # prepend the bin directory to the path
     fmt = r'%s\Scripts' if sys.platform == 'win32' else '%s/bin'
     binpath = fmt % abspath(prefix)
-    path = r'%s;%s' if sys.platform == 'win32' else '%s:%s'
-    path = path % (binpath, os.getenv('PATH'))
+    path = os.path.pathsep.join([binpath, os.getenv('PATH')])
     env = {'PATH': path}
     # copy existing environment variables, but not anything with PATH in it
     for k, v in iteritems(os.environ):


### PR DESCRIPTION
Ran into an issue where `conda run ls` doesn't work as expected because it's not explicitly in the environment.  Looking through the code's history I'm not sure why `join(binpath, cmd)` was used here, but it works fines without it.

This has been manually tested on OS X and Windows XP using `conda run ls` and `conda run ipconfig`, respectively.