### PR TITLE
Put strictness back.

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -134,12 +134,15 @@ class MatchSpec(object):
         self.name = parts[0]
         if nparts == 1:
             self.match_fast = self._match_any
+            self.strictness = 1
             return self
+        self.strictness = 2
         vspec = VersionSpec(parts[1])
         if vspec.is_exact():
             if nparts > 2 and '*' not in parts[2]:
                 self.version, self.build = parts[1:]
                 self.match_fast = self._match_exact
+                self.strictness = 3
                 return self
             if normalize and not parts[1].endswith('*'):
                 parts[1] += '*'


### PR DESCRIPTION
I didn't realize it was used outside of `conda`. @mingwandroid has a fix for `conda-build`, but it would probably be best if this one little thing didn't force people to upgrade `conda-build`, particularly since it's easy to reverse.

Note that because we've made the `MatchSpec` a bit more flexible, I'm reserving `strictness==3` for exact version/build matches (`is_exact()`). All other matches with version or build specifications are `strictness==2`. That's the best fit for prior logic.