### PR TITLE
Fix issue when trying to add 'pip' dependency to old python packages

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -217,7 +217,7 @@ def add_pip_dependency(index):
     for info in itervalues(index):
         if (info['name'] == 'python' and
                     info['version'].startswith(('2.', '3.'))):
-            info['depends'].append('pip')
+            info.setdefault('depends', []).append('pip')
 
 @memoized
 def fetch_index(channel_urls, use_cache=False, unknown=False):


### PR DESCRIPTION
Some packages do not have a 'depends' info key, which caused 'conda
search' to fail with KeyError.