### PR TITLE
Allow explicit file with all URLs of packages

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -495,12 +495,18 @@ def spec_from_line(line):
 def specs_from_url(url, json=False):
     from conda.fetch import TmpDownload
 
+    explicit = False
     with TmpDownload(url, verbose=False) as path:
         specs = []
         try:
             for line in open(path):
                 line = line.strip()
                 if not line or line.startswith('#'):
+                    continue
+                if line == '@EXPLICIT':
+                    explicit = True
+                if explicit:
+                    specs.append(line)
                     continue
                 spec = spec_from_line(line)
                 if spec is None:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -170,6 +170,9 @@ def install(args, parser, command='install'):
     if args.file:
         for fpath in args.file:
             specs.extend(common.specs_from_url(fpath, json=args.json))
+        if '@EXPLICIT' in specs:
+            misc.explicit(specs)
+            return
     elif getattr(args, 'all', False):
         linked = ci.linked(prefix)
         if not linked:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -171,7 +171,7 @@ def install(args, parser, command='install'):
         for fpath in args.file:
             specs.extend(common.specs_from_url(fpath, json=args.json))
         if '@EXPLICIT' in specs:
-            misc.explicit(specs)
+            misc.explicit(specs, prefix)
             return
     elif getattr(args, 'all', False):
         linked = ci.linked(prefix)

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -72,8 +72,8 @@ def configure_parser(sub_parsers):
     p.add_argument(
         '-e', "--export",
         action="store_true",
-        help="""Output requirement string only (output may be used by conda create
-                  --file).""",
+        help="Output requirement string only (output may be used by "
+             " conda create --file).",
     )
     p.add_argument(
         '-r', "--revisions",
@@ -112,7 +112,8 @@ def get_packages(installed, regex):
         yield dist
 
 
-def list_packages(prefix, installed, regex=None, format='human', show_channel_urls=config.show_channel_urls):
+def list_packages(prefix, installed, regex=None, format='human',
+                  show_channel_urls=config.show_channel_urls):
     res = 1
 
     result = []
@@ -147,7 +148,8 @@ def print_packages(prefix, regex=None, format='human', piplist=False,
         common.error_and_exit("""\
 Error: environment does not exist: %s
 #
-# Use 'conda create' to create an environment before listing its packages.""" % prefix,
+# Use 'conda create' to create an environment before listing its packages.""" %
+                              prefix,
                               json=json,
                               error_type="NoEnvironmentFound")
 
@@ -162,7 +164,8 @@ Error: environment does not exist: %s
     if piplist and config.use_pip and format == 'human':
         add_pip_installed(prefix, installed, json=json)
 
-    exitcode, output = list_packages(prefix, installed, regex, format=format, show_channel_urls=show_channel_urls)
+    exitcode, output = list_packages(prefix, installed, regex, format=format,
+                                     show_channel_urls=show_channel_urls)
     if not json:
         print('\n'.join(output))
     else:
@@ -203,5 +206,5 @@ def execute(args, parser):
         format = 'canonical'
 
     exitcode = print_packages(prefix, regex, format, piplist=args.pip,
-        json=args.json, show_channel_urls=args.show_channel_urls)
+                  json=args.json, show_channel_urls=args.show_channel_urls)
     sys.exit(exitcode)

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -194,7 +194,7 @@ def print_explicit(prefix):
             continue
         with open(join(meta_dir, fn)) as fi:
             meta = json.load(fi)
-        print(meta['url'] or '# no URL for: %s' % fn[:-5])
+        print(meta.get('url') or '# no URL for: %s' % fn[:-5])
 
 
 def execute(args, parser):

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -37,6 +37,18 @@ def conda_installed_files(prefix, exclude_self_build=False):
     return res
 
 
+def explicit(urls):
+    import conda.fetch as fetch
+
+    for url in urls:
+        if url == '@EXPLICIT':
+            continue
+        channel_url, fn = url.rsplit('/', 1)
+        index = fetch.fetch_index((channel_url + '/',))
+        info = index[fn]
+        #print(url, info)
+
+
 def rel_path(prefix, path, windows_forward_slashes=True):
     res = path[len(prefix) + 1:]
     if sys.platform == 'win32' and windows_forward_slashes:

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -36,16 +36,34 @@ def conda_installed_files(prefix, exclude_self_build=False):
     return res
 
 
-def explicit(urls, prefix):
+def force_extract_and_link(dists, prefix, verbose=False):
+    actions = defaultdict(list)
+    actions['PREFIX'] = prefix
+    actions['op_order'] = RM_EXTRACTED, EXTRACT, UNLINK, LINK
+    # maps names of installed packages to dists
+    linked = {install.name_dist(dist): dist for dist in install.linked(prefix)}
+    for dist in dists:
+        actions[RM_EXTRACTED].append(dist)
+        actions[EXTRACT].append(dist)
+        # unlink any installed package with that name
+        name = install.name_dist(dist)
+        if name in linked:
+            actions[UNLINK].append(linked[name])
+        actions[LINK].append(dist)
+    execute_actions(actions, verbose=verbose)
+
+
+def explicit(urls, prefix, verbose=True):
     import conda.fetch as fetch
     from conda.utils import md5_file
 
-    plan = [('PREFIX', prefix)]
+    dists = []
     for url in urls:
         if url == '@EXPLICIT':
             continue
         print("Fetching: %s" % url)
         channel_url, fn = url.rsplit('/', 1)
+        dists.append(fn[:-8])
         index = fetch.fetch_index((channel_url + '/',))
         info = index[fn]
         pkg_path = join(config.pkgs_dirs[0], fn)
@@ -59,9 +77,7 @@ def explicit(urls, prefix):
         else:
             fetch.fetch_pkg(info)
 
-#        plan.extend([
-#                inst.RM_EXTRACTED].append(dist)
-#        ])
+    force_extract_and_link(dists, prefix, verbose=verbose)
 
 
 def rel_path(prefix, path, windows_forward_slashes=True):
@@ -230,20 +246,7 @@ def install_local_packages(prefix, paths, verbose=False):
             continue
         shutil.copyfile(src_path, dst_path)
 
-    actions = defaultdict(list)
-    actions['PREFIX'] = prefix
-    actions['op_order'] = RM_EXTRACTED, EXTRACT, UNLINK, LINK
-    # maps names of installed packages to dists
-    linked = {install.name_dist(dist): dist for dist in install.linked(prefix)}
-    for dist in dists:
-        actions[RM_EXTRACTED].append(dist)
-        actions[EXTRACT].append(dist)
-        # unlink any installed package with that name
-        name = install.name_dist(dist)
-        if name in linked:
-            actions[UNLINK].append(linked[name])
-        actions[LINK].append(dist)
-    execute_actions(actions, verbose=verbose)
+    force_extract_and_link(dists, prefix, verbose=verbose)
 
 
 def environment_for_conda_environment(prefix=config.root_dir):

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -204,8 +204,7 @@ def plan_from_actions(actions):
         op_order = inst.action_codes
 
     assert inst.PREFIX in actions and actions[inst.PREFIX]
-    res = [
-           ('PREFIX', '%s' % actions[inst.PREFIX])]
+    res = [('PREFIX', '%s' % actions[inst.PREFIX])]
 
     if sys.platform == 'win32':
         # Always link/unlink menuinst first on windows in case a subsequent

--- a/tests/test_toposort.py
+++ b/tests/test_toposort.py
@@ -44,9 +44,9 @@ class TopoSortTests(unittest.TestCase):
         """
         This test checks a special invariant related to 'python' specifically.
         Python is part of a cycle (pip <--> python), which can cause it to be
-        installed *after* packages that need python (possibly in 
+        installed *after* packages that need python (possibly in
         post-install.sh).
-        
+
         A special case in toposort() breaks the cycle, to ensure that python
         isn't installed too late.  Here, we verify that it works.
         """


### PR DESCRIPTION
Using the `--file` option, this PR allows having an explicit file, which contains the URLs of all conda packages to be installed.  The first (non-comment) line of this file has to start with `@EXPLICIT`.