### PR TITLE
Initial commit: improvements to update behavior

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -436,10 +436,10 @@ def check_write(command, prefix, json=False):
 
 # -------------------------------------------------------------------------
 
-def arg2spec(arg, json=False):
+def arg2spec(arg, json=False, update=False):
     spec = spec_from_line(arg)
     if spec is None:
-        error_and_exit('Invalid package specification: %s' % arg,
+        error_and_exit('invalid package specification: %s' % arg,
                        json=json,
                        error_type="ValueError")
     parts = spec.split()
@@ -448,6 +448,12 @@ def arg2spec(arg, json=False):
         error_and_exit("specification '%s' is disallowed" % name,
                        json=json,
                        error_type="ValueError")
+    if len(parts) > 1 and update:
+        error_and_exit("""version specifications not allowed with 'update'; use
+    conda update  %s%s  or
+    conda install %s""" % (name, ' ' * (len(arg)-len(name)), arg),
+            json=json,
+            error_type="ValueError")
     if len(parts) == 2:
         ver = parts[1]
         if not ver.startswith(('=', '>', '<', '!')):

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -119,6 +119,8 @@ def install(args, parser, command='install'):
     conda install, conda update, and conda create
     """
     newenv = bool(command == 'create')
+    isupdate = bool(command == 'update')
+    isinstall = bool(command == 'install')
     if newenv:
         common.ensure_name_or_prefix(args, command)
     prefix = common.get_prefix(args, search=not newenv)
@@ -127,27 +129,22 @@ def install(args, parser, command='install'):
     if config.force_32bit and plan.is_root_prefix(prefix):
         common.error_and_exit("cannot use CONDA_FORCE_32BIT=1 in root env")
 
-    if command == 'update':
-        if not args.file:
-            if not args.all and len(args.packages) == 0:
-                common.error_and_exit("""no package names supplied
+    if isupdate and not (args.file or args.all or args.packages):
+        common.error_and_exit("""no package names supplied
 # If you want to update to a newer version of Anaconda, type:
 #
 # $ conda update --prefix %s anaconda
 """ % prefix,
-                                      json=args.json,
-                                      error_type="ValueError")
+                              json=args.json,
+                              error_type="ValueError")
 
-    if command == 'update' and not args.all:
-        linked = ci.linked(prefix)
+    linked = ci.linked(prefix)
+    lnames = {ci.name_dist(d) for d in linked}
+    if isupdate and not args.all:
         for name in args.packages:
