### PR TITLE
Adding tests to conda.install.rm_rf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes
-  - conda install pytest requests
+  - conda install pytest requests mock
   - if [[ "$PYCOSAT" ]]; then
       conda install pycosat=$PYCOSAT;
     fi

--- a/conda/install.py
+++ b/conda/install.py
@@ -168,14 +168,12 @@ def rm_rf(path, max_retries=5):
                         return
                     except OSError as e1:
                         msg += "Retry with onerror failed (%s)\n" % e1
-                        pass
 
                     try:
                         subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', path])
                         return
                     except subprocess.CalledProcessError as e2:
                         msg += '%s\n' % e2
-                        pass
                 log.debug(msg + "Retrying after %s seconds..." % i)
                 time.sleep(i)
         # Final time. pass exceptions to caller.

--- a/conda/install.py
+++ b/conda/install.py
@@ -167,15 +167,17 @@ def rm_rf(path, max_retries=5):
                         shutil.rmtree(path, onerror=_remove_readonly)
                         return
                     except OSError:
-                        pass
                 #     except OSError as e1:
                 #         msg += "Retry with onerror failed (%s)\n" % e1
+                        pass
 
-                #     try:
-                    subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', path])
-                    return
+                    try:
+                        subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', path])
+                        return
+                    except subprocess.CalledProcessError:
                 #     except subprocess.CalledProcessError as e2:
                 #         msg += '%s\n' % e2
+                        pass
                 log.debug(msg + "Retrying after %s seconds..." % i)
                 time.sleep(i)
         # Final time. pass exceptions to caller.

--- a/conda/install.py
+++ b/conda/install.py
@@ -154,24 +154,24 @@ def rm_rf(path, max_retries=5):
             try:
                 shutil.rmtree(path)
                 return
-            except OSError as e:
-                msg = "Unable to delete %s\n%s\n" % (path, e)
-                if on_win:
-                    try:
-                        def remove_readonly(func, path, excinfo):
-                            os.chmod(path, stat.S_IWRITE)
-                            func(path)
-                        shutil.rmtree(path, onerror=remove_readonly)
-                        return
-                    except OSError as e1:
-                        msg += "Retry with onerror failed (%s)\n" % e1
+            except OSError:
+                # msg = "Unable to delete %s\n%s\n" % (path, e)
+                # if on_win:
+                #     try:
+                #         def remove_readonly(func, path, excinfo):
+                #             os.chmod(path, stat.S_IWRITE)
+                #             func(path)
+                #         shutil.rmtree(path, onerror=remove_readonly)
+                #         return
+                #     except OSError as e1:
+                #         msg += "Retry with onerror failed (%s)\n" % e1
 
-                    try:
-                        subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', path])
-                        return
-                    except subprocess.CalledProcessError as e2:
-                        msg += '%s\n' % e2
-                log.debug(msg + "Retrying after %s seconds..." % i)
+                #     try:
+                #         subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', path])
+                #         return
+                #     except subprocess.CalledProcessError as e2:
+                #         msg += '%s\n' % e2
+                # log.debug(msg + "Retrying after %s seconds..." % i)
                 time.sleep(i)
         # Final time. pass exceptions to caller.
         shutil.rmtree(path)

--- a/conda/install.py
+++ b/conda/install.py
@@ -137,9 +137,8 @@ def _link(src, dst, linktype=LINK_HARD):
 
 # TODO Test
 def _remove_readonly(func, path, excinfo):
-    pass
-    # os.chmod(path, stat.S_IWRITE)
-    # func(path)
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
 
 
 def rm_rf(path, max_retries=5):

--- a/conda/install.py
+++ b/conda/install.py
@@ -154,8 +154,8 @@ def rm_rf(path, max_retries=5):
             try:
                 shutil.rmtree(path)
                 return
-            except OSError:
-                # msg = "Unable to delete %s\n%s\n" % (path, e)
+            except OSError as e:
+                msg = "Unable to delete %s\n%s\n" % (path, e)
                 # if on_win:
                 #     try:
                 #         def remove_readonly(func, path, excinfo):
