### PR TITLE
Fix #2415: infinite recursion in invalid_chains

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -26,7 +26,7 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
     if prefix:
         priorities = {c: p for c, p in itervalues(channel_urls)}
-        maxp = max(itervalues(priorities)) + 1
+        maxp = max(itervalues(priorities)) + 1 if priorities else 1
         for dist, info in iteritems(install.linked_data(prefix)):
             fn = info['fn']
             schannel = info['schannel']

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -332,7 +332,7 @@ environment does not exist: %s
             packages = {index[fn]['name'] for fn in index}
 
             nfound = 0
-            for pkg in e.pkgs:
+            for pkg in sorted(e.pkgs):
                 pkg = pkg.split()[0]
                 if pkg in packages:
                     continue

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -331,16 +331,23 @@ environment does not exist: %s
         else:
             packages = {index[fn]['name'] for fn in index}
 
+            nfound = 0
             for pkg in e.pkgs:
+                pkg = pkg.split()[0]
+                if pkg in packages:
+                    continue
                 close = get_close_matches(pkg, packages, cutoff=0.7)
-                if close:
-                    error_message += ("\n\nDid you mean one of these?"
-                                      "\n\n    %s" % (', '.join(close)))
-            error_message += '\n\nYou can search for this package on anaconda.org with'
+                if not close:
+                    continue
+                if nfound == 0:
+                    error_message += "\n\nClose matches found; did you mean one of these?\n"
+                error_message += "\n    %s: %s" % (pkg, ', '.join(close))
+                nfound += 1
+            error_message += '\n\nYou can search for packages on anaconda.org with'
             error_message += '\n\n    anaconda search -t conda %s' % pkg
             if len(e.pkgs) > 1:
                 # Note this currently only happens with dependencies not found
-                error_message += '\n\n (and similarly for the other packages)'
+                error_message += '\n\n(and similarly for the other packages)'
 
             if not find_executable('anaconda', include_others=False):
                 error_message += '\n\nYou may need to install the anaconda-client'

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -16,16 +16,17 @@ import tempfile
 import warnings
 from functools import wraps
 from logging import getLogger
-from os.path import basename, dirname, isdir, join
+from os.path import basename, dirname, join
 
 import requests
 
 from conda.compat import itervalues, input, urllib_quote, iterkeys, iteritems
 from conda.config import pkgs_dirs, DEFAULT_CHANNEL_ALIAS, remove_binstar_tokens, \
     hide_binstar_tokens, allowed_channels, add_pip_as_python_dependency, ssl_verify, \
-    rc, prioritize_channels
+    rc, prioritize_channels, url_channel
 from conda.connection import CondaSession, unparse_url, RETRIES
-from conda.install import add_cached_package, find_new_location
+from conda.install import add_cached_package, find_new_location, \
+    package_cache, _dist2filename
 from conda.lock import Locked
 from conda.utils import memoized
 
@@ -210,24 +211,28 @@ def get_proxy_username_and_pass(scheme):
 
 def add_unknown(index, priorities):
     maxp = max(itervalues(priorities)) + 1 if priorities else 1
-    for pkgs_dir in pkgs_dirs:
-        if not isdir(pkgs_dir):
+    for fkey, info in iteritems(package_cache()):
+        if fkey in index or not info['dirs']:
             continue
-        for dn in os.listdir(pkgs_dir):
-            fn = dn + '.tar.bz2'
-            if fn in index:
-                continue
-            try:
-                with open(join(pkgs_dir, dn, 'info', 'index.json')) as fi:
-                    meta = json.load(fi)
-            except IOError:
-                continue
-            channel = meta.setdefault('channel', '')
-            url = meta[url] = channel + fn
-            meta.setdefault('depends', [])
-            meta.setdefault('priority', priorities.get(channel, maxp))
-            log.debug("adding cached pkg to index: %s" % url)
-            index[url] = meta
+        try:
+            with open(join(info['dirs'][0], 'info', 'index.json')) as fi:
+                meta = json.load(fi)
+        except IOError:
+            continue
+        fname = _dist2filename(fkey)
+        if info['urls']:
+            url = info['urls'][0]
+        elif 'url' in meta:
+            url = meta['url']
+        else:
+            url = meta.get('channel', '<unknown>/') + fname
+        channel, schannel = url_channel(url)
+        priority = priorities.get(schannel, maxp)
+        meta.update({'fn': fname, 'url': url, 'channel': channel,
+                     'schannel': channel, 'priority': priority})
+        meta.setdefault('depends', [])
+        log.debug("adding cached pkg to index: %s" % url)
+        index[url] = meta
 
 def add_pip_dependency(index):
     for info in itervalues(index):

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -209,7 +209,7 @@ def get_proxy_username_and_pass(scheme):
     return username, passwd
 
 def add_unknown(index, priorities):
