### PR TITLE
remove unnecessary eval

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -395,7 +395,7 @@ environment does not exist: %s
             if not (command == 'update' and args.all):
                 try:
                     with open(join(prefix, 'conda-meta', 'history'), 'a') as f:
-                        f.write('# %s specs: %s\n' % (command, specs))
+                        f.write('# %s specs: %s\n' % (command, ','.join(specs)))
                 except IOError as e:
                     if e.errno == errno.EACCES:
                         log.debug("Can't write the history file")

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -187,7 +187,7 @@ def execute(args, parser):
         if specs:
             try:
                 with open(join(prefix, 'conda-meta', 'history'), 'a') as f:
-                    f.write('# remove specs: %s\n' % specs)
+                    f.write('# remove specs: %s\n' % ','.join(specs))
             except IOError as e:
                 if e.errno == errno.EACCES:
                     log.debug("Can't write the history file")

--- a/conda/history.py
+++ b/conda/history.py
@@ -146,7 +146,7 @@ class History(object):
                 if m:
                     action, specs = m.groups()
                     item['action'] = action
-                    item['specs'] = eval(specs)
+                    item['specs'] = specs.split(',')
             if 'cmd' in item:
                 res.append(item)
         return res


### PR DESCRIPTION
Removes an unnecessary and possibly unpredictable `eval` from conda.

Todo: figure out tests.