### PR TITLE
Performance improvements for large numbers of builds

### DIFF
--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -251,7 +251,7 @@ def test_generate_eq():
     dists, specs = r.get_dists(specs)
     groups, trackers = build_groups(dists)
     C = r.gen_clauses(groups, trackers, specs)
-    eq = r.generate_version_metric(C, groups, specs)
+    eqv, eqb = r.generate_version_metrics(C, groups, specs)
     # Should satisfy the following criteria:
     # - lower versions of the same package should should have higher
     #   coefficients.
@@ -260,7 +260,7 @@ def test_generate_eq():
     # - a package that only has one version should not appear, unless
     #   include=True as it will have a 0 coefficient. The same is true of the
     #   latest version of a package.
-    assert eq == {
+    assert eqv == {
         'astropy-0.2-np15py26_0.tar.bz2': 1,
         'astropy-0.2-np16py26_0.tar.bz2': 1,
         'astropy-0.2-np17py26_0.tar.bz2': 1,
@@ -269,8 +269,6 @@ def test_generate_eq():
         'bitarray-0.8.0-py33_0.tar.bz2': 1,
         'cython-0.18-py26_0.tar.bz2': 1,
         'cython-0.18-py33_0.tar.bz2': 1,
-        'dateutil-2.1-py26_0.tar.bz2': 1,
-        'dateutil-2.1-py33_0.tar.bz2': 1,
         'distribute-0.6.34-py26_1.tar.bz2': 1,
         'distribute-0.6.34-py33_1.tar.bz2': 1,
         'ipython-0.13.1-py26_1.tar.bz2': 1,
@@ -285,8 +283,8 @@ def test_generate_eq():
         'matplotlib-1.2.0-np17py33_1.tar.bz2': 1,
         'nose-1.2.1-py26_0.tar.bz2': 1,
         'nose-1.2.1-py33_0.tar.bz2': 1,
-        'numpy-1.5.1-py26_3.tar.bz2': 4,
-        'numpy-1.6.2-py26_3.tar.bz2': 3,
+        'numpy-1.5.1-py26_3.tar.bz2': 3,
+        'numpy-1.6.2-py26_3.tar.bz2': 2,
         'numpy-1.6.2-py26_4.tar.bz2': 2,
         'numpy-1.6.2-py27_4.tar.bz2': 2,
         'numpy-1.7.0-py26_0.tar.bz2': 1,
@@ -302,8 +300,6 @@ def test_generate_eq():
         'python-3.3.0-4.tar.bz2': 1,
         'pytz-2012j-py26_0.tar.bz2': 1,
         'pytz-2012j-py33_0.tar.bz2': 1,
-        'pyzmq-2.2.0.1-py26_0.tar.bz2': 1,
-        'pyzmq-2.2.0.1-py33_0.tar.bz2': 1,
         'requests-0.13.9-py26_0.tar.bz2': 1,
         'requests-0.13.9-py33_0.tar.bz2': 1,
         'scipy-0.11.0-np15py26_3.tar.bz2': 1,
@@ -312,15 +308,21 @@ def test_generate_eq():
         'scipy-0.11.0-np17py33_3.tar.bz2': 1,
         'six-1.2.0-py26_0.tar.bz2': 1,
         'six-1.2.0-py33_0.tar.bz2': 1,
-        'sphinx-1.1.3-py26_2.tar.bz2': 1,
-        'sphinx-1.1.3-py33_2.tar.bz2': 1,
         'sqlalchemy-0.7.8-py26_0.tar.bz2': 1,
         'sqlalchemy-0.7.8-py33_0.tar.bz2': 1,
-        'system-5.8-0.tar.bz2': 1,
         'tornado-2.4.1-py26_0.tar.bz2': 1,
         'tornado-2.4.1-py33_0.tar.bz2': 1,
         'xlrd-0.9.0-py26_0.tar.bz2': 1,
-        'xlrd-0.9.0-py33_0.tar.bz2': 1,
+        'xlrd-0.9.0-py33_0.tar.bz2': 1}
+    assert eqb == {
+        'dateutil-2.1-py26_0.tar.bz2': 1,
+        'dateutil-2.1-py33_0.tar.bz2': 1,
+        'numpy-1.6.2-py26_3.tar.bz2': 1,
+        'pyzmq-2.2.0.1-py26_0.tar.bz2': 1,
+        'pyzmq-2.2.0.1-py33_0.tar.bz2': 1,
+        'sphinx-1.1.3-py26_2.tar.bz2': 1,
+        'sphinx-1.1.3-py33_2.tar.bz2': 1,
+        'system-5.8-0.tar.bz2': 1,
         'zeromq-2.2.0-0.tar.bz2': 1}
 
 def test_unsat():


### PR DESCRIPTION
#2208 revealed an interesting performance issue that manifested itself only in situations where there are a _lot_ of builds, a situation likely to be encountered more by developers than users.

The crux of the issue is that, in the passes that maximize build numbers, the maximum build number for each package is being taken _across all versions_ of the package. So if an old version had 1000 builds, and the new one had only 200, the solver seemed to think the new version was a full 800 builds "old" Mathematically, this doesn't matter, and for typical repos the gap is not going to be big like that. But it slows the solver down, because now it has to bisect over 800 values to get to the true newest build.

Still, I'm not content to leave it there, so I fixed it by combining the "version" and "build" passes of `generate_version_metric` into a single function---smartly titled `generate_version_metrics`, genius, right? By building the version and build objectives at the same time I can ensure that the build objective starts at zero for each package version.

I don't consider this an urgent fix. While I'm sure developers with lots of builds will appreciate it, I think we need to make sure there aren't other urgent matters to address first, and I don't think this alone merits a release unless or until we have nothing better to do.