### PR TITLE
Exit on link error instead of logging it

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -1048,7 +1048,7 @@ def link(prefix, dist, linktype=LINK_HARD, index=None):
             try:
                 _link(src, dst, lt)
             except OSError as e:
-                log.error('failed to link (src=%r, dst=%r, type=%r, error=%r)' %
+                sys.exit('failed to link (src=%r, dst=%r, type=%r, error=%r)' %
                           (src, dst, lt, e))
 
         if name_dist(dist) == '_cache':


### PR DESCRIPTION
The failure to link to a file during installation is now treated like other errors -- it exits the script.  To address the silent swallowing of link errors described in [this comment](https://github.com/conda/conda/issues/2437#issuecomment-224662622) on issue #2437.