### PR TITLE
filter app index to only use current Python version

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -49,8 +49,13 @@ def app_get_index(all_version=False):
     By default only the latest version of each app is included in the result,
     unless all_version is set to True.
     """
+    import sys
+    pyxx = 'py%d%d' % sys.version_info[:2]
+    def filter_build(build):
+        return bool(pyxx in build) if 'py' in build else True
+
     index = {fn: info for fn, info in iteritems(get_index())
-             if info.get('type') == 'app'}
+             if info.get('type') == 'app' and filter_build(info['build'])}
     if all_version:
         return index
 


### PR DESCRIPTION
This should fix the problem with the launcher listing apps which cannot be installed into the current root environment.