### PR TITLE
improve repodata locking to enable parallel conda builds

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -19,7 +19,7 @@ from functools import wraps
 from logging import getLogger
 from os.path import basename, dirname, join
 
-from .compat import itervalues, input, urllib_quote, iterkeys, iteritems
+from .compat import itervalues, input, urllib_quote, iterkeys, iteritems, urlparse
 from .config import (pkgs_dirs, DEFAULT_CHANNEL_ALIAS, remove_binstar_tokens,
                      hide_binstar_tokens, allowed_channels, add_pip_as_python_dependency,
                      ssl_verify, rc, prioritize_channels, url_channel)
@@ -110,10 +110,17 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
         resp = session.get(url + filename, headers=headers, proxies=session.proxies)
         resp.raise_for_status()
         if resp.status_code != 304:
+            lock = None
+            if url.startswith("file://"):
+                pkg_file = urlparse.urlparse(url)
+                pkg_file = os.path.abspath(os.path.join(pkg_file.netloc, pkg_file.path))
+                lock = Locked(os.path.dirname(pkg_file))
             if filename.endswith('.bz2'):
                 json_str = bz2.decompress(resp.content).decode('utf-8')
             else:
                 json_str = resp.content.decode('utf-8')
+            if lock:
+                del lock
             cache = json.loads(json_str)
             add_http_value_to_dict(resp, 'Etag', cache, '_etag')
             add_http_value_to_dict(resp, 'Last-Modified', cache, '_mod')


### PR DESCRIPTION
Conda-build is growing the ability to do multiple builds in parallel.  It is held back by conda's locking.  That's OK for now - it just delays things a bit.  This PR fixes something that is not OK - one build trying to read repodata (local) while another build overwrites it.

See https://github.com/conda/conda-build/pull/1067 for more details.  This is a project requested by @joelhullcio for client work at JPM.  Please prioritize.