### PR TITLE
Respect add_defaults_to_specs in conda remove

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -466,13 +466,14 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
 def remove_actions(prefix, specs, index, force=False, pinned=True):
     r = Resolve(index)
     linked = r.installed
-    mss = list(map(MatchSpec, specs))
 
     if force:
+        mss = list(map(MatchSpec, specs))
         nlinked = {r.package_name(fn): fn[:-8]
                    for fn in linked
                    if not any(r.match(ms, fn) for ms in mss)}
     else:
+        add_defaults_to_specs(r, linked, specs, update=True)
         nlinked = {r.package_name(fn): fn[:-8] for fn in r.remove(specs, linked)}
 
     if pinned:
@@ -491,7 +492,7 @@ def remove_actions(prefix, specs, index, force=False, pinned=True):
             msg = "Cannot remove %s becaue it is pinned. Use --no-pin to override."
             raise RuntimeError(msg % dist)
         if name == 'conda' and name not in nlinked:
-            if any(ms.name == 'conda' for ms in mss):
+            if any(s.split(' ', 1)[0] == 'conda' for s in specs):
                 sys.exit("Error: 'conda' cannot be removed from the root environment")
             else:
                 msg = ("Error: this 'remove' command cannot be executed because it\n"

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -885,8 +885,9 @@ class Resolve(object):
         return pkgs
 
     def remove_specs(self, specs, installed):
-        # These never match true version/build combos so it forces removal
-        specs = [MatchSpec('%s @ @' % s, optional=True) for s in specs]
+        # Adding ' @ @' to the MatchSpec forces its removal
+        specs = [s if ' ' in s else s + ' @ @' for s in specs]
+        specs = [MatchSpec(s, optional=True) for s in specs]
         snames = {s.name for s in specs}
         limit, _ = self.bad_installed(installed, specs)
         preserve = []


### PR DESCRIPTION
```
conda create -n test anaconda python=2.7
conda remove -n test enum34
```
The `remove` command forces an upgrade to Python 3.4. That's because `remove` currently doesn't utilize `add_defaults_to_specs`. This change fixes that.