### PR TITLE
Fix for pinned spec matching

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -508,7 +508,7 @@ class Resolve(object):
         return any(n == ms.name and ms.match_fast(v, b) for ms in mss)
 
     def match(self, ms, fn):
-        return ms.match(self.index[fn])
+        return MatchSpec(ms).match(self.index[fn])
 
     def find_matches_group(self, ms, groups, trackers=None):
         ms = MatchSpec(ms)


### PR DESCRIPTION
This should fix the issue reported in #1967. I don't have a good test for this though---it involves pinned specs. Can one of you test it out before merging?