### PR TITLE
corrected --no-use-index-cache help in common.py

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -187,7 +187,7 @@ def add_parser_no_use_index_cache(p):
         action="store_false",
         default=True,
         dest="use_index_cache",
-        help="Use cache of channel index files.",
+        help="Force fetching of channel index files.",
     )
 
 def add_parser_copy(p):


### PR DESCRIPTION
after spotting duplicated description in docs:
```
       --no-use-index-cache
              Use cache of channel index files.

       --use-index-cache
              Use cache of channel index files.
```