### PR TITLE
Strip the anaconda cloud message from test stderr

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,6 +20,11 @@ from contextlib import contextmanager
 import conda.cli as cli
 from conda.compat import StringIO
 
+expected_error_prefix = 'Using Anaconda Cloud api site https://api.anaconda.org'
+def strip_expected(stderr):
+    if expected_error_prefix and stderr.startswith(expected_error_prefix):
+        stderr = stderr[len(expected_error_prefix):].lstrip()
+    return stderr
 
 def raises(exception, func, string=None):
     try:
@@ -39,7 +44,7 @@ def run_conda_command(*args):
 
     stdout, stderr = [stream.strip().decode('utf-8').replace('\r\n', '\n').replace('\\\\', '\\')
                       for stream in p.communicate()]
-    return stdout, stderr
+    return stdout, strip_expected(stderr)
 
 
 class CapturedText(object):
@@ -70,7 +75,7 @@ def captured(disallow_stderr=True):
     c = CapturedText()
     yield c
     c.stdout = outfile.getvalue()
-    c.stderr = errfile.getvalue()
+    c.stderr = strip_expected(errfile.getvalue())
     sys.stdout = stdout
     sys.stderr = stderr
     if disallow_stderr and c.stderr:
@@ -99,7 +104,7 @@ def capture_with_argv(*argv):
     print('>>>>>>>>> stderr >>>>>>>>>')
     print(stderr)
     print('>>>>>>>>>')
-    return stdout, stderr
+    return stdout, strip_expected(stderr)
 
 
 def capture_json_with_argv(*argv, **kwargs):


### PR DESCRIPTION
When running the test suite locally, I get a few test failures caused by the presence of the informational stderr message
```
Using Anaconda Cloud api site https://api.anaconda.org
```
This PR creates a variable called `expected_error_prefix`  n `tests/helpers.py`. The value of `expected_error_prefix` is initialized to the above string. The helper functions `run_conda_command` and `capture_with_argv` call a new function `strip_expected` on their captured value of `stderr`, which looks for the presence of the above string and removes it.

I'm open to alternative approaches but I'd really rather not have test failures locally.