### PR TITLE
add/subtract from PATH; kill folder output text

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -4,11 +4,12 @@
 @setlocal enabledelayedexpansion
 
 @set "CONDA_NEW_ENV=%~1"
+@SET "CONDA_EXE=%~dp0\..\Scripts\conda.exe"
 
 :: this finds either --help or -h and shows the help text
 @CALL ECHO "%~1"| @%SystemRoot%\System32\find.exe /I "-h" 1>NUL
 @IF NOT ERRORLEVEL 1 (
-    @call "%~dp0\..\Scripts\conda.exe" ..activate "cmd.exe" -h
+    @call "%CONDA_EXE%" ..activate "cmd.exe" -h
 ) else (
     :: reset errorlevel to 0
     cmd /c "exit /b 0"
@@ -25,17 +26,16 @@
     @set CONDA_NEW_ENV=root
 :skipmissingarg
 
-@SET "CONDA_EXE=%~dp0\..\Scripts\conda.exe"
 
 @REM Ensure that path or name passed is valid before deactivating anything
 @CALL "%CONDA_EXE%" ..checkenv "cmd.exe" "%CONDA_NEW_ENV%"
 @IF errorlevel 1 exit /b 1
 
-@call "%~dp0\deactivate.bat"
+@REM The argument here tells the deactivate script to leave a placeholder for us when it removes PATH entries,
+@REM    so that we can put our new path entries back in the same place
+@call "%~dp0\deactivate.bat" "hold"
 @if errorlevel 1 exit /b 1
 
-@REM take a snapshot of pristine state for later
-@SET "CONDA_PATH_BACKUP=%PATH%"
 @REM Activate the new environment
 @FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..activate "cmd.exe" "%CONDA_NEW_ENV%"') DO @SET "NEW_PATH=%%i"
 @IF errorlevel 1 exit /b 1
@@ -53,13 +53,22 @@
 @REM always store the full path to the environment, since CONDA_DEFAULT_ENV varies
 @FOR /F "tokens=1 delims=;" %%i in ("%NEW_PATH%") DO @SET "CONDA_PREFIX=%%i"
 
+@REM look if the deactivate script left a placeholder for us.
+@IF "x%PATH%" == "x%PATH:CONDA_PATH_PLACEHOLDER=%" (
+    @REM If it did not, prepend NEW_PATH
+    @SET "PATH=%NEW_PATH%;%PATH%"
+) ELSE (
+    @REM If it did, replace it with our NEW_PATH
+    @REM    Delayed expansion used here to do replacement with value of NEW_PATH
+    @CALL SET "PATH=%%PATH:CONDA_PATH_PLACEHOLDER=!NEW_PATH!%%"
+)
+
 @REM This persists env variables, which are otherwise local to this script right now.
 @endlocal & (
     @REM Used for deactivate, to make sure we restore original state after deactivation
-    @SET "CONDA_PATH_BACKUP=%CONDA_PATH_BACKUP%"
     @SET "CONDA_PS1_BACKUP=%CONDA_PS1_BACKUP%"
     @SET "PROMPT=%PROMPT%"
-    @SET "PATH=%NEW_PATH%;%PATH%"
+    @SET "PATH=%PATH%"
     @SET "CONDA_DEFAULT_ENV=%CONDA_NEW_ENV%"
     @SET "CONDA_PREFIX=%CONDA_PREFIX%"
 

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -1,7 +1,9 @@
 @REM @ symbols in this file indicate that output should not be printed.
 @REM   Setting it this way allows us to not touch the user's echo setting.
 @REM   For debugging, remove the @ on the section you need to study.
-@SETLOCAL
+@SETLOCAL enabledelayedexpansion
+
+@SET "CONDA_EXE=%~dp0\..\Scripts\conda.exe"
 
 :: this finds either --help or -h and shows the help text
 @CALL ECHO "%~1"| @%SystemRoot%\System32\find.exe /I "-h" 1>NUL
@@ -12,10 +14,23 @@
     cmd /c "exit /b 0"
 )
 
+@REM doesn't matter what the arg is, just that there is one.  Ideally, only the activate.bat script is ever
+@REM     passing this.
+@set "HOLD=%~1"
+
 @REM Deactivate a previous activation if it is live
-@IF "%CONDA_PATH_BACKUP%"=="" @GOTO NOPATH
-   @SET "PATH=%CONDA_PATH_BACKUP%"
-   @SET CONDA_PATH_BACKUP=
+@IF "%CONDA_PREFIX%"=="" @GOTO NOPATH
+   @REM get the activation path that would have been provided for this prefix
+   @FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..activate "cmd.exe" "%CONDA_PREFIX%"') DO @SET "NEW_PATH=%%i"
+   @REM in activate.bat, we replace a placeholder so that conda keeps its place in the PATH order
+   @REM The activate.bat script passes an argument here to activate that behavior - otherwise, PATH
+   @REM    is simply removed.
+   @REM In both cases, we have to used delayed expansion to have the value of NEW_PATH in the replacement.
+   @IF "%HOLD%" == "" (
+       @CALL SET "PATH=%%PATH:!NEW_PATH!;=%%"
+   ) ELSE (
+       @CALL SET "PATH=%%PATH:!NEW_PATH!=CONDA_PATH_PLACEHOLDER%%"
+   )
    :NOPATH
 
 @IF "%CONDA_PS1_BACKUP%"=="" @GOTO NOPROMPT

--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -108,7 +108,6 @@ def main():
             sys.exit("Error: ..activate expected exactly two arguments: shell and env name")
         binpath = binpath_from_arg(sys.argv[3], shelldict=shelldict)
         pathlist_str = pathlist_to_str(binpath)
-        sys.stderr.write("prepending %s to PATH\n" % shelldict['path_to'](pathlist_str))
 
         # prepend our new entries onto the existing path and make sure that the separator is native
         path = shelldict['pathsep'].join(binpath)

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -136,10 +136,6 @@ def test_activate_test1(shell):
         """).format(envs=envs, env_dirs=gen_test_env_paths(envs, shell), **shell_vars)
 
         stdout, stderr = run_in(commands, shell)
-        assert_equals(stderr, u'prepending {envpaths} to PATH'\
-                        .format(envpaths=pathlist_to_str(_envpaths(envs, 'test 1',
-                                                                   shelldict=shells[shell]),
-                                                         escape_backslashes=True)), shell)
         assert_in(shells[shell]['pathsep'].join(_envpaths(envs, 'test 1', shelldict=shells[shell])),
                  stdout, shell)
 
@@ -155,8 +151,6 @@ def test_activate_env_from_env_with_root_activate(shell):
         """).format(envs=envs, env_dirs=gen_test_env_paths(envs, shell), **shell_vars)
 
         stdout, stderr = run_in(commands, shell)
