### PR TITLE
bump max total time on exp_backoff to ~= 6.5 sec

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -232,16 +232,18 @@ def exp_backoff_fn(fn, *args):
         return fn(*args)
 
     import random
-    max_retries = 5
-    for n in range(max_retries):
+    # with max_tries = 5, max total time ~= 3.2 sec
+    # with max_tries = 6, max total time ~= 6.5 sec
+    max_tries = 6
+    for n in range(max_tries):
         try:
             result = fn(*args)
         except (OSError, IOError) as e:
             log.debug(repr(e))
             if e.errno in (errno.EPERM, errno.EACCES):
-                if n == max_retries-1:
+                if n == max_tries-1:
                     raise
-                time.sleep(((2 ** n) + random.random()) * 1e-1)
+                time.sleep(((2 ** n) + random.random()) * 0.1)
             else:
                 raise
         else:


### PR DESCRIPTION
@mcg1969 @mingwandroid 

I'm including this in the `4.1.6` release to go out shortly.

This changes the "max total time" from about 3.2 seconds to 6.5 seconds.  Meaning the final sleep has a time of 3.2 sec, with the total cumulative time before failure being 6.5 sec.