### PR TITLE
Detect and cleanly handle accidentally duplicated packages

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -233,44 +233,6 @@ def install(args, parser, command='install'):
     ospecs = list(specs)
     add_defaults_to_specs(r, linked, specs, update=isupdate)
 
-    # Don't update packages that are already up-to-date
-    if isupdate and not (args.all or args.force):
-        orig_packages = args.packages[:]
-        installed_metadata = [is_linked(prefix, dist) for dist in linked]
-        for name in orig_packages:
-            vers_inst = [m['version'] for m in installed_metadata if m['name'] == name]
-            build_inst = [m['build_number'] for m in installed_metadata if m['name'] == name]
-
-            try:
-                assert len(vers_inst) == 1, name
-                assert len(build_inst) == 1, name
-            except AssertionError as e:
-                if args.json:
-                    common.exception_and_exit(e, json=True)
-                else:
-                    raise
-
-            pkgs = sorted(r.get_pkgs(name))
-            if not pkgs:
-                # Shouldn't happen?
-                continue
-            latest = pkgs[-1]
-
-            if (latest.version == vers_inst[0] and
-                    latest.build_number == build_inst[0]):
-                args.packages.remove(name)
-        if not args.packages:
-            from .main_list import print_packages
-
-            if not args.json:
-                regex = '^(%s)$' % '|'.join(orig_packages)
-                print('# All requested packages already installed.')
-                print_packages(prefix, regex)
-            else:
-                common.stdout_json_success(
-                    message='All requested packages already installed.')
-            return
-
     if args.force:
         args.no_deps = True
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from itertools import chain
 
-from .compat import iterkeys, itervalues, iteritems
+from .compat import iterkeys, itervalues, iteritems, string_types
 from .config import subdir, channel_priority, canonical_channel_name, track_features
 from .console import setup_handlers
 from .install import dist2quad
@@ -663,6 +663,8 @@ class Resolve(object):
         return set(self.index[fkey].get('track_features', '').split())
 
     def package_quad(self, fkey):
+        if not fkey.endswith('.tar.bz2'):
+            fkey += '.tar.bz2'
         rec = self.index.get(fkey, None)
         if rec is None:
             return dist2quad(fkey.rsplit('[', 1)[0].rsplit('/', 1)[-1])
@@ -869,60 +871,84 @@ class Resolve(object):
 
     def bad_installed(self, installed, new_specs):
         log.debug('Checking if the current environment is consistent')
-        if not installed:
-            return None, []
         xtra = []
+        duplicates = set()
+        if not installed:
+            return None, xtra, duplicates
+
         dists = {}
-        specs = []
+        dnames = set()
         for fn in installed:
+            name = self.package_name(fn)
+            (duplicates if name in dnames else dnames).add(name)
             rec = self.index.get(fn)
             if rec is None:
                 xtra.append(fn)
             else:
                 dists[fn] = rec
-                specs.append(MatchSpec(' '.join(self.package_quad(fn)[:3])))
+
         if xtra:
-            log.debug('Packages missing from index: %s' % ', '.join(xtra))
-        r2 = Resolve(dists, True, True)
-        C = r2.gen_clauses(specs)
-        constraints = r2.generate_spec_constraints(C, specs)
+            log.debug('Packages missing from index: %s' % ', '.join(sorted(xtra)))
+        if duplicates:
+            dupfns = list(sorted(fn for fn in installed if self.package_name(fn) in duplicates))
+            stderrlog.warn('WARNING: duplicate packages detected in the environment:\n  - %s\n'
+                           'Specifications will be adjusted to correct this.\n' %
+                           ('\n  - '. join(dupfns),))
+            xtra = [fn for fn in xtra if self.package_name(fn) not in duplicates]
+        for fn in xtra:
+            dnames.remove(self.package_name(fn))
+
+        if duplicates:
+            snames = duplicates.copy()
+            for name in snames:
+                dists.update({fn: self.index[fn] for fn in self.groups[name]})
+        else:
+            snames = set()
+
+        r2 = Resolve(dists)
+        C = r2.gen_clauses([])
+        constraints = r2.generate_spec_constraints(C, map(MatchSpec, dnames))
         try:
             solution = C.sat(constraints)
         except TypeError:
             log.debug('Package set caused an unexpected error, assuming a conflict')
             solution = None
