### PR TITLE
Fix misc.install_local_packages

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -41,7 +41,7 @@ def install_tar(prefix, tar_path, verbose=False):
             if fn.endswith('.tar.bz2'):
                 paths.append(join(root, fn))
 
-    misc.install_local_packages(prefix, paths, verbose=verbose)
+    misc.explicit(paths, prefix, verbose=verbose)
     shutil.rmtree(tmp_dir)
 
 
@@ -189,8 +189,7 @@ def install(args, parser, command='install'):
     num_cp = sum(s.endswith('.tar.bz2') for s in args.packages)
     if num_cp:
         if num_cp == len(args.packages):
-            misc.install_local_packages(prefix, args.packages,
-                                        verbose=not args.quiet)
+            misc.explicit(args.packages, prefix, verbose=not args.quiet)
             return
         else:
             common.error_and_exit(

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -171,7 +171,7 @@ def install(args, parser, command='install'):
         for fpath in args.file:
             specs.extend(common.specs_from_url(fpath, json=args.json))
         if '@EXPLICIT' in specs:
-            misc.explicit(specs, prefix)
+            misc.explicit(specs, prefix, verbose=not args.quiet)
             return
     elif getattr(args, 'all', False):
         if not linked:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -59,7 +59,7 @@ def check_prefix(prefix, json=False):
         common.error_and_exit(error, json=json, error_type="ValueError")
 
 
-def clone(src_arg, dst_prefix, json=False, quiet=False, index=None):
+def clone(src_arg, dst_prefix, json=False, quiet=False, fetch_args=None):
     if os.sep in src_arg:
         src_prefix = abspath(src_arg)
         if not isdir(src_prefix):
@@ -74,13 +74,14 @@ def clone(src_arg, dst_prefix, json=False, quiet=False, index=None):
                                   error_type="NoEnvironmentFound")
 
     if not json:
