### PR TITLE
check whether hardlinking is available before make a link (third attempt)

### DIFF
--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -83,8 +83,11 @@ def split_linkarg(arg):
 
 
 def link(prefix, arg, index=None):
-    dist, pkgs_dir, lt = split_linkarg(arg)
-    install.link(pkgs_dir, prefix, dist, lt, index=index)
+    dist, pkgs_dir, linktype = split_linkarg(arg)
+    linktype = (install.LINK_HARD
+                 if install.try_hard_link(pkgs_dir, prefix, dist) else
+                 install.LINK_COPY)
+    install.link(pkgs_dir, prefix, dist, linktype, index=index)
 
 
 def LINK_CMD(state, arg):


### PR DESCRIPTION
After a discussion in #1490 I realized that yet another place has to be patched.

When I install a tarball to an env on another mount point from `~/.conda/envs/.pkgs` (e.g. `/tmp/env`, where `/tmp` and `/home` are different mount points), `conda install` fails silently because it tries to use hard links.

In my opinion, it is awful to check whether hardlinking is available everywhere you want to use link, but my previous pull-request #1410 was rejected. Thus, I fix this thing to close the bug that I hit this time, but I'm almost sure there are more related to this somewhere else. Good luck.

P.S. Don't ask me why it fallbacks from hardlinks to copying instead of symlinks.