### PR TITLE
allow conda to be installed into environments which start with _

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -390,9 +390,11 @@ def install_actions(prefix, index, specs, force=False, only_names=None, pinned=T
             if name in must_have:
                 del must_have[name]
     elif basename(prefix).startswith('_'):
+        # anything (including conda) can be installed into environments
+        # starting with '_', mainly to allow conda-build to build conda
         pass
     else:
-        # discard conda from other environments
+        # disallow conda from being installed into all other environments
         if 'conda' in must_have:
             sys.exit("Error: 'conda' can only be installed into "
                      "root environment")

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -14,7 +14,7 @@ import sys
 import os
 from logging import getLogger
 from collections import defaultdict
-from os.path import abspath, isfile, join, exists
+from os.path import abspath, basename, isfile, join, exists
 
 from conda import config
 from conda import install
@@ -389,6 +389,8 @@ def install_actions(prefix, index, specs, force=False, only_names=None, pinned=T
         for name in config.foreign:
             if name in must_have:
                 del must_have[name]
+    elif basename(prefix).startswith('_'):
+        pass
     else:
         # discard conda from other environments
         if 'conda' in must_have:


### PR DESCRIPTION
This small change allows conda to be installed into environments which start with an underscore '_'.  This will allow conda-build to build conda itself.