### PR TITLE
Workaround for https://github.com/boto/boto/issues/2617

### DIFF
--- a/conda/connection.py
+++ b/conda/connection.py
@@ -128,6 +128,7 @@ class S3Adapter(requests.adapters.BaseAdapter):
             import boto
 
             # silly patch for AWS because
+            # TODO: remove or change to warning once boto >2.39.0 is released
             # https://github.com/boto/boto/issues/2617
             from boto.pyami.config import Config, ConfigParser
 

--- a/conda/connection.py
+++ b/conda/connection.py
@@ -126,6 +126,20 @@ class S3Adapter(requests.adapters.BaseAdapter):
 
         try:
             import boto
+
+            # silly patch for AWS because
+            # https://github.com/boto/boto/issues/2617
+            from boto.pyami.config import Config, ConfigParser
+
+            def get(self, section, name, default=None, **kw):
+                try:
+                    val = ConfigParser.get(self, section, name, **kw)
+                except:
+                    val = default
+                return val
+
+            Config.get = get
+
         except ImportError:
             stderrlog.info('\nError: boto is required for S3 channels. '
                            'Please install it with `conda install boto`\n'


### PR DESCRIPTION
Boto doesn't actually work with config files on Python >= 3.4 because of this bug.