### PR TITLE
Fix channel_alias issue 2939; harden offline support

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -19,9 +19,9 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     """
     if use_local:
         channel_urls = ['local'] + list(channel_urls)
-    channel_urls = normalize_urls(channel_urls, platform, offline)
+    channel_urls = normalize_urls(channel_urls, platform)
     if prepend:
-        channel_urls.extend(get_channel_urls(platform, offline))
+        channel_urls.extend(get_channel_urls(platform))
     channel_urls = prioritize_channels(channel_urls)
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
     if prefix:
@@ -47,6 +47,6 @@ def get_index(channel_urls=(), prepend=True, platform=None,
 
 
 def get_package_versions(package, offline=False):
-    index = get_index(offline=offline)
+    index = get_index()
     r = Resolve(index)
     return r.get_pkgs(package, emptyok=True)

--- a/tests/condarc
+++ b/tests/condarc
@@ -14,6 +14,10 @@ channels:
 
 channel_alias: https://your.repo/
 
+# Disable binstar token addition
+
+add_binstar_token: False
+
 # Proxy settings: http://[username]:[password]@[server]:[port]
 proxy_servers:
     http: http://user:pass@corp.com:8080


### PR DESCRIPTION
Here's the strategy for fixing #2939 without re-breaking #2556:

- Created a new function `init_binstar()` to grab the binstar domain and the tokenized domain. Placed these in _separate variables_ from `channel_alias`, so we can still refer to them if the user has changed `channel_alias` to point away from their Anaconda Server instance (as we saw in #2556).

- Created a new function `channel_prefix()` that returns the proper value of `channel_alias`. From now on, `channel_alias` is accessed only through this function, so that it can be properly initialized when first needed. If `channel_alias` is `None` when this function is first called, it will be set to the Anaconda Server URL; but if it has been hardcoded, it will not be changed. 

- `channel_prefix` actually has two arguments: `token` and `offline`. If `token=True` _and_ `channel_alias` does in fact point to the AS instance, the token will be added to the returned URL. 

- `DEFAULT_CHANNEL_ALIAS` is now utilized only under two circumstances: if `offline` is True, or if anaconda-client is not installed. Note that if `offline` is True, then `DEFAULT_CHANNEL_ALIAS` will be filtered out during the normalization process (unless it's a `file:/` URL, of course).

- Created a new function `add_binstar_tokens` that respects the `add_anaconda_token` flag even when `channel_alias` points away from the AS instance. This is now used in `normalize_urls` to make sure the token is added in the case where `channel_alias` points away from the AS instance.