### PR TITLE
Updates no longer upgrade past features

### DIFF
--- a/conda/logic.py
+++ b/conda/logic.py
@@ -280,7 +280,7 @@ class Clauses(object):
 
     def AtMostOne_BDD_(self, vals, polarity=None, name=None):
         vals = [(1, v) for v in vals]
-        return self.LinearBound_(vals, 0, 1, True, polarity)
+        return self.LinearBound_(vals, 0, 1, True, 'BDD', polarity)
 
     def AtMostOne_BDD(self, vals, polarity=None, name=None):
         return self.Eval_(self.AtMostOne_BDD_, (list(vals),), polarity, name)
@@ -305,7 +305,7 @@ class Clauses(object):
 
     def ExactlyOne_BDD_(self, vals, polarity):
         vals = [(1, v) for v in vals]
-        return self.LinearBound_(vals, 1, 1, True, polarity)
+        return self.LinearBound_(vals, 1, 1, True, 'BDD', polarity)
 
     def ExactlyOne_BDD(self, vals, polarity=None, name=None):
         return self.Eval_(self.ExactlyOne_BDD_, (list(vals),), polarity, name)
@@ -331,7 +331,74 @@ class Clauses(object):
         equation = sorted(equation)
         return equation, offset
 
-    def LinearBound_(self, equation, lo, hi, preprocess, polarity):
+    def Sorter_(self, equation, polarity=None):
+        explode = sum(([a] * c for c, a in equation), [])
+        nterms = len(explode)
+        explode.extend([False] * (2**ceil(log2(nterms)) - nterms))
+
+        def cmp(a, b):
+            aa, bb = explode[a], explode[b]
+            explode[a], explode[b] = self.Or(aa, bb, polarity), self.And(aa, bb, polarity)
+
+        def merge(lo, hi, r):
+            step = r * 2
+            if step < hi - lo:
+                merge(lo, hi, step)
+                merge(lo + r, hi, step)
+                for i in range(lo + r, hi - r, step):
+                    cmp(i, i + r)
+            else:
+                cmp(lo, lo + r)
+
+        def sort(lo, hi):
+            if hi - lo >= 1:
+                mid = lo + ((hi - lo) // 2)
+                sort(lo, mid)
+                sort(mid + 1, hi)
+                merge(lo, hi, 1)
+
+        sort(0, len(explode) - 1)
+        return explode
+
+    def BDD_(self, equation, nterms, lo, hi, polarity):
+        # The equation is sorted in order of increasing coefficients.
+        # Then we take advantage of the following recurrence:
+        #                l      <= S + cN xN <= u
+        #  => IF xN THEN l - cN <= S         <= u - cN
+        #           ELSE l      <= S         <= u
+        # we use memoization to prune common subexpressions
+        total = sum(c for c, _ in equation[:nterms])
+        target = (nterms-1, 0, total)
+        call_stack = [target]
+        ret = {}
+        csum = 0
+        while call_stack:
+            ndx, csum, total = call_stack[-1]
+            lower_limit = lo - csum
+            upper_limit = hi - csum
+            if lower_limit <= 0 and upper_limit >= total:
+                ret[call_stack.pop()] = True
+                continue
+            if lower_limit > total or upper_limit < 0:
+                ret[call_stack.pop()] = False
+                continue
+            LC, LA = equation[ndx]
+            ndx -= 1
+            total -= LC
+            hi_key = (ndx, csum if LA < 0 else csum + LC, total)
+            thi = ret.get(hi_key)
+            if thi is None:
+                call_stack.append(hi_key)
+                continue
+            lo_key = (ndx, csum + LC if LA < 0 else csum, total)
+            tlo = ret.get(lo_key)
+            if tlo is None:
+                call_stack.append(lo_key)
+                continue
+            ret[call_stack.pop()] = self.ITE(abs(LA), thi, tlo, polarity)
+        return ret[target]
+
+    def LinearBound_(self, equation, lo, hi, preprocess, alg, polarity):
         if preprocess:
             equation, offset = self.LB_Preprocess_(equation)
             lo -= offset
@@ -344,57 +411,28 @@ class Clauses(object):
         else:
             nprune = 0
         # Tighten bounds
+        total = sum(c for c, _ in equation[:nterms])
         if preprocess:
             lo = max([lo, 0])
-            hi = min([hi, sum(c for c, a in equation[:nterms])])
+            hi = min([hi, total])
         if lo > hi:
             return False
         if nterms == 0:
             res = lo == 0
+        elif alg == 'BDD':
+            res = self.BDD_(equation, nterms, lo, hi, polarity)
         else:
-            # The equation is sorted in order of increasing coefficients.
-            # Then we take advantage of the following recurrence:
-            #                l      <= S + cN xN <= u
-            #  => IF xN THEN l - cN <= S         <= u - cN
-            #           ELSE l      <= S         <= u
-            # we use memoization to prune common subexpressions
-            total = sum(i for i, _ in equation)
-            target = (nterms-1, 0, total)
-            call_stack = [target]
-            ret = {}
-            csum = 0
-            while call_stack:
-                ndx, csum, total = call_stack[-1]
-                lower_limit = lo - csum
-                upper_limit = hi - csum
-                if lower_limit <= 0 and upper_limit >= total:
-                    ret[call_stack.pop()] = True
-                    continue
-                if lower_limit > total or upper_limit < 0:
-                    ret[call_stack.pop()] = False
-                    continue
-                LC, LA = equation[ndx]
-                ndx -= 1
-                total -= LC
-                hi_key = (ndx, csum if LA < 0 else csum + LC, total)
-                thi = ret.get(hi_key)
-                if thi is None:
-                    call_stack.append(hi_key)
-                    continue
-                lo_key = (ndx, csum + LC if LA < 0 else csum, total)
-                tlo = ret.get(lo_key)
-                if tlo is None:
-                    call_stack.append(lo_key)
-                    continue
-                ret[call_stack.pop()] = self.ITE(abs(LA), thi, tlo, polarity)
-            res = ret[target]
+            spol = False if lo == 0 else (None if hi < total else True)
+            sorter = self.Sorter_(equation, spol)
+            res = self.And(True if lo == 0 else sorter[lo-1],
+                           self.Not(sorter[hi]) if hi < total else True, True)
         if nprune:
             prune = self.All_([-a for c, a in equation[nterms:]], polarity)
             res = self.Combine_((res, prune), polarity)
         return res
 
-    def LinearBound(self, equation, lo, hi, preprocess=True, polarity=None, name=None):
-        return self.Eval_(self.LinearBound_, (equation, lo, hi, preprocess),
+    def LinearBound(self, equation, lo, hi, preprocess=True, alg='BDD', polarity=None, name=None):
+        return self.Eval_(self.LinearBound_, (equation, lo, hi, preprocess, alg),
                           polarity, name, conv=False)
 
     def sat(self, additional=None, includeIf=False, names=False, limit=0):
@@ -407,11 +445,14 @@ class Clauses(object):
         """
         if self.unsat:
             return None
+        if not self.m:
+            return set() if names else []
         if additional:
             additional = list(map(lambda x: tuple(map(self.varnum, x)), additional))
             clauses = chain(self.clauses, additional)
         else:
             clauses = self.clauses
+        clauses = list(clauses)
         solution = pycosat.solve(clauses, vars=self.m, prop_limit=limit)
         if solution in ("UNSAT", "UNKNOWN"):
             return None

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -160,7 +160,7 @@ class TestSolve(unittest.TestCase):
 
     def test_mkl(self):
         self.assertEqual(r.install(['mkl']),
-                         r.install(['mkl', 'mkl@']))
+                         r.install(['mkl 11*', 'mkl@']))
 
     def test_accelerate(self):
         self.assertEqual(


### PR DESCRIPTION
With the new solver, we were seeing cases where `conda update --all` would cause featured packages to lose those features. This was because 1) the newest versions of those packages did not have a featured version; and 2) the `update` command was prioritizing version number over feature count.

But if we reverse that priority, then we can't be sure that there will be tracked features to install at all. after all, we don't install features, we install packages with `track_features` settings. And some packages, like `mkl` or `python`, have different values for this field with different versions. To make sure we get the proper number of features, then, we *have* to pull their latest versions.

So what this PR does is this: first, it does a *preliminary* version maximization of all explicitly requested packages. Then it determines the number of `track_features` that it will see in this scenario. Then it *backs up*, locks in that `track_feature` account, and repeats the version maximization. This will prevent a package from being upgraded past a featured version.