### PR TITLE
WIP: More aggressive enforcement of --offline

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -8,8 +8,7 @@ from conda.resolve import Resolve
 
 
 def get_index(channel_urls=(), prepend=True, platform=None,
-              use_local=False, use_cache=False, unknown=False,
-              offline=False, prefix=None):
+              use_local=False, use_cache=False, unknown=False, prefix=None):
     """
     Return the index of packages available on the channels
 
@@ -19,9 +18,9 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     """
     if use_local:
         channel_urls = ['local'] + list(channel_urls)
-    channel_urls = normalize_urls(channel_urls, platform, offline)
+    channel_urls = normalize_urls(channel_urls, platform)
     if prepend:
-        channel_urls.extend(get_channel_urls(platform, offline))
+        channel_urls.extend(get_channel_urls(platform))
     channel_urls = prioritize_channels(channel_urls)
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
     if prefix:
@@ -45,7 +44,7 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     return index
 
 
-def get_package_versions(package, offline=False):
-    index = get_index(offline=offline)
+def get_package_versions(package):
+    index = get_index()
     r = Resolve(index)
     return r.get_pkgs(package, emptyok=True)

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -9,6 +9,7 @@ import textwrap
 from os.path import abspath, basename, expanduser, isdir, join
 
 from conda import console
+from conda import config
 from conda.config import (envs_dirs, default_prefix, platform, update_dependencies,
                           channel_priority, show_channel_urls, always_yes, root_env_name,
                           root_dir, root_writable, disallow)
@@ -310,11 +311,15 @@ def add_parser_use_local(p):
         help="Use locally built packages.",
     )
 
+class OfflineAction(argparse.Action):
+    def __call__(self, *args, **kwargs):
+        config.offline = True
+
 def add_parser_offline(p):
     p.add_argument(
         "--offline",
-        action="store_true",
-        default=False,
+        action=OfflineAction,
+        default=config.offline,
         help="Offline mode, don't connect to the Internet.",
     )
 

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -225,7 +225,6 @@ def install(args, parser, command='install'):
                                   use_cache=args.use_index_cache,
                                   unknown=args.unknown,
                                   json=args.json,
-                                  offline=args.offline,
                                   prefix=prefix)
     r = Resolve(index)
     ospecs = list(specs)

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -121,7 +121,6 @@ def execute(args, parser):
                                       use_local=args.use_local,
                                       use_cache=args.use_index_cache,
                                       json=args.json,
-                                      offline=args.offline,
                                       prefix=prefix)
     specs = None
     if args.features:

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -165,7 +165,7 @@ def execute_search(args, parser):
     index = common.get_index_trap(channel_urls=channel_urls, prepend=not args.override_channels,
                                   platform=args.platform, use_local=args.use_local,
                                   use_cache=args.use_index_cache, prefix=prefix,
-                                  unknown=args.unknown, json=args.json, offline=args.offline)
+                                  unknown=args.unknown, json=args.json)
 
     r = Resolve(index)
 


### PR DESCRIPTION
Studying the code while fixing other issues reveals that support for `--offline` is a bit of swiss cheese. 

This PR takes the approach of siphoning off the `--offline` argument and immediately dumping it into `config.offline`. By moving the `offline` spec into the global configuration, it greatly reduces the number of functions that need to maintain an `offline` input argument. Instead, only the functions that must explicitly make offline decisions (e.g., `normalize_urls`) need worry about offline logic.