### PR TITLE
Changes to min_sat

### DIFF
--- a/conda/compat.py
+++ b/conda/compat.py
@@ -33,6 +33,7 @@ if PY3:
     from math import log2, ceil
     from shlex import quote
     from tempfile import TemporaryDirectory
+    range = range
 else:
     import ConfigParser as configparser
     from cStringIO import StringIO
@@ -67,6 +68,7 @@ else:
     import warnings as _warnings
     import os as _os
     from tempfile import mkdtemp
+    range = xrange
 
     class TemporaryDirectory(object):
         """Create and return a temporary directory.  This has the same


### PR DESCRIPTION
This is required to get the true minimal solution, even if there are a lot of possibilities. Without this, things like `conda create -n test c asmeurer r-survival` produce two possible solutions, neither of which is the minimal one. The changes here only fallback to the slightly slower method when necessary, so the common case should stay exactly the same speed. 