### PR TITLE
Improve handling of local dependency information

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -43,7 +43,13 @@ def get_index(channel_urls=(), prepend=True, platform=None,
                        unknown=unknown)
     if prefix:
         for fn, info in iteritems(install.linked_data(prefix)):
-            index[fn+'.tar.bz2'] = info
+            fn = fn + '.tar.bz2'
+            orec = index.get(fn)
+            if orec is not None:
+                if orec.get('md5',None) == info.get('md5',None):
+                    continue
+                info.setdefault('depends',orec.get('depends',[]))
+            index[fn] = info
     return index
 
 


### PR DESCRIPTION
The breakage of 3.19.2 was caused by a recent fix which adds the metadata from installed packages, found in `conda-meta`, directly into the master index. If these metadata entries do not include a `depends` field, then the `Resolve.ms_depends` method choked.

This leads to the question: why did they not have a `depends` field? Apparently, some older packages did not populate the `depends` field inside the package data itself. But this explanation isn't enough: because when packages are downloaded from the repo, _that_ metadata is preferred, and written to `conda-meta`, and this metadata _does_ include a `depends` field.

So the only situation in which the `conda-meta` data will be missing dependency information is for packages included in the initial installation---which cannot go to the internet to retrieve a better result.

This PR adjusts the code that includes the installed packages by merging the `repodata.json` data intelligently. Here's the logic:

- If the MD5 of the downloaded package matches the one listed in `repodata.json`, then the `repodata.json` metadata is presumed to be the most recent, and is kept.
- Otherwise, the local data is preferred. _However..._
- If the `depends` field is empty, then the `repodata.json` version of that field alone will be retrieved. Since the version and build string match, this should be trustworthy, even though the MD5 fields don't match. It will certainly be more reliable than an empty dependency field.