### PR TITLE
remove excess output from conda -h

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -158,8 +158,10 @@ Error: You need to install conda-build in order to use the 'conda %s'
         super(ArgumentParser, self).print_help()
 
         if self.prog == 'conda' and sys.argv[1:] in ([], ['help'], ['-h'], ['--help']):
-            from .find_commands import help
-            help()
+            print("""
+other commands, such as "conda build", are avaialble when additional conda
+packages (e.g. conda-build) are installed
+""")
 
     def parse_args(self, *args, **kwargs):
         if argcomplete:

--- a/conda/cli/find_commands.py
+++ b/conda/cli/find_commands.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 import os
 import re
-import subprocess
 import sys
 from os.path import isdir, isfile, join, expanduser
 
@@ -62,33 +61,3 @@ def find_commands(include_others=True):
             if m:
                 res.add(m.group(1))
     return sorted(res)
-
-
-def filter_descr(cmd):
-    args = [find_executable('conda-' + cmd), '--help']
-    if not args[0]:
-        print('failed: %s (could not find executable)' % (cmd))
-        return
-    try:
-        output = subprocess.check_output(args)
-    except (OSError, subprocess.CalledProcessError):
-        print('failed: %s' % (' '.join(args)))
-        return
-    pat = re.compile(r'(\r?\n){2}(.*?)(\r?\n){2}', re.DOTALL)
-    m = pat.search(output.decode('utf-8'))
-    descr = ['<could not extract description>'] if m is None else m.group(2).splitlines()
-    # XXX: using some stuff from textwrap would be better here, as it gets
-    # longer than 80 characters
-    print('    %-12s %s' % (cmd, descr[0]))
-    for d in descr[1:]:
-        print('                 %s' % d)
-
-
-def help():
-    print("\nother commands:")
-    for cmd in find_commands():
-        filter_descr(cmd)
-
-
-if __name__ == '__main__':
-    help()


### PR DESCRIPTION
Currently, when typing `conda`, `conda -h`, `conda --help`, one get horrible output shown below.  Apart from the fact that this operation takes a long time, it is not really useful for the user.  In this PR, we remove all the subprocess calls, and reduce the conda help information to the conda builtin commands themselves.
```
$ conda --help
usage: conda [-h] [-V] [--debug] command ...

conda is a tool for managing and deploying applications, environments and packages.

Options:

positional arguments:
  command
    info         Display information about current conda install.
    help         Displays a list of available conda commands and their help
                 strings.
    list         List linked packages in a conda environment.
    search       Search for packages and display their information. The input
                 is a Python regular expression. To perform a search with a
                 search string that starts with a -, separate the search from
                 the options with --, like 'conda search -- -h'. A * in the
                 results means that package is installed in the current
                 environment. A . means that package is not installed but is
                 cached in the pkgs directory.
    create       Create a new conda environment from a list of specified
                 packages.
    install      Installs a list of packages into a specified conda
                 environment.
    update       Updates conda packages to the latest compatible version. This
                 command accepts a list of package names and updates them to
                 the latest versions that are compatible with all other
                 packages in the environment. Conda attempts to install the
                 newest versions of the requested packages. To accomplish
                 this, it may update some packages that are already installed,
                 or install additional packages. To prevent existing packages
                 from updating, use the --no-update-deps option. This may
                 force conda to install older versions of the requested
                 packages, and it does not prevent additional dependency
                 packages from being installed. If you wish to skip dependency
                 checking altogether, use the '--force' option. This may
                 result in an environment with incompatible packages, so this
                 option must be used with great caution.
    upgrade      Alias for conda update. See conda update --help.
    remove       Remove a list of packages from a specified conda environment.
    uninstall    Alias for conda remove. See conda remove --help.
    config       Modify configuration values in .condarc. This is modeled
                 after the git config command. Writes to the user .condarc
                 file (/home/ilan/.condarc) by default.
    init         Initialize conda into a regular environment (when conda was
                 installed as a Python package, e.g. using pip). (DEPRECATED)
    clean        Remove unused packages and caches.
    package      Low-level conda package utility. (EXPERIMENTAL)
    bundle       Create or extract a "bundle package" (EXPERIMENTAL)

optional arguments:
  -h, --help     Show this help message and exit.
  -V, --version  Show the conda version number and exit.
  --debug        Show debug output.

other commands:
    build        Tool for building conda packages. A conda package is a binary tarball
                 containing system-level libraries, Python modules, executable programs, or
                 other components. conda keeps track of dependencies between packages and
                 platform specifics, making it simple to create working environments from
                 different sets of packages.
    convert      Various tools to convert conda packages. Takes a pure Python package build for
                 one platform and converts it to work on one or more other platforms, or
                 all.
    develop      Install a Python package in 'development mode'.
    env          positional arguments:
                   {attach,create,export,list,remove,upload,update}
                     attach              Embeds information describing your conda environment
                                         into the notebook metadata
                     create              Create an environment based on an environment file
                     export              Export a given environment
                     list                List the Conda environments
                     remove              Remove an environment
                     upload              Upload an environment to anaconda.org
                     update              Update the current environment based on environment
                                         file
    index        Update package index metadata files in given directories.
Traceback (most recent call last):
  File "/home/ilan/minonda/bin/conda-inspect", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/ilan/conda-build/bin/conda-inspect", line 3, in <module>
    from conda_build.main_inspect import main
  File "/home/ilan/conda-build/conda_build/main_inspect.py", line 23, in <module>
    from conda.cli.install import check_install
ImportError: cannot import name check_install
failed: /home/ilan/minonda/bin/conda-inspect --help
    metapackage  Tool for building conda metapackages.  A metapackage is a package with no
                 files, only metadata.  They are typically used to collect several packages
                 together into a single package via dependencies.
    pipbuild     *** This command is no longer supported.  It will be removed in a future release of conda-build. ***
                 The recommended way to build conda packages from packages on
                 PyPI is using conda skeleton pypi and conda build.
                 Tool for building conda packages using pip install.
                         
    server       Anaconda Cloud command line manager
    sign         Tool for signing conda packages.  Signatures will be written alongside the
                 files as FILE.sig.
    skeleton     Generates a boilerplate/skeleton recipe, which you can then edit to create a
                 full recipe. Some simple skeleton recipes may not even need edits.
```
