### PR TITLE
Restore functionality in install.main

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -1228,7 +1228,7 @@ def main():
 
     prefix = opts.prefix
     pkgs_dir = join(prefix, 'pkgs')
-    pkgs_dirs[0] = [pkgs_dir]
+    pkgs_dirs = [pkgs_dir]
     if opts.verbose:
         print("prefix: %r" % prefix)
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -1069,9 +1069,6 @@ def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):
                 log.error('failed to link (src=%r, dst=%r, type=%r, error=%r)' %
                           (src, dst, lt, e))
 
-        if name_dist(dist) == '_cache':
-            return
-
         for f in sorted(has_prefix_files):
             placeholder, mode = has_prefix_files[f]
             try:
@@ -1202,7 +1199,7 @@ def duplicates_to_remove(dist_metas, keep_dists):
 
 def main():
     # This CLI is only invoked from the self-extracting shell installers
-    global pkgs_dirs, package_cache_, fname_table_
+    global pkgs_dirs
     from optparse import OptionParser
 
     p = OptionParser(description="conda link tool used by installer")
@@ -1249,9 +1246,6 @@ def main():
         if opts.verbose:
             print("linking: %s" % dist)
         link(prefix, dist, linktype)
-        if name_dist(dist) == '_cache':
-            package_cache_ = {}
-            fname_table_ = {}
 
     messages(prefix)
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -409,7 +409,7 @@ def update_prefix(path, new_prefix, placeholder=prefix_placeholder, mode='text')
         new_prefix = new_prefix.replace('\\', '/')
 
     path = os.path.realpath(path)
-    with exp_backoff_fn(open, path, 'wb') as fo:
+    with open(path, 'rb') as fi:
         original_data = data = fi.read()
 
     data = replace_prefix(mode, data, placeholder, new_prefix)
@@ -421,7 +421,7 @@ def update_prefix(path, new_prefix, placeholder=prefix_placeholder, mode='text')
     st = os.lstat(path)
     # Remove file before rewriting to avoid destroying hard-linked cache
     os.remove(path)
-    with open(path, 'wb') as fo:
+    with exp_backoff_fn(open, path, 'wb') as fo:
         fo.write(data)
     os.chmod(path, stat.S_IMODE(st.st_mode))
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -1202,6 +1202,7 @@ def duplicates_to_remove(dist_metas, keep_dists):
 
 def main():
     # This CLI is only invoked from the self-extracting shell installers
+    global pkgs_dirs
     from optparse import OptionParser
 
     p = OptionParser(description="conda link tool used by installer")

--- a/conda/install.py
+++ b/conda/install.py
@@ -1202,7 +1202,7 @@ def duplicates_to_remove(dist_metas, keep_dists):
 
 def main():
     # This CLI is only invoked from the self-extracting shell installers
-    global pkgs_dirs
+    global pkgs_dirs, package_cache_, fname_table_
     from optparse import OptionParser
 
     p = OptionParser(description="conda link tool used by installer")
@@ -1249,6 +1249,9 @@ def main():
         if opts.verbose:
             print("linking: %s" % dist)
         link(prefix, dist, linktype)
+        if name_dist(dist) == '_cache':
+            package_cache_ = {}
+            fname_table_ = {}
 
     messages(prefix)
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -41,7 +41,6 @@ import sys
 import tarfile
 import time
 import traceback
-import random
 from os.path import (abspath, basename, dirname, isdir, isfile, islink,
                      join, relpath, normpath)
 
@@ -225,21 +224,6 @@ def warn_failed_remove(function, path, exc_info):
         log.warn("Cannot remove, unknown reason: {0}".format(path))
 
 
-def exp_backoff_fn(fn, *args):
-    """Mostly for retrying file operations that fail on Windows due to virus scanners"""
-    max_retries = 5
-    for n in range(max_retries):
-        try:
-            result = fn(*args)
-        except Exception as e:
-            log.debug(repr(e))
-            if n == max_retries-1:
-                raise
-            time.sleep((2 ** n) + (random.randint(0, 1000) / 1000))
-        else:
-            return result
-
-
 def rm_rf(path, max_retries=5, trash=True):
     """
     Completely delete path
@@ -418,7 +402,7 @@ def update_prefix(path, new_prefix, placeholder=prefix_placeholder, mode='text')
     st = os.lstat(path)
     # Remove file before rewriting to avoid destroying hard-linked cache
     os.remove(path)
-    with exp_backoff_fn(open, path, 'wb') as fo:
+    with open(path, 'wb') as fo:
         fo.write(data)
     os.chmod(path, stat.S_IMODE(st.st_mode))
 
@@ -842,7 +826,7 @@ def extract(dist):
         with tarfile.open(fname) as t:
             t.extractall(path=temp_path)
         rm_rf(path)
-        exp_backoff_fn(os.rename, temp_path, path)
+        os.rename(temp_path, path)
         if sys.platform.startswith('linux') and os.getuid() == 0:
             # When extracting as root, tarfile will by restore ownership
             # of extracted files.  However, we want root to be the owner

--- a/conda/install.py
+++ b/conda/install.py
@@ -1236,9 +1236,10 @@ def main():
         idists = list(yield_lines(join(prefix, opts.file)))
     else:
         idists = sorted(extracted())
+    assert idists
 
     linktype = (LINK_HARD
-                if idists and try_hard_link(pkgs_dir, prefix, idists[0]) else
+                if try_hard_link(pkgs_dir, prefix, idists[0]) else
                 LINK_COPY)
     if opts.verbose:
         print("linktype: %s" % link_name_map[linktype])


### PR DESCRIPTION
This will need to be released before we can create Anaconda 4.1 installers.  Without those changes the link process (which follows the package extraction process, when running `.sh` installers) is broken.

CC @mcg1969 @kalefranz 