### PR TITLE
Handle clones of environments with no url metadata

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -96,7 +96,7 @@ def explicit(specs, prefix, verbose=False, force_extract=True, fetch_args=None, 
                 _, conflict = find_new_location(dist)
                 if conflict:
                     actions[RM_FETCHED].append(conflict)
-                if fn not in index or index[fn].get(not_fetched):
+                if fn not in index or index[fn].get('not_fetched'):
                     channels[url_p + '/'] = (schannel, 0)
                 actions[FETCH].append(dist)
                 verifies.append((dist + '.tar.bz2', md5))
@@ -297,7 +297,6 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, fetch_args=None):
 
     # Assemble the URL and channel list
     urls = {}
-    resolver = None
     for dist, info in iteritems(drecs):
         fkey = dist + '.tar.bz2'
         if fkey not in index:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -279,7 +279,7 @@ class Resolve(object):
             return
         self.index[fpkg] = {
             'name': fpkg, 'channel': '@', 'priority': 0,
-            'version': '0', 'build_number': 0,
+            'version': '0', 'build_number': 0, 'fn': fpkg,
             'build': '', 'depends': [], 'track_features': fstr}
         if group:
             self.groups[fpkg] = [fpkg]

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+import os
+import json
 from contextlib import contextmanager
 from glob import glob
 from logging import getLogger, Handler
@@ -179,15 +181,30 @@ class IntegrationTests(TestCase):
     @pytest.mark.skipif(on_win and bits == 32, reason="no 32-bit windows python on conda-forge")
     @pytest.mark.timeout(600)
     def test_dash_c_usage_replacing_python(self):
-        # a regression test for #2606
+        # Regression test for #2606
         with make_temp_env("-c conda-forge python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             run_command(Commands.INSTALL, prefix, "decorator")
             assert_package_is_installed(prefix, 'conda-forge::python-3.5')
 
-            with make_temp_env("--clone {0}".format(prefix)) as clone_prefix:
+            with make_temp_env("--clone", prefix) as clone_prefix:
                 assert_package_is_installed(clone_prefix, 'conda-forge::python-3.5')
                 assert_package_is_installed(clone_prefix, "decorator")
+
+            # Regression test for 2645
+            fn = glob(join(prefix, 'conda-meta', 'python-3.5*.json'))[-1]
+            with open(fn) as f:
+                data = json.load(f)
+            for field in ('url', 'channel', 'schannel'):
+                if field in data:
+                    del data[field]
+            with open(fn, 'w') as f:
+                json.dump(data, f)
+            linked_data_.clear()
+
+            with make_temp_env("--clone", prefix) as clone_prefix:
+                assert_package_is_installed(clone_prefix, 'python-3.5')
+                assert_package_is_installed(clone_prefix, 'decorator')
 
     @pytest.mark.timeout(600)
     def test_python2_pandas(self):


### PR DESCRIPTION
Addresses #2633, #2510 and others.

Clone functionality has already been greatly improved in 4.1. However, the new version of clone fails with older environments where the original URL is not available in the installed metadata (in the `conda-meta`) directory.

What this does is assemble a list of these "orphan" packages. If that list is non-empty, it fetches the channel index according to the current `.condarc` settings, and attempts to match each package filename to a record in that channel index. If a match cannot be found for one or more orphan packages, an error will be raised. The user can then add additional channels into their channel list and re-try.

Moving forward, the full URL where the package was retrieve is saved in the metadata, so future cloning operations can be done much more easily and precisely.
