### PR TITLE
allow wildcards in AND-connected version specs

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -88,25 +88,34 @@ def ver_eval(version, constraint):
                            constraint)
 
 
+class VersionSpecAtom(object):
+
+    def __init__(self, spec):
+        assert '|' not in spec
+        assert ',' not in spec
+        self.spec = spec
+        if spec.startswith(('=', '<', '>', '!')):
+            self.regex = False
+        else:
+            rx = spec.replace('.', r'\.')
+            rx = rx.replace('*', r'.*')
+            rx = r'(%s)$' % rx
+            self.regex = re.compile(rx)
+
+    def match(self, version):
+        if self.regex:
+            return bool(self.regex.match(version))
+        else:
+            return ver_eval(version, self.spec)
+
 class VersionSpec(object):
 
     def __init__(self, spec):
         assert '|' not in spec
-        if spec.startswith(('=', '<', '>', '!')):
-            self.regex = False
-            self.constraints = spec.split(',')
-        else:
-            self.regex = True
-            rx = spec.replace('.', r'\.')
-            rx = rx.replace('*', r'.*')
-            rx = r'(%s)$' % rx
-            self.pat = re.compile(rx)
+        self.constraints = [VersionSpecAtom(vs) for vs in spec.split(',')]
 
     def match(self, version):
-        if self.regex:
-            return bool(self.pat.match(version))
-        else:
-            return all(ver_eval(version, c) for c in self.constraints)
+        return all(c.match(version) for c in self.constraints)
 
 
 class MatchSpec(object):

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -56,6 +56,8 @@ class TestMatchSpec(unittest.TestCase):
             ('numpy >1.8,<2|==1.7', False),('numpy >1.8,<2|>=1.7.1', True),
             ('numpy >=1.8|1.7*', True),    ('numpy ==1.7', False),
             ('numpy >=1.5,>1.6', True),    ('numpy ==1.7.1', True),
+            ('numpy >=1,*.7.*', True),     ('numpy *.7.*,>=1', True),
+            ('numpy >=1,*.8.*', False),    ('numpy >=2,*.7.*', False),
             ('numpy 1.6*|1.7*', True),     ('numpy 1.6*|1.8*', False),
             ('numpy 1.6.2|1.7*', True),    ('numpy 1.6.2|1.7.1', True),
             ('numpy 1.6.2|1.7.0', False),  ('numpy 1.7.1 py27_0', True),


### PR DESCRIPTION
Use case: Imagine a version number convention that contains the version of the compiler used to build the package, such as `mypackage-2.4.vc11` (a convention like this makes particular sense for C++ code, because C++ binaries tend to be incompatible between compilers). At present, one can use this in a package's requirements section like this:
```yml
requirements:
  build:
    - mypackage  *.vc11    # [win]
```
but not in combination with another constraint like this:
```yml
    - mypackage  >=2,*.vc11    # [win]
```
since conda forbids wildcards `*` in comma-separated version specs. The present pull request simply lifts this restriction, making the second spec legal as well. It contains tests for the new option and should otherwise be fully backwards compatible.