### PR TITLE
Handle tarball installs from cache

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -41,7 +41,6 @@ import sys
 import tarfile
 import tempfile
 import time
-import tempfile
 import traceback
 from os.path import (abspath, basename, dirname, isdir, isfile, islink,
                      join, normpath)

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -69,14 +69,18 @@ def explicit(specs, prefix, verbose=False, force_extract=True, fetch_args=None, 
         prefix = pkg_path = dir_path = None
         if url.startswith('file://'):
             prefix = cached_url(url)
+            if prefix is not None:
+                schannel = 'defaults' if prefix == '' else prefix[:-2]
+                is_file = False
 
         # If not, determine the channel name from the URL
         if prefix is None:
             channel, schannel = url_channel(url)
+            is_file = schannel.startswith('file:') and schannel.endswith('/')
             prefix = '' if schannel == 'defaults' else schannel + '::'
+
         fn = prefix + fn
         dist = fn[:-8]
-        is_file = schannel.startswith('file:') and schannel.endswith('/')
         # Add explicit file to index so we'll see it later
         if is_file:
             index[fn] = {'fn': dist2filename(fn), 'url': url, 'md5': None}

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -260,11 +260,32 @@ class IntegrationTests(TestCase):
             assert not package_is_installed(prefix, 'flask-0.10.1')
             assert_package_is_installed(prefix, 'python')
 
-            # Regression test for 2812
-            # install from local channel
             from conda.config import pkgs_dirs
             flask_fname = flask_data['fn']
             tar_old_path = join(pkgs_dirs[0], flask_fname)
+
+            # regression test for #2886 (part 1 of 2)
+            # install tarball from package cache, default channel
+            run_command(Commands.INSTALL, prefix, tar_old_path)
+            assert_package_is_installed(prefix, 'flask-0.')
+
+            # regression test for #2626
+            # install tarball with full path, outside channel
+            tar_new_path = join(prefix, flask_fname)
+            copyfile(tar_old_path, tar_new_path)
+            run_command(Commands.INSTALL, prefix, tar_new_path)
+            assert_package_is_installed(prefix, 'flask-0')
+
+            # regression test for #2626
+            # install tarball with relative path, outside channel
+            run_command(Commands.REMOVE, prefix, 'flask')
+            assert not package_is_installed(prefix, 'flask-0.10.1')
+            tar_new_path = relpath(tar_new_path)
+            run_command(Commands.INSTALL, prefix, tar_new_path)
+            assert_package_is_installed(prefix, 'flask-0.')
+
+            # Regression test for 2812
+            # install from local channel
             for field in ('url', 'channel', 'schannel'):
                 del flask_data[field]
             repodata = {'info': {}, 'packages':{flask_fname: flask_data}}
@@ -279,21 +300,12 @@ class IntegrationTests(TestCase):
                 run_command(Commands.INSTALL, prefix, '-c', channel, 'flask')
                 assert_package_is_installed(prefix, channel + '::' + 'flask-')
 
-            # regression test for #2626
-            # install tarball with full path
-            tar_new_path = join(prefix, flask_fname)
-            copyfile(tar_old_path, tar_new_path)
-            run_command(Commands.INSTALL, prefix, tar_new_path)
-            assert_package_is_installed(prefix, 'flask-0')
-
+            # regression test for #2886 (part 2 of 2)
+            # install tarball from package cache, local channel
             run_command(Commands.REMOVE, prefix, 'flask')
             assert not package_is_installed(prefix, 'flask-0')
-
-            # regression test for #2626
-            # install tarball with relative path
-            tar_new_path = relpath(tar_new_path)
-            run_command(Commands.INSTALL, prefix, tar_new_path)
-            assert_package_is_installed(prefix, 'flask-0.')
+            run_command(Commands.INSTALL, prefix, tar_old_path)
+            assert_package_is_installed(prefix, channel + '::' + 'flask-')
 
             # regression test for #2599
             linked_data_.clear()


### PR DESCRIPTION
Fixes #2886, #2907. Installing a tarball _directly from the package cache_ was failing.

Fix provided, and the integration test `test_tarball_install_and_bad_metadata` has been expanded to include two different package cache installs: one from the `defaults` channel and one from a local channel.