### PR TITLE
print_packages breaks installation of a package with no "run" dependencies

### DIFF
--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -165,7 +165,7 @@ Error: environment does not exist: %s
         print('\n'.join(output))
     else:
         common.stdout_json(output)
-    sys.exit(exitcode)
+    return exitcode
 
 
 def execute(args, parser):
@@ -200,4 +200,5 @@ def execute(args, parser):
     if args.json:
         format = 'canonical'
 
-    print_packages(prefix, regex, format, piplist=args.pip, json=args.json)
+    exitcode = print_packages(prefix, regex, format, piplist=args.pip, json=args.json)
+    sys.exit(exitcode)


### PR DESCRIPTION
I moved `sys.exit` from `print_packages` to `execute` where it makes more sense because `print_packages` is also used in `cli/install.py`, where it makes no sense to return exit status 1 when a package was installed successfully, but had no dependencies.