### PR TITLE
Fix Windows UNC source path

### DIFF
--- a/conda/connection.py
+++ b/conda/connection.py
@@ -197,7 +197,8 @@ def url_to_path(url):
     path = urlparse.unquote(path)
     if _url_drive_re.match(path):
         path = path[0] + ':' + path[2:]
-    else:
+    elif not path.startswith(r'\\'):
+        # if not a Windows UNC path
         path = '/' + path
     return path
 


### PR DESCRIPTION
**Problem**:
meta.yaml source url using UNC path
> Error: HTTPError: 404 Client Error: None for url:  
    
```
source:
  fn: blah.blah [win]
  url: file://\\blah\blah.blah [win]
```
  
**Fix**:
Leave Windows UNC source url paths as is