### PR TITLE
Add missing quotation mark

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -5,7 +5,7 @@ for /f "delims=" %%i in ("%~dp0..\envs") do (
 )
 
 set CONDA_NEW_ENV=%1
-set CONDA_NEW_ENV=%CONDA_NEW_ENV:"=%
+set CONDA_NEW_ENV=%CONDA_NEW_ENV:"=%"
 
 if "%2" == "" goto skiptoomanyargs
     echo ERROR: Too many arguments provided


### PR DESCRIPTION
This appears to run with or without the quotation mark, but syntax highlighting fails without.
