### PR TITLE
add --shortcuts option that installs shortcuts.  Disables shortcuts b…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
   - conda install -q python=%PYTHON_VERSION%
   - conda install -q pytest requests mock
   - conda install -q pycrypto pyflakes pycosat
-  - conda install -q git git
+  - conda install -q git menuinst
   - pip install auxlib flake8 pytest-cov pytest-timeout
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -308,7 +308,8 @@ environment does not exist: %s
                                           pinned=args.pinned,
                                           always_copy=args.copy,
                                           minimal_hint=args.alt_hint,
-                                          update_deps=args.update_deps)
+                                          update_deps=args.update_deps,
+                                          shortcuts=args.shortcuts)
     except NoPackagesFound as e:
         error_message = e.args[0]
 

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -297,6 +297,8 @@ environment does not exist: %s
                                   json=args.json,
                                   error_type="NoEnvironmentFound")
 
+    shortcuts = args.shortcuts if hasattr(args, "shortcuts") else None
+
     try:
         if isinstall and args.revision:
             actions = revert_actions(prefix, get_revision(args.revision))
@@ -309,7 +311,7 @@ environment does not exist: %s
                                           always_copy=args.copy,
                                           minimal_hint=args.alt_hint,
                                           update_deps=args.update_deps,
-                                          shortcuts=args.shortcuts)
+                                          shortcuts=shortcuts)
     except NoPackagesFound as e:
         error_message = e.args[0]
 

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -5,6 +5,7 @@
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
 from __future__ import print_function, division, absolute_import
+import sys
 
 from .common import add_parser_install, add_parser_json
 from .install import install
@@ -29,6 +30,13 @@ def configure_parser(sub_parsers):
         help=help,
         epilog=example,
     )
+    if sys.platform == "win32":
+        p.add_argument(
+            "--shortcuts",
+            action="store_true",
+            help="Install start menu shortcuts"
+        )
+
     add_parser_install(p)
     add_parser_json(p)
     p.add_argument(

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -5,10 +5,10 @@
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
 from __future__ import print_function, division, absolute_import
-import sys
 
 from .common import add_parser_install, add_parser_json
 from .install import install
+from conda.install import on_win
 
 help = "Create a new conda environment from a list of specified packages. "
 descr = (help +
@@ -30,7 +30,7 @@ def configure_parser(sub_parsers):
         help=help,
         epilog=example,
     )
-    if sys.platform == "win32":
+    if on_win:
         p.add_argument(
             "--shortcuts",
             action="store_true",

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -5,6 +5,7 @@
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
 from __future__ import print_function, division, absolute_import
+import sys
 
 from .common import add_parser_install, add_parser_json
 from .install import install
@@ -53,6 +54,12 @@ def configure_parser(sub_parsers):
         help="Revert to the specified REVISION.",
         metavar='REVISION',
     )
+    if sys.platform == "win32":
+        p.add_argument(
+            "--shortcuts",
+            action="store_true",
+            help="Install start menu shortcuts"
+        )
     add_parser_install(p)
     add_parser_json(p)
     p.set_defaults(func=execute)

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -5,10 +5,10 @@
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
 from __future__ import print_function, division, absolute_import
-import sys
 
 from .common import add_parser_install, add_parser_json
 from .install import install
+from conda.install import on_win
 
 help = "Installs a list of packages into a specified conda environment."
 descr = help + """
@@ -54,7 +54,7 @@ def configure_parser(sub_parsers):
         help="Revert to the specified REVISION.",
         metavar='REVISION',
     )
-    if sys.platform == "win32":
+    if on_win:
         p.add_argument(
             "--shortcuts",
             action="store_true",

--- a/conda/install.py
+++ b/conda/install.py
@@ -1005,7 +1005,7 @@ def move_path_to_trash(path):
     return False
 
 
-def link(prefix, dist, linktype=LINK_HARD, index=None):
+def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):
     """
     Set up a package in a specified (environment) prefix.  We assume that
     the package has been extracted (using extract() above).
@@ -1065,7 +1065,8 @@ def link(prefix, dist, linktype=LINK_HARD, index=None):
                 sys.exit("ERROR: placeholder '%s' too short in: %s\n" %
                          (placeholder, dist))
 
-        mk_menus(prefix, files, remove=False)
+        if shortcuts:
+            mk_menus(prefix, files, remove=False)
 
         if not run_script(prefix, dist, 'post-link'):
             sys.exit("Error: post-link failed for: %s" % dist)
@@ -1194,6 +1195,13 @@ def main():
     p.add_option('-v', '--verbose',
                  action="store_true")
 
+    if sys.platform == "win32":
+        p.add_argument(
+            "--shortcuts",
+            action="store_true",
+            help="Install start menu shortcuts"
+        )
+
     opts, args = p.parse_args()
     if args:
         p.error('no arguments expected')
@@ -1220,7 +1228,7 @@ def main():
     for dist in idists:
         if opts.verbose:
             print("linking: %s" % dist)
-        link(prefix, dist, linktype)
+        link(prefix, dist, linktype, opts.shortcuts)
 
     messages(prefix)
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -1065,6 +1065,14 @@ def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):
                 sys.exit("ERROR: placeholder '%s' too short in: %s\n" %
                          (placeholder, dist))
 
