### PR TITLE
ability to have conda reside in private environment

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -147,6 +147,7 @@ def execute(args, parser):
     from os.path import dirname
 
     import conda
+    import conda.config as config
     from conda.config import (root_dir, get_channel_urls, subdir, pkgs_dirs,
                               root_writable, envs_dirs, default_prefix, rc_path,
                               user_rc_path, sys_rc_path, foreign, hide_binstar_tokens,
@@ -231,6 +232,8 @@ def execute(args, parser):
         conda_env_version=conda_env_version,
         conda_build_version=conda_build_version,
         root_prefix=root_dir,
+        conda_prefix=config.conda_prefix,
+        home_in_root=config.home_in_root,
         root_writable=root_writable,
         pkgs_dirs=pkgs_dirs,
         envs_dirs=envs_dirs,
@@ -260,6 +263,7 @@ Current conda install:
 
                platform : %(platform)s
           conda version : %(conda_version)s
+   conda's home in root : %(home_in_root)s
       conda-env version : %(conda_env_version)s
     conda-build version : %(conda_build_version)s
          python version : %(python_version)s

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -233,7 +233,7 @@ def execute(args, parser):
         conda_build_version=conda_build_version,
         root_prefix=root_dir,
         conda_prefix=config.conda_prefix,
-        home_in_root=config.home_in_root,
+        conda_private=config.conda_private,
         root_writable=root_writable,
         pkgs_dirs=pkgs_dirs,
         envs_dirs=envs_dirs,
@@ -263,7 +263,7 @@ Current conda install:
 
                platform : %(platform)s
           conda version : %(conda_version)s
-   conda's home in root : %(home_in_root)s
+       conda is private : %(conda_private)s
       conda-env version : %(conda_env_version)s
     conda-build version : %(conda_build_version)s
          python version : %(python_version)s

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -21,7 +21,7 @@ from .common import (add_parser_help, add_parser_yes, add_parser_json, add_parse
                      specs_from_args, names_in_specs, root_no_rm, stdout_json,
                      confirm_yn)
 from ..compat import iteritems, iterkeys
-from ..config import default_prefix
+from ..config import default_prefix, conda_in_root
 from ..console import json_progress_bars
 from ..exceptions import (CondaEnvironmentError, PackageNotFoundError,
                           CondaValueError)
@@ -148,7 +148,8 @@ def execute(args, parser):
 
     else:
         specs = specs_from_args(args.package_names)
-        if (plan.is_root_prefix(prefix) and names_in_specs(root_no_rm, specs)):
+        if (conda_in_root and plan.is_root_prefix(prefix) and
+                  names_in_specs(root_no_rm, specs)):
             raise CondaEnvironmentError('cannot remove %s from root environment' %
                                         ', '.join(root_no_rm), args.json)
         actions = plan.remove_actions(prefix, specs, index=index,

--- a/conda/config.py
+++ b/conda/config.py
@@ -107,12 +107,14 @@ rc_other = [
 if (basename(sys.prefix) == '_conda' and
            basename(dirname(sys.prefix)) == 'envs'):
     # conda is located in it's own private environment named '_conda'
-    home_in_root = False
+    conda_in_root = False
+    conda_private = True
     root_prefix = abspath(join(sys.prefix, '..', '..'))
     conda_prefix = sys.prefix
 else:
     # conda is located in the root environment
-    home_in_root = True
+    conda_in_root = True
+    conda_private = False
     root_prefix = conda_prefix = abspath(sys.prefix)
 
 # root_dir is an alias for root_prefix, we prefer the name "root_prefix"

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -17,7 +17,7 @@ from logging import getLogger
 from os.path import abspath, basename, dirname, join, exists
 
 from . import instructions as inst
-from .config import (always_copy as config_always_copy, channel_priority,
+from .config import (always_copy as config_always_copy, channel_priority, conda_in_root,
                      show_channel_urls as config_show_channel_urls, is_offline,
                      root_dir, allow_softlinks, default_python, auto_update_conda,
                      track_features, foreign, url_channel, canonical_channel_name)
@@ -557,7 +557,7 @@ def remove_actions(prefix, specs, index, force=False, pinned=True):
         if pinned and any(r.match(ms, dist) for ms in pinned_specs):
             msg = "Cannot remove %s becaue it is pinned. Use --no-pin to override."
             raise CondaRuntimeError(msg % dist)
-        if name == 'conda' and name not in nlinked:
+        if conda_in_root and name == 'conda' and name not in nlinked:
             if any(s.split(' ', 1)[0] == 'conda' for s in specs):
                 raise RemoveError("'conda' cannot be removed from the root environment")
             else:


### PR DESCRIPTION
In this PR, we add the ability for conda to reside in the `_conda` environment. Don't worry, conda will still work when installed in the root environment. This is achieved by having a Boolean config variable `config.conda_in_root` (and `config.conda_private` for convenience inience) in order preserve old behavior.  Also, because the `_conda` environment is considered private, it is not treated special in any way. That is, you can install or remove any package from `_conda`, even `conda remove -n _conda conda`.

To do (all these items imply that `config.conda_private` is `True`):
  * `conda update conda` will have to somehow alias to to `conda update -n _conda conda`. Should regular usage of conda try self updates too?
  * think about disallowing `conda install -n root conda`, as it would overwrite the symlinks.
  * think about `conda install conda-build`. Right now I'm thinking that any package which lists conda as a dependency gets installed into `_conda`. Note that conda build works out of the box already when you `conda install -n _conda conda-build`.
    think about implications for activate and deactivate.

The good news is that because of `config.conda_in_root`, we can for a long time (maybe even indefinitely) develop on a single conda codebase which supports both the classic root install of conda, and the new `_conda` environment.

What this means for the Anaconda (hopefully 4.2) installer, is that the anaconda and only its dependencies (which conda is already not) will be installed in the root environment, and conda in the `_conda` environment. The resulting installer will not be larger than before, and also not take up more space once installed, because of the use of hard-links. This will make Anaconda and Miniconda very similar, one has a populated root environment and the other does not.
