### PR TITLE
Change root prefix detection to avoid clobbering root activate scripts

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -575,7 +575,8 @@ def read_no_link(info_dir):
 # Should this be an API function?
 def symlink_conda(prefix, root_dir, shell=None):
     # do not symlink root env - this clobbers activate incorrectly.
-    if normpath(prefix) == normpath(sys.prefix):
+    # prefix should always be longer than, or outside the root dir.
+    if normpath(prefix) in normpath(root_dir):
         return
     if on_win:
         where = 'Scripts'


### PR DESCRIPTION
People are seeing strange issues with conda-build, where activation overwrites the root prefix activation scripts with the bat redirect scripts.  This avoids clobbering those scripts, which should at least prevent things from breaking.