### PR TITLE
Fixes to remove functionality and general performance issues

### DIFF
--- a/conda/logic.py
+++ b/conda/logic.py
@@ -518,7 +518,7 @@ class Clauses(object):
             # need to generate the constraints at least once
             try0 = lo = 0
             hi = bestval
-            m_orig = bestm = self.m
+            m_orig = self.m
             nz = len(self.clauses)
 
             log.debug("Initial range (%d,%d)" % (lo, hi))
@@ -613,9 +613,9 @@ def minimal_unsatisfiable_subset(clauses, sat, log=False):
         update = lambda x, y: logging.getLogger('progress.update').info(("%s/%s" % (x, y), x))
         stop = lambda: logging.getLogger('progress.stop').info(None)
     else:
-        start = lambda x: None  # noqa
-        update = lambda x, y: None  # noqa
-        stop = lambda: None  # noqa
+        start = lambda x: None
+        update = lambda x, y: None
+        stop = lambda: None
 
     clauses = tuple(clauses)
     if sat(clauses):

--- a/conda/logic.py
+++ b/conda/logic.py
@@ -477,17 +477,12 @@ class Clauses(object):
             yield sol
             exclude.append([-k for k in sol if -m <= k <= m])
 
-    def minimize(self, objective, bestsol, minval=None, increment=10):
+    def minimize(self, objective, bestsol):
         """
-        Bisect the solution space of a constraint, to minimize it.
-
-        func should be a function that is called with the arguments func(lo_rhs,
-        hi_rhs) and returns a list of constraints.
-
-        The midpoint of the bisection will not be more than lo_value + increment.
-        To not use it, set a very large increment. The increment argument should
-        be used if you expect the optimal solution to be near 0.
-
+        Minimize the objective function given either by (coeff, integer)
+        tuple pairs, or a dictionary of varname: coeff values. The actual
+        minimization is multiobjective: first, we minimize the largest
+        active coefficient value, then we minimize the sum.
         """
         if not objective:
             log.debug('Empty objective, trivial solution')
@@ -497,52 +492,74 @@ class Clauses(object):
             return bestsol, sum(abs(c) for c, a in objective) + 1
 
         if type(objective) is dict:
-            odict = {self.varnum(k): v for k, v in iteritems(objective)}
-            objective = [(v, k) for k, v in iteritems(odict)]
-        else:
-            odict = {self.varnum(atom): coeff for coeff, atom in objective}
+            objective = [(v, self.varnum(k)) for k, v in iteritems(objective)]
 
         objective, offset = self.LB_Preprocess_(objective)
-        minval = minval and minval - offset
+        maxval = max(c for c, a in objective)
 
-        m_orig = bestm = self.m
-        nz = len(self.clauses)
-        bestval = evaluate_eq(odict, bestsol)
+        def peak_val(sol, odict):
+            return max(odict.get(s, 0) for s in sol)
 
-        # If we got lucky and the initial solution is optimal, we still
-        # need to generate the constraints at least once
-        try0 = lo = min([bestval, max([0, minval]) if minval else 0])
-        mval = sum(c for c, a in objective)
-        hi = bestval
+        def sum_val(sol, odict):
+            return sum(odict.get(s, 0) for s in sol)
 
