### PR TITLE
Fix 'conda search --spec' breakage

### DIFF
--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -212,7 +212,7 @@ def execute_search(args, parser):
         else:
             if pat and pat.search(name) is None:
                 continue
-            if ms and name != ms.name:
+            if ms and name != ms.split()[0]:
                 continue
 
             if ms:


### PR DESCRIPTION
This PR cherry-picks the fix for `conda search --spec` breakage that's been merged to master as a part of #2343, and proposes that it be merged into the 4.0.x branch.