### PR TITLE
simplify get_index() prefix behavior

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -44,12 +44,11 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     if prefix:
         for fn, info in iteritems(install.linked_data(prefix)):
             fn = fn + '.tar.bz2'
-            orec = index.get(fn)
-            if orec is not None:
-                if orec.get('md5',None) == info.get('md5',None):
-                    continue
-                info.setdefault('depends',orec.get('depends',[]))
-            index[fn] = info
+            if fn not in index:
+                # only if the package in not in the repodata, use the local
+                # metadata (with 'depends' defaulting to [])
+                info.setdefault('depends', [])
+                index[fn] = info
     return index
 
 

--- a/conda/api.py
+++ b/conda/api.py
@@ -40,10 +40,10 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     if offline:
         channel_urls = [url for url in channel_urls if url.startswith('file:')]
     index = fetch_index(tuple(channel_urls), use_cache=use_cache,
-                       unknown=unknown)
+                        unknown=unknown)
     if prefix:
-        for fn, info in iteritems(install.linked_data(prefix)):
-            fn = fn + '.tar.bz2'
+        for dist, info in iteritems(install.linked_data(prefix)):
+            fn = dist + '.tar.bz2'
             if fn not in index:
                 # only if the package in not in the repodata, use local
                 # conda-meta (with 'depends' defaulting to [])

--- a/conda/api.py
+++ b/conda/api.py
@@ -45,8 +45,8 @@ def get_index(channel_urls=(), prepend=True, platform=None,
         for fn, info in iteritems(install.linked_data(prefix)):
             fn = fn + '.tar.bz2'
             if fn not in index:
-                # only if the package in not in the repodata, use the local
-                # metadata (with 'depends' defaulting to [])
+                # only if the package in not in the repodata, use local
+                # conda-meta (with 'depends' defaulting to [])
                 info.setdefault('depends', [])
                 index[fn] = info
     return index


### PR DESCRIPTION
This addresses issue #2179.

The new behavior us quite simple: only if a (local) package in not in the repodata, use the local `conda-meta`, with `depends` defaulting to [].

Needs testing.