### PR TITLE
install: Use bash not sh as POSIX shell on Windows

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -48,7 +48,10 @@ activate' from PATH. """)
 
 
 def prefix_from_arg(arg, shelldict):
-    if shelldict['sep'] in arg:
+    'Returns a platform-native path'
+    # MSYS2 converts Unix paths to Windows paths with unix seps
+    # so we must check for the drive identifier too.
+    if shelldict['sep'] in arg and not re.match('[a-zA-Z]:', arg):
         # strip is removing " marks, not \ - look carefully
         native_path = shelldict['path_from'](arg)
         if isdir(abspath(native_path.strip("\""))):
@@ -56,10 +59,10 @@ def prefix_from_arg(arg, shelldict):
         else:
             raise ValueError('could not find environment: %s' % native_path)
     else:
-        prefix = find_prefix_name(arg)
+        prefix = find_prefix_name(arg.replace('/', os.path.sep))
         if prefix is None:
             raise ValueError('could not find environment: %s' % arg)
-    return shelldict['path_to'](prefix)
+    return prefix
 
 
 def binpath_from_arg(arg, shelldict):

--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -71,10 +71,10 @@ def binpath_from_arg(arg, shelldict):
     if sys.platform == 'win32':
         paths = [
             prefix.rstrip("\\"),
-            os.path.join(prefix, 'Library', 'bin'),
-            os.path.join(prefix, 'Scripts'),
             os.path.join(prefix, 'Library', 'mingw-w64', 'bin'),
             os.path.join(prefix, 'Library', 'usr', 'bin'),
+            os.path.join(prefix, 'Library', 'bin'),
+            os.path.join(prefix, 'Scripts'),
                 ]
     else:
         paths = [

--- a/conda/install.py
+++ b/conda/install.py
@@ -146,7 +146,7 @@ if on_win:
         else:
             # This one is for bash/cygwin/msys
             with open(dst, "w") as f:
-                f.write("#!/bin/sh \n")
+                f.write("#!/usr/bin/env bash \n")
                 if src.endswith("conda"):
                     f.write('%s "$@"' % shells[shell]['path_to'](src+".exe"))
                 else:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -371,9 +371,9 @@ if sys.platform == "win32":
             binpath="/Scripts/",  # mind the trailing slash.
             path_from=cygwin_path_to_win,
             path_to=win_path_to_cygwin
-                      ),
+        ),
         # bash is whichever bash is on PATH.  If using Cygwin, you should use the cygwin
-        #    entry instead.  The only major difference is that it handle's cywin's /cygdrive
+        #    entry instead.  The only major difference is that it handle's cygwin's /cygdrive
         #    filesystem root.
         "bash.exe": dict(
             unix_shell_base,
@@ -381,7 +381,7 @@ if sys.platform == "win32":
             binpath="/Scripts/",  # mind the trailing slash.
             path_from=unix_path_to_win,
             path_to=win_path_to_unix
-                        ),
+        ),
     }
 
 else:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -3,10 +3,7 @@ from __future__ import print_function, absolute_import
 
 import os
 from os.path import dirname
-import shutil
-import shlex
 import stat
-import subprocess
 import sys
 
 import pytest
@@ -14,8 +11,7 @@ import pytest
 from conda.compat import TemporaryDirectory
 from conda.config import root_dir, platform
 from conda.install import symlink_conda
-from conda.utils import (win_path_to_unix, unix_path_to_win, win_path_to_cygwin, path_identity,
-                                cygwin_path_to_win, translate_stream, run_in, shells)
+from conda.utils import path_identity, run_in, shells
 from conda.cli.activate import pathlist_to_str, binpath_from_arg
 
 from tests.helpers import assert_equals, assert_in, assert_not_in
@@ -482,7 +478,6 @@ def test_PS1_no_changeps1(shell, bash_profile):
 @pytest.mark.slow
 def test_CONDA_DEFAULT_ENV(shell):
     shell_vars = _format_vars(shell)
-    shelldict = shells[shell]
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
         env_dirs=gen_test_env_paths(envs, shell)
         commands = (shell_vars['command_setup'] + """


### PR DESCRIPTION
We need to use the same shell name as is identified in utils.py
shells, otherwise find_parent_shell() will return an executable
that cannot be found there later.

Also use /usr/bin/env to run the shell, fix one typo and two
badly formatted lines.