### PR TITLE
Handle conda-meta files that can't be read in conda update

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -259,8 +259,8 @@ def install(args, parser, command='install'):
         r = Resolve(index)
         orig_packages = args.packages[:]
         for name in orig_packages:
-            installed_metadata = [ci.is_linked(prefix, dist)
-                                  for dist in linked]
+            installed_metadata = filter(None, [ci.is_linked(prefix, dist)
+                                  for dist in linked])
             vers_inst = [dist.rsplit('-', 2)[1] for dist in linked
                          if dist.rsplit('-', 2)[0] == name]
             build_inst = [m['build_number'] for m in installed_metadata if


### PR DESCRIPTION
Fixes #1460