### PR TITLE
Add get_user_requests method to History call

### DIFF
--- a/conda/history.py
+++ b/conda/history.py
@@ -122,6 +122,14 @@ class History(object):
         return res
 
     def get_requests(self):
+        """
+        return a list of user requested items.  Each item is a dict with the
+        following keys:
+        'date': the date and time running the command
+        'cmd': a list of argv of the actual command which was run
+        'action': install/remove/update
+        'specs': the specs being used
+        """
         res = []
         com_pat = re.compile(r'#\s*cmd:\s*(.+)')
         spec_pat = re.compile(r'#\s*(\w+)\s*specs:\s*(.+)')
@@ -138,7 +146,7 @@ class History(object):
                 if m:
                     action, specs = m.groups()
                     item['action'] = action
-                    item['specs'] = specs
+                    item['specs'] = eval(specs)
             if 'cmd' in item:
                 res.append(item)
         return res
@@ -249,7 +257,7 @@ class History(object):
                 fo.write('+%s\n' % fn)
 
 if __name__ == '__main__':
-    #from pprint import pprint
+    from pprint import pprint
     with History(sys.prefix) as h:
-        h.print_log()
-        #pprint(h.get_requests())
+        #h.print_log()
+        pprint(h.get_requests())

--- a/conda/history.py
+++ b/conda/history.py
@@ -121,7 +121,7 @@ class History(object):
                 res[-1][1].add(line)
         return res
 
-    def get_requests(self):
+    def get_user_requests(self):
         """
         return a list of user requested items.  Each item is a dict with the
         following keys:
@@ -260,4 +260,4 @@ if __name__ == '__main__':
     from pprint import pprint
     with History(sys.prefix) as h:
         #h.print_log()
-        pprint(h.get_requests())
+        pprint(h.get_user_requests())

--- a/conda/history.py
+++ b/conda/history.py
@@ -100,7 +100,7 @@ class History(object):
     def parse(self):
         """
         parse the history file and return a list of
-        tuples(datetime strings, set of distributions/diffs)
+        tuples(datetime strings, set of distributions/diffs, comments)
         """
         res = []
         if not isfile(self.path):
@@ -110,12 +110,13 @@ class History(object):
             lines = f.read().splitlines()
         for line in lines:
             line = line.strip()
-            if not line or line.startswith('#'):
+            if not line:
                 continue
             m = sep_pat.match(line)
             if m:
-                dt = m.group(1)
-                res.append((dt, set()))
+                res.append((m.group(1), set(), []))
+            elif line.startswith('#'):
+                res[-1][2].append(line)
             else:
                 res[-1][1].add(line)
         return res
@@ -126,7 +127,7 @@ class History(object):
         """
         res = []
         cur = set([])
-        for dt, cont in self.parse():
+        for dt, cont, unused_com in self.parse():
             if not is_diff(cont):
                 cur = cont
             else:
@@ -153,7 +154,7 @@ class History(object):
         return pkgs[rev]
 
     def print_log(self):
-        for i, (date, content) in enumerate(self.parse()):
+        for i, (date, content, unused_com) in enumerate(self.parse()):
             print('%s  (rev %d)' % (date, i))
             for line in pretty_content(content):
                 print('    %s' % line)
@@ -161,7 +162,7 @@ class History(object):
 
     def object_log(self):
         result = []
