### PR TITLE
resolve.py: properly escape periods in version numbers

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -280,7 +280,7 @@ class VersionSpecAtom(object):
             self.regex = False
         else:
             rx = spec.replace('.', r'\.')
-            rx = spec.replace('+', r'\+')
+            rx = rx.replace('+', r'\+')
             rx = rx.replace('*', r'.*')
             rx = r'(%s)$' % rx
             self.regex = re.compile(rx)


### PR DESCRIPTION
While investigating various version-number related issues happened upon this bug. The intended behavior is to escape literal periods in the version specification regex, but that escaping is overwritten by line 283.