### PR TITLE
improve default for --show-channel-urls in conda list

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -321,8 +321,7 @@ def add_parser_show_channel_urls(p):
         "--no-show-channel-urls",
         action="store_false",
         dest="show_channel_urls",
-        default=not config.show_channel_urls,
-        help="Don't show channel urls (default: %(default)s).",
+        help="Don't show channel urls.",
     )
 
 def ensure_override_channels_requires_channel(args, dashc=True, json=False):

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -127,6 +127,14 @@ def get_packages(installed, regex):
 def list_packages(prefix, installed, regex=None, format='human',
                   show_channel_urls=config.show_channel_urls):
     res = 1
+    if show_channel_urls is None and format == 'human':
+        show_channel_urls = False
+        for dist in get_packages(installed, regex):
+            info = install.is_linked(prefix, dist)
+            if info and config.canonical_channel_name(
+                               info.get('url')) != 'defaults':
+                show_channel_urls = True
+                break
 
     result = []
     for dist in get_packages(installed, regex):

--- a/conda/config.py
+++ b/conda/config.py
@@ -350,7 +350,8 @@ binstar_upload = rc.get('anaconda_upload',
 allow_softlinks = bool(rc.get('allow_softlinks', True))
 self_update = bool(rc.get('self_update', True))
 # show channel URLs when displaying what is going to be downloaded
-show_channel_urls = bool(rc.get('show_channel_urls', True))
+show_channel_urls = rc.get(
+        'show_channel_urls', None) # None means letting conda decide
 # set packages disallowed to be installed
 disallow = set(rc.get('disallow', []))
 # packages which are added to a newly created environment by default


### PR DESCRIPTION
When all packages come from the defaults channel, which is the case for most users, there is no need to show the channels. In this PR (by default) only show the channels, if at least one package comes from something other than defaults.

See also https://github.com/conda/conda/pull/1771
