### PR TITLE
Improved version & build matching

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -486,7 +486,7 @@ def arg2spec(arg, json=False, update=False):
                        json=json, error_type="ValueError")
     if spec.strictness != 2:
         return str(spec)
-    ver = spec.vspecs.spec
+    ver = spec.version.spec
     if isinstance(ver, tuple) or ver.startswith(('=', '>', '<', '!')) or ver.endswith('*'):
         return str(spec)
     elif ver.endswith('.0'):

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -470,7 +470,7 @@ def check_write(command, prefix, json=False):
 
 def arg2spec(arg, json=False, update=False):
     try:
-        spec = MatchSpec(spec_from_line(arg))
+        spec = MatchSpec(spec_from_line(arg), normalize=True)
     except:
         error_and_exit('invalid package specification: %s' % arg,
                        json=json, error_type="ValueError")
@@ -479,20 +479,12 @@ def arg2spec(arg, json=False, update=False):
         error_and_exit("specification '%s' is disallowed" % name,
                        json=json,
                        error_type="ValueError")
-    if spec.strictness > 1 and update:
+    if not spec.is_simple() and update:
         error_and_exit("""version specifications not allowed with 'update'; use
     conda update  %s%s  or
     conda install %s""" % (name, ' ' * (len(arg)-len(name)), arg),
                        json=json, error_type="ValueError")
-    if spec.strictness != 2:
-        return str(spec)
-    ver = spec.version.spec
-    if isinstance(ver, tuple) or ver.startswith(('=', '>', '<', '!')) or ver.endswith('*'):
-        return str(spec)
-    elif ver.endswith('.0'):
-        return '%s %s|%s*' % (name, ver[:-2], ver)
-    else:
-        return '%s %s*' % (name, ver)
+    return str(spec)
 
 
 def specs_from_args(args, json=False):

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -350,7 +350,7 @@ def add_defaults_to_specs(r, linked, specs, update=False):
                           # Default version required, but only used for Python
                           ('lua', None)]:
         ms = names_ms.get(name)
-        if ms and ms.strictness > 1:
+        if ms and not ms.is_simple():
             # if any of the specifications mention the Python/Numpy version,
             # we don't need to add the default spec
             log.debug('H1 %s' % name)
@@ -369,7 +369,7 @@ def add_defaults_to_specs(r, linked, specs, update=False):
             continue
 
         if (any_depends_on and len(specs) >= 1 and
-                MatchSpec(specs[0]).strictness == 3):
+                MatchSpec(specs[0]).is_exact()):
             # if something depends on Python/Numpy, but the spec is very
             # explicit, we also don't need to add the default spec
             log.debug('H2B %s' % name)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -136,24 +136,24 @@ class MatchSpec(object):
             self.match_fast = self._match_any
             return self
         vspec = VersionSpec(parts[1])
-        if normalize and vspec.is_exact():
-            ver = vspec.spec
-            if ver.endswith('.0'):
-                ver = '%s|%s' % (ver[:-2], ver)
-            ver += '*'
-            parts[1] = ver
-            vspec = VersionSpec(ver)
-            self.spec = ' '.join(parts)
+        if vspec.is_exact():
+            if nparts > 2 and '*' not in parts[2]:
+                self.version, self.build = parts[1:]
+                self.match_fast = self._match_exact
+                return self
+            if normalize:
+                ver = vspec.spec
+                if ver.endswith('.0'):
+                    ver = '%s|%s' % (ver[:-2], ver)
+                ver += '*'
+                parts[1] = ver
+                vspec = VersionSpec(ver)
+                self.spec = ' '.join(parts)
+        self.version = vspec
         if nparts == 2:
-            self.version = vspec
             self.match_fast = self._match_version
-        elif '*' not in parts[2] and vspec.is_exact():
-            self.version = parts[1]
-            self.build = parts[2]
-            self.match_fast = self._match_exact
         else:
             rx = r'^(?:%s)$' % parts[2].replace('*', r'.*')
-            self.version = vspec
             self.build = re.compile(rx)
             self.match_fast = self._match_full
         return self

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -106,9 +106,9 @@ class NoPackagesFound(RuntimeError):
 
 
 class MatchSpec(object):
-    def __new__(cls, spec, target=Ellipsis, optional=Ellipsis):
+    def __new__(cls, spec, target=Ellipsis, optional=Ellipsis, normalize=False):
         if isinstance(spec, cls):
-            if target is Ellipsis and optional is Ellipsis:
+            if target is Ellipsis and optional is Ellipsis and not normalize:
                 return spec
             target = spec.target if target is Ellipsis else target
             optional = spec.optional if optional is Ellipsis else optional
@@ -136,6 +136,14 @@ class MatchSpec(object):
             self.match_fast = self._match_any
             return self
         vspec = VersionSpec(parts[1])
