### PR TITLE
Fix issue when trying to add 'pip' dependency to old python packages

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -3,11 +3,8 @@ from __future__ import print_function, division, absolute_import
 import os
 import sys
 from os.path import isdir, join, abspath
-import errno
 
 from conda.cli.common import find_prefix_name
-import conda.config
-import conda.install
 
 def help():
     # sys.argv[1] will be ..checkenv in activate if an environment is already
@@ -74,6 +71,7 @@ def main():
         if 'CONDA_DEFAULT_ENV' not in os.environ:
             sys.exit("Error: No environment to deactivate")
         try:
+            import conda.config
             binpath = binpath_from_arg(os.getenv('CONDA_DEFAULT_ENV'))
             rootpath = binpath_from_arg(conda.config.root_env_name)
         except SystemExit:
@@ -96,9 +94,12 @@ def main():
         binpath = binpath_from_arg(sys.argv[2])
         # Make sure an env always has the conda symlink
         try:
+            import conda.config
             if binpath != join(conda.config.root_dir, 'bin'):
+                import conda.install
                 conda.install.symlink_conda(join(binpath, '..'), conda.config.root_dir)
         except (IOError, OSError) as e:
+            import errno
             if e.errno == errno.EPERM or e.errno == errno.EACCES:
                 sys.exit("Cannot activate environment {}, do not have write access to write conda symlink".format(sys.argv[2]))
             raise

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -40,24 +40,6 @@ Additional help for each command can be accessed by using:
 from __future__ import print_function, division, absolute_import
 
 import sys
-import argparse
-
-from conda.cli import common
-from conda.cli import conda_argparse
-from conda.cli import main_bundle
-from conda.cli import main_create
-from conda.cli import main_help
-from conda.cli import main_init
-from conda.cli import main_info
-from conda.cli import main_install
-from conda.cli import main_list
-from conda.cli import main_remove
-from conda.cli import main_package
-from conda.cli import main_run
-from conda.cli import main_search
-from conda.cli import main_update
-from conda.cli import main_config
-from conda.cli import main_clean
 
 def main():
     if len(sys.argv) > 1:
@@ -121,6 +103,8 @@ In short:
         sys.argv.append('-h')
 
     import logging
+    from conda.cli import conda_argparse
+    import argparse
     import conda
 
     p = conda_argparse.ArgumentParser(
@@ -147,20 +131,34 @@ In short:
         dest = 'cmd',
     )
 
+    from conda.cli import main_info
     main_info.configure_parser(sub_parsers)
+    from conda.cli import main_help
     main_help.configure_parser(sub_parsers)
+    from conda.cli import main_list
     main_list.configure_parser(sub_parsers)
+    from conda.cli import main_search
     main_search.configure_parser(sub_parsers)
+    from conda.cli import main_create
     main_create.configure_parser(sub_parsers)
+    from conda.cli import main_install
     main_install.configure_parser(sub_parsers)
+    from conda.cli import main_update
     main_update.configure_parser(sub_parsers)
+    from conda.cli import main_remove
     main_remove.configure_parser(sub_parsers)
     main_remove.configure_parser(sub_parsers, name='uninstall')
+    from conda.cli import main_run
     main_run.configure_parser(sub_parsers)
+    from conda.cli import main_config
     main_config.configure_parser(sub_parsers)
+    from conda.cli import main_init
     main_init.configure_parser(sub_parsers)
+    from conda.cli import main_clean
     main_clean.configure_parser(sub_parsers)
+    from conda.cli import main_package
     main_package.configure_parser(sub_parsers)
+    from conda.cli import main_bundle
     main_bundle.configure_parser(sub_parsers)
 
     try:
@@ -177,7 +175,6 @@ In short:
 
     if getattr(args, 'json', False):
         # Silence logging info to avoid interfering with JSON output
-        import logging
         for logger in logging.Logger.manager.loggerDict:
             if logger not in ('fetch', 'progress'):
                 logging.getLogger(logger).setLevel(logging.CRITICAL + 1)
@@ -190,6 +187,7 @@ In short:
         'init' not in sys.argv and 'info' not in sys.argv):
         if hasattr(args, 'name') and hasattr(args, 'prefix'):
             import conda.config as config
+            from conda.cli import common
             if common.get_prefix(args) == config.root_dir:
                 sys.exit("""\
 Error: This installation of conda is not initialized. Use 'conda create -n
@@ -203,6 +201,8 @@ activate it.
     args_func(args, p)
 
 def args_func(args, p):
+    from conda.cli import common
+
     use_json = getattr(args, 'json', False)
     try:
         args.func(args, p)

--- a/conda/cli/misc.py
+++ b/conda/cli/misc.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division, absolute_import
 import sys
 
 import conda.config
-import conda.plan
 
 
 def main():

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -217,7 +217,7 @@ def add_pip_dependency(index):
     for info in itervalues(index):
         if (info['name'] == 'python' and
                     info['version'].startswith(('2.', '3.'))):
-            info['depends'].append('pip')
+            info.setdefault('depends', []).append('pip')
 
 @memoized
 def fetch_index(channel_urls, use_cache=False, unknown=False):


### PR DESCRIPTION
Some packages do not have a 'depends' info key, which caused 'conda
search' to fail with KeyError.