### PR TITLE
Rename binstar -> conda_server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,12 +107,12 @@ http://docs.continuum.io/conda/build.html for documentation on how to build
 recipes.
 
 To upload to anaconda.org, create an account.  Then, install the
-conda-server client and login
+anaconda-client and login
 
 .. code-block:: bash
 
-   $ conda install conda-server
-   $ conda-server login
+   $ conda install anaconda-client
+   $ anaconda login
 
 Then, after you build your recipe
 

--- a/README.rst
+++ b/README.rst
@@ -98,20 +98,21 @@ To go back to the root environment, use
 Building Your Own Packages
 --------------------------
 
-You can easily build your own packages for conda, and upload them to `Binstar
-<https://binstar.org>`_, a free service for hosting packages for conda, as
-well as other package managers.  To build a package, create a recipe.  See
-http://github.com/conda/conda-recipes for many example recipes, and
+You can easily build your own packages for conda, and upload them
+to `anaconda.org <https://anaconda.org>`_, a free service for hosting
+packages for conda, as well as other package managers.
+To build a package, create a recipe.
+See http://github.com/conda/conda-recipes for many example recipes, and
 http://docs.continuum.io/conda/build.html for documentation on how to build
 recipes.
 
-To upload to Binstar, create an account on binstar.org.  Then, install the
-binstar client and login
+To upload to anaconda.org, create an account.  Then, install the
+conda-server client and login
 
 .. code-block:: bash
 
-   $ conda install binstar
-   $ binstar login
+   $ conda install conda-server
+   $ conda-server login
 
 Then, after you build your recipe
 
@@ -119,14 +120,14 @@ Then, after you build your recipe
 
    $ conda build <recipe-dir>
 
-you will be prompted to upload to binstar.
+you will be prompted to upload to anaconda.org.
 
-To add your Binstar channel, or the channel of others to conda so that ``conda
-install`` will find and install their packages, run
+To add your anaconda.org channel, or the channel of others to conda so
+that ``conda install`` will find and install their packages, run
 
 .. code-block:: bash
 
-   $ conda config --add channels https://conda.binstar.org/username
+   $ conda config --add channels https://conda.anaconda.org/username
 
 (replacing ``username`` with the user name of the person whose channel you want
 to add).

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -363,15 +363,15 @@ environment does not exist: %s
                 if close:
                     error_message += ("\n\nDid you mean one of these?"
                                       "\n\n    %s" % (', '.join(close)))
-            error_message += '\n\nYou can search for this package on Binstar with'
-            error_message += '\n\n    binstar search -t conda %s' % pkg
+            error_message += '\n\nYou can search for this package on anaconda.org with'
+            error_message += '\n\n    conda-server search -t conda %s' % pkg
             if len(e.pkgs) > 1:
                 # Note this currently only happens with dependencies not found
                 error_message += '\n\n (and similarly for the other packages)'
-            binstar = find_executable('binstar', include_others=False)
-            if not binstar:
-                error_message += '\n\nYou may need to install the Binstar command line client with'
-                error_message += '\n\n    conda install binstar'
+            cs = find_executable('conda-server', include_others=False)
+            if not cs:
+                error_message += '\n\nYou may need to install the conda-server command line client with'
+                error_message += '\n\n    conda install conda-server'
             common.error_and_exit(error_message, json=args.json)
     except SystemExit as e:
         # Unsatisfiable package specifications/no such revision/import error

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -364,14 +364,14 @@ environment does not exist: %s
                     error_message += ("\n\nDid you mean one of these?"
                                       "\n\n    %s" % (', '.join(close)))
             error_message += '\n\nYou can search for this package on anaconda.org with'
-            error_message += '\n\n    conda-server search -t conda %s' % pkg
+            error_message += '\n\n    anaconda search -t conda %s' % pkg
             if len(e.pkgs) > 1:
                 # Note this currently only happens with dependencies not found
                 error_message += '\n\n (and similarly for the other packages)'
-            cs = find_executable('conda-server', include_others=False)
+            cs = find_executable('anaconda', include_others=False)
             if not cs:
-                error_message += '\n\nYou may need to install the conda-server command line client with'
-                error_message += '\n\n    conda install conda-server'
+                error_message += '\n\nYou may need to install the anaconda-client command line client with'
+                error_message += '\n\n    conda install anaconda-client'
             common.error_and_exit(error_message, json=args.json)
     except SystemExit as e:
         # Unsatisfiable package specifications/no such revision/import error

