### PR TITLE
Reduce the amount of extraneous info in hints

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -401,13 +401,15 @@ class Resolve(object):
         touched = {}
         snames = set()
         nspecs = set()
-        unsat = []
+        unsat = set()
 
         def filter_group(matches, chains=None):
             # If we are here, then this dependency is mandatory,
             # so add it to the master list. That way it is still
             # participates in the pruning even if one of its
             # parents is pruned away
+            if unsat:
+                return False
             match1 = next(ms for ms in matches)
             name = match1.name
             first = name not in snames
@@ -445,8 +447,8 @@ class Resolve(object):
                             if not any(filter.get(f2, True) for f2 in self.find_matches(ms)):
                                 dep2.add(ms)
                     chains = [a + (b,) for a in chains for b in dep2]
-                unsat.extend(chains)
-                return nnew
+                unsat.update(chains)
+                return nnew != 0
             if not reduced and not first:
                 return False
 
@@ -485,7 +487,7 @@ class Resolve(object):
             onames = set(s.name for s in specs)
             for iter in range(10):
                 first = True
-                while sum(filter_group([s]) for s in slist):
+                while sum(filter_group([s]) for s in slist) and not unsat:
                     slist = specs + [MatchSpec(n) for n in snames - onames]
                     first = False
                 if unsat:


### PR DESCRIPTION
The new hint generation logic isn't quite as solid as I'd hoped; it includes a lot of extra information that is not helpful. This fix cuts all that extra cruft out by abandoning the solve _as soon as_ an incompatibility is detected. The downside is that this sometimes results in less helpful hints, but I think the _overall_ quality of hints goes up with this.