### PR TITLE
Move activation into conda-env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes
+  - conda update conda
   - conda install -c conda pytest requests conda-env
   - if [[ "$PYCOSAT" ]]; then
       conda install pycosat=$PYCOSAT;

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes
-  - conda install pytest requests
+  - conda install -c conda pytest requests conda-env
   - if [[ "$PYCOSAT" ]]; then
       conda install pycosat=$PYCOSAT;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - conda config --set always_yes yes
   - bin/conda install --force --no-deps conda requests
   - conda --version
-  - conda install pytest requests mock conda-env
+  - conda install -c conda pytest requests mock conda-env
   - if [[ "$PYCOSAT" ]]; then
       conda install pycosat=$PYCOSAT;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ init:
   - C:\Miniconda\Scripts\conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
   - C:\Miniconda\Scripts\conda update conda
-  - C:\Miniconda\Scripts\conda install pytest requests --quiet
+  - C:\Miniconda\Scripts\conda install -c conda pytest requests conda-env --quiet
 
 install:
   - C:\Miniconda\python.exe setup.py install

--- a/bin/_conda-env-missing
+++ b/bin/_conda-env-missing
@@ -1,0 +1,7 @@
+#!/bin/bash
+>&2 echo "You must install conda-env before using environments.  Please"
+>&2 echo "run the folllowing command before proceeding:"
+>&2 echo ""
+>&2 echo "    conda install -c conda conda-env"
+>&2 echo ""
+return 1

--- a/bin/_conda-env-missing
+++ b/bin/_conda-env-missing
@@ -1,6 +1,7 @@
 #!/bin/bash
->&2 echo "You must install conda-env before using environments.  Please"
->&2 echo "run the folllowing command before proceeding:"
+>&2 echo "We're making conda environments even better!  Part of this process"
+>&2 echo "is changing the way environment activation works.  You need to"
+>&2 echo "install the new conda-env package before you can use these feature:"
 >&2 echo ""
 >&2 echo "    conda install -c conda conda-env"
 >&2 echo ""

--- a/bin/_conda-env-missing
+++ b/bin/_conda-env-missing
@@ -4,4 +4,6 @@
 >&2 echo ""
 >&2 echo "    conda install -c conda conda-env"
 >&2 echo ""
+>&2 echo "For more information, please visit: https://github.com/conda/conda-env"
+>&2 echo ""
 return 1

--- a/bin/activate
+++ b/bin/activate
@@ -1,67 +1,7 @@
 #!/bin/bash
