### PR TITLE
Revert "add optional 'icondata' key to conda-meta"

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -342,7 +342,6 @@ def run_script(prefix, dist, action='post-link', env_prefix=None):
         return False
     return True
 
-
 def read_url(pkgs_dir, dist):
     try:
         data = open(join(pkgs_dir, 'urls.txt')).read()
@@ -350,17 +349,6 @@ def read_url(pkgs_dir, dist):
         for url in urls[::-1]:
             if url.endswith('/%s.tar.bz2' % dist):
                 return url
-    except IOError:
-        pass
-    return None
-
-
-def read_icondata(source_dir):
-    import base64
-
-    try:
-        data = open(join(source_dir, 'info', 'icon.png'), 'rb').read()
-        return base64.b64encode(data)
     except IOError:
         pass
     return None
@@ -569,8 +557,6 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
                              'type': link_name_map.get(linktype)}
         if 'channel' in meta_dict:
             meta_dict['channel'] = remove_binstar_tokens(meta_dict['channel'])
-        if 'icon' in meta_dict:
-            meta_dict['icondata'] = read_icondata(source_dir)
 
         create_meta(prefix, dist, info_dir, meta_dict)
 


### PR DESCRIPTION
This reverts commit ff0f221b4df24534134bf6249f7bea7b2f34d69a which was causing problems with the parsability of JSON in Python 3.

cc @bryevdv 