### PR TITLE
check whether hardlinking is available before make a link (second attempt)

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -802,7 +802,10 @@ def main():
         extract(pkgs_dir, dist)
 
     elif opts.link:
-        link(pkgs_dir, prefix, dist)
+        linktype = (LINK_HARD
+                    if try_hard_link(pkgs_dir, prefix, dist) else
+                    LINK_COPY)
+        link(pkgs_dir, prefix, dist, linktype)
 
     elif opts.unlink:
         unlink(prefix, dist)


### PR DESCRIPTION
When I install a tarball to an env on another mount point from `~/.conda/envs/.pkgs` (e.g. `/tmp/env`, where `/tmp` and `/home` are different mount points), conda install fails silently because it tries to use hard links.

In my opinion, it is awful to check whether hardlinking is available everywhere you want to use `link`, but my previous pull-request #1410 was rejected. Thus, I fix this thing to close the bug that I hit this time, but I'm almost sure there are more related to this somewhere else. Good luck.

P.S. Don't ask me why it fallbacks from hardlinks to copying instead of symlinks.