### PR TITLE
WIP: key:value "variant" support

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -500,9 +500,11 @@ def specs_from_args(args, json=False):
 
 
 spec_pat = re.compile(r'''
-(?P<name>[^=<>!\s]+)               # package name
+(?P<name>[^=<>!:\s]+)              # package name
 \s*                                # ignore spaces
 (
+  (?P<fc>:\s*[^=<>!\s]+)           # variant
+  |
   (?P<cc>=[^=<>!]+(=[^=<>!]+)?)    # conda constraint
   |
   (?P<pc>[=<>!]{1,2}.+)            # new (pip-style) constraint(s)
@@ -517,8 +519,10 @@ def spec_from_line(line):
     m = spec_pat.match(strip_comment(line))
     if m is None:
         return None
-    name, cc, pc = (m.group('name').lower(), m.group('cc'), m.group('pc'))
-    if cc:
+    name, fc, cc, pc = (m.group('name').lower(), m.group('fc'), m.group('cc'), m.group('pc'))
+    if fc:
+        return name + ' * ' + fc[1:]
+    elif cc:
         return name + cc.replace('=', ' ')
     elif pc:
         return name + ' ' + pc.replace(' ', '')

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -91,14 +91,14 @@ class NoPackagesFound(RuntimeError):
         missing packages and/or dependencies.
     '''
     def __init__(self, bad_deps):
-        deps = set(q[-1].spec for q in bad_deps)
+        deps = set(q[-1].spec.replace(' * ',':') for q in bad_deps)
         if all(len(q) > 1 for q in bad_deps):
             what = "Dependencies" if len(bad_deps) > 1 else "Dependency"
         elif all(len(q) == 1 for q in bad_deps):
             what = "Packages" if len(bad_deps) > 1 else "Package"
         else:
             what = "Packages/dependencies"
-        bad_deps = dashlist(' -> '.join(map(str, q)) for q in bad_deps)
+        bad_deps = dashlist(' -> '.join(str(q2).replace(' * ',':') for q2 in q) for q in bad_deps)
         msg = '%s missing in current %s channels: %s' % (what, config.subdir, bad_deps)
         super(NoPackagesFound, self).__init__(msg)
         self.pkgs = deps


### PR DESCRIPTION
This is an _experimental_ PR for the purposes of examining the potential syntax for "key:value" style variant selection, as outlined in [this discussion](https://github.com/conda-forge/staged-recipes/pull/525#issuecomment-216402723)

In that discussion we are using metapackages of the form `feature-0-variant.tar.bz2` to help guide the selection from a list of mutually exclusive options. On the current command line, these packages would be selected with a syntax `feature * variant`. This simply makes `feature:variant` synonymous with that.

The only works with "unversioned" key:value pairs. In that discussion we look ahead to doing fully versioned specs, such as `blas:openblas>=1.2`. In this case, the value on the right-hand side is expected to correspond to an actual package in the index. This change does _not_ support this variant, so it will only work with unversioned specs; e.g., `blas:openblas`.