### PR TITLE
Making bash command completion work with subcommands (like conda build)

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -152,4 +152,4 @@ Error: You need to install conda-build in order to use the 'conda %s'
         if argcomplete:
             CondaSubprocessCompletionFinder()(self)
 
-        super(ArgumentParser, self).set_defaults(*args, **kwargs)
+        return super(ArgumentParser, self).set_defaults(*args, **kwargs)

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -158,4 +158,4 @@ Error: You need to install conda-build in order to use the 'conda %s'
         if argcomplete:
             CondaSubprocessCompletionFinder()(self)
 
-        return super(ArgumentParser, self).set_defaults(*args, **kwargs)
+        return super(ArgumentParser, self).parse_args(*args, **kwargs)

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -19,10 +19,15 @@ from conda.cli import common
 build_commands = {'build', 'index', 'skeleton', 'package', 'metapackage',
     'pipbuild', 'develop', 'convert'}
 
+_ARGCOMPLETE_DEBUG = False
 def debug(msg):
-    f = open('/dev/ttys007', 'w')
-    f.write("\n%s\n" % msg)
-    f.flush()
+    # To debug this, replace ttys001 with the fd of the terminal you are using
+    # (use the `tty` command to find this), and set _ARGCOMPLETE_DEBUG above
+    # to True.
+    if _ARGCOMPLETE_DEBUG:
+        f = open('/dev/ttys001', 'w')
+        f.write("\n%s\n" % msg)
+        f.flush()
 
 try:
     import argcomplete

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -67,7 +67,6 @@ if argcomplete:
                     p = subprocess.Popen(args, env=environ, close_fds=False)
                     p.communicate()
                     sys.exit()
-                    p.wait()
             else:
                 debug("Not using subprocess")
                 debug(sys.argv)

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -19,11 +19,12 @@ from conda.cli import common
 build_commands = {'build', 'index', 'skeleton', 'package', 'metapackage',
     'pipbuild', 'develop', 'convert'}
 
-_ARGCOMPLETE_DEBUG = False
-def debug(msg):
+_ARGCOMPLETE_DEBUG = True
+def debug_argcomplete(msg):
     # To debug this, replace ttys001 with the fd of the terminal you are using
     # (use the `tty` command to find this), and set _ARGCOMPLETE_DEBUG above
-    # to True.
+    # to True. You can also `export _ARC_DEBUG=1` in the shell you are using
+    # to print debug messages from argcomplete.
     if _ARGCOMPLETE_DEBUG:
         f = open('/dev/ttys001', 'w')
         f.write("\n%s\n" % msg)
@@ -41,15 +42,15 @@ if argcomplete:
         def __call__(self, argument_parser, **kwargs):
             call_super = lambda: super(CondaSubprocessCompletionFinder, self).__call__(argument_parser, **kwargs)
 
-            debug("Working")
+            debug_argcomplete("Working")
 
             if argument_parser.prog != 'conda':
-                debug("Argument parser is not conda")
+                debug_argcomplete("Argument parser is not conda")
                 return call_super()
 
             environ = os.environ.copy()
             if 'COMP_LINE' not in environ:
-                debug("COMP_LINE not in environ")
+                debug_argcomplete("COMP_LINE not in environ")
                 return call_super()
 
             subcommands = find_commands()
@@ -57,18 +58,19 @@ if argcomplete:
                 if 'conda %s' % subcommand in environ['COMP_LINE']:
                     environ['COMP_LINE'] = environ['COMP_LINE'].replace('conda %s'
                         % subcommand, 'conda-%s' % subcommand)
-                    debug("Using subprocess")
-                    debug(sys.argv)
+                    debug_argcomplete("Using subprocess")
+                    debug_argcomplete(sys.argv)
                     import pprint
-                    debug(pprint.pformat(environ))
+                    debug_argcomplete(pprint.pformat(environ))
                     args = [find_executable('conda-%s' % subcommand)]
-                    debug(args)
+                    debug_argcomplete(args)
                     p = subprocess.Popen(args, env=environ, close_fds=False)
                     p.communicate()
                     sys.exit()
             else:
-                debug("Not using subprocess")
-                debug(sys.argv)
+                debug_argcomplete("Not using subprocess")
+                debug_argcomplete(sys.argv)
+                debug_argcomplete(argument_parser)
                 return call_super()
 
 class ArgumentParser(argparse.ArgumentParser):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -62,7 +62,6 @@ if argcomplete:
                     import pprint
                     debug(pprint.pformat(environ))
                     args = [find_executable('conda-%s' % subcommand)]
