### PR TITLE
Fix for Python 3.5

### DIFF
--- a/conda/compat.py
+++ b/conda/compat.py
@@ -20,7 +20,7 @@ if PY3:
     def lchmod(path, mode):
         try:
             os.chmod(path, mode, follow_symlinks=False)
-        except (TypeError, NotImplementedError):
+        except (TypeError, NotImplementedError, SystemError):
             # On systems that don't allow permissions on symbolic links, skip
             # links entirely.
             if not os.path.islink(path):


### PR DESCRIPTION
I was experiencing this issue:

```
NotImplementedError: chmod: follow_symlinks unavailable on this platform

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/scopatz/miniconda3/bin/conda-build", line 5, in <module>
    sys.exit(main())
  File "/home/scopatz/miniconda3/lib/python3.5/site-packages/conda_build/main_build.py", line 190, in main
    args_func(args, p)
  File "/home/scopatz/miniconda3/lib/python3.5/site-packages/conda_build/main_build.py", line 429, in args_func
    args.func(args, p)
  File "/home/scopatz/miniconda3/lib/python3.5/site-packages/conda_build/main_build.py", line 384, in execute
    override_channels=args.override_channels, include_recipe=args.include_recipe)
  File "/home/scopatz/miniconda3/lib/python3.5/site-packages/conda_build/build.py", line 458, in build
    post_build(m, sorted(files2 - files1))
  File "/home/scopatz/miniconda3/lib/python3.5/site-packages/conda_build/post.py", line 339, in post_build
    fix_permissions(files)
  File "/home/scopatz/miniconda3/lib/python3.5/site-packages/conda_build/post.py", line 329, in fix_permissions
    lchmod(join(root, dn), int('755', 8))
  File "/home/scopatz/miniconda3/lib/python3.5/site-packages/conda/compat.py", line 22, in lchmod
    os.chmod(path, mode, follow_symlinks=False)
SystemError: <built-in function chmod> returned a result with an error set
```

and here was my conda info

```
Current conda install:

             platform : linux-64
        conda version : 3.17.0
  conda-build version : 1.17.0
       python version : 3.5.0.final.0
     requests version : 2.7.0
     root environment : /home/scopatz/miniconda3  (writable)
  default environment : /home/scopatz/miniconda3
     envs directories : /home/scopatz/miniconda3/envs
        package cache : /home/scopatz/miniconda3/pkgs
         channel URLs : https://conda.binstar.org/cyclus/linux-64/
                        https://conda.binstar.org/cyclus/noarch/
                        https://conda.anaconda.org/pyne/linux-64/
                        https://conda.anaconda.org/pyne/noarch/
                        https://conda.anaconda.org/asmeurer/linux-64/
                        https://conda.anaconda.org/asmeurer/noarch/
                        https://conda.anaconda.org/pypi/linux-64/
                        https://conda.anaconda.org/pypi/noarch/
                        https://repo.continuum.io/pkgs/free/linux-64/
                        https://repo.continuum.io/pkgs/free/noarch/
                        https://repo.continuum.io/pkgs/pro/linux-64/
                        https://repo.continuum.io/pkgs/pro/noarch/
          config file : /home/scopatz/.condarc
    is foreign system : False
```