### PR TITLE
move_to_trash uses UNC paths on Windows to get around MAX_PATH 260

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -818,11 +818,14 @@ def is_linked(prefix, dist):
     """
     return load_meta(prefix, dist)
 
+def _get_trash_dir(pkg_dir):
+    unc_prefix = '\\\\?\\' if sys.platform == 'win32' else ''
+    return unc_prefix + join(pkg_dir, '.trash')
+
 def delete_trash(prefix=None):
     from conda import config
-
     for pkg_dir in config.pkgs_dirs:
-        trash_dir = join(pkg_dir, '.trash')
+        trash_dir = _get_trash_dir(pkg_dir)
         try:
             log.debug("Trying to delete the trash dir %s" % trash_dir)
             rm_rf(trash_dir, max_retries=1, trash=False)
@@ -850,7 +853,7 @@ def move_path_to_trash(path):
 
     for pkg_dir in config.pkgs_dirs:
         import tempfile
-        trash_dir = join(pkg_dir, '.trash')
+        trash_dir = _get_trash_dir(pkg_dir)
 
         try:
             os.makedirs(trash_dir)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4,12 +4,15 @@ import shutil
 import stat
 import tempfile
 import unittest
-from os.path import join
+from sys import platform
+from os.path import join, basename
+from os import makedirs, walk
 
 
-from conda import install
+from conda import install, config
 from conda.install import (PaddingError, binary_replace, update_prefix,
-                           warn_failed_remove, duplicates_to_remove)
+                           warn_failed_remove, duplicates_to_remove,
+                           delete_trash, move_path_to_trash, _get_trash_dir)
 
 from .decorators import skip_if_no_mock
 from .helpers import mock
@@ -94,6 +97,27 @@ class FileTests(unittest.TestCase):
                 b'\x7fELF.../usr/local/lib/libfoo.so\0\0\0\0\0\0\0\0'
             )
 
+    def test_trash_long_paths(self):
+        unc_prefix = '\\\\?\\' if platform == 'win32' else ''
+        pkg_dir = config.pkgs_dirs[0]
+        longfoldername="trash_with_a_very_very_long_and_silly_name_indeed"
+        tmpdir=pkg_dir
+        for i in range(6):
+            tmpdir = join(tmpdir, longfoldername)
+            if not i:
+                toptmpdir = tmpdir
+        tmpfile = join(tmpdir, self.tmpfname)
+        makedirs(unc_prefix + tmpdir)
+        with open(unc_prefix + tmpfile, 'w') as fo:
+            fo.write('trashy')
+        delete_trash(config.pkgs_dirs[0])
+        move_path_to_trash(toptmpdir)
+        trash = _get_trash_dir(config.pkgs_dirs[0])
+        contents = [basename(dp) for dp, dn, fn in walk(trash)]
+        self.assertIn(longfoldername, contents)
+        delete_trash(config.pkgs_dirs[0])
+        contents = [basename(dp) for dp, dn, fn in walk(trash)]
+        self.assertTrue(longfoldername not in contents)
 
 class remove_readonly_TestCase(unittest.TestCase):
     def test_takes_three_args(self):


### PR DESCRIPTION
Fixes https://github.com/conda/conda-build/issues/891