### PR TITLE
Detect threading issue

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -253,7 +253,8 @@ Allowed channels are:
             for future in future_to_url:
                 url = future_to_url[future]
                 repodatas.append((url, future.result()))
-    except ImportError:
+    except (ImportError, RuntimeError):
+        # RuntimeError is thrown if number of threads are limited by OS
         # concurrent.futures is only available in Python 3
         repodatas = map(lambda url: (url, fetch_repodata(url,
                                      use_cache=use_cache, session=session)),


### PR DESCRIPTION
`concurrent.futures` throws a RuntimeError if it cannot spawn new threads due for example to a limit from the OS.
Catching this exception and running fetch single-threaded.

See #1547

/cc @wasade @asmeurer 