### PR TITLE
Prevent version downgrades during removes

### DIFF
--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -59,16 +59,13 @@ class TestMatchSpec(unittest.TestCase):
 
     def test_hash(self):
         a, b = MatchSpec('numpy 1.7*'), MatchSpec('numpy 1.7*')
-        # optional should not change the hash, but negate should
-        c, d = MatchSpec('numpy 1.7* (negate)'), MatchSpec('numpy 1.7* (optional)')
+        # optional should not change the hash
+        d = MatchSpec('numpy 1.7* (optional)')
         self.assertTrue(a is not b)
-        self.assertTrue(a is not c)
         self.assertTrue(a is not d)
         self.assertEqual(a, b)
-        self.assertNotEqual(a, c)
         self.assertNotEqual(a, d)
         self.assertEqual(hash(a), hash(b))
-        self.assertNotEqual(hash(a), hash(c))
         self.assertEqual(hash(a), hash(d))
         c, d = MatchSpec('python'), MatchSpec('python 2.7.4')
         self.assertNotEqual(a, c)
@@ -77,8 +74,8 @@ class TestMatchSpec(unittest.TestCase):
         self.assertNotEqual(hash(c), hash(d))
 
     def test_string(self):
-        a = MatchSpec("foo1 >=1.3 2 (optional,negate,target=burg)")
-        assert a.optional and a.negate and a.target=='burg'
+        a = MatchSpec("foo1 >=1.3 2 (optional,target=burg)")
+        assert a.optional and a.target=='burg'
 
 class TestPackage(unittest.TestCase):
 


### PR DESCRIPTION
A simpler attempt to implement #2385 (with a nice side effect of ripping out some unused logic from the solver). See that PR's description for a full explanation of the problem.

This PR simply prevents `conda remove` from performing version downgrades on any remaining packages that might be suggested to resolve dependency losses; the package will just be removed instead. Version _upgrades_ are still allowed, and this seems fitting: if a package has been upgraded to remove a dependency, then it is reasonable to perform that upgrade when that dependency is removed.

Build downgrades are still possible (e.g., `1.7.0 1 -> 1.7.0 0`). I'd like to prevent that, but the `MatchSpec` logic doesn't quite allow it yet. Given the vast improvement in "remove" solutions that this produces, that seems like a minor annoyance.

Here is a clean illustration of the problem:
```
conda create -n rmtest anaconda
conda remove -n rmtest numba
```
With conda 3.x, this would remove `numba`, leaving `blaze` in a broken state.

With conda 4.0.5, this removes `numba`... and *installs* `bcolz` and `into`, *downgrades* `blaze`, `numpy`, and a bunch of other packages, and updates several others. See PR #2385 for an explanation why this is a reasonable solution for the solver to obtain, but a lousy user experience.

With this PR, this does nothing but remove `blaze`, `numba`, and the `anaconda` metapackage.

This PR also removes the `negate` option from MatchSpec. With the upgraded `optional` functionality this PR requires, it became redundant.