### PR TITLE
Fix/info on locked files

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -29,11 +29,7 @@ import conda.install as ci
 log = logging.getLogger(__name__)
 
 def check_perms_and_exit(path, access=os.W_OK, json=False):
-    if not os.path.exists(path):
-        common.error_and_exit(path + ' does not exist',
-                              json=json,
-                              error_type="RuntimeError")
-    if not os.access(path, access):
+    if os.path.exists(path) and not os.access(path, access):
         common.error_and_exit('No {} permissions for {}'.format(repr(access), path),
                               json=json,
                               error_type="RuntimeError")

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -207,16 +207,14 @@ Include the output of the command 'conda info' in your report.
 """ + traceback.format_exc()
     if getattr(e, 'errno', None) == 13:
         if os.name == 'nt':
-            proc = subprocess.Popen(['cmd', '/c', 'tasklist','/V'],
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT)
-            proc.wait()
             message += """
-Review this tasklist output to find
-possible source of permissions error.
-One process may be holding onto the named file.
+    Review this tasklist output to find
+    possible source of permissions error.
+    One process may be holding onto the named file.
 
-""" + proc.stdout.read().decode()
+"""
+            proc = subprocess.Popen(['cmd', '/c', 'tasklist','/V'])
+            proc.wait()
     if use_json:
         common.error_and_exit(message,
                               error_type="UnexpectedError", json=True)

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -224,7 +224,8 @@ def print_task_list():
         exe: {},
         cmdline: {},
         open_files: {}'''
-        print(template.format(proc.pid, exe, cmdline, open_files))
+        if exe:
+            print(template.format(proc.pid, exe, cmdline, open_files))
         if open_files:
             for f in open_files:
                 if f.startswith(sys.prefix):

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -189,6 +189,7 @@ def args_func(args, p):
 
 def print_issue_message(e, use_json=False):
     from conda.cli import common
+    import traceback
     message = ""
     if e.__class__.__name__ not in ('ScannerError', 'ParserError'):
             message = """\
@@ -213,7 +214,6 @@ One process may be holding onto the named file.
 
 """ + proc.stdout.read().decode()
     if use_json:
-        import traceback
         common.error_and_exit(message,
                               error_type="UnexpectedError", json=True)
     print(message)

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -189,6 +189,7 @@ def args_func(args, p):
 
 def print_issue_message(e, use_json=False):
     import os
+    import subprocess
     import traceback
 
     from conda.cli import common

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -225,6 +225,6 @@ Include the output of the command 'conda info' in your report.
     One process may be holding onto the named file.
 
 """)
-            print_task_list()
+        print_task_list()
 if __name__ == '__main__':
     main()

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -205,6 +205,10 @@ following traceback to the conda GitHub issue tracker at:
 Include the output of the command 'conda info' in your report.
 
 """ + traceback.format_exc()
+    if use_json:
+        common.error_and_exit(message,
+                              error_type="UnexpectedError", json=True)
+    print(message)
     if getattr(e, 'errno', None) == 13:
         if os.name == 'nt':
             message += """
@@ -215,10 +219,6 @@ Include the output of the command 'conda info' in your report.
 """
             proc = subprocess.Popen(['cmd', '/c', 'tasklist','/V'])
             proc.wait()
-    if use_json:
-        common.error_and_exit(message,
-                              error_type="UnexpectedError", json=True)
-    print(message)
 
 if __name__ == '__main__':
     main()

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -188,8 +188,11 @@ def args_func(args, p):
         raise  # as if we did not catch it
 
 def print_issue_message(e, use_json=False):
-    from conda.cli import common
+    import os
     import traceback
+
+    from conda.cli import common
+
     message = ""
     if e.__class__.__name__ not in ('ScannerError', 'ParserError'):
             message = """\

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -220,19 +220,12 @@ def print_task_list():
             open_files = proc.open_files()
         except psutil.AccessDenied:
             open_files = None
-        template = '''{} {}
+        template = '''PID: {}
         exe: {},
         cmdline: {},
         open_files: {}'''
-        if exe:
-            startswith = exe.startswith(sys.prefix)
-            if startswith:
-                print(template.format(proc.pid,
-                                      'running on same prefix',
-                                      exe, cmdline, open_files))
+        print(template.format(proc.pid, exe, cmdline, open_files))
         if open_files:
-            print(template.format(proc.pid, 'has open files.',
-                                  exe, cmdline, open_files))
             for f in open_files:
                 if f.startswith(sys.prefix):
                     print('Open file: ', f, 'is on sys.prefix.')

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -174,7 +174,9 @@ activate it.
 
 def args_func(args, p):
     from conda.cli import common
-
+    if os.name == 'nt':
+        print('Debug: print tasklist /V before main func:')
+        print_task_list()
     use_json = getattr(args, 'json', False)
     try:
         args.func(args, p)
@@ -187,9 +189,15 @@ def args_func(args, p):
         print_issue_message(e, use_json=use_json)
         raise  # as if we did not catch it
 
