### PR TITLE
fallback default process in find_parent_process

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -3,8 +3,10 @@
 # Determine the directory containing this script
 if [[ -n $BASH_VERSION ]]; then
     _SCRIPT_LOCATION=${BASH_SOURCE[0]}
+    SHELL="bash"
 elif [[ -n $ZSH_VERSION ]]; then
     _SCRIPT_LOCATION=${funcstack[1]}
+    SHELL="zsh"
 else
     echo "Only bash and zsh are supported"
     return 1
@@ -17,6 +19,15 @@ if [ $# -gt 1 ]; then
     return 1
 fi
 
+case "$(uname -s)" in
+    CYGWIN*|MINGW32*|MSYS*)
+        EXT=".exe"
+        ;;
+    *)
+        EXT=""
+        ;;
+esac
+
 # Export whatever PS setting we have, so it is available to Python subprocesses
 export PS1
 
@@ -27,11 +38,11 @@ if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "activate" ]]
     (>&2 echo "Error: activate must be sourced. Run 'source activate envname'
 instead of 'activate envname'.
 ")
-    "$_CONDA_DIR/conda" ..activate -h
+    "$_CONDA_DIR/conda" ..activate -h $SHELL$EXT
     exit 1
 fi
 
-"$_CONDA_DIR/conda" ..checkenv "$@"
+"$_CONDA_DIR/conda" ..checkenv $SHELL$EXT "$@"
 if (( $? != 0 )); then
     return 1
 fi
@@ -41,7 +52,7 @@ fi
 args=$@
 source "$_CONDA_DIR/deactivate"
 
-_NEW_PATH=$("$_CONDA_DIR/conda" ..activate "$args")
+_NEW_PATH=$("$_CONDA_DIR/conda" ..activate $SHELL$EXT "$args")
 if (( $? == 0 )); then
     export CONDA_PATH_BACKUP="$PATH"
     # export this to restore it upon deactivation
@@ -59,7 +70,7 @@ if (( $? == 0 )); then
     #    Last date of change: 2016-04-18
     export CONDA_ENV_PATH=$CONDA_DEFAULT_ENV
 
-    export PS1="$( "$_CONDA_DIR/conda" ..setps1 "$args" )"
+    export PS1="$( "$_CONDA_DIR/conda" ..setps1 $SHELL$EXT "$args" )"
 
     # Load any of the scripts found $PREFIX/etc/conda/activate.d AFTER activation
     _CONDA_D="${CONDA_DEFAULT_ENV}/etc/conda/activate.d"

--- a/bin/activate
+++ b/bin/activate
@@ -38,7 +38,7 @@ if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "activate" ]]
     (>&2 echo "Error: activate must be sourced. Run 'source activate envname'
 instead of 'activate envname'.
 ")
-    "$_CONDA_DIR/conda" ..activate -h $SHELL$EXT
+    "$_CONDA_DIR/conda" ..activate $SHELL$EXT -h
     exit 1
 fi
 

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -8,7 +8,7 @@
 :: this finds either --help or -h and shows the help text
 @CALL ECHO "%~1"| @%SystemRoot%\System32\find.exe /I "-h" 1>NUL
 @IF NOT ERRORLEVEL 1 (
-    @call "%~dp0\..\Scripts\conda.exe" ..activate -h "cmd.exe"
+    @call "%~dp0\..\Scripts\conda.exe" ..activate "cmd.exe" -h
 ) else (
     :: reset errorlevel to 0
     cmd /c "exit /b 0"

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -5,6 +5,15 @@
 
 @set "CONDA_NEW_ENV=%~1"
 
+:: this finds either --help or -h and shows the help text
+@CALL ECHO "%~1"| @%SystemRoot%\System32\find.exe /I "-h" 1>NUL
+@IF NOT ERRORLEVEL 1 (
+    @call "%~dp0\..\Scripts\conda.exe" ..activate -h "cmd.exe"
+) else (
+    :: reset errorlevel to 0
+    cmd /c "exit /b 0"
+)
+
 @if "%~2" == "" @goto skiptoomanyargs
     (@echo Error: did not expect more than one argument.) 1>&2
     (@echo     ^(Got %*^)) 1>&2
@@ -19,7 +28,7 @@
 @SET "CONDA_EXE=%~dp0\..\Scripts\conda.exe"
 
 @REM Ensure that path or name passed is valid before deactivating anything
-@call "%CONDA_EXE%" ..checkenv "%CONDA_NEW_ENV%"
+@call "%CONDA_EXE%" ..checkenv "cmd.exe" "%CONDA_NEW_ENV%"
 @if errorlevel 1 exit /b 1
 
 @call %~dp0\deactivate.bat
@@ -28,11 +37,11 @@
 @REM take a snapshot of pristine state for later
 @SET "CONDA_PATH_BACKUP=%PATH%"
 @REM Activate the new environment
-@FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..activate "%CONDA_NEW_ENV%"') DO @SET "PATH=%%i"
+@FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..activate "cmd.exe" "%CONDA_NEW_ENV%"') DO @SET "PATH=%%i"
 
 @REM take a snapshot of pristine state for later
 @set "CONDA_OLD_PS1=%PROMPT%"
-@FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..setps1 "%CONDA_NEW_ENV%"') DO @SET "PROMPT=%%i"
+@FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..setps1 "cmd.exe" "%CONDA_NEW_ENV%"') DO @SET "PROMPT=%%i"
 
 @REM Replace CONDA_NEW_ENV with the full path, if it is anything else
 @REM   (name or relative path).  This is to remove any ambiguity.

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -4,14 +4,25 @@
 if [[ -n $BASH_VERSION ]]; then
     _SCRIPT_LOCATION=${BASH_SOURCE[0]}
     export PROMPT_VAR="PS1"
+    SHELL="bash"
 elif [[ -n $ZSH_VERSION ]]; then
     _SCRIPT_LOCATION=${funcstack[1]}
     export PROMPT_VAR="PROMPT"
+    SHELL="zsh"
 else
     echo "Only bash and zsh are supported"
     return 1
 fi
 _CONDA_DIR=$(dirname "$_SCRIPT_LOCATION")
+
+case "$(uname -s)" in
+    CYGWIN*|MINGW32*|MSYS*)
+        EXT=".exe"
+        ;;
+    *)
+        EXT=""
+        ;;
+esac
 
 # shift over all args.  We don't accept any, so it's OK that we ignore them all here.
 while [[ $# > 0 ]]
@@ -38,7 +49,7 @@ if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "deactivate" 
     (>&2 echo "Error: deactivate must be sourced. Run 'source deactivate'
 instead of 'deactivate'.
 ")
-    "$_CONDA_DIR/conda" ..deactivate -h
+    "$_CONDA_DIR/conda" ..deactivate -h $SHELL$EXT
     exit 1
 fi
 

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -30,7 +30,7 @@ do
     key="$1"
     case $key in
         -h|--help)
-            "$_CONDA_DIR/conda" ..deactivate -h
+            "$_CONDA_DIR/conda" ..deactivate $SHELL$EXT -h
             if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "deactivate" ]]; then
                 exit 0
             else

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -3,9 +3,10 @@
 @REM   For debugging, remove the @ on the section you need to study.
 @SETLOCAL
 
