### PR TITLE
activate: Add MSYS2 entries to binpath_from_arg

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -70,6 +70,8 @@ def binpath_from_arg(arg, shelldict):
             prefix.rstrip("\\"),
             os.path.join(prefix, 'Library', 'bin'),
             os.path.join(prefix, 'Scripts'),
+            os.path.join(prefix, 'Library', 'mingw-w64', 'bin'),
+            os.path.join(prefix, 'Library', 'usr', 'bin'),
                 ]
     else:
         paths = [


### PR DESCRIPTION
.. which makes it into PATH via conda ..activate and activate.bat

@kalefranz as we discussed, in lieu of activate being used for the root env.