### PR TITLE
Fix for issue 1685

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -42,9 +42,8 @@ def install_tar(prefix, tar_path, verbose=False):
             if fn.endswith('.tar.bz2'):
                 paths.append(join(root, fn))
 
-    depends = misc.install_local_packages(prefix, paths, verbose=verbose)
+    misc.install_local_packages(prefix, paths, verbose=verbose)
     shutil.rmtree(tmp_dir)
-    return depends
 
 
 def check_prefix(prefix, json=False):
@@ -196,12 +195,9 @@ def install(args, parser, command='install'):
     num_cp = sum(s.endswith('.tar.bz2') for s in args.packages)
     if num_cp:
         if num_cp == len(args.packages):
-            depends = misc.install_local_packages(prefix, args.packages,
-                                                  verbose=not args.quiet)
-            if args.no_deps:
-                depends = []
-            specs = list(set(depends))
-            args.unknown = True
+            misc.install_local_packages(prefix, args.packages,
+                                        verbose=not args.quiet)
+            return
         else:
             common.error_and_exit(
                 "cannot mix specifications with conda package filenames",
@@ -212,11 +208,8 @@ def install(args, parser, command='install'):
     if len(args.packages) == 1:
         tar_path = args.packages[0]
         if tar_path.endswith('.tar'):
-            depends = install_tar(prefix, tar_path, verbose=not args.quiet)
-            if args.no_deps:
-                depends = []
-            specs = list(set(depends))
-            args.unknown = True
+            install_tar(prefix, tar_path, verbose=not args.quiet)
+            return
 
     if args.use_local:
         from conda.fetch import fetch_index

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -206,11 +206,15 @@ def install_local_packages(prefix, paths, verbose=False):
     actions = defaultdict(list)
     actions['PREFIX'] = prefix
     actions['op_order'] = RM_EXTRACTED, EXTRACT, UNLINK, LINK
+    # maps names of installed packages to dists
+    linked = {install.name_dist(dist): dist for dist in install.linked(prefix)}
     for dist in dists:
         actions[RM_EXTRACTED].append(dist)
         actions[EXTRACT].append(dist)
-        if install.is_linked(prefix, dist):
-            actions[UNLINK].append(dist)
+        # unlink any installed package with that name
+        name = install.name_dist(dist)
+        if name in linked:
+            actions[UNLINK].append(linked[name])
         actions[LINK].append(dist)
     execute_actions(actions, verbose=verbose)
 

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -218,16 +218,6 @@ def install_local_packages(prefix, paths, verbose=False):
         actions[LINK].append(dist)
     execute_actions(actions, verbose=verbose)
 
-    depends = []
-    for dist in dists:
-        try:
-            with open(join(pkgs_dir, dist, 'info', 'index.json')) as fi:
-                meta = json.load(fi)
-            depends.extend(meta['depends'])
-        except (IOError, KeyError):
-            continue
-    return depends
-
 
 def environment_for_conda_environment(prefix=config.root_dir):
     # prepend the bin directory to the path

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -5,7 +5,6 @@ from __future__ import print_function, division, absolute_import
 
 import os
 import sys
-import json
 import shlex
 import shutil
 import subprocess


### PR DESCRIPTION
We ensure that when installing packages directly, using `conda install <conda pkg>`, installed packages of the same names are also remove.  Otherwise, you can end up having two (or more) packages with the same name installed, which causes other problems.