### PR TITLE
partially revert no default shortcuts

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -26,6 +26,7 @@ from ..plan import (is_root_prefix, get_pinned_specs, install_actions, add_defau
                     display_actions, revert_actions, nothing_to_do, execute_actions)
 from ..resolve import NoPackagesFound, Unsatisfiable, Resolve
 from ..utils import find_parent_shell
+from .. import config
 
 log = logging.getLogger(__name__)
 
@@ -297,7 +298,8 @@ environment does not exist: %s
                                   json=args.json,
                                   error_type="NoEnvironmentFound")
 
-    shortcuts = args.shortcuts if hasattr(args, "shortcuts") else None
+    if hasattr(args, 'shortcuts'):
+        config.shortcuts = args.shortcuts and config.shortcuts
 
     try:
         if isinstall and args.revision:
@@ -310,8 +312,7 @@ environment does not exist: %s
                                           pinned=args.pinned,
                                           always_copy=args.copy,
                                           minimal_hint=args.alt_hint,
-                                          update_deps=args.update_deps,
-                                          shortcuts=shortcuts)
+                                          update_deps=args.update_deps)
     except NoPackagesFound as e:
         error_message = e.args[0]
 

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -32,9 +32,10 @@ def configure_parser(sub_parsers):
     )
     if on_win:
         p.add_argument(
-            "--shortcuts",
-            action="store_true",
-            help="Install start menu shortcuts"
+            "--no-shortcuts",
+            action="store_false",
+            help="Prevent installation of start menu shortcuts",
+            dest='shortcuts',
         )
 
     add_parser_install(p)

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -56,9 +56,10 @@ def configure_parser(sub_parsers):
     )
     if on_win:
         p.add_argument(
-            "--shortcuts",
-            action="store_true",
-            help="Install start menu shortcuts"
+            "--no-shortcuts",
+            action="store_false",
+            help="Install start menu shortcuts",
+            dest="shortcuts"
         )
     add_parser_install(p)
     add_parser_json(p)

