### PR TITLE
Eliminate unnecessary python updates

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -375,9 +375,7 @@ def add_defaults_to_specs(r, linked, specs, update=False):
             fkey = names_linked[name] + '.tar.bz2'
             info = r.index[fkey]
             ver = '.'.join(info['version'].split('.', 2)[:2])
-            spec = '%s %s*' % (info['name'], ver)
-            if update:
-                spec += ' (target=%s)' % fkey
+            spec = '%s %s* (target=%s)' % (info['name'], ver, fkey)
             specs.append(spec)
             continue
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -935,9 +935,8 @@ class Resolve(object):
         return specs, preserve
 
     def install(self, specs, installed=None, update_deps=True, returnall=False):
-        len0 = len(specs)
         specs, preserve = self.install_specs(specs, installed or [], update_deps)
-        pkgs = self.solve(specs, len0=len0, returnall=returnall)
+        pkgs = self.solve(specs, returnall=returnall)
         self.restore_bad(pkgs, preserve)
         return pkgs
 
@@ -966,15 +965,14 @@ class Resolve(object):
         self.restore_bad(pkgs, preserve)
         return pkgs
 
-    def solve(self, specs, len0=None, returnall=False):
+    def solve(self, specs, returnall=False):
         try:
             stdoutlog.info("Solving package specifications ...")
             dotlog.debug("Solving for %s" % (specs,))
 
             # Find the compliant packages
+            len0 = len(specs)
             specs = list(map(MatchSpec, specs))
-            if len0 is None:
-                len0 = len(specs)
             dists, new_specs = self.get_dists(specs)
             if not dists:
                 return False if dists is None else ([[]] if returnall else [])
@@ -1003,7 +1001,7 @@ class Resolve(object):
                 if s.name in specm:
                     specm.remove(s.name)
                 if not s.optional:
-                    (specr if k < len0 else speca).append(s)
+                    (speca if s.target or k > len0 else specr).append(s)
                 elif any(r2.find_matches(s)):
                     s = MatchSpec(s.name, optional=True, target=s.target)
                     speco.append(s)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -228,7 +228,7 @@ The following packages will be DOWNGRADED:
     assert c.stdout == """
 The following NEW packages will be INSTALLED:
 
-    numpy:    1.7.1-py33_0 \n\
+    numpy:    1.7.1-py33_0
 
 The following packages will be REMOVED:
 
@@ -375,7 +375,7 @@ The following packages will be DOWNGRADED:
     assert c.stdout == """
 The following NEW packages will be INSTALLED:
 
-    numpy:    1.7.1-py33_0  <unknown>
+    numpy:    1.7.1-py33_0 <unknown>
 
 The following packages will be REMOVED:
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -85,6 +85,7 @@ class TestAddDeaultsToSpec(unittest.TestCase):
     def check(self, specs, added):
         new_specs = list(specs + added)
         plan.add_defaults_to_specs(r, self.linked, specs)
+        specs = [s.split(' (')[0] for s in specs]
         self.assertEqual(specs, new_specs)
 
     def test_1(self):

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -67,6 +67,9 @@ class TestMatchSpec(unittest.TestCase):
         self.assertTrue(m2.spec == m3.spec and m2.optional == m3.optional and m2.target != m3.target)
         self.assertTrue(m == m4)
 
+        self.assertRaises(ValueError, MatchSpec, 'blas (optional')
+        self.assertRaises(ValueError, MatchSpec, 'blas (optional,test)')
+
     def test_to_filename(self):
         ms = MatchSpec('foo 1.7 52')
         self.assertEqual(ms.to_filename(), 'foo-1.7-52.tar.bz2')


### PR DESCRIPTION
Try this:
```
conda create -n test -c conda-forge python=3.5
conda install -n test decorator
```
(There's nothing special about `decorator`; any package will do.) On master, this will cause the `conda-forge` version of Python to be replaced with defaults, but there's no need for this. Furthermore, it _says_ it is replacing the conda-forge Python with... conda-forge Python. That's just a printing error, but it will be fixed in the second commit.