### PR TITLE
Automate some things for conda command help

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -12,6 +12,7 @@ import argparse
 from difflib import get_close_matches
 
 from conda.cli.find_commands import find_commands
+from conda.cli import common
 
 build_commands = {'build', 'index', 'skeleton', 'package', 'metapackage',
     'pipbuild', 'develop', 'convert'}
@@ -20,7 +21,16 @@ class ArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
         if not kwargs.get('formatter_class'):
             kwargs['formatter_class'] = argparse.RawDescriptionHelpFormatter
+        if 'add_help' not in kwargs:
+            add_custom_help = True
+            kwargs['add_help'] = False
+        else:
+            add_custom_help = False
         super(ArgumentParser, self).__init__(*args, **kwargs)
+
+        if add_custom_help:
+            common.add_parser_help(self)
+
         if self.description:
             self.description += "\n\nOptions:\n"
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -99,6 +99,6 @@ Error: You need to install conda-build in order to use the 'conda %s'
     def print_help(self):
         super(ArgumentParser, self).print_help()
 
-        if self.prog == 'cond' and sys.argv[1:] in ([], ['help'], ['-h'], ['--help']):
+        if self.prog == 'conda' and sys.argv[1:] in ([], ['help'], ['-h'], ['--help']):
             from conda.cli.find_commands import help
             help()

--- a/conda/cli/main_bundle.py
+++ b/conda/cli/main_bundle.py
@@ -1,8 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 from conda.cli import common
-from argparse import RawDescriptionHelpFormatter
-
 
 descr = 'Create or extract a "bundle package" (EXPERIMENTAL)'
 
@@ -10,12 +8,9 @@ descr = 'Create or extract a "bundle package" (EXPERIMENTAL)'
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'bundle',
-        formatter_class = RawDescriptionHelpFormatter,
         description = descr,
         help = descr,
-        add_help=False
     )
-    common.add_parser_help(p)
     cxgroup=p.add_mutually_exclusive_group()
     cxgroup.add_argument('-c', "--create",
                          action="store_true",

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -5,7 +5,6 @@
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 from __future__ import print_function, division, absolute_import
 
-from argparse import RawDescriptionHelpFormatter
 import os
 import sys
 
@@ -30,13 +29,10 @@ Examples:
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'clean',
-        formatter_class=RawDescriptionHelpFormatter,
         description=descr,
         help=descr,
         epilog=example,
-        add_help=False
     )
-    common.add_parser_help(p)
     common.add_parser_yes(p)
     common.add_parser_json(p)
     p.add_argument(

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -8,7 +8,6 @@ from __future__ import print_function, division, absolute_import
 import re
 import os
 import sys
-from argparse import RawDescriptionHelpFormatter
 from copy import deepcopy
 
 import conda.config as config
@@ -132,13 +131,10 @@ class BoolOrListKey(common.Completer):
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'config',
-        formatter_class=RawDescriptionHelpFormatter,
         description=descr,
         help=descr,
         epilog=additional_descr + example,
-        add_help=False
         )
-    common.add_parser_help(p)
     common.add_parser_json(p)
 
     # TODO: use argparse.FileType

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -6,8 +6,6 @@
 
 from __future__ import print_function, division, absolute_import
 
-from argparse import RawDescriptionHelpFormatter
-
 from conda.cli import common, install
 
 
@@ -27,13 +25,10 @@ Examples:
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'create',
-        formatter_class=RawDescriptionHelpFormatter,
         description=descr,
         help=help,
         epilog=example,
-        add_help=False,
     )
