### PR TITLE
Fix 2513, fix canonical_channel_name when platform is appended

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -1,10 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
-from operator import itemgetter
-
 from conda import install
 from conda.compat import iteritems, itervalues
-from conda.config import normalize_urls, get_channel_urls
+from conda.config import normalize_urls, prioritize_channels, get_channel_urls
 from conda.fetch import fetch_index
 from conda.resolve import Resolve
 
@@ -23,9 +21,8 @@ def get_index(channel_urls=(), prepend=True, platform=None,
         channel_urls = ['local'] + list(channel_urls)
     channel_urls = normalize_urls(channel_urls, platform, offline)
     if prepend:
-        pri0 = max(itervalues(channel_urls), key=itemgetter(1))[1] if channel_urls else 0
-        for url, rec in iteritems(get_channel_urls(platform, offline)):
-            channel_urls[url] = (rec[0], rec[1] + pri0)
+        channel_urls.extend(get_channel_urls(platform, offline))
+    channel_urls = prioritize_channels(channel_urls)
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
     if prefix:
         priorities = {c: p for c, p in itervalues(channel_urls)}

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -10,13 +10,11 @@ import json
 import os
 import re
 import sys
-from collections import defaultdict, OrderedDict
-from itertools import chain
+from collections import OrderedDict
 from os import listdir
 from os.path import exists, expanduser, join
 
 from conda.cli import common
-from conda.compat import iteritems
 
 help = "Display information about current conda install."
 
@@ -195,12 +193,7 @@ def execute(args, parser):
     else:
         conda_build_version = conda_build.__version__
 
-    # this is a hack associated with channel weight until we get the package cache reworked
-    #   in a future release
-    # for now, just ordering the channels for display in a semi-plausible way
-    d = defaultdict(list)
-    any(d[v[1]].append(k) for k, v in iteritems(get_channel_urls()))
-    channels = list(chain.from_iterable(d[q] for q in sorted(d, reverse=True)))
+    channels = get_channel_urls()
 
     info_dict = dict(
         platform=subdir,

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -23,7 +23,7 @@ import requests
 from conda.compat import itervalues, input, urllib_quote, iterkeys, iteritems
 from conda.config import pkgs_dirs, DEFAULT_CHANNEL_ALIAS, remove_binstar_tokens, \
     hide_binstar_tokens, allowed_channels, add_pip_as_python_dependency, ssl_verify, \
-    rc, normalize_urls
+    rc, prioritize_channels
 from conda.connection import CondaSession, unparse_url, RETRIES
 from conda.install import add_cached_package, find_new_location
 from conda.lock import Locked
@@ -242,7 +242,7 @@ def fetch_index(channel_urls, use_cache=False, unknown=False, index=None):
         index = {}
     stdoutlog.info("Fetching package metadata ...")
     if not isinstance(channel_urls, dict):
-        channel_urls = normalize_urls(channel_urls)
+        channel_urls = prioritize_channels(channel_urls)
     for url in iterkeys(channel_urls):
         if allowed_channels and url not in allowed_channels:
             sys.exit("""

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -22,7 +22,8 @@ import requests
 
 from conda.compat import itervalues, input, urllib_quote, iterkeys, iteritems
 from conda.config import pkgs_dirs, DEFAULT_CHANNEL_ALIAS, remove_binstar_tokens, \
-    hide_binstar_tokens, allowed_channels, add_pip_as_python_dependency, ssl_verify, rc
+    hide_binstar_tokens, allowed_channels, add_pip_as_python_dependency, ssl_verify, \
+    rc, normalize_urls
 from conda.connection import CondaSession, unparse_url, RETRIES
 from conda.install import add_cached_package, find_new_location
 from conda.lock import Locked
@@ -241,7 +242,7 @@ def fetch_index(channel_urls, use_cache=False, unknown=False, index=None):
         index = {}
     stdoutlog.info("Fetching package metadata ...")
     if not isinstance(channel_urls, dict):
-        channel_urls = {url: pri+1 for pri, url in enumerate(channel_urls)}
+        channel_urls = normalize_urls(channel_urls)
     for url in iterkeys(channel_urls):
         if allowed_channels and url not in allowed_channels:
             sys.exit("""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,20 +85,20 @@ class TestConfig(unittest.TestCase):
             'defaults', 'system', 'https://conda.anaconda.org/username',
             'file:///Users/username/repo', 'username'
             ], 'osx-64'),
-            {'file:///Users/username/repo/noarch/': ('file:///Users/username/repo', 6),
-             'file:///Users/username/repo/osx-64/': ('file:///Users/username/repo', 6),
+            {'file:///Users/username/repo/noarch/': ('file:///Users/username/repo', 5),
+             'file:///Users/username/repo/osx-64/': ('file:///Users/username/repo', 5),
              'http://repo.continuum.io/pkgs/free/noarch/': ('defaults', 1),
              'http://repo.continuum.io/pkgs/free/osx-64/': ('defaults', 1),
              'http://repo.continuum.io/pkgs/pro/noarch/': ('defaults', 1),
              'http://repo.continuum.io/pkgs/pro/osx-64/': ('defaults', 1),
              'http://some.custom/channel/noarch/': ('http://some.custom/channel', 3),
              'http://some.custom/channel/osx-64/': ('http://some.custom/channel', 3),
-             'https://conda.anaconda.org/username/noarch/': ('https://conda.anaconda.org/username', 5),
-             'https://conda.anaconda.org/username/osx-64/': ('https://conda.anaconda.org/username', 5),
+             'https://conda.anaconda.org/username/noarch/': ('https://conda.anaconda.org/username', 4),
+             'https://conda.anaconda.org/username/osx-64/': ('https://conda.anaconda.org/username', 4),
              'https://your.repo/binstar_username/noarch/': ('binstar_username', 2),
              'https://your.repo/binstar_username/osx-64/': ('binstar_username', 2),
-             'https://your.repo/username/noarch/': ('username', 7),
-             'https://your.repo/username/osx-64/': ('username', 7)})
+             'https://your.repo/username/noarch/': ('username', 6),
+             'https://your.repo/username/osx-64/': ('username', 6)})
 
 
 test_condarc = os.path.join(os.path.dirname(__file__), 'test_condarc')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,16 +76,32 @@ class TestConfig(unittest.TestCase):
         assert config.rc.get('channel_alias') == 'https://your.repo/'
         assert config.channel_alias == 'https://your.repo/'
 
