### PR TITLE
Fixes to symlink_conda issues

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -96,7 +96,8 @@ def main():
         binpath = binpath_from_arg(sys.argv[2])
         # Make sure an env always has the conda symlink
         try:
-            conda.install.symlink_conda(join(binpath, '..'), conda.config.root_dir)
+            if binpath != join(conda.config.root_dir, 'bin'):
+                conda.install.symlink_conda(join(binpath, '..'), conda.config.root_dir)
         except (IOError, OSError) as e:
             if e.errno == errno.EPERM or e.errno == errno.EACCES:
                 sys.exit("Cannot activate environment {}, do not have write access to write conda symlink".format(sys.argv[2]))

--- a/conda/install.py
+++ b/conda/install.py
@@ -382,13 +382,13 @@ def symlink_conda(prefix, root_dir):
     prefix_conda = join(prefix, 'bin', 'conda')
     prefix_activate = join(prefix, 'bin', 'activate')
     prefix_deactivate = join(prefix, 'bin', 'deactivate')
-    if not os.path.exists(join(prefix, 'bin')):
+    if not os.path.lexists(join(prefix, 'bin')):
         os.makedirs(join(prefix, 'bin'))
-    if not os.path.exists(prefix_conda):
+    if not os.path.lexists(prefix_conda):
         os.symlink(root_conda, prefix_conda)
-    if not os.path.exists(prefix_activate):
+    if not os.path.lexists(prefix_activate):
         os.symlink(root_activate, prefix_activate)
-    if not os.path.exists(prefix_deactivate):
+    if not os.path.lexists(prefix_deactivate):
         os.symlink(root_deactivate, prefix_deactivate)
 
 # ========================== begin API functions =========================

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -406,7 +406,7 @@ def install_actions(prefix, index, specs, force=False, only_names=None, pinned=T
     else:
         actions = ensure_linked_actions(smh, prefix)
 
-    if actions[inst.LINK] and sys.platform != 'win32':
+    if actions[inst.LINK] and sys.platform != 'win32' and prefix != config.root_dir:
         actions[inst.SYMLINK_CONDA] = [config.root_dir]
 
     for dist in sorted(linked):


### PR DESCRIPTION
- Use `lexists` instead of `exists`. The former returns True for broken symlinks.
- Don't attempt to symlink conda in the root environment. I believe this can lead to a situation where there is a broken symlink if, e.g., activate does not exist in the root environment, in which case it writes a symlink to itself (which is considered to be a broken symlink). 

I have not fully tested this yet. 