### PR TITLE
Fix channel_alias issues; improve offline enforcement

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -8,8 +8,7 @@ from .resolve import Resolve
 
 
 def get_index(channel_urls=(), prepend=True, platform=None,
-              use_local=False, use_cache=False, unknown=False,
-              offline=False, prefix=None):
+              use_local=False, use_cache=False, unknown=False, prefix=False):
     """
     Return the index of packages available on the channels
 
@@ -46,7 +45,7 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     return index
 
 
-def get_package_versions(package, offline=False):
+def get_package_versions(package):
     index = get_index()
     r = Resolve(index)
     return r.get_pkgs(package, emptyok=True)

--- a/conda/api.py
+++ b/conda/api.py
@@ -19,9 +19,9 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     """
     if use_local:
         channel_urls = ['local'] + list(channel_urls)
-    channel_urls = normalize_urls(channel_urls, platform, offline)
+    channel_urls = normalize_urls(channel_urls, platform)
     if prepend:
-        channel_urls.extend(get_channel_urls(platform, offline))
+        channel_urls.extend(get_channel_urls(platform))
     channel_urls = prioritize_channels(channel_urls)
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
     if prefix:
@@ -47,6 +47,6 @@ def get_index(channel_urls=(), prepend=True, platform=None,
 
 
 def get_package_versions(package, offline=False):
-    index = get_index(offline=offline)
+    index = get_index()
     r = Resolve(index)
     return r.get_pkgs(package, emptyok=True)

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -15,6 +15,7 @@ from ..config import (envs_dirs, default_prefix, platform, update_dependencies,
 from ..install import dist2quad
 from ..resolve import MatchSpec
 from ..utils import memoize
+from .. import config
 
 
 class Completer(object):
@@ -72,8 +73,7 @@ class Packages(Completer):
         call_dict = dict(channel_urls=args.channel or (),
                          use_cache=True,
                          prepend=not args.override_channels,
-                         unknown=args.unknown,
-                         offline=args.offline)
+                         unknown=args.unknown)
         if hasattr(args, 'platform'):  # in search
             call_dict['platform'] = args.platform
         index = get_index(**call_dict)
@@ -310,14 +310,19 @@ def add_parser_use_local(p):
         help="Use locally built packages.",
     )
 
+class OfflineAction(argparse.Action):
+    def __call__(self, *args, **kwargs):
+        config.offline = True
+
 def add_parser_offline(p):
+    global offline
     p.add_argument(
         "--offline",
-        action="store_true",
-        default=False,
+        action=OfflineAction,
+        default=config.offline,
         help="Offline mode, don't connect to the Internet.",
+        nargs=0
     )
-
 
 def add_parser_no_pin(p):
     p.add_argument(

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -173,8 +173,7 @@ def install(args, parser, command='install'):
         'channel_urls': args.channel or (),
         'unknown': args.unknown,
         'prepend': not args.override_channels,
-        'use_local': args.use_local,
-        'offline': args.offline
+        'use_local': args.use_local
     }
 
     specs = []

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -16,7 +16,7 @@ from os.path import exists, expanduser, join
 
 from ..compat import itervalues
 from .common import (add_parser_json, stdout_json, disp_features, arg2spec,
-                     handle_envs_list)
+                     handle_envs_list, add_parser_offline)
 
 help = "Display information about current conda install."
 
@@ -35,6 +35,7 @@ def configure_parser(sub_parsers):
         epilog=example,
     )
     add_parser_json(p)
+    add_parser_offline(p)
     p.add_argument(
         '-a', "--all",
         action="store_true",
@@ -148,7 +149,7 @@ def execute(args, parser):
     from conda.config import (root_dir, get_channel_urls, subdir, pkgs_dirs,
                               root_writable, envs_dirs, default_prefix, rc_path,
                               user_rc_path, sys_rc_path, foreign, hide_binstar_tokens,
-                              platform, offline)
+                              platform, offline_keep, offline)
     from conda.resolve import Resolve
     from conda.cli.main_init import is_initialized
     from conda.api import get_index
@@ -207,7 +208,7 @@ def execute(args, parser):
     else:
         conda_build_version = conda_build.__version__
 
-    channels = get_channel_urls(offline=offline)
+    channels = list(filter(offline_keep, get_channel_urls()))
 
     info_dict = dict(
         platform=subdir,

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -149,10 +149,13 @@ def execute(args, parser):
     from conda.config import (root_dir, get_channel_urls, subdir, pkgs_dirs,
                               root_writable, envs_dirs, default_prefix, rc_path,
                               user_rc_path, sys_rc_path, foreign, hide_binstar_tokens,
-                              platform, offline_keep, offline)
+                              platform, offline_keep, is_offline, init_binstar)
     from conda.resolve import Resolve
     from conda.cli.main_init import is_initialized
     from conda.api import get_index
