### PR TITLE
put --shortcuts option back for backward compatibility

### DIFF
--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -56,10 +56,18 @@ def configure_parser(sub_parsers):
     )
     if on_win:
         p.add_argument(
+            "--shortcuts",
+            action="store_true",
+            help="Install start menu shortcuts",
+            dest="shortcuts",
+            default=True
+        )
+        p.add_argument(
             "--no-shortcuts",
             action="store_false",
-            help="Install start menu shortcuts",
-            dest="shortcuts"
+            help="Don't install start menu shortcuts",
+            dest="shortcuts",
+            default=True
         )
     add_parser_install(p)
     add_parser_json(p)


### PR DESCRIPTION
CC @msarahan 

This is just adding both a `--shortcuts` and `--no-shortcuts` flag for backward compatibility now.  The default is still set to `True` for installing shortcuts..