### PR TITLE
create some create tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,4 @@
 coverage:
-  precision: 3
+  precision: 2
   round: nearest
   range: 60...100

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -244,14 +244,15 @@ def human_bytes(n):
     return '%.2f GB' % g
 
 
-@memoized
+# @memoized
 def find_parent_shell(path=False):
     """return process name or path of parent.  Default is to return only name of process."""
     try:
         import psutil
     except ImportError:
-        sys.exit("No psutil available.\n"
-                 "To proceed, please conda install psutil")
+        # sys.exit("No psutil available.\n"
+        #          "To proceed, please conda install psutil")
+        return None
     process = psutil.Process()
     while "conda" in process.parent().name():
         process = process.parent()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -38,6 +38,7 @@ def raises(exception, func, string=None):
 
 
 def run_conda_command(*args):
+    # used in tests_config (31 times) and test_info (6 times)
     env = os.environ.copy()
     p = subprocess.Popen((sys.executable, "-m", "conda") + args, stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE, env=env)
@@ -83,6 +84,7 @@ def captured(disallow_stderr=True):
 
 
 def capture_with_argv(*argv):
+    # only used in capture_json_with_argv()
     sys.argv = argv
     stdout, stderr = StringIO(), StringIO()
     oldstdout, oldstderr = sys.stdout, sys.stderr
@@ -108,6 +110,7 @@ def capture_with_argv(*argv):
 
 
 def capture_json_with_argv(*argv, **kwargs):
+    # used in test_config (6 times), test_info (2 times), test_list (5 times), and test_search (10 times)
     stdout, stderr = capture_with_argv(*argv)
 
     if kwargs.get('relaxed'):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,6 @@ import pytest
 
 import conda.config as config
 from conda.utils import get_yaml
-from conda.compat import iterkeys
 
 from tests.helpers import run_conda_command
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -60,11 +60,11 @@ def test_just_python2():
         assert os.path.exists(os.path.join(env_path, 'bin/python2'))
 
 
-# @pytest.mark.timeout(600)
-# def test_python2_anaconda():
-#     with make_env("python=2 anaconda") as env_path:
-#         assert os.path.isfile(os.path.join(env_path, 'bin/python2'))
-#         assert os.path.isfile(os.path.join(env_path, 'bin/numba'))
+@pytest.mark.timeout(600)
+def test_python2_anaconda():
+    with make_env("python=2 anaconda") as env_path:
+        assert os.path.isfile(os.path.join(env_path, 'bin/python2'))
+        assert os.path.isfile(os.path.join(env_path, 'bin/numba'))
 
 
 if __name__ == '__main__':

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -58,14 +58,14 @@ def make_env(*packages):
 def test_just_python():
     with make_env("python") as env_path:
         os.system('ls -al {0}'.format(os.path.join(env_path, 'bin')))
-        assert os.path.isfile(os.path.join(env_path, 'bin/python3'))
+        assert os.path.exists(os.path.join(env_path, 'bin/python3'))
 
 
 @pytest.mark.timeout(600)
 def test_just_python2():
     with make_env("python=2") as env_path:
         os.system('ls -al {0}'.format(os.path.join(env_path, 'bin')))
-        assert os.path.isfile(os.path.join(env_path, 'bin/python2'))
+        assert os.path.exists(os.path.join(env_path, 'bin/python2'))
 
 
 # @pytest.mark.timeout(600)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -48,23 +48,15 @@ def make_env(*packages):
         print(env_path)
 
 
-# def test_config():
-#     from conda import config
-#     assert config.changeps1, config.changeps1
-#     config.rc = config.load_condarc('')
-#     assert not config.get_proxy_servers(), config.get_proxy_servers()
-
 @pytest.mark.timeout(600)
-def test_just_python():
-    with make_env("python") as env_path:
-        os.system('ls -al {0}'.format(os.path.join(env_path, 'bin')))
+def test_just_python3():
+    with make_env("python=3") as env_path:
         assert os.path.exists(os.path.join(env_path, 'bin/python3'))
 
 
 @pytest.mark.timeout(600)
 def test_just_python2():
     with make_env("python=2") as env_path:
-        os.system('ls -al {0}'.format(os.path.join(env_path, 'bin')))
         assert os.path.exists(os.path.join(env_path, 'bin/python2'))
 
 
@@ -76,6 +68,6 @@ def test_just_python2():
 
 
 if __name__ == '__main__':
-    test_just_python()
+    test_just_python3()
     test_just_python2()
     # test_python2_anaconda()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+import pytest
