### PR TITLE
restore json cache of repodata

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -22,7 +22,7 @@ from functools import wraps
 from conda import config
 from conda.utils import memoized
 from conda.connection import CondaSession, unparse_url, RETRIES
-from conda.compat import itervalues, get_http_value, input, urllib_quote
+from conda.compat import itervalues, input, urllib_quote
 from conda.lock import Locked
 
 import requests
@@ -48,8 +48,8 @@ def cache_fn_url(url):
     return '%s.json' % hashlib.md5(url.encode('utf-8')).hexdigest()
 
 
-def add_http_value_to_dict(u, http_key, d, dict_key):
-    value = get_http_value(u, http_key)
+def add_http_value_to_dict(resp, http_key, d, dict_key):
+    value = resp.headers.get(http_key)
     if value:
         d[dict_key] = value
 
@@ -88,7 +88,7 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
         return cache
 
     headers = {}
-    if "_tag" in cache:
+    if "_etag" in cache:
         headers["If-None-Match"] = cache["_etag"]
     if "_mod" in cache:
         headers["If-Modified-Since"] = cache["_mod"]
@@ -100,6 +100,8 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
         resp.raise_for_status()
         if resp.status_code != 304:
             cache = json.loads(bz2.decompress(resp.content).decode('utf-8'))
+            add_http_value_to_dict(resp, 'Etag', cache, '_etag')
+            add_http_value_to_dict(resp, 'Last-Modified', cache, '_mod')
 
     except ValueError as e:
         raise RuntimeError("Invalid index file: %srepodata.json.bz2: %s" %


### PR DESCRIPTION
At some point (probably when switching to using `requests`), the keys `_etag` and `_mod` in the local cache of `repodata.json` had been removed.  This made the local cache useless, because the server would never respond with status 304 anymore.  This PR fixes restores the behavior, and will therefore help minimize bandwidth.