### PR TITLE
Rename binstar.org -> anaconda.org

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -155,7 +155,7 @@ def add_parser_channels(p):
         'defaults' to get the default packages for conda, and 'system' to get the system
         packages, which also takes .condarc into account.  You can also use any name and the
         .condarc channel_alias value will be prepended.  The default channel_alias
-        is http://conda.binstar.org/.""" # we can't put , here; invalid syntax
+        is http://conda.anaconda.org/.""" # we can't put , here; invalid syntax
     )
     p.add_argument(
         "--override-channels",

--- a/conda/config.py
+++ b/conda/config.py
@@ -53,7 +53,7 @@ rc_list_keys = [
     'envs_dirs'
     ]
 
-DEFAULT_CHANNEL_ALIAS = 'https://conda.binstar.org/'
+DEFAULT_CHANNEL_ALIAS = 'https://conda.anaconda.org/'
 
 ADD_BINSTAR_TOKEN = True
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -233,8 +233,8 @@ class TestJson(unittest.TestCase):
             capture_json_with_argv('conda', 'search', '--unknown', '--json'),
             capture_json_with_argv('conda', 'search', '--use-index-cache', '--json'),
             capture_json_with_argv('conda', 'search', '--outdated', '--json'),
-            capture_json_with_argv('conda', 'search', '-c', 'https://conda.binstar.org/asmeurer', '--json'),
-            capture_json_with_argv('conda', 'search', '-c', 'https://conda.binstar.org/asmeurer', '--override-channels', '--json'),
+            capture_json_with_argv('conda', 'search', '-c', 'https://conda.anaconda.org/asmeurer', '--json'),
+            capture_json_with_argv('conda', 'search', '-c', 'https://conda.anaconda.org/asmeurer', '--override-channels', '--json'),
             capture_json_with_argv('conda', 'search', '--platform', 'win-32', '--json'),):
             self.assertIsInstance(res, dict)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,16 +69,16 @@ class TestConfig(unittest.TestCase):
 
     def test_normalize_urls(self):
         current_platform = config.subdir
-        assert config.DEFAULT_CHANNEL_ALIAS == 'https://conda.binstar.org/'
+        assert config.DEFAULT_CHANNEL_ALIAS == 'https://conda.anaconda.org/'
         assert config.rc.get('channel_alias') == 'https://your.repo/'
 
         for channel in config.normalize_urls(['defaults', 'system',
-            'https://binstar.org/username', 'file:///Users/username/repo',
+            'https://anaconda.org/username', 'file:///Users/username/repo',
             'username']):
             assert (channel.endswith('/%s/' % current_platform) or
                     channel.endswith('/noarch/'))
         self.assertEqual(config.normalize_urls([
-            'defaults', 'system', 'https://conda.binstar.org/username',
+            'defaults', 'system', 'https://conda.anaconda.org/username',
             'file:///Users/username/repo', 'username'
             ], 'osx-64'),
             [
@@ -94,8 +94,8 @@ class TestConfig(unittest.TestCase):
                 'http://repo.continuum.io/pkgs/free/noarch/',
                 'http://repo.continuum.io/pkgs/pro/osx-64/',
                 'http://repo.continuum.io/pkgs/pro/noarch/',
-                'https://conda.binstar.org/username/osx-64/',
-                'https://conda.binstar.org/username/noarch/',
+                'https://conda.anaconda.org/username/osx-64/',
+                'https://conda.anaconda.org/username/noarch/',
                 'file:///Users/username/repo/osx-64/',
                 'file:///Users/username/repo/noarch/',
                 'https://your.repo/username/osx-64/',


### PR DESCRIPTION
Here, we merely focus on renaming `binstar.org` to `anaconda.org`.