-        limit = None
-        if not solution or xtra:
-            def get_(name, snames):
-                if name not in snames:
-                    snames.add(name)
-                    for fn in self.groups.get(name, []):
-                        for ms in self.ms_depends(fn):
-                            get_(ms.name, snames)
-            snames = set()
-            for spec in new_specs:
-                get_(MatchSpec(spec).name, snames)
-            xtra = [x for x in xtra if x not in snames]
-            if xtra or not (solution or all(s.name in snames for s in specs)):
-                limit = set(s.name for s in specs if s.name in snames)
-                xtra = [fn for fn in installed if self.package_name(fn) not in snames]
-                log.debug(
-                    'Limiting solver to the following packages: %s' %
-                    ', '.join(limit))
+        if solution:
+            return None, xtra, duplicates
+
+        def get_(name, snames):
+            if name not in snames and name in dnames:
+                snames.add(name)
+                for fn in self.groups.get(name, []):
+                    for ms in self.ms_depends(fn):
+                        get_(ms.name, snames)
+        for spec in new_specs:
+            get_(MatchSpec(spec).name, snames)
+        xtra = [fn for fn in installed if self.package_name(fn) not in snames]
+        if not xtra:
+            snames = None
+        else:
+            snames = list(sorted(snames))
+            log.debug(
+                'Limiting solver to the following packages: %s' % ', '.join(snames))
         if xtra:
             log.debug('Packages to be preserved: %s' % ', '.join(xtra))
-        return limit, xtra
+        return snames, xtra, duplicates
 
     def restore_bad(self, pkgs, preserve):
         if preserve:
             sdict = {self.package_name(pkg): pkg for pkg in pkgs}
             pkgs.extend(p for p in preserve if self.package_name(p) not in sdict)
+            pkgs.sort()
 
     def install_specs(self, specs, installed, update_deps=True):
         specs = list(map(MatchSpec, specs))
         snames = {s.name for s in specs}
         log.debug('Checking satisfiability of current install')
-        limit, preserve = self.bad_installed(installed, specs)
+        limit, preserve, duplicates = self.bad_installed(installed, specs)
+        for name in duplicates - snames:
+            specs.append(MatchSpec(name, optional=True))
+            snames.add(name)
         for pkg in installed:
             if pkg not in self.index:
                 continue
@@ -950,12 +976,15 @@ class Resolve(object):
         specs = [s if ' ' in s else s + ' @ @' for s in specs]
         specs = [MatchSpec(s, optional=True) for s in specs]
         snames = {s.name for s in specs}
-        limit, _ = self.bad_installed(installed, specs)
+        limit, _, duplicates = self.bad_installed(installed, specs)
         preserve = []
         for pkg in installed:
             nm, ver, build, schannel = self.package_quad(pkg)
             if nm in snames:
                 continue
+            elif nm in duplicates:
+                specs.append(MatchSpec(nm, optional=True))
+                snames.add(nm)
             elif limit is not None:
                 preserve.append(pkg)
             elif ver:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -231,6 +231,34 @@ class IntegrationTests(TestCase):
             assert_package_is_installed(prefix, 'python-3')
 
     @pytest.mark.timeout(300)
