### PR TITLE
plan: Fix re-install when sha1 differs

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -305,7 +305,7 @@ def fetch_pkg(info, dst_dir=None, session=None):
         url = info['channel'] + '/' + fn
     log.debug("url=%r" % url)
     if dst_dir is None:
-        dst_dir = dirname(find_new_location(fn[:-8])[0])
+        dst_dir = find_new_location(fn[:-8])[0]
     path = join(dst_dir, fn)
 
     download(url, path, session=session, md5=info['md5'], urlstxt=True)

--- a/conda/install.py
+++ b/conda/install.py
@@ -685,7 +685,7 @@ def find_new_location(dist):
             pkg_path = join(pkg_dir, fname)
             prefix = fname_table_.get(pkg_path)
             if p or prefix is None:
-                return pkg_path, prefix + dname if p else None
+                return pkg_dir, prefix + dname if p else None
 
 
 # ------- package cache ----- fetched

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -283,6 +283,7 @@ def ensure_linked_actions(dists, prefix, index=None, force=False, always_copy=Fa
         if not extracted_in and not fetched_in:
             # If there is a cache conflict, clean it up
             fetched_in, conflict = install.find_new_location(dist)
+            fetched_in = join(fetched_in, install._dist2filename(dist))
             if conflict is not None:
                 actions[inst.RM_FETCHED].append(conflict)
             actions[inst.FETCH].append(dist)


### PR DESCRIPTION
Hi @mcg1969, I'm not sure this is the right fix, it could be that find_new_location is meant to be returning something different (possibly not doing the dirname?).