### PR TITLE
Release branch for 3.11

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 2015-04-XX   3.11.0
 -------------------
   * fix issue where forced update on Windows could cause a package to break
+  * remove detection of running processes that might conflict
+  * deprecate --force-pscheck (now a no-op argument)
   * make conda search --outdated --names-only work, fixes #1252
   * handle the history file not having read or write permissions better
   * make multiple package resolutions warning easier to read

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+2015-04-XX   3.10.2:
+--------------------
+  * fix issue where forced update on Windows could cause a package to break
+
 2015-04-06   3.10.1:
 --------------------
   * fix logic in @memoized for unhashable args

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,4 +42,4 @@ install:
 
 test_script:
   - C:\Miniconda\Scripts\py.test -vvv
-  - IF %PYTHON%==2.7 IF DEFINED PYCOSAT C:\Miniconda\Scripts\conda install -f --force-pscheck menuinst ipython-notebook & echo "Finished menuinst test"
+  - IF %PYTHON%==2.7 IF DEFINED PYCOSAT C:\Miniconda\Scripts\conda install -f menuinst ipython-notebook & echo "Finished menuinst test"

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+from functools import wraps
 import re
 import os
 import sys
@@ -7,6 +8,7 @@ import argparse
 import contextlib
 from os.path import abspath, basename, expanduser, isdir, join
 import textwrap
+import warnings
 
 import conda.config as config
 from conda import console
@@ -181,9 +183,9 @@ def add_parser_install(p):
     )
     p.add_argument(
         "--force-pscheck",
-        action = "store_true",
-        help = ("force removal (when package process is running)"
-                if config.platform == 'win' else argparse.SUPPRESS)
+        action="store_true",
+        help=("force removal (when package process is running) (deprecated)"
+              if config.platform == 'win' else argparse.SUPPRESS)
     )
     p.add_argument(
         "--file",
@@ -575,3 +577,21 @@ def handle_envs_list(acc, output=True):
 
     if output:
         print()
+
+
+DEPRECATED = ["force_pscheck", ]
+
+
+def deprecation_warning(func):
+    """Wraps an execute function in a deprecated args checker"""
+
+    msg = "Argument %s is no longer used"
+
+    @wraps(func)
+    def inner(args, parser):
+        for key in DEPRECATED:
+            if not hasattr(args, key):
+                continue
+            warnings.warn(msg % key.replace("_", "-"), DeprecationWarning)
+        return func(args, parser)
+    return inner

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -21,7 +21,6 @@ import conda.plan as plan
 import conda.instructions as inst
 import conda.misc as misc
 from conda.api import get_index
-from conda.cli import pscheck
 from conda.cli import common
 from conda.cli.find_commands import find_executable
 from conda.resolve import NoPackagesFound, Resolve, MatchSpec
@@ -404,19 +403,10 @@ environment does not exist: %s
         common.check_write(command, prefix)
 
     if not args.json:
-        if not pscheck.main(args):
-            common.confirm_yn(args)
-    else:
-        if (sys.platform == 'win32' and not args.force_pscheck and
-            not pscheck.check_processes(prefix, verbose=False)):
-            common.error_and_exit(
-                    "Cannot continue operation while processes "
-                    "from packages are running without --force-pscheck.",
-                    json=True,
-                    error_type="ProcessesStillRunning")
-        elif args.dry_run:
-            common.stdout_json_success(actions=actions, dry_run=True)
-            sys.exit(0)
+        common.confirm_yn(args)
+    elif args.dry_run:
+        common.stdout_json_success(actions=actions, dry_run=True)
+        sys.exit(0)
 
     with common.json_progress_bars(json=args.json and not args.quiet):
         try:

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -47,5 +47,7 @@ def configure_parser(sub_parsers):
     )
     p.set_defaults(func=execute)
 
+
+@common.deprecation_warning
 def execute(args, parser):
     install.install(args, parser, 'create')

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -43,5 +43,7 @@ def configure_parser(sub_parsers):
     common.add_parser_json(p)
     p.set_defaults(func=execute)
 
+
+@common.deprecation_warning
 def execute(args, parser):
     install.install(args, parser, 'install')

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -14,6 +14,7 @@ import errno
 import logging
 
 from conda import config
+from conda import plan
 from conda.cli import common
 from conda.console import json_progress_bars
 
@@ -144,8 +145,9 @@ def execute(args, parser):
                                   json=args.json,
                                   error_type="CantRemoveRoot")
 
