### PR TITLE
Addresses issue #1751 by adding file permission tests and rm error ha…

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -151,9 +151,13 @@ def rm_tarballs(args, pkgs_dirs, totalsize, verbose=True):
 
     for pkgs_dir in pkgs_dirs:
         for fn in pkgs_dirs[pkgs_dir]:
-            if verbose:
-                print("removing %s" % fn)
-            os.unlink(os.path.join(pkgs_dir, fn))
+            if os.access(os.path.join(pkgs_dir, fn), os.W_OK):
+                if verbose:
+                    print("Removing %s" % fn)
+                os.unlink(os.path.join(pkgs_dir, fn))
+            else:
+                if verbose:
+                    print("WARNING: cannot remove, file premissions: %s" % fn)
 
 
 def find_pkgs():

--- a/conda/install.py
+++ b/conda/install.py
@@ -138,6 +138,13 @@ def _remove_readonly(func, path, excinfo):
     os.chmod(path, stat.S_IWRITE)
     func(path)
 
+def warn_failed_remove(function, path, exc_info):
+    if exc_info[1].errno == errno.EACCES:
+        log.warn( "WARNING: cannot remove, permission denied: %s" % path )
+    elif exc_info[1].errno == errno.ENOTEMPTY:
+        log.warn( "WARNING: cannot remove, not empty: %s" % path )
+    else:
+        log.warn( "WARNING: cannot remove, unknown reason: %s" % path )
 
 def rm_rf(path, max_retries=5, trash=True):
     """
@@ -152,12 +159,15 @@ def rm_rf(path, max_retries=5, trash=True):
         # Note that we have to check if the destination is a link because
         # exists('/path/to/dead-link') will return False, although
         # islink('/path/to/dead-link') is True.
-        os.unlink(path)
+        if os.access(path, os.W_OK):
+            os.unlink(path)
+        else:
+            log.warn("WARNING: cannot remove, permission denied: %s" % path)
 
     elif isdir(path):
         for i in range(max_retries):
             try:
-                shutil.rmtree(path)
+                shutil.rmtree(path, ignore_errors=False, onerror=warn_failed_remove)
                 return
             except OSError as e:
                 msg = "Unable to delete %s\n%s\n" % (path, e)
@@ -189,7 +199,7 @@ def rm_rf(path, max_retries=5, trash=True):
                 log.debug(msg + "Retrying after %s seconds..." % i)
                 time.sleep(i)
         # Final time. pass exceptions to caller.
-        shutil.rmtree(path)
+        shutil.rmtree(path, ignore_errors=False, onerror=warn_failed_remove)
 
 def rm_empty_dir(path):
     """


### PR DESCRIPTION
…ndling:

- for os.unlink() calls, added os.access() tests to check for write permissions
- for shutil.rmtree() calls, added error handling to test for various errno states
- tested with similar install path and scenario as reported by issue creator, but on OS X
- does not address issue 1752