### PR TITLE
Prevent $SHELL redefinition

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -3,10 +3,10 @@
 # Determine the directory containing this script
 if [[ -n $BASH_VERSION ]]; then
     _SCRIPT_LOCATION=${BASH_SOURCE[0]}
-    SHELL="bash"
+    _SHELL="bash"
 elif [[ -n $ZSH_VERSION ]]; then
     _SCRIPT_LOCATION=${funcstack[1]}
-    SHELL="zsh"
+    _SHELL="zsh"
 else
     echo "Only bash and zsh are supported"
     return 1
@@ -40,7 +40,7 @@ if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "activate" ]]
     (>&2 echo "Error: activate must be sourced. Run 'source activate envname'
 instead of 'activate envname'.
 ")
-    "$_CONDA_DIR/conda" ..activate $SHELL$EXT -h
+    "$_CONDA_DIR/conda" ..activate $_SHELL$EXT -h
     exit 1
 fi
 
@@ -50,7 +50,7 @@ else
     args=$@
 fi
 
-"$_CONDA_DIR/conda" ..checkenv $SHELL$EXT "$args"
+"$_CONDA_DIR/conda" ..checkenv $_SHELL$EXT "$args"
 if (( $? != 0 )); then
     return 1
 fi
@@ -58,7 +58,7 @@ fi
 # Ensure we deactivate any scripts from the old env
 source "$_CONDA_DIR/deactivate"
 
-_NEW_PART=$("$_CONDA_DIR/conda" ..activate $SHELL$EXT "$args")
+_NEW_PART=$("$_CONDA_DIR/conda" ..activate $_SHELL$EXT "$args")
 if (( $? == 0 )); then
     export CONDA_PATH_BACKUP="$PATH"
     # export this to restore it upon deactivation

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -3,10 +3,10 @@
 # Determine the directory containing this script
 if [[ -n $BASH_VERSION ]]; then
     _SCRIPT_LOCATION=${BASH_SOURCE[0]}
-    SHELL="bash"
+    _SHELL="bash"
 elif [[ -n $ZSH_VERSION ]]; then
     _SCRIPT_LOCATION=${funcstack[1]}
-    SHELL="zsh"
+    _SHELL="zsh"
 else
     echo "Only bash and zsh are supported"
     return 1
@@ -29,7 +29,7 @@ do
     key="$1"
     case $key in
         -h|--help)
-            "$_CONDA_DIR/conda" ..deactivate $SHELL$EXT -h
+            "$_CONDA_DIR/conda" ..deactivate $_SHELL$EXT -h
             if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "deactivate" ]]; then
                 exit 0
             else
@@ -48,7 +48,7 @@ if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "deactivate" 
     (>&2 echo "Error: deactivate must be sourced. Run 'source deactivate'
 instead of 'deactivate'.
 ")
-    "$_CONDA_DIR/conda" ..deactivate $SHELL$EXT -h
+    "$_CONDA_DIR/conda" ..deactivate $_SHELL$EXT -h
     exit 1
 fi
 


### PR DESCRIPTION
Fixes #2979 

**Reference:**
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08

> **8.1 Environment Variable Definition**
> [..] It is unwise to conflict with certain variables that are frequently exported by widely used command interpreters and applications:

> [..] SHELL

> [..] Conforming applications shall not set these environment variables to have meanings other than as described. See getenv and XCU Shell Execution Environment for methods of accessing these variables.

> **8.3 Other Environment Variables**
> [..]
> SHELL
This variable shall represent a pathname of the user's preferred command language interpreter. If this interpreter does not conform to the Shell Command Language in XCU Shell Command Language, utilities may behave differently from those described in POSIX.1-2008.