### PR TITLE
Manage BeeGFS hard-links non-POSIX configuration

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -515,7 +515,12 @@ def try_hard_link(pkgs_dir, prefix, dist):
         if not isdir(prefix):
             os.makedirs(prefix)
         _link(src, dst, LINK_HARD)
-        return True
+        # Some file systems (at least BeeGFS) do not support hard-links
+        # between files in different directories. Depending on the
+        # file system configuration, a symbolic link may be created
+        # instead. If a symbolic link is created instead of a hard link,
+        # return False.
+        return not os.path.islink(dst)
     except OSError:
         return False
     finally:


### PR DESCRIPTION
This is a try to fix #2345 

If BeeGFS is configured with:

    sysCreateHardlinksAsSymlinks  = true

Symbolic-link is created instead of a hard-link, which can cause problem, for
example:

    pkgs/bin/mpicc
    pkgs/lib/libopen-pal.so
    envs/bin/mpicc # symlink to pkgs/bin/mpicc instead of hardlink
    envs/lib/libopen-pal.so

Here, when envs/bin/mpicc is executed, it is actually pkgs/bin/mpicc that is
executed, and the library $PREFIX/../lib/libopen-pal.so actually loaded is
pkgs/lib/libopen-pal.so, which is different from envs/lib/libopen-pal.so for
which conda has fixed hard-coded prefix path, and as a final consequence mpicc
fails to find its configuration file.