-        actions = {inst.PREFIX: prefix,
-                   inst.UNLINK: sorted(linked(prefix))}
+        actions = {inst.PREFIX: prefix}
+        for dist in sorted(linked(prefix)):
+            plan.add_unlink(actions, dist)
 
     else:
         specs = common.specs_from_args(args.package_names)

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -74,8 +74,8 @@ def configure_parser(sub_parsers, name='remove'):
     p.add_argument(
         "--force-pscheck",
         action="store_true",
-        help=("force removal (when package process is running)"
-                if config.platform == 'win' else argparse.SUPPRESS)
+        help=("force removal (when package process is running) (deprecated)"
+              if config.platform == 'win' else argparse.SUPPRESS)
     )
     p.add_argument(
         'package_names',
@@ -87,12 +87,12 @@ def configure_parser(sub_parsers, name='remove'):
     p.set_defaults(func=execute)
 
 
+@common.deprecation_warning
 def execute(args, parser):
     import sys
 
     import conda.plan as plan
     import conda.instructions as inst
-    from conda.cli import pscheck
     from conda.install import rm_rf, linked
     from conda import config
 
@@ -185,15 +185,6 @@ def execute(args, parser):
         })
         return
 
-    if not args.json:
-        if not pscheck.main(args):
-            common.confirm_yn(args)
-    elif (sys.platform == 'win32' and not args.force_pscheck and
-          not pscheck.check_processes(prefix, verbose=False)):
-        common.error_and_exit("Cannot continue removal while processes "
-                              "from packages are running without --force-pscheck.",
-                              json=True,
-                              error_type="ProcessesStillRunning")
 
     if args.json and not args.quiet:
         with json_progress_bars():

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -37,5 +37,6 @@ def configure_parser(sub_parsers):
     p.set_defaults(func=execute)
 
 
+@common.deprecation_warning
 def execute(args, parser):
     install.install(args, parser, 'update')

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -6,3 +6,11 @@ class InvalidInstruction(CondaException):
     def __init__(self, instruction, *args, **kwargs):
         msg = "No handler for instruction: %r" % instruction
         super(InvalidInstruction, self).__init__(msg, *args, **kwargs)
+
+
+class UnableToWriteToPackage(RuntimeError, CondaException):
+    def __init__(self, pkg_name, *args, **kwargs):
+        msg = ("Unable to remove files for package: {pkg_name}\n\n"
+               "Please close all processes running code from {pkg_name} and "
+               "try again.\n".format(pkg_name=pkg_name))
+        super(UnableToWriteToPackage, self).__init__(msg, *args, **kwargs)

--- a/conda/install.py
+++ b/conda/install.py
@@ -651,7 +651,7 @@ def messages(prefix):
 
 def ensure_write(prefix, dist):
     meta = load_meta(prefix, dist)
