### PR TITLE
remove os.remove in update_prefix

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -418,8 +418,6 @@ def update_prefix(path, new_prefix, placeholder=prefix_placeholder, mode='text')
     if data == original_data:
         return
     st = os.lstat(path)
-    # Remove file before rewriting to avoid destroying hard-linked cache
-    os.remove(path)
     with exp_backoff_fn(open, path, 'wb') as fo:
         fo.write(data)
     os.chmod(path, stat.S_IMODE(st.st_mode))


### PR DESCRIPTION
There is no reason to have an `os.remove` (identical to `os.unlink`) here, because files which are going to processed by `update_prefix()` are already ensured to be copies, see https://github.com/conda/conda/blob/master/conda/install.py#L1060, so there is no danger in destroying the hard-linked cache.  Moreover, since we are writing a new file (as opposed to appending) a new inode created anyway.