### PR TITLE
Weak dependency resolution improvements

### DIFF
--- a/conda/logic.py
+++ b/conda/logic.py
@@ -443,7 +443,7 @@ class Clauses(object):
             yield sol
             exclude.append([-k for k in sol if -m <= k <= m])
 
-    def minimize(self, objective, bestsol):
+    def minimize(self, objective, bestsol, trymax=False):
         """
         Minimize the objective function given either by (coeff, integer)
         tuple pairs, or a dictionary of varname: coeff values. The actual
@@ -487,6 +487,8 @@ class Clauses(object):
             hi = bestval
             m_orig = self.m
             nz = len(self.clauses)
+            if trymax and not peak:
+                try0 = hi - 1
 
             log.debug("Initial range (%d,%d)" % (lo, hi))
             while True:

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -211,7 +211,6 @@ class TestFindSubstitute(unittest.TestCase):
             self.assertEqual(r.find_substitute(installed, f_mkl, old), new)
 
 
-@pytest.mark.slow
 def test_pseudo_boolean():
     # The latest version of iopro, 1.5.0, was not built against numpy 1.5
     assert r.install(['iopro', 'python 2.7*', 'numpy 1.5*'], returnall=True) == [[

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -251,7 +251,7 @@ def test_generate_eq():
     dists, specs = r.get_dists(specs)
     groups, trackers = build_groups(dists)
     C = r.gen_clauses(groups, trackers, specs)
-    eqv, eqb = r.generate_version_metrics(C, groups, specs)
+    eqv, eqb, _ = r.generate_version_metrics(C, groups, specs)
     # Should satisfy the following criteria:
     # - lower versions of the same package should should have higher
     #   coefficients.

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -251,7 +251,7 @@ def test_generate_eq():
     dists, specs = r.get_dists(specs)
     groups, trackers = build_groups(dists)
     C = r.gen_clauses(groups, trackers, specs)
-    eqv, eqb, _ = r.generate_version_metrics(C, groups, specs)
+    eqv, eqb = r.generate_version_metrics(C, groups, specs)
     # Should satisfy the following criteria:
     # - lower versions of the same package should should have higher
     #   coefficients.


### PR DESCRIPTION
Inspired by the discussion with @jjhelmus in #2219, I sought an alternative solver approach that would do a better job of preferring the latest builds of all packages. 

The existing merit functions gave a slight preference to removing packages completely as opposed to installing the latest version of a package. If enough of these "potential removals" accumulated, the solver would prefer downgrading a package so it could remove several others.

This fix removes that bias and replaces it with a lower-priority "package pruning" pass. That is to say, first the versions are maximized, and *then*, once they are locked in, a pass is performed to see if any of those packages can safely be removed. 

Just removing the bias without adding the extra pass isn't an option---that results in ambiguous results and multiple solutions. Going for the smaller package count is essential to restoring a unique solution in many circumstances.

Oh, and a side benefit, I was able to consolidate several optimization passes into one, so this is also faster. Ha!