+        if normalize and vspec.is_exact():
+            ver = vspec.spec
+            if ver.endswith('.0'):
+                ver = '%s|%s' % (ver[:-2], ver)
+            ver += '*'
+            parts[1] = ver
+            vspec = VersionSpec(ver)
+            self.spec = ' '.join(parts)
         if nparts == 2:
             self.version = vspec
             self.match_fast = self._match_version

--- a/conda/version.py
+++ b/conda/version.py
@@ -251,6 +251,9 @@ opdict = {'==': op.__eq__, '!=': op.__ne__, '<=': op.__le__,
           '>=': op.__ge__, '<': op.__lt__, '>': op.__gt__}
 
 class VersionSpec(object):
+    def exact_match_(self, vspec):
+        return self.spec == vspec
+
     def regex_match_(self, vspec):
         return bool(self.regex.match(vspec))
 
@@ -282,14 +285,15 @@ class VersionSpec(object):
             self.op = opdict[op]
             self.cmp = VersionOrder(b)
             self.match = self.veval_match_
-        else:
-            self.spec = spec
+        elif '*' in spec:
             rx = spec.replace('.', r'\.')
             rx = rx.replace('+', r'\+')
             rx = rx.replace('*', r'.*')
-            rx = r'(%s)$' % rx
+            rx = r'^(?:%s)$' % rx
             self.regex = re.compile(rx)
             self.match = self.regex_match_
+        else:
+            self.match = self.exact_match_
         return self
 
     def str(self, inand=False):

--- a/conda/version.py
+++ b/conda/version.py
@@ -306,6 +306,9 @@ class VersionSpec(object):
                 s = '(%s)' % s
         return s
 
+    def is_exact(self):
+        return self.match == self.exact_match_
+
     def __str__(self):
         return self.str()
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -51,6 +51,22 @@ class TestMatchSpec(unittest.TestCase):
         self.assertTrue(MatchSpec('numpy >=1.0.1a py27*').match('numpy-1.0.1z-py27_1.tar.bz2'))
         self.assertTrue(MatchSpec('blas * openblas').match('blas-1.0-openblas.tar.bz2'))
 
+        self.assertTrue(MatchSpec('blas').is_simple())
+        self.assertFalse(MatchSpec('blas').is_exact())
+        self.assertFalse(MatchSpec('blas 1.0').is_simple())
+        self.assertFalse(MatchSpec('blas 1.0').is_exact())
+        self.assertFalse(MatchSpec('blas 1.0 1').is_simple())
+        self.assertTrue(MatchSpec('blas 1.0 1').is_exact())
+        self.assertFalse(MatchSpec('blas 1.0 *').is_exact())
+
+        m = MatchSpec('blas 1.0', optional=True)
+        m2 = MatchSpec(m, optional=False)
+        m3 = MatchSpec(m2, target='blas-1.0-0.tar.bz2')
+        m4 = MatchSpec(m3, target=None, optional=True)
+        self.assertTrue(m.spec == m2.spec and m.optional != m2.optional)
+        self.assertTrue(m2.spec == m3.spec and m2.optional == m3.optional and m2.target != m3.target)
+        self.assertTrue(m == m4)
+
     def test_to_filename(self):
         ms = MatchSpec('foo 1.7 52')
         self.assertEqual(ms.to_filename(), 'foo-1.7-52.tar.bz2')

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -48,6 +48,8 @@ class TestMatchSpec(unittest.TestCase):
         self.assertTrue(MatchSpec('numpy <1.0.1').match('numpy-1.0.1a.vc11-0.tar.bz2'))
         self.assertFalse(MatchSpec('numpy >=1.0.1.vc11').match('numpy-1.0.1a-0.tar.bz2'))
         self.assertTrue(MatchSpec('numpy >=1.0.1a').match('numpy-1.0.1z-0.tar.bz2'))
+        self.assertTrue(MatchSpec('numpy >=1.0.1a py27*').match('numpy-1.0.1z-py27_1.tar.bz2'))
+        self.assertTrue(MatchSpec('blas * openblas').match('blas-1.0-openblas.tar.bz2'))
 
     def test_to_filename(self):
         ms = MatchSpec('foo 1.7 52')


### PR DESCRIPTION
The current version of conda requires exact string matches for three-element (package/version/build) matches; e.g., `numpy 1.10.0 py27_1`. This PR allows the version match to include inequalities or wildcards, and allows the build string to have wildcards as well.

So, for instance:
- `numpy >=1.0.1a py27*` will match `numpy-1.0.1z-py27_1.tar.bz2`.
- `blas * openblas` will match `blas-1.0-openblas.tar.bz2`. (@jakirkham will appreciate this one.)

