### PR TITLE
User-Agent for conda connections

### DIFF
--- a/conda/connection.py
+++ b/conda/connection.py
@@ -32,9 +32,9 @@ stderrlog = getLogger('stderrlog')
 
 # Collect relevant info from OS for reporting purposes (present in User-Agent)
 _user_agent = ("conda/{conda_ver} "
-                "requests/{requests_ver} "
-                "{python}/{py_ver} "
-                "{system}/{kernel} {dist}/{ver}")
+               "requests/{requests_ver} "
+               "{python}/{py_ver} "
+               "{system}/{kernel} {dist}/{ver}")
 
 glibc_ver = gnu_get_libc_version()
 if config.platform == 'linux':

--- a/conda/connection.py
+++ b/conda/connection.py
@@ -31,7 +31,10 @@ log = getLogger(__name__)
 stderrlog = getLogger('stderrlog')
 
 # Collect relevant info from OS for reporting purposes (present in User-Agent)
-_user_agent = "conda/{conda_ver} requests/{requests_ver} {python}/{py_ver} {system}/{kernel} {dist}/{ver}"
+_user_agent = ("conda/{conda_ver} "
+                "requests/{requests_ver} "
+                "{python}/{py_ver} "
+                "{system}/{kernel} {dist}/{ver}")
 
 glibc_ver = gnu_get_libc_version()
 if config.platform == 'linux':

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -17,12 +17,12 @@ def gnu_get_libc_version():
     """
     If on linux, get installed version of glibc, otherwise return None
     """
-    
+
     if not sys.platform.startswith('linux'):
         return None
 
     from ctypes import CDLL, cdll, c_char_p
-                
+
     cdll.LoadLibrary('libc.so.6')
     libc = CDLL('libc.so.6')
     f = libc.gnu_get_libc_version

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -13,6 +13,23 @@ import re
 log = logging.getLogger(__name__)
 stderrlog = logging.getLogger('stderrlog')
 
+def gnu_get_libc_version():
+    """
+    If on linux, get installed version of glibc, otherwise return None
+    """
+    
+    if not sys.platform.startswith('linux'):
+        return None
+
+    from ctypes import CDLL, cdll, c_char_p
+                
+    cdll.LoadLibrary('libc.so.6')
+    libc = CDLL('libc.so.6')
+    f = libc.gnu_get_libc_version
+    f.restype = c_char_p
+    return f()
+
+
 def can_open(file):
     """
     Return True if the given ``file`` can be opened for writing

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -13,6 +13,59 @@ import re
 log = logging.getLogger(__name__)
 stderrlog = logging.getLogger('stderrlog')
 
+class memoized(object):
+    """Decorator. Caches a function's return value each time it is called.
+    If called later with the same arguments, the cached value is returned
+    (not reevaluated).
+    """
+    def __init__(self, func):
+        self.func = func
+        self.cache = {}
+
+    def __call__(self, *args, **kw):
+        newargs = []
+        for arg in args:
+            if isinstance(arg, list):
+                newargs.append(tuple(arg))
+            elif not isinstance(arg, collections.Hashable):
+                # uncacheable. a list, for instance.
+                # better to not cache than blow up.
+                return self.func(*args, **kw)
+            else:
+                newargs.append(arg)
+        newargs = tuple(newargs)
+        key = (newargs, frozenset(sorted(kw.items())))
+        if key in self.cache:
+            return self.cache[key]
+        else:
+            value = self.func(*args, **kw)
+            self.cache[key] = value
+            return value
+
+
+# For instance methods only
+class memoize(object):  # 577452
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self.func
+        return partial(self, obj)
+
+    def __call__(self, *args, **kw):
+        obj = args[0]
+        try:
+            cache = obj.__cache
+        except AttributeError:
+            cache = obj.__cache = {}
+        key = (self.func, args[1:], frozenset(sorted(kw.items())))
+        try:
+            res = cache[key]
+        except KeyError:
+            res = cache[key] = self.func(*args, **kw)
+        return res
+
 @memoized
 def gnu_get_libc_version():
     """
@@ -156,60 +209,6 @@ def human_bytes(n):
         return '%.1f MB' % m
     g = m/1024
     return '%.2f GB' % g
-
-
-class memoized(object):
-    """Decorator. Caches a function's return value each time it is called.
-    If called later with the same arguments, the cached value is returned
-    (not reevaluated).
-    """
-    def __init__(self, func):
-        self.func = func
-        self.cache = {}
-
-    def __call__(self, *args, **kw):
-        newargs = []
-        for arg in args:
-            if isinstance(arg, list):
-                newargs.append(tuple(arg))
-            elif not isinstance(arg, collections.Hashable):
-                # uncacheable. a list, for instance.
-                # better to not cache than blow up.
-                return self.func(*args, **kw)
-            else:
-                newargs.append(arg)
-        newargs = tuple(newargs)
-        key = (newargs, frozenset(sorted(kw.items())))
-        if key in self.cache:
-            return self.cache[key]
-        else:
-            value = self.func(*args, **kw)
-            self.cache[key] = value
-            return value
-
-
-# For instance methods only
-class memoize(object):  # 577452
-    def __init__(self, func):
-        self.func = func
-
-    def __get__(self, obj, objtype=None):
-        if obj is None:
-            return self.func
-        return partial(self, obj)
-
-    def __call__(self, *args, **kw):
-        obj = args[0]
-        try:
-            cache = obj.__cache
-        except AttributeError:
-            cache = obj.__cache = {}
-        key = (self.func, args[1:], frozenset(sorted(kw.items())))
-        try:
-            res = cache[key]
-        except KeyError:
-            res = cache[key] = self.func(*args, **kw)
-        return res
 
 
 def find_parent_shell(path=False):

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -13,6 +13,7 @@ import re
 log = logging.getLogger(__name__)
 stderrlog = logging.getLogger('stderrlog')
 
+@memoized
 def gnu_get_libc_version():
     """
     If on linux, get installed version of glibc, otherwise return None
@@ -178,7 +179,7 @@ class memoized(object):
             else:
                 newargs.append(arg)
         newargs = tuple(newargs)
-        key = (newargs, frozenset(kw.items()))
+        key = (newargs, frozenset(sorted(kw.items())))
         if key in self.cache:
             return self.cache[key]
         else:
@@ -203,7 +204,7 @@ class memoize(object):  # 577452
             cache = obj.__cache
         except AttributeError:
             cache = obj.__cache = {}
-        key = (self.func, args[1:], frozenset(kw.items()))
+        key = (self.func, args[1:], frozenset(sorted(kw.items())))
         try:
             res = cache[key]
         except KeyError:


### PR DESCRIPTION
This PR replaces the old User-Agent string for conda connections with something a little more useful about the platforms and python versions conda is being used with.  This addresses a change made in requests 2.8.0.