### PR TITLE
Don't try and reinstall python if not specifically asked for

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -273,7 +273,7 @@ def install(args, parser, command='install'):
         args.no_deps = True
 
     if args.no_deps:
-        only_names = set(s.split()[0] for s in specs)
+        only_names = set(s.split()[0] for s in ospecs)
     else:
         only_names = None
 


### PR DESCRIPTION
The world's shortest pull request: *one character.*

The function `add_defaults_to_specs` adds a `python 2.7*` spec (or `3.5*`, etc. as appropriate) to the spec list for `conda install/update/remove` to ensure that Python is not upgraded undesirable version boundaries. Very useful function.

Unfortunately, `conda install --force` was incorporating this spec into its version upgrade. e.g, `conda install --force numpy` would reinstall _both_ `numpy` and `python`, when it should just install `python`.

Like I said, though, a one character fix.