### PR TITLE
pscheck: check for processes in the current environment

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -401,7 +401,7 @@ environment does not exist: %s
             common.confirm_yn(args)
     else:
         if (sys.platform == 'win32' and not args.force_pscheck and
-            not pscheck.check_processes(verbose=False)):
+            not pscheck.check_processes(prefix, verbose=False)):
             common.error_and_exit(
                     "Cannot continue operation while processes "
                     "from packages are running without --force-pscheck.",

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -173,7 +173,7 @@ def execute(args, parser):
         if not pscheck.main(args):
             common.confirm_yn(args)
     elif (sys.platform == 'win32' and not args.force_pscheck and
-          not pscheck.check_processes(verbose=False)):
+          not pscheck.check_processes(prefix, verbose=False)):
         common.error_and_exit("Cannot continue removal while processes "
                               "from packages are running without --force-pscheck.",
                               json=True,

--- a/conda/cli/pscheck.py
+++ b/conda/cli/pscheck.py
@@ -16,7 +16,7 @@ except NameError:
         pass
 
 
-def check_processes(verbose=True):
+def check_processes(dir=root_dir, verbose=True):
     # Conda should still work if psutil is not installed (it should not be a
     # hard dependency)
     try:
@@ -38,7 +38,7 @@ def check_processes(verbose=True):
         except psutil.NoSuchProcess:
             continue
         try:
-            if abspath(p.exe()).startswith(root_dir):
+            if abspath(p.exe()).startswith(dir):
                 processcmd = ' '.join(p.cmdline())
                 if 'conda' in processcmd:
                     continue


### PR DESCRIPTION
Previously it always looked for processes from the root environment.

@srossross this should fix the issue you were having at https://binstar.org/conda/conda-env/builds/115/9.