### PR TITLE
merge 4.0.x to master after 4.0.8

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+2016-06-03   4.0.8:
+-------------------
+  * fix a potential problem with moving files to trash, #2587
+
+
 2016-05-26   4.0.7:
 -------------------
   * workaround for boto bug, #2380

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,21 +14,21 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34_32"
-      PYTHON_VERSION: "3.4"
+    # - PYTHON: "C:\\Python34_32"
+    #   PYTHON_VERSION: "3.4"
+    #   PYTHON_ARCH: "32"
+
+    # - PYTHON: "C:\\Python34_64"
+    #   PYTHON_VERSION: "3.4"
+    #   PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35_32"
+      PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python34_64"
-      PYTHON_VERSION: "3.4"
+    - PYTHON: "C:\\Python35_64"
+      PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
-
-#    - PYTHON: "C:\\Python35_32"
-#      PYTHON_VERSION: "3.5"
-#      PYTHON_ARCH: "32"
-#
-#    - PYTHON: "C:\\Python35_64"
-#      PYTHON_VERSION: "3.5"
-#      PYTHON_ARCH: "64"
 
 init:
   - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %HOME%
@@ -36,21 +36,23 @@ init:
 install:
   # - utils/win_build_env.cmd
   - powershell ./utils/install.ps1
-  - set PATH=%HOME%/miniconda;%HOME%/miniconda/Scripts;%$HOME%/miniconda/Library/bin;%PATH%
+  # - set PATH=%HOME%/miniconda;%HOME%/miniconda/Scripts;%$HOME%/miniconda/Library/bin;%PATH%
+  - set PATH=%PYTHON%;%PYTHON%/Scripts;%$PYTHON%/Library/bin;%PATH%
   - conda info
   - conda config --set always_yes yes
-  - conda install --force --no-deps conda requests
+  - conda install --force --no-deps conda psutil ruamel_yaml requests
   # - conda info python
   - python -c "import sys; print(sys.version)"
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
-  - conda install python=%PYTHON_VERSION%
-  - conda install -c conda pytest requests mock pycrypto pyflakes pycosat
-  - conda install pip
-  - pip install auxlib flake8 pytest-cov
+  - conda install -q python=%PYTHON_VERSION%
+  - conda install -q pytest requests mock
+  - conda install -q pycrypto pyflakes pycosat
+  - conda install -q git git
+  - pip install auxlib flake8 pytest-cov pytest-timeout
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
-  - python setup.py install
+  - python setup.py install --old-and-unmanageable
 
 
 # Not a .NET project, we build scikit-image in the install step instead

--- a/conda/install.py
+++ b/conda/install.py
@@ -39,7 +39,8 @@ import sys
 import tarfile
 import time
 import traceback
-from os.path import abspath, basename, dirname, isdir, isfile, islink, join, relpath
+from os.path import (abspath, basename, dirname, isdir, isfile, islink, join,
+                     relpath, normpath)
 
 try:
     from conda.lock import Locked

--- a/conda/install.py
+++ b/conda/install.py
@@ -545,6 +545,21 @@ def _get_trash_dir(pkg_dir):
     unc_prefix = u'\\\\?\\' if sys.platform == 'win32' else ''
     return unc_prefix + join(pkg_dir, '.trash')
 
+
+def _safe_relpath(path, start_path):
+    """
+    Used in the move_to_trash flow. Ensures that the result does not
+    start with any '..' which would allow to escape the trash folder
+    (and root prefix) and potentially ruin the user's system.
+    """
+    result = normpath(relpath(path, start_path))
+    parts = result.rsplit(os.sep)
+    for idx, part in enumerate(parts):
+        if part != u'..':
+            return os.sep.join(parts[idx:])
+    return u''
+
+
 def delete_trash(prefix=None):
     from conda import config
     for pkg_dir in config.pkgs_dirs:
@@ -557,7 +572,7 @@ def delete_trash(prefix=None):
 
 def move_to_trash(prefix, f, tempdir=None):
     """
-    Move a file f from prefix to the trash
+    Move a file or folder f from prefix to the trash
 
     tempdir is a deprecated parameter, and will be ignored.
 
@@ -585,7 +600,7 @@ def move_path_to_trash(path):
                 continue
 
         trash_dir = tempfile.mkdtemp(dir=trash_dir)
-        trash_dir = join(trash_dir, relpath(os.path.dirname(path), config.root_dir))
+        trash_dir = join(trash_dir, _safe_relpath(os.path.dirname(path), config.root_dir))
 
         try:
             os.makedirs(trash_dir)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,7 +5,7 @@ import stat
 import tempfile
 import unittest
 from sys import platform
-from os.path import join, basename
+from os.path import join, basename, relpath, exists
 from os import makedirs, walk
 
 
@@ -120,6 +120,18 @@ class FileTests(unittest.TestCase):
         delete_trash(config.pkgs_dirs[0])
         contents = [basename(dp) for dp, dn, fn in walk(trash)]
         self.assertTrue(longfoldername not in contents)
+
+    def test_trash_outside_prefix(self):
+        from conda.config import root_dir
+        tmp_dir = tempfile.mkdtemp()
+        rel = relpath(tmp_dir, root_dir)
+        self.assertTrue(rel.startswith(u'..'))
+        move_path_to_trash(tmp_dir)
+        self.assertFalse(exists(tmp_dir))
+        makedirs(tmp_dir)
+        move_path_to_trash(tmp_dir)
+        self.assertFalse(exists(tmp_dir))
+
 
 class remove_readonly_TestCase(unittest.TestCase):
     def test_takes_three_args(self):


### PR DESCRIPTION
The relpath() calculation was only added as a debugging aid in
56539d, but it made a dangerous assumption that the path being
trashed was a subfolder of the root environment.

Now, people have been using it with folders that are not in the
same hierarchy at all and this leads to escaping the .trash dir
(and potentially the root prefix) so here we guard against this
security issue.

To do so, we normalize and remove any leading '..' from the path.
This has a nice side effect of preventing *any* '..' from making
their way to the final UNC trash path, which is required because
UNC paths must be absolute and normalized for Windows to process
them.

.. which fixes:
  https://github.com/conda/conda/issues/2582

.. and gets to the bottom of the code smell in:
  https://github.com/conda/conda/issues/2579