-
-# Ensure that this script is sourced, not executed
-# Note that if the script was executed, we're running inside bash!
-if [[ -n $BASH_VERSION ]] && [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    >&2 echo "Error: activate must be sourced. Run 'source activate envname'
-instead of 'activate envname'.
-"
-    "$(dirname "$0")/conda" ..activate -h
-    exit 1
-fi
-
-# Determine the directory containing this script
-if [[ -n $BASH_VERSION ]]; then
-    _SCRIPT_LOCATION=${BASH_SOURCE[0]}
-elif [[ -n $ZSH_VERSION ]]; then
-    _SCRIPT_LOCATION=${funcstack[1]}
+ROOT_PREFIX=$(conda info --json  | grep root_prefix | awk -F ':' '{print $2}' | awk -F '"' '{print $2}')
+if [[ -a "${ROOT_PREFIX}/bin/env-activate" ]]; then
+    source "${ROOT_PREFIX}/bin/env-activate" $@
 else
-    echo "Only bash and zsh are supported"
-    return 1
-fi
-_THIS_DIR=$(dirname "$_SCRIPT_LOCATION")
-
-# http://stackoverflow.com/a/21188136/161801
-get_abs_filename() {
-    echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
-}
-
-if "$_THIS_DIR/conda" ..checkenv "$@"; then
-    _NEW_PATH=$("$_THIS_DIR/conda" ..deactivate)
-    export PATH=$_NEW_PATH
-    if (( $("$_THIS_DIR/conda" ..changeps1) )); then
-        if [[ -n $CONDA_OLD_PS1 ]]; then
-            PS1=$CONDA_OLD_PS1
-            unset CONDA_OLD_PS1
-        fi
-    fi
-else
-    return 1
-fi
-
-_NEW_PATH=$("$_THIS_DIR/conda" ..activate "$@")
-if (( $? == 0 )); then
-    export PATH=$_NEW_PATH
-    # If the string contains / it's a path
-    if [[ "$@" == */* ]]; then
-        export CONDA_DEFAULT_ENV=$(get_abs_filename "$@")
-    else
-        export CONDA_DEFAULT_ENV="$@"
-    fi
-
-    if (( $("$_THIS_DIR/conda" ..changeps1) ));  then
-            CONDA_OLD_PS1="$PS1"
-            PS1="($CONDA_DEFAULT_ENV)$PS1"
-    fi
-else
-    return $?
-fi
-
-if [[ -n $BASH_VERSION ]]; then
-    hash -r
-elif [[ -n $ZSH_VERSION ]]; then
-    rehash
-else
-    echo "Only bash and zsh are supported"
-    return 1
+    source "${ROOT_PREFIX}/bin/_conda-env-missing"
 fi

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -1,44 +1,16 @@
 @echo off
+for /f "delims=" %%a in ('conda info --root') do @set root=%%a
 
-for /f "delims=" %%i in ("%~dp0..\envs") do (
-    set ANACONDA_ENVS=%%~fi
-)
-
-set CONDA_NEW_ENV=%1
-set CONDA_NEW_ENV=%CONDA_NEW_ENV:"=%
-
-if "%2" == "" goto skiptoomanyargs
-    echo ERROR: Too many arguments provided
-    goto usage
-:skiptoomanyargs
-
-if not "%CONDA_NEW_ENV%" == "" goto skipmissingarg
-:usage
-    echo Usage: activate envname
+if exists "%root%\Scripts\env-activate.bat" goto activate
+    echo You must install conda-env before using environments. Please
+    echo run the following command before proceeding:
     echo.
-    echo Deactivates previously activated Conda
-    echo environment, then activates the chosen one.
-    exit /b 1
-:skipmissingarg
+    echo     conda install -c conda conda-env
+    echo.
+    goto done
 
-if exist "%ANACONDA_ENVS%\%CONDA_NEW_ENV%\Python.exe" goto skipmissingenv
-    echo No environment named "%CONDA_NEW_ENV%" exists in %ANACONDA_ENVS%
-    set CONDA_NEW_ENV=
-    exit /b 1
-:skipmissingenv
+:activate
+    set args=%*
+    call %root%\Scripts\env-activate.bat %args%
 
-REM Deactivate a previous activation if it is live
-if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
-    REM This search/replace removes the previous env from the path
-    echo Deactivating environment "%CONDA_DEFAULT_ENV%"...
-    set CONDACTIVATE_PATH=%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%;%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\Scripts;
-    call set PATH=%%PATH:%CONDACTIVATE_PATH%=%%
-    set CONDA_DEFAULT_ENV=
-    set CONDACTIVATE_PATH=
-:skipdeactivate
-
-set CONDA_DEFAULT_ENV=%CONDA_NEW_ENV%
-set CONDA_NEW_ENV=
-echo Activating environment "%CONDA_DEFAULT_ENV%"...
-set PATH=%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%;%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\Scripts;%PATH%
-set PROMPT=[%CONDA_DEFAULT_ENV%] $P$G
+:done

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -1,7 +1,7 @@
 @echo off
 for /f "delims=" %%a in ('conda info --root') do @set root=%%a
 
-if exists "%root%\Scripts\env-activate.bat" goto activate
+if exist "%root%\Scripts\env-activate.bat" goto activate
     echo You must install conda-env before using environments. Please
     echo run the following command before proceeding:
     echo.

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -2,11 +2,15 @@
 for /f "delims=" %%a in ('conda info --root') do @set root=%%a
 
 if exist "%root%\Scripts\env-activate.bat" goto activate
-    echo You must install conda-env before using environments. Please
-    echo run the following command before proceeding:
-    echo.
+
+    echo We're making conda environments even better!  Part of this process
+    echo is changing the way environment activation works.  You need to
+    echo install the new conda-env package before you can use these features:
+    echo .
     echo     conda install -c conda conda-env
-    echo.
+    echo .
+    echo For more information, please visit: https://github.com/conda/conda-env
+    echo .
     goto done
 
 :activate

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -1,43 +1,7 @@
 #!/bin/bash
-
-# Ensure that this script is sourced, not executed
-# Note that if the script was executed, we're running inside bash!
-if [[ -n $BASH_VERSION ]] && [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    >&2 echo "Error: deactivate must be sourced. Run 'source deactivate'
-instead of 'deactivate'.
-"
-    "$(dirname $0)/conda" ..deactivate -h
-    exit 1
-fi
-
-# Determine the directory containing this script
-if [[ -n $BASH_VERSION ]]; then
-    _SCRIPT_LOCATION=${BASH_SOURCE[0]}
-elif [[ -n $ZSH_VERSION ]]; then
-    _SCRIPT_LOCATION=${funcstack[1]}
+ROOT_PREFIX=$(conda info --json  | grep root_prefix | awk -F ':' '{print $2}' | awk -F '"' '{print $2}')
+if [[ -a "${ROOT_PREFIX}/bin/env-deactivate" ]]; then
+    source "${ROOT_PREFIX}/bin/env-deactivate" $@
 else
-    echo "Only bash and zsh are supported"
-    return 1
-fi
-_THIS_DIR=$(dirname "$_SCRIPT_LOCATION")
-
-_NEW_PATH=$("$_THIS_DIR/conda" ..activateroot "$@")
-if (( $? == 0 )); then
-    export PATH=$_NEW_PATH
-    unset CONDA_DEFAULT_ENV
-    if (( $($_THIS_DIR/conda ..changeps1) )); then
-        PS1=$CONDA_OLD_PS1
-        unset CONDA_OLD_PS1
-    fi
-else
-    return $?
-fi
-
-if [[ -n $BASH_VERSION ]]; then
-    hash -r
-elif [[ -n $ZSH_VERSION ]]; then
-    rehash
-else
-    echo "Only bash and zsh are supported"
-    return 1
+    source "${ROOT_PREFIX}/bin/_conda-env-missing"
 fi

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -2,11 +2,14 @@
 for /f "delims=" %%a in ('conda info --root') do @set root=%%a
 
 if exist "%root%\Scripts\env-deactivate.bat" goto deactivate
-    echo You must install conda-env before using environments. Please
-    echo run the following command before proceeding:
-    echo.
+    echo We're making conda environments even better!  Part of this process
+    echo is changing the way environment activation works.  You need to
+    echo install the new conda-env package before you can use these features:
+    echo .
     echo     conda install -c conda conda-env
-    echo.
+    echo .
+    echo For more information, please visit: https://github.com/conda/conda-env
+    echo .
     goto done
 
 :deactivate

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -1,25 +1,16 @@
 @echo off
+for /f "delims=" %%a in ('conda info --root') do @set root=%%a
 
-for /f "delims=" %%i in ("%~dp0..\envs") do (
-    set ANACONDA_ENVS=%%~fi
-)
-
-if "%1" == "" goto skipmissingarg
-    echo Usage: deactivate
+if exists "%root%\Scripts\env-deactivate.bat" goto deactivate
+    echo You must install conda-env before using environments. Please
+    echo run the following command before proceeding:
     echo.
-    echo Deactivates previously activated Conda
-    echo environment.
-    exit /b 1
-:skipmissingarg
+    echo     conda install -c conda conda-env
+    echo.
+    goto done
 
-REM Deactivate a previous activation if it is live
-if "%CONDA_DEFAULT_ENV%" == "" goto skipdeactivate
-    REM This search/replace removes the previous env from the path
-    echo Deactivating environment "%CONDA_DEFAULT_ENV%"...
-    set CONDACTIVATE_PATH=%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%;%ANACONDA_ENVS%\%CONDA_DEFAULT_ENV%\Scripts;
-    call set PATH=%%PATH:%CONDACTIVATE_PATH%=%%
-    set CONDA_DEFAULT_ENV=
-    set CONDACTIVATE_PATH=
-:skipdeactivate
+:deactivate
+    set args=%*
+    call %root%\Scripts\env-deactivate.bat %args%
 
-set PROMPT=$P$G
+:done

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -1,7 +1,7 @@
 @echo off
 for /f "delims=" %%a in ('conda info --root') do @set root=%%a
 
-if exists "%root%\Scripts\env-deactivate.bat" goto deactivate
+if exist "%root%\Scripts\env-deactivate.bat" goto deactivate
     echo You must install conda-env before using environments. Please
     echo run the following command before proceeding:
     echo.

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,11 @@ if add_activate:
     if sys.platform == 'win32':
         kwds['scripts'].extend(['bin\\activate.bat', 'bin\\deactivate.bat'])
     else:
-        kwds['scripts'].extend(['bin/activate', 'bin/deactivate'])
+        kwds['scripts'].extend([
+            'bin/activate',
+            'bin/deactivate',
+            'bin/_conda-env-missing',
+        ])
 
 setup(
     name = "conda",


### PR DESCRIPTION
This provides a backwards compatible method of moving activation over to [conda-env][].  It requires conda-env v1.2.0 to be installed, but once that's installed everything works as it did + the new activation behavior.

[conda-env]: https://github.com/conda/conda-env