+    def test_create_duplicate_packages(self):
+        # Create an environment with two different versions of the same package.
+        # Make sure that conda can properly handle this
+        with make_temp_env("python=3") as prefix:
+            assert exists(join(prefix, PYTHON_BINARY))
+            assert_package_is_installed(prefix, 'python-3')
+
+            for attempt in range(2):
+                xz_metadata = glob(join(prefix, 'conda-meta', 'xz-*.json'))[-1]
+                xz_linked1 = basename(xz_metadata)[:-5]
+                copyfile(xz_metadata, xz_metadata + '.tmp')
+                run_command(Commands.INSTALL, prefix, 'xz<' + xz_linked1.rsplit('-', 2)[1])
+                assert_package_is_installed(prefix, 'xz')
+                xz_linked2 = basename(glob(join(prefix, 'conda-meta', 'xz-*.json'))[-1])[:-5]
+                assert xz_linked1 != xz_linked2
+                os.rename(xz_metadata + '.tmp', xz_metadata)
+                linked_data_.clear()
+
+                if attempt == 0:
+                    run_command(Commands.UPDATE, prefix, 'python')
+                    xz_metadata = glob(join(prefix, 'conda-meta', 'xz-*.json'))
+                    assert len(xz_metadata) == 1
+                    assert basename(xz_metadata[0])[:-5] == xz_linked1
+                else:
+                    run_command(Commands.REMOVE, prefix, 'xz')
+                    assert not package_is_installed(prefix, 'xz')
+
+    @pytest.mark.timeout(300)
     def test_list_with_pip_egg(self):
         with make_temp_env("python=3 pip") as prefix:
             check_call(PYTHON_BINARY + " -m pip install --egg --no-binary flask flask==0.10.1",

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -817,12 +817,20 @@ def test_broken_install():
         'system-5.8-1.tar.bz2',
         'tk-8.5.13-0.tar.bz2',
         'zlib-1.2.7-0.tar.bz2']
-    installed[1] = 'numpy-1.7.1-py33_p0.tar.bz2'
     installed.append('notarealpackage-2.0-0.tar.bz2')
-    assert r.install([], installed) == installed
-    installed2 = r.install(['numpy'], installed)
-    installed3 = r.remove(['pandas'], installed)
-    assert set(installed3) == set(installed[:3] + installed[4:])
+    installed.sort()
+    installed2 = list(installed)
+    installed2[2] = 'numpy-1.7.1-py33_p0.tar.bz2'
+    installed3 = r.install([], installed2)
+    installed4 = r.install(['numpy 1.6*'], installed2)
+    installed5 = r.install(['numpy'], installed2)
+    installed6 = r.remove(['pandas'], installed2)
+    installed7 = list(installed2)
+    installed7.remove('pandas-0.11.0-np16py27_1.tar.bz2')
+    assert installed3 == installed2
+    assert installed4 == installed
+    assert sum(x != y for x, y in zip(installed, installed5)) == 1
+    assert installed6 == installed7
 
 def test_remove():
     installed = r.install(['pandas', 'python 2.7*'])
@@ -931,6 +939,11 @@ def test_update_deps():
         'tk-8.5.13-0.tar.bz2',
         'zlib-1.2.7-0.tar.bz2',
     ]
+
+    # Test accidentally duplicated packages
+    installed2 = installed + ['sqlite-3.9.2-0.tar.bz2', 'six-1.10.0-py27_0.tar.bz2']
+    installed3 = r.install([], installed=installed2)
+    assert installed == installed3
 
     # scipy, and pandas should all be updated here. pytz is a new
     # dependency of pandas. But numpy does not _need_ to be updated


### PR DESCRIPTION
Resubmission of #2924 

Due perhaps to a bug in conda (new or old), sometimes the `conda-meta` directory contains data from two different versions of the same package. This confuses conda, for obvious reasons; and under some install/update operations, it will schedule the removal of one of these packages. Unfortunately, since the packages almost certainly share common files, it effectively renders the "remaining" package unusable, with sometimes catastrophic consequences. (https://github.com/conda/conda/issues/2913)

This PR attempts to rectify this by identifying duplicate packages and scheduling a correction. For example, suppose that `foo` is the duplicated package. Then:
- `conda remove <foo>` will remove both copies of the package.
- `conda install <foo>` / `conda update <foo>` will remove both copies, and replace it.
- any other `conda install/remove/update` will remove both copies, and replace it with the latest compatible version of the package.

Improvements above #2924:
- Integration test added in `test_create.py`; see `test_create_duplicate_packages`. Both updates and removals tested.
- `plan.display_actions` modified to better handle the duplicate case. In particular, for duplicated packages, the version string is replaced with `<multiple>`
- Explicit warning added that the specs are being adjusted to correct the duplication; e.g., from the integration test,

```
WARNING: duplicate packages detected in the environment:
  - xz-5.0.5-1.tar.bz2
  - xz-5.2.2-0.tar.bz2
Specifications will be adjusted to correct this.
```
