### PR TITLE
include cwd when searching for additional commands

### DIFF
--- a/conda/cli/find_commands.py
+++ b/conda/cli/find_commands.py
@@ -21,6 +21,8 @@ def find_executable(executable, include_others=True):
     else:
         dir_paths = []
 
+    dir_paths.append(os.getcwd())
+
     dir_paths.extend(os.environ['PATH'].split(os.pathsep))
 
     for dir_path in dir_paths:


### PR DESCRIPTION
This patch includes the current working directory when searching for external 
commands.

For example, assume there is a file in the current working directory, named
'conda-hello' that simply echos 'Hello Conda!'. Before this patch one needed:

```
 $ PATH=. conda hello
 Hello Conda!
```

Now one can simply do:

```
 $ conda hello
 Hello Conda!
```

The current working directory is obtained in a platform independet way and is 
placed in front of the entries in PATH to give commands in the current working 
directory precedence. This behaviour mimicks common Python, where the current 
working directory is always searched for modules. However, it differs from git
(from which this extension mechanism was presumably inspired) which doesn't
include the current working directory.