### PR TITLE
VersionSpec: expose full regex power

### DIFF
--- a/conda/version.py
+++ b/conda/version.py
@@ -302,6 +302,10 @@ class VersionSpec(object):
         self.spec = spec
         if isinstance(spec, tuple):
             self.match = self.all_match_ if spec[0] == 'all' else self.any_match_
+        elif spec.startswith("^") and spec.endswith("$"):
+            self.spec = spec
+            self.regex = re.compile(spec)
+            self.match = self.regex_match_
         elif '|' in spec:
             return VersionSpec(('any', tuple(VersionSpec(s) for s in spec.split('|'))))
         elif ',' in spec:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -168,7 +168,11 @@ class TestVersionSpec(unittest.TestCase):
             ('!=1.5', True),  ('!=1.7.1', False), ('==1.7.1', True),
             ('==1.7', False), ('==1.7.2', False), ('==1.7.1.0', True),
             ('1.7*|1.8*', True), ('1.8*|1.9*', False),
-            ('>1.7,<1.8', True), ('>1.7.1,<1.8', False)
+            ('>1.7,<1.8', True), ('>1.7.1,<1.8', False),
+            ('^1.7.1$', True), ('^1\.7\.1$', True), ('^1\.7\.[0-9]+$', True),
+            ('^1\.8.*$', False), ('^1\.[5-8]\.1$', True), ('^[^1].*$', False),
+            ('^[0-9+]+\.[0-9+]+\.[0-9]+$', True), ('^$', False),
+            ('^.*$', True),
             ]:
             m = VersionSpec(vspec)
             assert VersionSpec(m) is m

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -172,7 +172,9 @@ class TestVersionSpec(unittest.TestCase):
             ('^1.7.1$', True), ('^1\.7\.1$', True), ('^1\.7\.[0-9]+$', True),
             ('^1\.8.*$', False), ('^1\.[5-8]\.1$', True), ('^[^1].*$', False),
             ('^[0-9+]+\.[0-9+]+\.[0-9]+$', True), ('^$', False),
-            ('^.*$', True),
+            ('^.*$', True), ('1.7.*|^0.*$', True), ('1.6.*|^0.*$', False),
+            ('1.6.*|^0.*$|1.7.1', True), ('^0.*$|1.7.1', True),
+            ('1.6.*|^.*\.7\.1$|0.7.1', True),
             ]:
             m = VersionSpec(vspec)
             assert VersionSpec(m) is m


### PR DESCRIPTION
Treat version specification strings that start with "^" and end with "$" as a regular expression. Fixes #2716.

The main point left to discuss is where to put the regex detection when interpreting a version specification, see https://github.com/conda/conda/commit/a39c400ce75be6570d644eb65c5dbdbd63554a43.