-    maxpri = max(itervalues(priorities)) + 1
+    maxp = max(itervalues(priorities)) + 1 if priorities else 1
     for pkgs_dir in pkgs_dirs:
         if not isdir(pkgs_dir):
             continue
@@ -225,7 +225,7 @@ def add_unknown(index, priorities):
             channel = meta.setdefault('channel', '')
             url = meta[url] = channel + fn
             meta.setdefault('depends', [])
-            meta.setdefault('priority', priorities.get(channel, maxpri))
+            meta.setdefault('priority', priorities.get(channel, maxp))
             log.debug("adding cached pkg to index: %s" % url)
             index[url] = meta
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -20,6 +20,8 @@ class TestVersionSpec(unittest.TestCase):
            (VersionOrder("0.5z"),       [[0], [0], [5, 'z']]),
            (VersionOrder("0.5za"),      [[0], [0], [5, 'za']]),
            (VersionOrder("0.5"),        [[0], [0], [5]]),
+           (VersionOrder("0.5_5"),      [[0], [0], [5], [5]]),
+           (VersionOrder("0.5-5"),      [[0], [0], [5], [5]]),
            (VersionOrder("0.9.6"),      [[0], [0], [9], [6]]),
            (VersionOrder("0.960923"),   [[0], [0], [960923]]),
            (VersionOrder("1.0"),        [[0], [1], [0]]),
@@ -68,6 +70,8 @@ class TestVersionSpec(unittest.TestCase):
         with self.assertRaises(ValueError):
             VersionOrder("  ")
         with self.assertRaises(ValueError):
+            VersionOrder("3.5&1")
+        with self.assertRaises(ValueError):
             VersionOrder("5.5++")
         with self.assertRaises(ValueError):
             VersionOrder("5.5..mw")
@@ -77,6 +81,8 @@ class TestVersionSpec(unittest.TestCase):
             VersionOrder("!")
         with self.assertRaises(ValueError):
             VersionOrder("a!1.0")
+        with self.assertRaises(ValueError):
+            VersionOrder("a!b!1.0")
 
         # check __eq__
         self.assertEqual(VersionOrder("  0.4.rc  "), VersionOrder("0.4.RC"))
@@ -141,6 +147,14 @@ class TestVersionSpec(unittest.TestCase):
         self.assertEqual(ver_eval('1.0.0', '1.0*'), True)
         self.assertEqual(ver_eval('1.0', '1.0.0*'), True)
         self.assertEqual(ver_eval('1.0.1', '1.0.0*'), False)
+        self.assertEqual(ver_eval('2013a', '2013a*'), True)
+        self.assertEqual(ver_eval('2013a', '2013b*'), False)
+        self.assertEqual(ver_eval('2013ab', '2013a*'), True)
+        self.assertEqual(ver_eval('1.3.4', '1.2.4*'), False)
+        self.assertEqual(ver_eval('1.2.3+4.5.6', '1.2.3*'), True)
+        self.assertEqual(ver_eval('1.2.3+4.5.6', '1.2.3+4*'), True)
+        self.assertEqual(ver_eval('1.2.3+4.5.6', '1.2.3+5*'), False)
+        self.assertEqual(ver_eval('1.2.3+4.5.6', '1.2.4+5*'), False)
 
     def test_ver_eval_errors(self):
         self.assertRaises(RuntimeError, ver_eval, '3.0.0', '><2.4.5')
@@ -153,8 +167,13 @@ class TestVersionSpec(unittest.TestCase):
             ('1.7', False),   ('1.5*', False),    ('>=1.5', True),
             ('!=1.5', True),  ('!=1.7.1', False), ('==1.7.1', True),
             ('==1.7', False), ('==1.7.2', False), ('==1.7.1.0', True),
+            ('1.7*|1.8*', True), ('1.8*|1.9*', False),
+            ('>1.7,<1.8', True), ('>1.7.1,<1.8', False)
             ]:
             m = VersionSpec(vspec)
+            assert VersionSpec(m) is m
+            assert str(m) == vspec
+            assert repr(m) == "VersionSpec('%s')"%vspec
             self.assertEqual(m.match('1.7.1'), res)
 
     def test_local_identifier(self):


### PR DESCRIPTION
`invalid_chains` finds the "dependency" chains from a top-level package to any missing dependencies. In #2415 a report of infinite recursion was reported. This is fixed here; and while fixing, I cleaned up the error messages.