### PR TITLE
Close handles where possible.

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -98,6 +98,8 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
     try:
         resp = session.get(url + 'repodata.json.bz2',
                            headers=headers, proxies=session.proxies)
+                           headers=headers, proxies=session.proxies)
+        resp.close()
         resp.raise_for_status()
         if resp.status_code != 304:
             cache = json.loads(bz2.decompress(resp.content).decode('utf-8'))


### PR DESCRIPTION
Avoids some noisy warnings in Python 3 (I have ResourceWarnings enabled).