### PR TITLE
wrap root prefix check with normcase

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -43,7 +43,7 @@ import tempfile
 import time
 import traceback
 from os.path import (abspath, basename, dirname, isdir, isfile, islink,
-                     join, normpath)
+                     join, normpath, normcase)
 
 
 on_win = bool(sys.platform == "win32")
@@ -576,7 +576,7 @@ def read_no_link(info_dir):
 def symlink_conda(prefix, root_dir, shell=None):
     # do not symlink root env - this clobbers activate incorrectly.
     # prefix should always be longer than, or outside the root dir.
-    if normpath(prefix) in normpath(root_dir):
+    if normcase(normpath(prefix)) in normcase(normpath(root_dir)):
         return
     if on_win:
         where = 'Scripts'


### PR DESCRIPTION
Windows case insenstivity causes some major issues, ending in root activate scripts being overwritten with shortcuts, leading to infinite recursion and tears.

Solution suggested by @ajspeck in https://github.com/conda/conda/pull/2880/files/1e7673b4ccdeb8e625fb21c6aa0fe3378ef2e3dc#r69057375