### PR TITLE
add ability to set CONDA_FORCE_32BIT environment variable

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 stderrlog = logging.getLogger('stderrlog')
 
 default_python = '%d.%d' % sys.version_info[:2]
+force_32bit = bool(os.getenv('CONDA_FORCE_32BIT', 0))
 
 # ----- operating system and architecture -----
 
@@ -29,6 +30,11 @@ _sys_map = {'linux2': 'linux', 'linux': 'linux',
 non_x86_linux_machines = {'armv6l', 'armv7l', 'ppc64le'}
 platform = _sys_map.get(sys.platform, 'unknown')
 bits = 8 * tuple.__itemsize__
+if force_32bit:
+    if bits == 32:
+        sys.exit("Error: you cannot set CONDA_FORCE_32BIT using a "
+                 "32-bit Python running conda")
+    bits = 32
 
 if platform == 'linux' and machine() in non_x86_linux_machines:
     arch_name = machine()
@@ -151,7 +157,7 @@ envs_dirs = [abspath(expanduser(path)) for path in (
 
 def pkgs_dir_from_envs_dir(envs_dir):
     if abspath(envs_dir) == abspath(join(root_dir, 'envs')):
-        return join(root_dir, 'pkgs')
+        return join(root_dir, 'pkgs32' if force_32bit else 'pkgs')
     else:
         return join(envs_dir, '.pkgs')
 


### PR DESCRIPTION
This is meant to be used only for conda-build when building 32-bit binaries on a 64-bit system.