-        print("src_prefix: %r" % src_prefix)
-        print("dst_prefix: %r" % dst_prefix)
+        print("Source:      %r" % src_prefix)
+        print("Destination: %r" % dst_prefix)
 
     with common.json_progress_bars(json=json and not quiet):
         actions, untracked_files = misc.clone_env(src_prefix, dst_prefix,
                                                   verbose=not json,
-                                                  quiet=quiet, index=index)
+                                                  quiet=quiet,
+                                                  fetch_args=fetch_args)
 
     if json:
         common.stdout_json_success(
@@ -204,6 +205,20 @@ def install(args, parser, command='install'):
             install_tar(prefix, tar_path, verbose=not args.quiet)
             return
 
+    if newenv and args.clone:
+        if set(args.packages) - set(default_packages):
+            common.error_and_exit('did not expect any arguments for --clone',
+                                  json=args.json,
+                                  error_type="ValueError")
+        clone(args.clone, prefix, json=args.json, quiet=args.quiet,
+              fetch_args={'use_cache': args.use_index_cache,
+                          'unknown': args.unknown})
+        misc.append_env(prefix)
+        misc.touch_nonadmin(prefix)
+        if not args.json:
+            print_activate(args.name if args.name else prefix)
+        return
+
     index = common.get_index_trap(channel_urls=channel_urls,
                                   prepend=not args.override_channels,
                                   use_local=args.use_local,
@@ -215,18 +230,6 @@ def install(args, parser, command='install'):
     r = Resolve(index)
     ospecs = list(specs)
     plan.add_defaults_to_specs(r, linked, specs, update=isupdate)
-
-    if newenv and args.clone:
-        if set(args.packages) - set(default_packages):
-            common.error_and_exit('did not expect any arguments for --clone',
-                                  json=args.json,
-                                  error_type="ValueError")
-        clone(args.clone, prefix, json=args.json, quiet=args.quiet, index=index)
-        misc.append_env(prefix)
-        misc.touch_nonadmin(prefix)
-        if not args.json:
-            print_activate(args.name if args.name else prefix)
-        return
 
     # Don't update packages that are already up-to-date
     if isupdate and not (args.all or args.force):

--- a/conda/config.py
+++ b/conda/config.py
@@ -324,7 +324,7 @@ def url_channel(url):
         return None, '<unknown>'
     channel = url.rsplit('/', 2)[0]
     schannel = canonical_channel_name(channel)
-    return channel + '/', schannel
+    return channel, schannel
 
 # ----- allowed channels -----
 

--- a/conda/config.py
+++ b/conda/config.py
@@ -307,7 +307,7 @@ def get_channel_urls(platform=None, offline=False):
 def canonical_channel_name(channel, hide=True, no_unknown=False):
     if channel is None:
         return 'defaults' if no_unknown else '<unknown>'
-    channel = remove_binstar_tokens(channel)
+    channel = remove_binstar_tokens(channel).rstrip('/')
     if any(channel.startswith(i) for i in get_default_urls()):
         return 'defaults'
     elif any(channel.startswith(i) for i in get_local_urls(clear_cache=False)):
@@ -316,6 +316,10 @@ def canonical_channel_name(channel, hide=True, no_unknown=False):
         return 'filer'
     elif channel.startswith(channel_alias):
         return channel.split(channel_alias, 1)[1]
+    elif channel.startswith('http:/'):
+        channel2 = 'https' + channel[4:]
+        channel3 = canonical_channel_name(channel2, hide, no_unknown)
+        return channel3 if channel3 != channel2 else channel
     else:
         return channel
 

--- a/conda/config.py
+++ b/conda/config.py
@@ -324,7 +324,7 @@ def url_channel(url):
         return None, '<unknown>'
     channel = url.rsplit('/', 2)[0]
     schannel = canonical_channel_name(channel)
-    return channel, schannel
+    return channel + '/', schannel
 
 # ----- allowed channels -----
 

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -233,10 +233,11 @@ def add_pip_dependency(index):
                 info['version'].startswith(('2.', '3.'))):
             info.setdefault('depends', []).append('pip')
 
-def fetch_index(channel_urls, use_cache=False, unknown=False):
+def fetch_index(channel_urls, use_cache=False, unknown=False, index=None):
     log.debug('channel_urls=' + repr(channel_urls))
     # pool = ThreadPool(5)
-    index = {}
+    if index is None:
+        index = {}
     stdoutlog.info("Fetching package metadata ...")
     if not isinstance(channel_urls, dict):
         channel_urls = {url: pri+1 for pri, url in enumerate(channel_urls)}

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -297,7 +297,9 @@ def fetch_pkg(info, dst_dir=None, session=None):
     session = session or CondaSession()
 
     fn = info['fn']
-    url = info['channel'] + fn
+    url = info.get('url')
+    if url is None:
+        url = info['channel'] + fn
     log.debug("url=%r" % url)
     if dst_dir is None:
         dst_dir = dirname(find_new_location(fn[:-8])[0])

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -270,6 +270,7 @@ Allowed channels are:
     for channel, repodata in repodatas:
         if repodata is None:
             continue
+        channel = channel.rstrip('/')
         new_index = repodata['packages']
         url_s, priority = channel_urls[channel]
         for fn, info in iteritems(new_index):
@@ -277,7 +278,7 @@ Allowed channels are:
             info['schannel'] = url_s
             info['channel'] = channel
             info['priority'] = priority
-            info['url'] = channel + fn
+            info['url'] = channel + '/' + fn
             key = url_s + '::' + fn if url_s != 'defaults' else fn
             index[key] = info
 
@@ -299,7 +300,7 @@ def fetch_pkg(info, dst_dir=None, session=None):
     fn = info['fn']
     url = info.get('url')
     if url is None:
-        url = info['channel'] + fn
+        url = info['channel'] + '/' + fn
     log.debug("url=%r" % url)
     if dst_dir is None:
         dst_dir = dirname(find_new_location(fn[:-8])[0])
@@ -311,7 +312,7 @@ def fetch_pkg(info, dst_dir=None, session=None):
 
         fn2 = fn + '.sig'
         url = (info['channel'] if info['sig'] == '.' else
-               info['sig'].rstrip('/') + '/') + fn2
+               info['sig'].rstrip('/')) + '/' + fn2
         log.debug("signature url=%r" % url)
         download(url, join(dst_dir, fn2), session=session)
         try:

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -270,9 +270,9 @@ Allowed channels are:
     for channel, repodata in repodatas:
         if repodata is None:
             continue
