### PR TITLE
Fix 'conda search --spec' breakage

### DIFF
--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -212,7 +212,7 @@ def execute_search(args, parser):
         else:
             if pat and pat.search(name) is None:
                 continue
-            if ms and name != ms.name:
+            if ms and name != ms.split()[0]:
                 continue
 
             if ms:


### PR DESCRIPTION
If --spec is passed to conda search, ms is a string consisting of 'name version build'.

Currently, conda breaks as follows:
```
$ conda search --spec python=3.5.0
Fetching package metadata: ....
An unexpected error has occurred, please consider sending the
following traceback to the conda GitHub issue tracker at:

    https://github.com/conda/conda/issues

Include the output of the command 'conda info' in your report.


Traceback (most recent call last):
  File "/Users/ElCapitanVM/projects/conda-lsst/miniconda/bin/conda", line 6, in <module>
    sys.exit(main())
  File "/Users/ElCapitanVM/projects/conda-lsst/miniconda/lib/python2.7/site-packages/conda/cli/main.py", line 139, in main
    args_func(args, p)
  File "/Users/ElCapitanVM/projects/conda-lsst/miniconda/lib/python2.7/site-packages/conda/cli/main.py", line 146, in args_func
    args.func(args, p)
  File "/Users/ElCapitanVM/projects/conda-lsst/miniconda/lib/python2.7/site-packages/conda/cli/main_search.py", line 120, in execute
    execute_search(args, parser)
  File "/Users/ElCapitanVM/projects/conda-lsst/miniconda/lib/python2.7/site-packages/conda/cli/main_search.py", line 215, in execute_search
    if ms and name != ms.name:
AttributeError: 'str' object has no attribute 'name'
```