### PR TITLE
WIP - ability to have conda reside in '_conda' environment

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -202,6 +202,8 @@ def execute(args, parser):
                      conda_version=conda.__version__,
                      conda_build_version=conda_build_version,
                      root_prefix=config.root_dir,
+                     conda_prefix=config.conda_prefix,
+                     home_in_root=config.home_in_root,
                      root_writable=config.root_writable,
                      pkgs_dirs=config.pkgs_dirs,
                      envs_dirs=config.envs_dirs,
@@ -242,6 +244,7 @@ Current conda install:
   conda-build version : %(conda_build_version)s
        python version : %(python_version)s
      requests version : %(requests_version)s
+  conda's environment : %(conda_prefix)s
      root environment : %(root_prefix)s  (%(_rtwro)s)
   default environment : %(default_prefix)s
      envs directories : %(_envs_dirs)s

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -241,10 +241,10 @@ Current conda install:
 
              platform : %(platform)s
         conda version : %(conda_version)s
+ conda's home in root : %(home_in_root)s
   conda-build version : %(conda_build_version)s
        python version : %(python_version)s
      requests version : %(requests_version)s
-  conda's environment : %(conda_prefix)s
      root environment : %(root_prefix)s  (%(_rtwro)s)
   default environment : %(default_prefix)s
      envs directories : %(_envs_dirs)s

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -158,7 +158,7 @@ def execute(args, parser):
 
     else:
         specs = common.specs_from_args(args.package_names)
