### PR TITLE
Noarch (sub) directory support

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -240,6 +240,7 @@ def normalize_urls(urls, platform=None):
             newurls.extend(moreurls)
         else:
             newurls.append('%s/%s/' % (url.rstrip('/'), platform))
+            newurls.append('%s/noarch/' % url.rstrip('/'))
     return newurls
 
 def get_channel_urls(platform=None):

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -115,7 +115,8 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
         if e.response.status_code == 404:
             if url.startswith(config.DEFAULT_CHANNEL_ALIAS):
                 msg = ('Could not find Binstar user %s' %
-                   config.remove_binstar_tokens(url).split(config.DEFAULT_CHANNEL_ALIAS)[1].split('/')[0])
+                   config.remove_binstar_tokens(url).split(
+                        config.DEFAULT_CHANNEL_ALIAS)[1].split('/')[0])
             else:
                 if url.endswith('/noarch/'): # noarch directory might not exist
                     return None
@@ -131,7 +132,9 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
                 "'binstar login' to access private packages(%s, %s)" %
                 (config.hide_binstar_tokens(url), e))
             stderrlog.info(msg)
-            return fetch_repodata(config.remove_binstar_tokens(url), cache_dir=cache_dir, use_cache=use_cache, session=session)
+            return fetch_repodata(config.remove_binstar_tokens(url),
+                                  cache_dir=cache_dir,
+                                  use_cache=use_cache, session=session)
 
         else:
             msg = "HTTPError: %s: %s\n" % (e, config.remove_binstar_tokens(url))

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -116,6 +116,8 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
                 msg = ('Could not find Binstar user %s' %
                    config.remove_binstar_tokens(url).split(config.DEFAULT_CHANNEL_ALIAS)[1].split('/')[0])
             else:
+                if url.endswith('/noarch/'): # noarch directory might not exist
+                    return None
                 msg = 'Could not find URL: %s' % config.remove_binstar_tokens(url)
         elif (e.response.status_code == 401 and config.rc.get('channel_alias',
             config.DEFAULT_CHANNEL_ALIAS) in url):

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -1,4 +1,4 @@
-# (c) 2012-2014 Continuum Analytics, Inc. / http://continuum.io
+# (c) 2012-2015 Continuum Analytics, Inc. / http://continuum.io
 # All Rights Reserved
 #
 # conda is distributed under the terms of the BSD 3-clause license.
@@ -125,7 +125,7 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
             return None
 
         elif (e.response.status_code == 401 and config.rc.get('channel_alias',
-            config.DEFAULT_CHANNEL_ALIAS) in url):
+                        config.DEFAULT_CHANNEL_ALIAS) in url):
             # Note, this will not trigger if the binstar configured url does
             # not match the conda configured one.
             msg = ("Warning: you may need to login to binstar again with "

--- a/conda/install.py
+++ b/conda/install.py
@@ -564,7 +564,12 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
         meta_dict['url'] = read_url(pkgs_dir, dist)
         if meta_dict['url']:
             meta_dict['url'] = remove_binstar_tokens(meta_dict['url'])
-        meta_dict['files'] = files
+        try:
+            alt_files_path = join(prefix, 'conda-meta', dist + '.files')
+            meta_dict['files'] = list(yield_lines(alt_files_path))
+            os.unlink(alt_files_path)
+        except IOError:
+            meta_dict['files'] = files
         meta_dict['link'] = {'source': source_dir,
                              'type': link_name_map.get(linktype)}
         if 'channel' in meta_dict:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,21 +73,31 @@ class TestConfig(unittest.TestCase):
         for channel in config.normalize_urls(['defaults', 'system',
             'https://binstar.org/username', 'file:///Users/username/repo',
             'username']):
-            assert channel.endswith('/%s/' % current_platform)
+            assert (channel.endswith('/%s/' % current_platform) or
+                    channel.endswith('/noarch/'))
         self.assertEqual(config.normalize_urls([
             'defaults', 'system', 'https://conda.binstar.org/username',
             'file:///Users/username/repo', 'username'
             ], 'osx-64'),
             [
                 'http://repo.continuum.io/pkgs/free/osx-64/',
+                'http://repo.continuum.io/pkgs/free/noarch/',
                 'http://repo.continuum.io/pkgs/pro/osx-64/',
+                'http://repo.continuum.io/pkgs/pro/noarch/',
                 'https://your.repo/binstar_username/osx-64/',
+                'https://your.repo/binstar_username/noarch/',
                 'http://some.custom/channel/osx-64/',
+                'http://some.custom/channel/noarch/',
                 'http://repo.continuum.io/pkgs/free/osx-64/',
+                'http://repo.continuum.io/pkgs/free/noarch/',
                 'http://repo.continuum.io/pkgs/pro/osx-64/',
+                'http://repo.continuum.io/pkgs/pro/noarch/',
                 'https://conda.binstar.org/username/osx-64/',
+                'https://conda.binstar.org/username/noarch/',
                 'file:///Users/username/repo/osx-64/',
+                'file:///Users/username/repo/noarch/',
                 'https://your.repo/username/osx-64/',
+                'https://your.repo/username/noarch/',
                 ])
 
 test_condarc = os.path.join(os.path.dirname(__file__), 'test_condarc')


### PR DESCRIPTION
A directory named `noarch` (alongside `linux-64`, `linux-32`, `osx-64`, etc.) will be looked for, and (if present) used.