### PR TITLE
Fix #2596: Properly handle absence of package directory

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -689,8 +689,9 @@ def package_cache():
                     add_cached_package(pdir, url)
         except IOError:
             pass
-        for fn in os.listdir(pdir):
-            add_cached_package(pdir, fn)
+        if isdir(pdir):
+            for fn in os.listdir(pdir):
+                add_cached_package(pdir, fn)
     del package_cache_['@']
     return package_cache_
 


### PR DESCRIPTION
The new package cache logic fails if the package directory does not exist; see #2596