### PR TITLE
Moving files to trash if failed to remove them in windows

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -183,7 +183,7 @@ def rm_rf(path, max_retries=5, trash=True):
 
                     if trash:
                         try:
-                            move_to_trash(path)
+                            move_path_to_trash(path)
                             if not isdir(path):
                                 return
                         except OSError as e2:
@@ -507,7 +507,7 @@ def is_linked(prefix, dist):
     except IOError:
         return None
 
-def delete_trash():
+def delete_trash(prefix=None):
     from conda import config
 
     for pkg_dir in config.pkgs_dirs:
@@ -518,7 +518,17 @@ def delete_trash():
         except OSError as e:
             log.debug("Could not delete the trash dir %s (%s)" % (trash_dir, e))
 
-def move_to_trash(path):
+def move_to_trash(prefix, f, tempdir=None):
+    """
+    Move a file f from prefix to the trash
+
+    tempdir is a deprecated parameter, and will be ignored.
+
+    This function is deprecated in favor of `move_path_to_trash`.
+    """
+    return move_path_to_trash(join(prefix, f))
+
+def move_path_to_trash(path):
     """
     Move a path to the trash
     """
@@ -599,7 +609,7 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
                     log.error('failed to unlink: %r' % dst)
                     if on_win:
                         try:
-                            move_to_trash(dst)
+                            move_path_to_trash(dst)
                         except ImportError:
                             # This shouldn't be an issue in the installer anyway
                             pass
@@ -689,7 +699,7 @@ def unlink(prefix, dist):
                 if on_win and os.path.exists(join(prefix, f)):
                     try:
                         log.debug("moving to trash")
-                        move_to_trash(dst)
+                        move_path_to_trash(dst)
                     except ImportError:
                         # This shouldn't be an issue in the installer anyway
                         pass

--- a/conda/install.py
+++ b/conda/install.py
@@ -27,18 +27,18 @@ the standard library).
 
 from __future__ import print_function, division, absolute_import
 
-import time
-import os
-import json
 import errno
+import json
+import logging
+import os
+import shlex
 import shutil
 import stat
-import sys
 import subprocess
+import sys
 import tarfile
+import time
 import traceback
-import logging
-import shlex
 from os.path import abspath, basename, dirname, isdir, isfile, islink, join, relpath
 
 try:
@@ -531,14 +531,20 @@ def move_to_trash(path):
         import tempfile
         trash_dir = join(pkg_dir, '.trash')
 
-        if not isdir(trash_dir):
+        try:
             os.makedirs(trash_dir)
+        except OSError as e1:
+            if e1.errno != errno.EEXIST:
+                continue
 
         trash_dir = tempfile.mkdtemp(dir=trash_dir)
         trash_dir = join(trash_dir, relpath(os.path.dirname(path), config.root_dir))
 
-        if not isdir(trash_dir):
+        try:
             os.makedirs(trash_dir)
+        except OSError as e2:
+            if e2.errno != errno.EEXIST:
+                continue
 
         try:
             shutil.move(path, trash_dir)

--- a/conda/install.py
+++ b/conda/install.py
@@ -507,7 +507,7 @@ def is_linked(prefix, dist):
     except IOError:
         return None
 
-def delete_trash(prefix):
+def delete_trash():
     from conda import config
 
     for pkg_dir in config.pkgs_dirs:
@@ -565,11 +565,6 @@ def link(pkgs_dir, prefix, dist, linktype=LINK_HARD, index=None):
     Set up a package in a specified (environment) prefix.  We assume that
     the package has been extracted (using extract() above).
     '''
-    if on_win:
-        # Try deleting the trash every time we link something.
-        delete_trash(prefix)
-
-
     index = index or {}
     log.debug('pkgs_dir=%r, prefix=%r, dist=%r, linktype=%r' %
               (pkgs_dir, prefix, dist, linktype))


### PR DESCRIPTION
This change will attempt to 'fix' issues when removing locked files in Windows.

To avoid that problem, I just used the trash mechanism already implemented in conda, and put it into `rm_rf`.

I slightly broke the api for `move_to_trash, but it doesn't look like the `tempdir` was used anywhere.

Fixes #1594