### PR TITLE
bug: windows pip_path incorrect

### DIFF
--- a/conda/pip.py
+++ b/conda/pip.py
@@ -14,7 +14,7 @@ def pip_args(prefix):
     is not installed
     """
     if sys.platform == 'win32':
-        pip_path = join(prefix, 'pip.exe')
+        pip_path = join(prefix, 'Scripts', 'pip.exe')
     else:
         pip_path = join(prefix, 'bin', 'pip')
     if isfile(pip_path):


### PR DESCRIPTION
https://github.com/conda/conda/issues/2258

on Windows pip is installed in the Scripts folder

when one tries to conda env create/update from an exported environment with a pip section it fails miserably ... no more!