### PR TITLE
Allow track_features to be a string *or* a list in .condarc

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from os.path import abspath, expanduser, isfile, isdir, join
 from platform import machine
 
-from conda.compat import urlparse
+from conda.compat import urlparse, string_types
 from conda.utils import try_write, memoized, yaml_load
 
 log = logging.getLogger(__name__)
@@ -392,6 +392,9 @@ channel_priority = bool(rc.get('channel_priority', True))
 ssl_verify = rc.get('ssl_verify', True)
 
 try:
-    track_features = set(rc['track_features'])
+    track_features = rc['track_features']
+    if isinstance(track_features, string_types):
+        track_features = track_features.split()
+    track_features = set(track_features)
 except KeyError:
     track_features = None


### PR DESCRIPTION
In #2203, a user reported a "bug" in the processing of the `track_features` entry in `.condarc`. @ilanschnell "fixed" this in https://github.com/conda/conda/commit/c6c0ea1d6181da3be5b32da78857e74124d4e8eb

It turns out it wasn't a bug. Ever since the `track_features` setting was added to `.condarc`, it was expected to be a string, which was then `split()` to separate the elements into a list; see https://github.com/conda/conda/commit/9caa576ffa5b5db04883a129922ef3c3e8fd80ee

Sure enough, one user depended on the old behavior and reported issue #2524. Now we have users depending upon both syntaxes. This PR supports both, by splitting `track_features` only if it is a string.