-        channel = channel.rstrip('/')
         new_index = repodata['packages']
         url_s, priority = channel_urls[channel]
+        channel = channel.rstrip('/')
         for fn, info in iteritems(new_index):
             info['fn'] = fn
             info['schannel'] = url_s

--- a/conda/install.py
+++ b/conda/install.py
@@ -44,6 +44,7 @@ import re
 from os.path import (abspath, basename, dirname, isdir, isfile, islink,
                      join, relpath, normpath)
 from conda.config import url_channel
+from conda.utils import url_path
 from conda.compat import iteritems, iterkeys
 from conda import config
 
@@ -546,7 +547,7 @@ def try_hard_link(pkgs_dir, prefix, dist):
 # read this data multiple times.
 
 package_cache_ = {}
-fname_table = {}
+fname_table_ = {}
 def add_cached_package(pdir, url, overwrite=False, urlstxt=False):
     """
     Adds a new package to the cache. The URL is used to determine the
@@ -563,7 +564,7 @@ def add_cached_package(pdir, url, overwrite=False, urlstxt=False):
     else:
         fname = dist + '.tar.bz2'
     xpkg = join(pdir, fname)
-    if not overwrite and xpkg in fname_table:
+    if not overwrite and xpkg in fname_table_:
         return
     if not isfile(xpkg):
         xpkg = None
@@ -577,7 +578,8 @@ def add_cached_package(pdir, url, overwrite=False, urlstxt=False):
     url = remove_binstar_tokens(url)
     channel, schannel = url_channel(url)
     prefix = '' if schannel == 'defaults' else schannel + '::'
-    fname_table[xpkg] = prefix
+    xkey = xpkg or (xdir + '.tar.bz2')
+    fname_table_[xkey] = fname_table_[url_path(xkey)] = prefix
     fkey = prefix + dist
     rec = package_cache_.get(fkey)
     if rec is None:
@@ -622,6 +624,10 @@ def package_cache():
     del package_cache_['@']
     return package_cache_
 
+def cached_url(url):
+    package_cache()
+    return fname_table_[url]
+
 def find_new_location(dist):
     """
     Determines the download location for the given package, and the name
@@ -641,7 +647,7 @@ def find_new_location(dist):
     for p in range(2):
         for pkg_dir in config.pkgs_dirs:
             pkg_path = join(pkg_dir, fname)
-            prefix = fname_table.get(pkg_path)
+            prefix = fname_table_.get(pkg_path)
             if p or prefix is None:
                 return pkg_path, prefix + dname if p else None
 
@@ -669,7 +675,8 @@ def rm_fetched(dist):
     if rec is None:
         return
     for fname in rec['files']:
-        del fname_table[fname]
+        del fname_table_[fname]
+        del fname_table_[url_path(fname)]
         with Locked(dirname(fname)):
             rm_rf(fname)
     for fname in rec['dirs']:

--- a/conda/install.py
+++ b/conda/install.py
@@ -626,7 +626,7 @@ def package_cache():
 
 def cached_url(url):
     package_cache()
