### PR TITLE
Improve handling of file:// URLs inside channel

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -64,32 +64,32 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
             url_p = utils_url_path(url_p).rstrip('/')
         url = "{0}/{1}".format(url_p, fn)
 
-        # See if the URL refers to a package in our cache
-        prefix = pkg_path = dir_path = None
-        if url.startswith('file://'):
-            prefix = cached_url(url)
-            if prefix is not None:
-                schannel = 'defaults' if prefix == '' else prefix[:-2]
-                is_file = False
-
-        # If not, determine the channel name from the URL
-        if prefix is None:
+        # is_local: if the tarball is stored locally (file://)
+        # is_cache: if the tarball is sitting in our cache
+        is_local = url.startswith('file://')
+        prefix = cached_url(url) if is_local else None
+        is_cache = prefix is not None
+        if is_cache:
+            # Channel information from the cache
+            schannel = 'defaults' if prefix == '' else prefix[:-2]
+        else:
+            # Channel information from the URL
             channel, schannel = url_channel(url)
-            is_file = schannel.startswith('file:') and schannel.endswith('/')
             prefix = '' if schannel == 'defaults' else schannel + '::'
 
         fn = prefix + fn
         dist = fn[:-8]
-        # Add explicit file to index so we'll see it later
-        if is_file:
-            index[fn] = {'fn': dist2filename(fn), 'url': url, 'md5': None}
+        # Add explicit file to index so we'll be sure to see it later
+        if is_local:
+            index[fn] = {'fn': dist2filename(fn), 'url': url, 'md5': md5}
+            verifies.append((fn, md5))
 
         pkg_path = is_fetched(dist)
         dir_path = is_extracted(dist)
 
         # Don't re-fetch unless there is an MD5 mismatch
-        # Also remove explicit tarballs from cache
-        if pkg_path and (is_file or md5 and md5_file(pkg_path) != md5):
+        # Also remove explicit tarballs from cache, unless the path *is* to the cache
+        if pkg_path and not is_cache and (is_local or md5 and md5_file(pkg_path) != md5):
             # This removes any extracted copies as well
             actions[RM_FETCHED].append(dist)
             pkg_path = dir_path = None
@@ -104,9 +104,9 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
                 _, conflict = find_new_location(dist)
                 if conflict:
                     actions[RM_FETCHED].append(conflict)
-                if not is_file:
+                if not is_local:
                     if fn not in index or index[fn].get('not_fetched'):
-                        channels[url_p + '/'] = (schannel, 0)
+                        channels.add(channel)
                     verifies.append((dist + '.tar.bz2', md5))
                 actions[FETCH].append(dist)
             actions[EXTRACT].append(dist)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -299,12 +299,33 @@ class IntegrationTests(TestCase):
                 run_command(Commands.INSTALL, prefix, '-c', channel, 'flask')
                 assert_package_is_installed(prefix, channel + '::' + 'flask-')
 
+                run_command(Commands.REMOVE, prefix, 'flask')
+                assert not package_is_installed(prefix, 'flask-0')
+
+                # Regression test for 2970
+                # install from build channel as a tarball
+                conda_bld = join(sys.prefix, 'conda-bld')
+                conda_bld_sub = join(conda_bld, subdir)
+
+                tar_bld_path = join(conda_bld_sub, flask_fname)
+                if os.path.exists(conda_bld):
+                    try:
+                        os.rename(tar_new_path, tar_bld_path)
+                    except OSError:
+                        pass
+                else:
+                    os.makedirs(conda_bld)
+                    os.rename(subchan, conda_bld_sub)
+                run_command(Commands.INSTALL, prefix, tar_bld_path)
+                assert_package_is_installed(prefix, 'flask-')
+
             # regression test for #2886 (part 2 of 2)
             # install tarball from package cache, local channel
             run_command(Commands.REMOVE, prefix, 'flask')
             assert not package_is_installed(prefix, 'flask-0')
             run_command(Commands.INSTALL, prefix, tar_old_path)
-            assert_package_is_installed(prefix, channel + '::' + 'flask-')
+            # The last install was from the `local::` channel
+            assert_package_is_installed(prefix, 'flask-')
 
             # regression test for #2599
             linked_data_.clear()


### PR DESCRIPTION
See #2970. Really frustrating getting all of these corner case worked out. In this cases, someone is using an absolute path to a tarball in the `conda-bld` directory. You would think we have that case covered. Well, we do now, though with some difficulty---I will not be surprised if we have an initial test failure here. The reason is that local testing is necessarily different than CI testing in this case, because locally the tests are running against my existing installation.