### PR TITLE
simplify build sub-command handling

### DIFF
--- a/conda/cli/find_commands.py
+++ b/conda/cli/find_commands.py
@@ -85,7 +85,7 @@ def filter_descr(cmd):
 
 
 def help():
-    print("\nexternal commands:")
+    print("\nother commands:")
     for cmd in find_commands():
         filter_descr(cmd)
 


### PR DESCRIPTION
The point of this PR is to simplify how sub commands from conda-build handled, and also to only allow sub-commands coming from conda-build (and conda-env for the time being).