### PR TITLE
Pkg cache issues

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -48,7 +48,7 @@ def get_index(channel_urls=(), prepend=True, platform=None,
             if channel not in channel_urls:
                 channel_urls[channel] = (config.canonical_channel_name(channel, True, True), 0)
             url_s, priority = channel_urls[channel]
-            key = url_s + '::' + fn if url_s else fn
+            key = url_s + '##' + fn if url_s else fn
             if key not in index:
                 # only if the package in not in the repodata, use local
                 # conda-meta (with 'depends' defaulting to [])

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -290,9 +290,12 @@ Allowed channels are:
     return index
 
 
-def fetch_pkg(info, dst_dir=None, session=None):
+def fetch_pkg(info, dst_fn=None, dst_dir=None, session=None):
     '''
     fetch a package given by `info` and store it into `dst_dir`
+
+    If `dst_fn` is specified, use it, otherwise use the source
+    filename, `fn`.
     '''
     if dst_dir is None:
         dst_dir = config.pkgs_dirs[0]
@@ -302,7 +305,9 @@ def fetch_pkg(info, dst_dir=None, session=None):
     fn = '%(name)s-%(version)s-%(build)s.tar.bz2' % info
     url = info['channel'] + fn
     log.debug("url=%r" % url)
-    path = join(dst_dir, fn)
+    if dst_fn is None:
+        dst_fn = fn
+    path = join(dst_dir, dst_fn)
 
     download(url, path, session=session, md5=info['md5'], urlstxt=True)
     if info.get('sig'):

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -279,7 +279,7 @@ Allowed channels are:
             info['channel'] = channel
             info['priority'] = priority
             info['url'] = channel + fn
-            key = url_s + '::' + fn if url_s else fn
+            key = url_s + '##' + fn if url_s else fn
             index[key] = info
 
     stdoutlog.info('\n')

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -46,7 +46,7 @@ def PRINT_CMD(state, arg):
 def fetch(index, dist):
     assert index is not None
     fn = dist + '.tar.bz2'
-    fetch_pkg(index[fn])
+    fetch_pkg(index[fn], fn)
 
 
 def FETCH_CMD(state, arg):


### PR DESCRIPTION
@mcg1969 , @groutr I had to make these changes to be able to use conda-build.

Please review. Also, do you know if other projects call `fetch_pkg`? If so I may need to amend the call-sites (if they use any non-default arguments).