### PR TITLE
Allow menu items to be installed in non-root env

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -306,10 +306,16 @@ def create_meta(prefix, dist, info_dir, extra_info):
 
 
 def mk_menus(prefix, files, remove=False):
-    if abspath(prefix) != abspath(sys.prefix):
-        # we currently only want to create menu items for packages
-        # in default environment
+    """
+    Create cross-platform menu items (e.g. Windows Start Menu)
+
+    Passes all menu config files %PREFIX%/Menu/*.json to ``menuinst.install``.
+    ``remove=True`` will remove the menu items.
+    """
+    exclude_envs = ('_build', '_test')  # Exclude all envs starting with...
+    if basename(abspath(prefix)).lower().startswith(exclude_envs):
         return
+
     menu_files = [f for f in files
                   if f.startswith('Menu/') and f.endswith('.json')]
     if not menu_files:

--- a/conda/install.py
+++ b/conda/install.py
@@ -317,7 +317,8 @@ def mk_menus(prefix, files, remove=False):
         return
 
     menu_files = [f for f in files
-                  if f.startswith('Menu/') and f.endswith('.json')]
+                  if f.lower().startswith('menu/')
+                  and f.lower().endswith('.json')]
     if not menu_files:
         return
     try:


### PR DESCRIPTION
Currently `menuinst` menu items are only installed when installing into the root environment. This PR will relax this constraint. Suggest to filter out envs with names starting with "_build" and "_test" to prevent menu items being installed into build or test environments. 