### PR TITLE
Don't skip the activate tests if conda-env is not installed

### DIFF
--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -5,7 +5,6 @@ from os.path import dirname, join
 import shutil
 import stat
 import subprocess
-import unittest
 
 from conda.compat import TemporaryDirectory
 from conda.config import root_dir, platform
@@ -31,7 +30,6 @@ for shell in ['bash', 'zsh']:
     activate_path = output.strip().decode('utf-8')
     deactivate_path = join(dirname(activate_path), 'deactivate')
 
-    skip_tests = activate_path == u''
 
 
 if platform == 'win':
@@ -87,7 +85,6 @@ mkdir -p {envs}/test1/bin
 mkdir -p {envs}/test2/bin
 """
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_activate_test1():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -101,7 +98,6 @@ def test_activate_test1():
             assert stdout == envs + "/test1/bin:" + PATH
             assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test1/bin to PATH\n'.format(envs=envs, syspath=syspath)
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_activate_test1_test2():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -116,7 +112,6 @@ def test_activate_test1_test2():
             assert stdout == envs + "/test2/bin:" + PATH
             assert stderr == 'discarding {envs}/test1/bin from PATH\nprepending {envs}/test2/bin to PATH\n'.format(envs=envs)
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_activate_test3():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -130,7 +125,6 @@ def test_activate_test3():
             assert stdout == ROOTPATH
             assert stderr == 'Error: no such directory: {envs}/test3/bin\n'.format(envs=envs)
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_activate_test1_test3():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -146,7 +140,6 @@ def test_activate_test1_test3():
             assert stderr == 'Error: no such directory: {envs}/test3/bin\n'.format(envs=envs)
 
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_deactivate():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -161,7 +154,6 @@ def test_deactivate():
             assert stderr == 'Error: No environment to deactivate\n'
 
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_activate_test1_deactivate():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -177,7 +169,6 @@ def test_activate_test1_deactivate():
             assert stderr == 'discarding {envs}/test1/bin from PATH\n'.format(envs=envs)
 
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_wrong_args():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -219,7 +210,6 @@ def test_wrong_args():
             assert stderr == 'Error: too many arguments.\n'
 
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_activate_help():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -258,7 +248,6 @@ def test_activate_help():
             assert stdout == ''
             assert "Usage: source deactivate" in stderr
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_activate_symlinking():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -327,7 +316,6 @@ def test_activate_symlinking():
                 run_in('chmod 777 {envs}/test4/bin'.format(envs=envs), shell)
 
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_PS1():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -426,7 +414,6 @@ def test_PS1():
             assert stderr == 'Error: too many arguments.\n'
 
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_PS1_no_changeps1():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -532,7 +519,6 @@ changeps1: no
             assert stderr == 'Error: too many arguments.\n'
 
 
-@unittest.skipIf(skip_tests, "conda-env not installed on path")
 def test_CONDA_DEFAULT_ENV():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:


### PR DESCRIPTION
We want them to fail in this case, as we don't want to not notice test
failures.