@@ -171,7 +171,7 @@ def rm_rf(path, max_retries=5):
                 #         return
                 #     except subprocess.CalledProcessError as e2:
                 #         msg += '%s\n' % e2
-                # log.debug(msg + "Retrying after %s seconds..." % i)
+                log.debug(msg + "Retrying after %s seconds..." % i)
                 time.sleep(i)
         # Final time. pass exceptions to caller.
         shutil.rmtree(path)

--- a/conda/install.py
+++ b/conda/install.py
@@ -135,7 +135,6 @@ def _link(src, dst, linktype=LINK_HARD):
         raise Exception("Did not expect linktype=%r" % linktype)
 
 
-# TODO Test
 def _remove_readonly(func, path, excinfo):
     os.chmod(path, stat.S_IWRITE)
     func(path)

--- a/conda/install.py
+++ b/conda/install.py
@@ -163,14 +163,17 @@ def rm_rf(path, max_retries=5):
             except OSError as e:
                 msg = "Unable to delete %s\n%s\n" % (path, e)
                 if on_win:
-                    shutil.rmtree(path, onerror=_remove_readonly)
-                    return
+                    try:
+                        shutil.rmtree(path, onerror=_remove_readonly)
+                        return
+                    except OSError:
+                        pass
                 #     except OSError as e1:
                 #         msg += "Retry with onerror failed (%s)\n" % e1
 
                 #     try:
-                #         subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', path])
-                #         return
+                    subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', path])
+                    return
                 #     except subprocess.CalledProcessError as e2:
                 #         msg += '%s\n' % e2
                 log.debug(msg + "Retrying after %s seconds..." % i)

--- a/conda/install.py
+++ b/conda/install.py
@@ -166,17 +166,15 @@ def rm_rf(path, max_retries=5):
                     try:
                         shutil.rmtree(path, onerror=_remove_readonly)
                         return
-                    except OSError:
-                #     except OSError as e1:
-                #         msg += "Retry with onerror failed (%s)\n" % e1
+                    except OSError as e1:
+                        msg += "Retry with onerror failed (%s)\n" % e1
                         pass
 
                     try:
                         subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', path])
                         return
-                    except subprocess.CalledProcessError:
-                #     except subprocess.CalledProcessError as e2:
-                #         msg += '%s\n' % e2
+                    except subprocess.CalledProcessError as e2:
+                        msg += '%s\n' % e2
                         pass
                 log.debug(msg + "Retrying after %s seconds..." % i)
                 time.sleep(i)

--- a/conda/install.py
+++ b/conda/install.py
@@ -135,6 +135,13 @@ def _link(src, dst, linktype=LINK_HARD):
         raise Exception("Did not expect linktype=%r" % linktype)
 
 
