### PR TITLE
fix bug with channel priority.

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, absolute_import
 import os
 from collections import defaultdict
 from os.path import isdir, join
+from operator import itemgetter
 
 from conda import config
 from conda import install
@@ -36,7 +37,7 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     """
     channel_urls = config.normalize_urls(channel_urls, platform, offline)
     if prepend:
-        pri0 = max(itervalues(channel_urls)) if channel_urls else 0
+        pri0 = max(itervalues(channel_urls), key=itemgetter(1))[1] if channel_urls else 0
         for url, rec in iteritems(config.get_channel_urls(platform, offline)):
             channel_urls[url] = (rec[0], rec[1] + pri0)
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)


### PR DESCRIPTION
pri0 was a tuple, and not always the max value (because of how tuples are compared).

Because `pri0` was a tuple, I got the following exception
```
<snip>
  File "/Users/rgrout/continuum/projects/conda/conda/api.py", line 46, in get_index
    channel_urls[url] = (rec[0], rec[1] + pri0)
TypeError: unsupported operand type(s) for +: 'int' and 'tuple'
```
Looking at api.py in conda, I noticed that following line does not do what I think it was intended to do.
That is find the max priority from the values of a dictionary. 
```
pri0 = max(itervalues(channel_urls)) if channel_urls else 0
```
`pri0` will take on the wrong value in the following instance.
Example
```
In [14]: d2 = {'file:///Users/rgrout/miniconda/conda-bld/noarch/': ('file:///Users/rgrout/miniconda/conda-bld', 1), 'file:///Users/rgrout/miniconda/conda-bld/osx-64/': ('file:///Users/rgrout/miniconda/a', 2)}

In [15]: max(itervalues(d2))
Out[15]: ('file:///Users/rgrout/miniconda/conda-bld', 1)
```
Solution: Explicity compare and take the max of the numeric priority and assign `pri0` that numeric value.

@kalefranz