### PR TITLE
proof of concept for conda as shell function

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include versioneer.py
+include bin/conda.sh

--- a/bin/conda.sh
+++ b/bin/conda.sh
@@ -1,0 +1,57 @@
+# This file should be sourced by bash or zsh.  It should not itself be executed.
+
+
+_conda_hashr() {
+    [[ -z $BASH_VERSION ]] || hash -r
+    [[ -z $ZSH_VERSION ]] || rehash
+}
+
+
+_conda_env_exists() {
+    _env_location="$(conda-env-helper find_env_location $1)"
+    test -n "$_env_location"
+}
+
+
+_conda_currently_in_env() {
+    test -n "$CONDA_DEFAULT_ENV"
+}
+
+
+_conda_activate() {
+    if _conda_currently_in_env; then
+        _conda_deactivate
+    fi
+    if _conda_env_exists "$1"; then
+        echo "found $_env_location"
+        echo "activating"
+        source activate "$_env_location"
+    else
+        echo "creating"
+        # create
+    fi
+    _conda_hashr
+}
+
+
+_conda_deactivate() {
+    echo "deactivating $CONDA_DEFAULT_ENV"
+    source deactivate
+}
+
+
+conda() {
+    local cmd="$1" && shift
+    case "$cmd" in
+        activate)
+            _conda_activate "$@"
+            ;;
+        deactivate)
+            _conda_deactivate
+            ;;
+        *)
+            CONDA="$(which conda)"
+            $CONDA "$cmd" "$@"
+            ;;
+    esac
+}

--- a/conda/env_helper.py
+++ b/conda/env_helper.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+import os
+import types
+
+from ._vendor import click
+
+from .config import envs_dirs
+
+HOME = os.environ['HOME']
+PWD = os.environ['PWD']
+assert os.getcwd() == PWD
+
+
+def expand(path):
+    return os.path.join(PWD, os.path.normpath(os.path.expanduser(os.path.expandvars(path))))
+
+
+def take_first(maybe_iterable):
+    if isinstance(maybe_iterable, types.StringTypes):
+        return maybe_iterable
+    elif hasattr(maybe_iterable, '__iter__'):
+        if len(maybe_iterable) > 0:
+            return maybe_iterable[0]
+        else:
+            return None
+    else:
+        return maybe_iterable
+
+
+@click.group()
+def cli():
+    pass
+
+
+def is_env_location(path):
+    path = expand(path)
+    cm = os.path.join(path, 'conda-meta')
+    return os.path.isdir(path) and os.path.isdir(cm)
+
+
+def find_dot_conda_dir(path):
+    if path in (HOME, '/'):
+        return None
+    elif os.path.join(path, '.conda'):
+        return path
+    else:
+        return find_dot_conda_dir(os.path.dirname(path))
+
+
+def has_env_yml(path):
+    yml_path = os.path.join(path, '.condaenv.yml')
+    return os.path.isfile(yml_path)
+
+
+def _find_env_location(given='.'):
+    """
+    Args:
+        given:
+
+    Returns:
+
+
+    """
+    # Step 1: assume given is a path
+    given_as_path = expand(given)
+    if os.path.exists(given_as_path) and is_env_location(given_as_path):
+        return given_as_path
+
+    # Step 2: look up directory tree for .conda directory
+    #         - does that directory have a .condaenv.yml?
+    dot_conda_dir = find_dot_conda_dir(PWD)
+    if dot_conda_dir and has_env_yml(dot_conda_dir):
+        if given == '.':
+            basename = os.path.basename(dot_conda_dir)
+            env_location = os.path.join(dot_conda_dir, '.conda', basename)
+        else:
+            env_location = os.path.join(dot_conda_dir, '.conda', given)
+        if is_env_location(env_location):
+            return env_location
+
+    # Step 3: look for a named environment
+    for env_dir in envs_dirs:
+        named_path = os.path.join(env_dir, given)
+        if is_env_location(named_path):
+            return named_path
+
+
+def get_env_path(given=None):
+    location = _find_env_location(given)
+    if location:
+        return os.path.join(location, 'bin')
+
+
+@cli.command()
+@click.argument('given', nargs=-1)
+def find_env_location(given):
+    result = _find_env_location(take_first(given) or '.')
+    click.echo(result)

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,14 @@ versioneer.versionfile_build = 'conda/_version.py'
 versioneer.tag_prefix = '' # tags are like 1.2.0
 versioneer.parentdir_prefix = 'conda-' # dirname like 'myproject-1.2.0'
 
-kwds = {'scripts': []}
+kwds = {'scripts': [],
+        'entry_points': {'console_scripts': []},
+        }
 if sys.platform == 'win32' and using_setuptools:
-    kwds['entry_points'] = dict(console_scripts =
-                                        ["conda = conda.cli.main:main"])
+    kwds['entry_points']['console_scripts'].append("conda = conda.cli.main:main")
 else:
     kwds['scripts'].append('bin/conda')
-
+kwds['entry_points']['console_scripts'].append("conda-env-helper = conda.env_helper:cli")
 
 setup(
     name = "conda",


### PR DESCRIPTION
@ilanschnell, @msarahan, @groutr 

This initially is proof of concept code.  The idea is to turn wrap the conda executable within a `conda` shell function.  As such, `conda.sh` will need to be sourced as part of bash/zsh login, either by copying it to `/etc/profile.d/` or adding it to `.bashrc`.

To test it myself, I used

    mkdir conda/_vendor
    make click
    python setup.py develop
    source bin/conda.sh

and then went from there.  Executing `type -a conda` should show the shell resolution order.

One of the purposes here is to deprecate things like `source activate env_name`.  Especially the `source` part of that.