### PR TITLE
verify repodata signatures

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -24,6 +24,7 @@ from conda.utils import memoized
 from conda.connection import CondaSession, unparse_url, RETRIES
 from conda.compat import itervalues, input, urllib_quote
 from conda.lock import Locked
+from conda.verify_sig import verify_repodata
 
 import requests
 
@@ -257,6 +258,8 @@ Allowed channels are:
     for url, repodata in repodatas:
         if repodata is None:
             continue
+        if verify_repodata(repodata) == 'INVALID':
+            sys.exit("Error: Signature for %s is invalid." % url)
         new_index = repodata['packages']
         for info in itervalues(new_index):
             info['channel'] = url

--- a/conda/verify_sig.py
+++ b/conda/verify_sig.py
@@ -16,6 +16,18 @@ O4NaRivYsorIPxK37QIDAQAB
 """)
 
 
+def sig2ascii(i):
+    ret = []
+    while i:
+        i, r = divmod(i, 256)
+        ret.append(r)
+    if PY3:
+        s = bytes(n for n in ret[::-1])
+    else:
+        s = ''.join(chr(n) for n in ret[::-1])
+    return base64.b64encode(s).decode('utf-8')
+
+
 def ascii2sig(s):
     res = 0
     for c in base64.b64decode(s):

--- a/conda/verify_sig.py
+++ b/conda/verify_sig.py
@@ -1,0 +1,43 @@
+import base64
+import hashlib
+
+from conda.compat import PY3
+
+from Crypto.PublicKey import RSA
+
+
+KEY = RSA.importKey("""\
+-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDP2EHuYMftjf3dYODMif1s1eWj
+7+He5Y7LYaH27E6Kw3vr/yaY6R6G1AjyAPD+7i13AjSjYPeNfNmTk99HbYJFIX3M
+i+muS+7yOU9ItobZ/4btJbN/HScR9jPKBv3V/1QEjhFbtNNUoeZz9xZYgbkDrJo4
+O4NaRivYsorIPxK37QIDAQAB
+-----END PUBLIC KEY-----
+""")
+
+
+def ascii2sig(s):
+    res = 0
+    for c in base64.b64decode(s):
+        res *= 256
+        res += (c if PY3 else ord(c))
+    return res
+
+
+def hash_index(index):
+    h = hashlib.new('sha256')
+    for fn in sorted(index):
+        h.update('%s  %s\n' % (index[fn]['md5'], fn))
+    return h.hexdigest()
+
+
+def verify_repodata(repodata):
+    index = repodata['packages']
+    try:
+        sig = repodata['info']['signature']
+    except KeyError:
+        return "NO_SIGNATURE"
+    if KEY.verify(hash_index(index), (ascii2sig(sig),)):
+        return "VALID"
+    else:
+        return "INVALID"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,6 +1,7 @@
 import unittest
 
 from conda.fetch import cache_fn_url
+from conda.verify_sig import ascii2sig, sig2ascii
 
 
 class TestMisc(unittest.TestCase):
@@ -8,6 +9,16 @@ class TestMisc(unittest.TestCase):
     def test_cache_fn_url(self):
         url = "http://repo.continuum.io/pkgs/pro/osx-64/"
         self.assertEqual(cache_fn_url(url), '7618c8b6.json')
+
+    def test_ascii2sig(self):
+        self.assertEqual(sig2ascii(1234), 'BNI=')
+
+    def test_sig2ascii(self):
+        self.assertEqual(ascii2sig('BNI='), 1234)
+
+    def test_sig2ascii2sig(self):
+        for i in range(10000):
+            self.assertEqual(ascii2sig(sig2ascii(i)), i)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've updated the channels on repo.continuum.io with a signature in each `repodata.json` file.  This PR enables conda to verify these signatures.  When the repodata has a signature, the signature will be verified (using the public key which is hard-coded inside of conda), and if the signature is invalid, conda will exit.  Note that the signature in the repodata is optional, and when no signature is present nothing will happen.

We need to discuss the behavior in more detail.  In particular:
  * how does the user verify that the public key inside conda is the correct one?  I would say we publish it in the documentation
  * do we want to make PyCrypto a hard dependency of conda now?
  * is the current behavior what we want?
  * should add an option (to condarc) to only allow signed channels?
