### PR TITLE
Running tests also requires pytest-cov package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,6 @@ separate instance of `Miniconda <http://conda.pydata.org/miniconda.html>`_ and
 work off it. This is also the only way to test conda in both Python 2 and
 Python 3, as conda can only be installed into a root environment.
 
-Run the conda tests by ``conda install pytest`` and then running ``py.test``
+Run the conda tests by ``conda install pytest pytest-cov`` and then running ``py.test``
 in the conda directory. The tests are also run by Travis CI when you make a
 pull request.


### PR DESCRIPTION
Since #2094 was merged, tests require the `pytest-cov` package to run. Include this in the instructions.