### PR TITLE
BUG: request.Session not thread-safe

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -237,7 +237,6 @@ def fetch_index(channel_urls, use_cache=False, unknown=False):
     # pool = ThreadPool(5)
     index = {}
     stdoutlog.info("Fetching package metadata ...")
-    session = CondaSession()
     if not isinstance(channel_urls, dict):
         channel_urls = {url: pri+1 for pri, url in enumerate(channel_urls)}
     for url in iterkeys(channel_urls):
@@ -257,12 +256,13 @@ Allowed channels are:
         with concurrent.futures.ThreadPoolExecutor(10) as executor:
             future_to_url = OrderedDict([(executor.submit(
                             fetch_repodata, url, use_cache=use_cache,
-                            session=session), url)
+                            session=CondaSession()), url)
                                          for url in iterkeys(channel_urls)])
             for future in future_to_url:
                 url = future_to_url[future]
                 repodatas.append((url, future.result()))
     except ImportError:
+        session = CondaSession()
         # concurrent.futures is only available in Python 3
         repodatas = map(lambda url: (url, fetch_repodata(url,
                                      use_cache=use_cache, session=session)),


### PR DESCRIPTION
I was getting some very odd errors using s3 as an index. The `response.raw` object is sometimes empty, sometimes contains my index. Reading from the BufferedReader was sometimes empty. Seek sometimes works, tell is not always right, etc. Something about the sessions is not thread-safe. 

Using a new Session in each thread solves the issue reliably for me.

Related: https://github.com/kennethreitz/requests/issues/2766