-        for i, (date, content) in enumerate(self.parse()):
+        for i, (date, content, unused_com) in enumerate(self.parse()):
             # Based on Mateusz's code; provides more details about the
             # history event
             event = {

--- a/conda/history.py
+++ b/conda/history.py
@@ -121,6 +121,28 @@ class History(object):
                 res[-1][1].add(line)
         return res
 
+    def get_requests(self):
+        res = []
+        com_pat = re.compile(r'#\s*cmd:\s*(.+)')
+        spec_pat = re.compile(r'#\s*(\w+)\s*specs:\s*(.+)')
+        for dt, unused_cont, comments in self.parse():
+            item = {'date': dt}
+            for line in comments:
+                m = com_pat.match(line)
+                if m:
+                    argv = m.group(1).split()
+                    if argv[0].endswith('conda'):
+                        argv[0] = 'conda'
+                    item['cmd'] = argv
+                m = spec_pat.match(line)
+                if m:
+                    action, specs = m.groups()
+                    item['action'] = action
+                    item['specs'] = specs
+            if 'cmd' in item:
+                res.append(item)
+        return res
+
     def construct_states(self):
         """
         return a list of tuples(datetime strings, set of distributions)
@@ -227,5 +249,7 @@ class History(object):
                 fo.write('+%s\n' % fn)
 
 if __name__ == '__main__':
+    #from pprint import pprint
     with History(sys.prefix) as h:
         h.print_log()
+        #pprint(h.get_requests())

--- a/tests/conda-meta/history
+++ b/tests/conda-meta/history
@@ -1,0 +1,54 @@
+==> 2016-02-16 13:31:33 <==
+# cmd: /home/ilan/minonda/bin/conda update conda
+conda-3.19.0-py27_0
+conda-env-2.4.5-py27_0
+openssl-1.0.2d-0
+pip-7.1.2-py27_0
+pycosat-0.6.1-py27_0
+pycrypto-2.6.1-py27_0
+python-2.7.11-0
+pyyaml-3.11-py27_1
+readline-6.2-2
+requests-2.9.0-py27_0
+setuptools-18.8.1-py27_0
+sqlite-3.8.4.1-1
+tk-8.5.18-0
+wheel-0.26.0-py27_1
+yaml-0.1.6-0
+zlib-1.2.8-0
+==> 2016-02-16 13:31:41 <==
+# cmd: /home/ilan/minonda/bin/conda update conda
+-conda-3.19.0-py27_0
+-openssl-1.0.2d-0
+-pip-7.1.2-py27_0
+-requests-2.9.0-py27_0
+-setuptools-18.8.1-py27_0
+-sqlite-3.8.4.1-1
+-wheel-0.26.0-py27_1
++conda-3.19.1-py27_0
++openssl-1.0.2f-0
++pip-8.0.2-py27_0
++requests-2.9.1-py27_0
++setuptools-19.6.2-py27_0
++sqlite-3.9.2-0
++wheel-0.29.0-py27_0
+# update specs: ['conda', 'conda', 'python 2.7*']
+==> 2016-02-16 13:34:30 <==
+# cmd: /home/ilan/minonda/bin/conda install cas-mirror
++cas-mirror-1.4.0-py27_x0
++cheetah-2.4.4-py27_0
++lighttpd-1.4.36-0
+# install specs: ['cas-mirror', 'conda', 'python 2.7*']
+==> 2016-02-16 14:17:47 <==
+# cmd: /home/ilan/minonda/bin/conda update cas-mirror
+-cas-mirror-1.4.0-py27_x0
++cas-mirror-1.4.1-py27_x0
+# update specs: ['cas-mirror', 'conda', 'python 2.7*']
+==> 2016-02-16 17:19:39 <==
+# cmd: /home/ilan/minonda/bin/conda install grin
++grin-1.2.1-py27_1
+# install specs: ['grin', 'conda', 'python 2.7*']
+==> 2016-02-18 22:53:20 <==
+# cmd: /home/ilan/minonda/bin/conda install pyflakes
++pyflakes-1.0.0-py27_0
+# install specs: ['pyflakes', 'conda', 'python 2.7*']

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,9 +1,11 @@
+from os.path import dirname
 import unittest
 
 from .decorators import skip_if_no_mock
 from .helpers import mock
 
 from conda import history
+
 
 class HistoryTestCase(unittest.TestCase):
     def test_works_as_context_manager(self):
@@ -26,3 +28,24 @@ class HistoryTestCase(unittest.TestCase):
         with mock.patch.object(h, 'update'):
             with h as h2:
                 self.assertEqual(h, h2)
+
+
+class UserRequestsTestCase(unittest.TestCase):
+
+    h = history.History(dirname(__file__))
+    user_requests = h.get_user_requests()
+
+    def test_len(self):
+        self.assertEqual(len(self.user_requests), 6)
+
+    def test_0(self):
+        self.assertEqual(self.user_requests[0],
+                         {'cmd': ['conda', 'update', 'conda'],
+                          'date': '2016-02-16 13:31:33'})
+
+    def test_last(self):
+        self.assertEqual(self.user_requests[-1],
+                         {'action': 'install',
+                          'cmd': ['conda', 'install', 'pyflakes'],
+                          'date': '2016-02-18 22:53:20',
+                          'specs': ['pyflakes', 'conda', 'python 2.7*']})


### PR DESCRIPTION
The method `get_user_requests` adds information about user requested packages (all information is already in the `histroy` file), this method merely provides a convenient way for retrieving the data.  Here is an example:
```
>>> from conda.history import History
>>> h = History('/Users/ilan/anaconda')  # prefix
>>> h.get_user_requests()[237]
{'action': 'install',
  'cmd': ['conda', 'install', 'pandas'],
  'date': '2016-01-31 12:39:33',
  'specs': ['pandas', 'conda', 'python 2.7*']}
```
CC @mcg1969, @kalefranz, @groutr