+        # make sure that the child environment behaves like the parent,
+        #    wrt user/system install on win
+        # This is critical for doing shortcuts correctly
+        if on_win:
+            nonadmin = join(sys.prefix, ".nonadmin")
+            if isfile(nonadmin):
+                open(join(prefix, ".nonadmin"), 'w').close()
+
         if shortcuts:
             mk_menus(prefix, files, remove=False)
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -1104,6 +1104,7 @@ def unlink(prefix, dist):
         run_script(prefix, dist, 'pre-unlink')
 
         meta = load_meta(prefix, dist)
+        # Always try to run this - it should not throw errors where menus do not exist
         mk_menus(prefix, meta['files'], remove=True)
         dst_dirs1 = set()
 

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -71,7 +71,8 @@ def RM_FETCHED_CMD(state, arg):
 def split_linkarg(arg):
     "Return tuple(dist, linktype, shortcuts)"
     parts = arg.split()
-    return parts[0], int(LINK_HARD if len(parts) < 2 else parts[1]), False if len(parts) < 3 else parts[2]=='True'
+    return (parts[0], int(LINK_HARD if len(parts) < 2 else parts[1]),
+            False if len(parts) < 3 else parts[2] == 'True')
 
 
 def LINK_CMD(state, arg):

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -71,7 +71,7 @@ def RM_FETCHED_CMD(state, arg):
 def split_linkarg(arg):
     "Return tuple(dist, linktype, shortcuts)"
     parts = arg.split()
-    return parts[0], int(LINK_HARD if len(parts) < 2 else parts[1]), False if len(parts) < 3 else bool(parts[2])
+    return parts[0], int(LINK_HARD if len(parts) < 2 else parts[1]), False if len(parts) < 3 else parts[2]=='True'
 
 
 def LINK_CMD(state, arg):

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -69,14 +69,14 @@ def RM_FETCHED_CMD(state, arg):
 
 
 def split_linkarg(arg):
-    "Return tuple(dist, linktype)"
+    "Return tuple(dist, linktype, shortcuts)"
     parts = arg.split()
-    return parts[0], int(LINK_HARD if len(parts) < 2 else parts[1])
+    return parts[0], int(LINK_HARD if len(parts) < 2 else parts[1]), False if len(parts) < 3 else bool(parts[2])
 
 
 def LINK_CMD(state, arg):
-    dist, lt = split_linkarg(arg)
-    link(state['prefix'], dist, lt, index=state['index'])
+    dist, lt, shortcuts = split_linkarg(arg)
+    link(state['prefix'], dist, lt, index=state['index'], shortcuts=shortcuts)
 
 
 def UNLINK_CMD(state, arg):

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -92,7 +92,7 @@ def display_actions(actions, index, show_channel_urls=None):
     linktypes = {}
 
     for arg in actions.get(inst.LINK, []):
-        dist, lt = inst.split_linkarg(arg)
+        dist, lt, shortcuts = inst.split_linkarg(arg)
         fkey = dist + '.tar.bz2'
         rec = index[fkey]
         pkg = rec['name']
@@ -102,7 +102,7 @@ def display_actions(actions, index, show_channel_urls=None):
         linktypes[pkg] = lt
         features[pkg][1] = rec.get('features', '')
     for arg in actions.get(inst.UNLINK, []):
-        dist, lt = inst.split_linkarg(arg)
+        dist, lt, shortcuts = inst.split_linkarg(arg)
         fkey = dist + '.tar.bz2'
         rec = index.get(fkey)
         if rec is None:
@@ -261,7 +261,8 @@ def plan_from_actions(actions):
 
 # force_linked_actions has now been folded into this function, and is enabled by
 # supplying an index and setting force=True
-def ensure_linked_actions(dists, prefix, index=None, force=False, always_copy=False):
+def ensure_linked_actions(dists, prefix, index=None, force=False,
+                          always_copy=False, shortcuts=False):
     actions = defaultdict(list)
     actions[inst.PREFIX] = prefix
     actions['op_order'] = (inst.RM_FETCHED, inst.FETCH, inst.RM_EXTRACTED,
@@ -325,9 +326,9 @@ def ensure_linked_actions(dists, prefix, index=None, force=False, always_copy=Fa
                 lt = LINK_SOFT
             else:
                 lt = LINK_COPY
-            actions[inst.LINK].append('%s %d' % (dist, lt))
+            actions[inst.LINK].append('%s %d %s' % (dist, lt, shortcuts))
         except (OSError, IOError):
-            actions[inst.LINK].append(dist)
+            actions[inst.LINK].append(dist, LINK_COPY, shortcuts)
         finally:
             if not extracted_in:
                 # Remove the dummy data
@@ -409,7 +410,8 @@ def get_pinned_specs(prefix):
         return [i for i in f.read().strip().splitlines() if i and not i.strip().startswith('#')]
 
 def install_actions(prefix, index, specs, force=False, only_names=None, always_copy=False,
-                    pinned=True, minimal_hint=False, update_deps=True, prune=False):
+                    pinned=True, minimal_hint=False, update_deps=True, prune=False,
+                    shortcuts=False):
     r = Resolve(index)
     linked = r.installed
 
@@ -453,7 +455,8 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
     actions = ensure_linked_actions(
         smh, prefix,
         index=index if force else None,
-        force=force, always_copy=always_copy)
+        force=force, always_copy=always_copy,
+        shortcuts=shortcuts)
 
     if actions[inst.LINK]:
         actions[inst.SYMLINK_CONDA] = [root_dir]

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -256,6 +256,7 @@ def plan_from_actions(actions):
             res.append((inst.PROGRESS, '%d' % len(actions[op])))
         for arg in actions[op]:
             res.append((op, arg))
+
     return res
 
 
