### PR TITLE
pass env name and setup cmd to menuinst

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -317,6 +317,10 @@ def mk_menus(prefix, files, remove=False):
                   and f.lower().endswith('.json')]
     if not menu_files:
         return
+    elif basename(abspath(prefix)).startswith('_'):
+        logging.warn("Environment name starts with underscore (_).  Skipping menu installation.")
+        return
+
     try:
         import menuinst
     except ImportError as e:
@@ -326,13 +330,14 @@ def mk_menus(prefix, files, remove=False):
     for f in menu_files:
         try:
             env_name = os.getenv("CONDA_DEFAULT_ENV")
+            # this should always be the root, because Conda can only be installed in the root environment,
+            #   thus this script should only ever be running with the root interpreter.
             root_prefix = sys.prefix
             if env_name:
                 # Windows uses full paths; only the last folder is the env name.
                 # Other platforms still use just name.
                 end_name = os.path.split(env_name)
                 env_name = end_name[1] if end_name[1] else env_name
-                root_prefix = sys.prefix.split("envs")[0]
             if sys.platform == "win32":
                 env_setup_cmd = "activate {}"
             else:

--- a/conda/install.py
+++ b/conda/install.py
@@ -326,18 +326,21 @@ def mk_menus(prefix, files, remove=False):
     for f in menu_files:
         try:
             env_name = os.getenv("CONDA_DEFAULT_ENV")
+            root_prefix = sys.prefix
             if env_name:
                 # Windows uses full paths; only the last folder is the env name.
                 # Other platforms still use just name.
                 end_name = os.path.split(env_name)
                 env_name = end_name[1] if end_name[1] else env_name
+                root_prefix = sys.prefix.split("envs")[0]
             if sys.platform == "win32":
                 env_setup_cmd = "activate {}"
             else:
                 env_setup_cmd = "source activate {}"
             env_setup_cmd = env_setup_cmd.format(env_name) if env_name else None
-            menuinst.install(join(prefix, f), remove, prefix,
-                             env_name=env_name, env_setup_cmd=env_setup_cmd)
+            menuinst.install(join(prefix, f), remove, root_prefix=root_prefix,
+                             target_prefix=prefix, env_name=env_name,
+                             env_setup_cmd=env_setup_cmd)
         except:
             stdoutlog.error("menuinst Exception:")
             stdoutlog.error(traceback.format_exc())

--- a/conda/install.py
+++ b/conda/install.py
@@ -312,10 +312,6 @@ def mk_menus(prefix, files, remove=False):
     Passes all menu config files %PREFIX%/Menu/*.json to ``menuinst.install``.
     ``remove=True`` will remove the menu items.
     """
-    # exclude all envs starting with '_'
-    if basename(abspath(prefix)).startswith('_'):
-        return
-
     menu_files = [f for f in files
                   if f.lower().startswith('menu/')
                   and f.lower().endswith('.json')]
@@ -323,11 +319,25 @@ def mk_menus(prefix, files, remove=False):
         return
     try:
         import menuinst
-    except ImportError:
+    except ImportError as e:
+        logging.warn("Menuinst could not be imported:")
+        logging.warn(e.message)
         return
     for f in menu_files:
         try:
-            menuinst.install(join(prefix, f), remove, prefix)
+            env_name = os.getenv("CONDA_DEFAULT_ENV")
+            if env_name:
+                # Windows uses full paths; only the last folder is the env name.
+                # Other platforms still use just name.
+                end_name = os.path.split(env_name)
+                env_name = end_name[1] if end_name[1] else env_name
+            if sys.platform == "win32":
+                env_setup_cmd = "activate {}"
+            else:
+                env_setup_cmd = "source activate {}"
+            env_setup_cmd = env_setup_cmd.format(env_name) if env_name else None
+            menuinst.install(join(prefix, f), remove, prefix,
+                             env_name=env_name, env_setup_cmd=env_setup_cmd)
         except:
             stdoutlog.error("menuinst Exception:")
             stdoutlog.error(traceback.format_exc())


### PR DESCRIPTION
Removes restriction that shortcuts can only be installed in the root environment.  Passes information to menuinst that menuinst can use to customize shortcuts and add pre-run steps (such as activating an environment)

Part of a 4-part set of PRs across the conda system.  Other PRs:
  * https://github.com/conda/conda-env/pull/178
  * https://github.com/ContinuumIO/menuinst/pull/4
  * https://github.com/conda/conda-recipes/pull/439