### PR TITLE
More aggressive use of move_path_to_trash to fix permissions issues

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -1021,7 +1021,7 @@ def move_path_to_trash(path, preclean=True):
                 rm_rf(trash_file, max_retries=1, trash=False)
             return True
 
-    return None
+    return False
 
 
 def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):

--- a/conda/install.py
+++ b/conda/install.py
@@ -261,16 +261,26 @@ def rm_rf(path, max_retries=5, trash=True):
         # islink('/path/to/dead-link') is True.
         try:
             os.unlink(path)
+            return
         except (OSError, IOError):
             log.warn("Cannot remove, permission denied: {0}".format(path))
+            if trash and move_path_to_trash(path):
+                return
 
     elif isdir(path):
+
+        # On Windows, always move to trash first.
+        if trash and on_win and move_path_to_trash(path, preclean=False):
+            return
+
         try:
             for i in range(max_retries):
                 try:
                     shutil.rmtree(path, ignore_errors=False, onerror=warn_failed_remove)
                     return
                 except OSError as e:
+                    if trash and move_path_to_trash(path):
+                        return
                     msg = "Unable to delete %s\n%s\n" % (path, e)
                     if on_win:
                         try:
@@ -288,16 +298,6 @@ def rm_rf(path, max_retries=5, trash=True):
                         else:
                             if not isdir(path):
                                 return
-
-                        if trash:
-                            try:
-                                move_path_to_trash(path)
-                                if not isdir(path):
-                                    return
-                            except OSError as e2:
-                                raise
-                                msg += "Retry with onerror failed (%s)\n" % e2
-
                     log.debug(msg + "Retrying after %s seconds..." % i)
                     time.sleep(i)
             # Final time. pass exceptions to caller.
@@ -971,6 +971,8 @@ def is_linked(prefix, dist):
 def delete_trash(prefix=None):
     for pkg_dir in pkgs_dirs:
         trash_dir = join(pkg_dir, '.trash')
+        if not isdir(trash_dir):
+            continue
         try:
             log.debug("Trying to delete the trash dir %s" % trash_dir)
             rm_rf(trash_dir, max_retries=1, trash=False)
@@ -989,14 +991,14 @@ def move_to_trash(prefix, f, tempdir=None):
     return move_path_to_trash(join(prefix, f) if f else prefix)
 
 
-def move_path_to_trash(path):
+def move_path_to_trash(path, preclean=True):
     """
     Move a path to the trash
     """
     # Try deleting the trash every time we use it.
-    delete_trash()
+    if preclean:
+        delete_trash()
 
-    from conda.config import pkgs_dirs
     for pkg_dir in pkgs_dirs:
         trash_dir = join(pkg_dir, '.trash')
 
@@ -1009,14 +1011,17 @@ def move_path_to_trash(path):
         trash_file = tempfile.mktemp(dir=trash_dir)
 
         try:
-            shutil.move(path, trash_file)
+            os.rename(path, trash_file)
         except OSError as e:
             log.debug("Could not move %s to %s (%s)" % (path, trash_file, e))
         else:
+            log.debug("Moved to trash: %s" % (path,))
             delete_linked_data_any(path)
-            return trash_file
+            if not preclean:
+                rm_rf(trash_file, max_retries=1, trash=False)
+            return True
 
-    log.debug("Could not move %s to trash" % path)
+    return None
 
 
 def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):
@@ -1048,17 +1053,7 @@ def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):
                 os.makedirs(dst_dir)
             if os.path.exists(dst):
                 log.warn("file already exists: %r" % dst)
-                try:
-                    os.unlink(dst)
-                except OSError:
-                    log.error('failed to unlink: %r' % dst)
-                    if on_win:
-                        try:
-                            move_path_to_trash(dst)
-                        except ImportError:
-                            # This shouldn't be an issue in the installer anyway
-                            pass
-
+                rm_rf(dst)
             lt = linktype
             if f in has_prefix_files or f in no_link or islink(src):
                 lt = LINK_COPY
@@ -1122,18 +1117,7 @@ def unlink(prefix, dist):
         for f in meta['files']:
             dst = join(prefix, f)
             dst_dirs1.add(dirname(dst))
