### PR TITLE
auxlib: site_packages_paths fix

### DIFF
--- a/auxlib/path.py
+++ b/auxlib/path.py
@@ -25,7 +25,7 @@ def site_packages_paths():
     else:
         # not in a virtualenv
         log.debug('searching outside virtualenv')  # pragma: no cover
-        return get_python_lib()  # pragma: no cover
+        return [get_python_lib()]  # pragma: no cover
 
 
 class PackageFile(object):


### PR DESCRIPTION
`site_packages_paths` is supposed to return a list of strings, but in a branch not used in production, it returns a single string. I exercise this branch when I debug conda with iPython.