### PR TITLE
Default to `python` if nothing else is specified

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -91,7 +91,7 @@ def add_parser_use_index_cache(p):
         help = "use cache of channel index files",
     )
 
-def add_parser_install(p):
+def add_parser_install(p, default_to_python=False):
     add_parser_yes(p)
     p.add_argument(
         '-f', "--force",
@@ -132,12 +132,17 @@ def add_parser_install(p):
         action="store_true",
         default=False,
         help="Use an alternate algorithm to generate an unsatisfiable hint")
+    packages_kwargs = {
+        'metavar': 'package_spec',
+        'action': 'store',
+        'nargs': '*',
+        'help': 'package versions to install into conda environment',
+    }
+    if default_to_python:
+        packages_kwargs['default'] = ['python', ]
     p.add_argument(
         'packages',
-        metavar = 'package_spec',
-        action = "store",
-        nargs = '*',
-        help = "package versions to install into conda environment",
+        **packages_kwargs
     )
 
 def add_parser_use_local(p):

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -31,7 +31,7 @@ def configure_parser(sub_parsers):
         help = help,
         epilog  = example,
     )
-    common.add_parser_install(p)
+    common.add_parser_install(p, default_to_python=True)
     common.add_parser_json(p)
     p.add_argument(
         "--clone",


### PR DESCRIPTION
This mimics the behavior of virtualenv's create where a base version of
Python is installed.  This has no effect on create if one or more
packages are specified.
