### PR TITLE
Add binstar's conda channel to the defaults

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -176,8 +176,12 @@ def get_default_urls():
         if 'default_channels' in sys_rc:
             return sys_rc['default_channels']
 
-    return ['http://repo.continuum.io/pkgs/free',
-            'http://repo.continuum.io/pkgs/pro']
+    return [
+        'http://repo.continuum.io/pkgs/free',
+        'http://repo.continuum.io/pkgs/pro',
+        'https://conda.binstar.org/conda/',
+    ]
+
 
 def get_rc_urls():
     if rc.get('channels') is None:


### PR DESCRIPTION
This means that anything that's uploaded to binstar's main conda channel is available by default to all conda installs.  This simplifies the release of conda, conda-env, and conda-build as anyone with binstar access can make a release.

Note: this requires that a package be in the `main` channel of the conda organization in order to get picked up.