-                    # args.extend(sys.argv[2:])
                     debug(args)
                     p = subprocess.Popen(args, env=environ, close_fds=False)
                     p.communicate()

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -19,7 +19,7 @@ from conda.cli import common
 build_commands = {'build', 'index', 'skeleton', 'package', 'metapackage',
     'pipbuild', 'develop', 'convert'}
 
-_ARGCOMPLETE_DEBUG = True
+_ARGCOMPLETE_DEBUG = False
 def debug_argcomplete(msg):
     # To debug this, replace ttys001 with the fd of the terminal you are using
     # (use the `tty` command to find this), and set _ARGCOMPLETE_DEBUG above

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -161,49 +161,6 @@ In short:
     from conda.cli import main_bundle
     main_bundle.configure_parser(sub_parsers)
 
-    try:
-        def debug(msg):
-            f = open('/dev/ttys007', 'w')
-            f.write("\n%s\n" % msg)
-            f.flush()
-
-        import argcomplete
-        class SubprocessCompletionFinder(argcomplete.CompletionFinder):
-            def __call__(self, argument_parser, **kwargs):
-                debug("Working")
-                import os
-                import subprocess
-                from conda.cli.find_commands import find_executable
-                environ = os.environ.copy()
-                for subcommand in ['build', 'skeleton']:
-                    environ['COMP_LINE'] = environ['COMP_LINE'].replace('conda %s'
-                        % subcommand, 'conda-%s' % subcommand)
-
-                    if subcommand in environ['COMP_LINE']:
-                        debug("Using subprocess")
-                        debug(sys.argv)
-                        import pprint
-                        debug(pprint.pformat(environ))
-                        args = [find_executable('conda-%s' % subcommand)]
-                        # args.extend(sys.argv[2:])
-                        debug(args)
-                        p = subprocess.Popen(args, env=environ, close_fds=False)
-                        p.communicate()
-                        sys.exit()
-                        p.wait()
-                else:
-                    debug(sys.argv)
-                    return super().__call__(argument_parser, **kwargs)
-
-        SubprocessCompletionFinder()(p)
-
-    except ImportError:
-        pass
-    except AttributeError:
-        # On Python 3.3, argcomplete can be an empty namespace package when
-        # we are in the conda-recipes directory.
-        pass
-
     args = p.parse_args()
 
     if getattr(args, 'json', False):

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -161,6 +161,9 @@ In short:
     from conda.cli import main_bundle
     main_bundle.configure_parser(sub_parsers)
 
+    from conda.cli.find_commands import find_commands
+    sub_parsers.completer = lambda prefix, **kwargs: [i for i in
+        list(sub_parsers.choices) + find_commands() if i.startswith(prefix)]
     args = p.parse_args()
 
     if getattr(args, 'json', False):

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -162,8 +162,41 @@ In short:
     main_bundle.configure_parser(sub_parsers)
 
     try:
+        def debug(msg):
+            f = open('/dev/ttys007', 'w')
+            f.write("\n%s\n" % msg)
+            f.flush()
+
         import argcomplete
-        argcomplete.autocomplete(p)
+        class SubprocessCompletionFinder(argcomplete.CompletionFinder):
+            def __call__(self, argument_parser, **kwargs):
+                debug("Working")
+                import os
+                import subprocess
+                from conda.cli.find_commands import find_executable
+                environ = os.environ.copy()
+                for subcommand in ['build', 'skeleton']:
+                    environ['COMP_LINE'] = environ['COMP_LINE'].replace('conda %s'
+                        % subcommand, 'conda-%s' % subcommand)
+
+                    if subcommand in environ['COMP_LINE']:
+                        debug("Using subprocess")
+                        debug(sys.argv)
+                        import pprint
+                        debug(pprint.pformat(environ))
+                        args = [find_executable('conda-%s' % subcommand)]
+                        # args.extend(sys.argv[2:])
+                        debug(args)
+                        p = subprocess.Popen(args, env=environ, close_fds=False)
+                        p.communicate()
+                        sys.exit()
+                        p.wait()
+                else:
+                    debug(sys.argv)
+                    return super().__call__(argument_parser, **kwargs)
+
+        SubprocessCompletionFinder()(p)
+
     except ImportError:
         pass
     except AttributeError:


### PR DESCRIPTION
So far this is just a basic proof-of-concept. 

You have to install argcomplete into conda build and conda skeleton for this
to work. It does not yet detect subprocess commands (it hard-codes 'build' and
'skeleton'), and it does not yet complete the subprocess commands themselves.