### PR TITLE
Handle invalid metadata files

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -835,8 +835,8 @@ linked_data_ = {}
 
 def load_linked_data(prefix, dist, rec=None):
     schannel, dname = dist2pair(dist)
+    meta_file = join(prefix, 'conda-meta', dname + '.json')
     if rec is None:
-        meta_file = join(prefix, 'conda-meta', dname + '.json')
         try:
             with open(meta_file) as fi:
                 rec = json.load(fi)
@@ -849,6 +849,9 @@ def load_linked_data(prefix, dist, rec=None):
         rec['fn'] = url.rsplit('/', 1)[-1] if url else dname + '.tar.bz2'
     if not url and 'channel' in rec:
         url = rec['url'] = rec['channel'] + rec['fn']
+    if rec['fn'][:-8] != dname:
+        log.debug('Ignoring invalid package metadata file: %s' % meta_file)
+        return None
     channel, schannel = url_channel(url)
     rec['channel'] = channel
     rec['schannel'] = schannel

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -352,7 +352,7 @@ def add_defaults_to_specs(r, linked, specs, update=False):
         return
     log.debug('H0 specs=%r' % specs)
     linked = [d if d.endswith('.tar.bz2') else d + '.tar.bz2' for d in linked]
-    names_linked = {name_dist(dist): dist for dist in linked}
+    names_linked = {r.index[fn]['name']: fn for fn in linked if fn in r.index}
     mspecs = list(map(MatchSpec, specs))
 
     for name, def_ver in [('python', default_python),


### PR DESCRIPTION
See #2599 

This does three things:
- Ignores `.json` files in `conda-meta/` whose filenames do not match the underlying package name
- Ignore filenames in `add_defaults_to_specs` that aren't found in the index for some reason
- A change I had made to pull the dist name from `r.index` instead of using `name_dist` was reverted for some reason: I've put that back. That was actually the code that caused the bug anyway.

I'm adding an integration test. Wait for that before merging