+# TODO Test
+def _remove_readonly(func, path, excinfo):
+    pass
+    # os.chmod(path, stat.S_IWRITE)
+    # func(path)
+
+
 def rm_rf(path, max_retries=5):
     """
     Completely delete path
@@ -156,13 +163,9 @@ def rm_rf(path, max_retries=5):
                 return
             except OSError as e:
                 msg = "Unable to delete %s\n%s\n" % (path, e)
-                # if on_win:
-                #     try:
-                #         def remove_readonly(func, path, excinfo):
-                #             os.chmod(path, stat.S_IWRITE)
-                #             func(path)
-                #         shutil.rmtree(path, onerror=remove_readonly)
-                #         return
+                if on_win:
+                    shutil.rmtree(path, onerror=_remove_readonly)
+                    return
                 #     except OSError as e1:
                 #         msg += "Retry with onerror failed (%s)\n" % e1
 

--- a/tests/decorators.py
+++ b/tests/decorators.py
@@ -1,0 +1,20 @@
+from functools import wraps
+import unittest
+
+try:
+    from unittest import mock
+    skip_mock = False
+except ImportError:
+    try:
+        import mock
+        skip_mock = False
+    except ImportError:
+        skip_mock = True
+
+
+def skip_if_no_mock(func):
+    @wraps(func)
+    @unittest.skipIf(skip_mock, 'install mock library to test')
+    def inner(*args, **kwargs):
+        return func(*args, **kwargs)
+    return inner

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,14 @@ import sys
 import os
 import json
 
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
 from contextlib import contextmanager
 
 import conda.cli as cli

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,5 +1,6 @@
 try:
     from unittest import mock
+    from unittest.mock import patch
 except ImportError:
     import mock
     from mock import patch

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,12 +11,12 @@ class TestBinaryReplace(unittest.TestCase):
     def test_simple(self):
         self.assertEqual(
             binary_replace(b'xxxaaaaaxyz\x00zz', b'aaaaa', b'bbbbb'),
-                           b'xxxbbbbbxyz\x00zz')
+            b'xxxbbbbbxyz\x00zz')
 
     def test_shorter(self):
         self.assertEqual(
             binary_replace(b'xxxaaaaaxyz\x00zz', b'aaaaa', b'bbbb'),
-                           b'xxxbbbbxyz\x00\x00zz')
+            b'xxxbbbbxyz\x00\x00zz')
 
     def test_too_long(self):
         self.assertRaises(PaddingError, binary_replace,
@@ -24,12 +24,12 @@ class TestBinaryReplace(unittest.TestCase):
 
     def test_no_extra(self):
         self.assertEqual(binary_replace(b'aaaaa\x00', b'aaaaa', b'bbbbb'),
-                                        b'bbbbb\x00')
+                         b'bbbbb\x00')
 
     def test_two(self):
         self.assertEqual(
             binary_replace(b'aaaaa\x001234aaaaacc\x00\x00', b'aaaaa', b'bbbbb'),
-                           b'bbbbb\x001234bbbbbcc\x00\x00')
+            b'bbbbb\x001234bbbbbcc\x00\x00')
 
     def test_spaces(self):
         self.assertEqual(
@@ -45,6 +45,7 @@ class TestBinaryReplace(unittest.TestCase):
             b'bbbcbbb\x00\x00\x00')
         self.assertRaises(PaddingError, binary_replace,
                           b'aaaacaaaa\x00', b'aaaa', b'bbbbb')
+
 
 class FileTests(unittest.TestCase):
 
@@ -72,8 +73,10 @@ class FileTests(unittest.TestCase):
                       placeholder='/some-placeholder', mode='binary')
         with open(self.tmpfname, 'rb') as fi:
             data = fi.read()
-            self.assertEqual(data,
-                      b'\x7fELF.../usr/local/lib/libfoo.so\0\0\0\0\0\0\0\0')
+            self.assertEqual(
+                data,
+                b'\x7fELF.../usr/local/lib/libfoo.so\0\0\0\0\0\0\0\0'
+            )
 
 
 if __name__ == '__main__':

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -328,6 +328,7 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
             mock.call(random_path, onerror=install._remove_readonly)
         ]
         mocks['rmtree'].assert_has_calls(expected_call_list)
+        self.assertEqual(2, mocks['rmtree'].call_count)
 
     def test_dispatch_to_subprocess_on_error_on_windows(self):
         with self.generate_directory_mocks(on_win=True) as mocks:

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -1,11 +1,8 @@
 import random
 import unittest
 
-try:
-    import mock
-    skip_mocked = False
-except ImportError:
-    skip_mocked = True
+from .helpers import mock
+from .decorators import skip_if_no_mock
 
 from conda import pip
 
@@ -36,7 +33,7 @@ class PipPackageTestCase(unittest.TestCase):
 
 
 class installed_test(unittest.TestCase):
-    @unittest.skipIf(skip_mocked, 'install mock to test')
+    @skip_if_no_mock
     # TODO brittle test -- shows code that needs refactoring
     def test_stops_on_exception(self):
         with mock.patch.object(pip, 'subprocess') as subprocess:


### PR DESCRIPTION
This is to ready to merge and will not be ready to merge until all of the changes in `conda/install.py` have been undone.  As noted in 77f65c94579b6fe4d567d888958850ffb3b53e8c, the modifications there are to use this as TDD.  I started with a function that simply returned and have slowly been adding everything back in as each test is added to verify some additional functionality.

I'm pushing and opening the PR in case anyone's interested following along.