### PR TITLE
Improve fall-back comparison when version strings do not conform to PEP 386

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - conda config --set always_yes yes
   - bin/conda install --force --no-deps conda requests
   - conda --version
-  - conda install -c conda pytest requests mock conda-env pycrypto pyflakes
+  - conda install -c conda pytest requests mock conda-env pycrypto pyflakes six
   - if [[ "$PYCOSAT" ]]; then
       conda install pycosat=$PYCOSAT;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - conda config --set always_yes yes
   - bin/conda install --force --no-deps conda requests
   - conda --version
-  - conda install -c conda pytest requests mock conda-env pycrypto pyflakes six
+  - conda install -c conda pytest requests mock conda-env pycrypto pyflakes
   - if [[ "$PYCOSAT" ]]; then
       conda install pycosat=$PYCOSAT;
     fi

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -42,7 +42,7 @@ def version_to_list(version):
     
         '1.2.1099a4' => [1, 2, 1099, 'a', 4]
     """
-    version_split = re.findall(r'([0-9]+|[^0-9]+|\.)', version)
+    version_split = re.findall(r'([0-9]+|[^0-9.]+|\.)', version)
     return [int(k) if k.isdigit() else k for k in version_split if k != '.']
 
 class NoPackagesFound(RuntimeError):

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -32,6 +32,18 @@ def normalized_version(version):
             return verlib.NormalizedVersion(suggested_version)
         return version
 
+def version_to_list(version):
+    """
+    Splits a version string into a list of numbers and strings, where
+    the individual elements are formed by first splitting at dots '.' 
+    and then splitting again into maximal runs of numeric or non-numeric 
+    characters respectively. The function assumes that 'version' does not
+    contain '-'. Example:
+    
+        '1.2.1099a4' => [1, 2, 1099, 'a', 4]
+    """
+    version_split = re.findall(r'([0-9]+|[^0-9]+|\.)', version)
+    return [int(k) if k.isdigit() else k for k in version_split if k != '.']
 
 class NoPackagesFound(RuntimeError):
     def __init__(self, msg, pkgs):
@@ -175,6 +187,7 @@ class Package(object):
         self.build = info['build']
         self.channel = info.get('channel')
         self.norm_version = normalized_version(self.version)
+        self.list_version = version_to_list(self.version)
         self.info = info
 
     def _asdict(self):
@@ -203,8 +216,8 @@ class Package(object):
             return ((self.norm_version, self.build_number, other.build) <
                     (other.norm_version, other.build_number, self.build))
         except TypeError:
-            return ((self.version, self.build_number) <
-                    (other.version, other.build_number))
+            return ((self.list_version, self.build_number) <
+                    (other.list_version, other.build_number))
 
     def __eq__(self, other):
         if not isinstance(other, Package):

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -4,7 +4,8 @@ import re
 import sys
 import logging
 from collections import defaultdict
-from functools import partial
+from functools import partial, reduce
+import six
 
 from conda import verlib
 from conda.utils import memoize
@@ -32,18 +33,61 @@ def normalized_version(version):
             return verlib.NormalizedVersion(suggested_version)
         return version
 
-def version_to_list(version):
-    """
-    Splits a version string into a list of numbers and strings, where
-    the individual elements are formed by first splitting at dots '.' 
-    and then splitting again into maximal runs of numeric or non-numeric 
-    characters respectively. The function assumes that 'version' does not
-    contain '-'. Example:
-    
-        '1.2.1099a4' => [1, 2, 1099, 'a', 4]
-    """
-    version_split = re.findall(r'([0-9]+|[^0-9.]+|\.)', version)
-    return [int(k) if k.isdigit() else k for k in version_split if k != '.']
+def heterogeneous_compare(left, right):
+    if isinstance(left, six.string_types):
+        if isinstance(right, six.string_types):
+            # both string: lexicographic comparison
+            if left < right:
+                return -1
+            elif right < left:
+                return 1
+            else:
+                return 0
+        else:
+            # string is always bigger than number
+            return 1
+    else:
+        if isinstance(right, six.string_types):
+            # nuber is always less than string
+            return -1
+        else:
+            # both number: numeric comparison
+            if left < right:
+                return -1
+            elif right < left:
+                return 1
+            else:
+                return 0
+
+class VersionAsList(object):
+    def __init__(self, version):
+        """
+        Splits a version string into a list of numbers and strings, where
+        the individual elements are formed by first splitting at dots '.' 
+        and then splitting again into maximal runs of numeric or non-numeric 
+        characters respectively. The function assumes that 'version' does not
+        contain '-'. Example:
+        
+            '1.2.1099a4' => [1, 2, 1099, 'a', 4]
+        """
+        version_split = re.findall(r'([0-9]+|[^0-9.]+|\.)', version)
+        self.version = [int(k) if k.isdigit() else k for k in version_split if k != '.']
+        
+    def __eq__(self, other):
+        return self.version == other.version
+        
+    def __lt__(self, other):
+        """
+        Perform lexicographic comparison of two version lists. Corresponding elements 
+        are compared such that numbers use numeric comparison, strings use lexicographic
+        comparison, and numbers are smaller than strings (regardless of value) in mixed pairs.
+        """
+        res = reduce(lambda t, x: heterogeneous_compare(x[0], x[1]) if t == 0 else t,
+                     zip(self.version, other.version), 0)
+        if res == 0:
+            return len(self.version) < len(other.version)
+        else:
+            return res < 0
 
 class NoPackagesFound(RuntimeError):
     def __init__(self, msg, pkgs):
@@ -187,7 +231,7 @@ class Package(object):
         self.build = info['build']
         self.channel = info.get('channel')
         self.norm_version = normalized_version(self.version)
-        self.list_version = version_to_list(self.version)
+        self.list_version = VersionAsList(self.version)
         self.info = info
 
     def _asdict(self):
@@ -219,8 +263,6 @@ class Package(object):
             return ((self.norm_version, self.build_number, other.build) <
                     (other.norm_version, other.build_number, self.build))
         except TypeError:
-            # this comparison relies on the Python convention that an integer is
-            # always less than a string, regardless of values
             return ((self.list_version, self.build_number) <
                     (other.list_version, other.build_number))
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -5,11 +5,10 @@ import sys
 import logging
 from collections import defaultdict
 from functools import partial, reduce
-import six
 
 from conda import verlib
 from conda.utils import memoize
-from conda.compat import itervalues, iteritems
+from conda.compat import itervalues, iteritems, string_types
 from conda.logic import (false, true, sat, min_sat, generate_constraints,
     bisect_constraints, evaluate_eq, minimal_unsatisfiable_subset, MaximumIterationsError)
 from conda.console import setup_handlers
@@ -34,8 +33,8 @@ def normalized_version(version):
         return version
 
 def heterogeneous_compare(left, right):
-    if isinstance(left, six.string_types):
-        if isinstance(right, six.string_types):
+    if isinstance(left, string_types):
+        if isinstance(right, string_types):
             # both string: lexicographic comparison
             if left < right:
                 return -1
@@ -47,7 +46,7 @@ def heterogeneous_compare(left, right):
             # string is always bigger than number
             return 1
     else:
-        if isinstance(right, six.string_types):
+        if isinstance(right, string_types):
             # nuber is always less than string
             return -1
         else:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -213,9 +213,14 @@ class Package(object):
             raise TypeError('cannot compare packages with different '
                              'names: %r %r' % (self.fn, other.fn))
         try:
+            # FIXME: 'self.build' and 'other.build' are intentionally swapped
+            # FIXME: see https://github.com/conda/conda/commit/3cc3ecc662914abe1d98b8d9c4caaa7c932a838e
+            # FIXME: this should be reverted when the underlying problem is solved
             return ((self.norm_version, self.build_number, other.build) <
                     (other.norm_version, other.build_number, self.build))
         except TypeError:
+            # this comparison relies on the Python convention that an integer is
+            # always less than a string, regardless of values
             return ((self.list_version, self.build_number) <
                     (other.list_version, other.build_number))
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -5,7 +5,7 @@ from os.path import dirname, join
 
 import pytest
 
-from conda.resolve import ver_eval, VersionSpec, MatchSpec, Package, Resolve, NoPackagesFound
+from conda.resolve import ver_eval, VersionSpec, MatchSpec, Package, Resolve, NoPackagesFound, version_to_list
 
 from tests.helpers import raises
 
@@ -19,6 +19,39 @@ f_mkl = set(['mkl'])
 
 
 class TestVersionSpec(unittest.TestCase):
+
+    def test_version_split(self):
+        versions = [
+           ("0.4",        [0, 4]),
+           ("0.4.1",      [0, 4, 1]),
+           ("0.5",        [0, 5]),
+           ("0.5a1",      [0, 5, 'a', 1]),
+           ("0.5b3",      [0, 5, 'b', 3 ]),
+           ("0.9.6",      [0, 9, 6]),
+           ("0.960923",   [0, 960923]),
+           ("1.0",        [1, 0]),
+           ("1.0.4",      [1, 0, 4]),
+           ("1.0.4a3",    [1, 0, 4, 'a', 3]),
+           ("1.0.4b1",    [1, 0, 4, 'b', 1]),
+           ("1.13++",     [1, 13, '++']),
+           ("2.0b1pl0",   [2, 0, 'b', 1, 'pl', 0]),
+           ("2.2be5ta29", [2, 2, 'be', 5, 'ta', 29]),
+           ("2.2be.ta29", [2, 2, 'be', 'ta', 29]),
+           ("2.2beta29",  [2, 2, 'beta', 29]),
+           ("2g6",        [2, 'g', 6]),
+           ("3.1.1.6",    [3, 1, 1, 6]),
+           ("3.2.p.l0",   [3, 2, 'p', 'l', 0]),
+           ("3.2.pl0",    [3, 2, 'pl', 0]),
+           ("3.2.pl.1",   [3, 2, 'pl', 1]),
+           ("5.5.kw",     [5, 5, 'kw']),
+           ("5.5.mw.",    [5, 5, 'mw']),
+           ("11g",        [11, 'g']),
+           ("1996.07.12", [1996, 7, 12]),
+        ]
+        for v, l in versions:
+            self.assertEqual(version_to_list(v), l)
+        
+        self.assertEqual(sorted(versions, key=lambda x: x[1]), versions)
 
     def test_ver_eval(self):
         self.assertEqual(ver_eval('1.7.0', '==1.7'), True)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -5,7 +5,7 @@ from os.path import dirname, join
 
 import pytest
 
-from conda.resolve import ver_eval, VersionSpec, MatchSpec, Package, Resolve, NoPackagesFound, version_to_list
+from conda.resolve import ver_eval, VersionSpec, MatchSpec, Package, Resolve, NoPackagesFound, VersionAsList
 
 from tests.helpers import raises
 
@@ -22,36 +22,36 @@ class TestVersionSpec(unittest.TestCase):
 
     def test_version_split(self):
         versions = [
-           ("0.4",        [0, 4]),
-           ("0.4.1",      [0, 4, 1]),
-           ("0.5",        [0, 5]),
-           ("0.5a1",      [0, 5, 'a', 1]),
-           ("0.5b3",      [0, 5, 'b', 3 ]),
-           ("0.9.6",      [0, 9, 6]),
-           ("0.960923",   [0, 960923]),
-           ("1.0",        [1, 0]),
-           ("1.0.4",      [1, 0, 4]),
-           ("1.0.4a3",    [1, 0, 4, 'a', 3]),
-           ("1.0.4b1",    [1, 0, 4, 'b', 1]),
-           ("1.13++",     [1, 13, '++']),
-           ("2.0b1pl0",   [2, 0, 'b', 1, 'pl', 0]),
-           ("2.2be5ta29", [2, 2, 'be', 5, 'ta', 29]),
-           ("2.2be.ta29", [2, 2, 'be', 'ta', 29]),
-           ("2.2beta29",  [2, 2, 'beta', 29]),
-           ("2g6",        [2, 'g', 6]),
-           ("3.1.1.6",    [3, 1, 1, 6]),
-           ("3.2.p.l0",   [3, 2, 'p', 'l', 0]),
-           ("3.2.pl0",    [3, 2, 'pl', 0]),
-           ("3.2.pl.1",   [3, 2, 'pl', 1]),
-           ("5.5.kw",     [5, 5, 'kw']),
-           ("5.5.mw.",    [5, 5, 'mw']),
-           ("11g",        [11, 'g']),
-           ("1996.07.12", [1996, 7, 12]),
+           (VersionAsList("0.4"),        [0, 4]),
+           (VersionAsList("0.4.1"),      [0, 4, 1]),
+           (VersionAsList("0.5"),        [0, 5]),
+           (VersionAsList("0.5a1"),      [0, 5, 'a', 1]),
+           (VersionAsList("0.5b3"),      [0, 5, 'b', 3 ]),
+           (VersionAsList("0.9.6"),      [0, 9, 6]),
+           (VersionAsList("0.960923"),   [0, 960923]),
+           (VersionAsList("1.0"),        [1, 0]),
+           (VersionAsList("1.0.4"),      [1, 0, 4]),
+           (VersionAsList("1.0.4a3"),    [1, 0, 4, 'a', 3]),
+           (VersionAsList("1.0.4b1"),    [1, 0, 4, 'b', 1]),
+           (VersionAsList("1.13++"),     [1, 13, '++']),
+           (VersionAsList("2.0b1pl0"),   [2, 0, 'b', 1, 'pl', 0]),
+           (VersionAsList("2.2be5ta29"), [2, 2, 'be', 5, 'ta', 29]),
+           (VersionAsList("2.2be.ta29"), [2, 2, 'be', 'ta', 29]),
+           (VersionAsList("2.2beta29"),  [2, 2, 'beta', 29]),
+           (VersionAsList("2g6"),        [2, 'g', 6]),
+           (VersionAsList("3.1.1.6"),    [3, 1, 1, 6]),
+           (VersionAsList("3.2.p.l0"),   [3, 2, 'p', 'l', 0]),
+           (VersionAsList("3.2.pl0"),    [3, 2, 'pl', 0]),
+           (VersionAsList("3.2.pl.1"),   [3, 2, 'pl', 1]),
+           (VersionAsList("5.5.kw"),     [5, 5, 'kw']),
+           (VersionAsList("5.5.mw."),    [5, 5, 'mw']),
+           (VersionAsList("11g"),        [11, 'g']),
+           (VersionAsList("1996.07.12"), [1996, 7, 12]),
         ]
         for v, l in versions:
-            self.assertEqual(version_to_list(v), l)
+            self.assertEqual(v.version, l)
         
-        self.assertEqual(sorted(versions, key=lambda x: x[1]), versions)
+        self.assertEqual(sorted(versions, key=lambda x: x[0]), versions)
 
     def test_ver_eval(self):
         self.assertEqual(ver_eval('1.7.0', '==1.7'), True)


### PR DESCRIPTION
This PR resolves problem B in issue https://github.com/conda/conda/issues/1590 and possibly https://github.com/conda/conda/issues/915.