### PR TITLE
remove --shortcuts option to internal CLI code

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -1200,6 +1200,7 @@ def duplicates_to_remove(dist_metas, keep_dists):
 
 
 def main():
+    # This CLI is only invoked from the self-extracting shell installers
     from optparse import OptionParser
 
     p = OptionParser(description="conda link tool used by installer")
@@ -1217,13 +1218,6 @@ def main():
 
     p.add_option('-v', '--verbose',
                  action="store_true")
-
-    if sys.platform == "win32":
-        p.add_argument(
-            "--shortcuts",
-            action="store_true",
-            help="Install start menu shortcuts"
-        )
 
     opts, args = p.parse_args()
     if args:
@@ -1251,7 +1245,7 @@ def main():
     for dist in idists:
         if opts.verbose:
             print("linking: %s" % dist)
-        link(prefix, dist, linktype, opts.shortcuts)
+        link(prefix, dist, linktype)
 
     messages(prefix)
 


### PR DESCRIPTION
This bug, fixed the ability to create shell installers (using tolls like constructor).