--- a/conda/config.py
+++ b/conda/config.py
@@ -87,6 +87,7 @@ rc_bool_keys = [
     'allow_other_channels',
     'update_dependencies',
     'channel_priority',
+    'shortcuts',
 ]
 
 rc_string_keys = [
@@ -452,6 +453,7 @@ def load_condarc(path=None):
     create_default_packages = list(rc.get('create_default_packages', []))
     update_dependencies = bool(rc.get('update_dependencies', True))
     channel_priority = bool(rc.get('channel_priority', True))
+    shortcuts = bool(rc.get('shortcuts', True))
 
     # ssl_verify can be a boolean value or a filename string
     ssl_verify = rc.get('ssl_verify', True)

--- a/conda/install.py
+++ b/conda/install.py
@@ -52,6 +52,7 @@ try:
     from conda.lock import Locked
     from conda.utils import win_path_to_unix, url_path
     from conda.config import remove_binstar_tokens, pkgs_dirs, url_channel
+    import conda.config as config
 except ImportError:
     # Make sure this still works as a standalone script for the Anaconda
     # installer.
@@ -1026,7 +1027,7 @@ def move_path_to_trash(path, preclean=True):
     return False
 
 
-def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):
+def link(prefix, dist, linktype=LINK_HARD, index=None):
     """
     Set up a package in a specified (environment) prefix.  We assume that
     the package has been extracted (using extract() above).
@@ -1081,7 +1082,7 @@ def link(prefix, dist, linktype=LINK_HARD, index=None, shortcuts=False):
             if isfile(nonadmin):
                 open(join(prefix, ".nonadmin"), 'w').close()
 
-        if shortcuts:
+        if config.shortcuts:
             mk_menus(prefix, files, remove=False)
 
         if not run_script(prefix, dist, 'post-link'):

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -68,15 +68,14 @@ def RM_FETCHED_CMD(state, arg):
 
 
 def split_linkarg(arg):
-    "Return tuple(dist, linktype, shortcuts)"
+    "Return tuple(dist, linktype)"
     parts = arg.split()
-    return (parts[0], int(LINK_HARD if len(parts) < 2 else parts[1]),
-            False if len(parts) < 3 else parts[2] == 'True')
+    return (parts[0], int(LINK_HARD if len(parts) < 2 else parts[1]))
 
 
 def LINK_CMD(state, arg):
-    dist, lt, shortcuts = split_linkarg(arg)
-    link(state['prefix'], dist, lt, index=state['index'], shortcuts=shortcuts)
+    dist, lt = split_linkarg(arg)
+    link(state['prefix'], dist, lt, index=state['index'])
 
 
 def UNLINK_CMD(state, arg):

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -92,7 +92,7 @@ def display_actions(actions, index, show_channel_urls=None):
     linktypes = {}
 
     for arg in actions.get(inst.LINK, []):
-        dist, lt, shortcuts = inst.split_linkarg(arg)
+        dist, lt = inst.split_linkarg(arg)
         fkey = dist + '.tar.bz2'
         rec = index[fkey]
         pkg = rec['name']
@@ -102,7 +102,7 @@ def display_actions(actions, index, show_channel_urls=None):
         linktypes[pkg] = lt
         features[pkg][1] = rec.get('features', '')
     for arg in actions.get(inst.UNLINK, []):
-        dist, lt, shortcuts = inst.split_linkarg(arg)
+        dist, lt = inst.split_linkarg(arg)
         fkey = dist + '.tar.bz2'
         rec = index.get(fkey)
         if rec is None:
@@ -291,7 +291,7 @@ def plan_from_actions(actions):
 # force_linked_actions has now been folded into this function, and is enabled by
 # supplying an index and setting force=True
 def ensure_linked_actions(dists, prefix, index=None, force=False,
-                          always_copy=False, shortcuts=False):
+                          always_copy=False):
     actions = defaultdict(list)
     actions[inst.PREFIX] = prefix
     actions['op_order'] = (inst.RM_FETCHED, inst.FETCH, inst.RM_EXTRACTED,
@@ -355,10 +355,10 @@ def ensure_linked_actions(dists, prefix, index=None, force=False,
                 lt = LINK_SOFT
             else:
                 lt = LINK_COPY
-            actions[inst.LINK].append('%s %d %s' % (dist, lt, shortcuts))
+            actions[inst.LINK].append('%s %d' % (dist, lt))
 
         except (OSError, IOError):
-            actions[inst.LINK].append('%s %d %s' % (dist, LINK_COPY, shortcuts))
+            actions[inst.LINK].append('%s %d' % (dist, LINK_COPY))
         finally:
             if not extracted_in:
                 # Remove the dummy data
@@ -440,8 +440,7 @@ def get_pinned_specs(prefix):
         return [i for i in f.read().strip().splitlines() if i and not i.strip().startswith('#')]
 
 def install_actions(prefix, index, specs, force=False, only_names=None, always_copy=False,
-                    pinned=True, minimal_hint=False, update_deps=True, prune=False,
-                    shortcuts=False):
+                    pinned=True, minimal_hint=False, update_deps=True, prune=False):
     r = Resolve(index)
     linked = r.installed
 
@@ -492,8 +491,7 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
     actions = ensure_linked_actions(
         smh, prefix,
         index=index if force else None,
-        force=force, always_copy=always_copy,
-        shortcuts=shortcuts)
+        force=force, always_copy=always_copy)
 
     if actions[inst.LINK]:
         actions[inst.SYMLINK_CONDA] = [root_dir]


### PR DESCRIPTION
Closes https://github.com/ContinuumIO/navigator/issues/570

This changes shortcuts to again be installed by default, but adds a condarc setting "shortcuts" that can be set to False to disable shortcut installation.

CC @joelhullcio @csoja @multicastmatt