### PR TITLE
Adjust behavior for dependencies that need updating

### DIFF
--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -330,38 +330,6 @@ def test_generate_eq():
         'system-5.8-0.tar.bz2': 1,
         'zeromq-2.2.0-0.tar.bz2': 1}
 
-    # When installing or updating a new package, we want to minimize the
-    # disruption to the rest of the environment. The "target" capability in
-    # MatchSpec helps us prioritize the current version over any upgrades,
-    # followed by any downgrades. So the lowest numbers below represent
-    # the packages that are closest 
-    spec2 = [MatchSpec('pandas', target='pandas-0.9.1-np16py27_0.tar.bz2')]
-    eqv, eqb = r2.generate_version_metrics(C, spec2)
-    assert eqv == {
-        'pandas-0.10.0-np16py26_0.tar.bz2': 1,
-        'pandas-0.10.0-np16py27_0.tar.bz2': 1,
-        'pandas-0.10.0-np17py26_0.tar.bz2': 1,
-        'pandas-0.10.0-np17py27_0.tar.bz2': 1,
-        'pandas-0.10.1-np16py26_0.tar.bz2': 2,
-        'pandas-0.10.1-np16py27_0.tar.bz2': 2,
-        'pandas-0.10.1-np17py26_0.tar.bz2': 2,
-        'pandas-0.10.1-np17py27_0.tar.bz2': 2,
-        'pandas-0.10.1-np17py33_0.tar.bz2': 2,
-        'pandas-0.11.0-np16py26_1.tar.bz2': 3,
-        'pandas-0.11.0-np16py27_1.tar.bz2': 3,
-        'pandas-0.11.0-np17py26_1.tar.bz2': 3,
-        'pandas-0.11.0-np17py27_1.tar.bz2': 3,
-        'pandas-0.11.0-np17py33_1.tar.bz2': 3,
-        'pandas-0.8.1-np16py26_0.tar.bz2': 5,
-        'pandas-0.8.1-np16py27_0.tar.bz2': 5,
-        'pandas-0.8.1-np17py26_0.tar.bz2': 5,
-        'pandas-0.8.1-np17py27_0.tar.bz2': 5,
-        'pandas-0.9.0-np16py26_0.tar.bz2': 4,
-        'pandas-0.9.0-np16py27_0.tar.bz2': 4,
-        'pandas-0.9.0-np17py26_0.tar.bz2': 4,
-        'pandas-0.9.0-np17py27_0.tar.bz2': 4
-    }
-
 def test_unsat():
     # scipy 0.12.0b1 is not built for numpy 1.5, only 1.6 and 1.7
     assert raises(Unsatisfiable, lambda: r.install(['numpy 1.5*', 'scipy 0.12.0b1']))


### PR DESCRIPTION
@kalefranz: here you go, play with this please.

When installing or updating packages, `conda`'s first priority is to install latest possible versions of the packages explicitly listed on the command line, subject to dependency constraints. Its second priority is to minimize the change to the current environment that are needed to achieve this objective.

In particular: if it is possible to install the new package, or perform the requested updates, _without_ modifying any other package in the environment, it will not do so. This helps ensure that environments that are already working well don't break due to new installs or updates.

When some additional modifications to the environment _are_ necessary, `conda` seeks to minimize them---but this PR changes what that means. Prior to this PR, "minimum change" meant minimizing the sum of the version bumps over all changed packages. With this PR, "minimum change" means minimizing the *number* of packages that change. But once that minimum *number* is determined, those packages would be updated to the latest compatible version.