-    return fname_table_[url]
+    return fname_table_.get(url)
 
 def find_new_location(dist):
     """

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -264,6 +264,7 @@ def install_local_packages(prefix, paths, verbose=False):
         if not config.is_url(url):
             url = utils.url_path(url)
         url_path, fn = url.rsplit('/', 1)
+        dist = fn[:-8]
         schannel = None
         if url_path.startswith('file://'):
             for dd in config.pkgs_dirs:
@@ -273,7 +274,7 @@ def install_local_packages(prefix, paths, verbose=False):
             _, schannel = config.url_channel(url)
             info = {'fn': fn, 'url': url, 'schannel': schannel, 'md5': None}
             fetch.fetch_pkg(info)
-        dists.append('%s::%s' % (schannel, fn[:-8]))
+        dists.append('%s::%s' % (schannel, dist))
     force_extract_and_link(dists, prefix, verbose=verbose)
 
 
@@ -292,7 +293,7 @@ def environment_for_conda_environment(prefix=config.root_dir):
 
 def make_icon_url(info):
     if 'channel' in info and 'icon' in info:
-        base_url = dirname(info['channel'].rstrip('/'))
+        base_url = dirname(info['channel'])
         icon_fn = info['icon']
         # icon_cache_path = join(config.pkgs_dir, 'cache', icon_fn)
         # if isfile(icon_cache_path):

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -4,7 +4,6 @@
 from __future__ import print_function, division, absolute_import
 
 import os
-import re
 import shutil
 import sys
 from collections import defaultdict
@@ -14,9 +13,8 @@ from os.path import (abspath, dirname, expanduser, exists,
 from conda import config
 from conda import install
 from conda import utils
-from conda import fetch
 from conda.api import get_index
-from conda.compat import iteritems, itervalues
+from conda.compat import iteritems
 from conda.instructions import RM_FETCHED, FETCH, RM_EXTRACTED, EXTRACT, UNLINK, LINK
 from conda.plan import ensure_linked_actions, execute_actions
 from conda.utils import md5_file
@@ -44,7 +42,6 @@ def explicit(specs, prefix, verbose=False):
     actions['op_order'] = RM_FETCHED, FETCH, RM_EXTRACTED, EXTRACT, UNLINK, LINK
     linked = {install.name_dist(dist): dist for dist in install.linked(prefix)}
     index = {}
-    msgs = []
     for spec in specs:
         if spec == '@EXPLICIT':
             continue

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -69,7 +69,8 @@ def explicit(urls, prefix, verbose=True):
         _, schannel = config.url_channel(url)
         if m is None:
             sys.exit("Error: Could not parse: %s" % url)
-        fn = '%s::%s' % (schannel, fn)
+        if schannel != 'defaults':
+            fn = '%s::%s' % (schannel, fn)
         dists.append(fn[:-8])
         index = fetch.fetch_index((url_p + '/',))
         try:
@@ -274,7 +275,9 @@ def install_local_packages(prefix, paths, verbose=False):
             _, schannel = config.url_channel(url)
             info = {'fn': fn, 'url': url, 'schannel': schannel, 'md5': None}
             fetch.fetch_pkg(info)
-        dists.append('%s::%s' % (schannel, dist))
+        if schannel != 'defaults':
+            dist = '%s::%s' % (schannel, dist)
+        dists.append(dist)
     force_extract_and_link(dists, prefix, verbose=verbose)
 
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -238,6 +238,8 @@ def plan_from_actions(actions):
             continue
         if '_' not in op:
             res.append((inst.PRINT, '%sing packages ...' % op.capitalize()))
+        elif op.startswith('RM_'):
+            res.append((inst.PRINT, 'Pruning %s packages from the cache ...' % op[3:].lower()))
         if op in inst.progress_cmds:
             res.append((inst.PROGRESS, '%d' % len(actions[op])))
         for arg in actions[op]:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -739,14 +739,14 @@ class Resolve(object):
         return eqv, eqb
 
     def dependency_sort(self, must_have):
-        def lookup(value):
-            return set(ms.name for ms in self.ms_depends(value + '.tar.bz2'))
-        digraph = {}
         if not isinstance(must_have, dict):
             must_have = {self.package_name(dist): dist for dist in must_have}
+        digraph = {}
         for key, value in iteritems(must_have):
-            depends = lookup(value)
-            digraph[key] = depends
+            fn = value + '.tar.bz2'
+            if fn in self.index:
+                depends = set(ms.name for ms in self.ms_depends(fn))
+                digraph[key] = depends
         sorted_keys = toposort(digraph)
         must_have = must_have.copy()
         # Take all of the items in the sorted keys


### PR DESCRIPTION
Fixes the problems first noticed [in this conda-build issue](https://github.com/conda/conda-build/issues/899#issuecomment-214767717). `master` is currently not handling local `.tar.bz` packages properly. This rewrites `misc.install_local_packages` to use the cache machinery.