### PR TITLE
Add "prune" option to plan.install_actions

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -391,7 +391,7 @@ def get_pinned_specs(prefix):
 
 
 def install_actions(prefix, index, specs, force=False, only_names=None,
-                    pinned=True, minimal_hint=False, update_deps=True):
+                    pinned=True, minimal_hint=False, update_deps=True, prune=False):
     r = Resolve(index)
     linked = install.linked(prefix)
 
@@ -441,7 +441,9 @@ def install_actions(prefix, index, specs, force=False, only_names=None,
 
     for dist in sorted(linked):
         name = install.name_dist(dist)
-        if name in must_have and dist != must_have[name]:
+        replace_existing = name in must_have and dist != must_have[name]
+        prune_it = prune and dist not in smh
+        if replace_existing or prune_it:
             add_unlink(actions, dist)
 
     return actions


### PR DESCRIPTION
This will allow conda-env to implement "conda env update --prune" command,
as discussed in conda/conda-env#190

I could not figure out how to write tests for this though... any help here?

CC @malev 