### PR TITLE
Simple auxlib site_packages_path fix 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+2016-XX-XX   4.0.6:
+-------------------
+  * log "custom" versions as updates rather than downgrades, #2290
+
+
 2016-03-16   4.0.5:
 -------------------
   * improved help documentation for install, update, and remove, #2262

--- a/auxlib/path.py
+++ b/auxlib/path.py
@@ -25,7 +25,7 @@ def site_packages_paths():
     else:
         # not in a virtualenv
         log.debug('searching outside virtualenv')  # pragma: no cover
-        return get_python_lib()  # pragma: no cover
+        return [get_python_lib()]  # pragma: no cover
 
 
 class PackageFile(object):


### PR DESCRIPTION
`site_packages_path` is expected to return a list of directories. But in a rarely-used branch it returns a single path string, which is then interpreted as one path per letter.

It's not causing problems in production but that branch does get exercised when debugging in an iPython notebook.