### PR TITLE
config.py: Add pkgs/msys2 as a default channel

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -183,6 +183,8 @@ def get_local_urls(clear_cache=True):
 
 defaults_ = ['https://repo.continuum.io/pkgs/free',
              'https://repo.continuum.io/pkgs/pro']
+if platform == 'win':
+    defaults_.append('https://repo.continuum.io/pkgs/msys2')
 
 def get_default_urls(merged=False):
     if 'default_channels' in sys_rc:


### PR DESCRIPTION
@kalefranz @ilanschnell @csoja 

I believe 4.1 isn't planned to be released this week? In that case, can we get cut a 4.0.6 release with this change in it so that we can update R on Windows and have people able to update their existing R packages?