### PR TITLE
target_prefix

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -508,7 +508,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None, target_prefix=N
         return
 
     source_dir = join(pkgs_dir, dist)
-    if not run_script(source_dir, dist, 'pre-link', prefix, target_prefix):
+    if not run_script(dist, 'pre-link', prefix, target_prefix):
         sys.exit('Error: pre-link failed: %s' % dist)
 
     info_dir = join(source_dir, 'info')
@@ -666,7 +666,7 @@ def main():
 
     p.add_option('--target-prefix',
                  default=sys.prefix,
-                 help="target prefix (defaults to %default)")
+                 help="target prefix (defaults to %(default)s)")
 
     p.add_option('-p', '--prefix',
                  action="store",
@@ -720,14 +720,14 @@ def main():
         for dist in dists:
             if opts.verbose or linktype == LINK_COPY:
                 print("linking: %s" % dist)
-            link(pkgs_dir, prefix, dist, linktype)
+            link(pkgs_dir, prefix, dist, linktype, target_prefix=target_prefix)
         messages(prefix)
 
     elif opts.extract:
         extract(pkgs_dir, dist)
 
     elif opts.link:
-        link(pkgs_dir, prefix, dist)
+        link(pkgs_dir, prefix, dist, target_prefix=target_prefix)
 
     elif opts.unlink:
         unlink(prefix, dist)

--- a/conda/install.py
+++ b/conda/install.py
@@ -490,14 +490,16 @@ def is_linked(prefix, dist):
         return None
 
 
-def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
+def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None, target_prefix=None):
     '''
     Set up a package in a specified (environment) prefix.  We assume that
     the package has been extracted (using extract() above).
     '''
+    if target_prefix is None:
+        target_prefix = prefix
     index = index or {}
-    log.debug('pkgs_dir=%r, prefix=%r, dist=%r, linktype=%r' %
-              (pkgs_dir, prefix, dist, linktype))
+    log.debug('pkgs_dir=%r, prefix=%r, target_prefix=%r, dist=%r, linktype=%r' %
+              (pkgs_dir, prefix, target_prefix, dist, linktype))
     if (on_win and abspath(prefix) == abspath(sys.prefix) and
               name_dist(dist) in win_ignore_root):
         # on Windows we have the file lock problem, so don't allow
@@ -506,7 +508,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
         return
 
     source_dir = join(pkgs_dir, dist)
-    if not run_script(source_dir, dist, 'pre-link', prefix):
+    if not run_script(source_dir, dist, 'pre-link', prefix, target_prefix):
         sys.exit('Error: pre-link failed: %s' % dist)
 
     info_dir = join(source_dir, 'info')
@@ -542,14 +544,14 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
         for f in sorted(has_prefix_files):
             placeholder, mode = has_prefix_files[f]
             try:
-                update_prefix(join(prefix, f), prefix, placeholder, mode)
+                update_prefix(join(prefix, f), target_prefix, placeholder, mode)
             except PaddingError:
                 sys.exit("ERROR: placeholder '%s' too short in: %s\n" %
                          (placeholder, dist))
 
         mk_menus(prefix, files, remove=False)
 
-        if not run_script(prefix, dist, 'post-link'):
+        if not run_script(prefix, dist, 'post-link', target_prefix):
             sys.exit("Error: post-link failed for: %s" % dist)
 
         # Make sure the script stays standalone for the installer
@@ -662,6 +664,10 @@ def main():
                  action="store_true",
                  help="unlink a package")
 
+    p.add_option('--target-prefix',
+                 default=sys.prefix,
+                 help="target prefix (defaults to %default)")
+
     p.add_option('-p', '--prefix',
                  action="store",
                  default=sys.prefix,
@@ -696,6 +702,7 @@ def main():
 
     pkgs_dir = opts.pkgs_dir
     prefix = opts.prefix
+    target_prefix = opts.target_prefix
     if opts.verbose:
         print("pkgs_dir: %r" % pkgs_dir)
         print("prefix  : %r" % prefix)


### PR DESCRIPTION
This capability is to address a use case where the location the package is to be installed to is different from the location which 
```
conda install --no-deps 
```
is to deliver the build package to.

This is a valuable capability; for example, it enables conda to be used to create a linux package which will be installed as root, but will be built to another location by a non-root user during package creation; this is a common workflow for RPM, DEB etc.

Separating the handling of linked paths et al. from the conda install location opens up this space and is part of a potential approach for using conda recipes to produce customised operating system packages.

In many cases this separation is not required and the current behaviour and call signature is maintained for all these scenarios.

@pelson and I are working in this space and looking at some interesting potential approaches, which this change is a useful contribution towards.  