### PR TITLE
Test help on CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ install:
   - python setup.py install
   - conda info -a
 
-script: py.test
+script:
+  - py.test
+  - conda --help
 
 notifications:
     flowdock: ef3821a08a791106512ccfc04c92eccb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,4 +42,5 @@ install:
 
 test_script:
   - C:\Miniconda\Scripts\py.test -vvv
+  - C:\Miniconda\Scripts\conda --help
   - IF %PYTHON%==2.7 IF DEFINED PYCOSAT C:\Miniconda\Scripts\conda install -f menuinst ipython-notebook & echo "Finished menuinst test"


### PR DESCRIPTION
It would be nice to catch issues with `conda --help` in advance of a release. This is an easy way to do so.

Ultimately, something like this would be good, as well ( https://github.com/conda/conda-build/pull/400 ). Though it may need more work.