### PR TITLE
Print progress to the terminal rather than stdout

### DIFF
--- a/conda/console.py
+++ b/conda/console.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import os
 import sys
 import json
 import logging
@@ -7,7 +8,17 @@ import contextlib
 
 from conda.utils import memoized
 from conda.progressbar import (Bar, ETA, FileTransferSpeed, Percentage,
-                               ProgressBar)
+                               ProgressBar as _ProgressBar)
+
+
+class ProgressBar(_ProgressBar):
+    def __init__(self, *args, **kwargs):
+        _ = kwargs.pop('fd', None)
+        try:
+            tty = open(os.ctermid(), 'w')
+        except IOError:
+            tty = sys.stderr
+        super(ProgressBar, self).__init__(*args, fd=tty, **kwargs)
 
 
 fetch_progress = ProgressBar(

--- a/conda/console.py
+++ b/conda/console.py
@@ -11,13 +11,15 @@ from conda.progressbar import (Bar, ETA, FileTransferSpeed, Percentage,
                                ProgressBar as _ProgressBar)
 
 
+try:
+    tty = open(os.ctermid(), 'w')
+except IOError:
+    tty = sys.stderr
+
+
 class ProgressBar(_ProgressBar):
     def __init__(self, *args, **kwargs):
         kwargs.pop('fd', None)
-        try:
-            tty = open(os.ctermid(), 'w')
-        except IOError:
-            tty = sys.stderr
         super(ProgressBar, self).__init__(*args, fd=tty, **kwargs)
 
 
@@ -149,10 +151,9 @@ class PrintHandler(logging.Handler):
 class DotHandler(logging.Handler):
     def emit(self, record):
         try:
-            sys.stdout.write('.')
-            sys.stdout.flush()
+            tty.write('.')
+            tty.flush()
         except IOError:
-            # sys.stdout.flush doesn't work in pythonw
             pass
 
 class SysStdoutWriteHandler(logging.Handler):

--- a/conda/console.py
+++ b/conda/console.py
@@ -13,7 +13,7 @@ from conda.progressbar import (Bar, ETA, FileTransferSpeed, Percentage,
 
 class ProgressBar(_ProgressBar):
     def __init__(self, *args, **kwargs):
-        _ = kwargs.pop('fd', None)
+        kwargs.pop('fd', None)
         try:
             tty = open(os.ctermid(), 'w')
         except IOError:

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -233,7 +233,7 @@ def fetch_index(channel_urls, use_cache=False, unknown=False):
     log.debug('channel_urls=' + repr(channel_urls))
     # pool = ThreadPool(5)
     index = {}
-    stdoutlog.info("Fetching package metadata: ")
+    stdoutlog.info("Fetching package metadata ...")
     session = CondaSession()
     for url in reversed(channel_urls):
         if config.allowed_channels and url not in config.allowed_channels:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1052,7 +1052,7 @@ Note that the following features are enabled:
                 fn = pkg.fn
                 self.update_with_features(fn, features)
 
-        stdoutlog.info("Solving package specifications: ")
+        stdoutlog.info("Solving package specifications ...")
         try:
             return self.explicit(specs) or self.solve2(specs, features,
                 installed, minimal_hint=minimal_hint, update_deps=update_deps)


### PR DESCRIPTION
The ProgressBar class accepts an optional keyword argument `fd` which specifies the file to write to. Currently it is not set and defaults to `sys.stdout`. So you can't redirect the output of the conda command to a log file, at least not cleanly.

For example, `conda install docopt | tee log` produces:

    Fetching package metadata: ....
    Solving package specifications: .................
    Package plan for installation in environment /Users/ace/miniconda2:
    
    The following packages will be downloaded:
    
        package                    |            build
        ---------------------------|-----------------
        docopt-0.6.2               |           py27_0          18 KB
    
    The following NEW packages will be INSTALLED:
    
        docopt: 0.6.2-py27_0
    
    Proceed ([y]/n)? 
    Fetching packages ...
    docopt-0.6.2-p   0% |                              | ETA:  --:--:--   0.00  B/s
    ^Mdocopt-0.6.2-p  87% |###########################    | ETA:  0:00:00 340.32 kB/s^Mdocopt-0.6.2-p 100% |###############################| ETA:  0:00:00 384.09 kB/s^Mdocopt-0.6.2-p 100% |###############################| Time: 0:00:00 379.10 kB/s
    Extracting packages ...
    [                    ]|                                                  |   0%

The progress should print directly to the controlling terminal, or `sys.stderr`.