### PR TITLE
Fixes #2570, further cleanup of dist formatting

### DIFF
--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -148,7 +148,7 @@ def list_packages(prefix, installed, regex=None, format='human',
             result.append(disp)
         except (AttributeError, IOError, KeyError, ValueError) as e:
             log.debug(str(e))
-            result.append('%-25s %-15s %15s' % dist2quad(dist, channel=False))
+            result.append('%-25s %-15s %s' % dist2quad(dist)[:3])
 
     return res, result
 

--- a/conda/history.py
+++ b/conda/history.py
@@ -36,7 +36,9 @@ def pretty_diff(diff):
     removed = {}
     for s in diff:
         fn = s[1:]
-        name, version, unused_build = dist2quad(fn, channel=False)
+        name, version, _, channel = dist2quad(fn)
+        if channel != 'defaults':
+            version += ' (%s)' % channel
         if s.startswith('-'):
             removed[name.lower()] = version
         elif s.startswith('+'):
@@ -208,11 +210,11 @@ class History(object):
             removed = {}
             if is_diff(content):
                 for pkg in content:
-                    name, version, build = dist2quad(pkg[1:], channel=False)
+                    name, version, build, channel = dist2quad(pkg[1:])
                     if pkg.startswith('+'):
-                        added[name.lower()] = (version, build)
+                        added[name.lower()] = (version, build, channel)
                     elif pkg.startswith('-'):
-                        removed[name.lower()] = (version, build)
+                        removed[name.lower()] = (version, build, channel)
 
                 changed = set(added) & set(removed)
                 for name in sorted(changed):

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -284,7 +284,7 @@ def ensure_linked_actions(dists, prefix, index=None, force=False, always_copy=Fa
         if not extracted_in and not fetched_in:
             # If there is a cache conflict, clean it up
             fetched_in, conflict = install.find_new_location(dist)
-            fetched_in = join(fetched_in, install._dist2filename(dist))
+            fetched_in = join(fetched_in, install.dist2filename(dist))
             if conflict is not None:
                 actions[inst.RM_FETCHED].append(conflict)
             actions[inst.FETCH].append(dist)
@@ -340,7 +340,8 @@ def add_defaults_to_specs(r, linked, specs, update=False):
     if r.explicit(specs):
         return
     log.debug('H0 specs=%r' % specs)
-    names_linked = {install.name_dist(dist): dist for dist in linked}
+    linked = [fn if fn.endswith('.tar.bz2') else fn + '.tar.bz2' for fn in linked]
+    names_linked = {r.index[fn]['name']: fn for fn in linked}
     names_ms = {MatchSpec(s).name: MatchSpec(s) for s in specs}
 
     for name, def_ver in [('python', default_python),
@@ -376,7 +377,7 @@ def add_defaults_to_specs(r, linked, specs, update=False):
             # if Python/Numpy is already linked, we add that instead of the
             # default
             log.debug('H3 %s' % name)
-            fkey = names_linked[name] + '.tar.bz2'
+            fkey = names_linked[name]
             info = r.index[fkey]
             ver = '.'.join(info['version'].split('.', 2)[:2])
             spec = '%s %s*' % (info['name'], ver)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -306,7 +306,7 @@ class Resolve(object):
             groups.setdefault(info['name'], []).append(fkey)
             for feat in info.get('track_features', '').split():
                 trackers.setdefault(feat, []).append(fkey)
-            if 'link' in info:
+            if 'link' in info and not fkey.endswith(']'):
                 installed.add(fkey)
 
         self.groups = groups


### PR DESCRIPTION
Addresses #2570 and #2569, which is actually a continuation of the problem encountered in #2559 that I attempted to address in #2562.

Technically both #2570 and #2569 would go a way with the one-line fix in resolve.py included here. But in the process of studying the formatting issue in #2569 I realized that further cleanup of the dist string processing would be necessary, so that is included here as well.