### PR TITLE
write success messages on change of environment to stdout instead of stderr

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -50,7 +50,7 @@ def main():
             sys.exit("Error: did not expect more than one argument")
 
         paths = [binpath]
-        sys.stderr.write("prepending %s to PATH\n" % binpath)
+        sys.stdout.write("prepending %s to PATH\n" % binpath)
 
     elif sys.argv[1] == '..deactivate':
         if len(sys.argv) != 2:
@@ -62,7 +62,7 @@ def main():
             print(os.environ['PATH'])
             raise
         paths = []
-        sys.stderr.write("discarding %s from PATH\n" % binpath)
+        sys.stdout.write("discarding %s from PATH\n" % binpath)
 
     elif sys.argv[1] == '..activateroot':
         if len(sys.argv) != 2:
@@ -84,7 +84,7 @@ def main():
             paths = [rootpath]
         else:
             paths = []
-        sys.stderr.write("discarding %s from PATH\n" % binpath)
+        sys.stdout.write("discarding %s from PATH\n" % binpath)
 
     elif sys.argv[1] == '..checkenv':
         if len(sys.argv) < 3:


### PR DESCRIPTION
Currently a `$ source activate some_env` writes success messages about the switch of environment to `stderr`. In general informative, non-error messages are supposed to end up in `stdout`, though.

In many cases of automated scripts, `stdout` is redirected to `/dev/null` (or some log file) while `stderr` is left visible (or sent via mail etc.) because `stdout` is just not interesting unless something goes wrong and `stderr` is usually handled differently and prompts the user/maintainer of automated scripts.
For example in cronjobs I usually redirect `stdout` to `/dev/null` but have the cronjob mail me any `stderr` messages so that I know when things stop working etc. As it stands right now with `activate` sending both success and error messages to `stderr` this is not doable in an elegant way.

I'd adapt the tests if this change gets approved.