### PR TITLE
enable running 'conda run' in offline mode

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -164,8 +164,8 @@ def app_uninstall(fn, prefix=config.root_dir):
     plan.execute_actions(actions, index)
 
 
-def get_package_versions(package):
-    index = get_index()
+def get_package_versions(package, offline=False):
+    index = get_index(offline=offline)
     r = Resolve(index)
     if package in r.groups:
         return r.get_pkgs(MatchSpec(package))

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -36,6 +36,7 @@ def configure_parser(sub_parsers):
     common.add_parser_prefix(p)
     common.add_parser_quiet(p)
     common.add_parser_json(p)
+    common.add_parser_offline(p)
     p.add_argument(
         'package',
         metavar='COMMAND',
@@ -77,7 +78,7 @@ def execute(args, parser):
                                   error_type="PackageNotInstalled")
     else:
         installed = []
-        for pkg in get_package_versions(args.package):
+        for pkg in get_package_versions(args.package, args.offline):
             if app_is_installed(pkg.fn, prefixes=[prefix]):
                 installed.append(pkg)
 


### PR DESCRIPTION
This PR enables the --offline flag for the 'conda run' command, so that commands can be ran in an environment without fetching package information from online channels.