### PR TITLE
Switch to using entry_points for discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes
-  - conda install pytest requests
+  - conda install pytest requests setuptools
   - if [[ "$PYCOSAT" ]]; then
       conda install pycosat=$PYCOSAT;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ init:
   - C:\Miniconda\Scripts\conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
   - C:\Miniconda\Scripts\conda update conda
-  - C:\Miniconda\Scripts\conda install pytest requests --quiet
+  - C:\Miniconda\Scripts\conda install pytest requests setuptools --quiet
 
 install:
   - C:\Miniconda\python.exe setup.py install

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -41,23 +41,11 @@ from __future__ import print_function, division, absolute_import
 
 import sys
 import argparse
+from pkg_resources import iter_entry_points
 
 from conda.cli import common
 from conda.cli import conda_argparse
-from conda.cli import main_bundle
-from conda.cli import main_create
-from conda.cli import main_help
-from conda.cli import main_init
-from conda.cli import main_info
-from conda.cli import main_install
-from conda.cli import main_list
-from conda.cli import main_remove
-from conda.cli import main_package
-from conda.cli import main_run
-from conda.cli import main_search
-from conda.cli import main_update
-from conda.cli import main_config
-from conda.cli import main_clean
+
 
 def main():
     if len(sys.argv) > 1:
@@ -146,20 +134,9 @@ In short:
         dest = 'cmd',
     )
 
-    main_info.configure_parser(sub_parsers)
-    main_help.configure_parser(sub_parsers)
-    main_list.configure_parser(sub_parsers)
-    main_search.configure_parser(sub_parsers)
-    main_create.configure_parser(sub_parsers)
-    main_install.configure_parser(sub_parsers)
-    main_update.configure_parser(sub_parsers)
-    main_remove.configure_parser(sub_parsers)
-    main_run.configure_parser(sub_parsers)
-    main_config.configure_parser(sub_parsers)
-    main_init.configure_parser(sub_parsers)
-    main_clean.configure_parser(sub_parsers)
-    main_package.configure_parser(sub_parsers)
-    main_bundle.configure_parser(sub_parsers)
+    for cmd in iter_entry_points('conda.cmds'):
+        cmd_module = cmd.load()
+        getattr(cmd_module, 'configure_parser')(sub_parsers)
 
     try:
         import argcomplete
@@ -184,6 +161,8 @@ In short:
         logging.disable(logging.NOTSET)
         logging.basicConfig(level=logging.DEBUG)
 
+    # TODO Move this command into another module that's not the CLI script
+    from . import main_init
     if (not main_init.is_initialized() and
         'init' not in sys.argv and 'info' not in sys.argv):
         if hasattr(args, 'name') and hasattr(args, 'prefix'):

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -137,7 +137,7 @@ In short:
 
     for cmd in iter_entry_points(CMD_ENTRY_POINT):
         cmd_module = cmd.load()
-        cmd_module.configure_parser(sub_parsers)
+        cmd_module.configure_parser(sub_parsers, name=cmd.name)
 
     try:
         import argcomplete

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -137,7 +137,7 @@ In short:
 
     for cmd in iter_entry_points(CMD_ENTRY_POINT):
         cmd_module = cmd.load()
-        getattr(cmd_module, 'configure_parser')(sub_parsers)
+        cmd_module.configure_parser(sub_parsers)
 
     try:
         import argcomplete

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -45,6 +45,7 @@ from pkg_resources import iter_entry_points
 
 from conda.cli import common
 from conda.cli import conda_argparse
+from conda.constants import CMD_ENTRY_POINT
 
 
 def main():
@@ -134,7 +135,7 @@ In short:
         dest = 'cmd',
     )
 
-    for cmd in iter_entry_points('conda.cmds'):
+    for cmd in iter_entry_points(CMD_ENTRY_POINT):
         cmd_module = cmd.load()
         getattr(cmd_module, 'configure_parser')(sub_parsers)
 