+
+    # Quietly initialize binstar to drop the API info
+    init_binstar(True)
 
     if args.root:
         if args.json:
@@ -208,7 +211,19 @@ def execute(args, parser):
     else:
         conda_build_version = conda_build.__version__
 
-    channels = list(filter(offline_keep, get_channel_urls()))
+    channels = get_channel_urls()
+
+    if args.unsafe_channels:
+        if not args.json:
+            print("\n".join(channels))
+        else:
+            print(json.dumps({"channels": channels}))
+        return 0
+
+    channels = list(map(hide_binstar_tokens, channels))
+    if not args.json:
+        channels = [c + ('' if offline_keep(c) else '  (offline)')
+                    for c in channels]
 
     info_dict = dict(
         platform=subdir,
@@ -225,21 +240,12 @@ def execute(args, parser):
         user_rc_path=user_rc_path,
         sys_rc_path=sys_rc_path,
         is_foreign=bool(foreign),
-        offline=offline,
+        offline=is_offline(),
         envs=[],
         python_version='.'.join(map(str, sys.version_info)),
         requests_version=requests_version,
     )
 
-    if args.unsafe_channels:
-        if not args.json:
-            print("\n".join(info_dict["channels"]))
-        else:
-            print(json.dumps({"channels": info_dict["channels"]}))
-        return 0
-    else:
-        info_dict['channels'] = [hide_binstar_tokens(c) for c in
-                                 info_dict['channels']]
     if args.all or args.json:
         for option in options:
             setattr(args, option, True)

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -130,7 +130,6 @@ def execute(args, parser):
                                use_local=args.use_local,
                                use_cache=args.use_index_cache,
                                json=args.json,
-                               offline=args.offline,
                                prefix=prefix)
     specs = None
     if args.features:

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -169,7 +169,7 @@ def execute_search(args, parser):
     index = get_index_trap(channel_urls=channel_urls, prepend=not args.override_channels,
                            platform=args.platform, use_local=args.use_local,
                            use_cache=args.use_index_cache, prefix=prefix,
-                           unknown=args.unknown, json=args.json, offline=args.offline)
+                           unknown=args.unknown, json=args.json)
 
     r = Resolve(index)
 

--- a/conda/config.py
+++ b/conda/config.py
@@ -66,6 +66,7 @@ rc_list_keys = [
     'default_channels',
 ]
 
+# NOTE: offline mode assumes that this starts with 'https:/'
 DEFAULT_CHANNEL_ALIAS = 'https://conda.anaconda.org/'
 
 ADD_BINSTAR_TOKEN = True
