### PR TITLE
Mark slow tests to speed up unit test running

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo "Running tests on any file change"
+echo
+echo "Hit Ctrl+C to stop"
+echo
+watchmedo shell-command \
+  -c "py.test -m 'not slow'" \
+  -p "*.py" -R

--- a/runtests.sh
+++ b/runtests.sh
@@ -4,5 +4,5 @@ echo
 echo "Hit Ctrl+C to stop"
 echo
 watchmedo shell-command \
-  -c "py.test -m 'not slow'" \
+  -c "py.test -m 'not slow' $@" \
   -p "*.py" -R

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -6,6 +6,8 @@ import shutil
 import stat
 import subprocess
 
+import pytest
+
 from conda.compat import TemporaryDirectory
 from conda.config import root_dir, platform
 from tests.helpers import run_in
@@ -87,6 +89,8 @@ mkdir -p {envs}/test1/bin
 mkdir -p {envs}/test2/bin
 """
 
+
+@pytest.mark.slow
 def test_activate_test1():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -100,6 +104,8 @@ def test_activate_test1():
             assert stdout == envs + "/test1/bin:" + PATH
             assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test1/bin to PATH\n'.format(envs=envs, syspath=syspath)
 
+
+@pytest.mark.slow
 def test_activate_test1_test2():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -114,6 +120,8 @@ def test_activate_test1_test2():
             assert stdout == envs + "/test2/bin:" + PATH
             assert stderr == 'discarding {envs}/test1/bin from PATH\nprepending {envs}/test2/bin to PATH\n'.format(envs=envs)
 
+
+@pytest.mark.slow
 def test_activate_test3():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -127,6 +135,8 @@ def test_activate_test3():
             assert stdout == ROOTPATH
             assert stderr == 'Error: no such directory: {envs}/test3/bin\n'.format(envs=envs)
 
+
+@pytest.mark.slow
 def test_activate_test1_test3():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -142,6 +152,7 @@ def test_activate_test1_test3():
             assert stderr == 'Error: no such directory: {envs}/test3/bin\n'.format(envs=envs)
 
 
+@pytest.mark.slow
 def test_deactivate():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -156,6 +167,7 @@ def test_deactivate():
             assert stderr == 'Error: No environment to deactivate\n'
 
 
+@pytest.mark.slow
 def test_activate_test1_deactivate():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -171,6 +183,7 @@ def test_activate_test1_deactivate():
             assert stderr == 'discarding {envs}/test1/bin from PATH\n'.format(envs=envs)
 
 
+@pytest.mark.slow
 def test_wrong_args():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -212,6 +225,7 @@ def test_wrong_args():
             assert stderr == 'Error: too many arguments.\n'
 
 
+@pytest.mark.slow
 def test_activate_help():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -250,6 +264,8 @@ def test_activate_help():
             assert stdout == ''
             assert "Usage: source deactivate" in stderr
 
+
+@pytest.mark.slow
 def test_activate_symlinking():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -318,6 +334,7 @@ def test_activate_symlinking():
                 run_in('chmod 777 {envs}/test4/bin'.format(envs=envs), shell)
 
 
+@pytest.mark.slow
 def test_PS1():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -416,6 +433,7 @@ def test_PS1():
             assert stderr == 'Error: too many arguments.\n'
 
 
+@pytest.mark.slow
 def test_PS1_no_changeps1():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
@@ -521,6 +539,7 @@ changeps1: no
             assert stderr == 'Error: too many arguments.\n'
 
 
+@pytest.mark.slow
 def test_CONDA_DEFAULT_ENV():
     for shell in shells:
         with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,13 @@
 import unittest
 
+import pytest
+
 from conda.cli.common import arg2spec, spec_from_line
 
 from conda.compat import text_type
 
-from tests.helpers import capture_with_argv, capture_json_with_argv
+from tests.helpers import capture_json_with_argv
+
 
 class TestArg2Spec(unittest.TestCase):
 
@@ -127,6 +130,7 @@ class TestJson(unittest.TestCase):
         #                              '--force', '--json')
         # self.assertJsonError(res)
 
+    @pytest.mark.slow
     def test_info(self):
         res = capture_json_with_argv('conda', 'info', '--json')
         keys = ('channels', 'conda_version', 'default_prefix', 'envs',
@@ -190,6 +194,7 @@ class TestJson(unittest.TestCase):
     #                                  '-n', 'testing2', '--json', '--quiet')
     #     self.assertJsonSuccess(res)
 
+    @pytest.mark.slow
     def test_run(self):
         res = capture_json_with_argv('conda', 'run', 'not_installed', '--json')
         self.assertJsonError(res)
@@ -214,6 +219,7 @@ class TestJson(unittest.TestCase):
         res = capture_json_with_argv('conda', 'list', '--name', 'nonexistent', '-r', '--json')
         self.assertJsonError(res)
 
+    @pytest.mark.slow
     def test_search(self):
         res = capture_json_with_argv('conda', 'search', '--json')
         self.assertIsInstance(res, dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,8 @@ import unittest
 from os.path import dirname, join, exists
 import yaml
 
+import pytest
+
 import conda.config as config
 
 from tests.helpers import run_conda_command
@@ -106,6 +108,8 @@ def _read_test_condarc():
         return f.read()
 
 # Tests for the conda config command
+# FIXME This shoiuld be multiple individual tests
+@pytest.mark.slow
 def test_config_command_basics():
 
     try:
@@ -164,6 +168,9 @@ always_yes: yes
         except OSError:
             pass
 
+
+# FIXME Break into multiple tests
+@pytest.mark.slow
 def test_config_command_get():
     try:
         # Test --get
@@ -258,6 +265,9 @@ channel_alias: http://alpha.conda.binstar.org
         except OSError:
             pass
 
+
+# FIXME Break into multiple tests
+@pytest.mark.slow
 def test_config_command_parser():
     try:
         # Now test the YAML "parser"
@@ -427,6 +437,9 @@ disallow:
         except OSError:
             pass
 
+
+# FIXME Break into multiple tests
+@pytest.mark.slow
 def test_config_command_remove_force():
     try:
         # Finally, test --remove, --remove-key, and --force (right now
@@ -470,6 +483,9 @@ def test_config_command_remove_force():
         except OSError:
             pass
 
+
+# FIXME Break into multiple tests
+@pytest.mark.slow
 def test_config_command_bad_args():
     try:
         stdout, stderr = run_conda_command('config', '--file', test_condarc, '--add',

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,6 +1,7 @@
-import pycosat
-
 from itertools import product, chain, permutations
+
+import pycosat
+import pytest
 
 from conda.compat import log2, ceil
 from conda.logic import (Linear, Clauses, true, false, sat, min_sat,
@@ -448,6 +449,8 @@ def test_Linear():
     assert l.total == 0
     assert l([1, 2, 3]) == False
 
+
+@pytest.mark.slow
 def test_BDD():
     L = [
         Linear([(1, 1), (2, 2)], [0, 2]),
@@ -694,6 +697,8 @@ def test_odd_even_mergesort():
 
                 assert s == sorted(a, reverse=True), (a, s, sol)
 
+
+@pytest.mark.slow
 def test_sorter():
     L = [
         Linear([(1, 1), (2, 2)], [0, 2]),

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -3,6 +3,8 @@ import json
 import unittest
 from os.path import dirname, join
 
+import pytest
+
 from conda.resolve import ver_eval, VersionSpec, MatchSpec, Package, Resolve, NoPackagesFound
 
 from tests.helpers import raises
@@ -232,6 +234,8 @@ class TestFindSubstitute(unittest.TestCase):
             self.assertTrue(old in installed)
             self.assertEqual(r.find_substitute(installed, f_mkl, old), new)
 
+
+@pytest.mark.slow
 def test_pseudo_boolean():
     # The latest version of iopro, 1.5.0, was not built against numpy 1.5
     for alg in ['sorter', 'BDD']: #, 'BDD_recursive']:


### PR DESCRIPTION
This makes it easier to isolate the unit tests from the integration and slow tests.

To skip the slower tests:

```console
py.test -m 'not slow'
```

Running without the `-m` flag will run all of the tests the way it always has.

This also adds a simple `runtests.sh` file that uses [watchdog](https://pypi.python.org/pypi/watchdog) to automatically run the tests on any file save.