-        log.debug("Initial range (%d,%d)" % (lo, hi))
-        while True:
-            if try0 is None:
-                mid = min([lo + increment, (lo+hi)//2])
+        for peak in ((True, False) if maxval > 1 else (False,)):
+            if peak:
+                log.debug('Beginning peak minimization')
+                objval = peak_val
             else:
-                mid = try0
-                try0 = None
-            self.Require(self.LinearBound, objective, lo, mid, False)
-            log.debug('Bisection attempt: (%d,%d), (%d+%d) clauses' %
-                      (lo, mid, nz, len(self.clauses)-nz))
-            newsol = self.sat()
-            if newsol is None:
-                log.debug("Bisection failure")
-                lo = mid + 1
-            else:
-                done = lo == hi
-                bestsol = newsol
-                bestval = evaluate_eq(odict, newsol)
-                hi = bestval
-                log.debug("Bisection success, new range=(%d,%d)" % (lo, hi))
-                if done:
-                    break
-            self.m = m_orig
-            if len(self.clauses) > nz:
-                self.clauses = self.clauses[:nz]
-            self.unsat = False
+                log.debug('Beginning sum minimization')
+                objval = sum_val
 
-        return newsol, bestval
+            odict = {a: c for c, a in objective}
+            bestval = objval(bestsol, odict)
+
+            # If we got lucky and the initial solution is optimal, we still
+            # need to generate the constraints at least once
+            try0 = lo = 0
+            hi = bestval
+            m_orig = bestm = self.m
+            nz = len(self.clauses)
+
+            log.debug("Initial range (%d,%d)" % (lo, hi))
+            while True:
+                if try0 is None:
+                    mid = (lo+hi) // 2
+                else:
+                    mid = try0
+                    try0 = None
+                if peak:
+                    self.Prevent(self.Any, tuple(a for c, a in objective if c > mid))
+                else:
+                    self.Require(self.LinearBound, objective, 0, mid, False)
+                log.debug('Bisection attempt: (%d,%d), (%d+%d) clauses' %
+                          (lo, mid, nz, len(self.clauses)-nz))
+                newsol = self.sat()
+                if newsol is None:
+                    lo = mid + 1
+                    log.debug("Bisection failure, new range=(%d,%d)" % (lo, hi))
+                else:
+                    done = lo == mid
+                    bestsol = newsol
+                    bestval = objval(newsol, odict)
+                    hi = bestval
+                    log.debug("Bisection success, new range=(%d,%d)" % (lo, hi))
+                    if done:
+                        break
+                self.m = m_orig
+                if len(self.clauses) > nz:
+                    self.clauses = self.clauses[:nz]
+                self.unsat = False
+
+            log.debug('Final %s objective: %d' % ('peak' if peak else 'sum', bestval))
+            if bestval == 0:
+                break
+            elif peak:
+                objective = [(c, a) for c, a in objective if c <= bestval]
+            else:
+                log.debug('New peak objective: %d' % peak_val(bestsol, odict))
+
+        return bestsol, bestval
 
 
 def evaluate_eq(eq, sol):

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -10,7 +10,6 @@ from conda.version import VersionSpec, normalized_version
 from conda.console import setup_handlers
 from conda import config
 from conda.toposort import toposort
-from conda.install import name_dist
 
 log = logging.getLogger(__name__)
 dotlog = logging.getLogger('dotupdate')
@@ -591,7 +590,6 @@ class Resolve(object):
 
     def gen_clauses(self, groups, trackers, specs):
         C = Clauses()
-        polarities = {}
 
         def push_MatchSpec(ms):
             name = self.ms_to_v(ms)
@@ -651,7 +649,9 @@ class Resolve(object):
         for s in specs:
             s = MatchSpec(s)  # needed for testing
             sdict.setdefault(s.name, []).append(s)
-        key = lambda x: self.version_key(x, vtype)
+
+        def key(x):
+            return self.version_key(x, vtype)
         for name, pkgs in iteritems(groups):
             mss = sdict.get(name, [])
             bmss = bool(mss)


### PR DESCRIPTION
@dhirschfeld's issue (https://github.com/conda/conda/issues/2158) brings together two issues with the revamped solver: strange remove behavior and occasional performance hangs. This is a not-so-minor PR to address both.

The primary cause of the remove problems was an incorrect ordering of priorities in the optimization passes. When removing a package, the primary goal of the solver should be to _preserve as many of the remaining packages as possible_. Sometimes, additional packages must be removed, because the package that was _explicitly_ requested for removal was a dependency. And if a track_feature is removed, alternative versions of the packages without that feature should be sought. Otherwise, the environment should be left as close to its original state as possible.

In the current version of the solver, however, the attempt to minimize the number of removed packages was made _after_ the passes which determine feature counts and maximizes versions. This would lead the solver into states where it needed to remove additional packages or make larger changes than necessary. By moving the "removal count" pass to the top of the priority list, this problem seems to have been fixed.

To fix the occasional hangs/performance issues, I've rejiggered the `logic.minimize` function. This function accepts a list of variables and coefficients, and attempts to minimize a weighted sum of those variables via bisection; $\sum_i c_i x_i$ for you math folks. This has been changed to a _two-stage_ minimization. First, it attempts to minimize the *largest* active coefficient; i.e., $\max_i c_i x_i$. Only once that has been achieved does it minimize the sum. This "peak minimization" step is significantly cheaper and should never cause the solver to hang; and once it is completed, it allows the weighted sum minimization complexity to be greatly reduced in many circumstances.

OK, so the math may make no sense: here's what it means in terms of `conda` package management. One of `conda`'s goals is to make sure that you get the latest possible versions of the packages you have requested. However, sometimes, due to dependency conflicts, it must select an *older* version of a package. The older the package, the larger the coefficient $c_i$. The "weighted sum" objective basically tries to minimize the total number of downgrade steps across all packages. In contrast, the "peak minimization" objective attempts to minimize the *worst-case* downgrade---that one package that is really causing all the trouble. 

Frankly, I think most people will agree that's a good idea *anyway*. And in fact, changing the objective function didn't break any of our unit tests, because most of the time, the two objectives do identical things. But in terms of practical *performance*, peak minimization is cheaper and faster. We still have to follow up with the weighted sum pass, because otherwise we'll get multiple solutions. But at least that pass will now be faster, too.