### PR TITLE
Always attempt to delete files in `rm_rf`

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -159,9 +159,9 @@ def rm_rf(path, max_retries=5, trash=True):
         # Note that we have to check if the destination is a link because
         # exists('/path/to/dead-link') will return False, although
         # islink('/path/to/dead-link') is True.
-        if os.access(path, os.W_OK):
+        try:
             os.unlink(path)
-        else:
+        except (OSError, IOError):
             log.warn("Cannot remove, permission denied: {0}".format(path))
 
     elif isdir(path):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -227,11 +227,11 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
         mocks['unlink'].assert_called_with(some_path)
 
     @skip_if_no_mock
-    def test_does_not_call_unlink_on_os_access_false(self):
+    def test_calls_unlink_on_os_access_false(self):
         with self.generate_mocks(os_access=False) as mocks:
             some_path = self.generate_random_path
             install.rm_rf(some_path)
-        self.assertFalse(mocks['unlink'].called)
+        mocks['unlink'].assert_called_with(some_path)
 
     @skip_if_no_mock
     def test_does_not_call_isfile_if_islink_is_true(self):


### PR DESCRIPTION
Ask for forgiveness, rather than permission.

When creating a user environment based on a root environment, extra package files would be left in the root of the new user environment. `os.access` checks if the inode itself is writable, not if the directory containing it is writable (which is all that is needed to unlink a file).

Fixes conda/conda#1861