### PR TITLE
Ensure info['link'] is accurate even for old installations

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -35,7 +35,8 @@ def get_index(channel_urls=(), prepend=True, platform=None,
             key = prefix + fn
             if key in index:
                 # Copy the link information so the resolver knows this is installed
-                index[key]['link'] = info.get('link')
+                index[key] = index[key].copy()
+                index[key]['link'] = info.get('link') or True
             else:
                 # only if the package in not in the repodata, use local
                 # conda-meta (with 'depends' defaulting to [])

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -235,6 +235,8 @@ def add_unknown(index, priorities):
         if schannel2 != schannel:
             continue
         priority = priorities.get(schannel, maxp)
+        if 'link' in meta:
+            del meta['link']
         meta.update({'fn': fname, 'url': url, 'channel': channel,
                      'schannel': schannel, 'priority': priority})
         meta.setdefault('depends', [])

--- a/conda/install.py
+++ b/conda/install.py
@@ -861,6 +861,7 @@ def load_linked_data(prefix, dist, rec=None):
     channel, schannel = url_channel(url)
     rec['channel'] = channel
     rec['schannel'] = schannel
+    rec['link'] = rec.get('link') or True
     cprefix = '' if schannel == 'defaults' else schannel + '::'
     linked_data_[prefix][str(cprefix + dname)] = rec
     return rec


### PR DESCRIPTION
Fixes #2693. conda 4.1 is depending on the `link` entry in the `conda-meta` metadata to track which packages in the index are installed. Sufficiently old versions of Anaconda, such as those used by AppVeyor, are missing this information. We need to create it, otherwise `conda` will think packages are not installed, and install duplicates.