### PR TITLE
Log the package name that has a bad package name to stderr

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -357,7 +357,13 @@ class Package(object):
         self.build_number = info['build_number']
         self.build = info['build']
         self.channel = info.get('channel')
-        self.norm_version = VersionOrder(self.version)
+        try:
+            self.norm_version = VersionOrder(self.version)
+        except ValueError as ve:
+            stderrlog.error("\nThe following stack trace is in reference to "
+                            "package:\n\n\t%s\n\n" % fn)
+            raise
+
         self.info = info
 
     def _asdict(self):

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -359,7 +359,7 @@ class Package(object):
         self.channel = info.get('channel')
         try:
             self.norm_version = VersionOrder(self.version)
-        except ValueError as ve:
+        except ValueError:
             stderrlog.error("\nThe following stack trace is in reference to "
                             "package:\n\n\t%s\n\n" % fn)
             raise


### PR DESCRIPTION
If the resolver comes across a badly formed version in a conda package name, conda-build barfs but does not tell you **which** package is causing the error.  This PR adds a little bit of helper functionality to conda-build by outputting the package name that is raising the version string error.  The extra output is this for the error that I am getting:
```
The following stack trace is in reference to package:

        databroker-.post-_npNonepy34.tar.bz2
```

Full stack trace:
```
BUILD END: datamuxer-v0.3.0.post1-py27_0
TEST START: datamuxer-v0.3.0.post1-py27_0
Fetching package metadata: ............

The following stack trace is in reference to package:

        databroker-.post-_npNonepy34.tar.bz2

An unexpected error has occurred, please consider sending the
following traceback to the conda GitHub issue tracker at:

    https://github.com/conda/conda-build/issues

Include the output of the command 'conda info' in your report.


Traceback (most recent call last):
  File "/Users/edill/mc/bin/conda-build", line 5, in <module>
    sys.exit(main())
  File "/Users/edill/mc/lib/python3.4/site-packages/conda_build/main_build.py", line 190, in main
    args_func(args, p)
  File "/Users/edill/mc/lib/python3.4/site-packages/conda_build/main_build.py", line 468, in args_func
    args.func(args, p)
  File "/Users/edill/mc/lib/python3.4/site-packages/conda_build/main_build.py", line 455, in execute
    channel_urls=channel_urls, override_channels=args.override_channels)
  File "/Users/edill/mc/lib/python3.4/site-packages/conda_build/build.py", line 540, in test
    channel_urls=channel_urls, override_channels=override_channels)
  File "/Users/edill/mc/lib/python3.4/site-packages/conda_build/build.py", line 283, in create_env
    actions = plan.install_actions(prefix, index, specs)
  File "/Users/edill/dev/conda/conda/conda/plan.py", line 411, in install_actions
    update_deps=update_deps):
  File "/Users/edill/dev/conda/conda/conda/resolve.py", line 1052, in solve
    for pkg in self.get_pkgs(ms, max_only=max_only):
  File "/Users/edill/dev/conda/conda/conda/resolve.py", line 550, in get_pkgs
    pkgs = [Package(fn, self.index[fn]) for fn in self.find_matches(ms)]
  File "/Users/edill/dev/conda/conda/conda/resolve.py", line 550, in <listcomp>
    pkgs = [Package(fn, self.index[fn]) for fn in self.find_matches(ms)]
  File "/Users/edill/dev/conda/conda/conda/resolve.py", line 361, in __init__
    self.norm_version = VersionOrder(self.version)
  File "/Users/edill/dev/conda/conda/conda/resolve.py", line 187, in __init__
    raise ValueError(message + "empty version component.")
ValueError: Malformed version string '.post': empty version component.
```