### PR TITLE
Version changes to/from "custom" are now both logged as "updates"

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -145,7 +145,7 @@ def display_actions(actions, index, show_channel_urls=None):
             newer = (P0.name, P0.norm_version, P0.build_number) <= (P1.name, P1.norm_version, P1.build_number)
         except TypeError:
             newer = (P0.name, P0.version, P0.build_number) <= (P1.name, P1.version, P1.build_number)
-        if newer:
+        if newer or str(P1.version) == 'custom':
             updated.add(pkg)
         else:
             downgraded.add(pkg)


### PR DESCRIPTION
One of our first support requests regarding the new Anaconda "custom" package: someone asked on Gitter why Anaconda was being "downgraded" to custom when performing certain actions.

This simply changes the version comparison logic in plan.py so that if a version is changed to "custom" it is _always_ treated as an "update" instead of a "downgrade". If we want to go further than this, we should add text to plan.py to full explain what the "custom" version is.

Probably could be cherry-picked to 4.0.x.

```
0203-mgrant:conda mgrant$ python conda/cli/main.py update -n testa pandas
Using Anaconda Cloud api site https://api.anaconda.org
Fetching package metadata .......
Solving package specifications ............

Package plan for installation in environment /Users/mgrant/miniconda2/envs/testa:

The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    pandas-0.18.0              |      np110py35_0         5.8 MB

The following packages will be UPDATED:

    anaconda: 2.5.0-np110py35_0  --> custom-py35_0     
    pandas:   0.17.1-np110py35_0 --> 0.18.0-np110py35_0

Proceed ([y]/n)? n
```