-        if (plan.is_root_prefix(prefix) and
+        if (config.home_in_root and plan.is_root_prefix(prefix) and
             common.names_in_specs(common.root_no_rm, specs)):
             common.error_and_exit('cannot remove %s from root environment' %
                                   ', '.join(common.root_no_rm),

--- a/conda/config.py
+++ b/conda/config.py
@@ -129,10 +129,12 @@ sys_rc = load_condarc(sys_rc_path) if isfile(sys_rc_path) else {}
 if basename(sys.prefix) == '_conda':
     assert basename(basename(sys.prefix)) == 'envs'
     home_env = '_conda'
+    home_in_root = False
     root_prefix = abspath(dirname(dirname(sys.prefix)))
     conda_prefix = sys.prefix
 else:
     home_env = 'root'
+    home_in_root = True
     root_prefix = conda_prefix = abspath(sys.prefix)
 
 root_dir = root_prefix

--- a/conda/config.py
+++ b/conda/config.py
@@ -126,14 +126,12 @@ sys_rc = load_condarc(sys_rc_path) if isfile(sys_rc_path) else {}
 
 # ----- local directories -----
 
-if basename(sys.prefix) == '_conda':
-    assert basename(dirname(sys.prefix)) == 'envs', sys.prefix
-    home_env = '_conda'
+if (basename(sys.prefix) == '_conda' and
+          basename(dirname(sys.prefix)) == 'envs'):
     home_in_root = False
     root_prefix = abspath(dirname(dirname(sys.prefix)))
     conda_prefix = sys.prefix
 else:
-    home_env = 'root'
     home_in_root = True
     root_prefix = conda_prefix = abspath(sys.prefix)
 

--- a/conda/config.py
+++ b/conda/config.py
@@ -10,7 +10,7 @@ import os
 import sys
 import logging
 from platform import machine
-from os.path import abspath, expanduser, isfile, isdir, join
+from os.path import abspath, basename, dirname, expanduser, isfile, isdir, join
 import re
 
 from conda.compat import urlparse
@@ -126,12 +126,17 @@ sys_rc = load_condarc(sys_rc_path) if isfile(sys_rc_path) else {}
 
 # ----- local directories -----
 
-# root_dir should only be used for testing, which is why don't mention it in
-# the documentation, to avoid confusion (it can really mess up a lot of
-# things)
-root_dir = abspath(expanduser(os.getenv('CONDA_ROOT',
-                                        rc.get('root_dir', sys.prefix))))
-root_writable = try_write(root_dir)
+if basename(sys.prefix) == '_conda':
+    assert basename(basename(sys.prefix)) == 'envs'
+    home_env = '_conda'
+    root_prefix = abspath(dirname(dirname(sys.prefix)))
+    conda_prefix = sys.prefix
+else:
+    home_env = 'root'
+    root_prefix = conda_prefix = abspath(sys.prefix)
+
+root_dir = root_prefix
+root_writable = try_write(root_prefix)
 root_env_name = 'root'
 
 def _default_envs_dirs():

--- a/conda/config.py
+++ b/conda/config.py
@@ -129,7 +129,7 @@ sys_rc = load_condarc(sys_rc_path) if isfile(sys_rc_path) else {}
 if (basename(sys.prefix) == '_conda' and
           basename(dirname(sys.prefix)) == 'envs'):
     home_in_root = False
-    root_prefix = abspath(dirname(dirname(sys.prefix)))
+    root_prefix = abspath(join(sys.prefix, '..', '..'))
     conda_prefix = sys.prefix
 else:
     home_in_root = True

--- a/conda/config.py
+++ b/conda/config.py
@@ -127,7 +127,7 @@ sys_rc = load_condarc(sys_rc_path) if isfile(sys_rc_path) else {}
 # ----- local directories -----
 
 if basename(sys.prefix) == '_conda':
-    assert basename(basename(sys.prefix)) == 'envs'
+    assert basename(dirname(sys.prefix)) == 'envs', sys.prefix
     home_env = '_conda'
     home_in_root = False
     root_prefix = abspath(dirname(dirname(sys.prefix)))

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -477,7 +477,7 @@ def remove_actions(prefix, specs, index, force=False, pinned=True):
         if pinned and any(r.match(ms, dist) for ms in pinned_specs):
             raise RuntimeError(
                 "Cannot remove %s because it is pinned. Use --no-pin to override." % dist)
-        if name == 'conda' and name not in nlinked:
+        if config.home_in_root and name == 'conda' and name not in nlinked:
             if any(ms.name == 'conda' for ms in mss):
                 sys.exit("Error: 'conda' cannot be removed from the root environment")
             else:

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -395,7 +395,8 @@ def install_actions(prefix, index, specs, force=False, only_names=None,
     r = Resolve(index)
     linked = install.linked(prefix)
 
-    if config.auto_update_conda and is_root_prefix(prefix):
+    if (config.home_in_root and config.auto_update_conda and
+                is_root_prefix(prefix)):
         specs.append('conda')
 
     if pinned:


### PR DESCRIPTION
In this PR, we add the ability for conda to reside in the `_conda` environment.  Don't worry, conda will still work when installed in the `root` environment.  This is achieved by having a Boolean config variable `config.home_in_root` in order preserve old behavior.  Also, because the `_conda` environment is considered private, it is not treated special in any way.  That is, you can install or remove any package from `_conda`, even `conda remove -n _conda conda`.

To do (all these items imply that `config.home_in_root` is `False`):
  * `conda update conda` will have to somehow alias to to `conda update -n _conda conda`.  Should regular usage of conda try self updates too?
  * think about disallowing `conda install -n root conda`, as it would overwrite the symlinks.
  * think about `conda install conda-build`.  Right now I'm thinking that any package which lists `conda` as a dependency gets installed into `_conda`.  Note that `conda build` works out of the box already when you `conda install -n _conda conda-build`.
  * think about implications for `activate` and `deactivate`.

The good news is that because of `config.home_in_root`, we can for a long time (maybe even indefinitely) develop on a single conda codebase which supports both the classic `root` install of conda, and the new `_conda` environment.

What this means for the Anaconda (hopefully 4.2) installer, is that the `anaconda` and *only* its dependencies (which conda is already not) will be installed in the `root` environment, and `conda` in the `_conda` environment.  The resulting installer will not be larger than before, and also not take up more space once installed, because of the use of hard-links.  This will make Anaconda and Miniconda very similar, one has a populated `root` environment and the other does not.