### PR TITLE
deactivate.bat: Use full path for Windows find.exe

### DIFF
--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -3,7 +3,7 @@
 @REM   For debugging, remove the @ on the section you need to study.
 @SETLOCAL
 
-@CALL ECHO "%~1"| @FIND /I "-h" 1>NUL
+@CALL ECHO "%~1"| @%SystemRoot%\System32\find.exe /I "-h" 1>NUL
 @IF NOT ERRORLEVEL 1 (
     @call "%~dp0\..\Scripts\conda.exe" ..deactivate -h
 ) else (


### PR DESCRIPTION
Otherwise other find executables such as GNU find may
get found and the parameters won't be understood.

GNU find returns:
FIND: unknown predicate `-h'
.. and therefore `conda ..deactivate -h` does not get called.

Note, we explicitly using `System32` here, but that's the
right thing to do since Windows substitutes this for `SysWOW64`
at a low level when appropriate.

Also use the correct case for find.exe since it is possible
(but uncommon) to run the Windows kernel case-sensitively.