### PR TITLE
Gracely remove duplicate packages from conda-meta

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -234,44 +234,6 @@ def install(args, parser, command='install'):
     ospecs = list(specs)
     add_defaults_to_specs(r, linked, specs, update=isupdate)
 
-    # Don't update packages that are already up-to-date
-    if isupdate and not (args.all or args.force):
-        orig_packages = args.packages[:]
-        installed_metadata = [is_linked(prefix, dist) for dist in linked]
-        for name in orig_packages:
-            vers_inst = [m['version'] for m in installed_metadata if m['name'] == name]
-            build_inst = [m['build_number'] for m in installed_metadata if m['name'] == name]
-
-            try:
-                assert len(vers_inst) == 1, name
-                assert len(build_inst) == 1, name
-            except AssertionError as e:
-                if args.json:
-                    common.exception_and_exit(e, json=True)
-                else:
-                    raise
-
-            pkgs = sorted(r.get_pkgs(name))
-            if not pkgs:
-                # Shouldn't happen?
-                continue
-            latest = pkgs[-1]
-
-            if (latest.version == vers_inst[0] and
-                    latest.build_number == build_inst[0]):
-                args.packages.remove(name)
-        if not args.packages:
-            from .main_list import print_packages
-
-            if not args.json:
-                regex = '^(%s)$' % '|'.join(orig_packages)
-                print('# All requested packages already installed.')
-                print_packages(prefix, regex)
-            else:
-                common.stdout_json_success(
-                    message='All requested packages already installed.')
-            return
-
     if args.force:
         args.no_deps = True
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -17,6 +17,7 @@ from logging import getLogger
 from os.path import abspath, basename, dirname, join, exists
 
 from . import instructions as inst
+from .compat import iteritems, itervalues
 from .config import (always_copy as config_always_copy, channel_priority,
                      show_channel_urls as config_show_channel_urls,
                      root_dir, allow_softlinks, default_python, auto_update_conda,
@@ -24,8 +25,8 @@ from .config import (always_copy as config_always_copy, channel_priority,
 from .exceptions import CondaException
 from .history import History
 from .install import (dist2quad, LINK_HARD, link_name_map, name_dist, is_fetched,
-                      is_extracted, is_linked, find_new_location, dist2filename, LINK_COPY,
-                      LINK_SOFT, try_hard_link, rm_rf)
+                      is_extracted, find_new_location, dist2filename, LINK_COPY,
+                      LINK_SOFT, try_hard_link, rm_rf, linked_data)
 from .resolve import MatchSpec, Resolve, Package
 from .utils import md5_file, human_bytes
 
@@ -111,10 +112,16 @@ def display_actions(actions, index, show_channel_urls=None):
                        schannel='<unknown>',
                        build_number=int(build) if build.isdigit() else 0)
         pkg = rec['name']
-        channels[pkg][0] = channel_str(rec)
-        packages[pkg][0] = rec['version'] + '-' + rec['build']
-        records[pkg][0] = Package(fkey, rec)
-        features[pkg][0] = rec.get('features', '')
+        if packages[pkg][0] != '':
+            channels[pkg][0] = ''
+            packages[pkg][0] = '<multiple>'
+            features[pkg][0] = ''
+            records[pkg][0] = None
+        else:
+            channels[pkg][0] = channel_str(rec)
+            packages[pkg][0] = rec['version'] + '-' + rec['build']
+            records[pkg][0] = Package(fkey, rec)
+            features[pkg][0] = rec.get('features', '')
 
     #                     Put a minimum length here---.    .--For the :
     #                                                 v    v
@@ -163,6 +170,9 @@ def display_actions(actions, index, show_channel_urls=None):
         newfmt[pkg] += lt
 
         P0 = records[pkg][0]
+        if P0 is None:
+            updated.add(pkg)
+            continue
         P1 = records[pkg][1]
         pri0 = P0.priority
         pri1 = P1.priority
@@ -241,7 +251,8 @@ def nothing_to_do(actions):
 def add_unlink(actions, dist):
     if inst.UNLINK not in actions:
         actions[inst.UNLINK] = []