--- a/conda/cli/main_bundle.py
+++ b/conda/cli/main_bundle.py
@@ -7,9 +7,9 @@ from argparse import RawDescriptionHelpFormatter
 descr = 'Create or extract a "bundle package" (EXPERIMENTAL)'
 
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='bundle'):
     p = sub_parsers.add_parser(
-        'bundle',
+        name,
         formatter_class = RawDescriptionHelpFormatter,
         description = descr,
         help = descr,

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -24,9 +24,9 @@ examples:
     conda clean --tarballs
 """
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='clean'):
     p = sub_parsers.add_parser(
-        'clean',
+        name,
         formatter_class = RawDescriptionHelpFormatter,
         description = descr,
         help = descr,

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -129,9 +129,9 @@ class BoolOrListKey(object):
         for i in config.rc_bool_keys:
             yield i
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='config'):
     p = sub_parsers.add_parser(
-        'config',
+        name,
         formatter_class = RawDescriptionHelpFormatter,
         description = descr,
         help = descr,

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -23,9 +23,9 @@ examples:
 
 """
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='create'):
     p = sub_parsers.add_parser(
-        'create',
+        name,
         formatter_class = RawDescriptionHelpFormatter,
         description = descr,
         help = help,

--- a/conda/cli/main_help.py
+++ b/conda/cli/main_help.py
@@ -8,8 +8,8 @@ from __future__ import print_function, division, absolute_import
 
 descr = "Displays a list of available conda commands and their help strings."
 
-def configure_parser(sub_parsers):
-    p = sub_parsers.add_parser('help',
+def configure_parser(sub_parsers, name='help'):
+    p = sub_parsers.add_parser(name,
                                description = descr,
                                help = descr)
     p.add_argument(

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -19,8 +19,8 @@ from conda.cli import common
 help = "Display information about current conda install."
 
 
-def configure_parser(sub_parsers):
-    p = sub_parsers.add_parser('info',
+def configure_parser(sub_parsers, name='info'):
+    p = sub_parsers.add_parser(name,
                                description = help,
                                help = help)
     common.add_parser_json(p)

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -17,9 +17,9 @@ descr = ("Initialize conda into a regular environment (when conda was "
          "installed as a Python package, e.g. using pip). (DEPRECATED)")
 
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='init'):
     p = sub_parsers.add_parser(
-        'init',
+        name,
         description = descr,
         help = descr,
     )

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -24,9 +24,9 @@ examples:
 
 """
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='install'):
     p = sub_parsers.add_parser(
-        'install',
+        name,
         formatter_class = RawDescriptionHelpFormatter,
         description = descr,
         help = help,

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -24,9 +24,9 @@ descr = "List linked packages in a conda environment."
 
 log = logging.getLogger(__name__)
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='list'):
     p = sub_parsers.add_parser(
-        'list',
+        name,
         description = descr,
         help = descr,
     )

--- a/conda/cli/main_package.py
+++ b/conda/cli/main_package.py
@@ -12,8 +12,8 @@ from conda.cli import common
 descr = "Low-level conda package utility. (EXPERIMENTAL)"
 
 
-def configure_parser(sub_parsers):
-    p = sub_parsers.add_parser('package', description=descr, help=descr)
+def configure_parser(sub_parsers, name='package'):
+    p = sub_parsers.add_parser(name, description=descr, help=descr)
 
     common.add_parser_prefix(p)
     p.add_argument(

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -13,8 +13,8 @@ from conda.cli import common
 
 descr = "Launches an application installed with Conda."
 
-def configure_parser(sub_parsers):
-    p = sub_parsers.add_parser('run',
+def configure_parser(sub_parsers, name='run'):
+    p = sub_parsers.add_parser(name,
                                description = descr,
                                help = descr)
     common.add_parser_prefix(p)

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -35,9 +35,9 @@ class Platforms(object):
         for i in ['win-32', 'win-64', 'osx-64', 'linux-32', 'linux-64']:
             yield i
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='search'):
     p = sub_parsers.add_parser(
-        'search',
+        name,
         formatter_class = RawDescriptionHelpFormatter,
         description = descr,
         help = descr,

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -18,9 +18,9 @@ examples:
 
 """
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers, name='update'):
     p = sub_parsers.add_parser(
-        'update',
+        name,
         formatter_class = RawDescriptionHelpFormatter,
         description = descr,
         help = descr,

--- a/conda/constants.py
+++ b/conda/constants.py
@@ -1,0 +1,1 @@
+CMD_ENTRY_POINT = 'conda.cmds'

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,13 @@ else:
     kwds['scripts'].append('bin/conda')
 
 
+from conda.constants import CMD_ENTRY_POINT
 cmds = [
     'bundle', 'clean', 'config', 'create', 'help', 'info', 'init', 'install',
     'list', 'package', 'remove', 'run', 'search', 'update',
 ]
 internal_entry_point = lambda a: '{0} = conda.cli.main_{0}'.format(a)
-kwds['entry_points']['conda.cmds'] = [internal_entry_point(a) for a in cmds]
+kwds['entry_points'][CMD_ENTRY_POINT] = [internal_entry_point(a) for a in cmds]
 
 if add_activate:
     if sys.platform == 'win32':

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,19 @@ versioneer.versionfile_build = 'conda/_version.py'
 versioneer.tag_prefix = '' # tags are like 1.2.0
 versioneer.parentdir_prefix = 'conda-' # dirname like 'myproject-1.2.0'
 
-kwds = {'scripts': []}
+kwds = {'scripts': [], 'entry_points': {}}
 if sys.platform == 'win32':
-    kwds['entry_points'] = dict(console_scripts =
-                                        ["conda = conda.cli.main:main"])
+    kwds['entry_points']['console_scripts'] = ["conda = conda.cli.main:main", ]
 else:
     kwds['scripts'].append('bin/conda')
+
+
+cmds = [
+    'bundle', 'clean', 'config', 'create', 'help', 'info', 'init', 'install',
+    'list', 'package', 'remove', 'run', 'search', 'update',
+]
+internal_entry_point = lambda a: '{0} = conda.cli.main_{0}'.format(a)
+kwds['entry_points']['conda.cmds'] = [internal_entry_point(a) for a in cmds]
 
 if add_activate:
     if sys.platform == 'win32':

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,8 @@
 import sys
 import os
 
-try:
-    from setuptools import setup
-    using_setuptools = True
-except ImportError:
-    from distutils.core import setup
-    using_setuptools = False
+from setuptools import setup
+using_setuptools = True
 
 add_activate = True
 
@@ -38,7 +34,7 @@ versioneer.tag_prefix = '' # tags are like 1.2.0
 versioneer.parentdir_prefix = 'conda-' # dirname like 'myproject-1.2.0'
 
 kwds = {'scripts': []}
-if sys.platform == 'win32' and using_setuptools:
+if sys.platform == 'win32':
     kwds['entry_points'] = dict(console_scripts =
                                         ["conda = conda.cli.main:main"])
 else:

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,11 @@ cmds = [
 internal_entry_point = lambda a: '{0} = conda.cli.main_{0}'.format(a)
 kwds['entry_points'][CMD_ENTRY_POINT] = [internal_entry_point(a) for a in cmds]
 
+# Add any aliases
+kwds['entry_points'][CMD_ENTRY_POINT] += [
+    'uninstall = conda.cli.main_remove'
+]
+
 if add_activate:
     if sys.platform == 'win32':
         kwds['scripts'].extend(['bin\\activate.bat', 'bin\\deactivate.bat'])


### PR DESCRIPTION
This simplifies the discovery of subcommands by moving to [Entry Points][1] for sub-command discovery.  All internal sub-commands are loaded this way and other extensions such as conda-env or conda-build could be moved over to this.

Benefits:

* Simplify the discovery of sub-commands.  This code doesn't remove the `conda-*` search code, but that would be an obvious next step once conda-build and conda-env are updated.
* Allows all extensions to conda to utilize the tab completion already setup

[1]: https://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins