### PR TITLE
skip binary replacement on win; force / in replacement prefix on win.

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -372,8 +372,11 @@ def replace_prefix(mode, data, placeholder, new_prefix):
         data = data.replace(placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
     # Skip binary replacement in Windows.  Some files do have prefix information embedded, but
     #    this should not matter, as it is not used for things like RPATH.
-    elif mode == 'binary' and not on_win:
-        data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
+    elif mode == 'binary':
+        if not on_win:
+            data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
+        else:
+            logging.debug("Skipping prefix replacement in binary on Windows")
     else:
         sys.exit("Invalid mode: %s" % mode)
     return data

--- a/conda/install.py
+++ b/conda/install.py
@@ -374,7 +374,7 @@ def replace_prefix(mode, data, placeholder, new_prefix):
     elif mode == 'binary' and sys.platform != "win32":
         data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
     else:
-        sys.exit("Invalid mode:" % mode)
+        sys.exit("Invalid mode: %s" % mode)
     return data
 
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -369,7 +369,9 @@ def replace_long_shebang(mode, data):
 def replace_prefix(mode, data, placeholder, new_prefix):
     if mode == 'text':
         data = data.replace(placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
-    elif mode == 'binary':
+    # Skip binary replacement in Windows.  Some files do have prefix information embedded, but
+    #    this should not matter, as it is not used for things like RPATH.
+    elif mode == 'binary' and sys.platform != "win32":
         data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
     else:
         sys.exit("Invalid mode:" % mode)
@@ -377,8 +379,8 @@ def replace_prefix(mode, data, placeholder, new_prefix):
 
 
 def update_prefix(path, new_prefix, placeholder=prefix_placeholder, mode='text'):
-    if on_win and (placeholder != prefix_placeholder) and ('/' in placeholder):
-        # original prefix uses unix-style path separators
+    if on_win:
+        # force all prefix replacements to forward slashes to simplify need to escape backslashes
         # replace with unix-style path separators
         new_prefix = new_prefix.replace('\\', '/')
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -44,6 +44,9 @@ import traceback
 from os.path import (abspath, basename, dirname, isdir, isfile, islink,
                      join, relpath, normpath)
 
+
+on_win = bool(sys.platform == "win32")
+
 try:
     from conda.lock import Locked
     from conda.utils import win_path_to_unix, url_path
@@ -75,7 +78,7 @@ except ImportError:
 
     def url_path(path):
         path = abspath(path)
-        if sys.platform == 'win32':
+        if on_win:
             path = '/' + path.replace(':', '|').replace('\\', '/')
         return 'file://%s' % path
 
@@ -88,8 +91,6 @@ except ImportError:
         return url.rsplit('/', 2)[0] + '/' if url and '/' in url else None, 'defaults'
 
     pkgs_dirs = [join(sys.prefix, 'pkgs')]
-
-on_win = bool(sys.platform == "win32")
 
 if on_win:
     import ctypes
@@ -371,7 +372,7 @@ def replace_prefix(mode, data, placeholder, new_prefix):
         data = data.replace(placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
     # Skip binary replacement in Windows.  Some files do have prefix information embedded, but
     #    this should not matter, as it is not used for things like RPATH.
-    elif mode == 'binary' and sys.platform != "win32":
+    elif mode == 'binary' and on_win:
         data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
     else:
         sys.exit("Invalid mode: %s" % mode)
@@ -926,7 +927,7 @@ def is_linked(prefix, dist):
 
 
 def _get_trash_dir(pkg_dir):
-    unc_prefix = u'\\\\?\\' if sys.platform == 'win32' else ''
+    unc_prefix = u'\\\\?\\' if on_win else ''
     return unc_prefix + join(pkg_dir, '.trash')
 
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -372,7 +372,7 @@ def replace_prefix(mode, data, placeholder, new_prefix):
         data = data.replace(placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
     # Skip binary replacement in Windows.  Some files do have prefix information embedded, but
     #    this should not matter, as it is not used for things like RPATH.
-    elif mode == 'binary' and on_win:
+    elif mode == 'binary' and not on_win:
         data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
     else:
         sys.exit("Invalid mode: %s" % mode)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -99,6 +99,7 @@ class FileTests(unittest.TestCase):
             self.assertEqual(data, '#!/usr/bin/env python -O\n'
                                    'echo "Hello"\n')
 
+    @pytest.mark.skipif(on_win, reason="no binary replacement done on win")
     def test_binary(self):
         with open(self.tmpfname, 'wb') as fo:
             fo.write(b'\x7fELF.../some-placeholder/lib/libfoo.so\0')


### PR DESCRIPTION
This might be a fix for https://github.com/conda/conda-build/issues/997