### PR TITLE
Remove error when CONDA_FORCE_32BIT is set on 32-bit systems

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -34,9 +34,6 @@ non_x86_linux_machines = {'armv6l', 'armv7l', 'ppc64le'}
 platform = _sys_map.get(sys.platform, 'unknown')
 bits = 8 * tuple.__itemsize__
 if force_32bit:
-    if bits == 32:
-        sys.exit("Error: you cannot set CONDA_FORCE_32BIT using "
-                 "32-bit already.")
     bits = 32
 
 if platform == 'linux' and machine() in non_x86_linux_machines:


### PR DESCRIPTION
This is harmless.  It's redundant, but has no ill effects AFAICT.  On the other hand, this error message gets in my way sometimes.