### PR TITLE
make windows shortcuts always activate an environment

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -331,7 +331,10 @@ def mk_menus(prefix, files, remove=False):
 
     env_name = (None if abspath(prefix) == abspath(sys.prefix) else
                 basename(prefix))
-    env_setup_cmd = ("activate %s" % env_name) if env_name else None
+    # only windows is provided right now.  Add "source activate" if on Unix platforms
+    env_setup_cmd = "activate"
+    if env_name:
+        env_setup_cmd = env_setup_cmd + " %s" % env_name
     for f in menu_files:
         try:
             if menuinst.__version__.startswith('1.0'):


### PR DESCRIPTION
This is necessary because without this change, if the root environment is not on PATH, then shortcuts can fail to run due to missing MSVC runtime on PATH.