### PR TITLE
install: Make move_to_trash less frightening

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,7 +5,7 @@ import stat
 import tempfile
 import unittest
 from sys import platform
-from os.path import join, basename
+from os.path import join, basename, relpath, exists
 from os import makedirs, walk
 
 import pytest
@@ -135,6 +135,16 @@ class FileTests(unittest.TestCase):
         contents = [basename(dp) for dp, dn, fn in walk(trash)]
         self.assertTrue(longfoldername not in contents)
 
+    def test_trash_outside_prefix(self):
+        from conda.config import root_dir
+        tmp_dir = tempfile.mkdtemp()
+        rel = relpath(tmp_dir, root_dir)
+        self.assertTrue(rel.startswith(u'..'))
+        move_path_to_trash(tmp_dir)
+        self.assertFalse(exists(tmp_dir))
+        makedirs(tmp_dir)
+        move_path_to_trash(tmp_dir)
+        self.assertFalse(exists(tmp_dir))
 
 class remove_readonly_TestCase(unittest.TestCase):
     def test_takes_three_args(self):


### PR DESCRIPTION
The relpath() calculation was only added as a debugging aid in
56539d, but it made a dangerous assumption that the path being
trashed was a subfolder of the root environment.

Now, people have been using it with folders that are not in the
same hierarchy at all and this leads to escaping the .trash dir
(and potentially the root prefix) so here we guard against this
security issue.

To do so, we normalize and remove any leading '..' from the path.
This has a nice side effect of preventing *any* '..' from making
their way to the final UNC trash path, which is required because
UNC paths must be absolute and normalized for Windows to process
them.

.. which fixes:
  https://github.com/conda/conda/issues/2582

.. and gets to the bottom of the code smell in:
  https://github.com/conda/conda/issues/2579