### PR TITLE
Reduce priority for packages removed from the index

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from . import install
 from .compat import iteritems, itervalues
-from .config import normalize_urls, prioritize_channels, get_channel_urls
+from .config import normalize_urls, prioritize_channels, get_channel_urls, MAX_PRIORITY
 from .fetch import fetch_index
 from .resolve import Resolve
 
@@ -24,13 +24,12 @@ def get_index(channel_urls=(), prepend=True, platform=None,
     channel_urls = prioritize_channels(channel_urls)
     index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
     if prefix:
-        priorities = {c: p for c, p in itervalues(channel_urls)}
-        maxp = max(itervalues(priorities)) + 1 if priorities else 1
+        schannels = {c for c, p in itervalues(channel_urls)}
+        maxp = max(p for c, p in itervalues(channel_urls)) if channel_urls else 1
         for dist, info in iteritems(install.linked_data(prefix)):
             fn = info['fn']
             schannel = info['schannel']
             prefix = '' if schannel == 'defaults' else schannel + '::'
-            priority = priorities.get(schannel, maxp)
             key = prefix + fn
             if key in index:
                 # Copy the link information so the resolver knows this is installed
@@ -40,7 +39,11 @@ def get_index(channel_urls=(), prepend=True, platform=None,
                 # only if the package in not in the repodata, use local
                 # conda-meta (with 'depends' defaulting to [])
                 info.setdefault('depends', [])
-                info['priority'] = priority
+                # If the schannel is known but the package is not in the index, it is
+                # because 1) the channel is unavailable offline or 2) the package has
+                # been removed from that channel. Either way, we should prefer any
+                # other version of the package to this one.
+                info['priority'] = MAX_PRIORITY if schannel in schannels else maxp
                 index[key] = info
     return index
 

--- a/conda/config.py
+++ b/conda/config.py
@@ -269,6 +269,9 @@ def hide_binstar_tokens(url):
 def remove_binstar_tokens(url):
     return BINSTAR_TOKEN_PAT.sub(r'\1', url)
 
+# Maximum priority, reserved for packages we really want to remove
+MAX_PRIORITY = 10000
+
 def prioritize_channels(channels):
     newchans = OrderedDict()
     priority = 0
@@ -278,8 +281,7 @@ def prioritize_channels(channels):
         if channel not in newchans:
             channel_s = canonical_channel_name(channel.rsplit('/', 2)[0])
             if channel_s not in schans:
-                priority += 1
-                schans[channel_s] = priority
+                schans[channel_s] = priority = min(priority + 1, MAX_PRIORITY - 1)
             newchans[channel] = (channel_s, schans[channel_s])
     return newchans
 


### PR DESCRIPTION
If someone installs a package, and then that package is removed from the index, the current version of `conda` will still treat it as if it is a legitimate member of the index with the same install priority. 

It would be preferable for conda to update this package to one that remains in the index, if possible. We've adjusted the logic to accommodate this. In short, if that package is scheduled for an update, the missing version will be given the lowest priority.