### PR TITLE
Stop infinite recursion during certain resolve operations

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -478,7 +478,7 @@ class Resolve(object):
         def is_valid(fn):
             val = valid.get(fn, None)
             if val is None:
-                val = True
+                val = valid[fn] = True
                 for ms in self.ms_depends(fn):
                     if not any(is_valid(f2) for f2 in self.find_matches(ms, True)):
                         val = False


### PR DESCRIPTION
This addresses issue [https://github.com/conda/conda/issues/1748](1748). Setting `valid[fn]` temporarily ensures that if a dependency cycle is detected, it will terminate. It is not clear to me why this *isn't* there; it was in a previous version of my code. My apologies for the omission.