### PR TITLE
remove ref to pip-script.py

### DIFF
--- a/conda/pip.py
+++ b/conda/pip.py
@@ -14,7 +14,7 @@ def pip_args(prefix):
     is not installed
     """
     if sys.platform == 'win32':
-        pip_path = join(prefix, 'Scripts', 'pip-script.py')
+        pip_path = join(prefix, 'Scripts', 'pip.exe')
         py_path = join(prefix, 'python.exe')
     else:
         pip_path = join(prefix, 'bin', 'pip')


### PR DESCRIPTION
On Windows, recent versions of pip apparently do not create "-script.py" wrappers: see pypa/virtualenv#539

As a result, conda should not rely on the presence of `pip-script.py` when listing packages. I encountered this problem after upgrading pip on Windows using the recommended `python -m pip --upgrade pip` command. Since pip installs itself using a wheel, it doesn't create the `pip-script.py` file. Subsequently, `conda list` is unable to list any pip-installed packages.

I confirmed that changing `"pip-script.py"` to `"pip.exe"` in this file fixed the behavior of `conda list`.