### PR TITLE
Fix dependency on dist string format

### DIFF
--- a/conda/bundle.py
+++ b/conda/bundle.py
@@ -15,6 +15,7 @@ import conda.plan as plan
 from conda.api import get_index
 from conda.config import arch_name, platform, envs_dirs
 from conda.misc import untracked, discard_conda
+from conda.compat import itervalues
 
 
 ISO8601 = "%Y-%m-%d %H:%M:%S %z"
@@ -105,8 +106,8 @@ def create_bundle(prefix=None, data_path=None, bundle_name=None,
                 path = join(prefix, f)
                 add_file(t, path, f)
         meta['bundle_prefix'] = prefix
-        meta['depends'] = [' '.join(dist.rsplit('-', 2)) for dist in
-                           sorted(install.linked(prefix))]
+        meta['depends'] = ['%(name)s %(version)s %(build)s' % info
+                           for info in itervalues(install.linked_data(prefix))]
 
     if data_path:
         add_data(t, data_path)

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -14,6 +14,7 @@ from conda.config import (envs_dirs, default_prefix, platform, update_dependenci
                           root_dir, root_writable, disallow)
 from conda.resolve import MatchSpec
 from conda.utils import memoize
+from conda.install import dist2quad
 
 
 class Completer(object):
@@ -76,7 +77,7 @@ class Packages(Completer):
         if hasattr(args, 'platform'):  # in search
             call_dict['platform'] = args.platform
         index = get_index(**call_dict)
-        return [i.rsplit('-', 2)[0] for i in index]
+        return [dist2quad(i)[0] for i in index]
 
 class InstalledPackages(Completer):
     def __init__(self, prefix, parsed_args, **kwargs):
@@ -87,7 +88,7 @@ class InstalledPackages(Completer):
     def _get_items(self):
         import conda.install
         packages = conda.install.linked(get_prefix(self.parsed_args))
-        return [i.rsplit('-', 2)[0] for i in packages]
+        return [dist2quad(i)[0] for i in packages]
 
 def add_parser_help(p):
     """

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -74,8 +74,8 @@ def clone(src_arg, dst_prefix, json=False, quiet=False, fetch_args=None):
                                   error_type="NoEnvironmentFound")
 
     if not json:
-        print("Source:      %r" % src_prefix)
-        print("Destination: %r" % dst_prefix)
+        print("Source:      %s" % src_prefix)
+        print("Destination: %s" % dst_prefix)
 
     with common.json_progress_bars(json=json and not quiet):
         actions, untracked_files = misc.clone_env(src_prefix, dst_prefix,

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -17,6 +17,7 @@ import conda.install as install
 from conda.cli import common
 from conda.config import show_channel_urls, subdir, use_pip
 from conda.egg_info import get_egg_info
+from conda.install import dist2quad
 
 
 descr = "List linked packages in a conda environment."
@@ -132,7 +133,7 @@ def list_packages(prefix, installed, regex=None, format='human',
             result.append(dist)
             continue
         if format == 'export':
-            result.append('='.join(dist.rsplit('-', 2)))
+            result.append('='.join(dist2quad(dist)[:3]))
             continue
 
         try:
@@ -147,7 +148,7 @@ def list_packages(prefix, installed, regex=None, format='human',
             result.append(disp)
         except (AttributeError, IOError, KeyError, ValueError) as e:
             log.debug(str(e))
-            result.append('%-25s %-15s %15s' % tuple(dist.rsplit('-', 2)))
+            result.append('%-25s %-15s %15s' % dist2quad(dist, channel=False))
 
     return res, result
 

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -10,6 +10,7 @@ from conda.cli import common
 from conda.config import subdir, canonical_channel_name
 from conda.misc import make_icon_url
 from conda.resolve import NoPackagesFound, Package
+from conda.install import dist2quad
 
 descr = """Search for packages and display their information. The input is a
 Python regular expression.  To perform a search with a search string that starts
@@ -222,8 +223,8 @@ def execute_search(args, parser):
             json[name] = []
 
         if args.outdated:
-            vers_inst = [dist.rsplit('-', 2)[1] for dist in linked
-                         if dist.rsplit('-', 2)[0] == name]
+            vers_inst = [dist[1] for dist in map(dist2quad, linked)
+                         if dist[0] == name]
             if not vers_inst:
                 continue
             assert len(vers_inst) == 1, name

--- a/conda/history.py
+++ b/conda/history.py
@@ -10,6 +10,7 @@ import errno
 import logging
 
 from conda import install
+from conda.install import dist2quad
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ def pretty_diff(diff):
     removed = {}
     for s in diff:
         fn = s[1:]
-        name, version, unused_build = fn.rsplit('-', 2)
+        name, version, unused_build = dist2quad(fn, channel=False)
         if s.startswith('-'):
             removed[name.lower()] = version
         elif s.startswith('+'):
@@ -207,7 +208,7 @@ class History(object):
             removed = {}
             if is_diff(content):
                 for pkg in content:
-                    name, version, build = pkg[1:].rsplit('-', 2)
+                    name, version, build = dist2quad(pkg[1:], channel=False)
                     if pkg.startswith('+'):
                         added[name.lower()] = (version, build)
                     elif pkg.startswith('-'):

--- a/conda/packup.py
+++ b/conda/packup.py
@@ -14,16 +14,15 @@ import tempfile
 from os.path import basename, isfile, islink, join
 
 import conda.install as install
-from conda.compat import PY3
+from conda.compat import PY3, itervalues
 from conda.config import platform, arch_name
 from conda.misc import untracked
 
 
 def get_installed_version(prefix, name):
-    for dist in install.linked(prefix):
-        n, v, b = dist.rsplit('-', 2)
-        if n == name:
-            return v
+    for info in itervalues(install.linked_data(prefix)):
+        if info['name'] == name:
+            return str(info['version'])
     return None
 
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -333,11 +333,6 @@ def is_root_prefix(prefix):
     return abspath(prefix) == abspath(root_dir)
 
 
-def dist2spec3v(dist):
-    name, version, unused_build = dist.rsplit('-', 2)
-    return '%s %s*' % (name, version[:3])
-
-
 def add_defaults_to_specs(r, linked, specs, update=False):
     # TODO: This should use the pinning mechanism. But don't change the API:
     # cas uses it.
@@ -380,9 +375,12 @@ def add_defaults_to_specs(r, linked, specs, update=False):
             # if Python/Numpy is already linked, we add that instead of the
             # default
             log.debug('H3 %s' % name)
-            spec = dist2spec3v(names_linked[name])
+            fkey = names_linked[name] + '.tar.bz2'
+            info = r.index[fkey]
+            ver = '.'.join(info['version'].split('.', 2)[:2])
+            spec = '%s %s*' % (info['name'], ver)
             if update:
-                spec = '%s (target=%s.tar.bz2)' % (spec, names_linked[name])
+                spec += ' (target=%s)' % fkey
             specs.append(spec)
             continue
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -26,6 +26,7 @@ from conda.exceptions import CondaException
 from conda.history import History
 from conda.resolve import MatchSpec, Resolve, Package
 from conda.utils import md5_file, human_bytes
+from conda.install import dist2quad
 
 # For backwards compatibility
 
@@ -36,8 +37,8 @@ def print_dists(dists_extras):
     print(fmt % ('package', 'build'))
     print(fmt % ('-' * 27, '-' * 17))
     for dist, extra in dists_extras:
-        _, dist = install._dist2pair(dist)
-        line = fmt % tuple(dist.rsplit('-', 1))
+        dist = dist2quad(dist)
+        line = fmt % (dist[0]+'-'+dist[1], dist[2])
         if extra:
             line += extra
         print(line)
@@ -96,7 +97,7 @@ def display_actions(actions, index, show_channel_urls=None):
         dist, lt = inst.split_linkarg(arg)
         rec = index.get(dist + '.tar.bz2')
         if rec is None:
-            pkg, ver, build = dist.split('::', 2)[-1].rsplit('-', 2)
+            pkg, ver, build, schannel = dist2quad(dist)
             rec = dict(name=pkg, version=ver, build=build, channel=None,
                        schannel='<unknown>',
                        build_number=int(build) if build.isdigit() else 0)


### PR DESCRIPTION
There were still a couple of places that rely on the `dist` strings taking the form `name-version-build`, though they are now `channel::name-version-build`. The best thing to do in general is to retrieve `name`, `version`, and/or `build` from the package index itself and not rely on parsing the build string.

I'll look carefully for other places where this assumption is made.

Addresses #2543