### PR TITLE
Don't write to the history file if nothing has changed

### DIFF
--- a/conda/history.py
+++ b/conda/history.py
@@ -197,6 +197,8 @@ class History(object):
         return result
 
     def write_dists(self, dists):
+        if not dists:
+            return
         if not isdir(self.meta_dir):
             os.makedirs(self.meta_dir)
         with open(self.path, 'w') as fo:


### PR DESCRIPTION
Maybe this is not good behavior, but it fixes the issue where if you cancel a `conda create` at the download stage, the environment is still created with just an empty history file. 