### PR TITLE
Ensure latest versions preserved after features selected

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -941,36 +941,22 @@ class Resolve(object):
             solution, obj7 = C.minimize(eq_optional_c, solution)
             dotlog.debug('Package removal metric: %d' % obj7)
 
-            nz = len(C.clauses)
-            nv = C.m
-
             # Requested packages: maximize versions, then builds
             eq_req_v, eq_req_b = self.generate_version_metrics(C, groups, specr)
             solution, obj3 = C.minimize(eq_req_v, solution)
             solution, obj4 = C.minimize(eq_req_b, solution)
             dotlog.debug('Initial package version/build metrics: %d/%d' % (obj3, obj4))
 
-            # Track features: minimize count
+            # Track features: minimize feature count
             eq_feature_count = self.generate_feature_count(C, trackers)
             solution, obj1 = C.minimize(eq_feature_count, solution)
             dotlog.debug('Track feature count: %d' % obj1)
 
-            # Now that we have the feature count, lock it in and re-optimize
-            C.clauses = C.clauses[:nz]
-            C.m = nv
-            C.Require(C.LinearBound, eq_feature_count, obj1, obj1)
-            solution = C.sat()
-
-            # Featured packages: maximize count
+            # Featured packages: maximize featured package count
             eq_feature_metric, ftotal = self.generate_feature_metric(C, groups)
             solution, obj2 = C.minimize(eq_feature_metric, solution)
             obj2 = ftotal - obj2
             dotlog.debug('Package feature count: %d' % obj2)
-
-            # Re-optimize requested packages: maximize versions, then builds
-            solution, obj3 = C.minimize(eq_req_v, solution)
-            solution, obj4 = C.minimize(eq_req_b, solution)
-            dotlog.debug('Requested package version/build metrics: %d/%d' % (obj3, obj4))
 
             # Remaining packages: maximize versions, then builds, then count
             eq_v, eq_b = self.generate_version_metrics(C, groups, speca)

--- a/tests/integration/regression.bats
+++ b/tests/integration/regression.bats
@@ -10,3 +10,9 @@ load base
     refute_output_contains "DOWNGRADED"
     assert_success
 }
+
+@test "regression test for #2197: New solver should prefer newer versions" {
+    run conda create --dry-run -n $TEST_ENV accelerate python=2.7
+    refute_output_contains "accelerate: 1.0"
+    assert_success
+}


### PR DESCRIPTION
To address #2259 ... and https://github.com/Anaconda-Server/support/issues/26 ... this is resulting in further code simplification and fewer optimization passes, which is a good sign, but it means we _must_ test this more before merge. Specifically, please test it against `mkl`/`nomkl` weirdness, and the issues we recently put to bed with Accelerate, so that there are no regressions.

As a result of this simplification, the optimization passes proceed as follows:

0. (Remove only) Minimize the number of removed packages
1. (Install/update only) Maximize requested version numbers
2. (Install/update only) Maximize requested builds
3. Minimize number of active features
4. Maximize number of packages with features (or, more precisely: minimize the number of packages that *have* a featured option, but for which that option is not selected.)
5. Maximize version numbers for all non-requested packages (if the package is already present, minimize the change to the current version, preferring all upgrades to downgrades)
6. Maximize build numbers for all non-requested packages (if the package is already present, minimize the change to the current version, preferring all upgrades to downgrades)
7. Minimize the number of installed packages
