### PR TITLE
Allow user-level specification of default channels

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -176,6 +176,9 @@ def get_default_urls():
         if 'default_channels' in sys_rc:
             return sys_rc['default_channels']
 
+    if 'default_channels' in rc:
+        return rc['default_channels']
+
     return ['http://repo.continuum.io/pkgs/free',
             'http://repo.continuum.io/pkgs/pro']
 


### PR DESCRIPTION
The only way to override the default channels currently is through a system-level RC file.  This adds an additional check that lets the user provide a `default_channels` array.