### PR TITLE
Get channel information during remove --all

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -169,6 +169,9 @@ class IntegrationTests(TestCase):
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-2')
 
+            run_command(Commands.REMOVE, prefix, '--all')
+            assert not exists(prefix)
+
     def test_python2_install_numba(self):
         with make_temp_env("python=2") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))


### PR DESCRIPTION
The current version of `conda remove -n env --all` doesn't retrieve any information about the installed packages. Previously this didn't matter, but now that we care more about channels, it does. The current version, for instance, prints this:
```
Package plan for package removal in environment /Users/mgrant/miniconda2/envs/test2:

The following packages will be REMOVED:

    openssl:    1.0.2h-1      <unknown>
    pip:        8.1.2-py27_0  <unknown>
    python:     2.7.11-0      <unknown>
    readline:   6.2-2         <unknown>
    setuptools: 22.0.5-py27_0 <unknown>
    sqlite:     3.13.0-0      <unknown>
    tk:         8.5.18-0      <unknown>
    wheel:      0.29.0-py27_0 <unknown>
    zlib:       1.2.8-3       <unknown>
```
But it should print something like this:
```
Package plan for package removal in environment /Users/mgrant/miniconda2/envs/test2:

The following packages will be REMOVED:

    openssl:    1.0.2h-1      http://bremen/pkgs/free
    pip:        8.1.2-py27_0  http://bremen/pkgs/free
    python:     2.7.11-0      http://bremen/pkgs/free
    readline:   6.2-2         http://bremen/pkgs/free
    setuptools: 22.0.5-py27_0 http://bremen/pkgs/free
    sqlite:     3.13.0-0      http://bremen/pkgs/free
    tk:         8.5.18-0      http://bremen/pkgs/free
    wheel:      0.29.0-py27_0 http://bremen/pkgs/free
    zlib:       1.2.8-3       http://bremen/pkgs/free
```
It's a simple fix---just provide `plan.display_actions` with the metadata from the environment before removing the packages. That metadata is _already_ retrieved when getting the list of packages to remove, so it's free.