@@ -327,6 +328,7 @@ def ensure_linked_actions(dists, prefix, index=None, force=False,
             else:
                 lt = LINK_COPY
             actions[inst.LINK].append('%s %d %s' % (dist, lt, shortcuts))
+
         except (OSError, IOError):
             actions[inst.LINK].append(dist, LINK_COPY, shortcuts)
         finally:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -5,7 +5,8 @@ from contextlib import contextmanager
 from glob import glob
 import json
 from logging import getLogger, Handler
-from os.path import exists, isdir, join, relpath
+from os.path import exists, isdir, isfile, join, relpath
+import os
 from shlex import split
 from shutil import rmtree, copyfile
 import subprocess
@@ -14,7 +15,6 @@ from tempfile import gettempdir
 from unittest import TestCase
 from uuid import uuid4
 
-from menuinst.win32 import dirs as win_locations
 import pytest
 
 from conda import config
@@ -228,6 +228,7 @@ class IntegrationTests(TestCase):
 
 @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
 def test_shortcut_in_underscore_env_shows_message():
+    from menuinst.win32 import dirs as win_locations
     with TemporaryDirectory() as tmp:
         cmd = ["conda", "create", '-y', '--shortcuts', '-p', join(tmp, '_conda'), "console_shortcut"]
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -239,6 +240,7 @@ def test_shortcut_in_underscore_env_shows_message():
 
 @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
 def test_shortcut_not_attempted_without_shortcuts_arg():
+    from menuinst.win32 import dirs as win_locations
     with TemporaryDirectory() as tmp:
         cmd = ["conda", "create", '-y', '-p', join(tmp, '_conda'), "console_shortcut"]
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -252,6 +254,7 @@ def test_shortcut_not_attempted_without_shortcuts_arg():
 
 @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
 def test_shortcut_creation_installs_shortcut():
+    from menuinst.win32 import dirs as win_locations
     with TemporaryDirectory() as tmp:
         subprocess.check_call(["conda", "create", '-y', '--shortcuts', '-p',
                                join(tmp, 'conda'), "console_shortcut"])
@@ -267,11 +270,13 @@ def test_shortcut_creation_installs_shortcut():
         try:
             assert not isfile(shortcut_file)
         finally:
-            os.remove(shortcut_file)
+            if isfile(shortcut_file):
+                os.remove(shortcut_file)
 
 
 @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
 def test_shortcut_absent_does_not_barf_on_uninstall():
+    from menuinst.win32 import dirs as win_locations
     with TemporaryDirectory() as tmp:
         # not including --shortcuts, should not get shortcuts installed
         subprocess.check_call(["conda", "create", '-y', '-p', join(tmp, 'conda'), "console_shortcut"])

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -284,19 +284,23 @@ def test_shortcut_creation_installs_shortcut():
 def test_shortcut_absent_does_not_barf_on_uninstall():
     from menuinst.win32 import dirs as win_locations
 
-    if isfile(shortcut_file):
-        os.remove(shortcut_file)
-
     user_mode = 'user' if exists(join(sys.prefix, u'.nonadmin')) else 'system'
     shortcut_dir = win_locations[user_mode]["start"]
     shortcut_dir = join(shortcut_dir, "Anaconda{} ({}-bit)".format(sys.version_info.major, config.bits))
-    assert not isfile(join(shortcut_dir, "Anaconda Prompt (conda).lnk"))
+    shortcut_file = join(shortcut_dir, "Anaconda Prompt (conda).lnk")
+
+    # kill shortcut from any other misbehaving test
+    if isfile(shortcut_file):
+        os.remove(shortcut_file)
+
+    assert not isfile(shortcut_file)
 
     with TemporaryDirectory() as tmp:
         # not including --shortcuts, should not get shortcuts installed
         subprocess.check_call(["conda", "create", '-y', '-p', join(tmp, 'conda'), "console_shortcut"])
 
-        assert not isfile(join(shortcut_dir, "Anaconda Prompt (conda).lnk"))
+        # make sure it didn't get created
+        assert not isfile(shortcut_file)
 
         # make sure that cleanup does not barf trying to remove non-existent shortcuts
         subprocess.check_call(["conda", "remove", '-y', '-p', join(tmp, 'conda'), "console_shortcut"])

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,17 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-import pytest
-import json
 from contextlib import contextmanager
 from glob import glob
+import json
 from logging import getLogger, Handler
 from os.path import exists, isdir, join, relpath
 from shlex import split
 from shutil import rmtree, copyfile
+import subprocess
+import sys
 from tempfile import gettempdir
 from unittest import TestCase
 from uuid import uuid4
+
+from menuinst.win32 import dirs as win_locations
+import pytest
 
 from conda import config
 from conda.cli import conda_argparse
@@ -22,6 +26,7 @@ from conda.cli.main_update import configure_parser as update_configure_parser
 from conda.config import pkgs_dirs, bits
 from conda.install import linked as install_linked, linked_data_
 from conda.install import on_win
+from conda.compat import PY3, TemporaryDirectory
 
 log = getLogger(__name__)
 PYTHON_BINARY = 'python.exe' if on_win else 'bin/python'
@@ -219,3 +224,62 @@ class IntegrationTests(TestCase):
         with make_temp_env("python=2 pandas") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'numpy')
