### PR TITLE
Don't replace rc with dev99999

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -23,7 +23,6 @@ setup_handlers()
 
 
 def normalized_version(version):
-    version = version.replace('rc', '.dev99999')
     try:
         return verlib.NormalizedVersion(version)
     except verlib.IrrationalVersionError:


### PR DESCRIPTION
suggest_normalized_version already replaces "rc" with "c", which gives the
correct ordering. dev99999 is wrong when compared against a dev version with a
number that is greater than 99999.