-            common.arg2spec(name, json=args.json)
-            if '=' in name:
-                common.error_and_exit("Invalid package name: '%s'" % (name),
-                                      json=args.json,
-                                      error_type="ValueError")
-            if name not in set(ci.name_dist(d) for d in linked):
-                common.error_and_exit("package '%s' is not installed in %s" %
+            common.arg2spec(name, json=args.json, update=True)
+            if name not in lnames:
+                common.error_and_exit("Package '%s' is not installed in %s" %
                                       (name, prefix),
                                       json=args.json,
                                       error_type="ValueError")
@@ -173,22 +170,13 @@ def install(args, parser, command='install'):
             misc.explicit(specs, prefix)
             return
     elif getattr(args, 'all', False):
-        linked = ci.linked(prefix)
         if not linked:
             common.error_and_exit("There are no packages installed in the "
                 "prefix %s" % prefix)
-        for pkg in linked:
-            name, ver, build = pkg.rsplit('-', 2)
-            if name in getattr(args, '_skip', ['anaconda']):
-                continue
-            if name == 'python' and ver.startswith('2'):
-                # Oh Python 2...
-                specs.append('%s >=%s,<3' % (name, ver))
-            else:
-                specs.append('%s' % name)
+        specs.extend(nm for nm in lnames)
     specs.extend(common.specs_from_args(args.packages, json=args.json))
 
-    if command == 'install' and args.revision:
+    if isinstall and args.revision:
         get_revision(args.revision, json=args.json)
     elif not (newenv and args.clone):
         common.check_specs(prefix, specs, json=args.json,
@@ -238,6 +226,8 @@ def install(args, parser, command='install'):
                                   json=args.json,
                                   offline=args.offline,
                                   prefix=prefix)
+    r = Resolve(index)
+    plan.add_defaults_to_specs(r, linked, specs, update=isupdate)
 
     if newenv and args.clone:
         if set(args.packages) - set(default_packages):
@@ -252,8 +242,7 @@ def install(args, parser, command='install'):
         return
 
     # Don't update packages that are already up-to-date
-    if command == 'update' and not (args.all or args.force):
-        r = Resolve(index)
+    if isupdate and not (args.all or args.force):
         orig_packages = args.packages[:]
         for name in orig_packages:
             installed_metadata = [ci.is_linked(prefix, dist)
@@ -321,11 +310,10 @@ environment does not exist: %s
                                   error_type="NoEnvironmentFound")
 
     try:
-        if command == 'install' and args.revision:
+        if isinstall and args.revision:
             actions = plan.revert_actions(prefix, get_revision(args.revision))
         else:
             with common.json_progress_bars(json=args.json and not args.quiet):
-
                 actions = plan.install_actions(prefix, index, specs,
                                                force=args.force,
                                                only_names=only_names,
@@ -342,7 +330,7 @@ environment does not exist: %s
     except NoPackagesFound as e:
         error_message = e.args[0]
 
-        if command == 'update' and args.all:
+        if isupdate and args.all:
             # Packages not found here just means they were installed but
             # cannot be found any more. Just skip them.
             if not args.json:
@@ -458,6 +446,8 @@ def check_install(packages, platform=None, channel_urls=(), prepend=True,
         specs = common.specs_from_args(packages)
         index = get_index(channel_urls=channel_urls, prepend=prepend,
                           platform=platform, prefix=prefix)
+        linked = ci.linked(prefix)
+        plan.add_defaults_to_specs(Resolve(index), linked, specs)
         actions = plan.install_actions(prefix, index, specs, pinned=False,
                                        minimal_hint=minimal_hint)
         plan.display_actions(actions, index)

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -328,7 +328,7 @@ def dist2spec3v(dist):
     return '%s %s*' % (name, version[:3])
 
 
-def add_defaults_to_specs(r, linked, specs):
+def add_defaults_to_specs(r, linked, specs, update=False):
     # TODO: This should use the pinning mechanism. But don't change the API:
     # cas uses it.
     if r.explicit(specs):
@@ -370,7 +370,10 @@ def add_defaults_to_specs(r, linked, specs):
             # if Python/Numpy is already linked, we add that instead of the
             # default
             log.debug('H3 %s' % name)
-            specs.append(dist2spec3v(names_linked[name]))
+            spec = dist2spec3v(names_linked[name])
+            if update:
+                spec = '%s (target=%s.tar.bz2)' % (spec,names_linked[name])
+            specs.append(spec)
             continue
 
         if (name, def_ver) in [('python', '3.3'), ('python', '3.4'),
@@ -402,9 +405,6 @@ def install_actions(prefix, index, specs, force=False, only_names=None,
         pinned_specs = get_pinned_specs(prefix)
         log.debug("Pinned specs=%s" % pinned_specs)
         specs += pinned_specs
-
-    # TODO: Improve error messages here
-    add_defaults_to_specs(r, linked, specs)
 
     must_have = {}
     if config.track_features:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -36,7 +36,7 @@ class Unsatisfiable(RuntimeError):
         unsatisfiable specifications.
     '''
     def __init__(self, bad_deps, chains=True):
-        bad_deps = [list(map(str, dep)) for dep in bad_deps]
+        bad_deps = [list(map(lambda x: x.spec, dep)) for dep in bad_deps]
         if chains:
             chains = {}
             for dep in sorted(bad_deps, key=len, reverse=True):
@@ -103,11 +103,14 @@ class NoPackagesFound(RuntimeError):
 
 
 class MatchSpec(object):
-    def __new__(cls, spec, target=None, optional=False, negate=False):
+    def __new__(cls, spec):
         if isinstance(spec, cls):
             return spec
         self = object.__new__(cls)
-        self.spec = spec
+        spec, _, oparts = spec.partition('(')
+        self.spec = spec.strip()
+        if oparts and oparts.strip()[-1] != ')':
+            raise ValueError("Invalid MatchSpec: %s" % spec)
         parts = spec.split()
         self.strictness = len(parts)
         assert 1 <= self.strictness <= 3, repr(spec)
@@ -116,9 +119,19 @@ class MatchSpec(object):
             self.vspecs = VersionSpec(parts[1])
         elif self.strictness == 3:
             self.ver_build = tuple(parts[1:3])
-        self.target = target
-        self.optional = optional
-        self.negate = negate
+        self.target = None
+        self.optional = False
+        self.negate = False
+        if oparts:
+            for opart in oparts.strip()[:-1].split(','):
+                if opart == 'optional':
+                    self.optional = True
+                elif opart == 'negate':
+                    self.negate = True
+                elif opart.startswith('target='):
+                    self.target = opart.split('=')[1].strip()
+                else:
+                    raise ValueError("Invalid MatchSpec: %s" % spec)
         return self
 
     def match_fast(self, version, build):
@@ -148,32 +161,27 @@ class MatchSpec(object):
             return None
 
     def __eq__(self, other):
-        return type(other) is MatchSpec and self.spec == other.spec
+        return (type(other) is MatchSpec and
+                (self.spec, self.optional, self.negate, self.target) ==
+                (other.spec, other.optional, other.negate, other.target))
 
     def __hash__(self):
         return hash((self.spec, self.negate))
 
     def __repr__(self):
-        res = 'MatchSpec(' + repr(self.spec)
-        if self.target:
-            res += ',target=' + repr(self.target)
-        if self.optional:
-            res += ',optional=True'
-        if self.negate:
-            res += ',negate=True'
-        return res + ')'
+        return "MatchSpec('%s')" % self.__str__()
 
     def __str__(self):
         res = self.spec
-        if self.target or self.optional:
-            mods = []
-            if self.target:
-                mods.append('target='+str(self.target))
+        if self.optional or self.negate or self.target:
+            args = []
             if self.optional:
-                mods.append('optional')
+                args.append('optional')
             if self.negate:
-                mods.append('negate')
-            res += ' (' + ', '.join(mods) + ')'
+                args.append('negate')
+            if self.target:
+                args.append('target='+self.target)
+            res = '%s (%s)' % (res, ','.join(args))
         return res
 
 
@@ -379,12 +387,12 @@ class Resolve(object):
             if ms.name[-1] == '@':
                 feats.add(ms.name[:-1])
                 continue
-            if ms.negate:
-                rems.append(MatchSpec(ms.spec))
             if not ms.optional:
                 spec2.append(ms)
-            elif any(self.find_matches(ms)):
+            elif any(True for _ in self.find_matches(ms)):
                 opts.append(ms)
+            else:
+                rems.append(ms)
         for ms in spec2:
             filter = self.default_filter(feats)
             if not self.valid(ms, filter):
@@ -478,7 +486,7 @@ class Resolve(object):
         def full_prune(specs, removes, optional, features):
             self.default_filter(features, filter)
             for ms in removes:
-                for fn in self.find_matches(ms):
+                for fn in self.groups.get(ms.name, []):
                     filter[fn] = False
             feats = set(self.trackers.keys())
             snames.clear()
@@ -860,7 +868,7 @@ class Resolve(object):
             # the solver can minimize the version change. If update_deps=False,
             # fix the version and build so that no change is possible.
             if update_deps:
-                spec = MatchSpec(name, target=pkg)
+                spec = MatchSpec('%s (target=%s)' % (name, pkg))
             else:
                 spec = MatchSpec(' % s %s %s' % (name, version, build))
             specs.append(spec)
@@ -874,7 +882,7 @@ class Resolve(object):
         return pkgs
 
     def remove_specs(self, specs, installed):
-        specs = [MatchSpec(s, optional=True, negate=True) for s in specs]
+        specs = [MatchSpec(s + ' (optional,negate)') for s in specs]
         snames = {s.name for s in specs}
         limit, _ = self.bad_installed(installed, specs)
         preserve = []
@@ -883,7 +891,7 @@ class Resolve(object):
             if nm in snames:
                 continue
             elif limit is None:
-                specs.append(MatchSpec(self.package_name(pkg), optional=True, target=pkg))
+                specs.append(MatchSpec('%s (optional,target=%s)' % (self.package_name(pkg), pkg)))
             else:
                 preserve.append(pkg)
         return specs, preserve

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -58,9 +58,17 @@ class TestMatchSpec(unittest.TestCase):
 
     def test_hash(self):
         a, b = MatchSpec('numpy 1.7*'), MatchSpec('numpy 1.7*')
+        # optional should not change the hash, but negate should
+        c, d = MatchSpec('numpy 1.7* (negate)'), MatchSpec('numpy 1.7* (optional)')
         self.assertTrue(a is not b)
+        self.assertTrue(a is not c)
+        self.assertTrue(a is not d)
         self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+        self.assertNotEqual(a, d)
         self.assertEqual(hash(a), hash(b))
+        self.assertNotEqual(hash(a), hash(c))
+        self.assertEqual(hash(a), hash(d))
         c, d = MatchSpec('python'), MatchSpec('python 2.7.4')
         self.assertNotEqual(a, c)
         self.assertNotEqual(hash(a), hash(c))
@@ -68,8 +76,8 @@ class TestMatchSpec(unittest.TestCase):
         self.assertNotEqual(hash(c), hash(d))
 
     def test_string(self):
-        a = MatchSpec("foo1 >=1.3 2",optional=True,target='burg',negate=True)
-        assert str(a) == 'foo1 >=1.3 2 (target=burg, optional, negate)'
+        a = MatchSpec("foo1 >=1.3 2 (optional,negate,target=burg)")
+        assert a.optional and a.negate and a.target=='burg'
 
 class TestPackage(unittest.TestCase):
 


### PR DESCRIPTION
Cleaning up the behavior of `conda update`, in particular `conda update --all`. Notes:

- Because of [this commit](https://github.com/conda/conda/commit/da8dea22e0acdb28dcb76de68b9be1a77df697b3), `anaconda` is being removed from the update list. This is useless now that `conda` verifies that updates remain consistent with the rest of the installed packages.

- Because of [this commit](https://github.com/conda/conda/commit/1301aae0e3d28623b8d14df46537e7ae6964d6ce), `cli.install.install` has a hard-coded test to prevent accidental/unwanted upgrades from Python 2 to Python 3. That's handled better and more generally by `plan.add_defaults_to_specs`. For example, `add_defaults_to_specs` now does similar version protection for Lua, so it would be nice to have that for `conda update --all`.

- On the other hand, `plan.add_defaults_to_specs` has a side effect (actually, the hard-coded solution does too): it schedules an update to Python _whether you want it or not_, and whether it is necessary or not (see [this code](https://github.com/conda/conda/blob/master/conda/plan.py#L369-L382)). This commit uses MatchSpec's "target" capability to instruct the solver to prefer no upgrade at all.

Adding this functionality either required importing the `MatchSpec` object into `cli.install` or extending MatchSpec's string parsing capability to handle target versions. I opted to do the latter.

More testing and/or discussion is needed here, but I think this is a solid step towards getting `conda update --all` working.