### PR TITLE
Require `pycrypto` as an install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     description = "package management tool",
     long_description = open('README.rst').read(),
     packages = ['conda', 'conda.cli', 'conda.progressbar'],
-    install_requires = ['pycosat', 'pyyaml', 'requests'],
+    install_requires = ['pycosat', 'pycrypto', 'pyyaml', 'requests'],
     **kwds
 )


### PR DESCRIPTION
Fixes conda/conda#1434.