### PR TITLE
Fix symlink errors during clone

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -218,6 +218,9 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index=None):
             os.unlink(dst_dir)
         if not isdir(dst_dir):
             os.makedirs(dst_dir)
+        if islink(src):
+            os.symlink(os.readlink(src), dst)
+            continue
 
         try:
             with open(src, 'rb') as fi:


### PR DESCRIPTION
`clone_env` doesn't handle symlinks properly---specifically it copies the file instead. This is causing problems on the Mac during the `shutil.copystat` call. This is an attempt to rectify this. It's a three-line fix but please review.

But @ilanschnell, I'm curious why `clone_env` is using low-level file operations to do a file copy instead of `shutil.copy`?