@@ -103,7 +104,10 @@ rc_other = [
 user_rc_path = abspath(expanduser('~/.condarc'))
 sys_rc_path = join(sys.prefix, '.condarc')
 local_channel = []
-rc = root_dir = root_writable = BINSTAR_TOKEN_PAT = channel_alias = None
+root_dir = root_writable = None
+offline = offline_ = False
+add_anaconda_token = ADD_BINSTAR_TOKEN
+rc = {}
 
 def get_rc_path():
     path = os.getenv('CONDARC')
@@ -181,8 +185,9 @@ def get_local_urls(clear_cache=True):
         pass
     return local_channel
 
-defaults_ = ['https://repo.continuum.io/pkgs/free',
-             'https://repo.continuum.io/pkgs/pro']
+defaults_ = [
+    'https://repo.continuum.io/pkgs/free',
+    'https://repo.continuum.io/pkgs/pro']
 
 def get_default_urls(merged=False):
     if 'default_channels' in sys_rc:
@@ -205,23 +210,54 @@ def is_url(url):
         p = urlparse.urlparse(url)
         return p.netloc != "" or p.scheme == "file"
 
-def binstar_channel_alias(channel_alias):
-    if channel_alias.startswith('file:/'):
-        return channel_alias
-    if rc.get('add_anaconda_token',
-              rc.get('add_binstar_token', ADD_BINSTAR_TOKEN)):
+
+def init_binstar(offline=False):
+    global binstar_client, binstar_domain, binstar_domain_tok
+    global binstar_regex, BINSTAR_TOKEN_PAT
+    if binstar_domain is not None:
+        return
+    if offline or offline_:
+        binstar_client = ()
+    elif binstar_client is None:
         try:
             from binstar_client.utils import get_binstar
-            bs = get_binstar()
-            bs_domain = bs.domain.replace("api", "conda").rstrip('/') + '/'
-            if channel_alias.startswith(bs_domain) and bs.token:
-                channel_alias += 't/%s/' % bs.token
+            binstar_client = get_binstar()
         except ImportError:
             log.debug("Could not import binstar")
-            pass
+            binstar_client = ()
         except Exception as e:
             stderrlog.info("Warning: could not import binstar_client (%s)" % e)
-    return channel_alias
+    if binstar_client == ():
+        binstar_domain = DEFAULT_CHANNEL_ALIAS
+        binstar_domain_tok = None
+    else:
+        binstar_domain = binstar_client.domain.replace("api", "conda").rstrip('/') + '/'
+        if add_anaconda_token:
+            binstar_domain_tok = binstar_domain + 't/%s/' % (binstar_client.token,)
+    binstar_regex = (r'((:?%s|binstar\.org|anaconda\.org)/?)(t/[0-9a-zA-Z\-<>]{4,})/' %
+                     re.escape(binstar_domain[:-1]))
+    BINSTAR_TOKEN_PAT = re.compile(binstar_regex)
+
+
+def channel_prefix(token=False, offline=False):
+    global channel_alias, channel_alias_tok
+    if channel_alias is None or (channel_alias_tok is None and token):
+        init_binstar(offline)
+        if channel_alias is None or channel_alias == binstar_domain:
+            channel_alias = binstar_domain
+            channel_alias_tok = binstar_domain_tok
+        if channel_alias is None:
+            channel_alias = DEFAULT_CHANNEL_ALIAS
+    if channel_alias_tok is None:
+        channel_alias_tok = channel_alias
+    return channel_alias_tok if token and add_anaconda_token else channel_alias
+
+def add_binstar_tokens(url):
+    if binstar_domain_tok and url.startswith(binstar_domain):
+        url2 = BINSTAR_TOKEN_PAT.sub(r'\1', url)
+        if url2 == url:
+            return binstar_domain_tok + url.split(binstar_domain, 1)[1]
+    return url
 
 def hide_binstar_tokens(url):
     return BINSTAR_TOKEN_PAT.sub(r'\1t/<TOKEN>/', url)
@@ -231,20 +267,21 @@ def remove_binstar_tokens(url):
 
 def prioritize_channels(channels):
     newchans = OrderedDict()
-    lastchan = None
     priority = 0
+    schans = {}
     for channel in channels:
         channel = channel.rstrip('/') + '/'
         if channel not in newchans:
             channel_s = canonical_channel_name(channel.rsplit('/', 2)[0])
-            priority += channel_s != lastchan
-            newchans[channel] = (channel_s, priority)
-            lastchan = channel_s
+            if channel_s not in schans:
+                priority += 1
+                schans[channel_s] = priority
+            newchans[channel] = (channel_s, schans[channel_s])
     return newchans
 
-def normalize_urls(urls, platform=None, offline_only=False):
+def normalize_urls(urls, platform=None, offline=False):
+    offline = offline or offline_
     defaults = tuple(x.rstrip('/') + '/' for x in get_default_urls(False))
-    alias = None
     newurls = []
     while urls:
         url = urls[0]
@@ -261,10 +298,10 @@ def normalize_urls(urls, platform=None, offline_only=False):
         for url0 in t_urls:
             url0 = url0.rstrip('/')
             if not is_url(url0):
-                if alias is None:
-                    alias = binstar_channel_alias(channel_alias)
-                url0 = alias + url0
-            if offline_only and not url0.startswith('file:'):
+                url0 = channel_prefix(True, offline) + url0
+            else:
+                url0 = add_binstar_tokens(url0)
+            if offline and not url0.startswith('file:'):
                 continue
             for plat in (platform or subdir, 'noarch'):
                 newurls.append('%s/%s/' % (url0, plat))
@@ -289,9 +326,8 @@ def canonical_channel_name(channel):
         return 'defaults'
     elif any(channel.startswith(i) for i in get_local_urls(clear_cache=False)):
         return 'local'
-    elif channel.startswith('http://filer/'):
-        return 'filer'
-    elif channel.startswith(channel_alias):
+    channel_alias = channel_prefix(False)
+    if channel.startswith(channel_alias):
         return channel.split(channel_alias, 1)[1]
     elif channel.startswith('http:/'):
         channel2 = 'https' + channel[4:]
@@ -339,8 +375,10 @@ def get_proxy_servers():
     sys.exit("Error: proxy_servers setting not a mapping")
 
 
-def load_condarc(path):
-    rc = load_condarc_(path)
+def load_condarc(path=None):
+    global rc
+    if path is not None:
+        rc = load_condarc_(path)
 
     root_dir = abspath(expanduser(os.getenv('CONDA_ROOT', rc.get('root_dir', sys.prefix))))
     root_writable = try_write(root_dir)
@@ -376,16 +414,18 @@ def load_condarc(path):
     except IOError:
         foreign = [] if isdir(join(root_dir, 'conda-meta')) else ['python']
 
-    channel_alias = rc.get('channel_alias', DEFAULT_CHANNEL_ALIAS)
+    binstar_regex = r'((:?binstar\.org|anaconda\.org)/?)(t/[0-9a-zA-Z\-<>]{4,})/'
+    BINSTAR_TOKEN_PAT = re.compile(binstar_regex)
+    channel_alias = rc.get('channel_alias', None)
     if not sys_rc.get('allow_other_channels', True) and 'channel_alias' in sys_rc:
         channel_alias = sys_rc['channel_alias']
+    if channel_alias is not None:
+        channel_alias = remove_binstar_tokens(channel_alias.rstrip('/') + '/')
+    channel_alias_tok = binstar_client = binstar_domain = binstar_domain_tok = None
 
-    channel_alias = channel_alias.rstrip('/')
-    _binstar = r'((:?%s|binstar\.org|anaconda\.org)/?)(t/[0-9a-zA-Z\-<>]{4,})/'
-    BINSTAR_TOKEN_PAT = re.compile(_binstar % re.escape(channel_alias))
-    channel_alias = BINSTAR_TOKEN_PAT.sub(r'\1', channel_alias + '/')
-
-    offline = bool(rc.get('offline', False))
+    offline = offline_ = bool(rc.get('offline', False))
+    add_anaconda_token = rc.get('add_anaconda_token',
+                                rc.get('add_binstar_token', ADD_BINSTAR_TOKEN))
 
     add_pip_as_python_dependency = bool(rc.get('add_pip_as_python_dependency', True))
     always_yes = bool(rc.get('always_yes', False))

--- a/conda/config.py
+++ b/conda/config.py
@@ -10,7 +10,7 @@ import logging
 import os
 import re
 import sys
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from os.path import abspath, expanduser, isfile, isdir, join
 from platform import machine
 
@@ -209,20 +209,13 @@ def is_url(url):
         p = urlparse.urlparse(url)
         return p.netloc != "" or p.scheme == "file"
 
+def is_offline():
+    return offline
+
 def offline_keep(url):
     return not offline or not is_url(url) or url.startswith('file:/')
 
-class OfflineBinstar(object):
-    def __init__(self, token, domain, verify):
-        self.token = token
-        self.domain = domain
-        self.verify = verify
-
-class OfflineBinstarArgs(object):
-    def __init__(self):
-        self.log_level = 0
-
-def init_binstar():
+def init_binstar(quiet=False):
     global binstar_client, binstar_domain, binstar_domain_tok
     global binstar_regex, BINSTAR_TOKEN_PAT
     if binstar_domain is not None:
@@ -230,9 +223,9 @@ def init_binstar():
     elif binstar_client is None:
         try:
             from binstar_client.utils import get_binstar
-            binstar_client = get_binstar(
-                args=OfflineBinstarArgs() if offline else None,
-                cls=OfflineBinstar if offline else None)
+            # Turn off output in offline mode so people don't think we're going online
+            args = namedtuple('args', 'log_level')(0) if quiet or offline else None
+            binstar_client = get_binstar(args)
         except ImportError:
             log.debug("Could not import binstar")
             binstar_client = ()

--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -22,7 +22,7 @@ from os.path import basename, dirname, join
 from .compat import itervalues, input, urllib_quote, iterkeys, iteritems
 from .config import (pkgs_dirs, DEFAULT_CHANNEL_ALIAS, remove_binstar_tokens,
                      hide_binstar_tokens, allowed_channels, add_pip_as_python_dependency,
-                     ssl_verify, rc, prioritize_channels, url_channel)
+                     ssl_verify, rc, prioritize_channels, url_channel, offline_keep)
 from .connection import CondaSession, unparse_url, RETRIES
 from .install import (add_cached_package, find_new_location, package_cache, dist2pair,
                       rm_rf, exp_backoff_fn)