+from contextlib import contextmanager
+import os
+from logging import getLogger
+from shlex import split
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from conda.cli import conda_argparse
+from conda.cli.main_create import configure_parser
+from conda import config
+
+log = getLogger(__name__)
+
+
+@contextmanager
+def make_env(*packages):
+    try:
+        # try to clear any config that's been set by other tests
+        config.rc = config.load_condarc('')
+
+        env_path = mkdtemp()
+        try:
+            rmtree(env_path)  # rm here because create complains if directory exists
+        except OSError as e:
+            print("OSError", e)
+        if not os.path.exists(os.path.dirname(env_path)):
+            os.mkdir(os.path.dirname(env_path))
+
+        p = conda_argparse.ArgumentParser()
+        sub_parsers = p.add_subparsers(metavar='command', dest='cmd')
+        configure_parser(sub_parsers)
+
+        command = "create -p {0} {1}".format(env_path, " ".join(packages))
+
+        args = p.parse_args(split(command))
+        args.func(args, p)
+
+        yield env_path
+    finally:
+        try:
+            rmtree(env_path)
+        except OSError:
+            print("{0} does not exist".format(env_path))
+        print(env_path)
+
+
+# def test_config():
+#     from conda import config
+#     assert config.changeps1, config.changeps1
+#     config.rc = config.load_condarc('')
+#     assert not config.get_proxy_servers(), config.get_proxy_servers()
+
+@pytest.mark.timeout(600)
+def test_just_python():
+    with make_env("python") as env_path:
+        os.system('ls -al {0}'.format(os.path.join(env_path, 'bin')))
+        assert os.path.isfile(os.path.join(env_path, 'bin/python3'))
+
+
+@pytest.mark.timeout(600)
+def test_just_python2():
+    with make_env("python=2") as env_path:
+        os.system('ls -al {0}'.format(os.path.join(env_path, 'bin')))
+        assert os.path.isfile(os.path.join(env_path, 'bin/python2'))
+
+
+# @pytest.mark.timeout(600)
+# def test_python2_anaconda():
+#     with make_env("python=2 anaconda") as env_path:
+#         assert os.path.isfile(os.path.join(env_path, 'bin/python2'))
+#         assert os.path.isfile(os.path.join(env_path, 'bin/numba'))
+
+
+if __name__ == '__main__':
+    test_just_python()
+    test_just_python2()
+    # test_python2_anaconda()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,35 +1,41 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-import pytest
 from contextlib import contextmanager
-import os
 from logging import getLogger
+from os.path import exists, isdir, isfile, join
 from shlex import split
 from shutil import rmtree
-from tempfile import mkdtemp
+from tempfile import gettempdir
+from uuid import uuid1
 
+import pytest
+
+from conda import config
 from conda.cli import conda_argparse
 from conda.cli.main_create import configure_parser
-from conda import config
 
 log = getLogger(__name__)
 
 
+def make_temp_env_path():
+    tempdir = gettempdir()
+    dirname = str(uuid1())[:8]
+    env_path = join(tempdir, dirname)
+    if exists(env_path):
+        # rm here because create complains if directory exists
+        rmtree(env_path)
+    assert isdir(tempdir)
+    return env_path
+
+
 @contextmanager
-def make_env(*packages):
+def make_temp_env(*packages):
+    env_path = make_temp_env_path()
     try:
         # try to clear any config that's been set by other tests
         config.rc = config.load_condarc('')
-
-        env_path = mkdtemp()
-        try:
-            rmtree(env_path)  # rm here because create complains if directory exists
-        except OSError as e:
-            print("OSError", e)
-        if not os.path.exists(os.path.dirname(env_path)):
-            os.mkdir(os.path.dirname(env_path))
-
+        
         p = conda_argparse.ArgumentParser()
         sub_parsers = p.add_subparsers(metavar='command', dest='cmd')
         configure_parser(sub_parsers)
@@ -41,33 +47,28 @@ def make_env(*packages):
 
         yield env_path
     finally:
-        try:
-            rmtree(env_path)
-        except OSError:
-            print("{0} does not exist".format(env_path))
-        print(env_path)
+        rmtree(env_path, ignore_errors=True)
 
 
 @pytest.mark.timeout(600)
 def test_just_python3():
-    with make_env("python=3") as env_path:
-        assert os.path.exists(os.path.join(env_path, 'bin/python3'))
+    with make_temp_env("python=3") as env_path:
+        assert exists(join(env_path, 'bin/python3'))
 
 
 @pytest.mark.timeout(600)
 def test_just_python2():
-    with make_env("python=2") as env_path:
-        assert os.path.exists(os.path.join(env_path, 'bin/python2'))
+    with make_temp_env("python=2") as env_path:
+        assert exists(join(env_path, 'bin/python2'))
 
 
 @pytest.mark.timeout(600)
 def test_python2_anaconda():
-    with make_env("python=2 anaconda") as env_path:
-        assert os.path.isfile(os.path.join(env_path, 'bin/python2'))
-        assert os.path.isfile(os.path.join(env_path, 'bin/numba'))
+    with make_temp_env("python=2 anaconda") as env_path:
+        assert isfile(join(env_path, 'bin/python2'))
+        assert isfile(join(env_path, 'bin/numba'))
 
 
 if __name__ == '__main__':
     test_just_python3()
     test_just_python2()
-    # test_python2_anaconda()


### PR DESCRIPTION
This PR contains a simple, an in-process integration test framework for conda installs.  Right now, all relevant code is in the new `tests/test_create.py` file.  The framework right now is limited to a one-shot `conda create ...` call.  In the future, I'll extend it to be able to run additional `conda install ...` calls within the temporary environment.

CC @mcg1969 