### PR TITLE
Fix TypeError from using a unicode string in env var on windows

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -331,11 +331,11 @@ def run_script(prefix, dist, action='post-link', env_prefix=None):
     else:
         args = ['/bin/bash', path]
     env = os.environ
-    env['PREFIX'] = env_prefix or prefix
+    env['PREFIX'] = str(env_prefix or prefix)
     env['PKG_NAME'], env['PKG_VERSION'], env['PKG_BUILDNUM'] = \
                 str(dist).rsplit('-', 2)
     if action == 'pre-link':
-        env['SOURCE_DIR'] = prefix
+        env['SOURCE_DIR'] = str(prefix)
     try:
         subprocess.check_call(args, env=env)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
When installing a package on windows with a pre-link script, I was getting TypeErrors thrown.

```
Traceback (most recent call last):
  File "C:\moonbot\tools\env\Scripts\conda-script.py", line 4, in <module>
    sys.exit(main())
  File "C:\moonbot\tools\env\lib\site-packages\conda\cli\main.py", line 202, in main
    args_func(args, p)
  File "C:\moonbot\tools\env\lib\site-packages\conda\cli\main.py", line 207, in args_func
    args.func(args, p)
  File "C:\moonbot\tools\env\lib\site-packages\conda\cli\main_install.py", line 46, in execute
    install.install(args, parser, 'install')
  File "C:\moonbot\tools\env\lib\site-packages\conda\cli\install.py", line 417, in install
    plan.execute_actions(actions, index, verbose=not args.quiet)
  File "C:\moonbot\tools\env\lib\site-packages\conda\plan.py", line 500, in execute_actions
    inst.execute_instructions(plan, index, verbose)
  File "C:\moonbot\tools\env\lib\site-packages\conda\instructions.py", line 140, in execute_instructions
    cmd(state, arg)
  File "C:\moonbot\tools\env\lib\site-packages\conda\instructions.py", line 84, in LINK_CMD
    link(state['prefix'], arg, index=state['index'])
  File "C:\moonbot\tools\env\lib\site-packages\conda\instructions.py", line 80, in link
    install.link(pkgs_dir, prefix, dist, lt, index=index)
  File "C:\moonbot\tools\env\lib\site-packages\conda\install.py", line 512, in link
    if not run_script(source_dir, dist, 'pre-link', prefix):
  File "C:\moonbot\tools\env\lib\site-packages\conda\install.py", line 340, in run_script
    subprocess.check_call(args, env=env)
  File "C:\moonbot\tools\env\lib\subprocess.py", line 535, in check_call
    retcode = call(*popenargs, **kwargs)
  File "C:\moonbot\tools\env\lib\subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "C:\moonbot\tools\env\lib\subprocess.py", line 710, in __init__
    errread, errwrite)
  File "C:\moonbot\tools\env\lib\subprocess.py", line 958, in _execute_child
    startupinfo)
TypeError: environment can only contain strings
```

Didn't get the exception thrown on mac, but it was thrown using cygwin in windows.
Figured out it was coming from a unicode string in the env dict passed to subprocess.check_call.
Fixed by casting the prefix to a string.
