### PR TITLE
change lock to file-based

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -56,6 +56,8 @@ def check_prefix(prefix, json=False):
     if name == root_env_name:
         error = "'%s' is a reserved environment name" % name
     if exists(prefix):
+        if isdir(prefix) and not os.listdir(prefix):
+            return None
         error = "prefix already exists: %s" % prefix
 
     if error:

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -162,7 +162,7 @@ class CrossPlatformStLink(object):
 def find_lock():
     from os.path import join
 
-    from conda.lock import LOCKFN
+    from conda.lock import LOCK_EXTENSION
 
     lock_dirs = config_pkgs_dirs[:]
     lock_dirs += [root_dir]
@@ -182,7 +182,7 @@ def find_lock():
         if not os.path.exists(dir):
             continue
         for dn in os.listdir(dir):
-            if os.path.isdir(join(dir, dn)) and dn.startswith(LOCKFN):
+            if os.path.exists(join(dir, dn)) and dn.endswith(LOCK_EXTENSION):
                 path = join(dir, dn)
                 yield path
 
@@ -191,7 +191,8 @@ def rm_lock(locks, verbose=True):
     for path in locks:
         if verbose:
             print('removing: %s' % path)
-        os.rmdir(path)
+        from ..install import rm_rf
+        rm_rf(path)
 
 
 def find_tarballs():

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -26,7 +26,7 @@ from .config import (pkgs_dirs, DEFAULT_CHANNEL_ALIAS, remove_binstar_tokens,
 from .connection import CondaSession, unparse_url, RETRIES
 from .install import (add_cached_package, find_new_location, package_cache, dist2pair,
                       rm_rf, exp_backoff_fn)
-from .lock import Locked
+from .lock import FileLock as Locked
 from .utils import memoized
 
 
@@ -366,7 +366,7 @@ def download(url, dst_path, session=None, md5=None, urlstxt=False,
 
     if retries is None:
         retries = RETRIES
-    with Locked(dst_dir):
+    with Locked(join(dst_dir, url.rsplit("/", 1)[1][:-8])):
 
         rm_rf(dst_path)
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -47,8 +47,9 @@ from os.path import (abspath, basename, dirname, isdir, isfile, islink,
 
 on_win = bool(sys.platform == "win32")
 
+
 try:
-    from conda.lock import Locked
+    from conda.lock import FileLock as Locked
     from conda.utils import win_path_to_unix, url_path
     from conda.config import remove_binstar_tokens, pkgs_dirs, url_channel
 except ImportError:
@@ -788,10 +789,10 @@ def rm_fetched(dist):
     for fname in rec['files']:
         del fname_table_[fname]
         del fname_table_[url_path(fname)]
-        with Locked(dirname(fname)):
+        with Locked(join(dirname(fname), dist)):
             rm_rf(fname)
     for fname in rec['dirs']:
-        with Locked(dirname(fname)):
+        with Locked(join(dirname(fname), dist)):
             rm_rf(fname)
     del package_cache_[dist]
 
@@ -822,7 +823,7 @@ def rm_extracted(dist):
     if rec is None:
         return
     for fname in rec['dirs']:
-        with Locked(dirname(fname)):
+        with Locked(join(dirname(fname), dist)):
             rm_rf(fname)
     if rec['files']:
         rec['dirs'] = []
@@ -840,7 +841,7 @@ def extract(dist):
     fname = rec['files'][0]
     assert url and fname
     pkgs_dir = dirname(fname)
-    with Locked(pkgs_dir):
+    with Locked(join(pkgs_dir, dist)):
         path = fname[:-8]
         temp_path = path + '.tmp'
         rm_rf(temp_path)
@@ -1038,7 +1039,12 @@ def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):
     has_prefix_files = read_has_prefix(join(info_dir, 'has_prefix'))
     no_link = read_no_link(info_dir)
 
-    with Locked(prefix), Locked(pkgs_dir):
+    # for the lock issue
+    # may run into lock if prefix not exist
+    if not isdir(prefix):
+        os.makedirs(prefix)
+
+    with Locked(join(prefix, dist)), Locked(join(pkgs_dir, dist)):
         for f in files:
             src = join(source_dir, f)
             dst = join(prefix, f)
@@ -1110,7 +1116,7 @@ def unlink(prefix, dist):
     Remove a package from the specified environment, it is an error if the
     package does not exist in the prefix.
     """
-    with Locked(prefix):
+    with Locked(join(prefix, dist)):
         run_script(prefix, dist, 'pre-unlink')
 
         meta = load_meta(prefix, dist)

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -20,52 +20,75 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 import time
-
+from glob import glob
+from os.path import abspath, isdir, dirname
+from .compat import range
 from .exceptions import LockError
 
-LOCKFN = '.conda_lock'
+LOCK_EXTENSION = 'conda_lock'
 
+# Keep the string "LOCKERROR" in this string so that external
+# programs can look for it.
+LOCKSTR = """\
+LOCKERROR: It looks like conda is already doing something.
+The lock %s was found. Wait for it to finish before continuing.
+If you are sure that conda is not running, remove it and try again.
+You can also use: $ conda clean --lock
+"""
 
 stdoutlog = logging.getLogger('stdoutlog')
+log = logging.getLogger(__name__)
 
 
-class Locked(object):
+def touch(file_name, times=None):
+    """ Touch function like touch in Unix shell
+    :param file_name: the name of file
+    :param times: the access and modified time
+    Examples:
+        touch("hello_world.py")
+    """
+    with open(file_name, 'a'):
+        os.utime(file_name, times)
+
+
+class FileLock(object):
     """
     Context manager to handle locks.
     """
-    def __init__(self, path, retries=10):
-        self.path = path
-        self.end = "-" + str(os.getpid())
-        self.lock_path = os.path.join(self.path, LOCKFN + self.end)
+    def __init__(self, file_path, retries=10):
+        """
+        :param filepath: The file or directory to be locked
+        :param retries: max number of retries
+        :return:
+        """
+        self.file_path = abspath(file_path)
         self.retries = retries
 
     def __enter__(self):
-        # Keep the string "LOCKERROR" in this string so that external
-        # programs can look for it.
-        lockstr = ("""\
-    LOCKERROR: It looks like conda is already doing something.
-    The lock %s was found. Wait for it to finish before continuing.
-    If you are sure that conda is not running, remove it and try again.
-    You can also use: $ conda clean --lock\n""")
-        sleeptime = 1
+        assert isdir(dirname(self.file_path)), "{0} doesn't exist".format(self.file_path)
+
+        sleep_time = 1
+        self.lock_path = "{0}.pid{1}.{2}".format(self.file_path, os.getpid(), LOCK_EXTENSION)
+        lock_glob_str = "{0}.pid*.{1}".format(self.file_path, LOCK_EXTENSION)
+        last_glob_match = None
 
         for _ in range(self.retries):
-            if os.path.isdir(self.lock_path):
-                stdoutlog.info(lockstr % self.lock_path)
-                stdoutlog.info("Sleeping for %s seconds\n" % sleeptime)
+            # search, whether there is process already locked on this file
+            glob_result = glob(lock_glob_str)
+            if glob_result:
+                log.debug(LOCKSTR % glob_result[0])
+                log.debug("Sleeping for %s seconds\n" % sleep_time)
 
-                time.sleep(sleeptime)
-                sleeptime *= 2
+                time.sleep(sleep_time/10)
+                sleep_time *= 2
+                last_glob_match = glob_result
             else:
-                os.makedirs(self.lock_path)
+                touch(self.lock_path)
                 return self
 
         stdoutlog.error("Exceeded max retries, giving up")
-        raise LockError(lockstr % self.lock_path)
+        raise LockError(LOCKSTR % last_glob_match[0])
 
     def __exit__(self, exc_type, exc_value, traceback):
-        try:
-            os.rmdir(self.lock_path)
-            os.rmdir(self.path)
-        except OSError:
-            pass
+        from .install import rm_rf
+        rm_rf(self.lock_path)

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -29,11 +29,12 @@ LOCK_EXTENSION = 'conda_lock'
 
 # Keep the string "LOCKERROR" in this string so that external
 # programs can look for it.
-LOCKSTR = "\
-LOCKERROR: It looks like conda is already doing something.\
-The lock %s was found. Wait for it to finish before continuing.\
-If you are sure that conda is not running, remove it and try again. \
-You can also use: $ conda clean --lock"
+LOCKSTR = """
+LOCKERROR: It looks like conda is already doing something.
+The lock {0} was found. Wait for it to finish before continuing.
+If you are sure that conda is not running, remove it and try again.
+You can also use: $ conda clean --lock
+"""
 
 stdoutlog = logging.getLogger('stdoutlog')
 log = logging.getLogger(__name__)
@@ -49,6 +50,7 @@ def touch(file_name, times=None):
     with open(file_name, 'a'):
         os.utime(file_name, times)
 
+
 def preprocess_name(path):
     if "https:" in path:
         return path.split("https:")[0]+path.rsplit("/", 1)[1]
@@ -56,11 +58,13 @@ def preprocess_name(path):
         return path.split("file:")[0] + path.rsplit("/", 1)[1]
     else:
         return path
+
+
 class FileLock(object):
     """
     Context manager to handle locks.
     """
-    def __init__(self, file_path, max_tries=10):
+    def __init__(self, file_path, retries=10):
         """
         :param filepath: The file or directory to be locked
         :param retries: max number of retries
@@ -68,8 +72,7 @@ class FileLock(object):
         """
         file_path = preprocess_name(file_path)
         self.file_path = abspath(file_path)
-        self.retries = 0
-        self.max_tries = max_tries
+        self.retries = retries
 
     def __enter__(self):
         assert isdir(dirname(self.file_path)), "{0} doesn't exist".format(self.file_path)
@@ -79,24 +82,22 @@ class FileLock(object):
         lock_glob_str = "{0}.pid*.{1}".format(self.file_path, LOCK_EXTENSION)
         last_glob_match = None
 
-        while self.retries <= self.max_tries:
+        for q in range(self.retries + 1):
             # search, whether there is process already locked on this file
             glob_result = glob(lock_glob_str)
             if glob_result:
-                log.debug(LOCKSTR % glob_result[0])
+                log.debug(LOCKSTR.format(glob_result))
                 log.debug("Sleeping for %s seconds\n" % sleep_time)
 
-                time.sleep(sleep_time/10)
+                time.sleep(sleep_time / 10)
                 sleep_time *= 2
                 last_glob_match = glob_result
             else:
                 touch(self.lock_path)
                 return self
 
-            self.retries += 1
-
         stdoutlog.error("Exceeded max retries, giving up")
-        raise LockError(LOCKSTR % str(last_glob_match))
+        raise LockError(LOCKSTR.format(last_glob_match))
 
     def __exit__(self, exc_type, exc_value, traceback):
         from .install import rm_rf

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -29,12 +29,11 @@ LOCK_EXTENSION = 'conda_lock'
 
 # Keep the string "LOCKERROR" in this string so that external
 # programs can look for it.
-LOCKSTR = """\
-LOCKERROR: It looks like conda is already doing something.
-The lock %s was found. Wait for it to finish before continuing.
-If you are sure that conda is not running, remove it and try again.
-You can also use: $ conda clean --lock
-"""
+LOCKSTR = "\
+LOCKERROR: It looks like conda is already doing something.\
+The lock %s was found. Wait for it to finish before continuing.\
+If you are sure that conda is not running, remove it and try again. \
+You can also use: $ conda clean --lock"
 
 stdoutlog = logging.getLogger('stdoutlog')
 log = logging.getLogger(__name__)
@@ -50,19 +49,27 @@ def touch(file_name, times=None):
     with open(file_name, 'a'):
         os.utime(file_name, times)
 
-
+def preprocess_name(path):
+    if "https:" in path:
+        return path.split("https:")[0]+path.rsplit("/", 1)[1]
+    elif "file" in path:
+        return path.split("file:")[0] + path.rsplit("/", 1)[1]
+    else:
+        return path
 class FileLock(object):
     """
     Context manager to handle locks.
     """
-    def __init__(self, file_path, retries=10):
+    def __init__(self, file_path, max_tries=10):
         """
         :param filepath: The file or directory to be locked
         :param retries: max number of retries
         :return:
         """
+        file_path = preprocess_name(file_path)
         self.file_path = abspath(file_path)
-        self.retries = retries
+        self.retries = 0
+        self.max_tries = max_tries
 
     def __enter__(self):
         assert isdir(dirname(self.file_path)), "{0} doesn't exist".format(self.file_path)
@@ -72,7 +79,7 @@ class FileLock(object):
         lock_glob_str = "{0}.pid*.{1}".format(self.file_path, LOCK_EXTENSION)
         last_glob_match = None
 
-        for _ in range(self.retries):
+        while self.retries <= self.max_tries:
             # search, whether there is process already locked on this file
             glob_result = glob(lock_glob_str)
             if glob_result:
@@ -86,8 +93,10 @@ class FileLock(object):
                 touch(self.lock_path)
                 return self
 
+            self.retries += 1
+
         stdoutlog.error("Exceeded max retries, giving up")
-        raise LockError(LOCKSTR % last_glob_match[0])
+        raise LockError(LOCKSTR % str(last_glob_match))
 
     def __exit__(self, exc_type, exc_value, traceback):
         from .install import rm_rf

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -50,10 +50,8 @@ def make_temp_prefix(name=None):
     tempdir = gettempdir()
     dirname = str(uuid4())[:8] if name is None else name
     prefix = join(tempdir, dirname)
-    if exists(prefix):
-        # rm here because create complains if directory exists
-        rmtree(prefix)
-    assert isdir(tempdir)
+    os.makedirs(prefix)
+    assert isdir(prefix)
     return prefix
 
 
@@ -482,16 +480,3 @@ class IntegrationTests(TestCase):
             if isfile(shortcut_file):
                 os.remove(shortcut_file)
 
-
-def test_symlinks_created_with_env():
-    bindir = 'Scripts' if on_win else 'bin'
-
-    with TemporaryDirectory() as tmp:
-        check_call(["conda", "create", '-y', '-p', join(tmp, 'conda'), "python=2.7"])
-        assert isfile(join(tmp, 'conda', bindir, 'activate'))
-        assert isfile(join(tmp, 'conda', bindir, 'deactivate'))
-        assert isfile(join(tmp, 'conda', bindir, 'conda'))
-        if on_win:
-            assert isfile(join(tmp, 'conda', bindir, 'activate.bat'))
-            assert isfile(join(tmp, 'conda', bindir, 'deactivate.bat'))
-            assert isfile(join(tmp, 'conda', bindir, 'conda.bat'))

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,5 +1,5 @@
 import pytest
-from os.path import basename, join
+from os.path import basename, join, exists
 from conda.lock import FileLock, LOCKSTR, LOCK_EXTENSION, LockError
 
 
@@ -24,7 +24,7 @@ def test_filelock_locks(tmpdir):
         assert tmpdir.join(path).exists()
 
         with pytest.raises(LockError) as execinfo:
-            with FileLock(tmpfile, retries=1) as lock2:
+            with FileLock(tmpfile, max_tries=1) as lock2:
                 assert False  # this should never happen
             assert lock2.lock_path == lock1.lock_path
         assert "LOCKERROR" in str(execinfo)
@@ -46,14 +46,60 @@ def test_filelock_folderlocks(tmpdir):
         assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
 
         with pytest.raises(LockError) as execinfo:
-            with FileLock(tmpfile, retries=1) as lock2:
+            with FileLock(tmpfile, max_tries=1) as lock2:
                 assert False  # this should never happen
             assert lock2.lock_path == lock1.lock_path
         assert "LOCKERROR" in str(execinfo)
         assert "conda is already doing something" in str(execinfo)
+        assert lock1.lock_path in str(execinfo), "haha {0}".format(str(execinfo))
 
         assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
 
     # lock should clean up after itself
     assert not tmpdir.join(path).exists()
 
+
+def lock_thread(tmpdir, file_path):
+    with FileLock(file_path) as lock1:
+        path = basename(lock1.lock_path)
+        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
+    assert not tmpdir.join(path).exists()
+
+def test_lock_thread(tmpdir):
+
+    from threading import Thread
+    package_name = "conda_file_3"
+    tmpfile = join(tmpdir.strpath, package_name)
+    t = Thread(target=lock_thread, args=(tmpdir, tmpfile))
+
+    with FileLock(tmpfile) as lock1:
+        t.start()
+        path = basename(lock1.lock_path)
+        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
+
+    t.join()
+    # lock should clean up after itself
+    assert not tmpdir.join(path).exists()
+
+
+
+def lock_thread_retries(tmpdir, file_path):
+    with FileLock(file_path, max_tries=0) as lock1:
+        assert  False # should never enter here, since max_tires is 0
+
+
+def test_lock_retries(tmpdir):
+
+    from threading import Thread
+    package_name = "conda_file_3"
+    tmpfile = join(tmpdir.strpath, package_name)
+    t = Thread(target=lock_thread_retries, args=(tmpdir, tmpfile))
+
+    with FileLock(tmpfile) as lock1:
+        t.start()
+        path = basename(lock1.lock_path)
+        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
+
+    t.join()
+    # lock should clean up after itself
+    assert not tmpdir.join(path).exists()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,5 +1,5 @@
 import pytest
-from os.path import basename, join, exists
+from os.path import basename, join
 from conda.lock import FileLock, LOCKSTR, LOCK_EXTENSION, LockError
 
 
@@ -14,7 +14,6 @@ def test_filelock_passes(tmpdir):
     assert not tmpdir.join(path).exists()
 
 
-
 def test_filelock_locks(tmpdir):
 
     package_name = "conda_file_2"
@@ -24,12 +23,11 @@ def test_filelock_locks(tmpdir):
         assert tmpdir.join(path).exists()
 
         with pytest.raises(LockError) as execinfo:
-            with FileLock(tmpfile, max_tries=1) as lock2:
+            with FileLock(tmpfile, retries=1) as lock2:
                 assert False  # this should never happen
             assert lock2.lock_path == lock1.lock_path
-        assert "LOCKERROR" in str(execinfo)
-        assert "conda is already doing something" in str(execinfo)
-
+        assert "LOCKERROR" in execinfo.value.message
+        assert "conda is already doing something" in execinfo.value.message
         assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
 
     # lock should clean up after itself
@@ -46,12 +44,12 @@ def test_filelock_folderlocks(tmpdir):
         assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
 
         with pytest.raises(LockError) as execinfo:
-            with FileLock(tmpfile, max_tries=1) as lock2:
+            with FileLock(tmpfile, retries=1) as lock2:
                 assert False  # this should never happen
             assert lock2.lock_path == lock1.lock_path
-        assert "LOCKERROR" in str(execinfo)
-        assert "conda is already doing something" in str(execinfo)
-        assert lock1.lock_path in str(execinfo), "haha {0}".format(str(execinfo))
+        assert "LOCKERROR" in execinfo.value.message
+        assert "conda is already doing something" in execinfo.value.message
+        assert lock1.lock_path in execinfo.value.message
 
         assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
 
@@ -64,6 +62,7 @@ def lock_thread(tmpdir, file_path):
         path = basename(lock1.lock_path)
         assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
     assert not tmpdir.join(path).exists()
+
 
 def test_lock_thread(tmpdir):
 
@@ -82,10 +81,9 @@ def test_lock_thread(tmpdir):
     assert not tmpdir.join(path).exists()
 
 
-
 def lock_thread_retries(tmpdir, file_path):
-    with FileLock(file_path, max_tries=0) as lock1:
-        assert  False # should never enter here, since max_tires is 0
+    with FileLock(file_path, retries=0):
+        assert False  # should never enter here, since max_tires is 0
 
 
 def test_lock_retries(tmpdir):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,32 +1,59 @@
-import os.path
 import pytest
+from os.path import basename, join
+from conda.lock import FileLock, LOCKSTR, LOCK_EXTENSION, LockError
 
-from conda.lock import Locked, LockError
 
-
-def test_lock_passes(tmpdir):
-    with Locked(tmpdir.strpath) as lock:
-        path = os.path.basename(lock.lock_path)
-        assert tmpdir.join(path).exists() and tmpdir.join(path).isdir()
+def test_filelock_passes(tmpdir):
+    package_name = "conda_file1"
+    tmpfile = join(tmpdir.strpath, package_name)
+    with FileLock(tmpfile) as lock:
+        path = basename(lock.lock_path)
+        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
 
     # lock should clean up after itself
     assert not tmpdir.join(path).exists()
-    assert not tmpdir.exists()
 
-def test_lock_locks(tmpdir):
-    with Locked(tmpdir.strpath) as lock1:
-        path = os.path.basename(lock1.lock_path)
-        assert tmpdir.join(path).exists() and tmpdir.join(path).isdir()
+
+
+def test_filelock_locks(tmpdir):
+
+    package_name = "conda_file_2"
+    tmpfile = join(tmpdir.strpath, package_name)
+    with FileLock(tmpfile) as lock1:
+        path = basename(lock1.lock_path)
+        assert tmpdir.join(path).exists()
 
         with pytest.raises(LockError) as execinfo:
-            with Locked(tmpdir.strpath, retries=1) as lock2:
+            with FileLock(tmpfile, retries=1) as lock2:
                 assert False  # this should never happen
             assert lock2.lock_path == lock1.lock_path
         assert "LOCKERROR" in str(execinfo)
         assert "conda is already doing something" in str(execinfo)
 
-        assert tmpdir.join(path).exists() and tmpdir.join(path).isdir()
+        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
 
     # lock should clean up after itself
     assert not tmpdir.join(path).exists()
-    assert not tmpdir.exists()
+
+
+def test_filelock_folderlocks(tmpdir):
+    import os
+    package_name = "conda_file_2"
+    tmpfile = join(tmpdir.strpath, package_name)
+    os.makedirs(tmpfile)
+    with FileLock(tmpfile) as lock1:
+        path = basename(lock1.lock_path)
+        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
+
+        with pytest.raises(LockError) as execinfo:
+            with FileLock(tmpfile, retries=1) as lock2:
+                assert False  # this should never happen
+            assert lock2.lock_path == lock1.lock_path
+        assert "LOCKERROR" in str(execinfo)
+        assert "conda is already doing something" in str(execinfo)
+
+        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
+
+    # lock should clean up after itself
+    assert not tmpdir.join(path).exists()
+


### PR DESCRIPTION
Originally, the lock is based on process id and path. For example, if download a file into /var/pkgs, the progress will block all the other operations on this directory. Now, the new lock will lock on a hash digest of a file, giving the opportunities for parallel downloading, extracting, and linking