+
+
+@pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
+def test_shortcut_in_underscore_env_shows_message():
+    with TemporaryDirectory() as tmp:
+        cmd = ["conda", "create", '-y', '--shortcuts', '-p', join(tmp, '_conda'), "console_shortcut"]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, error = p.communicate()
+        if PY3:
+            error = error.decode("UTF-8")
+        assert "Environment name starts with underscore '_'.  Skipping menu installation." in error
+
+
+@pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
+def test_shortcut_not_attempted_without_shortcuts_arg():
+    with TemporaryDirectory() as tmp:
+        cmd = ["conda", "create", '-y', '-p', join(tmp, '_conda'), "console_shortcut"]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, error = p.communicate()
+        if PY3:
+            error = error.decode("UTF-8")
+        # This test is sufficient, because it effectively verifies that the code
+        #  path was not visited.
+        assert "Environment name starts with underscore '_'.  Skipping menu installation." not in error
+
+
+@pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
+def test_shortcut_creation_installs_shortcut():
+    with TemporaryDirectory() as tmp:
+        subprocess.check_call(["conda", "create", '-y', '--shortcuts', '-p',
+                               join(tmp, 'conda'), "console_shortcut"])
+
+        user_mode = 'user' if exists(join(sys.prefix, u'.nonadmin')) else 'system'
+        shortcut_dir = win_locations[user_mode]["start"]
+        shortcut_dir = join(shortcut_dir, "Anaconda{} ({}-bit)".format(sys.version_info.major, config.bits))
+        shortcut_file = join(shortcut_dir, "Anaconda Prompt (conda).lnk")
+        assert isfile(shortcut_file)
+
+        # make sure that cleanup without specifying --shortcuts still removes shortcuts
+        subprocess.check_call(["conda", "remove", '-y', '-p', join(tmp, 'conda'), "console_shortcut"])
+        try:
+            assert not isfile(shortcut_file)
+        finally:
+            os.remove(shortcut_file)
+
+
+@pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
+def test_shortcut_absent_does_not_barf_on_uninstall():
+    with TemporaryDirectory() as tmp:
+        # not including --shortcuts, should not get shortcuts installed
+        subprocess.check_call(["conda", "create", '-y', '-p', join(tmp, 'conda'), "console_shortcut"])
+
+        user_mode = 'user' if exists(join(sys.prefix, u'.nonadmin')) else 'system'
+        shortcut_dir = win_locations[user_mode]["start"]
+        shortcut_dir = join(shortcut_dir, "Anaconda{} ({}-bit)".format(sys.version_info.major, config.bits))
+        assert not isfile(join(shortcut_dir, "Anaconda Prompt (conda).lnk"))
+
+        # make sure that cleanup does not barf trying to remove non-existent shortcuts
+        subprocess.check_call(["conda", "remove", '-y', '-p', join(tmp, 'conda'), "console_shortcut"])

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -36,8 +36,9 @@ class TestMisc(unittest.TestCase):
 
     def test_split_linkarg(self):
         for arg, res in [
-            ('w3-1.2-0', ('w3-1.2-0', LINK_HARD)),
-            ('w3-1.2-0 1', ('w3-1.2-0', 1))]:
+            ('w3-1.2-0', ('w3-1.2-0', LINK_HARD, False)),
+            ('w3-1.2-0 1', ('w3-1.2-0', 1, False)),
+            ('w3-1.2-0 1 True', ('w3-1.2-0', 1, True))]:
             self.assertEqual(inst.split_linkarg(arg), res)
 
 


### PR DESCRIPTION
Purpose here is to provide a --shortcut argument to conda create and conda install that enables shortcut installation.  This replaces the current default of always installing shortcuts, which causes problems on Windows when a system-wide install is given to users - though they may have write permissions to the root conda environment, they can't do the elevation to install shortcuts as all users.

Needs tests.  I'm thinking it should be a test that runs a dummy creation/install with:
    - install console_shortcut package, known to have a shortcut
    - environment starting with _ should have output text about prefix starting with '_', so no shortcuts installed.  This is sufficient to know that the correct code path is exercised.
    - environment not starting with _ should not raise any exceptions.  Do we want to clean up any shortcut files that this would create?

I have not altered removal logic, with the thought that removal can safely always happen - this needs a test, too: install console_shortcut to a prefix without --shortcuts, (shortcuts should not be created), then remove the package with conda remove - any barfs?

Where should these tests go, Kale?   Do you see any way to do these in-process?

@kalefranz @joelhullcio 