-    if not can_open_all_files_in_prefix(prefix, dist['files']):
+    if not can_open_all_files_in_prefix(prefix, meta["files"]):
         # TODO Should eventually return rather than exiting
         sys.exit(
             "Unable to modify files for updating.  Please close all "

--- a/conda/install.py
+++ b/conda/install.py
@@ -600,7 +600,9 @@ def unlink(prefix, dist):
         with open(meta_path) as fi:
             meta = json.load(fi)
 
+        # TODO Refactor to if not pkg.is_writable
         if on_win and not can_open_all_files_in_prefix(prefix, meta['files']):
+            # TODO Should eventually return rather than exiting
             sys.exit(
                 "Unable to all files for updating.  Please close all running "
                 "processes and try again."
@@ -614,7 +616,7 @@ def unlink(prefix, dist):
             dst_dirs1.add(dirname(dst))
             try:
                 os.unlink(dst)
-            except OSError: # file might not exist
+            except OSError:  # file might not exist
                 log.debug("could not remove file: '%s'" % dst)
 
         # remove the meta-file last

--- a/conda/install.py
+++ b/conda/install.py
@@ -654,8 +654,9 @@ def ensure_write(prefix, dist):
     if not can_open_all_files_in_prefix(prefix, meta["files"]):
         # TODO Should eventually return rather than exiting
         sys.exit(
-            "Unable to modify files for updating.  Please close all "
-            "running processes and try again."
+            "Unable to remove files for package {pkg_name}.  Please\n"
+            "close all running processes and try again.".format(
+                pkg_name=meta["name"])
         )
 
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -40,6 +40,7 @@ import logging
 import shlex
 from os.path import abspath, basename, dirname, isdir, isfile, islink, join
 
+from conda.utils import can_open_all_files_in_prefix
 try:
     from conda.lock import Locked
 except ImportError:
@@ -579,6 +580,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
 
         create_meta(prefix, dist, info_dir, meta_dict)
 
+
 def unlink(prefix, dist):
     '''
     Remove a package from the specified environment, it is an error if the
@@ -597,6 +599,12 @@ def unlink(prefix, dist):
         meta_path = join(prefix, 'conda-meta', dist + '.json')
         with open(meta_path) as fi:
             meta = json.load(fi)
+
+        if on_win and not can_open_all_files_in_prefix(prefix, meta['files']):
+            sys.exit(
+                "Unable to all files for updating.  Please close all running "
+                "processes and try again."
+            )
 
         mk_menus(prefix, meta['files'], remove=True)
         dst_dirs1 = set()

--- a/conda/install.py
+++ b/conda/install.py
@@ -40,19 +40,24 @@ import logging
 import shlex
 from os.path import abspath, basename, dirname, isdir, isfile, islink, join
 
-from conda.utils import can_open_all_files_in_prefix
 try:
     from conda.lock import Locked
+    from conda.utils import can_open_all_files_in_prefix
 except ImportError:
     # Make sure this still works as a standalone script for the Anaconda
     # installer.
     class Locked(object):
         def __init__(self, *args, **kwargs):
             pass
+
         def __enter__(self):
             pass
+
         def __exit__(self, exc_type, exc_value, traceback):
             pass
+
+    def can_open_all_files_in_prefix(*args, **kwargs):
+        return True
 
 on_win = bool(sys.platform == 'win32')
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -609,8 +609,8 @@ def unlink(prefix, dist):
         if on_win and not can_open_all_files_in_prefix(prefix, meta['files']):
             # TODO Should eventually return rather than exiting
             sys.exit(
-                "Unable to all files for updating.  Please close all running "
-                "processes and try again."
+                "Unable to modify files for updating.  Please close all "
+                "running processes and try again."
             )
 
         mk_menus(prefix, meta['files'], remove=True)

--- a/conda/install.py
+++ b/conda/install.py
@@ -497,6 +497,11 @@ def is_linked(prefix, dist):
         return None
 
 
+# FIXME This should contain the implementation that loads meta, not is_linked()
+def load_meta(prefix, dist):
+    return is_linked(prefix, dist)
+
+
 def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
     '''
     Set up a package in a specified (environment) prefix.  We assume that
@@ -645,6 +650,7 @@ def messages(prefix):
 
 
 def ensure_write(prefix, dist):
+    meta = load_meta(prefix, dist)
     if not can_open_all_files_in_prefix(prefix, dist['files']):
         # TODO Should eventually return rather than exiting
         sys.exit(

--- a/conda/install.py
+++ b/conda/install.py
@@ -483,6 +483,7 @@ def linked(prefix):
     return set(fn[:-5] for fn in os.listdir(meta_dir) if fn.endswith('.json'))
 
 
+# FIXME Functions that begin with `is_` should return True/False
 def is_linked(prefix, dist):
     """
     Return the install meta-data for a linked package in a prefix, or None

--- a/conda/install.py
+++ b/conda/install.py
@@ -605,14 +605,6 @@ def unlink(prefix, dist):
         with open(meta_path) as fi:
             meta = json.load(fi)
 
-        # TODO Refactor to if not pkg.is_writable
-        if on_win and not can_open_all_files_in_prefix(prefix, meta['files']):
-            # TODO Should eventually return rather than exiting
-            sys.exit(
-                "Unable to modify files for updating.  Please close all "
-                "running processes and try again."
-            )
-
         mk_menus(prefix, meta['files'], remove=True)
         dst_dirs1 = set()
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -650,7 +650,18 @@ def messages(prefix):
     finally:
         rm_rf(path)
 
+
+def ensure_write(prefix, dist):
+    if not can_open_all_files_in_prefix(prefix, dist['files']):
+        # TODO Should eventually return rather than exiting
+        sys.exit(
+            "Unable to modify files for updating.  Please close all "
+            "running processes and try again."
+        )
+
+
 # =========================== end API functions ==========================
+
 
 def main():
     from pprint import pprint

--- a/conda/install.py
+++ b/conda/install.py
@@ -41,6 +41,7 @@ import shlex
 from os.path import abspath, basename, dirname, isdir, isfile, islink, join
 
 try:
+    from conda.exceptions import UnableToWriteToPackage
     from conda.lock import Locked
     from conda.utils import can_open_all_files_in_prefix
 except ImportError:
@@ -55,6 +56,9 @@ except ImportError:
 
         def __exit__(self, exc_type, exc_value, traceback):
             pass
+
+    class UnableToWriteToPackage(RuntimeError):
+        pass
 
     def can_open_all_files_in_prefix(*args, **kwargs):
         return True
@@ -652,12 +656,7 @@ def messages(prefix):
 def ensure_write(prefix, dist):
     meta = load_meta(prefix, dist)
     if not can_open_all_files_in_prefix(prefix, meta["files"]):
-        # TODO Should eventually return rather than exiting
-        sys.exit(
-            "Unable to remove files for package {pkg_name}.  Please\n"
-            "close all running processes and try again.".format(
-                pkg_name=meta["name"])
-        )
+        raise UnableToWriteToPackage(meta["name"])
 
 
 # =========================== end API functions ==========================

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -24,8 +24,16 @@ SYMLINK_CONDA = 'SYMLINK_CONDA'
 
 
 progress_cmds = set([EXTRACT, RM_EXTRACTED, LINK, UNLINK])
-action_codes = (FETCH, EXTRACT, UNLINK, LINK, SYMLINK_CONDA, RM_EXTRACTED,
-                RM_FETCHED)
+action_codes = (
+    FETCH,
+    EXTRACT,
+    ENSURE_WRITE,
+    UNLINK,
+    LINK,
+    SYMLINK_CONDA,
+    RM_EXTRACTED,
+    RM_FETCHED,
+)
 
 
 def PREFIX_CMD(state, arg):

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -12,6 +12,7 @@ log = getLogger(__name__)
 # op codes
 FETCH = 'FETCH'
 EXTRACT = 'EXTRACT'
+ENSURE_WRITE = 'ENSURE_WRITE'
 UNLINK = 'UNLINK'
 LINK = 'LINK'
 RM_EXTRACTED = 'RM_EXTRACTED'
@@ -91,6 +92,11 @@ def UNLINK_CMD(state, arg):
 def SYMLINK_CONDA_CMD(state, arg):
     install.symlink_conda(state['prefix'], arg)
 
+
+def ENSURE_WRITE_CMD():
+    install.ensure_write()
+
+
 # Map instruction to command (a python function)
 commands = {
     PREFIX: PREFIX_CMD,
@@ -103,6 +109,7 @@ commands = {
     LINK: LINK_CMD,
     UNLINK: UNLINK_CMD,
     SYMLINK_CONDA: SYMLINK_CONDA_CMD,
+    ENSURE_WRITE: ENSURE_WRITE_CMD,
 }
 
 

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -93,8 +93,8 @@ def SYMLINK_CONDA_CMD(state, arg):
     install.symlink_conda(state['prefix'], arg)
 
 
-def ENSURE_WRITE_CMD():
-    install.ensure_write()
+def ENSURE_WRITE_CMD(state, arg):
+    install.ensure_write(state["prefix"], arg)
 
 
 # Map instruction to command (a python function)

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -184,6 +184,12 @@ def nothing_to_do(actions):
     return True
 
 
+def add_unlink(actions, dist):
+    if inst.UNLINK not in actions:
+        actions[inst.UNLINK] = []
+    actions[inst.UNLINK].append(dist)
+
+
 def plan_from_actions(actions):
     if 'op_order' in actions and actions['op_order']:
         op_order = actions['op_order']
@@ -296,7 +302,7 @@ def force_linked_actions(dists, index, prefix):
         actions[inst.RM_EXTRACTED].append(dist)
         actions[inst.EXTRACT].append(dist)
         if isfile(join(prefix, 'conda-meta', dist + '.json')):
-            actions[inst.UNLINK].append(dist)
+            add_unlink(actions, dist)
         actions[inst.LINK].append(dist)
     return actions
 
@@ -426,7 +432,7 @@ def install_actions(prefix, index, specs, force=False, only_names=None,
     for dist in sorted(linked):
         name = install.name_dist(dist)
         if name in must_have and dist != must_have[name]:
-            actions[inst.UNLINK].append(dist)
+            add_unlink(actions, dist)
 
     return actions
 
@@ -454,7 +460,7 @@ def remove_actions(prefix, specs, index=None, pinned=True):
                     "Cannot remove %s because it is pinned. Use --no-pin "
                     "to override." % dist)
 
-            actions[inst.UNLINK].append(dist)
+            add_unlink(actions, dist)
             if r and fn in index and r.track_features(fn):
                 features_actions = remove_features_actions(
                     prefix, index, r.track_features(fn))
@@ -482,9 +488,9 @@ def remove_features_actions(prefix, index, features):
         if fn not in index:
             continue
         if r.track_features(fn).intersection(features):
-            actions[inst.UNLINK].append(dist)
+            add_unlink(actions, dist)
         if r.features(fn).intersection(features):
-            actions[inst.UNLINK].append(dist)
+            add_unlink(actions, dist)
             subst = r.find_substitute(_linked, features, fn)
             if subst:
                 to_link.append(subst[:-8])
@@ -508,7 +514,7 @@ def revert_actions(prefix, revision=-1):
 
     actions = ensure_linked_actions(state, prefix)
     for dist in curr - state:
-        actions[inst.UNLINK].append(dist)
+        add_unlink(actions, dist)
 
     return actions
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -187,6 +187,10 @@ def nothing_to_do(actions):
 def add_unlink(actions, dist):
     if inst.UNLINK not in actions:
         actions[inst.UNLINK] = []
+    if sys.platform == "win32":
+        if inst.ENSURE_WRITE not in actions:
+            actions[inst.ENSURE_WRITE] = []
+        actions[inst.ENSURE_WRITE].append(dist)
     actions[inst.UNLINK].append(dist)
 
 

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -9,6 +9,9 @@ import os
 
 
 def can_open(file):
+    """
+    Return True if the given ``file`` can be opened for writing
+    """
     try:
         fp = open(file, "ab")
         fp.close()
@@ -18,6 +21,9 @@ def can_open(file):
 
 
 def can_open_all(prefix, files):
+    """
+    Return True if all of the provided ``files`` can be successfully opened
+    """
     for f in files:
         if not can_open(os.path.join(prefix, f)):
             return False

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -20,14 +20,21 @@ def can_open(file):
         return False
 
 
-def can_open_all(prefix, files):
+def can_open_all(files):
     """
-    Return True if all of the provided ``files`` can be successfully opened
+    Return True if all of the provided ``files`` can be opened
     """
     for f in files:
-        if not can_open(os.path.join(prefix, f)):
+        if not can_open(f):
             return False
     return True
+
+
+def can_open_all_files_in_prefix(prefix, files):
+    """
+    Returns True if all ``files`` at a given ``prefix`` can be opened
+    """
+    return can_open_all([os.path.join(prefix, f) for f in files])
 
 
 def try_write(dir_path):

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -7,6 +7,17 @@ from functools import partial
 from os.path import abspath, isdir, join
 import os
 
+
+def can_open_all(prefix, files):
+    try:
+        for f in files:
+            fp = open(os.path.join(prefix, f), "ab")
+            fp.close()
+        return True
+    except IOError:
+        return False
+
+
 def try_write(dir_path):
     assert isdir(dir_path)
     try:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -8,14 +8,20 @@ from os.path import abspath, isdir, join
 import os
 
 
-def can_open_all(prefix, files):
+def can_open(file):
     try:
-        for f in files:
-            fp = open(os.path.join(prefix, f), "ab")
-            fp.close()
+        fp = open(file, "ab")
+        fp.close()
         return True
     except IOError:
         return False
+
+
+def can_open_all(prefix, files):
+    for f in files:
+        if not can_open(os.path.join(prefix, f)):
+            return False
+    return True
 
 
 def try_write(dir_path):

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -34,7 +34,7 @@ def can_open_all_files_in_prefix(prefix, files):
     """
     Returns True if all ``files`` at a given ``prefix`` can be opened
     """
-    return can_open_all([os.path.join(prefix, f) for f in files])
+    return can_open_all((os.path.join(prefix, f) for f in files))
 
 
 def try_write(dir_path):

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -1,11 +1,14 @@
 from __future__ import print_function, division, absolute_import
 
+import logging
 import sys
 import hashlib
 import collections
 from functools import partial
 from os.path import abspath, isdir, join
 import os
+
+log = logging.getLogger(__name__)
 
 
 def can_open(file):
@@ -17,6 +20,7 @@ def can_open(file):
         fp.close()
         return True
     except IOError:
+        log.debug("Unable to open %s" % file)
         return False
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -18,3 +18,28 @@ class InvalidExceptionTestCase(unittest.TestCase):
         e = exceptions.InvalidInstruction(random_instruction)
         expected = "No handler for instruction: %s" % random_instruction
         self.assertEqual(expected, str(e))
+
+
+class UnableToWriteToPackageExceptionTestCase(unittest.TestCase):
+
+    def test_requires_a_package(self):
+        with self.assertRaises(TypeError):
+            exceptions.UnableToWriteToPackage()
+
+    def test_extends_from_conda_exception(self):
+        e = exceptions.UnableToWriteToPackage("foo")
+        self.assertIsInstance(e, exceptions.CondaException)
+
+    def test_extends_from_runtime_error(self):
+        e = exceptions.UnableToWriteToPackage("bar")
+        self.assertIsInstance(e, RuntimeError)
+
+    def test_creates_expected_message(self):
+        pkg = "foobar_%s" % random.randint(100, 200)
+        expected = (
+            "Unable to remove files for package: {pkg_name}\n\n"
+            "Please close all processes running code from {pkg_name} and "
+            "try again.\n"
+        ).format(pkg_name=pkg)
+        e = exceptions.UnableToWriteToPackage(pkg)
+        self.assertEqual(expected, str(e))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -155,7 +155,7 @@ class ensure_write_TestCase(unittest.TestCase):
 
     def test_dispatches_to_can_open_all_files(self):
         with self.generate_mock_check() as can:
-            install.ensure_write(self.prefix, self.meta)
+            install.ensure_write(self.prefix, self.dist)
         can.assert_called_with(self.prefix, self.meta['files'])
 
     def test_returns_none_on_true(self):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -167,8 +167,11 @@ class ensure_write_TestCase(unittest.TestCase):
         with self.generate_mock_check(return_value=False):
             with patch.object(install, 'sys') as sys:
                 install.ensure_write(self.prefix, self.meta)
-        expected = ("Unable to modify files for updating.  Please close all "
-                    "running processes and try again.")
+        expected = (
+            "Unable to remove files for package {pkg_name}.  Please\n"
+            "close all running processes and try again.".format(
+                pkg_name=self.dist)
+        )
         sys.exit.assert_called_with(expected)
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,6 +9,7 @@ from os.path import join
 
 import pytest
 
+from conda import exceptions
 from conda import install
 from conda.install import PaddingError, binary_replace, update_prefix
 
@@ -163,16 +164,10 @@ class ensure_write_TestCase(unittest.TestCase):
             actual = install.ensure_write(self.prefix, self.meta)
             self.assertTrue(actual is None)
 
-    def test_calls_sys_exit_if_cannot_write(self):
+    def test_raises_correct_exception_if_unable_to_write(self):
         with self.generate_mock_check(return_value=False):
-            with patch.object(install, 'sys') as sys:
+            with self.assertRaises(exceptions.UnableToWriteToPackage):
                 install.ensure_write(self.prefix, self.meta)
-        expected = (
-            "Unable to remove files for package {pkg_name}.  Please\n"
-            "close all running processes and try again.".format(
-                pkg_name=self.dist)
-        )
-        sys.exit.assert_called_with(expected)
 
 
 class rm_rf_file_and_link_TestCase(unittest.TestCase):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,7 +1,3 @@
-from .decorators import skip_if_no_mock
-from .helpers import mock
-patch = mock.patch if mock else None
-
 from contextlib import contextmanager
 import random
 import shutil
@@ -13,6 +9,11 @@ from os.path import join
 
 from conda import install
 from conda.install import PaddingError, binary_replace, update_prefix
+
+from .decorators import skip_if_no_mock
+from .helpers import mock
+
+patch = mock.patch if mock else None
 
 
 def generate_random_path():
@@ -41,7 +42,8 @@ class TestBinaryReplace(unittest.TestCase):
 
     def test_two(self):
         self.assertEqual(
-            binary_replace(b'aaaaa\x001234aaaaacc\x00\x00', b'aaaaa', b'bbbbb'),
+            binary_replace(b'aaaaa\x001234aaaaacc\x00\x00', b'aaaaa',
+                           b'bbbbb'),
             b'bbbbb\x001234bbbbbcc\x00\x00')
 
     def test_spaces(self):
@@ -120,7 +122,6 @@ class remove_readonly_TestCase(unittest.TestCase):
         with patch.object(install.os, 'chmod'):
             install._remove_readonly(func, some_path, {})
         func.assert_called_with(some_path)
-
 
 
 class rm_rf_file_and_link_TestCase(unittest.TestCase):
@@ -308,7 +309,8 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
             mocks['rmtree'].side_effect = OSError
             max_retries = random.randint(1, 10)
             with self.assertRaises(OSError):
-                install.rm_rf(self.generate_random_path, max_retries=max_retries)
+                install.rm_rf(self.generate_random_path,
+                              max_retries=max_retries)
 
         expected = [mock.call(i) for i in range(max_retries)]
         mocks['sleep'].assert_has_calls(expected)
@@ -357,11 +359,12 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
         check_call.assert_called_with(expected_arg)
 
     @skip_if_no_mock
-    def test_continues_calling_until_max_tries_on_called_process_errors_on_windows(self):
+    def test_calls_until_max_tries_on_called_process_errors_on_windows(self):
         max_retries = random.randint(6, 10)
         with self.generate_directory_mocks(on_win=True) as mocks:
             mocks['rmtree'].side_effect = OSError
-            mocks['check_call'].side_effect = subprocess.CalledProcessError(1, "cmd")
+            mocks['check_call'].side_effect = subprocess.CalledProcessError(
+                1, "cmd")
             with self.assertRaises(OSError):
                 install.rm_rf(generate_random_path(), max_retries=max_retries)
 
@@ -373,7 +376,8 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
         with self.generate_directory_mocks(on_win=True) as mocks:
             random_path = self.generate_random_path
             mocks['rmtree'].side_effect = OSError(random_path)
-            mocks['check_call'].side_effect = subprocess.CalledProcessError(1, "cmd")
+            mocks['check_call'].side_effect = subprocess.CalledProcessError(
+                1, "cmd")
             max_retries = random.randint(1, 10)
             with self.assertRaises(OSError):
                 install.rm_rf(random_path, max_retries=max_retries)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -139,15 +139,19 @@ def test_ensure_write_takes_two_arguments(args):
 class ensure_write_TestCase(unittest.TestCase):
     def setUp(self):
         self.prefix = generate_random_path()
+        self.dist = "foobar-%s-0" % random.randint(100, 200)
         self.meta = {
-            "files": ["a", "b", "c", ],
+            "name": self.dist,
+            "files": ["a", "b", "c"],
         }
 
     @contextmanager
     def generate_mock_check(self, return_value=True):
         with patch.object(install, 'can_open_all_files_in_prefix') as mocked:
             mocked.return_value = return_value
-            yield mocked
+            with patch.object(install, "load_meta") as load_meta:
+                load_meta.return_value = self.meta
+                yield mocked
 
     def test_dispatches_to_can_open_all_files(self):
         with self.generate_mock_check() as can:

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -1,4 +1,5 @@
 from logging import getLogger, Handler, DEBUG
+import random
 import types
 import unittest
 
@@ -30,10 +31,25 @@ class TestEnsureWriteCommand(unittest.TestCase):
         self.assertTrue(isinstance(commands['ENSURE_WRITE'],
                                    types.FunctionType))
 
+    def test_takes_two_args(self):
+        cmd = commands['ENSURE_WRITE']
+
+        with self.assertRaises(TypeError):
+            cmd()  # No args
+
+        with self.assertRaises(TypeError):
+            cmd("one")
+
+        with self.assertRaises(TypeError):
+            cmd("one", "two", "three")
+
     def test_ensure_dispatches_to_install_ensure_unlink(self):
+        prefix = "/some/random/prefix/%s" % random.randint(100, 200)
+        state = {"prefix": prefix}
+        dist = object()
         with mock.patch.object(instructions, 'install') as install:
-            commands['ENSURE_WRITE']()
-        self.assertTrue(install.ensure_write.called)
+            commands['ENSURE_WRITE'](state, dist)
+        install.ensure_write.assert_called_with(prefix, dist)
 
 
 class TestExecutePlan(unittest.TestCase):

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -18,6 +18,7 @@ def test_expected_operation_order():
     expected = (
         instructions.FETCH,
         instructions.EXTRACT,
+        instructions.ENSURE_WRITE,
         instructions.UNLINK,
         instructions.LINK,
         instructions.SYMLINK_CONDA,

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -13,6 +13,20 @@ from conda import instructions
 from conda.instructions import execute_instructions, commands, PROGRESS_CMD
 
 
+def test_expected_operation_order():
+    """Ensure expected order of operations"""
+    expected = (
+        instructions.FETCH,
+        instructions.EXTRACT,
+        instructions.UNLINK,
+        instructions.LINK,
+        instructions.SYMLINK_CONDA,
+        instructions.RM_EXTRACTED,
+        instructions.RM_FETCHED,
+    )
+    assert expected == instructions.action_codes
+
+
 class TestHandler(Handler):
     def __init__(self):
         Handler.__init__(self)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -811,7 +811,7 @@ The following packages will be DOWNGRADED:
 
 """
 
-class TestDepricatedExecutePlan(unittest.TestCase):
+class TestDeprecatedExecutePlan(unittest.TestCase):
 
     def test_update_old_plan(self):
         old_plan = ['# plan', 'INSTRUCTION arg']

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -54,10 +54,7 @@ def test_add_unlink_takes_two_arguments(args):
 
 class add_unlink_TestCase(unittest.TestCase):
     def generate_random_dist(self):
-        return {
-            "name": "foobar%s" % random.randint(100, 200),
-            "files": ["a", "b", "c"]
-        }
+        return "foobar-%s-0" % random.randint(100, 200)
 
     @contextmanager
     def mock_platform(self, windows=False):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,25 @@ def create_mock_open():
     return mock.patch.object(utils, "open", create=True)
 
 
+class can_open_TestCase(unittest.TestCase):
+    def test_returns_true_if_can_open(self):
+        with create_mock_open():
+            self.assertTrue(utils.can_open("/some/path/some/file"))
+
+    def test_returns_false_if_unable_to_open(self):
+        with create_mock_open() as o:
+            o.side_effect = IOError
+            self.assertFalse(utils.can_open("/some/path/some/file"))
+
+    def test_closes_file_handler_if_successful(self):
+        with create_mock_open() as o:
+            utils.can_open("/some/file")
+        o.assert_has_calls([
+            mock.call("/some/file", "ab"),
+            mock.call().close(),
+        ])
+
+
 class can_open_all_TestCase(unittest.TestCase):
     def test_returns_true_on_success(self):
         with create_mock_open() as o:
@@ -28,21 +47,18 @@ class can_open_all_TestCase(unittest.TestCase):
             o.side_effect = IOError
             self.assertFalse(utils.can_open_all(SOME_PREFIX, SOME_FILES))
 
+    def test_dispatches_to_can_can_call(self):
+        with mock.patch.object(utils, "can_open") as can_open:
+            utils.can_open_all(SOME_PREFIX, SOME_FILES)
+        self.assertTrue(can_open.called)
+
     def test_tries_to_open_all_files(self):
         random_files = ['%s' % i for i in range(random.randint(10, 20))]
-        with create_mock_open() as o:
+        with mock.patch.object(utils, "can_open") as can_open:
             utils.can_open_all(SOME_PREFIX, random_files)
-        self.assertEqual(o.call_count, len(random_files))
 
-    def test_passes_full_path_into_open(self):
-        with create_mock_open() as o:
-            utils.can_open_all(SOME_PREFIX, SOME_FILES)
-
-        o.assert_has_calls([
-            mock.call(join(SOME_PREFIX, SOME_FILES[0]), "ab"),
-            mock.call().close(),
-            mock.call(join(SOME_PREFIX, SOME_FILES[1]), "ab"),
-            mock.call().close(),
-            mock.call(join(SOME_PREFIX, SOME_FILES[2]), "ab"),
-            mock.call().close(),
-        ])
+    def test_stops_checking_as_soon_as_the_first_file_fails(self):
+        with mock.patch.object(utils, "can_open") as can_open:
+            can_open.side_effect = [True, False, True]
+            self.assertFalse(utils.can_open_all(SOME_PREFIX, SOME_FILES))
+        self.assertEqual(can_open.call_count, 2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,6 +34,14 @@ class can_open_TestCase(unittest.TestCase):
             o.side_effect = IOError
             self.assertFalse(utils.can_open("/some/path/some/file"))
 
+    def test_logs_file_to_debug_log(self):
+        random_file = "/some/path/to/a/file/%s" % random.randint(100, 200)
+        with create_mock_open() as o:
+            o.side_effect = IOError
+            with mock.patch.object(utils, "log") as log:
+                utils.can_open(random_file)
+        log.debug.assert_called_with("Unable to open %s" % random_file)
+
     def test_closes_file_handler_if_successful(self):
         with create_mock_open() as o:
             utils.can_open("/some/file")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,48 @@
+from contextlib import contextmanager
+from os.path import join
+import random
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+from conda import utils
+
+SOME_PREFIX = "/some/prefix"
+SOME_FILES = ["a", "b", "c"]
+
+
+def create_mock_open():
+    return mock.patch.object(utils, "open", create=True)
+
+
+class can_open_all_TestCase(unittest.TestCase):
+    def test_returns_true_on_success(self):
+        with create_mock_open() as o:
+            self.assertTrue(utils.can_open_all(SOME_PREFIX, SOME_FILES))
+
+    def test_returns_false_if_unable_to_open_file_for_writing(self):
+        with create_mock_open() as o:
+            o.side_effect = IOError
+            self.assertFalse(utils.can_open_all(SOME_PREFIX, SOME_FILES))
+
+    def test_tries_to_open_all_files(self):
+        random_files = ['%s' % i for i in range(random.randint(10, 20))]
+        with create_mock_open() as o:
+            utils.can_open_all(SOME_PREFIX, random_files)
+        self.assertEqual(o.call_count, len(random_files))
+
+    def test_passes_full_path_into_open(self):
+        with create_mock_open() as o:
+            utils.can_open_all(SOME_PREFIX, SOME_FILES)
+
+        o.assert_has_calls([
+            mock.call(join(SOME_PREFIX, SOME_FILES[0]), "ab"),
+            mock.call().close(),
+            mock.call(join(SOME_PREFIX, SOME_FILES[1]), "ab"),
+            mock.call().close(),
+            mock.call(join(SOME_PREFIX, SOME_FILES[2]), "ab"),
+            mock.call().close(),
+        ])


### PR DESCRIPTION
Didn't realize that I didn't have the latest code when I was on the plane working on #1273.  This creates a branch off of the latest release so the Windows upgrade changes are isolated and can be release independently.

This supersedes #1273.

## Steps to Test
* Before installing, create a new environment with pandas 0.16
* Open `python` console and type `import pandas` and `pandas.__version__` to verify the version is as expected
* Leave `python` console open
* In another terminal window, attempt to install `pandas=0.14*`
* When prompted, select `f` to force installation

At this point, you can repeats step 2 and you should receive an error.

To fix this, you have to close all running `python` consoles, then install `pandas` again.

Once you've reset, you can install this code and test -- it shouldn't allow you to force the installation.