### PR TITLE
Fixes issue related to upgrades on Windows.

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -600,7 +600,9 @@ def unlink(prefix, dist):
         with open(meta_path) as fi:
             meta = json.load(fi)
 
+        # TODO Refactor to if not pkg.is_writable
         if on_win and not can_open_all_files_in_prefix(prefix, meta['files']):
+            # TODO Should eventually return rather than exiting
             sys.exit(
                 "Unable to all files for updating.  Please close all running "
                 "processes and try again."
@@ -614,7 +616,7 @@ def unlink(prefix, dist):
             dst_dirs1.add(dirname(dst))
             try:
                 os.unlink(dst)
-            except OSError: # file might not exist
+            except OSError:  # file might not exist
                 log.debug("could not remove file: '%s'" % dst)
 
         # remove the meta-file last

--- a/conda/install.py
+++ b/conda/install.py
@@ -40,6 +40,7 @@ import logging
 import shlex
 from os.path import abspath, basename, dirname, isdir, isfile, islink, join
 
+from conda.utils import can_open_all_files_in_prefix
 try:
     from conda.lock import Locked
 except ImportError:
@@ -579,6 +580,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
 
         create_meta(prefix, dist, info_dir, meta_dict)
 
+
 def unlink(prefix, dist):
     '''
     Remove a package from the specified environment, it is an error if the
@@ -597,6 +599,12 @@ def unlink(prefix, dist):
         meta_path = join(prefix, 'conda-meta', dist + '.json')
         with open(meta_path) as fi:
             meta = json.load(fi)
+
+        if on_win and not can_open_all_files_in_prefix(prefix, meta['files']):
+            sys.exit(
+                "Unable to all files for updating.  Please close all running "
+                "processes and try again."
+            )
 
         mk_menus(prefix, meta['files'], remove=True)
         dst_dirs1 = set()

--- a/conda/install.py
+++ b/conda/install.py
@@ -40,19 +40,24 @@ import logging
 import shlex
 from os.path import abspath, basename, dirname, isdir, isfile, islink, join
 
-from conda.utils import can_open_all_files_in_prefix
 try:
     from conda.lock import Locked
+    from conda.utils import can_open_all_files_in_prefix
 except ImportError:
     # Make sure this still works as a standalone script for the Anaconda
     # installer.
     class Locked(object):
         def __init__(self, *args, **kwargs):
             pass
+
         def __enter__(self):
             pass
+
         def __exit__(self, exc_type, exc_value, traceback):
             pass
+
+    def can_open_all_files_in_prefix(*args, **kwargs):
+        return True
 
 on_win = bool(sys.platform == 'win32')
 

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -9,6 +9,9 @@ import os
 
 
 def can_open(file):
+    """
+    Return True if the given ``file`` can be opened for writing
+    """
     try:
         fp = open(file, "ab")
         fp.close()
@@ -18,6 +21,9 @@ def can_open(file):
 
 
 def can_open_all(prefix, files):
+    """
+    Return True if all of the provided ``files`` can be successfully opened
+    """
     for f in files:
         if not can_open(os.path.join(prefix, f)):
             return False

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -20,14 +20,21 @@ def can_open(file):
         return False
 
 
-def can_open_all(prefix, files):
+def can_open_all(files):
     """
-    Return True if all of the provided ``files`` can be successfully opened
+    Return True if all of the provided ``files`` can be opened
     """
     for f in files:
-        if not can_open(os.path.join(prefix, f)):
+        if not can_open(f):
             return False
     return True
+
+
+def can_open_all_files_in_prefix(prefix, files):
+    """
+    Returns True if all ``files`` at a given ``prefix`` can be opened
+    """
+    return can_open_all([os.path.join(prefix, f) for f in files])
 
 
 def try_write(dir_path):

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -7,6 +7,17 @@ from functools import partial
 from os.path import abspath, isdir, join
 import os
 
+
+def can_open_all(prefix, files):
+    try:
+        for f in files:
+            fp = open(os.path.join(prefix, f), "ab")
+            fp.close()
+        return True
+    except IOError:
+        return False
+
+
 def try_write(dir_path):
     assert isdir(dir_path)
     try:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -8,14 +8,20 @@ from os.path import abspath, isdir, join
 import os
 
 
-def can_open_all(prefix, files):
+def can_open(file):
     try:
-        for f in files:
-            fp = open(os.path.join(prefix, f), "ab")
-            fp.close()
+        fp = open(file, "ab")
+        fp.close()
         return True
     except IOError:
         return False
+
+
+def can_open_all(prefix, files):
+    for f in files:
+        if not can_open(os.path.join(prefix, f)):
+            return False
+    return True
 
 
 def try_write(dir_path):

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -34,7 +34,7 @@ def can_open_all_files_in_prefix(prefix, files):
     """
     Returns True if all ``files`` at a given ``prefix`` can be opened
     """
-    return can_open_all([os.path.join(prefix, f) for f in files])
+    return can_open_all((os.path.join(prefix, f) for f in files))
 
 
 def try_write(dir_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,25 @@ def create_mock_open():
     return mock.patch.object(utils, "open", create=True)
 
 
+class can_open_TestCase(unittest.TestCase):
+    def test_returns_true_if_can_open(self):
+        with create_mock_open():
+            self.assertTrue(utils.can_open("/some/path/some/file"))
+
+    def test_returns_false_if_unable_to_open(self):
+        with create_mock_open() as o:
+            o.side_effect = IOError
+            self.assertFalse(utils.can_open("/some/path/some/file"))
+
+    def test_closes_file_handler_if_successful(self):
+        with create_mock_open() as o:
+            utils.can_open("/some/file")
+        o.assert_has_calls([
+            mock.call("/some/file", "ab"),
+            mock.call().close(),
+        ])
+
+
 class can_open_all_TestCase(unittest.TestCase):
     def test_returns_true_on_success(self):
         with create_mock_open() as o:
@@ -28,21 +47,18 @@ class can_open_all_TestCase(unittest.TestCase):
             o.side_effect = IOError
             self.assertFalse(utils.can_open_all(SOME_PREFIX, SOME_FILES))
 
+    def test_dispatches_to_can_can_call(self):
+        with mock.patch.object(utils, "can_open") as can_open:
+            utils.can_open_all(SOME_PREFIX, SOME_FILES)
+        self.assertTrue(can_open.called)
+
     def test_tries_to_open_all_files(self):
         random_files = ['%s' % i for i in range(random.randint(10, 20))]
-        with create_mock_open() as o:
+        with mock.patch.object(utils, "can_open") as can_open:
             utils.can_open_all(SOME_PREFIX, random_files)
-        self.assertEqual(o.call_count, len(random_files))
 
-    def test_passes_full_path_into_open(self):
-        with create_mock_open() as o:
-            utils.can_open_all(SOME_PREFIX, SOME_FILES)
-
-        o.assert_has_calls([
-            mock.call(join(SOME_PREFIX, SOME_FILES[0]), "ab"),
-            mock.call().close(),
-            mock.call(join(SOME_PREFIX, SOME_FILES[1]), "ab"),
-            mock.call().close(),
-            mock.call(join(SOME_PREFIX, SOME_FILES[2]), "ab"),
-            mock.call().close(),
-        ])
+    def test_stops_checking_as_soon_as_the_first_file_fails(self):
+        with mock.patch.object(utils, "can_open") as can_open:
+            can_open.side_effect = [True, False, True]
+            self.assertFalse(utils.can_open_all(SOME_PREFIX, SOME_FILES))
+        self.assertEqual(can_open.call_count, 2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,48 @@
+from contextlib import contextmanager
+from os.path import join
+import random
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+from conda import utils
+
+SOME_PREFIX = "/some/prefix"
+SOME_FILES = ["a", "b", "c"]
+
+
+def create_mock_open():
+    return mock.patch.object(utils, "open", create=True)
+
+
+class can_open_all_TestCase(unittest.TestCase):
+    def test_returns_true_on_success(self):
+        with create_mock_open() as o:
+            self.assertTrue(utils.can_open_all(SOME_PREFIX, SOME_FILES))
+
+    def test_returns_false_if_unable_to_open_file_for_writing(self):
+        with create_mock_open() as o:
+            o.side_effect = IOError
+            self.assertFalse(utils.can_open_all(SOME_PREFIX, SOME_FILES))
+
+    def test_tries_to_open_all_files(self):
+        random_files = ['%s' % i for i in range(random.randint(10, 20))]
+        with create_mock_open() as o:
+            utils.can_open_all(SOME_PREFIX, random_files)
+        self.assertEqual(o.call_count, len(random_files))
+
+    def test_passes_full_path_into_open(self):
+        with create_mock_open() as o:
+            utils.can_open_all(SOME_PREFIX, SOME_FILES)
+
+        o.assert_has_calls([
+            mock.call(join(SOME_PREFIX, SOME_FILES[0]), "ab"),
+            mock.call().close(),
+            mock.call(join(SOME_PREFIX, SOME_FILES[1]), "ab"),
+            mock.call().close(),
+            mock.call(join(SOME_PREFIX, SOME_FILES[2]), "ab"),
+            mock.call().close(),
+        ])


### PR DESCRIPTION
Description pulled from commit message for commit 07d9880cf3b3b2d9ea87be617f2af7a9901fe7bb.

Talked with @jreback at pycon about this.  Users are leaving IPython Notebook sessions open with `pandas` imported, then trying to update pandas.  Attempting a force install when prompted to continue causes the installation to partially update.

The partial update is caused when conda attempts to relink files that are open.  Some of them work, other's don't.  Unfortunately, we don't know that until we attempt to write to them.

The try/except a few lines down that catches OSError is swallowing the `WindowsError(5, "Access is denied")` that is being thrown by `os.unlink`.  Simply modifying that, however, causes an issue where some of the files would be removed before we know that we can't update.

Fixes issue #1239
Related to ContinuumIO/anaconda-issues#256