### PR TITLE
Better handling of channel collisions

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -37,23 +37,24 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     channel_urls = config.normalize_urls(channel_urls, platform, offline)
     if prepend:
         pri0 = max(itervalues(channel_urls)) if channel_urls else 0
-        newurls = config.get_channel_urls(platform, offline)
-        channel_urls.update({url: pri0+pri for url, pri in iteritems(newurls)})
+        for url, rec in iteritems(config.get_channel_urls(platform, offline)):
+            channel_urls[url] = (rec[0], rec[1] + pri0)
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
     if prefix:
         for dist, info in iteritems(install.linked_data(prefix)):
             fn = dist + '.tar.bz2'
-            channel = info.get('channel','')
-            if fn not in index:
+            channel = info.get('channel', '')
+            url_s, priority = channel_urls.get(channel, (channel, 0))
+            key = url_s + fn
+            if key not in index:
                 # only if the package in not in the repodata, use local
                 # conda-meta (with 'depends' defaulting to [])
-                url = channel + fn
                 info.setdefault('depends', [])
                 info['fn'] = fn
                 info['channel'] = channel
-                info['url'] = url
-                info['priority'] = channel_urls.get(channel, 0)
-                index[url] = info
+                info['url'] = channel + fn
+                info['priority'] = priority
+                index[key] = info
     return index
 
 

