### PR TITLE
do not extract already extracted packages

### DIFF
--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -59,7 +59,8 @@ def PROGRESS_CMD(state, arg):
 
 
 def EXTRACT_CMD(state, arg):
-    install.extract(config.pkgs_dirs[0], arg)
+    if not install.is_extracted(config.pkgs_dirs[0], arg):
+        install.extract(config.pkgs_dirs[0], arg)
 
 
 def RM_EXTRACTED_CMD(state, arg):


### PR DESCRIPTION
This is meant to address Windows permissions issues with files being in use during conda installing things.  In particular, Conda should not extract already-extracted files, because these already-extracted files may be in use.  This patch should prevent conda create from hitting the file locking issues when creating an environment with the same python version as the root python.  It does not attempt to address the issue of any permissions issues that may arise from (force) updating packages that Conda uses directly in the root environment.

xref:
* https://github.com/ContinuumIO/anaconda/pull/465
* #1936 
* https://github.com/Anaconda-Server/nb_conda/pull/9#issuecomment-179265547
* #2079 

Ping @insertinterestingnamehere @groutr @ilanschnell @PeterDSteinberg

See discussion in Anaconda Build flow for more information.