### PR TITLE
Reduced priority for packages installed with `-c`

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -26,11 +26,12 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
     if prefix:
         priorities = {c: p for c, p in itervalues(channel_urls)}
+        maxp = max(itervalues(priorities)) + 1
         for dist, info in iteritems(install.linked_data(prefix)):
             fn = info['fn']
             schannel = info['schannel']
             prefix = '' if schannel == 'defaults' else schannel + '::'
-            priority = priorities.get(schannel, 0)
+            priority = priorities.get(schannel, maxp)
             key = prefix + fn
             if key in index:
                 # Copy the link information so the resolver knows this is installed


### PR DESCRIPTION
While investigating #2538 I noticed something interesting. On Linux-64, I did this:
```
conda install -c Massimo cryptography
conda update cryptography
```
The first command installs version `1.1.1` of `cryptography`, as found in the `Massimo` channel. So far so good. The current version of `cryptography` in the default channel is `1.3.2`, so I expected the second command to upgrade it---but instead it kept the original version. 

The reason for this is that Massimo is not in the channel list for the second command---and packages that come from channels _outside_ the channel list are now being assigned the _highest_ channel priority. I thought this was going to be the best choice, because it would prevent accidental upgrades. But I'm afraid it has a worse effect, which is to prevent _deliberate_ upgrades. Furthermore, just adding `Massimo` to the channel list won't solve the problem, because it will add it to the beginning of the channel list, and give it the highest priority. The only way to get the upgrade is to add the channel to the _end_ of the channel list; i.e.,
```
channels:
  - defaults
  - Massimo
```
With this configuration, `conda update cryptography` will see version 1.3.2 from the default channel and upgrade it. That's too cumbersome a solution---and so is asking people to remove a package before replacing it, in my view.

So this PR changes the behavior I put in place, so that any package installed using `-c`, and whose channel is not present in the channel list, is given the _lowest_ channel priority.