### PR TITLE
WIP: Use CacheControl to aggressively cache repodata.json.bz2

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -26,7 +26,7 @@ def _fn2fullspec(fn):
 
 
 def get_index(channel_urls=(), prepend=True, platform=None,
-              use_cache=False, unknown=False, offline=False):
+              use_cache=True, unknown=False, offline=False):
     """
     Return the index of packages available on the channels
 

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -172,18 +172,9 @@ def add_parser_known(p):
              "directly implies this option).",
     )
 
-def add_parser_use_index_cache(p):
-    p.add_argument(
-        "--use-index-cache",
-        action="store_true",
-        default=False,
-        help="Use cache of channel index files.",
-    )
-
-
 def add_parser_no_use_index_cache(p):
     p.add_argument(
-        "--no-use-index-cache",
+        "--no-index-cache",
         action="store_false",
         default=True,
         dest="use_index_cache",
@@ -234,7 +225,7 @@ def add_parser_install(p):
         action="store_true",
         help="Create the environment directory if necessary.",
     )
-    add_parser_use_index_cache(p)
+    add_parser_no_use_index_cache(p)
     add_parser_use_local(p)
     add_parser_offline(p)
     add_parser_no_pin(p)

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -68,9 +68,7 @@ def configure_parser(sub_parsers, name='remove'):
     common.add_parser_channels(p)
     common.add_parser_prefix(p)
     common.add_parser_quiet(p)
-    # Putting this one first makes it the default
     common.add_parser_no_use_index_cache(p)
-    common.add_parser_use_index_cache(p)
     common.add_parser_use_local(p)
     common.add_parser_offline(p)
     common.add_parser_pscheck(p)

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -73,7 +73,7 @@ def configure_parser(sub_parsers):
         help="Output only package names.",
     )
     common.add_parser_known(p)
-    common.add_parser_use_index_cache(p)
+    common.add_parser_no_use_index_cache(p)
     p.add_argument(
         '-o', "--outdated",
         action="store_true",


### PR DESCRIPTION
This implements #1853. It requires two external packages, `cachecontrol` and `lockfile`, so it's probably not suitable to merge directly, as they would need to either be vendored or pulled in as dependencies. But it does illustrate the idea.