### PR TITLE
Add linked packages to the output of get_index()

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -26,20 +26,26 @@ def _fn2fullspec(fn):
 
 
 def get_index(channel_urls=(), prepend=True, platform=None,
-              use_cache=False, unknown=False, offline=False):
+              use_cache=False, unknown=False, offline=False,
+              prefix=None):
     """
     Return the index of packages available on the channels
 
     If prepend=False, only the channels passed in as arguments are used.
     If platform=None, then the current platform is used.
+    If prefix is supplied, then the packages installed in that prefix are added.
     """
     channel_urls = config.normalize_urls(channel_urls, platform=platform)
     if prepend:
         channel_urls += config.get_channel_urls(platform=platform)
     if offline:
         channel_urls = [url for url in channel_urls if url.startswith('file:')]
-    return fetch_index(tuple(channel_urls), use_cache=use_cache,
+    index = fetch_index(tuple(channel_urls), use_cache=use_cache,
                        unknown=unknown)
+    if prefix:
+        for fn, info in iteritems(install.linked_data(prefix)):
+            index[fn+'.tar.bz2'] = info
+    return index
 
 
 def app_get_index(all_version=False):
@@ -75,7 +81,7 @@ def app_get_icon_url(fn):
     return make_icon_url(info)
 
 
-def app_info_packages(fn):
+def app_info_packages(fn, prefix=config.root_dir):
     """
     given the filename of a package, return which packages (and their sizes)
     still need to be downloaded, in order to install the package.  That is,
@@ -85,7 +91,7 @@ def app_info_packages(fn):
     """
     from conda.resolve import Resolve
 
-    index = get_index()
+    index = get_index(prefix=prefix)
     r = Resolve(index)
     res = []
     for fn2 in r.solve([_fn2fullspec(fn)]):
@@ -122,7 +128,7 @@ def app_install(fn, prefix=config.root_dir):
     """
     import conda.plan as plan
 
-    index = get_index()
+    index = get_index(prefix=prefix)
     actions = plan.install_actions(prefix, index, [_fn2spec(fn)])
     plan.execute_actions(actions, index)
 
@@ -149,7 +155,7 @@ def app_uninstall(fn, prefix=config.root_dir):
     import conda.cli.common as common
     import conda.plan as plan
 
-    index = None
+    index = get_index(prefix=prefix)
     specs = [_fn2spec(fn)]
     if (plan.is_root_prefix(prefix) and
         common.names_in_specs(common.root_no_rm, specs)):

--- a/conda/api.py
+++ b/conda/api.py
@@ -94,11 +94,12 @@ def app_info_packages(fn, prefix=config.root_dir):
     index = get_index(prefix=prefix)
     r = Resolve(index)
     res = []
-    for fn2 in r.solve([_fn2fullspec(fn)]):
+    for fn2 in r.solve([_fn2fullspec(fn)], installed=install.linked(prefix)):
         info = index[fn2]
-        res.append((info['name'], info['version'], info['size'],
-                    any(install.is_fetched(pkgs_dir, fn2[:-8])
-                        for pkgs_dir in config.pkgs_dirs)))
+        if 'link' not in info:
+            res.append((info['name'], info['version'], info['size'],
+                        any(install.is_fetched(pkgs_dir, fn2[:-8])
+                            for pkgs_dir in config.pkgs_dirs)))
     return res
 
 

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -236,7 +236,8 @@ def install(args, parser, command='install'):
                                   use_cache=args.use_index_cache,
                                   unknown=args.unknown,
                                   json=args.json,
-                                  offline=args.offline)
+                                  offline=args.offline,
+                                  prefix=prefix)
 
     if newenv and args.clone:
         if set(args.packages) - set(default_packages):
@@ -456,7 +457,7 @@ def check_install(packages, platform=None, channel_urls=(), prepend=True,
         prefix = tempfile.mkdtemp('conda')
         specs = common.specs_from_args(packages)
         index = get_index(channel_urls=channel_urls, prepend=prepend,
-                          platform=platform)
+                          platform=platform, prefix=prefix)
         actions = plan.install_actions(prefix, index, specs, pinned=False,
                                        minimal_hint=minimal_hint)
         plan.display_actions(actions, index)

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -121,13 +121,15 @@ def execute(args, parser):
                                       prepend=not args.override_channels,
                                       use_cache=args.use_index_cache,
                                       json=args.json,
-                                      offline=args.offline)
+                                      offline=args.offline,
+                                      prefix=prefix)
     else:
         index = common.get_index_trap(channel_urls=channel_urls,
                                       prepend=not args.override_channels,
                                       use_cache=args.use_index_cache,
                                       json=args.json,
-                                      offline=args.offline)
+                                      offline=args.offline,
+                                      prefix=prefix)
     specs = None
     if args.features:
         features = set(args.package_names)

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -184,12 +184,12 @@ def execute_search(args, parser):
         index = common.get_index_trap(channel_urls=channel_urls,
                                       prepend=not args.override_channels,
                                       use_cache=args.use_index_cache,
-                                      unknown=args.unknown,
+                                      unknown=args.unknown, prefix=prefix,
                                       json=args.json, platform=args.platform, offline=args.offline)
     else:
         index = common.get_index_trap(channel_urls=channel_urls, prepend=not
                                       args.override_channels, platform=args.platform,
-                                      use_cache=args.use_index_cache,
+                                      use_cache=args.use_index_cache, prefix=prefix,
                                       unknown=args.unknown, json=args.json, offline=args.offline)
 
     r = Resolve(index)

--- a/conda/install.py
+++ b/conda/install.py
@@ -504,6 +504,21 @@ def rm_extracted(pkgs_dir, dist):
 
 # ------- linkage of packages
 
+def linked_data(prefix):
+    """
+    Return a dictionary of the linked packages in prefix.
+    """
+    res = {}
+    meta_dir = join(prefix, 'conda-meta')
+    if isdir(meta_dir):
+        for fn in os.listdir(meta_dir):
+            if fn.endswith('.json'):
+                try:
+                    res[fn[:-5]] = json.load(open(join(meta_dir,fn)))
+                except IOError:
+                    pass
+    return res
+
 def linked(prefix):
     """
     Return the (set of canonical names) of linked packages in prefix.


### PR DESCRIPTION
Suppose an environment has a package that was installed using the `-c` command line option: that is, from a channel that is _not_ in the default channel list. Subsequent calls to `install` or `update` will be unable to properly handle that package's presence for the purposes of dependency resolution. In particular, it will be possible to break said package by modifying its dependencies.

This PR solves the problem by adding a `prefix=` keyword argument to `api.get_index`, which in turn calls a new function `install.linked_data`. When a non-empty `prefix` is supplied, it will add the JSON data it finds in that `prefix` into the index. Now that it is available, the solver will have full dependency and version data available when it sees that package in the `installed` list.