### PR TITLE
OpenBSD 5.x support

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -29,7 +29,7 @@ force_32bit = bool(int(os.getenv('CONDA_FORCE_32BIT', 0)))
 # ----- operating system and architecture -----
 
 _sys_map = {'linux2': 'linux', 'linux': 'linux',
-            'darwin': 'osx', 'win32': 'win'}
+            'darwin': 'osx', 'win32': 'win', 'openbsd5': 'openbsd'}
 non_x86_linux_machines = {'armv6l', 'armv7l', 'ppc64le'}
 platform = _sys_map.get(sys.platform, 'unknown')
 bits = 8 * tuple.__itemsize__

--- a/conda/install.py
+++ b/conda/install.py
@@ -364,7 +364,7 @@ def run_script(prefix, dist, action='post-link', env_prefix=None):
         except KeyError:
             return False
     else:
-        args = ['/bin/bash', path]
+        args = ['/bin/sh', path]
     env = os.environ
     env['ROOT_PREFIX'] = sys.prefix
     env['PREFIX'] = str(env_prefix or prefix)


### PR DESCRIPTION
Hello,

I would really like to be able to use conda on OpenBSD 5.x.
This only requires two minor changes:

- Conda should be able to detect OpenBSD as a new platform `openbsd` instead of `unknown`. This way it is possible to create a repository e.g. "openbsd-64". Unlike linux, ABI compatibility is not guaranteed between BSDs so Open/Net/FreeBSD should have their own platform.

- Conda should not rely on `/bin/bash` being available. First because many linux distributions (or other unixes) install it somewhere else (e.g. `/usr/local/bin/bash`). And more importantly because `bash` is not part of POSIX, so you cannot rely on it being present. Instead conda should use `/bin/sh`, which is guaranteed to be present on any POSIX/coreutils compliant system (Linux + BSDs). Luckily, shells scripts in cause here do not rely on any bash-specific syntax, they are all sh-compliant.

These changes are minor, but allow the use of conda on OpenBSD 5.x.