### PR TITLE
Fix for mysterious pycosat 0.6.1 behavior

### DIFF
--- a/conda/logic.py
+++ b/conda/logic.py
@@ -418,8 +418,17 @@ class Clauses(object):
             clauses = chain(self.clauses, additional)
         else:
             clauses = self.clauses
-        clauses = list(clauses)
-        solution = pycosat.solve(clauses, vars=self.m, prop_limit=limit)
+        try:
+            solution = pycosat.solve(clauses, vars=self.m, prop_limit=limit)
+        except TypeError:
+            # pycosat 0.6.1 should not require this; pycosat 0.6.0 did, but we
+            # have made conda dependent on pycosat 0.6.1. However, issue #2276
+            # suggests that some people are still seeing this behavior even when
+            # pycosat 0.6.1 is installed. Until we can understand why, this
+            # needs to stay. I still don't want to invoke it unnecessarily,
+            # because for large clauses lists it is slow.
+            clauses = list(map(list, clauses))
+            solution = pycosat.solve(clauses, vars=self.m, prop_limit=limit)
         if solution in ("UNSAT", "UNKNOWN"):
             return None
         if additional and includeIf:


### PR DESCRIPTION
pycosat 0.6.1 is supposed to accept an iterator of iterators as input, whereas pycosat 0.6.0 requires a true list of lists. The former is preferred for a variety of reasons, including performance, so we introduced a `pycosat 0.6.1` version requirement for recent versions of `conda`, and dropped code that implemented the old list-of-lists conversion.

But for some reasons, issues like #2276 reveal that _even people who have `pycosat 0.6.1` installed_ are seeing this old behavior, which manifests itself by a `TypeError: list expected` exception. This PR intercepts that exception, performs the conversion, and re-calls pycosat.