### PR TITLE
Basic fixes for add_defaults_to_specs

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -340,35 +340,30 @@ def add_defaults_to_specs(r, linked, specs, update=False):
     if r.explicit(specs):
         return
     log.debug('H0 specs=%r' % specs)
-    linked = [fn if fn.endswith('.tar.bz2') else fn + '.tar.bz2' for fn in linked]
-    names_linked = {r.index[fn]['name']: fn for fn in linked}
-    names_ms = {MatchSpec(s).name: MatchSpec(s) for s in specs}
+    names_linked = {install.name_dist(dist): dist for dist in linked}
+    mspecs = list(map(MatchSpec, specs))
 
     for name, def_ver in [('python', default_python),
                           # Default version required, but only used for Python
                           ('lua', None)]:
-        ms = names_ms.get(name)
-        if ms and not ms.is_simple():
+        if any(s.name == name and not s.is_simple() for s in mspecs):
             # if any of the specifications mention the Python/Numpy version,
             # we don't need to add the default spec
             log.debug('H1 %s' % name)
             continue
 
-        any_depends_on = any(ms2.name == name
-                             for spec in specs
-                             for fn in r.find_matches(spec)
-                             for ms2 in r.ms_depends(fn))
+        depends_on = {s for s in mspecs if r.depends_on(s, name)}
+        any_depends_on = bool(depends_on)
         log.debug('H2 %s %s' % (name, any_depends_on))
 
-        if not any_depends_on and name not in names_ms:
+        if not any_depends_on:
             # if nothing depends on Python/Numpy AND the Python/Numpy is not
             # specified, we don't need to add the default spec
             log.debug('H2A %s' % name)
             continue
 
-        if (any_depends_on and len(specs) >= 1 and
-                MatchSpec(specs[0]).is_exact()):
-            # if something depends on Python/Numpy, but the spec is very
+        if any(s.is_exact() for s in depends_on):
+            # If something depends on Python/Numpy, but the spec is very
             # explicit, we also don't need to add the default spec
             log.debug('H2B %s' % name)
             continue
@@ -377,7 +372,7 @@ def add_defaults_to_specs(r, linked, specs, update=False):
             # if Python/Numpy is already linked, we add that instead of the
             # default
             log.debug('H3 %s' % name)
-            fkey = names_linked[name]
+            fkey = names_linked[name] + '.tar.bz2'
             info = r.index[fkey]
             ver = '.'.join(info['version'].split('.', 2)[:2])
             spec = '%s %s*' % (info['name'], ver)
@@ -386,13 +381,13 @@ def add_defaults_to_specs(r, linked, specs, update=False):
             specs.append(spec)
             continue
 
-        if (name, def_ver) in [('python', '3.3'), ('python', '3.4'),
-                               ('python', '3.5')]:
+        if name == 'python' and def_ver.startswith('3.'):
             # Don't include Python 3 in the specs if this is the Python 3
             # version of conda.
             continue
 
-        specs.append('%s %s*' % (name, def_ver))
+        if def_ver is not None:
+            specs.append('%s %s*' % (name, def_ver))
     log.debug('HF specs=%r' % specs)
 
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -634,6 +634,20 @@ class Resolve(object):
             self.ms_depends_[fkey] = deps
         return deps
 
+    def depends_on(self, spec, target):
+        touched = set()
+
+        def depends_on_(spec):
+            if spec.name == target:
+                return True
+            if spec.name in touched:
+                return False
+            touched.add(spec.name)
+            return any(depends_on_(ms)
+                       for fn in self.find_matches(spec)
+                       for ms in self.ms_depends(fn))
+        return depends_on_(MatchSpec(spec))
+
     def version_key(self, fkey, vtype=None):
         rec = self.index[fkey]
         cpri = -rec.get('priority', 1)


### PR DESCRIPTION
An initial attempt to address #2572 revealed several issues:

- [Lines 368-369](https://github.com/conda/conda/blob/6c19525611c8fd4f4f02bad3ff752931860fd637/conda/plan.py#L368-L369): why just look at `specs[0]`?
- [Lines 388-389](https://github.com/conda/conda/blob/6c19525611c8fd4f4f02bad3ff752931860fd637/conda/plan.py#L388-L389): we should make this independent of the minor version of Python
- [Line 394](https://github.com/conda/conda/blob/6c19525611c8fd4f4f02bad3ff752931860fd637/conda/plan.py#L394) This needs to be skipped for `lua`, otherwise we end up inserting `lua None*` as a spec.

Another issue _not_ addressed by this PR is in [lines 356-359](https://github.com/conda/conda/blob/6c19525611c8fd4f4f02bad3ff752931860fd637/conda/plan.py#L394): this only scans the first layer of dependencies for a given package. If Python is an implicit dependency (a couple of layers deep in the dependency tree), this won't catch it.

Furthermore I'm concerned that lines 388-389, even as fixed, are insufficient. It strikes me as too strict. For instance, if I have `python >=3` in my spec list, this won't be strong enough for that logic, and `python 2.7*` would be added as well. 

Despite these concerns I believe we should merge this simple fix, because it fixes genuinely incorrect behavior in #2572, and discuss more in-depth changes carefully.

