### PR TITLE
Make an attempt to format the correct URL with the `--explicit` flag on conda list

### DIFF
--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -208,13 +208,26 @@ def print_explicit(prefix, add_md5=False):
         with open(join(meta_dir, fn)) as fi:
             meta = json.load(fi)
         url = meta.get('url')
-        if not url or url.startswith('file'):
-            # try to format the correct url
+        def format_url():
+            return '%s%s-%s-%s.tar.bz2' % (meta['channel'], meta['name'],
+                                           meta['version'], meta['build'])
+        # two cases in which we want to try to format the url:
+        # 1. There is no url key in the metadata
+        # 2. The url key in the metadata is referencing a file on the local
+        #    machine
+        if not url:
             try:
-                url = '%s%s-%s-%s.tar.bz2' % (meta['channel'], meta['name'],
-                                              meta['version'], meta['build'])
+                url = format_url()
             except KeyError:
+                # Declare failure :-(
                 print('# no URL for: %s' % fn[:-5])
+                continue
+        if url.startswith('file'):
+            try:
+                url = format_url()
+            except KeyError:
+                # declare failure and allow the url to be the file from which it was
+                # originally installed
                 continue
         md5 = meta.get('md5')
         print(url + ('#%s' % md5 if add_md5 and md5 else ''))

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -207,11 +207,17 @@ def print_explicit(prefix, add_md5=False):
             continue
         with open(join(meta_dir, fn)) as fi:
             meta = json.load(fi)
-        if not meta.get('url'):
-            print('# no URL for: %s' % fn[:-5])
-            continue
+        url = meta.get('url')
+        if not url or url.startswith('file'):
+            # try to format the correct url
+            try:
+                url = '%s%s-%s-%s.tar.bz2' % (meta['channel'], meta['name'],
+                                              meta['version'], meta['build'])
+            except KeyError:
+                print('# no URL for: %s' % fn[:-5])
+                continue
         md5 = meta.get('md5')
-        print(meta['url'] + ('#%s' % md5 if add_md5 and md5 else ''))
+        print(url + ('#%s' % md5 if add_md5 and md5 else ''))
 
 
 def execute(args, parser):


### PR DESCRIPTION
Create a minimal environment

```
$ conda create -p /tmp/foo python=3.4
Fetching package metadata: ..........
Solving package specifications: .........
Package plan for installation in environment /tmp/foo:

The following NEW packages will be INSTALLED:

    openssl:    1.0.2d-0      defaults
    pip:        7.1.2-py34_0  defaults
    python:     3.4.3-2       defaults
    readline:   6.2-2         defaults
    setuptools: 18.4-py34_0   defaults
    sqlite:     3.8.4.1-1     defaults
    tk:         8.5.18-0      defaults
    wheel:      0.26.0-py34_1 defaults
    xz:         5.0.5-0       defaults
    zlib:       1.2.8-0       defaults

Proceed ([y]/n)? y

Linking packages ...
#
# To activate this environment, use:
# $ source activate /tmp/foo
#
# To deactivate this environment, use:
# $ source deactivate
#
```

activate the environment and install a package from my anaconda channel

```
edill$ sa /tmp/foo
discarding /Users/edill/mc/bin from PATH
prepending /tmp/foo/bin to PATH

(/tmp/foo)edill$ conda install -c ericdill boltons
Fetching package metadata: ............
Solving package specifications: ............
Package plan for installation in environment /tmp/foo:

The following NEW packages will be INSTALLED:

    boltons: 15.0.0-py34_0 ericdill

Proceed ([y]/n)? y

Linking packages ...
[      COMPLETE      ]|#################################################################################| 100%
```

List the packages that are installed with the `--explicit` flag
```
(/tmp/foo)10-4-24-242:info edill$ conda list --explicit
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: osx-64
@EXPLICIT
file:///Users/edill/mc/conda-bld/osx-64/boltons-15.0.0-py34_0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/openssl-1.0.2d-0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/pip-7.1.2-py34_0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/python-3.4.3-2.tar.bz2
# no URL for: readline-6.2-2
https://repo.continuum.io/pkgs/free/osx-64/setuptools-18.4-py34_0.tar.bz2
# no URL for: sqlite-3.8.4.1-1
# no URL for: tk-8.5.18-0
https://repo.continuum.io/pkgs/free/osx-64/wheel-0.26.0-py34_1.tar.bz2
# no URL for: xz-5.0.5-0
# no URL for: zlib-1.2.8-0
```

Note specifically that there are number of failures here:
- There is apparently no url for many of the packages that are, in theory, shipped by Continuum
- The url for my custom package is a file that is local to this computer. That is not at all
  helpful if I want to send list to someone else and expect them to install this list of packages.

However, the metadata that conda has access to contains all of the information that is needed to
rebuild that url where the conda package was originally obtained from.  With this PR, the `--explicit`
flag now shows the following: 

```
(/tmp/foo)10-4-24-242:info edill$ conda list --explicit
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: osx-64
@EXPLICIT
https://conda.anaconda.org/ericdill/osx-64/boltons-15.0.0-py34_0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/openssl-1.0.2d-0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/pip-7.1.2-py34_0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/python-3.4.3-2.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/readline-6.2-2.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/setuptools-18.4-py34_0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/sqlite-3.8.4.1-1.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/tk-8.5.18-0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/wheel-0.26.0-py34_1.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/xz-5.0.5-0.tar.bz2
https://repo.continuum.io/pkgs/free/osx-64/zlib-1.2.8-0.tar.bz2
```