### PR TITLE
Restore explicit file installs

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -297,6 +297,8 @@ def url_channel(url):
         return None, '<unknown>'
     channel = url.rsplit('/', 2)[0]
     schannel = canonical_channel_name(channel)
+    if url.startswith('file://') and schannel != 'local':
+        channel = schannel = url.rsplit('/', 1)[0]
     return channel, schannel
 
 # ----- allowed channels -----


### PR DESCRIPTION
fixes #2688. Logic needed to be added to `explicit` to better differentiate between file-based channels and bare files.