### PR TITLE
don't overwrite existing redirect shortcuts when symlinking envs

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -142,8 +142,9 @@ if on_win:
                 raise
 
         # bat file redirect
-        with open(dst+'.bat', 'w') as f:
-            f.write('@echo off\ncall "%s" %%*\n' % src)
+        if not os.path.isfile(dst + '.bat'):
+            with open(dst + '.bat', 'w') as f:
+                f.write('@echo off\ncall "%s" %%*\n' % src)
 
         # TODO: probably need one here for powershell at some point
 
@@ -151,17 +152,20 @@ if on_win:
         # set default shell to bash.exe when not provided, as that's most common
         if not shell:
             shell = "bash.exe"
-        with open(dst, "w") as f:
-            f.write("#!/usr/bin/env bash \n")
-            if src.endswith("conda"):
-                f.write('%s "$@"' % shells[shell]['path_to'](src+".exe"))
-            else:
-                f.write('source %s "$@"' % shells[shell]['path_to'](src))
-        # Make the new file executable
-        # http://stackoverflow.com/a/30463972/1170370
-        mode = os.stat(dst).st_mode
-        mode |= (mode & 292) >> 2    # copy R bits to X
-        os.chmod(dst, mode)
+
+        # technically these are "links" - but islink doesn't work on win
+        if not os.path.isfile(dst):
+            with open(dst, "w") as f:
+                f.write("#!/usr/bin/env bash \n")
+                if src.endswith("conda"):
+                    f.write('%s "$@"' % shells[shell]['path_to'](src+".exe"))
+                else:
+                    f.write('source %s "$@"' % shells[shell]['path_to'](src))
+            # Make the new file executable
+            # http://stackoverflow.com/a/30463972/1170370
+            mode = os.stat(dst).st_mode
+            mode |= (mode & 292) >> 2    # copy R bits to X
+            os.chmod(dst, mode)
 
 log = logging.getLogger(__name__)
 stdoutlog = logging.getLogger('stdoutlog')


### PR DESCRIPTION
People are seeing issues with bat file redirects in the root environment being overwritten, leading to infinite loops.  I tried to solve this in before by refining the path checking, but that apparently didn't work.  This is more of a hack, but safer.

Issues: 
* https://github.com/conda-forge/conda-smithy-feedstock/pull/29#issuecomment-231543820
* https://github.com/conda-forge/conda-build-all-feedstock/issues/12#issuecomment-231340770

probably others that I'm missing.
