### PR TITLE
use actual bytes read for download progress

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -327,7 +327,8 @@ def download(url, dst_path, session=None, md5=None, urlstxt=False,
                         raise RuntimeError("Failed to write to %r." % pp)
                     if md5:
                         h.update(chunk)
-                    n += len(chunk)
+                    # update n with actual bytes read
+                    n = resp.raw.tell()
                     if size and 0 <= n <= size:
                         getLogger('fetch.update').info(n)
         except IOError as e:


### PR DESCRIPTION
instead of len(chunk), which may be decompressed and thus the wrong value, relative to Content-Length.

related to conda/conda-build#224
