### PR TITLE
Accept old default names and new ones when canonicalizing channel URLs

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -181,11 +181,17 @@ def get_local_urls(clear_cache=True):
         pass
     return local_channel
 
-def get_default_urls():
+defaults_ = ['https://repo.continuum.io/pkgs/free',
+             'https://repo.continuum.io/pkgs/pro']
+
+def get_default_urls(merged=False):
     if 'default_channels' in sys_rc:
-        return sys_rc['default_channels']
-    return ['https://repo.continuum.io/pkgs/free',
-            'https://repo.continuum.io/pkgs/pro']
+        res = sys_rc['default_channels']
+        if merged:
+            res = list(res)
+            res.extend(c for c in defaults_ if c not in res)
+        return res
+    return defaults_
 
 def get_rc_urls():
     if rc.get('channels') is None:
@@ -237,7 +243,7 @@ def prioritize_channels(channels):
     return newchans
 
 def normalize_urls(urls, platform=None, offline_only=False):
-    defaults = tuple(x.rstrip('/') + '/' for x in get_default_urls())
+    defaults = tuple(x.rstrip('/') + '/' for x in get_default_urls(False))
     alias = None
     newurls = []
     while urls:
@@ -279,7 +285,7 @@ def canonical_channel_name(channel):
     if channel is None:
         return '<unknown>'
     channel = remove_binstar_tokens(channel).rstrip('/')
-    if any(channel.startswith(i) for i in get_default_urls()):
+    if any(channel.startswith(i) for i in get_default_urls(True)):
         return 'defaults'
     elif any(channel.startswith(i) for i in get_local_urls(clear_cache=False)):
         return 'local'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,10 +21,14 @@ yaml = get_yaml()
 # use condarc from source tree to run these tests against
 config.rc_path = join(dirname(__file__), 'condarc')
 
-def _get_default_urls():
-    return ['http://repo.continuum.io/pkgs/free',
-            'http://repo.continuum.io/pkgs/pro']
-config.get_default_urls = _get_default_urls
+# unset 'default_channels' and override config.defaults_ so that 
+# get_default_channels has predictable behavior
+try:
+    del config.sys_rc['default_channels']
+except KeyError:
+    pass
+config.defaults_ = ['http://repo.continuum.io/pkgs/free',
+                    'http://repo.continuum.io/pkgs/pro']
 
 # unset CIO_TEST.  This is a Continuum-internal variable that draws packages from an internal server instead of
 #     repo.continuum.io
@@ -32,7 +36,6 @@ try:
     del os.environ['CIO_TEST']
 except KeyError:
     pass
-
 
 class TestConfig(unittest.TestCase):
 


### PR DESCRIPTION
When someone mirrors the Anaconda repository and points the `default_channels` setting to their internal mirror, packages installed from the installer will be assigned the channel `<unknown>`. This PR recognizes these old URLs when canonicalizing the channel names, which helps to avoid an unnecessary "upgrade" from `<unknown>` to `defaults`.

A couple of potential improvements for later:
- Add `https://conda.anaconda.org/anaconda` to the hardcoded list
- Even better, make this configurable.