### PR TITLE
Ask at the end of conda install to add channels to condarc

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -11,6 +11,7 @@ import sys
 import shutil
 import tarfile
 import tempfile
+import textwrap
 from os.path import isdir, join, basename, exists, abspath
 from difflib import get_close_matches
 
@@ -18,13 +19,17 @@ import conda.config as config
 import conda.plan as plan
 import conda.instructions as inst
 import conda.misc as misc
+import conda.utils as utils
 from conda.api import get_index
 from conda.cli import pscheck
 from conda.cli import common
 from conda.cli.find_commands import find_executable
 from conda.resolve import NoPackagesFound, Resolve, MatchSpec
+from conda.config_file import write_config, CouldntParse
 import conda.install as ci
 
+
+filldedent = lambda s, w=70: '\n' + textwrap.fill(textwrap.dedent(str(s)).strip('\n'), width=w)
 
 def install_tar(prefix, tar_path, verbose=False):
     from conda.misc import install_local_packages
@@ -439,6 +444,33 @@ environment does not exist: %s
     if args.json:
         common.stdout_json_success(actions=actions)
 
+    if not args.quiet and not args.json and not args.dry_run:
+        new_channels = [c for c in args.channel if config.normalize_urls([c])[0] not in config.get_channel_urls()]
+        # Should we use confirm_yn here? The difference is that it will
+        # respect --yes and config.always_yes
+        fmt = {
+            'channels': utils.comma_join(list(map(repr, new_channels))),
+            'c_channel': utils.comma_join([repr('-c %s') % c for c in new_channels]),
+            'these_channels': 'this channel' if len(new_channels) == 1 else 'these channels',
+            }
+        res = common.confirm(args, filldedent("""
+        Do you want to add {channels} to your condarc file? If you do
+        not, you will need to use {c_channel} in the future to install or
+        update packages from {these_channels}.""".format(**fmt)))
+        if res == 'yes':
+            try:
+                json_result = write_config(config.rc_path, add=[('channels', c)
+                    for c in new_channels])
+            except CouldntParse as e:
+                print("Error writing config: %s" % e.reason, file=sys.stderr)
+            else:
+                for warning in json_result['warnings']:
+                    print(warning, file=sys.stderr)
+                for message in json_result['result']:
+                    print(message)
+        else:
+            print("You can use 'conda config %s' if you decide to add it later."
+                % ' '.join(['--add channels %s' % c for c in new_channels]))
 
 def check_install(packages, platform=None, channel_urls=(), prepend=True,
                   minimal_hint=False):

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -12,6 +12,7 @@ from argparse import RawDescriptionHelpFormatter
 from copy import deepcopy
 
 import conda.config as config
