### PR TITLE
Gracefully handle unexpected errors in bad_installed

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -818,7 +818,7 @@ class Resolve(object):
         constraints = self.generate_spec_constraints(C, specs)
         try:
             solution = C.sat(constraints)
-        except:
+        except TypeError:
             log.debug('Package set caused an unexpected error, assuming a conflict')
             solution = None
         limit = None

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -816,7 +816,11 @@ class Resolve(object):
         groups, trackers = build_groups(dists)
         C = self.gen_clauses(groups, trackers, specs)
         constraints = self.generate_spec_constraints(C, specs)
-        solution = C.sat(constraints)
+        try:
+            solution = C.sat(constraints)
+        except:
+            log.debug('Package set caused an unexpected error, assuming a conflict')
+            solution = None
         limit = None
         if not solution or xtra:
             def get_(name, snames):


### PR DESCRIPTION
An attempt to address #2229 and #2250.

I honestly do not know what a particular combination of installed packages is causing my code to generate bad inputs to `C.sat`. However, for now, I'm going to make an assumption here that only broken installations are doing so. And since all I need to know is if an install is broken or not, catching the exception and acting accordingly will work just fine.

I know I should figure out exactly why the bad input is being generated, and I will, but in the meanwhile this is preventing people from updating conda.