### PR TITLE
Allowed configuration of pkgs_dirs.

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -149,7 +149,17 @@ def pkgs_dir_from_envs_dir(envs_dir):
     else:
         return join(envs_dir, '.pkgs')
 
-pkgs_dirs = [pkgs_dir_from_envs_dir(envs_dir) for envs_dir in envs_dirs]
+
+def _get_pkgs_dirs(envs_dirs):
+    if 'pkgs_dirs' in rc:
+        pkgs = rc['pkgs_dirs']
+    elif 'pkgs_dirs' in sys_rc:
+        pkgs = sys_rc['pkgs_dirs']
+    else:
+        pkgs = [pkgs_dir_from_envs_dir(envs_dir) for envs_dir in envs_dirs]
+    return pkgs
+
+pkgs_dirs = _get_pkgs_dirs(envs_dirs)
 
 # ----- default environment prefix -----
 


### PR DESCRIPTION
Allows either site (sys_rc) or user (rc) configuration of the pkgs directories using the ``pkgs_dirs`` section in the yaml config.