### PR TITLE
cli: Added 'openssl' and 'requests' to root_no_rm

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -466,7 +466,7 @@ def stdout_json_success(success=True, **kwargs):
     result.update(kwargs)
     stdout_json(result)
 
-root_no_rm = 'python', 'pycosat', 'pyyaml', 'conda'
+root_no_rm = 'python', 'pycosat', 'pyyaml', 'conda', 'openssl', 'requests'
 
 
 def handle_envs_list(acc, output=True):


### PR DESCRIPTION
There is a list of packages which must never be removed from the root environment: [`conda.cli.common.root_no_rm`][1]
Apparently two more packages (`requests` and `openssl`) should be added to that list.

[1]: https://github.com/conda/conda/blob/master/conda/cli/common.py#L530

For the curious, here are the error messages you'll see if you accidentally remove `requests` or `openssl` from the root environment:

```
$ conda info --env
# conda environments:
#
root                  *  /tmp/miniconda
```

```
$ conda remove -y requests > /dev/null 
$ conda list
Traceback (most recent call last):
  File "/tmp/miniconda/bin/conda", line 3, in <module>
    from conda.cli import main
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/cli/__init__.py", line 8, in <module>
    from conda.cli.main import main
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/cli/main.py", line 48, in <module>
    from conda.cli import main_create
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/cli/main_create.py", line 11, in <module>
    from conda.cli import common, install
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/cli/install.py", line 18, in <module>
    import conda.plan as plan
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/plan.py", line 24, in <module>
    from conda import instructions as inst
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/instructions.py", line 7, in <module>
    from conda.fetch import fetch_pkg
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/fetch.py", line 24, in <module>
    from conda.connection import CondaSession, unparse_url, RETRIES
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/connection.py", line 22, in <module>
    import requests
ImportError: No module named requests
```

```
$ conda remove -y openssl > /dev/null
$ conda list
ERROR:root:code for hash md5 was not found.
Traceback (most recent call last):
  File "/tmp/miniconda/lib/python2.7/hashlib.py", line 147, in <module>
    globals()[__func_name] = __get_hash(__func_name)
  File "/tmp/miniconda/lib/python2.7/hashlib.py", line 97, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type md5
ERROR:root:code for hash sha1 was not found.
Traceback (most recent call last):
  File "/tmp/miniconda/lib/python2.7/hashlib.py", line 147, in <module>
    globals()[__func_name] = __get_hash(__func_name)
  File "/tmp/miniconda/lib/python2.7/hashlib.py", line 97, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type sha1
Traceback (most recent call last):
  File "/tmp/miniconda/bin/conda", line 3, in <module>
    from conda.cli import main
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/cli/__init__.py", line 8, in <module>
    from conda.cli.main import main
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/cli/main.py", line 48, in <module>
    from conda.cli import main_create
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/cli/main_create.py", line 11, in <module>
    from conda.cli import common, install
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/cli/install.py", line 18, in <module>
    import conda.plan as plan
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/plan.py", line 24, in <module>
    from conda import instructions as inst
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/instructions.py", line 7, in <module>
    from conda.fetch import fetch_pkg
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/fetch.py", line 24, in <module>
    from conda.connection import CondaSession, unparse_url, RETRIES
  File "/tmp/miniconda/lib/python2.7/site-packages/conda/connection.py", line 22, in <module>
    import requests
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/__init__.py", line 58, in <module>
    from . import utils
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/utils.py", line 26, in <module>
    from .compat import parse_http_list as _parse_list_header
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/compat.py", line 7, in <module>
    from .packages import chardet
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/packages/__init__.py", line 3, in <module>
    from . import urllib3
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/packages/urllib3/__init__.py", line 10, in <module>
    from .connectionpool import (
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 31, in <module>
    from .connection import (
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/packages/urllib3/connection.py", line 45, in <module>
    from .util.ssl_ import (
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/packages/urllib3/util/__init__.py", line 5, in <module>
    from .ssl_ import (
  File "/tmp/miniconda/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py", line 2, in <module>
    from hashlib import md5, sha1
ImportError: cannot import name md5
```
