### PR TITLE
Sort the output of conda info package

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -177,7 +177,7 @@ def execute(args, parser):
 
         for spec in specs:
             versions = r.get_pkgs(MatchSpec(spec))
-            for pkg in versions:
+            for pkg in sorted(versions):
                 pretty_package(pkg)
 
         return


### PR DESCRIPTION
That way, packages with versions greater than 9 will be sorted correctly.