### PR TITLE
Git Bash executable is called bash on Windows

### DIFF
--- a/conda/utils.py
+++ b/conda/utils.py
@@ -401,6 +401,9 @@ if sys.platform == "win32":
         "bash.exe": dict(
             msys2_shell_base, exe="bash.exe",
         ),
+        "bash": dict(
+            msys2_shell_base, exe="bash",
+        ),
         "sh.exe": dict(
             msys2_shell_base, exe="sh.exe",
         ),


### PR DESCRIPTION
Wasn't able to use `source activate` on Windows with Git Bash, but this fixed it.