### PR TITLE
Handle cases where info['url'], info['channel'] is None

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -232,9 +232,9 @@ def add_unknown(index, priorities):
             continue
         if info['urls']:
             url = info['urls'][0]
-        elif 'url' in meta:
+        elif meta.get('url'):
             url = meta['url']
-        elif 'channel' in meta:
+        elif meta.get('channel'):
             url = meta['channel'].rstrip('/') + '/' + fname
         else:
             url = '<unknown>/' + fname

--- a/conda/install.py
+++ b/conda/install.py
@@ -467,7 +467,7 @@ def create_meta(prefix, dist, info_dir, extra_info):
         meta = json.load(fi)
     # add extra info, add to our intenral cache
     meta.update(extra_info)
-    if 'url' not in meta:
+    if not meta.get('url'):
         meta['url'] = read_url(dist)
     # write into <env>/conda-meta/<dist>.json
     meta_dir = join(prefix, 'conda-meta')
@@ -890,6 +890,7 @@ def load_linked_data(prefix, dist, rec=None):
         if not url or (url.startswith('file:') and channel[0] != '<unknown>'):
             url = rec['url'] = channel + '/' + fn
     channel, schannel = url_channel(url)
+    rec['url'] = url
     rec['channel'] = channel
     rec['schannel'] = schannel
     rec['link'] = rec.get('link') or True

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -279,7 +279,7 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, fetch_args=None):
     # Resolve URLs for packages that do not have URLs
     r = None
     index = {}
-    unknowns = [dist for dist, info in iteritems(drecs) if 'url' not in info]
+    unknowns = [dist for dist, info in iteritems(drecs) if not info.get('url')]
     notfound = []
     if unknowns:
         fetch_args = fetch_args or {}
@@ -372,7 +372,7 @@ def environment_for_conda_environment(prefix=root_dir):
 
 
 def make_icon_url(info):
-    if 'channel' in info and 'icon' in info:
+    if info.get('channel') and info.get('icon'):
         base_url = dirname(info['channel'])
         icon_fn = info['icon']
         # icon_cache_path = join(pkgs_dir, 'cache', icon_fn)

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -50,11 +50,11 @@ def display_actions(actions, index, show_channel_urls=None):
         show_channel_urls = config_show_channel_urls
 
     def channel_str(rec):
-        if 'schannel' in rec:
+        if rec.get('schannel'):
             return rec['schannel']
-        if 'url' in rec:
+        if rec.get('url'):
             return url_channel(rec['url'])[1]
-        if 'channel' in rec:
+        if rec.get('channel'):
             return canonical_channel_name(rec['channel'])
         return '<unknown>'
 


### PR DESCRIPTION
fixes #2746 

Some of the branches were using logic like `'url' in info`, but it looks like there are certain scenarios where the key could be present, but the value could be `None`---and we need to treat that case as well. This does some cleanup to that effect.

I believe this is the cause of issue #2746.