+def print_task_list():
+    import subprocess
+    if os.name == 'nt':
+        proc = subprocess.Popen(['cmd', '/c', 'tasklist','/V'])
+        proc.wait()
+
+
 def print_issue_message(e, use_json=False):
     import os
-    import subprocess
     import traceback
 
     from conda.cli import common
@@ -204,21 +212,19 @@ following traceback to the conda GitHub issue tracker at:
 
 Include the output of the command 'conda info' in your report.
 
-""" + traceback.format_exc()
+"""
     if use_json:
-        common.error_and_exit(message,
+        common.error_and_exit(message + traceback.format_exc(),
                               error_type="UnexpectedError", json=True)
     print(message)
     if getattr(e, 'errno', None) == 13:
-        if os.name == 'nt':
-            message += """
-    Review this tasklist output to find
+
+        print("""
+    Review this tasklist /V output to find
     possible source of permissions error.
     One process may be holding onto the named file.
 
-"""
-            proc = subprocess.Popen(['cmd', '/c', 'tasklist','/V'])
-            proc.wait()
-
+""")
+            print_task_list()
 if __name__ == '__main__':
     main()

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -199,10 +199,22 @@ following traceback to the conda GitHub issue tracker at:
 
 Include the output of the command 'conda info' in your report.
 