+from conda.config_file import (write_config, ConfigKeyError, ConfigTypeError, ConfigValueError)
 from conda.cli import common
 
 descr = """
@@ -210,23 +211,11 @@ the file path given by the 'CONDARC' environment variable, if it is set.
 
 def execute(args, parser):
     try:
-        execute_config(args, parser)
-    except (CouldntParse, NotImplementedError) as e:
-        if args.json:
-            common.exception_and_exit(e, json=True)
-        else:
-            raise
-
-
-def execute_config(args, parser):
-    try:
         import yaml
+        yaml
     except ImportError:
         common.error_and_exit("pyyaml is required to modify configuration",
                               json=args.json, error_type="ImportError")
-
-    json_warnings = []
-    json_get = {}
 
     if args.system:
         rc_path = config.sys_rc_path
@@ -235,215 +224,22 @@ def execute_config(args, parser):
     else:
         rc_path = config.user_rc_path
 
-    # Create the file if it doesn't exist
-    if not os.path.exists(rc_path):
-        if args.add and 'channels' in list(zip(*args.add))[0] and not ['channels', 'defaults'] in args.add:
-            # If someone adds a channel and their .condarc doesn't exist, make
-            # sure it includes the defaults channel, or else they will end up
-            # with a broken conda.
-            rc_text = """\
-channels:
-  - defaults
-"""
-        else:
-            rc_text = ""
-    else:
-        with open(rc_path, 'r') as rc:
-            rc_text = rc.read()
-    rc_config = yaml.load(rc_text)
-    if rc_config is None:
-        rc_config = {}
-
-    # Get
-    if args.get is not None:
-        if args.get == []:
-            args.get = sorted(rc_config.keys())
-        for key in args.get:
-            if key not in config.rc_list_keys + config.rc_bool_keys:
-                if key not in config.rc_other:
-                    if not args.json:
-                        message = "unknown key %s" % key
-                        print(message, file=sys.stderr)
-                    else:
-                        json_warnings.append(message)
-                continue
-            if key not in rc_config:
-                continue
-
-            if args.json:
-                json_get[key] = rc_config[key]
-                continue
-
-            if isinstance(rc_config[key], bool):
-                print("--set", key, rc_config[key])
-            else:
-                # Note, since conda config --add prepends, these are printed in
-                # the reverse order so that entering them in this order will
-                # recreate the same file
-                for item in reversed(rc_config.get(key, [])):
-                    # Use repr so that it can be pasted back in to conda config --add
-                    print("--add", key, repr(item))
-
-
-    # PyYaml does not support round tripping, so if we use yaml.dump, it
-    # will clear all comments and structure from the configuration file.
-    # There are no yaml parsers that do this.  Our best bet is to do a
-    # simple parsing of the file ourselves.  We can check the result at
-    # the end to see if we did it right.
-
-    # First, do it the pyyaml way
-    new_rc_config = deepcopy(rc_config)
-
-    # Add
-    for key, item in args.add:
-        if key not in config.rc_list_keys:
-            common.error_and_exit("key must be one of %s, not %r" %
-                                  (config.rc_list_keys, key), json=args.json,
-                                  error_type="ValueError")
-        if not isinstance(rc_config.get(key, []), list):
-            raise CouldntParse("key %r should be a list, not %s." % (key,
-                rc_config[key].__class__.__name__))
-        if item in rc_config.get(key, []):
-            # Right now, all list keys should not contain duplicates
-            message = "Skipping %s: %s, item already exists" % (key, item)
-            if not args.json:
-                print(message, file=sys.stderr)
-            else:
-                json_warnings.append(message)
-            continue
-        new_rc_config.setdefault(key, []).insert(0, item)
-
-    # Set
-    for key, item in args.set:
-        yamlitem = yaml.load(item)
-        if not isinstance(yamlitem, bool):
-            common.error_and_exit("%r is not a boolean" % item, json=args.json,
-                                  error_type="TypeError")
-
-        new_rc_config[key] = yamlitem
-
-    # Remove
-    for key, item in args.remove:
-        if key not in new_rc_config:
-            common.error_and_exit("key %r is not in the config file" % key, json=args.json,
-                                  error_type="KeyError")
-        if item not in new_rc_config[key]:
-            common.error_and_exit("%r is not in the %r key of the config file" %
-                                  (item, key), json=args.json, error_type="KeyError")
-        new_rc_config[key] = [i for i in new_rc_config[key] if i != item]
-
-    # Remove Key
-    for key, in args.remove_key:
-        if key not in new_rc_config:
-            common.error_and_exit("key %r is not in the config file" % key, json=args.json,
-                                  error_type="KeyError")
-        del new_rc_config[key]
-
-    if args.force:
-        # Note, force will also remove any checking that the keys are in
-        # config.rc_keys
-        with open(rc_path, 'w') as rc:
-            rc.write(yaml.dump(new_rc_config, default_flow_style=False))
-
+    try:
+        json_result = write_config(rc_path, add=args.add, get=args.get,
+            set_=args.set, remove=args.remove, remove_key=args.remove_key, force=args.force)
+    except (NotImplementedError, ConfigValueError, ConfigTypeError, ConfigKeyError) as e:
         if args.json:
-            common.stdout_json_success(
-                rc_path=rc_path,
-                warnings=json_warnings,
-                get=json_get
-            )
-        return
-
-    # Now, try to parse the condarc file.
-
-    # Just support "   key:  " for now
-    listkeyregexes = {key:re.compile(r"( *)%s *" % key)
-        for key in dict(args.add)
-        }
-    setkeyregexes = {key:re.compile(r"( *)%s( *):( *)" % key)
-        for key in dict(args.set)
-        }
-
-    new_rc_text = rc_text[:].split("\n")
-
-    for key, item in args.add:
-        if key not in config.rc_list_keys:
-            common.error_and_exit("key must be one of %s, not %s" %
-                                  (config.rc_list_keys, key), json=args.json,
-                                  error_type="ValueError")
-
-        if item in rc_config.get(key, []):
-            # Skip duplicates. See above
-            continue
-        added = False
-        for pos, line in enumerate(new_rc_text[:]):
-            matched = listkeyregexes[key].match(line)
-            if matched:
-                leading_space = matched.group(1)
-                # TODO: Try to guess how much farther to indent the
-                # item. Right now, it is fixed at 2 spaces.
-                new_rc_text.insert(pos + 1, "%s  - %s" % (leading_space, item))
-                added = True
-        if not added:
-            if key in rc_config:
-                # We should have found it above
-                raise CouldntParse("existing list key couldn't be found")
-            # TODO: Try to guess the correct amount of leading space for the
-            # key. Right now it is zero.
-            new_rc_text += ['%s:' % key, '  - %s' % item]
-            if key == 'channels' and ['channels', 'defaults'] not in args.add:
-                # If channels key is added for the first time, make sure it
-                # includes 'defaults'
-                new_rc_text += ['  - defaults']
-                new_rc_config['channels'].append('defaults')
-
-    for key, item in args.set:
-        if key not in config.rc_bool_keys:
-            common.error_and_exit("Error key must be one of %s, not %s" %
-                                  (config.rc_bool_keys, key), json=args.json,
-                                  error_type="ValueError")
-        added = False
-        for pos, line in enumerate(new_rc_text[:]):
-            matched = setkeyregexes[key].match(line)
-            if matched:
-                leading_space = matched.group(1)
-                precol_space = matched.group(2)
-                postcol_space = matched.group(3)
-                new_rc_text[pos] = '%s%s%s:%s%s' % (leading_space, key,
-                    precol_space, postcol_space, item)
-                added = True
-        if not added:
-            if key in rc_config:
-                raise CouldntParse("existing bool key couldn't be found")
-            new_rc_text += ['%s: %s' % (key, item)]
-
-    for key, item in args.remove:
-        raise NotImplementedError("--remove without --force is not implemented "
-            "yet")
-
-    for key, in args.remove_key:
-        raise NotImplementedError("--remove-key without --force is not "
-            "implemented yet")
-
-    if args.add or args.set:
-        # Verify that the new rc text parses to the same thing as if we had
-        # used yaml.
-        try:
-            parsed_new_rc_text = yaml.load('\n'.join(new_rc_text).strip('\n'))
-        except yaml.parser.ParserError:
-            raise CouldntParse("couldn't parse modified yaml")
+            common.exception_and_exit(e, json=True)
         else:
-            if not parsed_new_rc_text == new_rc_config:
-                raise CouldntParse("modified yaml doesn't match what it "
-                                   "should be")
-
-    if args.add or args.set:
-        with open(rc_path, 'w') as rc:
-            rc.write('\n'.join(new_rc_text).strip('\n'))
-            rc.write('\n')
+            sys.exit("Error: %s" % e.args[0])
 
     if args.json:
         common.stdout_json_success(
             rc_path=rc_path,
-            warnings=json_warnings,
-            get=json_get
+            **json_result
         )
+    else:
+        for warning in json_result['warnings']:
+            print(warning, file=sys.stderr)
+        for result in json_result['result']:
+            print(result)

--- a/conda/config.py
+++ b/conda/config.py
@@ -61,6 +61,7 @@ rc_bool_keys = [
     'add_binstar_token',
     'always_yes',
     'allow_softlinks',
+    'auto_add_channels',
     'changeps1',
     'use_pip',
     'offline',
@@ -324,6 +325,7 @@ except IOError:
 
 # ----- misc -----
 
+auto_add_channels = rc.get('auto_add_channels', None) # None means ask
 always_yes = bool(rc.get('always_yes', False))
 changeps1 = bool(rc.get('changeps1', True))
 use_pip = bool(rc.get('use_pip', True))

--- a/conda/config_file.py
+++ b/conda/config_file.py
@@ -1,0 +1,242 @@
+# (c) 2012-2015 Continuum Analytics, Inc. / http://continuum.io
+# All Rights Reserved
+#
+# conda is distributed under the terms of the BSD 3-clause license.
+# Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
+"""
+Functions modifying conda configuration files (.condarc)
+"""
+from __future__ import print_function, division, absolute_import
+
+import re
+import os
+import sys
+from copy import deepcopy
+
+import conda.config as config
+
+class CouldntParse(NotImplementedError):
+    def __init__(self, reason):
+        self.args = ["""Could not parse the yaml file. Use -f to use the
+yaml parser (this will remove any structure or comments from the existing
+.condarc file). Reason: %s""" % reason]
+
+
+class ConfigValueError(ValueError):
+    pass
+
+class ConfigTypeError(TypeError):
+    pass
+
+class ConfigKeyError(TypeError):
+    pass
+
+def execute(args, parser):
+    try:
+        execute_config(args, parser)
+    except (CouldntParse, NotImplementedError) as e:
+        if args.json:
+            common.exception_and_exit(e, json=True)
+        else:
+            raise
+
+
+def write_config(rc_path, add=(), get=None, set_=(), remove=(),
+    remove_key=(), force=False, dry_run=False):
+    # conda.cli.main_config imports yaml and gives an error to the user if it
+    # is not installed, so keep this import inside the function.
+    import yaml
+
+    json_result = {'warnings': [], 'get': {}, 'result': []}
+
+    # Create the file if it doesn't exist
+    if not os.path.exists(rc_path):
+        if add and 'channels' in list(zip(*add))[0] and not ['channels', 'defaults'] in add:
+            # If someone adds a channel and their .condarc doesn't exist, make
+            # sure it includes the defaults channel, or else they will end up
+            # with a broken conda.
+            rc_text = """\
+channels:
+  - defaults
+"""
+        else:
+            rc_text = ""
+    else:
+        with open(rc_path, 'r') as rc:
+            rc_text = rc.read()
+    rc_config = yaml.load(rc_text)
+    if rc_config is None:
+        rc_config = {}
+
+    # Get
+    if get is not None:
+        if not get:
+            get = sorted(rc_config.keys())
+        for key in get:
+            if key not in config.rc_list_keys + config.rc_bool_keys:
+                if key not in config.rc_other:
+                    message = "unknown key %s" % key
+                    json_result['warnings'].append(message)
+                continue
+            if key not in rc_config:
+                continue
+
+            json_result['get'][key] = rc_config[key]
+
+            if isinstance(rc_config[key], bool):
+                json_result['result'].append(' '.join(["--set", str(key), repr(rc_config[key])]))
+            else:
+                # Note, since conda config --add prepends, these are printed in
+                # the reverse order so that entering them in this order will
+                # recreate the same file
+                for item in reversed(rc_config.get(key, [])):
+                    # Use repr so that it can be pasted back in to conda config --add
+                    json_result['result'].append(' '.join(["--add", str(key), repr(item)]))
+
+            continue
+
+    # PyYaml does not support round tripping, so if we use yaml.dump, it
+    # will clear all comments and structure from the configuration file.
+    # There are no yaml parsers that do this.  Our best bet is to do a
+    # simple parsing of the file ourselves.  We can check the result at
+    # the end to see if we did it right.
+
+    # First, do it the pyyaml way
+    new_rc_config = deepcopy(rc_config)
+
+    # Add
+    for key, item in add:
+        if key not in config.rc_list_keys:
+            raise ConfigValueError("key must be one of %s, not %r" %
+                                  (config.rc_list_keys, key))
+        if not isinstance(rc_config.get(key, []), list):
+            raise CouldntParse("key %r should be a list, not %s." % (key,
+                rc_config[key].__class__.__name__))
+        if item in rc_config.get(key, []):
+            # Right now, all list keys should not contain duplicates
+            message = "Skipping %s: %s, item already exists" % (key, item)
+            json_result['warnings'].append(message)
+            continue
+        new_rc_config.setdefault(key, []).insert(0, item)
+
+    # Set
+    for key, item in set_:
+        yamlitem = yaml.load(item)
+        if not isinstance(yamlitem, bool):
+            raise ConfigTypeError("%r is not a boolean" % item)
+
+        new_rc_config[key] = yamlitem
+
+    # Remove
+    for key, item in remove:
+        if key not in new_rc_config:
+            raise ConfigKeyError("key %r is not in the config file" % key)
+        if item not in new_rc_config[key]:
+            raise ConfigKeyError("%r is not in the %r key of the config file" % (item, key))
+        new_rc_config[key] = [i for i in new_rc_config[key] if i != item]
+
+    # Remove Key
+    for key, in remove_key:
+        if key not in new_rc_config:
+            raise ConfigKeyError("key %r is not in the config file" % key)
+        del new_rc_config[key]
+
+    if force:
+        # Note, force will also remove any checking that the keys are in
+        # config.rc_keys
+        if not dry_run:
+            with open(rc_path, 'w') as rc:
+                rc.write(yaml.dump(new_rc_config, default_flow_style=False))
+
+        return json_result
+
+    # Now, try to parse the condarc file.
+
+    # Just support "   key:  " for now
+    listkeyregexes = {key:re.compile(r"( *)%s *" % key)
+        for key in dict(add)
+        }
+    setkeyregexes = {key:re.compile(r"( *)%s( *):( *)" % key)
+        for key in dict(set_)
+        }
+
+    new_rc_text = rc_text[:].split("\n")
+
+    for key, item in add:
+        if key not in config.rc_list_keys:
+            raise ConfigValueError("key must be one of %s, not %s" %
+                                  (config.rc_list_keys, key))
+
+        if item in rc_config.get(key, []):
+            # Skip duplicates. See above
+            continue
+        added = False
+        for pos, line in enumerate(new_rc_text[:]):
+            matched = listkeyregexes[key].match(line)
+            if matched:
+                leading_space = matched.group(1)
+                # TODO: Try to guess how much farther to indent the
+                # item. Right now, it is fixed at 2 spaces.
+                new_rc_text.insert(pos + 1, "%s  - %s" % (leading_space, item))
+                added = True
+        if not added:
+            if key in rc_config:
+                # We should have found it above
+                raise CouldntParse("existing list key couldn't be found")
+            # TODO: Try to guess the correct amount of leading space for the
+            # key. Right now it is zero.
+            new_rc_text += ['%s:' % key, '  - %s' % item]
+            if key == 'channels' and ['channels', 'defaults'] not in add:
+                # If channels key is added for the first time, make sure it
+                # includes 'defaults'
+                new_rc_text += ['  - defaults']
+                new_rc_config['channels'].append('defaults')
+
+    for key, item in set_:
+        if key not in config.rc_bool_keys:
+            raise ConfigValueError("Error key must be one of %s, not %s" %
+                                  (config.rc_bool_keys, key))
+        added = False
+        for pos, line in enumerate(new_rc_text[:]):
+            matched = setkeyregexes[key].match(line)
+            if matched:
+                leading_space = matched.group(1)
+                precol_space = matched.group(2)
+                postcol_space = matched.group(3)
+                new_rc_text[pos] = '%s%s%s:%s%s' % (leading_space, key,
+                    precol_space, postcol_space, item)
+                added = True
+        if not added:
+            if key in rc_config:
+                raise CouldntParse("existing bool key couldn't be found")
+            new_rc_text += ['%s: %s' % (key, item)]
+
+    # These error messages propagate up to the conda config command, so we use
+    # the command flags in the messages.
+    for key, item in remove:
+        raise NotImplementedError("--remove without --force is not implemented "
+            "yet")
+
+    for key, in remove_key:
+        raise NotImplementedError("--remove-key without --force is not "
+            "implemented yet")
+
+    if add or set_:
+        # Verify that the new rc text parses to the same thing as if we had
+        # used yaml.
+        try:
+            parsed_new_rc_text = yaml.load('\n'.join(new_rc_text).strip('\n'))
+        except yaml.parser.ParserError:
+            raise CouldntParse("couldn't parse modified yaml")
+        else:
+            if not parsed_new_rc_text == new_rc_config:
+                raise CouldntParse("modified yaml doesn't match what it "
+                                   "should be")
+
+    if add or set:
+        if not dry_run:
+            with open(rc_path, 'w') as rc:
+                rc.write('\n'.join(new_rc_text).strip('\n'))
+                rc.write('\n')
+
+    return json_result

--- a/conda/config_file.py
+++ b/conda/config_file.py
@@ -233,7 +233,7 @@ channels:
                 raise CouldntParse("modified yaml doesn't match what it "
                                    "should be")
 
-    if add or set:
+    if add or set_:
         if not dry_run:
             with open(rc_path, 'w') as rc:
                 rc.write('\n'.join(new_rc_text).strip('\n'))

--- a/conda/config_file.py
+++ b/conda/config_file.py
@@ -20,6 +20,7 @@ class CouldntParse(NotImplementedError):
         self.args = ["""Could not parse the yaml file. Use -f to use the
 yaml parser (this will remove any structure or comments from the existing
 .condarc file). Reason: %s""" % reason]
+        self.reason = reason
 
 
 class ConfigValueError(ValueError):

--- a/conda/config_file.py
+++ b/conda/config_file.py
@@ -147,7 +147,8 @@ channels:
 
     for key, item in add:
         add_defaults = (key == 'channels' and ['channels', 'defaults'] not in
-            add and 'channels' not in rc_config)
+            add and 'channels' not in rc_config and 'defaults' not in
+            new_rc_config['channels'])
         add_rc_key(key, item, new_rc_text, rc_config, add_defaults=add_defaults)
         if add_defaults:
             new_rc_config['channels'].append('defaults')

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -43,6 +43,11 @@ def url_path(path):
     return 'file://%s' % path
 
 
+def comma_join(items):
+    if len(items) <= 2:
+        return ' and '.join(items)
+    return ', '.join(items[:-1]) + ', and ' + items[-1]
+
 def human_bytes(n):
     """
     Return the number of bytes n in more human readable form.


### PR DESCRIPTION
For example:

```
$conda install -c asmeurer -c ilan -c travis spoofmac
Fetching package metadata: ..........
Solving package specifications: .
Package plan for installation in environment /Users/aaronmeurer/anaconda:

The following NEW packages will be INSTALLED:

    spoofmac: 2.0.4-py34_0 https://conda.binstar.org/asmeurer/osx-64/

Linking packages ...
[      COMPLETE      ] |######################################################################################################################################################################################| 100%

Do you want to add 'asmeurer', 'ilan', and 'travis' to your condarc
file? If you do not, you will need to use '-c asmeurer', '-c ilan',
and '-c travis' in the future to install or update packages from these
channels. ([y]/n)?
```

If you choose no, you get a message like 

```
You can use 'conda config --add channels asmeurer --add channels ilan --add channels travis' if you decide to add it later.
```

Note that this pull request depends on https://github.com/conda/conda/pull/1240.

TODOS:

- [x] Add config options to always answer yes or no to this
- [ ] Make this more robust against unreadable condarc files
- [ ] Make this more robust against permissions issues writing to condarc?