### PR TITLE
Fixed solver string format.

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -884,7 +884,7 @@ class Resolve(object):
     def solve(self, specs, len0=None, returnall=False):
         try:
             stdoutlog.info("Solving package specifications: ")
-            dotlog.debug("Solving for %s" % specs)
+            dotlog.debug("Solving for %s" % (specs,))
 
             # Find the compliant packages
             specs = list(map(MatchSpec, specs))


### PR DESCRIPTION
If using old form string formatting, it is generally safer to put the thing you want formatting into a tuple:

```
>>> bar = (1, 2); print("foo %s" % bar)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
```

```
bar = (1, 2); print("foo %s" % (bar, ))
foo (1, 2)
```