### PR TITLE
Adjust channel priority superseded list

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -180,7 +180,8 @@ def display_actions(actions, index, show_channel_urls=None):
             newver = P0.version < P1.version
             oldver = P0.version > P1.version
         oldbld = P0.build_number > P1.build_number
-        if channel_priority and pri1 < pri0 and (oldver or not newver and oldbld):
+        newbld = P0.build_number < P1.build_number
+        if channel_priority and pri1 < pri0 and (oldver or not newver and not newbld):
             channeled.add(pkg)
         elif newver:
             updated.add(pkg)


### PR DESCRIPTION
If a package is being replaced with a version with the _same_ version number but a higher priority channel, it should be in the "superseded" list.