-"""
+""" + traceback.format_exc()
+    if getattr(e, 'errno', None) == 13:
+        if os.name == 'nt':
+            proc = subprocess.Popen(['cmd', '\c', 'tasklist','/V'],
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+            proc.wait()
+            message += """
+Review this tasklist output to find
+possible source of permissions error.
+One process may be holding onto the named file.
+
+""" + proc.stdout.read().decode()
     if use_json:
         import traceback
-        common.error_and_exit(message + traceback.format_exc(),
+        common.error_and_exit(message,
                               error_type="UnexpectedError", json=True)
     print(message)
 

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -207,7 +207,7 @@ Include the output of the command 'conda info' in your report.
 """ + traceback.format_exc()
     if getattr(e, 'errno', None) == 13:
         if os.name == 'nt':
-            proc = subprocess.Popen(['cmd', '\c', 'tasklist','/V'],
+            proc = subprocess.Popen(['cmd', '/c', 'tasklist','/V'],
                              stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT)
             proc.wait()

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -177,9 +177,6 @@ activate it.
 
 def args_func(args, p):
     from conda.cli import common
-    if os.name == 'nt':
-        print('Debug: print tasklist /V before main func:')
-        print_task_list()
     use_json = getattr(args, 'json', False)
     try:
         args.func(args, p)

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -37,7 +37,9 @@ Additional help for each command can be accessed by using:
 
 from __future__ import print_function, division, absolute_import
 
+import os
 import sys
+import traceback
 
 def main():
     if len(sys.argv) > 1:
@@ -197,8 +199,6 @@ def print_task_list():
 
 
 def print_issue_message(e, use_json=False):
-    import os
-    import traceback
 
     from conda.cli import common
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -474,14 +474,19 @@ def extracted(pkgs_dir):
                if (isfile(join(pkgs_dir, dn, 'info', 'files')) and
                    isfile(join(pkgs_dir, dn, 'info', 'index.json'))))
 
-def extract(pkgs_dir, dist):
+def extract(pkgs_dir, dist, json=False):
     """
     Extract a package, i.e. make a package available for linkage.  We assume
     that the compressed packages is located in the packages directory.
     """
+    from conda.cli.install import check_perms_and_exit
+
     with Locked(pkgs_dir):
         path = join(pkgs_dir, dist)
-        t = tarfile.open(path + '.tar.bz2')
+        check_perms_and_exit(path, access=os.W_OK, json=json)
+        tar_path = path + '.tar.bz2'
+        check_perms_and_exit(tar_path, access=os.W_OK, json=json)
+        t = tarfile.open(tar_path)
         t.extractall(path=path)
         t.close()
         if sys.platform.startswith('linux') and os.getuid() == 0:

--- a/conda/install.py
+++ b/conda/install.py
@@ -492,7 +492,7 @@ def extract(pkgs_dir, dist, json=False):
         check_perms_and_exit(tar_path, access=os.W_OK, json=json)
         t = tarfile.open(tar_path)
         for member in t.getmembers():
-            member_target = os.path.join(path, member.name)
+            member_target = os.path.join(path, os.path.join(*os.path.split(member.name)))
             print(member_target, file=sys.stderr)
             check_perms_and_exit(member_target, access=os.W_OK, json=json)
         t.extractall(path=path)

--- a/conda/install.py
+++ b/conda/install.py
@@ -492,7 +492,7 @@ def extract(pkgs_dir, dist, json=False):
         check_perms_and_exit(tar_path, access=os.W_OK, json=json)
         t = tarfile.open(tar_path)
         for member in t.getmembers():
-            member_target = os.path.join(path, os.path.join(*os.path.split(member.name)))
+            member_target = os.path.join(path, os.path.normpath(member.name))
             print(member_target, file=sys.stderr)
             check_perms_and_exit(member_target, access=os.W_OK, json=json)
         t.extractall(path=path)

--- a/conda/install.py
+++ b/conda/install.py
@@ -493,7 +493,6 @@ def extract(pkgs_dir, dist, json=False):
         t = tarfile.open(tar_path)
         for member in t.getmembers():
             member_target = os.path.join(path, os.path.normpath(member.name))
-            print(member_target, file=sys.stderr)
             check_perms_and_exit(member_target, access=os.W_OK, json=json)
         t.extractall(path=path)
         t.close()

--- a/conda/install.py
+++ b/conda/install.py
@@ -114,6 +114,8 @@ link_name_map = {
 }
 
 def _link(src, dst, linktype=LINK_HARD):
+    from conda.cli.install import check_perms_and_exit
+    check_perms_and_exit(dst, access=os.W_OK, json=False)
     if linktype == LINK_HARD:
         if on_win:
             win_hard_link(src, dst)
@@ -155,6 +157,8 @@ def rm_rf(path, max_retries=5, trash=True):
 
     If removing path fails and trash is True, files will be moved to the trash directory.
     """
+    from conda.cli.install import check_perms_and_exit
+    check_perms_and_exit(path, access=os.W_OK, json=False)
     if islink(path) or isfile(path):
         # Note that we have to check if the destination is a link because
         # exists('/path/to/dead-link') will return False, although
@@ -503,7 +507,9 @@ def is_extracted(pkgs_dir, dist):
             isfile(join(pkgs_dir, dist, 'info', 'index.json')))
 
 def rm_extracted(pkgs_dir, dist):
+
     with Locked(pkgs_dir):
+        from conda.cli.install import check_perms_and_exit
         path = join(pkgs_dir, dist)
         rm_rf(path)
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -491,6 +491,9 @@ def extract(pkgs_dir, dist, json=False):
         tar_path = path + '.tar.bz2'
         check_perms_and_exit(tar_path, access=os.W_OK, json=json)
         t = tarfile.open(tar_path)
+        for member in t.getmembers():
+            member_target = os.path.join(path, member.name)
+            check_perms_and_exit(member_target, access=os.W_OK, json=json)
         t.extractall(path=path)
         t.close()
         if sys.platform.startswith('linux') and os.getuid() == 0:

--- a/conda/install.py
+++ b/conda/install.py
@@ -493,6 +493,7 @@ def extract(pkgs_dir, dist, json=False):
         t = tarfile.open(tar_path)
         for member in t.getmembers():
             member_target = os.path.join(path, member.name)
+            print(member_target, file=sys.stderr)
             check_perms_and_exit(member_target, access=os.W_OK, json=json)
         t.extractall(path=path)
         t.close()

--- a/conda/install.py
+++ b/conda/install.py
@@ -512,7 +512,6 @@ def is_extracted(pkgs_dir, dist):
 def rm_extracted(pkgs_dir, dist):
 
     with Locked(pkgs_dir):
-        from conda.cli.install import check_perms_and_exit
         path = join(pkgs_dir, dist)
         rm_rf(path)
 

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -59,6 +59,7 @@ url_pat = re.compile(r'(?P<url>.+)/(?P<fn>[^/#]+\.tar\.bz2)'
 def explicit(urls, prefix, verbose=True):
     import conda.fetch as fetch
     from conda.utils import md5_file
+    from conda.cli import check_perms_and_exit
 
     dists = []
     for url in urls:
@@ -79,6 +80,7 @@ def explicit(urls, prefix, verbose=True):
             sys.exit("Error: MD5 in explicit files does not match index")
         pkg_path = join(config.pkgs_dirs[0], fn)
         if isfile(pkg_path):
+            check_perms_and_exit(pkg_path, access=os.W_OK, json=False)
             try:
                 if md5_file(pkg_path) != info['md5']:
                     install.rm_rf(pkg_path)
@@ -244,9 +246,11 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index=None):
     return actions, untracked_files
 
 
-def install_local_packages(prefix, paths, verbose=False):
+def install_local_packages(prefix, paths, verbose=False, json=False):
     # copy packages to pkgs dir
+    from conda.cli.install import check_perms_and_exit
     pkgs_dir = config.pkgs_dirs[0]
+    check_perms_and_exit(pkgs_dir, access=os.W_OK, json=json)
     dists = []
     for src_path in paths:
         assert src_path.endswith('.tar.bz2')
@@ -255,6 +259,7 @@ def install_local_packages(prefix, paths, verbose=False):
         dst_path = join(pkgs_dir, fn)
         if abspath(src_path) == abspath(dst_path):
             continue
+        check_perms_and_exit(dst_path, access=os.W_OK, json=json)
         shutil.copyfile(src_path, dst_path)
 
     force_extract_and_link(dists, prefix, verbose=verbose)


### PR DESCRIPTION
This is an experiment on printing more information about windows permissions error on attempted extraction of tarfiles to the pkgs dir.  This is aimed at helping anaconda-build.  

Edit 2/3/2016: This PR is ready to merge.  It affects nothing other than diagnostic printing when windows encounters a permissions error trying to unpack a tarfile.