-    actions[inst.UNLINK].append(dist)
+    if dist not in actions[inst.UNLINK]:
+        actions[inst.UNLINK].append(dist)
 
 
 def plan_from_actions(actions):
@@ -296,6 +307,17 @@ def ensure_linked_actions(dists, prefix, index=None, force=False,
     actions[inst.PREFIX] = prefix
     actions['op_order'] = (inst.RM_FETCHED, inst.FETCH, inst.RM_EXTRACTED,
                            inst.EXTRACT, inst.UNLINK, inst.LINK, inst.SYMLINK_CONDA)
+
+    dnames = set()
+    duplicates = set()
+    ldata = linked_data(prefix)
+    for dist, rec in iteritems(ldata):
+        (duplicates if rec['name'] in dnames else dnames).add(rec['name'])
+    if duplicates:
+        for dist in ldata.keys():
+            if ldata[dist]['name'] in duplicates:
+                add_unlink(actions, dist)
+
     for dist in dists:
         fetched_in = is_fetched(dist)
         extracted_in = is_extracted(dist)
@@ -313,7 +335,7 @@ def ensure_linked_actions(dists, prefix, index=None, force=False,
             except KeyError:
                 sys.stderr.write('Warning: cannot lookup MD5 of: %s' % fn)
 
-        if not force and is_linked(prefix, dist):
+        if not force and dist in ldata and ldata[dist]['name'] not in duplicates:
             continue
 
         if extracted_in and force:
@@ -529,21 +551,20 @@ def remove_actions(prefix, specs, index, force=False, pinned=True):
 
     actions = ensure_linked_actions(r.dependency_sort(nlinked), prefix)
     for old_fn in reversed(r.dependency_sort(linked)):
+        if old_fn != nlinked.get(r.package_name(old_fn), ''):
+            add_unlink(actions, old_fn)
+    for old_fn in actions.get(inst.UNLINK, []):
         dist = old_fn + '.tar.bz2'
-        name = r.package_name(dist)
-        if old_fn == nlinked.get(name, ''):
-            continue
         if pinned and any(r.match(ms, dist) for ms in pinned_specs):
             msg = "Cannot remove %s becaue it is pinned. Use --no-pin to override."
             raise RuntimeError(msg % dist)
-        if name == 'conda' and name not in nlinked:
+        if r.package_name(dist) == 'conda':
             if any(s.split(' ', 1)[0] == 'conda' for s in specs):
                 sys.exit("Error: 'conda' cannot be removed from the root environment")
             else:
                 msg = ("Error: this 'remove' command cannot be executed because it\n"
                        "would require removing 'conda' dependencies")
                 sys.exit(msg)
-        add_unlink(actions, old_fn)
 
     return actions
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -932,6 +932,11 @@ def test_update_deps():
         'zlib-1.2.7-0.tar.bz2',
     ]
 
+    # Test accidentally duplicated packages
+    installed2 = installed + ['sqlite-3.9.2-0.tar.bz2', 'six-1.10.0-py27_0.tar.bz2']
+    installed3 = r.install([], installed=installed2)
+    assert installed == installed3
+
     # scipy, and pandas should all be updated here. pytz is a new
     # dependency of pandas. But numpy does not _need_ to be updated
     # to get the latest version of pandas, so it stays put.


### PR DESCRIPTION
Due perhaps to a bug in conda (new or old), sometimes the `conda-meta` directory contains data from two different versions of the same package. This confuses conda, for obvious reasons; and under some install/update operations, it will schedule the removal of one of these packages. Unfortunately, since the packages almost certainly share common files, it effectively renders the "remaining" package unusable, with sometimes catastrophic consequences. (https://github.com/conda/conda/issues/2913)

This PR attempts to rectify this by identifying duplicate packages and scheduling a correction. For example, suppose that `foo` is the duplicated package. Then:
- `conda remove <foo>` will remove both copies of the package.
- `conda install <foo>` / `conda update <foo>` will remove both copies, and replace it.
- any other `conda install/remove/update` will remove both copies, and replace it with the latest compatible version of the package.

Two potential improvements:
- Currently, due to the way `plan.display_actions` performs formatting, it can only print a single removal per package name, even if two or more packages are being removed.
- There is no explicit warning that this corrupt metadata was present.