### PR TITLE
Quick fix: shouldn't add `config.track_features` contents to remove spec

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -471,8 +471,6 @@ def remove_actions(prefix, specs, index, force=False, pinned=True):
                    for fn in linked
                    if not any(r.match(ms, fn) for ms in mss)}
     else:
-        if config.track_features:
-            specs.extend(x + '@' for x in config.track_features)
         nlinked = {r.package_name(fn): fn[:-8] for fn in r.remove(specs, linked)}
 
     if pinned:


### PR DESCRIPTION
I made a mistake when revising `plan.remove`. If `config.track_features` is set, it would add those features to the remove list. Obviously that's not what is desired. Fortunately, I believe very few people hardcode a `track_features` value into their `.condarc`.