-            try:
-                os.unlink(dst)
-            except OSError:  # file might not exist
-                log.debug("could not remove file: '%s'" % dst)
-                if on_win and os.path.exists(join(prefix, f)):
-                    try:
-                        log.debug("moving to trash")
-                        move_path_to_trash(dst)
-                    except ImportError:
-                        # This shouldn't be an issue in the installer anyway
-                        #   but it can potentially happen with importing conda.config
-                        log.debug("cannot import conda.config; probably not an issue")
+            rm_rf(dst)
 
         # remove the meta-file last
         delete_linked_data(prefix, dist, delete=True)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -215,6 +215,10 @@ class IntegrationTests(TestCase):
             run_command(Commands.INSTALL, prefix, 'flask=0.10')
             assert_package_is_installed(prefix, 'flask-0.10.1')
 
+            # Test force reinstall
+            run_command(Commands.INSTALL, prefix, '--force', 'flask=0.10')
+            assert_package_is_installed(prefix, 'flask-0.10.1')
+
             run_command(Commands.UPDATE, prefix, 'flask')
             assert not package_is_installed(prefix, 'flask-0.10.1')
             assert_package_is_installed(prefix, 'flask')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -324,7 +324,7 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
             mocks['rmtree'].side_effect = OSError
             some_path = self.generate_random_path
             with self.assertRaises(OSError):
-                install.rm_rf(some_path)
+                install.rm_rf(some_path, trash=False)
         self.assertEqual(6, mocks['rmtree'].call_count)
 
     @skip_if_no_mock
@@ -334,7 +334,7 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
             mocks['rmtree'].side_effect = OSError
             some_path = self.generate_random_path
             with self.assertRaises(OSError):
-                install.rm_rf(some_path, max_retries=max_retries)
+                install.rm_rf(some_path, max_retries=max_retries, trash=False)
         self.assertEqual(max_retries + 1, mocks['rmtree'].call_count)
 
     @skip_if_no_mock
@@ -342,7 +342,7 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
         with self.generate_directory_mocks() as mocks:
             mocks['rmtree'].side_effect = [OSError, OSError, None]
             some_path = self.generate_random_path
-            install.rm_rf(some_path)
+            install.rm_rf(some_path, trash=False)
         self.assertEqual(3, mocks['rmtree'].call_count)
 
     @skip_if_no_mock
@@ -352,7 +352,7 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
             max_retries = random.randint(1, 10)
             with self.assertRaises(OSError):
                 install.rm_rf(self.generate_random_path,
-                              max_retries=max_retries)
+                              max_retries=max_retries, trash=False)
 
         expected = [mock.call(i) for i in range(max_retries)]
         mocks['sleep'].assert_has_calls(expected)
@@ -364,7 +364,7 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
             mocks['rmtree'].side_effect = OSError(random_path)
             max_retries = random.randint(1, 10)
             with self.assertRaises(OSError):
-                install.rm_rf(random_path, max_retries=max_retries)
+                install.rm_rf(random_path, max_retries=max_retries, trash=False)
 
         log_template = "\n".join([
             "Unable to delete %s" % random_path,
@@ -381,7 +381,7 @@ class rm_rf_file_and_link_TestCase(unittest.TestCase):
         with self.generate_directory_mocks(on_win=True) as mocks:
             random_path = self.generate_random_path
             mocks['rmtree'].side_effect = [OSError, None]
-            install.rm_rf(random_path)
+            install.rm_rf(random_path, trash=False)
 
         expected_call_list = [
             mock.call(random_path, ignore_errors=False, onerror=warn_failed_remove),


### PR DESCRIPTION
A proper fix for #2876 and related issues.

The problem is this: when removing an extracted package from the package cache, the `rm_rf` command will fail if any one of the files inside that package directory is open. This prevents conda from moving the new package into place.

The solution, in my view, is to make more aggressive use of `move_path_to_trash`: specifically, the _first_ step on Windows should be to move the directory to the trash, _then_ attempt a full deletion. The `os.rename` in `move_path_to_trash` is far more likely to succeed, and any failure during the deletion process will be benign (except for the unclaimed disk space).

For files, it is still better to try `os.unlink` first, but then if that fails, attempt `move_path_to_trash` as well.

This logic allows us to simplify other parts of the code; everywhere we currently see `move_path_to_trash` we can replace it with `rm_rf`.

I have also added `move_path_to_trash` calls on Unix _if_ there is an initial failure in the remove step. This is an entirely benign addition when the removal succeeds; and this may help us solve some of the other strange permissions issues we're seeing on Mac, for instance.

I recommend a backport to 4.0.x, which roughly involves a straight application of these diffs, _except_ for a removal of the calls to `delete_linked_data_any(path)`.
