### PR TITLE
Fix the occasional/random package resolution errors

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1001,7 +1001,7 @@ class Resolve(object):
                 if s.name in specm:
                     specm.remove(s.name)
                 if not s.optional:
-                    (speca if s.target or k > len0 else specr).append(s)
+                    (speca if s.target or k >= len0 else specr).append(s)
                 elif any(r2.find_matches(s)):
                     s = MatchSpec(s.name, optional=True, target=s.target)
                     speco.append(s)


### PR DESCRIPTION
On some of our Linux 64 Travis CI test we were finding that _sometimes_ `conda` give this package list for `conda create -n test -c conda-forge install python=3.5`:
```
    ca-certificates: 2016.2.28-0   conda-forge
    ncurses:         5.9-7         conda-forge
    openssl:         1.0.2h-0      conda-forge
    pip:             8.1.2-py35_0
    python:          3.5.1-0
    readline:        6.2-0         conda-forge
    setuptools:      23.0.0-py35_0
    sqlite:          3.13.0-1      conda-forge
    tk:              8.5.19-0      conda-forge
    wheel:           0.29.0-py35_0
    xz:              5.0.5-1       conda-forge
    zlib:            1.2.8-3       conda-forge
```
Notice the fact that `python` is _not_ coming from conda-forge as requested. What it _should_ be doing, and indeed it was doing correctly most of the time, is this:
```
    ca-certificates: 2016.2.28-0   conda-forge
    ncurses:         5.9-7         conda-forge
    openssl:         1.0.2h-0      conda-forge
    pip:             8.1.2-py35_0
    python:          3.5.1-0       conda-forge
    readline:        6.2-0         conda-forge
    setuptools:      23.0.0-py35_0
    sqlite:          3.9.2-0       conda-forge
    tk:              8.5.19-0      conda-forge
    wheel:           0.29.0-py35_0
    xz:              5.0.5-1       conda-forge
    zlib:            1.2.8-3       conda-forge
```
The problem, it turns out, was subtle. 

When conda is determining package versions, it puts the highest priority on maximizing the versions of the *requested* package---in this case, `python`---before it maximizes the versions of the other packages. But due to a `>` versus `>=` error in the code, it was adding one additional package to this initial version maximization pass; in this case, `sqlite`.

Why does this matter? Well, `conda-forge::python-3.5.0-0` depends on `sqlite 3.9*`, which is an *older* version of `sqlite`. So this puts `conda` into a bit of a quandary: pick the newest version of Python, or pick the newest version of sqlite? There is enough non-determinism in the solver, due to Python's hash seed randomization, that ties are broken randomly. 

Of course, there *shouldn't* be a tie in this case. So we've fixed that.