### PR TITLE
Fix install order for all python packages: Add special case in conda.toposort()

### DIFF
--- a/conda/toposort.py
+++ b/conda/toposort.py
@@ -96,6 +96,16 @@ def toposort(data, safe=True):
 
     data = {k:set(v) for k, v in data.items()}
 
+    if 'python' in data:
+        # Special case: Remove circular dependency between python and pip,
+        # to ensure python is always installed before anything that needs it.
+        # For more details:
+        # - https://github.com/conda/conda/issues/1152
+        # - https://github.com/conda/conda/pull/1154
+        # - https://github.com/conda/conda-build/issues/401
+        # - https://github.com/conda/conda/pull/1614
+        data['python'].discard('pip')
+
     if safe:
         return list(_safe_toposort(data))
     else:

--- a/tests/test_toposort.py
+++ b/tests/test_toposort.py
@@ -40,6 +40,44 @@ class TopoSortTests(unittest.TestCase):
         # Results do not have an guaranteed order
         self.assertEqual(set(results[3:]), {'1', '2'})
 
+    def test_python_is_prioritized(self):
+        """
+        This test checks a special invariant related to 'python' specifically.
+        Python is part of a cycle (pip <--> python), which can cause it to be
+        installed *after* packages that need python (possibly in 
+        post-install.sh).
+        
+        A special case in toposort() breaks the cycle, to ensure that python
+        isn't installed too late.  Here, we verify that it works.
+        """
+        # This is the actual dependency graph for python (as of the time of this writing, anyway)
+        data = {'python' : ['pip', 'openssl', 'readline', 'sqlite', 'tk', 'xz', 'zlib'],
+                'pip': ['python', 'setuptools', 'wheel'],
+                'setuptools' : ['python'],
+                'wheel' : ['python'],
+                'openssl' : [],
+                'readline' : [],
+                'sqlite' : [],
+                'tk' : [],
+                'xz' : [],
+                'zlib' : []}
+
+        # Here are some extra pure-python libs, just for good measure.
+        data.update({'psutil' : ['python'],
+                     'greenlet' : ['python'],
+                     'futures' : ['python'],
+                     'six' : ['python']})
+
+        results = toposort(data)
+
+        # Python always comes before things that need it!
+        self.assertLess(results.index('python'), results.index('setuptools'))
+        self.assertLess(results.index('python'), results.index('wheel'))
+        self.assertLess(results.index('python'), results.index('pip'))
+        self.assertLess(results.index('python'), results.index('psutil'))
+        self.assertLess(results.index('python'), results.index('greenlet'))
+        self.assertLess(results.index('python'), results.index('futures'))
+        self.assertLess(results.index('python'), results.index('six'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Update:** I simplified this PR with @asmeurer's suggestion to simply break the `python`/`pip` cycle before sorting.  See comments below.

----

When an environment is constructed, the package install order is chosen by `conda.toposort()`.

If the list of package specs contains any circular dependencies, then `conda.toposort()` uses a [simple heuristic](https://github.com/conda/conda/blob/81a3a34b8b5fda9095ccfa3e8ffac636a2b80343/conda/toposort.py#L49-L50) to guide the package install order.  Yet, recipes may still occasionally fail to build, or `post-link.sh` may fail to execute, due to an unfortunate install order. (For example, see conda/conda-build#401)

The **most common culprit** is the circular dependency between `python` and `pip`.  Since python is used by many many recipes, it seems worth enhancing `toposort()` with a special case that ensures `python` is installed as early as possible. That is, if we're choosing arbitrarily among several packages, and `python` is one of the choices, choose `python` first.

This PR doesn't fix the install order for other circular dependencies, but at least it fixes the most common (maybe only?) circular dependency that package maintainers are likely to encounter to date.