### PR TITLE
Use `splitlines` to break up multiple lines

### DIFF
--- a/conda/cli/find_commands.py
+++ b/conda/cli/find_commands.py
@@ -76,7 +76,7 @@ def filter_descr(cmd):
         return
     pat = re.compile(r'(\r?\n){2}(.*?)(\r?\n){2}', re.DOTALL)
     m = pat.search(output.decode('utf-8'))
-    descr = ['<could not extract description>'] if m is None else m.group(2).split('\n')
+    descr = ['<could not extract description>'] if m is None else m.group(2).splitlines()
     # XXX: using some stuff from textwrap would be better here, as it gets
     # longer than 80 characters
     print('    %-12s %s' % (cmd, descr[0]))

--- a/conda/pip.py
+++ b/conda/pip.py
@@ -53,7 +53,7 @@ def installed(prefix, output=True):
     try:
         pipinst = subprocess.check_output(
             args, universal_newlines=True
-        ).split('\n')
+        ).splitlines()
     except Exception:
         # Any error should just be ignored
         if output:

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -381,7 +381,7 @@ def get_pinned_specs(prefix):
     if not exists(pinfile):
         return []
     with open(pinfile) as f:
-        return [i for i in f.read().strip().split('\n') if i and not i.strip().startswith('#')]
+        return [i for i in f.read().strip().splitlines() if i and not i.strip().startswith('#')]
 
 
 def install_actions(prefix, index, specs, force=False, only_names=None,

--- a/tests/mk_index.py
+++ b/tests/mk_index.py
@@ -20,7 +20,7 @@ for info in index.itervalues():
 print(len(index))
 
 data = json.dumps(index, indent=2, sort_keys=True)
-data = '\n'.join(line.rstrip() for line in data.split('\n'))
+data = '\n'.join(line.rstrip() for line in data.splitlines())
 if not data.endswith('\n'):
     data += '\n'
 with open('index.json', 'w') as fo:


### PR DESCRIPTION
Continuation of the work here ( conda/conda-build#516 ) except with `conda` proper.