### PR TITLE
Fix #2444

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -148,7 +148,7 @@ def execute(args, parser):
     import conda.config as config
     from conda.resolve import Resolve
     from conda.cli.main_init import is_initialized
-    from conda.api import get_index, get_package_versions
+    from conda.api import get_index
 
     if args.root:
         if args.json:
@@ -158,21 +158,19 @@ def execute(args, parser):
         return
 
     if args.packages:
-        if args.json:
-            results = defaultdict(list)
-            for arg in args.packages:
-                for pkg in get_package_versions(arg):
-                    results[arg].append(pkg._asdict())
-            common.stdout_json(results)
-            return
         index = get_index()
         r = Resolve(index)
-        specs = map(common.arg2spec, args.packages)
-
-        for spec in specs:
-            versions = r.get_pkgs(spec)
-            for pkg in sorted(versions):
-                pretty_package(pkg)
+        if args.json:
+            common.stdout_json({
+                package: [p._asdict()
+                          for p in sorted(r.get_pkgs(common.arg2spec(package)))]
+                for package in args.packages
+            })
+        else:
+            for package in args.packages:
+                versions = r.get_pkgs(common.arg2spec(package))
+                for pkg in sorted(versions):
+                    pretty_package(pkg)
         return
 
     options = 'envs', 'system', 'license'

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, absolute_import, division
+import json
 
 from conda import config
+from conda.cli import main_info
 
 from tests.helpers import run_conda_command, assert_in, assert_equals
 
@@ -32,3 +34,21 @@ def test_info():
     assert_in(conda_info_out, conda_info_all_out)
     assert_in(conda_info_e_out, conda_info_all_out)
     assert_in(conda_info_s_out, conda_info_all_out)
+
+
+def test_info_package_json():
+    out, err = run_conda_command("info", "--json", "numpy=1.11.0=py35_0")
+    assert err == ""
+
+    out = json.loads(out)
+    assert set(out.keys()) == {"numpy=1.11.0=py35_0"}
+    assert len(out["numpy=1.11.0=py35_0"]) == 1
+    assert isinstance(out["numpy=1.11.0=py35_0"], list)
+
+    out, err = run_conda_command("info", "--json", "numpy")
+    assert err == ""
+
+    out = json.loads(out)
+    assert set(out.keys()) == {"numpy"}
+    assert len(out["numpy"]) > 1
+    assert isinstance(out["numpy"], list)


### PR DESCRIPTION
In `conda info <packages>`, make the `--json` route and the normal route use the same logic.