### PR TITLE
Support for pinning Lua by default

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -9,7 +9,6 @@ from __future__ import print_function, division, absolute_import
 import os
 import sys
 import logging
-from subprocess import check_output
 from platform import machine
 from os.path import abspath, expanduser, isfile, isdir, join
 import re

--- a/conda/config.py
+++ b/conda/config.py
@@ -9,6 +9,7 @@ from __future__ import print_function, division, absolute_import
 import os
 import sys
 import logging
+from subprocess import check_output
 from platform import machine
 from os.path import abspath, expanduser, isfile, isdir, join
 import re
@@ -21,6 +22,11 @@ log = logging.getLogger(__name__)
 stderrlog = logging.getLogger('stderrlog')
 
 default_python = '%d.%d' % sys.version_info[:2]
+try: # UNTESTED ON WINDOWS. PERHAPS CAN GRAB FROM THE CONDA_BUILD DEFAULT?
+    default_lua = check_output(["lua", "-v"])
+    default_lua = ".".join(default_lua.split(" ")[1].split(".")[:2]) # e.g. 5.2
+except:
+    default_lua = None
 # CONDA_FORCE_32BIT should only be used when running conda-build (in order
 # to build 32-bit packages on a 64-bit system).  We don't want to mention it
 # in the documentation, because it can mess up a lot of things.

--- a/conda/config.py
+++ b/conda/config.py
@@ -22,11 +22,6 @@ log = logging.getLogger(__name__)
 stderrlog = logging.getLogger('stderrlog')
 
 default_python = '%d.%d' % sys.version_info[:2]
-try: # UNTESTED ON WINDOWS. PERHAPS CAN GRAB FROM THE CONDA_BUILD DEFAULT?
-    default_lua = check_output(["lua", "-v"])
-    default_lua = ".".join(default_lua.split(" ")[1].split(".")[:2]) # e.g. 5.2
-except:
-    default_lua = None
 # CONDA_FORCE_32BIT should only be used when running conda-build (in order
 # to build 32-bit packages on a 64-bit system).  We don't want to mention it
 # in the documentation, because it can mess up a lot of things.

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -338,7 +338,7 @@ def add_defaults_to_specs(r, linked, specs):
     names_ms = {MatchSpec(s).name: MatchSpec(s) for s in specs}
 
     for name, def_ver in [('python', config.default_python),
-                          ('lua', config.default_lua)]:
+                          ('lua', None)]:
                          # ('numpy', "config.default_numpy")]:
         ms = names_ms.get(name)
         if ms and ms.strictness > 1:

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -338,7 +338,7 @@ def add_defaults_to_specs(r, linked, specs):
     names_ms = {MatchSpec(s).name: MatchSpec(s) for s in specs}
 
     for name, def_ver in [('python', config.default_python),
-                          ('lua', None)]:
+                          ('lua', None)]: # Default version required, but only used for Python
                          # ('numpy', "config.default_numpy")]:
         ms = names_ms.get(name)
         if ms and ms.strictness > 1:

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -337,8 +337,9 @@ def add_defaults_to_specs(r, linked, specs):
     names_linked = {install.name_dist(dist): dist for dist in linked}
     names_ms = {MatchSpec(s).name: MatchSpec(s) for s in specs}
 
-    for name, def_ver in [('python', config.default_python), ]:
-                         # ('numpy', config.default_numpy)]:
+    for name, def_ver in [('python', config.default_python),
+                          ('lua', config.default_lua)]:
+                         # ('numpy', "config.default_numpy")]:
         ms = names_ms.get(name)
         if ms and ms.strictness > 1:
             # if any of the specifications mention the Python/Numpy version,


### PR DESCRIPTION
This pull request is a small accompaniment for a larger PR in the `conda-build` repo here: https://github.com/conda/conda-build/pull/719

This pull request pins Lua versions by default, because Lua releases, like Python, do not occur often, but when they do, they often break packages.