### PR TITLE
turned off S3 bucket validation

### DIFF
--- a/conda/connection.py
+++ b/conda/connection.py
@@ -111,14 +111,19 @@ class S3Adapter(requests.adapters.BaseAdapter):
 
         bucket_name, key_string = url_to_S3_info(request.url)
 
+        # Get the bucket without validation that it exists and that we have
+        # permissions to list its contents.
+        bucket = conn.get_bucket(bucket_name, validate=False)
+
         try:
-            bucket = conn.get_bucket(bucket_name)
+            key = bucket.get_key(key_string)
         except boto.exception.S3ResponseError as exc:
+            # This exception will occur if the bucket does not exist or if the
+            # user does not have permission to list its contents.
             resp.status_code = 404
             resp.raw = exc
             return resp
 
-        key = bucket.get_key(key_string)
         if key and key.exists:
             modified = key.last_modified
             content_type = key.content_type or "text/plain"


### PR DESCRIPTION
Currently, for s3 channels, conda uses boto's default `validate=True` for `get_bucket` (cf. [boto docs](http://boto.cloudhackers.com/en/latest/ref/s3.html?highlight=get_bucket#boto.s3.connection.S3Connection.get_bucket)) when grabbing packages from s3.  This requires one to have permissions both for the root of the bucket (e.g., `s3://my-bucket/`) as well as the specific key where the conda repository lives (e.g., `s3://my-bucket/path/to/conda/`).

It seems better to use `validate=False` so that one can put a conda repo in a place on s3 where not all the users would have to have permissions for the root of the bucket.

Also, the current error message if you don't have permissions for the root of the bucket is fairly confusing. 

```
> conda install my-package -c s3://my-bucket/path/to/conda/
Fetching package metadata: .....Error: Could not find URL: s3://my-bucket/path/to/conda/linux-64/
```

And where that error is printed, it's actually catching a 404 error, even though it's ultimately a permissions-related error raise by boto (IIRC, something like `A client error (AccessDenied) occurred when calling the ListObjects operation: Access Denied`, which is what I get if I do `aws s3 ls s3://my-bucket/`).