### PR TITLE
Allow overriding of pkgs_dirs in .condarc

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -420,7 +420,10 @@ def load_condarc(path=None):
             _default_envs_dirs()
             )]
 
-    pkgs_dirs = [pkgs_dir_from_envs_dir(envs_dir) for envs_dir in envs_dirs]
+    if 'pkgs_dirs' in rc:
+        pkgs_dirs = rc['pkgs_dirs']
+    else:
+        pkgs_dirs = [pkgs_dir_from_envs_dir(envs_dir) for envs_dir in envs_dirs]
 
     _default_env = os.getenv('CONDA_DEFAULT_ENV')
     if _default_env in (None, root_env_name):


### PR DESCRIPTION
We like to have temp/cache info under /var.  This allows us to set:
~~~~~
pkgs_dirs:
 - /var/cache/conda/pkgs
~~~~~