### PR TITLE
add config option to makes the python dependency on pip optional

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -70,6 +70,7 @@ ADD_BINSTAR_TOKEN = True
 rc_bool_keys = [
     'add_binstar_token',
     'add_anaconda_token',
+    'add_pip_as_python_dependency',
     'always_yes',
     'allow_softlinks',
     'changeps1',
@@ -336,6 +337,7 @@ except IOError:
 
 # ----- misc -----
 
+add_pip_as_python_dependency = bool(rc.get('add_pip_as_python_dependency', True))
 always_yes = bool(rc.get('always_yes', False))
 changeps1 = bool(rc.get('changeps1', True))
 use_pip = bool(rc.get('use_pip', True))

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -274,8 +274,10 @@ Allowed channels are:
     stdoutlog.info('\n')
     if unknown:
         add_unknown(index)
-    add_pip_dependency(index)
+    if config.add_pip_as_python_dependency:
+        add_pip_dependency(index)
     return index
+
 
 def fetch_pkg(info, dst_dir=None, session=None):
     '''


### PR DESCRIPTION
As of conda 3.9.0, `pip` is automatically added as a dependency of `python` (2 or 3).  This behavior might not always be desirable, and this PR adds an option to the condarc file in order to make this behavior optional:
```
# Adds pip as Python dependency.  The default is True
add_pip_as_python_dependency: False
```