### PR TITLE
Fix the sort order for updates

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -718,9 +718,9 @@ class Resolve(object):
             targets = [ms.target for ms in mss if ms.target and ms.target in self.index]
             if targets:
                 v1 = [(self.version_key(p), p) for p in targets]
-                tver = max(v1)
-                v2 = list(reversed([p for p in pkgs if p > tver]))
-                v3 = [p for p in pkgs if p <= tver and p not in v1]
+                tver = min(v1)[0]
+                v2 = list(reversed([(p, q) for p, q in pkgs if p >= tver and q not in targets]))
+                v3 = [(p, q) for p, q in pkgs if p < tver]
                 pkgs = v1 + v2 + v3
             pkey = None
             for nkey, npkg in pkgs:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -719,8 +719,8 @@ class Resolve(object):
             if targets:
                 v1 = [(self.version_key(p), p) for p in targets]
                 tver = max(v1)
-                v2 = [p for p in pkgs if p > tver]
-                v3 = list(reversed([p for p in pkgs if p <= tver and p not in v1]))
+                v2 = list(reversed([p for p in pkgs if p > tver]))
+                v3 = [p for p in pkgs if p <= tver and p not in v1]
                 pkgs = v1 + v2 + v3
             pkey = None
             for nkey, npkg in pkgs:

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -330,6 +330,38 @@ def test_generate_eq():
         'system-5.8-0.tar.bz2': 1,
         'zeromq-2.2.0-0.tar.bz2': 1}
 
+    # When installing or updating a new package, we want to minimize the
+    # disruption to the rest of the environment. The "target" capability in
+    # MatchSpec helps us prioritize the current version over any upgrades,
+    # followed by any downgrades. So the lowest numbers below represent
+    # the packages that are closest 
+    spec2 = [MatchSpec('pandas', target='pandas-0.9.1-np16py27_0.tar.bz2')]
+    eqv, eqb = r2.generate_version_metrics(C, spec2)
+    assert eqv == {
+        'pandas-0.10.0-np16py26_0.tar.bz2': 1,
+        'pandas-0.10.0-np16py27_0.tar.bz2': 1,
+        'pandas-0.10.0-np17py26_0.tar.bz2': 1,
+        'pandas-0.10.0-np17py27_0.tar.bz2': 1,
+        'pandas-0.10.1-np16py26_0.tar.bz2': 2,
+        'pandas-0.10.1-np16py27_0.tar.bz2': 2,
+        'pandas-0.10.1-np17py26_0.tar.bz2': 2,
+        'pandas-0.10.1-np17py27_0.tar.bz2': 2,
+        'pandas-0.10.1-np17py33_0.tar.bz2': 2,
+        'pandas-0.11.0-np16py26_1.tar.bz2': 3,
+        'pandas-0.11.0-np16py27_1.tar.bz2': 3,
+        'pandas-0.11.0-np17py26_1.tar.bz2': 3,
+        'pandas-0.11.0-np17py27_1.tar.bz2': 3,
+        'pandas-0.11.0-np17py33_1.tar.bz2': 3,
+        'pandas-0.8.1-np16py26_0.tar.bz2': 5,
+        'pandas-0.8.1-np16py27_0.tar.bz2': 5,
+        'pandas-0.8.1-np17py26_0.tar.bz2': 5,
+        'pandas-0.8.1-np17py27_0.tar.bz2': 5,
+        'pandas-0.9.0-np16py26_0.tar.bz2': 4,
+        'pandas-0.9.0-np16py27_0.tar.bz2': 4,
+        'pandas-0.9.0-np17py26_0.tar.bz2': 4,
+        'pandas-0.9.0-np17py27_0.tar.bz2': 4
+    }
+
 def test_unsat():
     # scipy 0.12.0b1 is not built for numpy 1.5, only 1.6 and 1.7
     assert raises(Unsatisfiable, lambda: r.install(['numpy 1.5*', 'scipy 0.12.0b1']))


### PR DESCRIPTION
The weighting function for dependencies that are _already installed_ but may require updating to meet specifications was broken somehow in recent updates. 

Updates are supposed to prefer *maximum* updates for packages specified on the command line, and *minimum* updates for everything else. The idea is that `conda` should not be modifying a user's environment any more than necessary to do what is requested. It was the "minimum" update ordering that was broken, so it was updating more aggressively as a result.

I blame myself and/or a messed up merge.