### PR TITLE
Mk menu elevation

### DIFF
--- a/bin/mk_menus.bat
+++ b/bin/mk_menus.bat
@@ -7,7 +7,6 @@ REM    of correct menu grouping
 set "PYTHON=%~dp0..\pythonw.exe"
 set "SCRIPT=install_menu.py"
 set "PREFIX=%~1"
-set "FORWARD_SLASHED_PREFIX=%PREFIX:\=/%"
 set "MENU_FILE=%~2"
 if "%~3" == "REMOVE" (set REMOVE=1) else (set REMOVE=0)
 
@@ -15,10 +14,10 @@ echo import sys > "%SCRIPT%"
 echo import os >> "%SCRIPT%"
 echo from os.path import abspath, basename, join >> "%SCRIPT%"
 echo import menuinst >> "%SCRIPT%"
-echo prefix = "%FORWARD_SLASHED_PREFIX%" >> "%SCRIPT%"
+echo prefix = r"%%s" %% "%PREFIX%" >> "%SCRIPT%"
 echo env_name = (None if abspath(prefix) == abspath(sys.prefix) else >> "%SCRIPT%"
 echo     basename(prefix)) >> "%SCRIPT%"
-echo env_setup_cmd = ("activate %%s" %% env_name) if env_name else None >> "%SCRIPT%"
+echo env_setup_cmd = ('activate "%%s"' %% env_name) if env_name else None >> "%SCRIPT%"
 echo menuinst.install(join(prefix, "%MENU_FILE%"), int("%REMOVE%"), root_prefix=sys.prefix, >> "%SCRIPT%"
 echo         target_prefix=prefix, env_name=env_name, env_setup_cmd=env_setup_cmd) >> "%SCRIPT%"
 

--- a/bin/mk_menus.bat
+++ b/bin/mk_menus.bat
@@ -42,22 +42,25 @@ call :install_system_menu "%PYTHON%" "%SCRIPT%" & goto finish
     VER | FINDSTR /IL "4." > NUL
     IF %ERRORLEVEL% == 0 SET NewOSWith_UAC=NO
 
+    set "PYTHON=%~1"
+    set "SCRIPT=%~2"
+
     REM Test if Admin
     CALL NET SESSION >nul 2>&1
     IF NOT %ERRORLEVEL% == 0 (
 
-    set "PYTHON=%~1"
-    set "SCRIPT=%~2"
     if /i "%NewOSWith_UAC%"=="YES" (
     echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
-    :: Should unquote the path, so extra ""'s don't mess things up
     echo UAC.ShellExecute "%PYTHON%", "%SCRIPT%", "", "runas", 1 >> "%temp%\getadmin.vbs"
     "%SystemRoot%\System32\WScript.exe" "%temp%\getadmin.vbs"
     del "%temp%\getadmin.vbs"
+    )
+    ) else (
+    REM   Already elevated.  Just run the script.
+    "%PYTHON%" "%SCRIPT%"
+    )
+
     del "%SCRIPT%"
-    exit /B
-    )
-    )
     goto :eof
 
 :finish

--- a/bin/mk_menus.bat
+++ b/bin/mk_menus.bat
@@ -4,7 +4,7 @@
 REM Menu installation needs to be always done with the root python for sake
 REM    of correct menu grouping
 
-set "PYTHON=%~dp0..\python.exe"
+set "PYTHON=%~dp0..\pythonw.exe"
 set "SCRIPT=install_menu.py"
 set "PREFIX=%~1"
 set "FORWARD_SLASHED_PREFIX=%PREFIX:\=/%"

