### PR TITLE
Skip dependency version/build optimization if no dependency updates

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -770,11 +770,15 @@ class Resolve(object):
         sdict = {}
         for s in specs:
             s = MatchSpec(s)  # needed for testing
-            sdict.setdefault(s.name, []).append(s)
-        for name, mss in iteritems(sdict):
+            rec = sdict.setdefault(s.name, [])
+            if s.target:
+                rec.append(s.target)
+        for name, targets in iteritems(sdict):
             pkgs = [(self.version_key(p), p) for p in self.groups.get(name, [])]
             pkey = None
             for nkey, npkg in pkgs:
+                if targets and any(npkg == t for t in targets):
+                    continue
                 if pkey is None:
                     iv = ib = 0
                 elif pkey[0] != nkey[0] or pkey[1] != nkey[1]:
@@ -1036,7 +1040,7 @@ class Resolve(object):
             solution, obj50 = C.minimize(eq_u, solution)
             dotlog.debug('Dependency update count: %d' % (obj50,))
 
-            # Remaining packages: maximize versions, then builds, then count
+            # Remaining packages: maximize versions, then builds
             eq_v, eq_b = r2.generate_version_metrics(C, speca)
             solution, obj5 = C.minimize(eq_v, solution)
             solution, obj6 = C.minimize(eq_b, solution)


### PR DESCRIPTION
@ilanschnell was encountering a performance issue where a `conda update` with a `-c` channel was causing a significant slowdown. 

This is only going to be a problem when the additional channel has a lot of the same packages as the existing channels. What happens is that `conda` tries to minimize the number of existing packages that need to be "touched" in order to accomplish a given install/update. Once that minimum number is established, _then_ it seeks to maximize the version and build numbers for those packages.

Well, if _none_ of the packages need changing, that second pass should be lightning-fast, because there's nothing to do. Only, it's not. For technical reasons, it is still including those packages in the version maximization pass---and thanks to the addition of a new high-priority channel via the `-c` option, that leads to *large* downgrade scores for those packages. Large downgrade scores mean lower performance.

What I've done here is a quick fix: if conda determines that no packages need upgrading, I remove them from consideration in those subsequent optimization passes. I have another idea I'll be trying out as well that may work if there are a non-zero, but small, number of upgrades.