### PR TITLE
Make clone_env link packages in toposorted order

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -237,16 +237,11 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index=None):
             fo.write(data)
         shutil.copystat(src, dst)
 
-    must_have = {}
-    for dist in dists:
-        name = install.name_dist(dist)
-        must_have[name] = dist
-
     if index is None:
         index = get_index()
 
     r = Resolve(index)
-    sorted_dists = r.graph_sort(must_have)
+    sorted_dists = r.dependency_sort(dists)
 
     actions = ensure_linked_actions(sorted_dists, prefix2)
     execute_actions(actions, index=index, verbose=not quiet)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -14,6 +14,7 @@ from conda.logic import (false, true, sat, min_sat, generate_constraints,
 from conda.console import setup_handlers
 from conda import config
 from conda.toposort import toposort
+from conda.install import name_dist
 
 log = logging.getLogger(__name__)
 dotlog = logging.getLogger('dotupdate')
@@ -731,6 +732,10 @@ class Resolve(object):
         if filtered:
             self.clear_filter()
         return dists
+
+    def dependency_sort(self, dists):
+        sort_info = {name_dist(dist): dist for dist in dists}
+        return self.graph_sort(sort_info)
 
     def graph_sort(self, must_have):
 


### PR DESCRIPTION
Currently, conda create --clone <env> links all packages in <env>
into a new environment. This is done without respecting package
dependencies. This can cause issues with packages that have
install-time dependencies (for example, post-link scripts).

This fixes https://github.com/conda/conda/issues/1451.