--- a/conda/config.py
+++ b/conda/config.py
@@ -60,12 +60,14 @@ ADD_BINSTAR_TOKEN = True
 
 rc_bool_keys = [
     'add_binstar_token',
+    'add_conda_server_token',
     'always_yes',
     'allow_softlinks',
     'changeps1',
     'use_pip',
     'offline',
     'binstar_upload',
+    'conda_server_upload',
     'show_channel_urls',
     'allow_other_channels',
     ]
@@ -195,7 +197,8 @@ def is_url(url):
 
 @memoized
 def binstar_channel_alias(channel_alias):
-    if rc.get('add_binstar_token', ADD_BINSTAR_TOKEN):
+    if rc.get('add_conda_server_token',
+              rc.get('add_binstar_token', ADD_BINSTAR_TOKEN)):
         try:
             from binstar_client.utils import get_binstar
             bs = get_binstar()
@@ -327,7 +330,8 @@ except IOError:
 always_yes = bool(rc.get('always_yes', False))
 changeps1 = bool(rc.get('changeps1', True))
 use_pip = bool(rc.get('use_pip', True))
-binstar_upload = rc.get('binstar_upload', None) # None means ask
+binstar_upload = rc.get('conda_server_upload',
+                        rc.get('binstar_upload', None)) # None means ask
 allow_softlinks = bool(rc.get('allow_softlinks', True))
 self_update = bool(rc.get('self_update', True))
 # show channel URLs when displaying what is going to be downloaded

--- a/conda/config.py
+++ b/conda/config.py
@@ -60,14 +60,14 @@ ADD_BINSTAR_TOKEN = True
 
 rc_bool_keys = [
     'add_binstar_token',
-    'add_conda_server_token',
+    'add_anaconda_token',
     'always_yes',
     'allow_softlinks',
     'changeps1',
     'use_pip',
     'offline',
     'binstar_upload',
-    'conda_server_upload',
+    'anaconda_upload',
     'show_channel_urls',
     'allow_other_channels',
     ]
@@ -197,7 +197,7 @@ def is_url(url):
 
 @memoized
 def binstar_channel_alias(channel_alias):
-    if rc.get('add_conda_server_token',
+    if rc.get('add_anaconda_token',
               rc.get('add_binstar_token', ADD_BINSTAR_TOKEN)):
         try:
             from binstar_client.utils import get_binstar
@@ -330,7 +330,7 @@ except IOError:
 always_yes = bool(rc.get('always_yes', False))
 changeps1 = bool(rc.get('changeps1', True))
 use_pip = bool(rc.get('use_pip', True))
-binstar_upload = rc.get('conda_server_upload',
+binstar_upload = rc.get('anaconda_upload',
                         rc.get('binstar_upload', None)) # None means ask
 allow_softlinks = bool(rc.get('allow_softlinks', True))
 self_update = bool(rc.get('self_update', True))

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -133,7 +133,7 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
             # Note, this will not trigger if the binstar configured url does
             # not match the conda configured one.
             msg = ("Warning: you may need to login to anaconda.org again with "
-                "'conda-server login' to access private packages(%s, %s)" %
+                "'anaconda login' to access private packages(%s, %s)" %
                 (config.hide_binstar_tokens(url), e))
             stderrlog.info(msg)
             return fetch_repodata(config.remove_binstar_tokens(url),

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -118,7 +118,7 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
 
         if e.response.status_code == 404:
             if url.startswith(config.DEFAULT_CHANNEL_ALIAS):
-                msg = ('Could not find Binstar user %s' %
+                msg = ('Could not find anaconda.org user %s' %
                    config.remove_binstar_tokens(url).split(
                         config.DEFAULT_CHANNEL_ALIAS)[1].split('/')[0])
             else:
@@ -132,8 +132,8 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
                         config.DEFAULT_CHANNEL_ALIAS) in url):
             # Note, this will not trigger if the binstar configured url does
             # not match the conda configured one.
-            msg = ("Warning: you may need to login to binstar again with "
-                "'binstar login' to access private packages(%s, %s)" %
+            msg = ("Warning: you may need to login to anaconda.org again with "
+                "'conda-server login' to access private packages(%s, %s)" %
                 (config.hide_binstar_tokens(url), e))
             stderrlog.info(msg)
             return fetch_repodata(config.remove_binstar_tokens(url),


### PR DESCRIPTION
allow renamed entries in condarc, ie.
```
add_binstar_token -> add_anaconda_token
binstar_upload -> anaconda_upload
```
For backwards compatibility the old names can still be used.
If both are defined in the `~/.condarc` file, the new ones take precedence, e.g.
```
binstar_upload: True
anaconda_upload: False
```
will result in `anaconda_upload` being set to `False`.

Also the readme, and user facing messages are updated.

Internal (in the code) occurrences of binstar are **NOT** renamed.