-        assert_equals(stderr, u'prepending {envpaths2} to PATH'\
-            .format(envpaths2=pathlist_to_str(_envpaths(envs, 'test 2', shelldict=shells[shell]))))
         assert_in(shells[shell]['pathsep'].join(_envpaths(envs, 'test 2', shelldict=shells[shell])), stdout)
 
 
@@ -308,16 +302,6 @@ def test_activate_symlinking(shell):
     files/links exist, and that they point where they should."""
     shell_vars = _format_vars(shell)
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
-        commands = (shell_vars['command_setup'] + """
-        {source} "{syspath}{binpath}activate" "{env_dirs[0]}"
-        """).format(envs=envs, env_dirs=gen_test_env_paths(envs, shell), **shell_vars)
-        stdout, stderr = run_in(commands, shell)
-        assert_equals(stderr, u'prepending {envpaths1} to PATH'\
-                .format(syspath=pathlist_to_str(_envpaths(root_dir, shelldict=shells[shell])),
-                        envpaths1=shells[shell]["path_to"](pathlist_to_str(_envpaths(envs,
-                                                                                     'test 1',
-                                                                                     shelldict=shells[shell])))))
-
         where = 'Scripts' if sys.platform == 'win32' else 'bin'
         for env in gen_test_env_paths(envs, shell)[:2]:
             scripts = ["conda", "activate", "deactivate"]


### PR DESCRIPTION
This is meant to address #2914.  Rather than store a backup PATH, we add/remove with shell scripting.  This also has a placeholder feature with the deactivate script - when passed any argument, it leaves a placeholder.  The activate script then puts the new path entries there, rather than always prepending.

This PR does not address this issue with the bash shell scripts.