### PR TITLE
revert disabling of .netrc files

### DIFF
--- a/conda/connection.py
+++ b/conda/connection.py
@@ -90,8 +90,6 @@ class CondaSession(requests.Session):
         proxies = get_proxy_servers()
         if proxies:
             self.proxies = proxies
-        self.trust_env = False  # disable .netrc file
-                                # also disables REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE env variables
 
         # Configure retries
         if retries:

--- a/conda/connection.py
+++ b/conda/connection.py
@@ -90,8 +90,8 @@ class CondaSession(requests.Session):
         proxies = get_proxy_servers()
         if proxies:
             self.proxies = proxies
-        self.auth = NullAuth()  # disable .netrc file. for reference, see
-                                #   https://github.com/Anaconda-Platform/anaconda-client/pull/298
+        self.trust_env = False  # disable .netrc file
+                                # also disables REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE env variables
 
         # Configure retries
         if retries:
@@ -111,22 +111,6 @@ class CondaSession(requests.Session):
         self.headers['User-Agent'] = user_agent
 
         self.verify = ssl_verify
-
-
-class NullAuth(requests.auth.AuthBase):
-    '''force requests to ignore the ``.netrc``
-    Some sites do not support regular authentication, but we still
-    want to store credentials in the ``.netrc`` file and submit them
-    as form elements. Without this, requests would otherwise use the
-    .netrc which leads, on some sites, to a 401 error.
-    https://github.com/kennethreitz/requests/issues/2773
-    Use with::
-        requests.get(url, auth=NullAuth())
-    '''
-
-    def __call__(self, r):
-        return r
-
 
 class S3Adapter(requests.adapters.BaseAdapter):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,13 +15,13 @@ markers =
 
 [pep8]
 max-line-length = 99
-ignore = E121,E123,E126,E133,E226,E241,E242,E302,E704
+ignore = E116,E121,E123,E126,E133,E226,E241,E242,E302,E704
 exclude = build/*,.tox/*,tests/*,ve/*,*/_vendor/*,auxlib/*,conda/progressbar/*,conda/compat.py
 
 
 [flake8]
 max-line-length = 99
-ignore = E121,E123,E126,E133,E226,E241,E242,E302,E704
+ignore = E116,E121,E123,E126,E133,E226,E241,E242,E302,E704
 exclude = build/*,.tox/*,tests/*,ve/*,*/_vendor/*,auxlib/*,conda/progressbar/*,conda/compat.py
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,13 +15,13 @@ markers =
 
 [pep8]
 max-line-length = 99
-ignore = E116,E121,E123,E126,E133,E226,E241,E242,E302,E704
+ignore = E121,E123,E126,E133,E226,E241,E242,E302,E704
 exclude = build/*,.tox/*,tests/*,ve/*,*/_vendor/*,auxlib/*,conda/progressbar/*,conda/compat.py
 
 
 [flake8]
 max-line-length = 99
-ignore = E116,E121,E123,E126,E133,E226,E241,E242,E302,E704
+ignore = E121,E123,E126,E133,E226,E241,E242,E302,E704
 exclude = build/*,.tox/*,tests/*,ve/*,*/_vendor/*,auxlib/*,conda/progressbar/*,conda/compat.py
 
 


### PR DESCRIPTION
Closes #2725.

@dsludwig @bkreider 

I'm reverting the commits that disabled netrc files.  There's quite a bit of history here, and I just can't seem to get it right so far I guess.

Previous PRs were #2514 and #2695.

Issues filed were #2677 and #2725.  The original ticket is #2161, which I'm re-opening for discussion.