### PR TITLE
add support for local ssl certificates.

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -321,7 +321,9 @@ def get_local_ssl_cert():
             return (ssl_cert, ssl_key)
         elif ssl_cert:
             return ssl_cert
-    sys.exit("Error: ssl_cert must have cert and/or key defined")
+        else:
+            sys.exit("Error: ssl_cert must have cert and/or key defined")
+    sys.exit("Error: ssl_cert setting is not a mapping")
 
 ssl_verify = bool(rc.get('ssl_verify', True))
 

--- a/conda/config.py
+++ b/conda/config.py
@@ -75,6 +75,7 @@ rc_other = [
     'proxy_servers',
     'root_dir',
     'channel_alias',
+    'ssl_cert'
     ]
 
 user_rc_path = abspath(expanduser('~/.condarc'))
@@ -309,6 +310,21 @@ def get_proxy_servers():
         return res
     sys.exit("Error: proxy_servers setting not a mapping")
 
+# ----- SSL Verification ----
+
+def get_local_ssl_cert():
+    res = rc.get('ssl_cert') or {}
+    if isinstance(res, dict):
+        ssl_key = res.get('key', None)
+        ssl_cert = res.get('cert', None)
+        if ssl_cert and ssl_key:
+            return (ssl_cert, ssl_key)
+        elif ssl_cert:
+            return ssl_cert
+    sys.exit("Error: ssl_cert must have cert and/or key defined")
+
+ssl_verify = bool(rc.get('ssl_verify', True))
+
 # ----- foreign -----
 
 try:
@@ -331,7 +347,6 @@ show_channel_urls = bool(rc.get('show_channel_urls', False))
 disallow = set(rc.get('disallow', []))
 # packages which are added to a newly created environment by default
 create_default_packages = list(rc.get('create_default_packages', []))
-ssl_verify = bool(rc.get('ssl_verify', True))
 try:
     track_features = set(rc['track_features'].split())
 except KeyError:

--- a/conda/connection.py
+++ b/conda/connection.py
@@ -64,6 +64,10 @@ class CondaSession(requests.Session):
         if proxies:
             self.proxies = proxies
 
+        cert = get_local_ssl_cert()
+        if cert:
+            self.cert = cert
+
         # Configure retries
         if retries:
             http_adapter = requests.adapters.HTTPAdapter(max_retries=retries)

--- a/conda/connection.py
+++ b/conda/connection.py
@@ -19,7 +19,7 @@ import tempfile
 
 import conda
 from conda.compat import urlparse, StringIO
-from conda.config import get_proxy_servers
+from conda.config import get_proxy_servers, get_local_ssl_cert
 
 import requests
 

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -97,7 +97,8 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
     try:
         resp = session.get(url + 'repodata.json.bz2',
                            headers=headers, proxies=session.proxies,
-                           verify=config.ssl_verify)
+                           verify=config.ssl_verify,
+                           cert=session.cert)
         resp.raise_for_status()
         if resp.status_code != 304:
             cache = json.loads(bz2.decompress(resp.content).decode('utf-8'))


### PR DESCRIPTION
This PR addresses https://github.com/conda/conda/issues/1387

Adds support for ```ssl_cert``` section to .condarc for specifying local SSL certificates.
```
ssl_cert:
    cert: <path to local certificate>
    key: [optional] <path to keyfile>
```

Needs testing.