### PR TITLE
Use MatchSpec to verify specs supplied on the command line

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -11,6 +11,7 @@ import textwrap
 import conda.config as config
 from conda import console
 from conda.utils import memoize
+from conda.resolve import MatchSpec
 
 
 class Completer(object):
@@ -437,31 +438,30 @@ def check_write(command, prefix, json=False):
 # -------------------------------------------------------------------------
 
 def arg2spec(arg, json=False, update=False):
-    spec = spec_from_line(arg)
-    if spec is None:
+    try:
+        spec = MatchSpec(spec_from_line(arg))
+    except:
         error_and_exit('invalid package specification: %s' % arg,
-                       json=json,
-                       error_type="ValueError")
-    parts = spec.split()
-    name = parts[0]
+                       json=json, error_type="ValueError")
+    name = spec.name
     if name in config.disallow:
         error_and_exit("specification '%s' is disallowed" % name,
                        json=json,
                        error_type="ValueError")
-    if len(parts) > 1 and update:
+    if spec.strictness > 1 and update:
         error_and_exit("""version specifications not allowed with 'update'; use
     conda update  %s%s  or
     conda install %s""" % (name, ' ' * (len(arg)-len(name)), arg),
-            json=json,
-            error_type="ValueError")
-    if len(parts) == 2:
-        ver = parts[1]
-        if not ver.startswith(('=', '>', '<', '!')):
-            if ver.endswith('.0'):
-                return '%s %s|%s*' % (name, ver[:-2], ver)
-            else:
-                return '%s %s*' % (name, ver)
-    return spec
+                       json=json, error_type="ValueError")
+    if spec.strictness != 2:
+        return str(spec)
+    ver = spec.vspecs.spec
+    if isinstance(ver, tuple) or ver.startswith(('=', '>', '<', '!')) or ver.endswith('*'):
+        return str(spec)
+    elif ver.endswith('.0'):
+        return '%s %s|%s*' % (name, ver[:-2], ver)
+    else:
+        return '%s %s*' % (name, ver)
 
 
 def specs_from_args(args, json=False):

--- a/conda/version.py
+++ b/conda/version.py
@@ -299,8 +299,11 @@ class VersionSpec(object):
                 s = '(%s)'%s
         return s
 
+    def __str__(self):
+        return self.str()
+
     def __repr__(self):
-        return 'VersionSpec(%s)'%(self.str())
+        return "VersionSpec('%s')" % self.str()
 
     def __and__(self, other):
         if not isinstance(other, VersionSpec):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ class TestArg2Spec(unittest.TestCase):
     def test_simple(self):
         self.assertEqual(arg2spec('python'), 'python')
         self.assertEqual(arg2spec('python=2.6'), 'python 2.6*')
+        self.assertEqual(arg2spec('python=2.6*'), 'python 2.6*')
         self.assertEqual(arg2spec('ipython=0.13.2'), 'ipython 0.13.2*')
         self.assertEqual(arg2spec('ipython=0.13.0'), 'ipython 0.13|0.13.0*')
         self.assertEqual(arg2spec('foo=1.3.0=3'), 'foo 1.3.0 3')


### PR DESCRIPTION
_Copied from #2234_

Without this fix, the steps taken to verify specs supplied on the command line (e.g., `python=3*`) are not as strict as those performed by the solver. So if an invalid spec leaks through to the solver, we get a crash. It's the user's fault, sure, but we're telling the user to file an issue instead of fix their spec. So it's a bug.

This fix uses the solver's own MatchSpec parser to assist in the verification process. Thus if a spec makes it out of this function, we know that the solver will like it later.

Lines 451-455 aren't exercised yet, but will be in master. (And note that if you cherry pick this over there you'll want to resolve the conflict to this version.)

Needed to tune up the `__str__` function for `VersionSpec` to get this to work well.