### PR TITLE
Added a pruning step for more efficient solves

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -507,7 +507,7 @@ class Resolve(object):
                 self.touch_package(fn, True)
         return True
 
-    def find_matches(self, ms, getall=True):
+    def find_matches(self, ms, getall=False):
         for fn in self.groups.get(ms.name,[]):
             if (getall or self.touched_[fn]) and ms.match(fn):
                 yield fn

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1039,6 +1039,8 @@ Note that the following features are enabled:
             features = self.installed_features(installed)
 
         for spec in specs:
+            # XXX: This does not work when a spec only contains the name,
+            # and different versions of the package have different features.
             ms = MatchSpec(spec)
             for pkg in self.get_pkgs(ms, max_only=max_only):
                 fn = pkg.fn

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1038,7 +1038,6 @@ Note that the following features are enabled:
             installed = []
         if features is None:
             features = self.installed_features(installed)
-
         for spec in specs:
             # XXX: This does not work when a spec only contains the name,
             # and different versions of the package have different features.


### PR DESCRIPTION
This adds a method `prune_packages` and some supporting methods that reduces the number of dists that the subsequent Resolve processing sees. This pruning step is relatively fast compared to the typical processing time, and yet significantly speeds up the solve process in some of the more difficult cases we've encountered.

The pruning pass consists of two stages. The first stage identifies what I call "strong" dependencies, and eliminates any packages that do not satisfy those dependencies. A "strong" dependency is one that all versions of a given package rely upon. 

For instance, consider `anaconda`. Anaconda _always_ depends on some version of `python`. Therefore, if `anaconda` is included in the spec, we can immediately prune away all versions of `python` that are not accepted by at least one version of `anaconda`. On the other hand, `llvm` is _not_ a strong dependency; some versions of `anaconda` include it, some do not. Therefore, we _cannot_ prune away any versions of `llvm` when `anaconda` is included.

The second step identifies all dependencies of the specs and the installed packages, and prunes away the others. This is a pretty standard depth-first search, with one caveat: we verify that every dist we include has at least one valid combination of dependencies. It's possible, after all, that the first pass has pruned away their dependencies completely.

My claim is that this pruning pass in no way changes the space of *possible* installs. But it undoubtedly reduces the size of the problem passed to the SAT-based solver. And in cases where a given package depends on particularly old versions of other packages (e.g., `llvmmath`), the pruning process should greatly reduce the number of bisection steps required to find a solution.

I have attempted to ensure that the pruning step behaves properly in difficult cases. For example, if there are packages installed that are missing from the index altogether, the pruning process just ignores them. The subsequent processing notifies the user of this and skips them, so the behavior hasn't changed. I've successfully tested this: in one of my environments I have some R packages installed that aren't connected to any channels, and it was handled as expected.

If the pruning process detects that one or more of the specs cannot be satisfied, it raises a NoPackagesFound exception. I need to test that case more so that we can be sure it behaves in a user-friendly way.
