### PR TITLE
Add option --create-env to conda install command

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -49,7 +49,7 @@ def install_tar(prefix, tar_path, verbose=False):
     return depends
 
 
-def check_prefix(prefix, json=False):
+def check_prefix(prefix, json=False, create_env=False):
     from conda.config import root_env_name
 
     name = basename(prefix)
@@ -58,7 +58,7 @@ def check_prefix(prefix, json=False):
         error = "environment name cannot start with '.': %s" % name
     if name == root_env_name:
         error = "'%s' is a reserved environment name" % name
-    if exists(prefix):
+    if not create_env and exists(prefix):
         error = "prefix already exists: %s" % prefix
 
     if error:
@@ -125,12 +125,12 @@ def install(args, parser, command='install'):
     """
     conda install, conda update, and conda create
     """
-    newenv = bool(command == 'create')
+    newenv = bool(command == 'create' or (command == 'install' and args.create_env))
     if newenv:
         common.ensure_name_or_prefix(args, command)
     prefix = common.get_prefix(args, search=not newenv)
     if newenv:
-        check_prefix(prefix, json=args.json)
+        check_prefix(prefix, json=args.json, create_env=args.create_env)
 
     if command == 'update':
         if args.all:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -130,7 +130,7 @@ def install(args, parser, command='install'):
         common.ensure_name_or_prefix(args, command)
     prefix = common.get_prefix(args, search=not newenv)
     if args.create_env and newenv and exists(prefix):
-        newenv = False
+        newenv = False  # only create a new environment if it does not exist yet
     if newenv:
         check_prefix(prefix, json=args.json)
 

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -49,7 +49,7 @@ def install_tar(prefix, tar_path, verbose=False):
     return depends
 
 
-def check_prefix(prefix, json=False, create_env=False):
+def check_prefix(prefix, json=False):
     from conda.config import root_env_name
 
     name = basename(prefix)
@@ -58,7 +58,7 @@ def check_prefix(prefix, json=False, create_env=False):
         error = "environment name cannot start with '.': %s" % name
     if name == root_env_name:
         error = "'%s' is a reserved environment name" % name
-    if not create_env and exists(prefix):
+    if exists(prefix):
         error = "prefix already exists: %s" % prefix
 
     if error:
@@ -129,8 +129,10 @@ def install(args, parser, command='install'):
     if newenv:
         common.ensure_name_or_prefix(args, command)
     prefix = common.get_prefix(args, search=not newenv)
+    if args.create_env and newenv and exists(prefix):
+        newenv = False
     if newenv:
-        check_prefix(prefix, json=args.json, create_env=args.create_env)
+        check_prefix(prefix, json=args.json)
 
     if command == 'update':
         if args.all:

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -36,6 +36,11 @@ def configure_parser(sub_parsers):
         help="Revert to the specified REVISION.",
         metavar='REVISION',
     )
+    p.add_argument(
+        "--create-env",
+        action="store_true",
+        help="Create the environment if it does not exist yet.",
+    )
     common.add_parser_install(p)
     common.add_parser_json(p)
     p.set_defaults(func=execute)


### PR DESCRIPTION
In continuous integration scenarios I currently resort to the following boilerplate to ensure that a conda environment is used:

```
conda create --yes --quiet --name <env> <packages>
conda install --yes --quiet --name <env> <packages>
call activate <env>
<interesting actions here>
call deactivate <env>
```

Obviously, after the first run, the `conda create` call will always throw an error.

This PR makes it possible to avoid the boilerplate, by creating the environment if it does not exist yet in the `conda install` command, by adding the option `--create-env`:

`conda install --yes --quiet --name <env> <packages> --create-env`