-        for channel in iterkeys(config.normalize_urls(['defaults', 'system',
-            'https://anaconda.org/username', 'file:///Users/username/repo',
-            'username'])):
-            assert (channel.endswith('/%s/' % current_platform) or
-                    channel.endswith('/noarch/'))
-        self.assertEqual(config.normalize_urls([
+        normurls = config.normalize_urls([
             'defaults', 'system', 'https://conda.anaconda.org/username',
             'file:///Users/username/repo', 'username'
-            ], 'osx-64'),
-            {'file:///Users/username/repo/noarch/': ('file:///Users/username/repo', 5),
+            ], 'osx-64')
+        assert normurls == [
+             'http://repo.continuum.io/pkgs/free/osx-64/',
+             'http://repo.continuum.io/pkgs/free/noarch/',
+             'http://repo.continuum.io/pkgs/pro/osx-64/',
+             'http://repo.continuum.io/pkgs/pro/noarch/',
+             'https://your.repo/binstar_username/osx-64/',
+             'https://your.repo/binstar_username/noarch/',
+             'http://some.custom/channel/osx-64/',
+             'http://some.custom/channel/noarch/',
+             'http://repo.continuum.io/pkgs/free/osx-64/',
+             'http://repo.continuum.io/pkgs/free/noarch/',
+             'http://repo.continuum.io/pkgs/pro/osx-64/',
+             'http://repo.continuum.io/pkgs/pro/noarch/',
+             'https://conda.anaconda.org/username/osx-64/',
+             'https://conda.anaconda.org/username/noarch/',
+             'file:///Users/username/repo/osx-64/',
+             'file:///Users/username/repo/noarch/',
+             'https://your.repo/username/osx-64/',
+             'https://your.repo/username/noarch/']
+        priurls = config.prioritize_channels(normurls)
+        assert dict(priurls) == {
+             'file:///Users/username/repo/noarch/': ('file:///Users/username/repo', 5),
              'file:///Users/username/repo/osx-64/': ('file:///Users/username/repo', 5),
              'http://repo.continuum.io/pkgs/free/noarch/': ('defaults', 1),
              'http://repo.continuum.io/pkgs/free/osx-64/': ('defaults', 1),
@@ -98,7 +114,7 @@ class TestConfig(unittest.TestCase):
              'https://your.repo/binstar_username/noarch/': ('binstar_username', 2),
              'https://your.repo/binstar_username/osx-64/': ('binstar_username', 2),
              'https://your.repo/username/noarch/': ('username', 6),
-             'https://your.repo/username/osx-64/': ('username', 6)})
+             'https://your.repo/username/osx-64/': ('username', 6)}
 
 
 test_condarc = os.path.join(os.path.dirname(__file__), 'test_condarc')


### PR DESCRIPTION
Motivated by #2513. While investigating that issue, I discovered that `canonical_channel_name` would not return the correct result if the platform suffix (e.g., `/noarch`, `/osx-64`) was included in the URL, so I fixed that as well.

The primary fix for #2513 is to have `fetch_index` call `normalize_urls` if the caller passes in a bare list/iterable of channels. This converts the list into the format needed later in `fetch_index` which is a dictionary: the keys are the long channel URLs, and the keys are (canonical channel name, priority) tuples.

Removed some unused options in `canonical_channel_name` as well.