### PR TITLE
add pip as a Python dependency

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -210,6 +210,12 @@ def add_unknown(index):
             log.debug("adding cached pkg to index: %s" % fn)
             index[fn] = meta
 
+def add_pip_dependency(index):
+    for info in index.itervalues():
+        if (info['name'] == 'python' and
+                    info['version'].startswith(('2.', '3.'))):
+            info['depends'].append('pip')
+
 @memoized
 def fetch_index(channel_urls, use_cache=False, unknown=False):
     log.debug('channel_urls=' + repr(channel_urls))
@@ -256,7 +262,7 @@ Allowed channels are:
     stdoutlog.info('\n')
     if unknown:
         add_unknown(index)
-
+    add_pip_dependency(index)
     return index
 
 def fetch_pkg(info, dst_dir=None, session=None):

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -211,7 +211,7 @@ def add_unknown(index):
             index[fn] = meta
 
 def add_pip_dependency(index):
-    for info in index.itervalues():
+    for info in itervalues(index):
         if (info['name'] == 'python' and
                     info['version'].startswith(('2.', '3.'))):
             info['depends'].append('pip')


### PR DESCRIPTION
This small change adds pip as a Python dependency.  The reason this is done here, and not in the `repodata.json` on the server is because older versions of conda don't handle circular dependencies, and this would `conda update conda` cause to fail.