--- a/conda/api.py
+++ b/conda/api.py
@@ -45,7 +45,7 @@ def get_index(channel_urls=(), prepend=True, platform=None,
             fn = dist + '.tar.bz2'
             channel = info.get('channel', '')
             if channel not in channel_urls:
-                channel_url[channel] = (config.canonical_channel_name(channel, True, True), 0)
+                channel_urls[channel] = (config.canonical_channel_name(channel, True, True), 0)
             url_s, priority = channel_urls[channel]
             key = url_s + '::' + fn if url_s else fn
             if key not in index:

--- a/conda/api.py
+++ b/conda/api.py
@@ -45,12 +45,13 @@ def get_index(channel_urls=(), prepend=True, platform=None,
             fn = dist + '.tar.bz2'
             channel = info.get('channel', '')
             url_s, priority = channel_urls.get(channel, (channel, 0))
-            key = url_s + fn
+            key = url_s + '::' + fn if url_s else fn
             if key not in index:
                 # only if the package in not in the repodata, use local
                 # conda-meta (with 'depends' defaulting to [])
                 info.setdefault('depends', [])
                 info['fn'] = fn
+                info['schannel'] = url_s
                 info['channel'] = channel
                 info['url'] = channel + fn
                 info['priority'] = priority

--- a/conda/api.py
+++ b/conda/api.py
@@ -44,7 +44,9 @@ def get_index(channel_urls=(), prepend=True, platform=None,
         for dist, info in iteritems(install.linked_data(prefix)):
             fn = dist + '.tar.bz2'
             channel = info.get('channel', '')
-            url_s, priority = channel_urls.get(channel, (channel, 0))
+            if channel not in channel_urls:
+                channel_url[channel] = (config.canonical_channel_name(channel, True, True), 0)
+            url_s, priority = channel_urls[channel]
             key = url_s + '::' + fn if url_s else fn
             if key not in index:
                 # only if the package in not in the repodata, use local

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -267,14 +267,16 @@ def add_parser_install(p):
         action="store_true",
         dest="channel_priority",
         default=config.channel_priority,
-        help="Channel priority takes precedence over packaage version (default: %(defaults))."
+        help="Channel priority takes precedence over packaage version (default: %(defaults)). "
+             "Note: This feature is in beta and may change in a future release."
     )
     p.add_argument(
         "--no-channel-priority", "--no-channel-pri", "--no-chan-pri",
         action="store_true",
         dest="channel_priority",
         default=not config.channel_priority,
-        help="Package version takes precedence over channel priority (default: %(defaults))."
+        help="Package version takes precedence over channel priority (default: %(defaults)). "
+             "Note: This feature is in beta and may change in a future release."
     )
     add_parser_show_channel_urls(p)
 

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -262,6 +262,20 @@ def add_parser_install(p):
         default=not config.update_dependencies,
         help="Don't update dependencies (default: %(default)s).",
     )
+    p.add_argument(
+        "--channel-priority", "--channel-pri", "--chan-pri",
+        action="store_true",
+        dest="channel_priority",
+        default=config.channel_priority,
+        help="Channel priority takes precedence over packaage version (default: %(defaults))."
+    )
+    p.add_argument(
+        "--no-channel-priority", "--no-channel-pri", "--no-chan-pri",
+        action="store_true",
+        dest="channel_priority",
+        default=not config.channel_priority,
+        help="Package version takes precedence over channel priority (default: %(defaults))."
+    )
     add_parser_show_channel_urls(p)
 
     if 'update' in p.prog:

--- a/conda/config.py
+++ b/conda/config.py
@@ -223,6 +223,7 @@ channel_alias = rc.get('channel_alias', DEFAULT_CHANNEL_ALIAS)
 if not sys_rc.get('allow_other_channels', True) and 'channel_alias' in sys_rc:
     channel_alias = sys_rc['channel_alias']
 channel_alias = channel_alias.rstrip('/') + '/'
+channel_alias_ = channel_alias
 
 _binstar = r'((:?%s|binstar\.org|anaconda\.org)/?)(t/[0-9a-zA-Z\-<>]{4,})/'
 BINSTAR_TOKEN_PAT = re.compile(_binstar % re.escape(channel_alias))
@@ -286,7 +287,7 @@ def canonical_channel_name(channel, hide=True, drop_defaults=False, channel_alia
     if channel is None:
         return '<unknown>'
     channel = remove_binstar_tokens(channel)
-    channel_alias = channel_alias or config.channel_alias
+    channel_alias = channel_alias or channel_alias_
     if channel.startswith(channel_alias):
         end = channel.split(channel_alias, 1)[1]
         url = end.split('/')[0]

--- a/conda/config.py
+++ b/conda/config.py
@@ -239,7 +239,6 @@ def normalize_urls(urls, platform=None, offline_only=False):
     defaults = tuple(x.rstrip('/') + '/' for x in get_default_urls())
     channel_alias = binstar_channel_alias(rc.get('channel_alias',
                                                  DEFAULT_CHANNEL_ALIAS))
-    n_alias = len(channel_alias)
 
     def normalize_(url):
         url = url.rstrip('/')

--- a/conda/config.py
+++ b/conda/config.py
@@ -236,24 +236,28 @@ def normalize_urls(urls, platform=None, offline_only=False):
     channel_alias = binstar_channel_alias(rc.get('channel_alias',
                                           DEFAULT_CHANNEL_ALIAS))
     newurls = {}
-    pri = 0
+    priority = 0
     for url in urls:
+        incr = True
         if url == "defaults" or url == "system" and not rc_path:
             t_urls = get_default_urls()
+            incr = False
         elif url == "system":
             t_urls = get_rc_urls()
-        elif not is_url(url):
-            t_urls = [channel_alias + url]
         else:
             t_urls = [url]
-        if offline_only:
-            t_urls = [url for url in t_urls if url.startswith('file:')]
-        if t_urls:
-            pri += 1
-            for url0 in t_urls:
-                url0 = url0.rstrip('/')
-                for plat in (platform, 'noarch'):
-                    newurls.setdefault('%s/%s/' % (url0, plat), pri)
+        if not incr:
+            priority += 1
+        for url0 in t_urls:
+            if incr:
+                priority += 1
+            if not is_url(url0):
+                url0 = channel_alias + url0
+            if offline_only and not url0.startswith('file:'):
+                continue
+            url0 = url0.rstrip('/')
+            for plat in (platform, 'noarch'):
+                newurls.setdefault('%s/%s/' % (url0, plat), priority)
     return newurls
 
 offline = bool(rc.get('offline', False))

--- a/conda/config.py
+++ b/conda/config.py
@@ -79,6 +79,7 @@ rc_bool_keys = [
     'show_channel_urls',
     'allow_other_channels',
     'update_dependencies',
+    'channel_priority',
 ]
 
 rc_string_keys = [
@@ -242,25 +243,26 @@ def normalize_urls(urls, platform=None, offline_only=False):
         if is_url(url):
             url = url.rstrip('/') + '/'
             if any(url.startswith(x) for x in defaults):
-                url_s = ''
+                url_s = None
             elif url.startswith(channel_alias):
-                url_s = url[n_alias:]
+                url_s = url[n_alias:-1]
             else:
-                url_s = url
+                url_s = url[:-1]
         else:
-            url_s = url.rstrip('/') + '/'
-            url = channel_alias + url_s
+            url_s = url.rstrip('/')
+            url = channel_alias + url_s + '/'
         return url_s, url
     newurls = {}
     priority = 0
     while urls:
-        url = urls.pop()
+        url = urls[0]
+        urls = urls[1:]
         if url == "system" and rc_path:
             urls = get_rc_urls() + urls
             continue
         elif url in ("defaults", "system"):
             t_urls = defaults
-        elif url in defaults:
+        else:
             t_urls = [url]
         priority += 1
         for url0 in t_urls:
@@ -269,7 +271,6 @@ def normalize_urls(urls, platform=None, offline_only=False):
                 continue
             for plat in (platform, 'noarch'):
                 newurls.setdefault(url0 + plat + '/', (url_s, priority))
-    print(newurls)
     return newurls
 
 offline = bool(rc.get('offline', False))
@@ -355,6 +356,7 @@ disallow = set(rc.get('disallow', []))
 # packages which are added to a newly created environment by default
 create_default_packages = list(rc.get('create_default_packages', []))
 update_dependencies = bool(rc.get('update_dependencies', True))
+channel_priority = bool(rc.get('channel_priority', True))
 
 # ssl_verify can be a boolean value or a filename string
 ssl_verify = rc.get('ssl_verify', True)

--- a/conda/config.py
+++ b/conda/config.py
@@ -237,20 +237,17 @@ def normalize_urls(urls, platform=None, offline_only=False):
                                           DEFAULT_CHANNEL_ALIAS))
     newurls = {}
     priority = 0
-    for url in urls:
-        incr = True
-        if url == "defaults" or url == "system" and not rc_path:
+    while urls:
+        url = urls.pop()
+        if url == "system" and rc_path:
+            urls = get_rc_urls() + urls
+            continue
+        elif url in ("defaults", "system"):
             t_urls = get_default_urls()
-            incr = False
-        elif url == "system":
-            t_urls = get_rc_urls()
         else:
             t_urls = [url]
-        if not incr:
-            priority += 1
+        priority += 1
         for url0 in t_urls:
-            if incr:
-                priority += 1
             if not is_url(url0):
                 url0 = channel_alias + url0
             if offline_only and not url0.startswith('file:'):
@@ -266,7 +263,7 @@ def get_channel_urls(platform=None, offline=False):
     if os.getenv('CIO_TEST'):
         import cio_test
         base_urls = cio_test.base_urls
-    elif 'channels' in rc and rc_path:
+    elif 'channels' in rc:
         base_urls = ['system']
     else:
         base_urls = ['defaults']

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -271,15 +271,14 @@ Allowed channels are:
     for channel, repodata in repodatas:
         if repodata is None:
             continue
-        priority = channel_urls[channel]
         new_index = repodata['packages']
+        url_s, priority = channel_urls[channel]
         for fn, info in iteritems(new_index):
-            url = channel + fn
             info['fn'] = fn
             info['channel'] = channel
-            info['url'] = url
             info['priority'] = priority
-            index[url] = info
+            info['url'] = channel + fn
+            index[url_s + fn] = info
 
     stdoutlog.info('\n')
     if unknown:

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -275,10 +275,12 @@ Allowed channels are:
         url_s, priority = channel_urls[channel]
         for fn, info in iteritems(new_index):
             info['fn'] = fn
+            info['schannel'] = url_s
             info['channel'] = channel
             info['priority'] = priority
             info['url'] = channel + fn
-            index[url_s + fn] = info
+            key = url_s + '::' + fn if url_s else fn
+            index[key] = info
 
     stdoutlog.info('\n')
     if unknown:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -242,27 +242,27 @@ class Package(object):
 def build_groups(index):
     groups = {}
     trackers = {}
-    for fn, info in iteritems(index):
-        groups.setdefault(info['name'], []).append(fn)
+    for fkey, info in iteritems(index):
+        groups.setdefault(info['name'], []).append(fkey)
         for feat in info.get('track_features', '').split():
-            trackers.setdefault(feat, []).append(fn)
+            trackers.setdefault(feat, []).append(fkey)
     return groups, trackers
 
 
 class Resolve(object):
     def __init__(self, index):
         self.index = index.copy()
-        for fn, info in iteritems(index):
+        for fkey, info in iteritems(index):
             for fstr in chain(info.get('features', '').split(),
                               info.get('track_features', '').split()):
                 fpkg = fstr + '@'
                 if fpkg not in self.index:
                     self.index[fpkg] = {
-                        'name': fpkg, 'version': '0', 'build_number': 0,
+                        'name': fpkg, 'channel': '@', 'priority': 0,
+                        'version': '0', 'build_number': 0,
                         'build': '', 'depends': [], 'track_features': fstr}
             for fstr in iterkeys(info.get('with_features_depends', {})):
-                fn2 = fn + '[' + fstr + ']'
-                self.index[fn2] = info
+                self.index['%s[%s]' % (fkey, fstr)] = info
         self.groups, self.trackers = build_groups(self.index)
         self.find_matches_ = {}
         self.ms_depends_ = {}
@@ -282,8 +282,8 @@ class Resolve(object):
         dependencies, assuming cyclic dependencies are always valid.
 
         Args:
-            fn: a package key, a MatchSpec, or an iterable of these.
-            filter: a dictionary of (fn,valid) pairs, used to consider a subset
+            fkey: a package key, a MatchSpec, or an iterable of these.
+            filter: a dictionary of (fkey,valid) pairs, used to consider a subset
                 of dependencies, and to eliminate repeated searches.
 
         Returns:
@@ -292,16 +292,16 @@ class Resolve(object):
             search results.
         """
         def v_(spec):
-            return v_ms_(spec) if isinstance(spec, MatchSpec) else v_fn_(spec)
+            return v_ms_(spec) if isinstance(spec, MatchSpec) else v_fkey_(spec)
 
         def v_ms_(ms):
-            return ms.optional or any(v_fn_(fn) for fn in self.find_matches(ms))
+            return ms.optional or any(v_fkey_(fkey) for fkey in self.find_matches(ms))
 
-        def v_fn_(fn):
-            val = filter.get(fn)
+        def v_fkey_(fkey):
+            val = filter.get(fkey)
             if val is None:
-                filter[fn] = True
-                val = filter[fn] = all(v_ms_(ms) for ms in self.ms_depends(fn))
+                filter[fkey] = True
+                val = filter[fkey] = all(v_ms_(ms) for ms in self.ms_depends(fkey))
             return val
 
         return v_(spec)
@@ -312,10 +312,10 @@ class Resolve(object):
            solved, so there is no guarantee a solution exists.
 
         Args:
-            fn: a package key or MatchSpec
+            fkey: a package key or MatchSpec
             touched: a dict into which to accumulate the result. This is
                 useful when processing multiple specs.
-            filter: a dictionary of (fn,valid) pairs to be used when
+            filter: a dictionary of (fkey, valid) pairs to be used when
                 testing for package validity.
 
         This function works in two passes. First, it verifies that the package has
@@ -323,20 +323,20 @@ class Resolve(object):
         is _not_ touched, nor are its dependencies. If so, then it is marked as
         touched, and any of its valid dependencies are as well.
         """
-        def t_fn_(fn):
-            val = touched.get(fn)
+        def t_fkey_(fkey):
+            val = touched.get(fkey)
             if val is None:
-                val = touched[fn] = self.valid(fn, filter)
+                val = touched[fkey] = self.valid(fkey, filter)
                 if val:
-                    for ms in self.ms_depends(fn):
+                    for ms in self.ms_depends(fkey):
                         if ms.name[0] != '@':
                             t_ms_(ms)
 
         def t_ms_(ms):
-            for fn in self.find_matches(ms):
-                t_fn_(fn)
+            for fkey in self.find_matches(ms):
+                t_fkey_(fkey)
 
-        return t_ms_(spec) if isinstance(spec, MatchSpec) else t_fn_(spec)
+        return t_ms_(spec) if isinstance(spec, MatchSpec) else t_fkey_(spec)
 
     def invalid_chains(self, spec, filter):
         """Constructs a set of 'dependency chains' for invalid specs.
@@ -349,7 +349,7 @@ class Resolve(object):
 
         Args:
             spec: a package key or MatchSpec
-            filter: a dictionary of (fn,valid) pairs to be used when
+            filter: a dictionary of (fkey, valid) pairs to be used when
                 testing for package validity.
 
         Returns:
@@ -360,8 +360,8 @@ class Resolve(object):
                 return []
             notfound = set()
             specs = self.find_matches(spec) if isinstance(spec, MatchSpec) else [spec]
-            for fn in specs:
-                for m2 in self.ms_depends(fn):
+            for fkey in specs:
+                for m2 in self.ms_depends(fkey):
                     notfound.update(chains_(m2))
             return [(spec,) + x for x in notfound] if notfound else [(spec,)]
         return chains_(spec)
@@ -427,15 +427,15 @@ class Resolve(object):
             # or which have unsatisfiable dependencies
             nold = 0
             bad_deps = []
-            for fn in group:
-                if filter.setdefault(fn, True):
+            for fkey in group:
+                if filter.setdefault(fkey, True):
                     nold += 1
-                    sat = self.match_any(matches, fn)
+                    sat = self.match_any(matches, fkey)
                     sat = sat and all(any(filter.get(f2, True) for f2 in self.find_matches(ms))
-                                      for ms in self.ms_depends(fn))
-                    filter[fn] = sat
+                                      for ms in self.ms_depends(fkey))
+                    filter[fkey] = sat
                     if not sat:
-                        bad_deps.append(fn)
+                        bad_deps.append(fkey)
 
             # Build dependency chains if we detect unsatisfiability
             nnew = nold - len(bad_deps)
@@ -445,13 +445,13 @@ class Resolve(object):
             if nnew == 0:
                 if name in snames:
                     snames.remove(name)
-                bad_deps = [fn for fn in bad_deps if self.match_any(matches, fn)]
+                bad_deps = [fkey for fkey in bad_deps if self.match_any(matches, fkey)]
                 matches = [(ms,) for ms in matches]
                 chains = [a + b for a in chains for b in matches] if chains else matches
                 if bad_deps:
                     dep2 = set()
-                    for fn in bad_deps:
-                        for ms in self.ms_depends(fn):
+                    for fkey in bad_deps:
+                        for ms in self.ms_depends(fkey):
                             if not any(filter.get(f2, True) for f2 in self.find_matches(ms)):
                                 dep2.add(ms)
                     chains = [a + (b,) for a in chains for b in dep2]
@@ -468,9 +468,9 @@ class Resolve(object):
                 if match1 not in specs:
                     nspecs.add(MatchSpec(name))
             cdeps = defaultdict(list)
-            for fn in group:
-                if filter[fn]:
-                    for m2 in self.ms_depends(fn):
+            for fkey in group:
+                if filter[fkey]:
+                    for m2 in self.ms_depends(fkey):
                         if m2.name[0] != '@' and not m2.optional:
                             cdeps[m2.name].append(m2)
             cdeps = {mname: set(deps) for mname, deps in iteritems(cdeps) if len(deps) == nnew}
@@ -487,8 +487,8 @@ class Resolve(object):
         def full_prune(specs, removes, optional, features):
             self.default_filter(features, filter)
             for ms in removes:
-                for fn in self.groups.get(ms.name, []):
-                    filter[fn] = False
+                for fkey in self.groups.get(ms.name, []):
+                    filter[fkey] = False
             feats = set(self.trackers.keys())
             snames.clear()
             specs = slist = list(specs)
@@ -508,17 +508,17 @@ class Resolve(object):
                 for spec in chain(specs, optional):
                     self.touch(spec, touched, filter)
                 nfeats = set()
-                for fn, val in iteritems(touched):
+                for fkey, val in iteritems(touched):
                     if val:
-                        nfeats.update(self.track_features(fn))
+                        nfeats.update(self.track_features(fkey))
                 if len(nfeats) >= len(feats):
                     return True
                 pruned = False
                 feats &= nfeats
-                for fn, val in iteritems(touched):
-                    if val and self.features(fn) - feats:
-                        touched[fn] = filter[fn] = False
-                        filter[fn] = False
+                for fkey, val in iteritems(touched):
+                    if val and self.features(fkey) - feats:
+                        touched[fkey] = filter[fkey] = False
+                        filter[fkey] = False
                         pruned = True
                 if not pruned:
                     return True
@@ -537,27 +537,27 @@ class Resolve(object):
             save_unsat.update((ms,) for ms in hint)
             raise Unsatisfiable(save_unsat)
 
-        dists = {fn: self.index[fn] for fn, val in iteritems(touched) if val}
+        dists = {fkey: self.index[fkey] for fkey, val in iteritems(touched) if val}
         return dists, list(map(MatchSpec, snames - {ms.name for ms in specs}))
 
-    def match_any(self, mss, fn):
-        rec = self.index[fn]
+    def match_any(self, mss, fkey):
+        rec = self.index[fkey]
         n, v, b = rec['name'], rec['version'], rec['build']
         return any(n == ms.name and ms.match_fast(v, b) for ms in mss)
 
-    def match(self, ms, fn):
-        return MatchSpec(ms).match(self.index[fn])
+    def match(self, ms, fkey):
+        return MatchSpec(ms).match(self.index[fkey])
 
     def find_matches_group(self, ms, groups, trackers=None):
         ms = MatchSpec(ms)
         if ms.name[0] == '@' and trackers:
-            for fn in trackers.get(ms.name[1:], []):
-                yield fn
+            for fkey in trackers.get(ms.name[1:], []):
+                yield fkey
         else:
-            for fn in groups.get(ms.name, []):
-                rec = self.index[fn]
+            for fkey in groups.get(ms.name, []):
+                rec = self.index[fkey]
                 if ms.match_fast(rec['version'], rec['build']):
-                    yield fn
+                    yield fkey
 
     def find_matches(self, ms):
         ms = MatchSpec(ms)
@@ -569,46 +569,48 @@ class Resolve(object):
                 res = self.find_matches_[ms] = list(self.find_matches_group(ms, self.groups))
         return res
 
-    def ms_depends(self, fn):
-        deps = self.ms_depends_.get(fn, None)
+    def ms_depends(self, fkey):
+        deps = self.ms_depends_.get(fkey, None)
         if deps is None:
-            if fn[-1] == ']':
-                fn2, fstr = fn[:-1].split('[')
-                fdeps = {d.name: d for d in self.ms_depends(fn2)}
-                for dep in self.index[fn2]['with_features_depends'][fstr]:
+            rec = self.index[fkey]
+            if fkey.endswith(']'):
+                f2, fstr = fkey.rsplit('[', 1)
+                fdeps = {d.name: d for d in self.ms_depends(f2)}
+                for dep in rec['with_features_depends'][fstr[:-1]]:
                     dep = MatchSpec(dep)
                     fdeps[dep.name] = dep
                 deps = list(fdeps.values())
             else:
-                deps = [MatchSpec(d) for d in self.index[fn].get('depends', [])]
-            deps.extend(MatchSpec('@'+feat) for feat in self.features(fn))
-            self.ms_depends_[fn] = deps
+                deps = [MatchSpec(d) for d in rec.get('depends', [])]
+            deps.extend(MatchSpec('@'+feat) for feat in self.features(fkey))
+            self.ms_depends_[fkey] = deps
         return deps
 
-    def version_key(self, fn, vtype=None):
-        rec = self.index[fn]
+    def version_key(self, fkey, vtype=None):
+        rec = self.index[fkey]
         return (normalized_version(rec['version']), rec['build_number'])
 
-    def features(self, fn):
-        return set(self.index[fn].get('features', '').split())
+    def features(self, fkey):
+        return set(self.index[fkey].get('features', '').split())
 
-    def track_features(self, fn):
-        return set(self.index[fn].get('track_features', '').split())
+    def track_features(self, fkey):
+        return set(self.index[fkey].get('track_features', '').split())
 
-    def package_triple(self, fn):
-        if not fn.endswith('.tar.bz2'):
-            return self.package_triple(fn + '.tar.bz2')
-        rec = self.index.get(fn, None)
+    def package_triple(self, fkey):
+        rec = self.index.get(fkey, None)
         if rec is None:
-            return fn[:-8].rsplit('-', 2)
+            fkey = fkey.rsplit('[',1)[0].rsplit('/',1)[-1]
+            if fkey.endswith('.tar.bz2'):
+                fkey = fkey[:-8]
+            return fkey.rsplit('-', 2)
         return (rec['name'], rec['version'], rec['build'])
 
-    def package_name(self, fn):
-        return self.package_triple(fn)[0]
+    def package_name(self, fkey):
+        return self.package_triple(fkey)[0]
 
     def get_pkgs(self, ms, emptyok=False):
         ms = MatchSpec(ms)
-        pkgs = [Package(fn, self.index[fn]) for fn in self.find_matches(ms)]
+        pkgs = [Package(fkey, self.index[fkey]) for fkey in self.find_matches(ms)]
         if not pkgs and not emptyok:
             raise NoPackagesFound([(ms,)])
         return pkgs
@@ -630,7 +632,7 @@ class Resolve(object):
             name = self.ms_to_v(ms)
             m = C.from_name(name)
             if m is None:
-                libs = [fn for fn in self.find_matches_group(ms, groups, trackers)]
+                libs = [fkey for fkey in self.find_matches_group(ms, groups, trackers)]
                 # If the MatchSpec is optional, then there may be cases where we want
                 # to assert that it is *not* True. This requires polarity=None.
                 m = C.Any(libs, polarity=None if ms.optional else True, name=name)
@@ -639,8 +641,9 @@ class Resolve(object):
         # Creates a variable that represents the proposition:
         #     Does the package set include package "fn"?
         for group in itervalues(groups):
-            for fn in group:
-                C.new_var(fn)
+            gnames = []
+            for fkey in group:
+                C.new_var(fkey)
             # Install no more than one version of each package
             C.Require(C.AtMostOne, group)
 
@@ -661,10 +664,11 @@ class Resolve(object):
         # Create propositions that assert:
         #     If package "fn" is installed, its dependencie must be satisfied
         for group in itervalues(groups):
-            for fn in group:
-                for ms in self.ms_depends(fn):
+            for fkey in group:
+                nkey = C.Not(fkey)
+                for ms in self.ms_depends(fkey):
                     if not ms.optional:
-                        C.Require(C.Or, C.Not(fn), push_MatchSpec(ms))
+                        C.Require(C.Or, nkey, push_MatchSpec(ms))
         return C
 
     def generate_spec_constraints(self, C, specs):
@@ -677,7 +681,7 @@ class Resolve(object):
         eq = {}
         total = 0
         for name, group in iteritems(groups):
-            nf = [len(self.features(fn)) for fn in group]
+            nf = [len(self.features(fkey)) for fkey in group]
             maxf = max(nf)
             eq.update({fn: maxf-fc for fn, fc in zip(group, nf) if fc < maxf})
             total += maxf
@@ -689,7 +693,7 @@ class Resolve(object):
     def generate_package_count(self, C, groups, missing):
         eq = {}
         for name in missing:
-            eq.update({fn: 1 for fn in groups.get(name, [])})
+            eq.update({fkey: 1 for fkey in groups.get(name, [])})
         return eq
 
     def generate_version_metrics(self, C, groups, specs):

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -263,9 +263,7 @@ class Resolve(object):
         groups = {}
         trackers = {}
         for fkey, info in iteritems(index):
-            name = info['name']
-            priority = info.get('priority', 0)
-            groups.setdefault(name, []).append(fkey)
+            groups.setdefault(info['name'], []).append(fkey)
             for feat in info.get('track_features', '').split():
                 trackers.setdefault(feat, []).append(fkey)
 
@@ -662,7 +660,6 @@ class Resolve(object):
         # Creates a variable that represents the proposition:
         #     Does the package set include package "fn"?
         for name, group in iteritems(self.groups):
-            gnames = []
             for fkey in group:
                 C.new_var(fkey)
             # Install no more than one version of each package
@@ -728,10 +725,10 @@ class Resolve(object):
                 v2 = [p for p in pkgs if p > tver]
                 v3 = list(reversed([p for p in pkgs if p <= tver and p not in v1]))
                 pkgs = v1 + v2 + v3
-            pkey = ppkg = None
+            pkey = None
             for nkey, npkg in pkgs:
                 if pkey is None:
-                    ic = iv = ib = 0
+                    iv = ib = 0
                 elif pkey[0] != nkey[0] or pkey[1] != nkey[1]:
                     iv += 1
                     ib = 0
@@ -741,7 +738,7 @@ class Resolve(object):
                     eqv[npkg] = iv
                 if ib:
                     eqb[npkg] = ib
-                pkey, ppkg = nkey, npkg
+                pkey = nkey
         return eqv, eqb
 
     def dependency_sort(self, must_have):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,20 +83,20 @@ class TestConfig(unittest.TestCase):
             'defaults', 'system', 'https://conda.anaconda.org/username',
             'file:///Users/username/repo', 'username'
             ], 'osx-64'),
-            {'file:///Users/username/repo/noarch/': ('file:///Users/username/repo/', 6),
-             'file:///Users/username/repo/osx-64/': ('file:///Users/username/repo/', 6),
-             'http://repo.continuum.io/pkgs/free/noarch/': ('', 1),
-             'http://repo.continuum.io/pkgs/free/osx-64/': ('', 1),
-             'http://repo.continuum.io/pkgs/pro/noarch/': ('', 1),
-             'http://repo.continuum.io/pkgs/pro/osx-64/': ('', 1),
-             'http://some.custom/channel/noarch/': ('http://some.custom/channel/', 3),
-             'http://some.custom/channel/osx-64/': ('http://some.custom/channel/', 3),
-             'https://conda.anaconda.org/username/noarch/': ('https://conda.anaconda.org/username/', 5),
-             'https://conda.anaconda.org/username/osx-64/': ('https://conda.anaconda.org/username/', 5),
-             'https://your.repo/binstar_username/noarch/': ('binstar_username/', 2),
-             'https://your.repo/binstar_username/osx-64/': ('binstar_username/', 2),
-             'https://your.repo/username/noarch/': ('username/', 7),
-             'https://your.repo/username/osx-64/': ('username/', 7)})
+            {'file:///Users/username/repo/noarch/': ('file:///Users/username/repo', 6),
+             'file:///Users/username/repo/osx-64/': ('file:///Users/username/repo', 6),
+             'http://repo.continuum.io/pkgs/free/noarch/': (None, 1),
+             'http://repo.continuum.io/pkgs/free/osx-64/': (None, 1),
+             'http://repo.continuum.io/pkgs/pro/noarch/': (None, 1),
+             'http://repo.continuum.io/pkgs/pro/osx-64/': (None, 1),
+             'http://some.custom/channel/noarch/': ('http://some.custom/channel', 3),
+             'http://some.custom/channel/osx-64/': ('http://some.custom/channel', 3),
+             'https://conda.anaconda.org/username/noarch/': ('https://conda.anaconda.org/username', 5),
+             'https://conda.anaconda.org/username/osx-64/': ('https://conda.anaconda.org/username', 5),
+             'https://your.repo/binstar_username/noarch/': ('binstar_username', 2),
+             'https://your.repo/binstar_username/osx-64/': ('binstar_username', 2),
+             'https://your.repo/username/noarch/': ('username', 7),
+             'https://your.repo/username/osx-64/': ('username', 7)})
 
 
 test_condarc = os.path.join(os.path.dirname(__file__), 'test_condarc')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,22 +83,21 @@ class TestConfig(unittest.TestCase):
             'defaults', 'system', 'https://conda.anaconda.org/username',
             'file:///Users/username/repo', 'username'
             ], 'osx-64'),
-			{'file:///Users/username/repo/noarch/': 6,
-			 'file:///Users/username/repo/osx-64/': 6,
-			 'http://some.custom/channel/noarch/': 3,
-			 'http://some.custom/channel/osx-64/': 3,
-			 'https://conda.anaconda.org/username/noarch/': 5,
-			 'https://conda.anaconda.org/username/osx-64/': 5,
-			 'https://repo.continuum.io/pkgs/free/noarch/': 1,
-			 'https://repo.continuum.io/pkgs/free/osx-64/': 1,
-			 'https://repo.continuum.io/pkgs/pro/noarch/': 1,
-			 'https://repo.continuum.io/pkgs/pro/osx-64/': 1,
-			 'https://your.repo/binstar_username/noarch/': 2,
-			 'https://your.repo/binstar_username/osx-64/': 2,
-			 'https://your.repo/defaults/noarch/': 4,
-			 'https://your.repo/defaults/osx-64/': 4,
-			 'https://your.repo/username/noarch/': 7,
-			 'https://your.repo/username/osx-64/': 7})
+            {'file:///Users/username/repo/noarch/': ('file:///Users/username/repo/', 6),
+             'file:///Users/username/repo/osx-64/': ('file:///Users/username/repo/', 6),
+             'http://repo.continuum.io/pkgs/free/noarch/': ('', 1),
+             'http://repo.continuum.io/pkgs/free/osx-64/': ('', 1),
+             'http://repo.continuum.io/pkgs/pro/noarch/': ('', 1),
+             'http://repo.continuum.io/pkgs/pro/osx-64/': ('', 1),
+             'http://some.custom/channel/noarch/': ('http://some.custom/channel/', 3),
+             'http://some.custom/channel/osx-64/': ('http://some.custom/channel/', 3),
+             'https://conda.anaconda.org/username/noarch/': ('https://conda.anaconda.org/username/', 5),
+             'https://conda.anaconda.org/username/osx-64/': ('https://conda.anaconda.org/username/', 5),
+             'https://your.repo/binstar_username/noarch/': ('binstar_username/', 2),
+             'https://your.repo/binstar_username/osx-64/': ('binstar_username/', 2),
+             'https://your.repo/username/noarch/': ('username/', 7),
+             'https://your.repo/username/osx-64/': ('username/', 7)})
+
 
 test_condarc = os.path.join(os.path.dirname(__file__), 'test_condarc')
 def _read_test_condarc():

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -256,7 +256,7 @@ def test_get_dists():
 def test_generate_eq():
     specs = ['anaconda']
     dists, specs = r.get_dists(specs)
-    r2 = Resolve(r, dists, True)
+    r2 = Resolve(dists, True, True)
     C = r2.gen_clauses(specs)
     eqv, eqb = r2.generate_version_metrics(C, specs)
     # Should satisfy the following criteria:

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -7,6 +7,7 @@ import pytest
 
 from conda.resolve import MatchSpec, Package, Resolve, NoPackagesFound, Unsatisfiable
 from tests.helpers import raises
+from conda import config
 
 with open(join(dirname(__file__), 'index.json')) as fi:
     index = json.load(fi)
@@ -848,6 +849,32 @@ def test_remove():
         'system-5.8-1.tar.bz2',
         'tk-8.5.13-0.tar.bz2',
         'zlib-1.2.7-0.tar.bz2']
+
+def test_channel_priority():
+    fn1 = 'pandas-0.10.1-np17py27_0.tar.bz2'
+    fn2 = 'other::' + fn1
+    spec = ['pandas', 'python 2.7*']
+    index2 = index.copy()
+    index2[fn2] = index2[fn1].copy()
+    r2 = Resolve(index2)
+    rec = r2.index[fn2]
+    config.channel_priority = True
+    rec['priority'] = 0
+    # Should select the "other", older package because it
+    # has a lower channel priority number
+    installed1 = r2.install(spec)
+    # Should select the newer package because now the "other"
+    # package has a higher priority number
+    rec['priority'] = 2
+    installed2 = r2.install(spec)
+    # Should also select the newer package because we have
+    # turned off channel priority altogether
+    config.channel_priority = False
+    rec['priority'] = 0
+    installed3 = r2.install(spec)
+    assert installed1 != installed2 
+    assert installed1 != installed3
+    assert installed2 == installed3
 
 def test_graph_sort():
     specs = ['pandas','python 2.7*','numpy 1.6*']

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -5,7 +5,7 @@ from os.path import dirname, join
 
 import pytest
 
-from conda.resolve import MatchSpec, Package, Resolve, NoPackagesFound, Unsatisfiable, build_groups
+from conda.resolve import MatchSpec, Package, Resolve, NoPackagesFound, Unsatisfiable
 from tests.helpers import raises
 
 with open(join(dirname(__file__), 'index.json')) as fi:
@@ -256,9 +256,9 @@ def test_get_dists():
 def test_generate_eq():
     specs = ['anaconda']
     dists, specs = r.get_dists(specs)
-    groups, trackers = build_groups(dists)
-    C = r.gen_clauses(groups, trackers, specs)
-    eqv, eqb = r.generate_version_metrics(C, groups, specs)
+    r2 = Resolve(r, dists, True)
+    C = r2.gen_clauses(specs)
+    eqv, eqb = r2.generate_version_metrics(C, specs)
     # Should satisfy the following criteria:
     # - lower versions of the same package should should have higher
     #   coefficients.


### PR DESCRIPTION
cc: @ukoethe @jakirkham 

This is what I hope will be the first attempt to properly handle cases where packages with the same name are hosted in multiple channels. The current behavior does the following:

1. When the package filenames are identical, the version found in a lower priority channel is dropped from consideration, even if that would have been the right choice for dependency reasons.
2. Even when package filenames are distinct, they are prioritized as if they all came from the same channel. In particular, build numbers are assumed to imply consistent chronology across channels. But this clearly is not a correct assumption; build 5 in channel A could in fact be _older_ than build 10 in channel B.

To fix this we have done the following:

- Assign a _channel priority number_ to each channel. For now, this number is assigned internally depending on the order of appearance in the channel list. The `defaults` channel actually consists of two different channels, but it is treated as one for the purposes of prioritization.

- The solver's internal representation of the package list is currently a dictionary, where the key is the filename (`name-version-build.tar.bz2`). To solve problem 1, the key for any package outside of the default channel is prepended with the _canonical_ (short) channel name plus `::`. For example, using the default configuration settings, the channel `https://anaconda.org/conda-forge` translates to a prefix `conda-forge::` This eliminates problem 1 above; packages with the same filename, but in different channels, may now both be considered by the solver.

- Packages in the default channel still use `filename` as the key; that is, with no `::` prefix. This aids transition and reduced the necessary modifications to the test suite. Note however that this means that package filenames must be unique across all of the channels aggregated into `defaults`. I think this is the right choice anyway.

- A new configuration option `config.channel_priority` has been created. 
  - If `True`, the package sort order favors higher priority channels over version numbers. This ensures that if a user adds a new channel to their channel list, they can be sure that `conda` will pull from that channel as long as the dependency relationships allow it. If for some reason dependency requirements do *not* allow the packages from the favored channel to be installed, `conda` will drop down to the next priority channel.
  - If `False`, the package sorting algorithm favors version numbers over channel priority. This means that the user wishes to obtain the latest version of a package, no matter what channel it comes from. Version number ties are broken by channel priority. This latter option *sounds* like the old behavior, but it is different in a very important respect: build numbers are *not* interleaved across channels.

To do:

- We may want to add a third option that forces `conda` to consider *only* the highest priority channel where the package exists, and ignore completely any versions of the same package in lower priority channels.
- I think we need a way to override the default channel priority on a per-package basis.
- I think we need a way for a package to specify which channel its dependencies come from. Note that this needs to be done with great care lest it break older versions of `conda` (and even prevent them from upgrading to new versions). We can certainly allow a syntax like `channel::package` on the command line, but introducing those channels into the `depends` metadata would be problematic. This suggests the need to use new metadata fields to handle this.
- A simple way to address the previous challenge for some packages is to have a boolean field called, say, `channel_lock`. If specified, all dependencies must come from the same (canonical) channel as the package itself. This seems like the right option for, say, `anaconda` itself.


