### PR TITLE
Show conda-env version in conda info

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 from os import listdir
 from os.path import exists, expanduser, join
 
+from ..compat import itervalues
 from .common import (add_parser_json, stdout_json, disp_features, arg2spec,
                      handle_envs_list)
 
@@ -178,12 +179,24 @@ def execute(args, parser):
     options = 'envs', 'system', 'license'
 
     try:
+        from conda.install import linked_data
+        root_pkgs = linked_data(sys.prefix)
+    except:
+        root_pkgs = None
+
+    try:
         import requests
         requests_version = requests.__version__
     except ImportError:
         requests_version = "could not import"
     except Exception as e:
         requests_version = "Error %s" % e
+
+    try:
+        cenv = [p for p in itervalues(root_pkgs) if p['name'] == 'conda-env']
+        conda_env_version = cenv[0]['version']
+    except:
+        conda_env_version = "not installed"
 
     try:
         import conda_build
@@ -199,6 +212,7 @@ def execute(args, parser):
     info_dict = dict(
         platform=subdir,
         conda_version=conda.__version__,
+        conda_env_version=conda_env_version,
         conda_build_version=conda_build_version,
         root_prefix=root_dir,
         root_writable=root_writable,
@@ -239,6 +253,7 @@ Current conda install:
 
              platform : %(platform)s
         conda version : %(conda_version)s
+    conda-env version : %(conda_env_version)s
   conda-build version : %(conda_build_version)s
        python version : %(python_version)s
      requests version : %(requests_version)s


### PR DESCRIPTION
Given how many issues we're having with `conda env` being out of date it seems wise for `conda info` to print out its version. At least until we do the right thing and merge it into core conda.