### PR TITLE
Throw away stderr when calling pip list

### DIFF
--- a/conda/pip.py
+++ b/conda/pip.py
@@ -40,11 +40,10 @@ def installed(prefix, output=True):
     args = pip_args(prefix)
     if args is None:
         return
-    args.append('list')
+    args.extend(('list', '--disable-pip-version-check'))
     try:
         pipinst = subprocess.check_output(
-            args, universal_newlines=True,
-            stderr=subprocess.DEVNULL
+            args, universal_newlines=True
         ).split('\n')
     except Exception:
         # Any error should just be ignored

--- a/conda/pip.py
+++ b/conda/pip.py
@@ -43,7 +43,8 @@ def installed(prefix, output=True):
     args.append('list')
     try:
         pipinst = subprocess.check_output(
-            args, universal_newlines=True
+            args, universal_newlines=True,
+            stderr=subprocess.DEVNULL
         ).split('\n')
     except Exception:
         # Any error should just be ignored

--- a/conda/pip.py
+++ b/conda/pip.py
@@ -20,7 +20,16 @@ def pip_args(prefix):
         pip_path = join(prefix, 'bin', 'pip')
         py_path = join(prefix, 'bin', 'python')
     if isfile(pip_path) and isfile(py_path):
-        return [py_path, pip_path]
+        ret = [py_path, pip_path]
+
+        # Check the version of pip
+        # --disable-pip-version-check was introduced in pip 6.0
+        # If older than that, they should probably get the warning anyway.
+        pip_version = subprocess.check_output(ret + ['-V']).split()[1]
+        major_ver = pip_version.split('.')[0]
+        if int(major_ver) >= 6:
+            ret.append('--disable-pip-version-check')
+        return ret
     else:
         return None
 
@@ -40,7 +49,7 @@ def installed(prefix, output=True):
     args = pip_args(prefix)
     if args is None:
         return
-    args.extend(('list', '--disable-pip-version-check'))
+    args.append('list')
     try:
         pipinst = subprocess.check_output(
             args, universal_newlines=True


### PR DESCRIPTION
This causes weird console coloring issues on windows.
We could redirect it to STDOUT and just ignore when we parse it, or we can just throw it away from the beginning.