### PR TITLE
More conservative auto updates of conda

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -445,14 +445,19 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
     r = Resolve(index)
     linked = r.installed
 
-    if auto_update_conda and is_root_prefix(prefix):
-        specs.append('conda')
-        specs.append('conda-env')
-
     if pinned:
         pinned_specs = get_pinned_specs(prefix)
         log.debug("Pinned specs=%s" % pinned_specs)
         specs += pinned_specs
+
+    # Only add a conda spec if conda and conda-env are not in the specs.
+    if auto_update_conda and is_root_prefix(prefix):
+        mss = [MatchSpec(s) for s in specs if s.startswith('conda')]
+        mss = [ms for ms in mss if ms.name in ('conda', 'conda-env')]
+        if not mss:
+            from . import __version__ as conda_version
+            specs.append('conda >=' + conda_version)
+            specs.append('conda-env')
 
     must_have = {}
     if track_features:


### PR DESCRIPTION
Until such time as we remove auto updating of conda altogether, or make it more default to `false`, I propose we add these changes to make it more conservative:

- Don't add updates to `conda` or `conda-env` if either of them are explicitly specified or pinned.
- Don't allow version downgrades for `conda` (unless explicitly requested, of course, but this is covered by the previous rule).

Motivated by #2898.