### PR TITLE
Pull in dependencies of strictness=3 MatchSpec's

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -579,8 +579,7 @@ class Resolve(object):
                         continue
                     res[pkg2.fn] = pkg2
                     try:
-                        if ms.strictness < 3:
-                            add_dependents(pkg2.fn, max_only=max_only)
+                        add_dependents(pkg2.fn, max_only=max_only)
                     except NoPackagesFound as e:
                         for pkg in e.pkgs:
                             if pkg not in notfound:


### PR DESCRIPTION
Before this change, MatchSpec's (i.e. package dependencies) of
strictness=3 (i.e. with an equality constraint on all of name, version
and build) did not bring the dependencies of the packages they
depend on into consideration, which resulted in assertion failures.

For example, let's consider three packages:

host-plugin/meta.yaml:
```
package:
  name: host-plugin
  version: {{ environ.get("GIT_DESCRIBE_TAG", "") }}
build:
  string: {{ environ.get("GIT_DESCRIBE_HASH", "") }}
requirements:
  build:
    - host
  run:
    - host {{ "{tag} {hash}".format(
                  tag=environ.get("GIT_DESCRIBE_TAG"), 
                  hash=environ.get("GIT_DESCRIBE_HASH")) 
                if "GIT_DESCRIBE_TAG" in environ else "" }}
```

host/meta.yaml:
```
package:
  name: host
  version: {{ environ.get("GIT_DESCRIBE_TAG", "") }}
build:
  string: {{ environ.get("GIT_DESCRIBE_HASH", "") }}
requirements:
  run:
    - dep
```
dep/meta.yaml:
```
package:
  name: dep
...
```

This results in the following failure while trying to install
host-plugin:

```
  File "~/.miniconda/lib/python3.4/site-packages/conda/resolve.py", line 624, in gen_clauses
    assert len(clause) > 1, '%s %r' % (fn1, ms)
AssertionError: host-plugin-0.0-g123456.tar.bz2 MatchSpec('dep')
```

After this change, the installation succeeds.