-    common.add_parser_help(p)
     common.add_parser_install(p)
     common.add_parser_json(p)
     p.add_argument(

--- a/conda/cli/main_help.py
+++ b/conda/cli/main_help.py
@@ -6,10 +6,6 @@
 
 from __future__ import print_function, division, absolute_import
 
-from argparse import RawDescriptionHelpFormatter
-
-from conda.cli import common
-
 descr = "Displays a list of available conda commands and their help strings."
 
 example = """
@@ -21,12 +17,9 @@ def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'help',
         description=descr,
-        formatter_class=RawDescriptionHelpFormatter,
         help=descr,
         epilog=example,
-        add_help=False
     )
-    common.add_parser_help(p)
     p.add_argument(
         'command',
         metavar='COMMAND',

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -12,7 +12,6 @@ import os
 from os import listdir
 from os.path import isfile, exists, expanduser, join
 from collections import defaultdict, OrderedDict
-from argparse import RawDescriptionHelpFormatter
 
 from conda.cli import common
 
@@ -31,11 +30,8 @@ def configure_parser(sub_parsers):
         'info',
         description=help,
         help=help,
-        formatter_class=RawDescriptionHelpFormatter,
         epilog=example,
-        add_help=False,
     )
-    common.add_parser_help(p)
     common.add_parser_json(p)
     p.add_argument(
         '-a', "--all",

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -8,11 +8,9 @@ from __future__ import print_function, division, absolute_import
 
 import sys
 from os.path import isdir, join
-from argparse import RawDescriptionHelpFormatter
 
 import conda
 import conda.config as config
-from conda.cli import common
 
 descr = """
 Initialize conda into a regular environment (when conda was installed as a
@@ -34,11 +32,8 @@ def configure_parser(sub_parsers):
         'init',
         description=descr,
         epilog=warning,
-        formatter_class=RawDescriptionHelpFormatter,
         help=descr,
-        add_help=False,
     )
-    common.add_parser_help(p)
     p.set_defaults(func=execute)
 
 

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -6,8 +6,6 @@
 
 from __future__ import print_function, division, absolute_import
 
-from argparse import RawDescriptionHelpFormatter
-
 from conda.cli import common, install
 
 
@@ -28,13 +26,10 @@ Examples:
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'install',
-        formatter_class=RawDescriptionHelpFormatter,
         description=descr,
         help=help,
         epilog=example,
-        add_help=False,
     )
-    common.add_parser_help(p)
     p.add_argument(
         "--revision",
         action="store",

--- a/conda/cli/main_package.py
+++ b/conda/cli/main_package.py
@@ -19,10 +19,7 @@ def configure_parser(sub_parsers):
         'package',
         description=descr,
         help=descr,
-        formatter_class=RawTextHelpFormatter,
-        add_help=False,
     )
-    common.add_parser_help(p)
     common.add_parser_prefix(p)
     p.add_argument(
         '-w', "--which",

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -8,7 +8,6 @@ from __future__ import print_function, division, absolute_import
 
 import sys
 import logging
-from argparse import RawDescriptionHelpFormatter
 
 from conda.cli import common
 
@@ -25,11 +24,8 @@ def configure_parser(sub_parsers):
         'run',
         description=descr,
         help=descr,
-        formatter_class=RawDescriptionHelpFormatter,
         epilog=examples,
-        add_help=False,
     )
-    common.add_parser_help(p)
     common.add_parser_prefix(p)
     common.add_parser_quiet(p)
     common.add_parser_json(p)

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -9,7 +9,6 @@ from __future__ import print_function, division, absolute_import
 from conda.cli import common
 from conda.misc import make_icon_url
 from conda.resolve import NoPackagesFound
-from argparse import RawDescriptionHelpFormatter
 from conda import config
 
 descr = """Search for packages and display their information. The input is a
@@ -51,13 +50,10 @@ class Platforms(common.Completer):
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'search',
-        formatter_class=RawDescriptionHelpFormatter,
         description=descr,
         help=descr,
         epilog=example,
-        add_help=False,
     )
-    common.add_parser_help(p)
     common.add_parser_prefix(p)
     p.add_argument(
         "--canonical",

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -6,8 +6,6 @@
 
 from __future__ import print_function, division, absolute_import
 
-from argparse import RawDescriptionHelpFormatter
-
 from conda.cli import common, install
 
 
@@ -22,13 +20,10 @@ Examples:
 def configure_parser(sub_parsers):
     p = sub_parsers.add_parser(
         'update',
-        formatter_class=RawDescriptionHelpFormatter,
         description=descr,
         help=descr,
         epilog=example,
-        add_help=False,
     )
-    common.add_parser_help(p)
     common.add_parser_install(p)
     common.add_parser_json(p)
     p.add_argument(


### PR DESCRIPTION
@tswicegood you'll want to be using `conda.cli.conda_argparse.ArgumentParser` instead of `argparse.ArgumentParser` in conda-env to get these standardized fixes. Let me know if you have any issues with it. 