### PR TITLE
use CONDA_PREFIX, not CONDA_DEFAULT_ENV for activate.d

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -90,7 +90,7 @@ if (( $? == 0 )); then
     fi
 
     # Load any of the scripts found $PREFIX/etc/conda/activate.d AFTER activation
-    _CONDA_D="${CONDA_DEFAULT_ENV}/etc/conda/activate.d"
+    _CONDA_D="${CONDA_PREFIX}/etc/conda/activate.d"
     if [[ -d "$_CONDA_D" ]]; then
         IFS=$(echo -en "\n\b")&>/dev/null  && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
     fi

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -64,8 +64,8 @@
     @SET "CONDA_PREFIX=%CONDA_PREFIX%"
 
     @REM Run any activate scripts
-    @IF EXIST "%CONDA_NEW_ENV%\etc\conda\activate.d" (
-        @PUSHD "%CONDA_NEW_ENV%\etc\conda\activate.d"
+    @IF EXIST "%CONDA_PREFIX%\etc\conda\activate.d" (
+        @PUSHD "%CONDA_PREFIX%\etc\conda\activate.d"
         @FOR %%g in (*.bat) DO @CALL "%%g"
         @POPD
     )

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -62,7 +62,7 @@ fi
 
 if (( $? == 0 )); then
     # Inverse of activation: run deactivate scripts prior to deactivating env
-    _CONDA_D="${CONDA_DEFAULT_ENV}/etc/conda/deactivate.d"
+    _CONDA_D="${CONDA_PREFIX}/etc/conda/deactivate.d"
     if [[ -d $_CONDA_D ]]; then
         IFS=$(echo -en "\n\b") && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
     fi

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -25,8 +25,8 @@
 
 @ENDLOCAL & (
             REM Run any deactivate scripts
-            @IF EXIST "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d" (
-                @PUSHD "%CONDA_DEFAULT_ENV%\etc\conda\deactivate.d"
+            @IF EXIST "%CONDA_PREFIX%\etc\conda\deactivate.d" (
+                @PUSHD "%CONDA_PREFIX%\etc\conda\deactivate.d"
                 @FOR %%g IN (*.bat) DO @CALL "%%g"
                 @POPD
             )

--- a/shell/conda.fish
+++ b/shell/conda.fish
@@ -146,7 +146,7 @@ end
 function deactivate --description 'Deactivate the current conda environment.'
     if set -q CONDA_DEFAULT_ENV  # don't deactivate the root environment
           # check if there are any *.fish scripts in deactivate.d
-          set -l deactivate_d $CONDA_DEFAULT_ENV/etc/conda/deactivate.d
+          set -l deactivate_d $CONDA_PREFIX/etc/conda/deactivate.d
           if test -d "$deactivate_d"
               source $deactivate_d/*.fish
           end
@@ -195,7 +195,7 @@ function activate --description 'Activate a conda environment.'
         set -gx CONDA_PREFIX (echo $PATH[1] | sed 's|/bin$||g')
 
         # check if there are any *.fish scripts in activate.d
-        set -l activate_d $CONDA_DEFAULT_ENV/etc/conda/activate.d
+        set -l activate_d $CONDA_PREFIX/etc/conda/activate.d
         if test -d "$activate_d"
             . $activate_d/*.fish
         end


### PR DESCRIPTION
CONDA_DEFAULT_ENV is not always valid here.  For environments activated by name, activate.d scripts will (usually) not actually run, since the path logic will fail.  This fixes those to use CONDA_PREFIX.

CC @kalefranz - please get this in before you release the other related changes that you have already merged.