### PR TITLE
Better error behavior if conda is spec'ed for a non-root environment

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from itertools import chain
 
-from .compat import iterkeys, itervalues, iteritems
+from .compat import iterkeys, itervalues, iteritems, string_types
 from .config import subdir, channel_priority, canonical_channel_name, track_features
 from .console import setup_handlers
 from .install import dist2quad
@@ -637,9 +637,11 @@ class Resolve(object):
 
     def depends_on(self, spec, target):
         touched = set()
+        if isinstance(target, string_types):
+            target = (target,)
 
         def depends_on_(spec):
-            if spec.name == target:
+            if spec.name in target:
                 return True
             if spec.name in touched:
                 return False

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -230,6 +230,14 @@ class IntegrationTests(TestCase):
             assert not package_is_installed(prefix, 'flask')
             assert_package_is_installed(prefix, 'python-3')
 
+            sout, serr = run_command(Commands.INSTALL, prefix, 'conda')
+            assert not package_is_installed(prefix, 'conda')
+            assert 'Error:' in serr
+
+            sout, serr = run_command(Commands.INSTALL, prefix, 'constructor')
+            assert not package_is_installed(prefix, 'constructor')
+            assert 'Error:' in serr
+
     @pytest.mark.timeout(300)
     def test_list_with_pip_egg(self):
         with make_temp_env("python=3 pip") as prefix:


### PR DESCRIPTION
Inspired by #2946. Do a better job of error messaging if someone attempts to install `conda` into a non-root environment. In particular, if `conda` is selected _by dependency_, then this will find out which specs may have caused it.