### PR TITLE
Deprecating json kwarg in favor of output

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+from functools import wraps
 import re
 import os
 import sys
@@ -460,3 +461,20 @@ def handle_envs_list(acc, output=True):
 
     if output:
         print()
+
+
+def deprecated_json_kwarg(func):
+    """
+    Maps deprecated json kwarg to output=!json
+
+    This is for backwards compatibility.  We should eventually log a
+    warning when `json is not None` and fix all of those warnings.
+    """
+    @wraps(func)
+    def inner(*args, **kwargs):
+        if 'json' in kwargs:
+            json = kwargs.pop('json')
+            kwargs['output'] = not json
+            print("output == %s" % kwargs['output'])
+        return func(*args, **kwargs)
+    return inner

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -475,6 +475,5 @@ def deprecated_json_kwarg(func):
         if 'json' in kwargs:
             json = kwargs.pop('json')
             kwargs['output'] = not json
-            print("output == %s" % kwargs['output'])
         return func(*args, **kwargs)
     return inner


### PR DESCRIPTION
In #658 I introduced the `handle_envs_list` function that has an `output=True` kwarg that controls whether the function generates any output or not.  Originally, it was implemented following the pattern of `json=False` that's used through the CLI layer.  The fact that JSON is being generated and displayed is an implementation detail that is not necessary for many of the functions -- they simply need to know whether they should generate any output or stay silent.