### PR TITLE
Graceful exit for `conda --debug`, `conda --json`, etc. with no command

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -86,6 +86,9 @@ def main():
         metavar='command',
         dest='cmd',
     )
+    # http://bugs.python.org/issue9253
+    # http://stackoverflow.com/a/18283730/1599393
+    sub_parsers.required = True
 
     main_modules = ["info", "help", "list", "search", "create", "install", "update",
                     "remove", "config", "clean"]


### PR DESCRIPTION
See #2864, #2801. Simple fix necessitated by a change in argparse in Python 3.3; see
http://stackoverflow.com/questions/18282403/argparse-with-required-subcommands

I recommend cherry picking to 4.0.x and 4.1.x.