### PR TITLE
allow progressbar to handle too-small maxval

### DIFF
--- a/conda/progressbar/__init__.py
+++ b/conda/progressbar/__init__.py
@@ -267,8 +267,8 @@ class ProgressBar(object):
         if value is not None and value is not UnknownLength:
             if (self.maxval is not UnknownLength
                 and not 0 <= value <= self.maxval):
-
-                raise ValueError('Value out of range')
+                # maxval was reported incorrectly. warn?
+                value = self.maxval
 
             self.currval = value
 


### PR DESCRIPTION
can come up for servers reporting incorrect Content-Length, or requests decompressing content.

progress bar will sit at 100% while value >= maxval

closes conda/conda-build#224