@@ -73,6 +73,8 @@ class dotlog_on_return(object):
 
 @dotlog_on_return("fetching repodata:")
 def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
+    if not offline_keep(url):
+        return {'packages': {}}
     cache_path = join(cache_dir or create_cache_dir(), cache_fn_url(url))
     try:
         with open(cache_path) as f:
@@ -276,6 +278,7 @@ Allowed channels are:
   - %s
 """ % (url, '\n  - '.join(allowed_channels)))
 
+    urls = tuple(filter(offline_keep, channel_urls))
     try:
         import concurrent.futures
         executor = concurrent.futures.ThreadPoolExecutor(10)
@@ -284,10 +287,9 @@ Allowed channels are:
         # RuntimeError is thrown if number of threads are limited by OS
         session = CondaSession()
         repodatas = [(url, fetch_repodata(url, use_cache=use_cache, session=session))
-                     for url in iterkeys(channel_urls)]
+                     for url in urls]
     else:
         try:
-            urls = tuple(channel_urls)
             futures = tuple(executor.submit(fetch_repodata, url, use_cache=use_cache,
                                             session=CondaSession()) for url in urls)
             repodatas = [(u, f.result()) for u, f in zip(urls, futures)]
@@ -350,8 +352,10 @@ def fetch_pkg(info, dst_dir=None, session=None):
         sys.exit("Error: Signature for '%s' is invalid." % (basename(path)))
 
 
-def download(url, dst_path, session=None, md5=None, urlstxt=False,
-             retries=None):
+def download(url, dst_path, session=None, md5=None, urlstxt=False, retries=None):
+    if not offline_keep(url):
+        raise RuntimeError("Cannot download in offline mode: %s" % (url,))
+
     pp = dst_path + '.part'
     dst_dir = dirname(dst_path)
     session = session or CondaSession()

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -18,7 +18,7 @@ from os.path import abspath, basename, dirname, join, exists
 
 from . import instructions as inst
 from .config import (always_copy as config_always_copy, channel_priority,
-                     show_channel_urls as config_show_channel_urls,
+                     show_channel_urls as config_show_channel_urls, is_offline,
                      root_dir, allow_softlinks, default_python, auto_update_conda,
                      track_features, foreign, url_channel, canonical_channel_name)
 from .exceptions import CondaException
@@ -451,7 +451,8 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
         specs += pinned_specs
 
     # Only add a conda spec if conda and conda-env are not in the specs.
-    if auto_update_conda and is_root_prefix(prefix):
+    # Also skip this step if we're offline.
+    if auto_update_conda and not is_offline() and is_root_prefix(prefix):
         mss = [MatchSpec(s) for s in specs if s.startswith('conda')]
         mss = [ms for ms in mss if ms.name in ('conda', 'conda-env')]
         if not mss:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -162,20 +162,6 @@ class TestConfig(unittest.TestCase):
            'https://your.repo/username/osx-64/': ('username', 8)
         }
 
-        normurls = config.normalize_urls(channel_urls, platform, offline=True)
-        assert normurls == [
-             'file:///Users/username/repo/osx-64/',
-             'file:///Users/username/repo/noarch/']
-
-        # If config.rc['offline'] is True, then it doesn't matter what the offline
-        # argument is normalize_urls
-        config.rc['offline'] = True
-        config.load_condarc()
-        normurls = config.normalize_urls(channel_urls, platform, offline=False)
-        assert normurls == [
-             'file:///Users/username/repo/osx-64/',
-             'file:///Users/username/repo/noarch/']
-
         # Delete the channel alias so now the short channels point to binstar
         del config.rc['channel_alias']
         config.rc['offline'] = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,18 +17,15 @@ from conda.utils import get_yaml
 from tests.helpers import run_conda_command
 
 yaml = get_yaml()
+testrc = config.load_condarc_(join(dirname(__file__), 'condarc'))
 
 # use condarc from source tree to run these tests against
-config.rc_path = join(dirname(__file__), 'condarc')
 
-# unset 'default_channels' and override config.defaults_ so that 
-# get_default_channels has predictable behavior
+# unset 'default_channels' so get_default_channels has predictable behavior
 try:
     del config.sys_rc['default_channels']
 except KeyError:
     pass
-config.defaults_ = ['http://repo.continuum.io/pkgs/free',
-                    'http://repo.continuum.io/pkgs/pro']
 
 # unset CIO_TEST.  This is a Continuum-internal variable that draws packages from an internal server instead of
 #     repo.continuum.io
@@ -37,17 +34,28 @@ try:
 except KeyError:
     pass
 
+
+class BinstarTester(object):
+    def __init__(self, domain=None, token=None):
+       self.domain = domain or 'https://mybinstar.com'
+       self.token = token or '01234abcde'
+
+
 class TestConfig(unittest.TestCase):
 
     # These tests are mostly to ensure API stability
 
-    def __init__(self, *args, **kwargs):
-        config.rc = config.load_condarc(config.rc_path)
-        # Otherwise normalization tests will fail if the user is logged into
-        # binstar.
-        config.rc['add_binstar_token'] = False
-        config.channel_alias = config.rc['channel_alias']
-        super(TestConfig, self).__init__(*args, **kwargs)
+    def setUp(self):
+        # Load the test condarc file
+        self.rc, config.rc = config.rc, testrc
+        config.load_condarc()
+        config.binstar_client = BinstarTester()
+        config.init_binstar()
+
+    def tearDown(self):
+        # Restore original condarc
+        config.rc = self.rc
+        config.load_condarc()
 
     def test_globals(self):
         self.assertTrue(config.root_dir)
@@ -78,48 +86,194 @@ class TestConfig(unittest.TestCase):
         current_platform = config.subdir
         assert config.DEFAULT_CHANNEL_ALIAS == 'https://conda.anaconda.org/'
         assert config.rc.get('channel_alias') == 'https://your.repo/'
-        assert config.channel_alias == 'https://your.repo/'
+        assert config.channel_prefix(False) == 'https://your.repo/'
+        assert config.binstar_domain == 'https://mybinstar.com/'
+        assert config.binstar_domain_tok == 'https://mybinstar.com/t/01234abcde/'
 
-        normurls = config.normalize_urls([
-            'defaults', 'system', 'https://conda.anaconda.org/username',
-            'file:///Users/username/repo', 'username'
-            ], 'osx-64')
+        channel_urls = [
+            'defaults', 'system', 
+            'https://conda.anaconda.org/username',
+            'file:///Users/username/repo', 
+            'https://mybinstar.com/t/5768wxyz/test2', 
+            'https://mybinstar.com/test', 
+            'https://conda.anaconda.org/t/abcdefgh/username', 
+            'username'
+        ]
+        platform = 'osx-64'
+
+        normurls = config.normalize_urls(channel_urls, platform)
         assert normurls == [
-             'http://repo.continuum.io/pkgs/free/osx-64/',
-             'http://repo.continuum.io/pkgs/free/noarch/',
-             'http://repo.continuum.io/pkgs/pro/osx-64/',
-             'http://repo.continuum.io/pkgs/pro/noarch/',
-             'https://your.repo/binstar_username/osx-64/',
-             'https://your.repo/binstar_username/noarch/',
-             'http://some.custom/channel/osx-64/',
-             'http://some.custom/channel/noarch/',
-             'http://repo.continuum.io/pkgs/free/osx-64/',
-             'http://repo.continuum.io/pkgs/free/noarch/',
-             'http://repo.continuum.io/pkgs/pro/osx-64/',
-             'http://repo.continuum.io/pkgs/pro/noarch/',
-             'https://conda.anaconda.org/username/osx-64/',
-             'https://conda.anaconda.org/username/noarch/',
-             'file:///Users/username/repo/osx-64/',
-             'file:///Users/username/repo/noarch/',
-             'https://your.repo/username/osx-64/',
-             'https://your.repo/username/noarch/']
+           # defaults
+           'https://repo.continuum.io/pkgs/free/osx-64/',
+           'https://repo.continuum.io/pkgs/free/noarch/',
+           'https://repo.continuum.io/pkgs/pro/osx-64/',
+           'https://repo.continuum.io/pkgs/pro/noarch/',
+           # system (condarc)
+           'https://your.repo/binstar_username/osx-64/',
+           'https://your.repo/binstar_username/noarch/',
+           'http://some.custom/channel/osx-64/',
+           'http://some.custom/channel/noarch/',
+           # defaults is repeated in condarc; that's OK
+           'https://repo.continuum.io/pkgs/free/osx-64/',
+           'https://repo.continuum.io/pkgs/free/noarch/',
+           'https://repo.continuum.io/pkgs/pro/osx-64/',
+           'https://repo.continuum.io/pkgs/pro/noarch/',
+           # conda.anaconda.org is not our default binstar clinet
+           'https://conda.anaconda.org/username/osx-64/',
+           'https://conda.anaconda.org/username/noarch/',
+           'file:///Users/username/repo/osx-64/',
+           'file:///Users/username/repo/noarch/',
+           # mybinstar.com is not channel_alias, but we still add tokens
+           'https://mybinstar.com/t/5768wxyz/test2/osx-64/',
+           'https://mybinstar.com/t/5768wxyz/test2/noarch/',
+           # token already supplied, do not change/remove it
+           'https://mybinstar.com/t/01234abcde/test/osx-64/',
+           'https://mybinstar.com/t/01234abcde/test/noarch/',
+           # we do not remove tokens from conda.anaconda.org
+           'https://conda.anaconda.org/t/abcdefgh/username/osx-64/',
+           'https://conda.anaconda.org/t/abcdefgh/username/noarch/',
+           # short channel; add channel_alias
+           'https://your.repo/username/osx-64/',
+           'https://your.repo/username/noarch/']
+
         priurls = config.prioritize_channels(normurls)
         assert dict(priurls) == {
-             'file:///Users/username/repo/noarch/': ('file:///Users/username/repo', 5),
-             'file:///Users/username/repo/osx-64/': ('file:///Users/username/repo', 5),
-             'http://repo.continuum.io/pkgs/free/noarch/': ('defaults', 1),
-             'http://repo.continuum.io/pkgs/free/osx-64/': ('defaults', 1),
-             'http://repo.continuum.io/pkgs/pro/noarch/': ('defaults', 1),
-             'http://repo.continuum.io/pkgs/pro/osx-64/': ('defaults', 1),
-             'http://some.custom/channel/noarch/': ('http://some.custom/channel', 3),
-             'http://some.custom/channel/osx-64/': ('http://some.custom/channel', 3),
-             'https://conda.anaconda.org/username/noarch/': ('https://conda.anaconda.org/username', 4),
-             'https://conda.anaconda.org/username/osx-64/': ('https://conda.anaconda.org/username', 4),
-             'https://your.repo/binstar_username/noarch/': ('binstar_username', 2),
-             'https://your.repo/binstar_username/osx-64/': ('binstar_username', 2),
-             'https://your.repo/username/noarch/': ('username', 6),
-             'https://your.repo/username/osx-64/': ('username', 6)}
+           # defaults appears twice, keep higher priority
+           'https://repo.continuum.io/pkgs/free/noarch/': ('defaults', 1),
+           'https://repo.continuum.io/pkgs/free/osx-64/': ('defaults', 1),
+           'https://repo.continuum.io/pkgs/pro/noarch/': ('defaults', 1),
+           'https://repo.continuum.io/pkgs/pro/osx-64/': ('defaults', 1),
+           'https://your.repo/binstar_username/noarch/': ('binstar_username', 2),
+           'https://your.repo/binstar_username/osx-64/': ('binstar_username', 2),
+           'http://some.custom/channel/noarch/': ('http://some.custom/channel', 3),
+           'http://some.custom/channel/osx-64/': ('http://some.custom/channel', 3),
+           'https://conda.anaconda.org/t/abcdefgh/username/noarch/': ('https://conda.anaconda.org/username', 4),
+           'https://conda.anaconda.org/t/abcdefgh/username/osx-64/': ('https://conda.anaconda.org/username', 4),
+           'file:///Users/username/repo/noarch/': ('file:///Users/username/repo', 5),
+           'file:///Users/username/repo/osx-64/': ('file:///Users/username/repo', 5),
+           # the tokenized version came first, but we still give it the same priority
+           'https://conda.anaconda.org/username/noarch/': ('https://conda.anaconda.org/username', 4),
+           'https://conda.anaconda.org/username/osx-64/': ('https://conda.anaconda.org/username', 4),
+           'https://mybinstar.com/t/5768wxyz/test2/noarch/': ('https://mybinstar.com/test2', 6),
+           'https://mybinstar.com/t/5768wxyz/test2/osx-64/': ('https://mybinstar.com/test2', 6),
+           'https://mybinstar.com/t/01234abcde/test/noarch/': ('https://mybinstar.com/test', 7),
+           'https://mybinstar.com/t/01234abcde/test/osx-64/': ('https://mybinstar.com/test', 7),
+           'https://your.repo/username/noarch/': ('username', 8),
+           'https://your.repo/username/osx-64/': ('username', 8)
+        }
 
+        normurls = config.normalize_urls(channel_urls, platform, offline=True)
+        assert normurls == [
+             'file:///Users/username/repo/osx-64/',
+             'file:///Users/username/repo/noarch/']
+
+        # If config.rc['offline'] is True, then it doesn't matter what the offline
+        # argument is normalize_urls
+        config.rc['offline'] = True
+        config.load_condarc()
+        normurls = config.normalize_urls(channel_urls, platform, offline=False)
+        assert normurls == [
+             'file:///Users/username/repo/osx-64/',
+             'file:///Users/username/repo/noarch/']
+
+        # Delete the channel alias so now the short channels point to binstar
+        del config.rc['channel_alias']
+        config.rc['offline'] = False
+        config.load_condarc()
+        config.binstar_client = BinstarTester()
+        normurls = config.normalize_urls(channel_urls, platform)
+        # all your.repo references should be changed to mybinstar.com
+        assert normurls == [
+           'https://repo.continuum.io/pkgs/free/osx-64/',
+           'https://repo.continuum.io/pkgs/free/noarch/',
+           'https://repo.continuum.io/pkgs/pro/osx-64/',
+           'https://repo.continuum.io/pkgs/pro/noarch/',
+           'https://mybinstar.com/t/01234abcde/binstar_username/osx-64/',
+           'https://mybinstar.com/t/01234abcde/binstar_username/noarch/',
+           'http://some.custom/channel/osx-64/',
+           'http://some.custom/channel/noarch/',
+           'https://repo.continuum.io/pkgs/free/osx-64/',
+           'https://repo.continuum.io/pkgs/free/noarch/',
+           'https://repo.continuum.io/pkgs/pro/osx-64/',
+           'https://repo.continuum.io/pkgs/pro/noarch/',
+           'https://conda.anaconda.org/username/osx-64/',
+           'https://conda.anaconda.org/username/noarch/',
+           'file:///Users/username/repo/osx-64/',
+           'file:///Users/username/repo/noarch/',
+           'https://mybinstar.com/t/5768wxyz/test2/osx-64/',
+           'https://mybinstar.com/t/5768wxyz/test2/noarch/',
+           'https://mybinstar.com/t/01234abcde/test/osx-64/',
+           'https://mybinstar.com/t/01234abcde/test/noarch/',
+           'https://conda.anaconda.org/t/abcdefgh/username/osx-64/',
+           'https://conda.anaconda.org/t/abcdefgh/username/noarch/',
+           'https://mybinstar.com/t/01234abcde/username/osx-64/',
+           'https://mybinstar.com/t/01234abcde/username/noarch/'
+        ]
+
+        # Turn off add_anaconda_token
+        config.rc['add_binstar_token'] = False
+        config.load_condarc()
+        config.binstar_client = BinstarTester()
+        normurls = config.normalize_urls(channel_urls, platform)
+        # tokens should not be added (but supplied tokens are kept)
+        assert normurls == [
+           'https://repo.continuum.io/pkgs/free/osx-64/',
+           'https://repo.continuum.io/pkgs/free/noarch/',
+           'https://repo.continuum.io/pkgs/pro/osx-64/',
+           'https://repo.continuum.io/pkgs/pro/noarch/',
+           'https://mybinstar.com/binstar_username/osx-64/',
+           'https://mybinstar.com/binstar_username/noarch/',
+           'http://some.custom/channel/osx-64/',
+           'http://some.custom/channel/noarch/',
+           'https://repo.continuum.io/pkgs/free/osx-64/',
+           'https://repo.continuum.io/pkgs/free/noarch/',
+           'https://repo.continuum.io/pkgs/pro/osx-64/',
+           'https://repo.continuum.io/pkgs/pro/noarch/',
+           'https://conda.anaconda.org/username/osx-64/',
+           'https://conda.anaconda.org/username/noarch/',
+           'file:///Users/username/repo/osx-64/',
+           'file:///Users/username/repo/noarch/',
+           'https://mybinstar.com/t/5768wxyz/test2/osx-64/',
+           'https://mybinstar.com/t/5768wxyz/test2/noarch/',
+           'https://mybinstar.com/test/osx-64/',
+           'https://mybinstar.com/test/noarch/',
+           'https://conda.anaconda.org/t/abcdefgh/username/osx-64/',
+           'https://conda.anaconda.org/t/abcdefgh/username/noarch/',
+           'https://mybinstar.com/username/osx-64/',
+           'https://mybinstar.com/username/noarch/'
+        ]
+
+        # Disable binstar client altogether
+        config.load_condarc()
+        config.binstar_client = ()
+        normurls = config.normalize_urls(channel_urls, platform)
+        # should drop back to conda.anaconda.org
+        assert normurls == [
+          'https://repo.continuum.io/pkgs/free/osx-64/',
+          'https://repo.continuum.io/pkgs/free/noarch/',
+          'https://repo.continuum.io/pkgs/pro/osx-64/',
+          'https://repo.continuum.io/pkgs/pro/noarch/',
+          'https://conda.anaconda.org/binstar_username/osx-64/',
+          'https://conda.anaconda.org/binstar_username/noarch/',
+          'http://some.custom/channel/osx-64/',
+          'http://some.custom/channel/noarch/',
+          'https://repo.continuum.io/pkgs/free/osx-64/',
+          'https://repo.continuum.io/pkgs/free/noarch/',
+          'https://repo.continuum.io/pkgs/pro/osx-64/',
+          'https://repo.continuum.io/pkgs/pro/noarch/',
+          'https://conda.anaconda.org/username/osx-64/',
+          'https://conda.anaconda.org/username/noarch/',
+          'file:///Users/username/repo/osx-64/',
+          'file:///Users/username/repo/noarch/',
+          'https://mybinstar.com/t/5768wxyz/test2/osx-64/',
+          'https://mybinstar.com/t/5768wxyz/test2/noarch/',
+          'https://mybinstar.com/test/osx-64/',
+          'https://mybinstar.com/test/noarch/',
+          'https://conda.anaconda.org/t/abcdefgh/username/osx-64/',
+          'https://conda.anaconda.org/t/abcdefgh/username/noarch/',
+          'https://conda.anaconda.org/username/osx-64/',
+          'https://conda.anaconda.org/username/noarch/'
+        ]
 
 @contextmanager
 def make_temp_condarc(value=None):


### PR DESCRIPTION
Here's the strategy for fixing #2939 without re-breaking #2556:

- Created a new function `init_binstar()` to grab the binstar domain and the tokenized domain. Placed these in _separate variables_ from `channel_alias`, so we can still refer to them if the user has changed `channel_alias` to point away from their Anaconda Server instance (as we saw in #2556).

- Created a new function `channel_prefix()` that returns the proper value of `channel_alias`. From now on, `channel_alias` is accessed only through this function, so that it can be properly initialized when first needed. If `channel_alias` is `None` when this function is first called, it will be set to the Anaconda Server URL; but if it has been hardcoded, it will not be changed. 

- `channel_prefix` actually has two arguments: `token` and `offline`. If `token=True` _and_ `channel_alias` does in fact point to the AS instance, the token will be added to the returned URL. 

- `DEFAULT_CHANNEL_ALIAS` is now utilized only under two circumstances: if `offline` is True, or if anaconda-client is not installed. Note that if `offline` is True, then `DEFAULT_CHANNEL_ALIAS` will be filtered out during the normalization process (unless it's a `file:/` URL, of course).

- Created a new function `add_binstar_tokens` that respects the `add_anaconda_token` flag even when `channel_alias` points away from the AS instance. This is now used in `normalize_urls` to make sure the token is added in the case where `channel_alias` points away from the AS instance.