### PR TITLE
suppress help text for --unknown option

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -167,9 +167,7 @@ def add_parser_known(p):
         action="store_true",
         default=False,
         dest='unknown',
-        help="Use index metadata from the local package cache, "
-             "which are from unknown channels (installing local packages "
-             "directly implies this option).",
+        help=argparse.SUPPRESS,
     )
 
 def add_parser_use_index_cache(p):


### PR DESCRIPTION
The conda package cache, has been (from my point of view at least) been more and more abused to get to data which is available on the local system, in order to make conda work better in offline mode. However, the package cache was originally never designed for that purpose.  The `--unknown` option is one such example.  This option has a very confusing name, and does not always work correctly.

In this PR, we remove the help text for this option (to confuse people less).  Hopefully, it will be possible to remove the functionality soon as well.