### PR TITLE
Initial support for instaling in /usr/bin

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -35,6 +35,8 @@ def binpath_from_arg(arg):
     path = join(prefix_from_arg(arg), 'bin')
     if not isdir(path):
         sys.exit("Error: no such directory: %s" % path)
+    if path == '/usr/bin':
+        return None
     return path
 
 def main():
@@ -62,7 +64,8 @@ def main():
             print(os.environ['PATH'])
             raise
         paths = []
-        sys.stderr.write("discarding %s from PATH\n" % binpath)
+        if binpath is not None:
+            sys.stderr.write("discarding %s from PATH\n" % binpath)
 
     elif sys.argv[1] == '..activateroot':
         if len(sys.argv) != 2:
@@ -80,11 +83,12 @@ def main():
         # deactivate is the same as activate root (except without setting
         # CONDA_DEFAULT_ENV or PS1). XXX: The user might want to put the root
         # env back somewhere in the middle of the PATH, not at the beginning.
-        if rootpath not in os.getenv('PATH').split(os.pathsep):
+        if rootpath not in os.getenv('PATH').split(os.pathsep) and rootpath is not None:
             paths = [rootpath]
         else:
             paths = []
-        sys.stderr.write("discarding %s from PATH\n" % binpath)
+        if binpath is not None:
+            sys.stderr.write("discarding %s from PATH\n" % binpath)
 
     elif sys.argv[1] == '..checkenv':
         if len(sys.argv) < 3:

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -405,7 +405,7 @@ def name_prefix(prefix):
     return basename(prefix)
 
 def check_write(command, prefix, json=False):
-    if inroot_notwritable(prefix):
+    if inroot_notwritable(prefix) or prefix == '/usr':
         from conda.cli.help import root_read_only
 
         root_read_only(command, prefix, json=json)

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -107,7 +107,7 @@ def test_activate_test1():
             assert stdout == envs + "/test1/bin:" + PATH
             expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
             if syspath != '/usr/bin':
-                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(syspath=syspath, expected=expected)
             assert stderr == expected
 
 
@@ -284,7 +284,7 @@ def test_activate_symlinking():
             assert not stdout
             expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
             if syspath != '/usr/bin':
-                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(syspath=syspath, expected=expected)
             assert stderr == expected
             for f in ['conda', 'activate', 'deactivate']:
                 assert os.path.lexists('{envs}/test1/bin/{f}'.format(envs=envs, f=f))
@@ -310,7 +310,7 @@ def test_activate_symlinking():
                 assert not stdout
                 expected = 'prepending {envs}/test3/bin to PATH\n'.format(envs=envs)
                 if syspath != '/usr/bin':
-                    expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+                    expected = 'discarding {syspath} from PATH\n{expected}'.format(syspath=syspath, expected=expected)
                 assert stderr == expected
 
                 # Make sure it stays the same
@@ -360,7 +360,7 @@ def test_PS1():
             assert stdout == '({envs}/test1)$'.format(envs=envs)
             expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
             if syspath != '/usr/bin':
-                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(syspath=syspath, expected=expected)
             assert stderr == expected
 
             commands = (command_setup + """
@@ -469,7 +469,7 @@ changeps1: no
             assert stdout == '$'
             expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
             if syspath != '/usr/bin':
-                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(syspath=syspath, expected=expected)
             assert stderr == expected
 
             commands = (command_setup + condarc + """
@@ -571,7 +571,7 @@ def test_CONDA_DEFAULT_ENV():
             assert stdout == '{envs}/test1'.format(envs=envs)
             expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
             if syspath != '/usr/bin':
-                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(syspath=syspath, expected=expected)
             assert stderr == expected
 
             commands = (command_setup + """

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -65,7 +65,10 @@ syspath = join(root_dir, 'bin')
 # dirname, which is used in the activate script, is typically installed in
 # /usr/bin (not sure if it has to be)
 PATH = ':'.join(['/bin', '/usr/bin'])
-ROOTPATH = syspath + ':' + PATH
+if syspath != '/usr/bin':
+    ROOTPATH = syspath + ':' + PATH
+else:
+    ROOTPATH = PATH
 PYTHONPATH = os.path.dirname(os.path.dirname(__file__))
 
 CONDA_ENTRY_POINT="""\
@@ -102,7 +105,10 @@ def test_activate_test1():
 
             stdout, stderr = run_in(commands, shell)
             assert stdout == envs + "/test1/bin:" + PATH
-            assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test1/bin to PATH\n'.format(envs=envs, syspath=syspath)
+            expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
+            if syspath != '/usr/bin':
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+            assert stderr == expected
 
 
 @pytest.mark.slow
@@ -276,7 +282,10 @@ def test_activate_symlinking():
 
             stdout, stderr = run_in(commands, shell)
             assert not stdout
-            assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test1/bin to PATH\n'.format(envs=envs, syspath=syspath)
+            expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
+            if syspath != '/usr/bin':
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+            assert stderr == expected
             for f in ['conda', 'activate', 'deactivate']:
                 assert os.path.lexists('{envs}/test1/bin/{f}'.format(envs=envs, f=f))
                 assert os.path.exists('{envs}/test1/bin/{f}'.format(envs=envs, f=f))
@@ -299,7 +308,10 @@ def test_activate_symlinking():
                 """).format(envs=envs, activate=activate, deactivate=deactivate, conda=conda)
                 stdout, stderr = run_in(commands, shell)
                 assert not stdout
-                assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test3/bin to PATH\n'.format(envs=envs, syspath=syspath)
+                expected = 'prepending {envs}/test3/bin to PATH\n'.format(envs=envs)
+                if syspath != '/usr/bin':
+                    expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+                assert stderr == expected
 
                 # Make sure it stays the same
                 for f in ['conda', 'activate', 'deactivate']:
@@ -346,7 +358,10 @@ def test_PS1():
 
             stdout, stderr = run_in(commands, shell)
             assert stdout == '({envs}/test1)$'.format(envs=envs)
-            assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test1/bin to PATH\n'.format(envs=envs, syspath=syspath)
+            expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
+            if syspath != '/usr/bin':
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+            assert stderr == expected
 
             commands = (command_setup + """
             source {activate} {envs}/test1 2> /dev/null
@@ -452,7 +467,10 @@ changeps1: no
 
             stdout, stderr = run_in(commands, shell)
             assert stdout == '$'
-            assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test1/bin to PATH\n'.format(envs=envs, syspath=syspath)
+            expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
+            if syspath != '/usr/bin':
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+            assert stderr == expected
 
             commands = (command_setup + condarc + """
             source {activate} {envs}/test1 2> /dev/null
@@ -551,7 +569,10 @@ def test_CONDA_DEFAULT_ENV():
 
             stdout, stderr = run_in(commands, shell)
             assert stdout == '{envs}/test1'.format(envs=envs)
-            assert stderr == 'discarding {syspath} from PATH\nprepending {envs}/test1/bin to PATH\n'.format(envs=envs, syspath=syspath)
+            expected = 'prepending {envs}/test1/bin to PATH\n'.format(envs=envs)
+            if syspath != '/usr/bin':
+                expected = 'discarding {syspath} from PATH\n{expected}'.format(expected=expected)
+            assert stderr == expected
 
             commands = (command_setup + """
             source {activate} {envs}/test1 2> /dev/null


### PR DESCRIPTION
This is an initial attempt at supporting #1643.  It prevents removal of /usr/bin from the path and tries to prevent installs into /usr.  It's a lot of ugly '/usr/bin's scattered around so a different approach should probably be used if this is seen as an acceptable use case.