### PR TITLE
Prevent repeated processing of with_features_depends

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -289,6 +289,8 @@ class Resolve(object):
         self.index = index
         if not processed:
             for fkey, info in iteritems(index.copy()):
+                if fkey.endswith(']'):
+                    continue
                 for fstr in chain(info.get('features', '').split(),
                                   info.get('track_features', '').split(),
                                   track_features or ()):


### PR DESCRIPTION
Fixes https://github.com/conda/conda/issues/2559, which was caused by the way the `Resolve` class handles the obscure `with_features_depends` metadata entry.

May we never document that feature, and cease to use it ourselves. It should be replaced with separate packages with distinguishing build strings. But at least this prevents it from breaking for the packages that already use it.