### PR TITLE
Revert the use of UNC paths; shorten trash filenames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ sudo: false
 language: python
 python:
   - '2.7'
+  - '3.4'
   - '3.5'
 
 os:
   - linux
-#  - osx
+  - osx
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 os:
   - linux
-  - osx
+  # - osx
 
 addons:
   apt:

--- a/conda/install.py
+++ b/conda/install.py
@@ -42,7 +42,7 @@ import tarfile
 import time
 import traceback
 from os.path import (abspath, basename, dirname, isdir, isfile, islink,
-                     join, relpath, normpath)
+                     join, normpath)
 
 
 on_win = bool(sys.platform == "win32")
@@ -990,7 +990,6 @@ def move_path_to_trash(path):
     """
     # Try deleting the trash every time we use it.
     delete_trash()
-    from conda.config import root_dir
     import tempfile
 
     for pkg_dir in pkgs_dirs:

--- a/conda/install.py
+++ b/conda/install.py
@@ -963,28 +963,9 @@ def is_linked(prefix, dist):
     return load_meta(prefix, dist)
 
 
-def _get_trash_dir(pkg_dir):
-    unc_prefix = u'\\\\?\\' if on_win else ''
-    return unc_prefix + join(pkg_dir, '.trash')
-
-
-def _safe_relpath(path, start_path):
-    """
-    Used in the move_to_trash flow. Ensures that the result does not
-    start with any '..' which would allow to escape the trash folder
-    (and root prefix) and potentially ruin the user's system.
-    """
-    result = normpath(relpath(path, start_path))
-    parts = result.rsplit(os.sep)
-    for idx, part in enumerate(parts):
-        if part != u'..':
-            return os.sep.join(parts[idx:])
-    return u''
-
-
 def delete_trash(prefix=None):
     for pkg_dir in pkgs_dirs:
-        trash_dir = _get_trash_dir(pkg_dir)
+        trash_dir = join(pkg_dir, '.trash')
         try:
             log.debug("Trying to delete the trash dir %s" % trash_dir)
             rm_rf(trash_dir, max_retries=1, trash=False)
@@ -1010,10 +991,10 @@ def move_path_to_trash(path):
     # Try deleting the trash every time we use it.
     delete_trash()
     from conda.config import root_dir
+    import tempfile
 
     for pkg_dir in pkgs_dirs:
-        import tempfile
-        trash_dir = _get_trash_dir(pkg_dir)
+        trash_dir = join(pkg_dir, '.trash')
 
         try:
             os.makedirs(trash_dir)
@@ -1021,25 +1002,17 @@ def move_path_to_trash(path):
             if e1.errno != errno.EEXIST:
                 continue
 
-        trash_dir = tempfile.mkdtemp(dir=trash_dir)
-        trash_dir = join(trash_dir, _safe_relpath(os.path.dirname(path), root_dir))
+        trash_file = tempfile.mktemp(dir=trash_dir)
 
         try:
-            os.makedirs(trash_dir)
-        except OSError as e2:
-            if e2.errno != errno.EEXIST:
-                continue
-
-        try:
-            shutil.move(path, trash_dir)
+            shutil.move(path, trash_file)
         except OSError as e:
-            log.debug("Could not move %s to %s (%s)" % (path, trash_dir, e))
+            log.debug("Could not move %s to %s (%s)" % (path, trash_file, e))
         else:
             delete_linked_data_any(path)
-            return True
+            return trash_file
 
     log.debug("Could not move %s to trash" % path)
-    return False
 
 
 def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -112,28 +112,6 @@ class FileTests(unittest.TestCase):
                 b'\x7fELF.../usr/local/lib/libfoo.so\0\0\0\0\0\0\0\0'
             )
 
-    def test_trash_long_paths(self):
-        pkg_dir = config.pkgs_dirs[0]
-        longfoldername="trash_with_a_very_very_long_and_silly_name_indeed"
-        tmpdir=pkg_dir
-        for i in range(8):
-            tmpdir = join(tmpdir, longfoldername)
-            if not i:
-                toptmpdir = tmpdir
-        tmpfile = join(tmpdir, 'tempfile')
-        makedirs(tmpdir)
-        with open(tmpfile, 'w') as fo:
-            fo.write('trashy')
-        delete_trash(config.pkgs_dirs[0])
-        delete_trash(config.pkgs_dirs[0])
-        dest = move_path_to_trash(toptmpdir)
-        assert dest is not None
-        assert not exists(tmpfile)
-        assert exists(dest)
-        delete_trash(config.pkgs_dirs[0])
-        delete_trash(config.pkgs_dirs[0])
-        assert not exists(dest)
-
     def test_trash_outside_prefix(self):
         from conda.config import root_dir
         tmp_dir = tempfile.mkdtemp()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,7 +14,7 @@ from conda import install, config
 from conda.install import (PaddingError, binary_replace, update_prefix,
                            warn_failed_remove, duplicates_to_remove, dist2quad,
                            dist2name, dist2dirname, dist2filename, dist2pair, name_dist,
-                           delete_trash, move_path_to_trash, _get_trash_dir, on_win)
+                           delete_trash, move_path_to_trash, on_win)
 
 from .decorators import skip_if_no_mock
 from .helpers import mock
@@ -113,28 +113,26 @@ class FileTests(unittest.TestCase):
             )
 
     def test_trash_long_paths(self):
-        unc_prefix = u'\\\\?\\' if platform == 'win32' else ''
         pkg_dir = config.pkgs_dirs[0]
         longfoldername="trash_with_a_very_very_long_and_silly_name_indeed"
         tmpdir=pkg_dir
-        for i in range(6):
+        for i in range(8):
             tmpdir = join(tmpdir, longfoldername)
             if not i:
                 toptmpdir = tmpdir
-        tmpfile = join(tmpdir, self.tmpfname)
-        makedirs(unc_prefix + tmpdir)
-        with open(unc_prefix + tmpfile, 'w') as fo:
+        tmpfile = join(tmpdir, 'tempfile')
+        makedirs(tmpdir)
+        with open(tmpfile, 'w') as fo:
             fo.write('trashy')
         delete_trash(config.pkgs_dirs[0])
         delete_trash(config.pkgs_dirs[0])
-        move_path_to_trash(toptmpdir)
-        trash = _get_trash_dir(config.pkgs_dirs[0])
-        contents = [basename(dp) for dp, dn, fn in walk(trash)]
-        self.assertIn(longfoldername, contents)
+        dest = move_path_to_trash(toptmpdir)
+        assert dest is not None
+        assert not exists(tmpfile)
+        assert exists(dest)
         delete_trash(config.pkgs_dirs[0])
         delete_trash(config.pkgs_dirs[0])
-        contents = [basename(dp) for dp, dn, fn in walk(trash)]
-        self.assertTrue(longfoldername not in contents)
+        assert not exists(dest)
 
     def test_trash_outside_prefix(self):
         from conda.config import root_dir


### PR DESCRIPTION
cc: @kalefranz @msarahan @mingwandroid 

Using bisection I determined that issue #2846 has been with us since 4.0.6. It turns out that the cause was [this commit](https://github.com/conda/conda/commit/226ac99f07e8394e025de6f18be86f2a927d3c1c), submitted in PR #2542. It turns out that, for reasons yet undetermined, `shutil.move` is unable to move open files to the trash when the trash directory uses a UNC pathname. We don't know why.

So why use UNC pathnames at all? The motivation for this PR was https://github.com/conda/conda-build/issues/891; the pathnames generated for `move_path_to_trash` were too long for Windows. But that's in part because, for some reason, `conda` was determined to preserve the _entire path_ to the deleted file (relative to `root_dir`) inside the `.trash` directory. Presumably this was chosen to aid in debugging. Well, that backfired.

This rips out all of the UNC logic, and replaces the multilevel path generated for the trash destination with a single random unique filename. This shortens the paths seen by `shutil.move` to a length that is shorter than most of the tarballs in the package cache itself---and certainly shorter than their extracted contents. If users are having trouble with long path names in the package cache, we have bigger problems.

Now, I fully understand if anyone reading this is concerned we might be breaking https://github.com/conda/conda-build/issues/891 or related issues. But I would propose that we solve this problem not by using UNC paths but rather with judicious tree-walking. After all, we don't know why UNC pathnames are causing `shutil.move` trouble.