### PR TITLE
Don't fetch the package metadata from the network with conda remove

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -180,6 +180,16 @@ def add_parser_use_index_cache(p):
         help="Use cache of channel index files.",
     )
 
+
+def add_parser_no_use_index_cache(p):
+    p.add_argument(
+        "--no-use-index-cache",
+        action="store_false",
+        default=True,
+        dest="use_index_cache",
+        help="Use cache of channel index files.",
+    )
+
 def add_parser_copy(p):
     p.add_argument(
         '--copy',

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -68,7 +68,7 @@ def configure_parser(sub_parsers, name='remove'):
     common.add_parser_channels(p)
     common.add_parser_prefix(p)
     common.add_parser_quiet(p)
-    common.add_parser_use_index_cache(p)
+    common.add_parser_no_use_index_cache(p)
     common.add_parser_use_local(p)
     common.add_parser_offline(p)
     common.add_parser_pscheck(p)

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -68,7 +68,9 @@ def configure_parser(sub_parsers, name='remove'):
     common.add_parser_channels(p)
     common.add_parser_prefix(p)
     common.add_parser_quiet(p)
+    # Putting this one first makes it the default
     common.add_parser_no_use_index_cache(p)
+    common.add_parser_use_index_cache(p)
     common.add_parser_use_local(p)
     common.add_parser_offline(p)
     common.add_parser_pscheck(p)


### PR DESCRIPTION
The index cache is now used by default. The index is needed only to display
the channel information when show_channel_urls is set to True. The worst that
will happen when there is no cache present is that the channel will show as
`<unknown>` instead of the actual channel. This makes conda remove much
faster.

The index can still be forcibly fetched with conda remove
--no-use-index-cache.

Fixes #1667.