+:: this finds either --help or -h and shows the help text
 @CALL ECHO "%~1"| @%SystemRoot%\System32\find.exe /I "-h" 1>NUL
 @IF NOT ERRORLEVEL 1 (
-    @call "%~dp0\..\Scripts\conda.exe" ..deactivate -h
+    @call "%~dp0\..\Scripts\conda.exe" ..deactivate -h "cmd.exe"
 ) else (
     :: reset errorlevel to 0
     cmd /c "exit /b 0"

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -6,7 +6,7 @@
 :: this finds either --help or -h and shows the help text
 @CALL ECHO "%~1"| @%SystemRoot%\System32\find.exe /I "-h" 1>NUL
 @IF NOT ERRORLEVEL 1 (
-    @call "%~dp0\..\Scripts\conda.exe" ..deactivate -h "cmd.exe"
+    @call "%~dp0\..\Scripts\conda.exe" ..deactivate "cmd.exe" -h
 ) else (
     :: reset errorlevel to 0
     cmd /c "exit /b 0"

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - python
     - conda-env
     - menuinst  [win]
-    - psutil
     - pycosat >=0.6.1
     - pyyaml
     - ruamel_yaml
@@ -36,7 +35,6 @@ requirements:
     - python
     - conda-env
     - menuinst  [win]
-    - psutil
     - pycosat >=0.6.1
     - pyyaml
     - ruamel_yaml

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -25,6 +25,7 @@ from ..misc import explicit, clone_env, append_env, touch_nonadmin
 from ..plan import (is_root_prefix, get_pinned_specs, install_actions, add_defaults_to_specs,
                     display_actions, revert_actions, nothing_to_do, execute_actions)
 from ..resolve import NoPackagesFound, Unsatisfiable, Resolve
+from ..utils import find_parent_shell
 
 log = logging.getLogger(__name__)
 
@@ -95,10 +96,10 @@ def clone(src_arg, dst_prefix, json=False, quiet=False, fetch_args=None):
 
 
 def print_activate(arg):
-    from ..utils import find_parent_shell
+    shell = find_parent_shell(path=False)
     print("#")
     print("# To activate this environment, use:")
-    if find_parent_shell() in ["powershell.exe", "cmd.exe"]:
+    if shell in ["powershell.exe", "cmd.exe"]:
         print("# > activate %s" % arg)
         print("#")
         print("# To deactivate this environment, use:")

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -85,7 +85,7 @@ def UNLINK_CMD(state, arg):
 
 
 def SYMLINK_CONDA_CMD(state, arg):
-    symlink_conda(state['prefix'], arg, find_parent_shell())
+    symlink_conda(state['prefix'], arg, find_parent_shell(path=False))
 
 # Map instruction to command (a python function)
 commands = {

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -255,8 +255,16 @@ def find_parent_shell(path=False):
         #          "To proceed, please conda install psutil")
         return None
     process = psutil.Process()
-    while "conda" in process.parent().name():
-        process = process.parent()
+    pname = process.parent().name().lower()
+    while any(proc in pname for proc in ["conda", "python", "py.test"]):
+        if process:
+            process = process.parent()
+        else:
+            # fallback defaults to system default
+            if sys.platform == 'win32':
+                return 'cmd.exe'
+            else:
+                return 'bash'
     if path:
         return process.parent().exe()
     return process.parent().name()

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -244,6 +244,33 @@ def human_bytes(n):
     g = m/1024
     return '%.2f GB' % g
 
+# This is necessary for Windows, for linking the environment, and for printing the correct
+# activation instructions on Windows, depending on the shell type.  It would be great to
+# get rid of it, but I don't know how to otherwise detect which shell is used to create
+# or install conda packages.
+def find_parent_shell(path=False):
+    """return process name or path of parent.  Default is to return only name of process."""
+    try:
+        import psutil
+    except ImportError:
+        logger.warn("No psutil available.\n"
+                    "To proceed, please conda install psutil")
+        return None
+    process = psutil.Process()
+    pname = process.parent().name().lower()
+    while any(proc in pname for proc in ["conda", "python", "py.test"]):
+        if process:
+            process = process.parent()
+        else:
+            # fallback defaults to system default
+            if sys.platform == 'win32':
+                return 'cmd.exe'
+            else:
+                return 'bash'
+    if path:
+        return process.parent().exe()
+    return process.parent().name()
+
 
 @memoized
 def get_yaml():

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -253,8 +253,8 @@ def find_parent_shell(path=False):
     try:
         import psutil
     except ImportError:
-        logger.warn("No psutil available.\n"
-                    "To proceed, please conda install psutil")
+        stderrlog.warn("No psutil available.\n"
+                       "To proceed, please conda install psutil")
         return None
     process = psutil.Process()
     pname = process.parent().name().lower()

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -245,31 +245,6 @@ def human_bytes(n):
     return '%.2f GB' % g
 
 
-# @memoized
-def find_parent_shell(path=False):
-    """return process name or path of parent.  Default is to return only name of process."""
-    try:
-        import psutil
-    except ImportError:
-        # sys.exit("No psutil available.\n"
-        #          "To proceed, please conda install psutil")
-        return None
-    process = psutil.Process()
-    pname = process.parent().name().lower()
-    while any(proc in pname for proc in ["conda", "python", "py.test"]):
-        if process:
-            process = process.parent()
-        else:
-            # fallback defaults to system default
-            if sys.platform == 'win32':
-                return 'cmd.exe'
-            else:
-                return 'bash'
-    if path:
-        return process.parent().exe()
-    return process.parent().name()
-
-
 @memoized
 def get_yaml():
     try:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'sdist': auxlib.SDistCommand,
     },
     install_requires=[
-        'psutil',
         'pycosat >=0.6.1',
         'pyyaml',
         'requests',

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -585,14 +585,20 @@ def test_activate_relative_path(shell):
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
         env_dirs = gen_test_env_paths(envs, shell)
         env_dir = os.path.basename(env_dirs[0])
+        work_dir = os.path.dirname(env_dir)
         commands = (shell_vars['command_setup'] + """
+        cd {work_dir}
         {source} "{syspath}{binpath}activate" "{env_dir}"
         {printdefaultenv}
-        """).format(envs=envs, env_dir=env_dir, **shell_vars)
+        """).format(work_dir=envs, envs=envs, env_dir=env_dir, **shell_vars)
         cwd = os.getcwd()
+        # this is not effective for running bash on windows.  It starts
+        #    in your home dir no matter what.  That's what the cd is for above.
         os.chdir(envs)
         try:
             stdout, stderr = run_in(commands, shell, cwd=envs)
+        except:
+            raise
         finally:
             os.chdir(cwd)
         assert_equals(stdout.rstrip(), env_dirs[0], stderr)


### PR DESCRIPTION
As we very briefly discussed, this change ensures that some system prompt process is returned from find_parent_process, so that we can make a shell behave appropriately.

This should not affect activation scripts at all - their parents are always shells.