--- a/bin/mk_menus.bat
+++ b/bin/mk_menus.bat
@@ -1,0 +1,66 @@
+@setlocal enableextensions enabledelayedexpansion
+@echo off
+
+REM Menu installation needs to be always done with the root python for sake
+REM    of correct menu grouping
+
+set "PYTHON=%~dp0..\python.exe"
+set "SCRIPT=install_menu.py"
+set "PREFIX=%~1"
+set "FORWARD_SLASHED_PREFIX=%PREFIX:\=/%"
+set "MENU_FILE=%~2"
+if "%~3" == "REMOVE" (set REMOVE=1) else (set REMOVE=0)
+
+echo import sys > "%SCRIPT%"
+echo import os >> "%SCRIPT%"
+echo from os.path import abspath, basename, join >> "%SCRIPT%"
+echo import menuinst >> "%SCRIPT%"
+echo prefix = "%FORWARD_SLASHED_PREFIX%" >> "%SCRIPT%"
+echo env_name = (None if abspath(prefix) == abspath(sys.prefix) else >> "%SCRIPT%"
+echo     basename(prefix)) >> "%SCRIPT%"
+echo env_setup_cmd = ("activate %%s" %% env_name) if env_name else None >> "%SCRIPT%"
+echo menuinst.install(join(prefix, "%MENU_FILE%"), int("%REMOVE%"), root_prefix=sys.prefix, >> "%SCRIPT%"
+echo         target_prefix=prefix, env_name=env_name, env_setup_cmd=env_setup_cmd) >> "%SCRIPT%"
+
+:: User-level install
+if EXIST "%PREFIX%\.nonadmin" call :install_user_menu "%PYTHON%" "%SCRIPT%" & goto finish
+call :install_system_menu "%PYTHON%" "%SCRIPT%" & goto finish
+
+:install_user_menu
+    set "PYTHON=%~1"
+    set "SCRIPT=%~2"
+    "%PYTHON%" "%SCRIPT%"
+    del "%SCRIPT%"
+    goto :eof
+
+:install_system_menu
+    REM http://stackoverflow.com/questions/4051883/batch-script-how-to-check-for-admin-rights
+    REM Quick test for Windows generation: UAC aware or not ; all OS before NT4 ignored for simplicity
+    SET NewOSWith_UAC=YES
+    VER | FINDSTR /IL "5." > NUL
+    IF %ERRORLEVEL% == 0 SET NewOSWith_UAC=NO
+    VER | FINDSTR /IL "4." > NUL
+    IF %ERRORLEVEL% == 0 SET NewOSWith_UAC=NO
+
+    REM Test if Admin
+    CALL NET SESSION >nul 2>&1
+    IF NOT %ERRORLEVEL% == 0 (
+
+    set "PYTHON=%~1"
+    set "SCRIPT=%~2"
+    if /i "%NewOSWith_UAC%"=="YES" (
+    echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
+    :: Should unquote the path, so extra ""'s don't mess things up
+    echo UAC.ShellExecute "%PYTHON%", "%SCRIPT%", "", "runas", 1 >> "%temp%\getadmin.vbs"
+    "%SystemRoot%\System32\WScript.exe" "%temp%\getadmin.vbs"
+    del "%temp%\getadmin.vbs"
+    del "%SCRIPT%"
+    exit /B
+    )
+    )
+    goto :eof
+
+:finish
+
+:END
+endlocal

--- a/conda/install.py
+++ b/conda/install.py
@@ -332,13 +332,6 @@ def mk_menus(prefix, files, remove=False):
                      "Skipping menu installation.")
         return
 
-    try:
-        import menuinst
-    except:
-        logging.warn("Menuinst could not be imported:")
-        logging.warn(traceback.format_exc())
-        return
-
     remove_or_install = "REMOVE" if remove else "INSTALL"
     for f in menu_files:
         try:

--- a/conda/install.py
+++ b/conda/install.py
@@ -38,7 +38,6 @@ import subprocess
 import sys
 import tarfile
 import time
-import traceback
 from os.path import abspath, basename, dirname, isdir, isfile, islink, join, relpath
 
 try:

--- a/conda/install.py
+++ b/conda/install.py
@@ -339,21 +339,13 @@ def mk_menus(prefix, files, remove=False):
         logging.warn(traceback.format_exc())
         return
 
-    env_name = (None if abspath(prefix) == abspath(sys.prefix) else
-                basename(prefix))
-    env_setup_cmd = ("activate %s" % env_name) if env_name else None
+    remove_or_install = "REMOVE" if remove else "INSTALL"
     for f in menu_files:
         try:
-            if menuinst.__version__.startswith('1.0'):
-                menuinst.install(join(prefix, f), remove, prefix)
-            else:
-                menuinst.install(join(prefix, f), remove,
-                                 root_prefix=sys.prefix,
-                                 target_prefix=prefix, env_name=env_name,
-                                 env_setup_cmd=env_setup_cmd)
-        except:
-            stdoutlog.error("menuinst Exception:")
-            stdoutlog.error(traceback.format_exc())
+            subprocess.check_call([join(sys.prefix, "Scripts", "mk_menus.bat"), prefix, f, remove_or_install])
+        except subprocess.CalledProcessError:
+            print("Failed to %s menu %s" % (remove_or_install.lower(), f))
+            print('To try again, run "%s" "%s" "%s" %s' % (join(sys.prefix, "Scripts", "mk_menus.bat"), prefix, f, remove_or_install))
 
 
 def run_script(prefix, dist, action='post-link', env_prefix=None):

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ kwds = {'scripts': []}
 if sys.platform == 'win32' and using_setuptools:
     kwds['entry_points'] = dict(console_scripts =
                                         ["conda = conda.cli.main:main"])
+    kwds['scripts'].append('bin/mk_menus.bat')
 else:
     kwds['scripts'].append('bin/conda')
 


### PR DESCRIPTION
This calls a bat file subprocess to achieve process elevation.  It elevates only for system-wide installs.

There is a known wart encountered during testing:
You get two elevation requests per shortcut.  One during unlinking, and another during linking.  To fix this, we'd have to move shortcut handling completely outside of the main conda process, so that it handled both removal and installation at once.  I find this less palatable than two elevation requests.