### PR TITLE
PEP-440 Fix

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -98,6 +98,7 @@ class VersionSpecAtom(object):
             self.regex = False
         else:
             rx = spec.replace('.', r'\.')
+            rx = spec.replace('+', r'\+')
             rx = rx.replace('*', r'.*')
             rx = r'(%s)$' % rx
             self.regex = re.compile(rx)


### PR DESCRIPTION
According to [PEP-440](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers) the separator for the local version identifier should be a`+` which isn't currently handled by conda.

This PR simply allows for `+` to be used as a separator. Without it conda can't handle PEP-440 compliant package names and gives either a somewhat misleading *"Could not find some dependencies"* error or an assertion error of the form:
```
Traceback (most recent call last):
  File "C:\dev\bin\Anaconda\Scripts\conda-script.py", line 4, in <module>
    sys.exit(main())
  File "C:\dev\bin\Anaconda\lib\site-packages\conda\cli\main.py", line 194, in main
    args_func(args, p)
  File "C:\dev\bin\Anaconda\lib\site-packages\conda\cli\main.py", line 201, in args_func
    args.func(args, p)
  File "C:\dev\bin\Anaconda\lib\site-packages\conda\cli\main_create.py", line 49, in execute
    install.install(args, parser, 'create')
  File "C:\dev\bin\Anaconda\lib\site-packages\conda\cli\install.py", line 334, in install
    minimal_hint=args.alt_hint)
  File "C:\dev\bin\Anaconda\lib\site-packages\conda\plan.py", line 403, in install_actions
    config.track_features, minimal_hint=minimal_hint):
  File "C:\dev\bin\Anaconda\lib\site-packages\conda\resolve.py", line 750, in solve
    minimal_hint=minimal_hint)
  File "C:\dev\bin\Anaconda\lib\site-packages\conda\resolve.py", line 495, in solve2
    clauses = set(self.gen_clauses(v, dists, specs, features))
  File "C:\dev\bin\Anaconda\lib\site-packages\conda\resolve.py", line 353, in gen_clauses
    assert len(clause) > 1, '%s %r' % (fn1, ms)
AssertionError: pymkl-0.1.0.post051+gff66387-py27_0.tar.bz2 MatchSpec(u'gmt-ci')
```