### PR TITLE
call scripts with redirect on win; more error checking to activate

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -38,10 +38,12 @@
 @SET "CONDA_PATH_BACKUP=%PATH%"
 @REM Activate the new environment
 @FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..activate "cmd.exe" "%CONDA_NEW_ENV%"') DO @SET "NEW_PATH=%%i"
+@IF errorlevel 1 exit /b 1
 
 @REM take a snapshot of pristine state for later
 @SET "CONDA_PS1_BACKUP=%PROMPT%"
 @FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..changeps1') DO @SET "CHANGE_PROMPT=%%i"
+@IF errorlevel 1 exit /b 1
 
 :: if our prompt var does not contain reference to CONDA_DEFAULT_ENV, set prompt
 @IF "%CHANGE_PROMPT%" == "1" @IF "x%PROMPT:CONDA_DEFAULT_ENV=%" == "x%PROMPT%" (

--- a/conda/install.py
+++ b/conda/install.py
@@ -140,7 +140,7 @@ if on_win:
 
         # bat file redirect
         with open(dst+'.bat', 'w') as f:
-            f.write('@echo off\n"%s" %%*\n' % src)
+            f.write('@echo off\ncall "%s" %%*\n' % src)
 
         # TODO: probably need one here for powershell at some point
 


### PR DESCRIPTION
Calling the activate scripts is especially important. This was causing builds to mysteriously stop just after activation.

Error checking here isn't strictly necessary, but it probably doesn't hurt.

CC @kalefranz @mingwandroid

Originally submitted as #2849 - resubmitted here to apply to 4.1.x branch.