### PR TITLE
Close session handles

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -98,6 +98,7 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
     try:
         resp = session.get(url + 'repodata.json.bz2',
                            headers=headers, proxies=session.proxies)
+        resp.close()
         resp.raise_for_status()
         if resp.status_code != 304:
             cache = json.loads(bz2.decompress(resp.content).decode('utf-8'))
@@ -329,6 +330,7 @@ def download(url, dst_path, session=None, md5=None, urlstxt=False,
     with Locked(dst_dir):
         try:
             resp = session.get(url, stream=True, proxies=session.proxies)
+            resp.close()
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 407: # Proxy Authentication Required


### PR DESCRIPTION
Replaces #1072 from @pelson, who says:

> Avoids some noisy warnings in Python 3 (I have ResourceWarnings enabled).