### PR TITLE
Make environments work again

### DIFF
--- a/conda-env/conda_env/cli/main_export.py
+++ b/conda-env/conda_env/cli/main_export.py
@@ -62,6 +62,13 @@ def configure_parser(sub_parsers):
         help='Remove build specification from dependencies'
     )
 
+    p.add_argument(
+        '--skip-channel-prefix',
+        default=False,
+        action='store_true',
+        required=False,
+        help='Do not include channel names as prefixes to package names.')
+
     p.set_defaults(func=execute)
 
 
@@ -84,7 +91,8 @@ def execute(args, parser):
     else:
         name = args.name
     prefix = common.get_prefix(args)
-    env = from_environment(name, prefix, no_builds=args.no_builds)
+    env = from_environment(name, prefix, no_builds=args.no_builds,
+                           skip_channel_prefix=args.skip_channel_prefix)
 
     if args.override_channels:
         env.remove_channels()

--- a/conda-env/conda_env/env.py
+++ b/conda-env/conda_env/env.py
@@ -36,8 +36,8 @@ def load_from_directory(directory):
 
 # TODO This should lean more on conda instead of divining it from the outside
 # TODO tests!!!
-def from_environment(name, prefix, no_builds=False):
-    installed = install.linked(prefix)
+def from_environment(name, prefix, no_builds=False, skip_channel_prefix=False):
+    installed = install.linked(prefix, skip_channel_prefix=skip_channel_prefix)
     conda_pkgs = copy(installed)
     # json=True hides the output, data is added to installed
     add_pip_installed(prefix, installed, json=True)

--- a/conda/install.py
+++ b/conda/install.py
@@ -867,7 +867,7 @@ def extract(dist):
 linked_data_ = {}
 
 
-def load_linked_data(prefix, dist, rec=None):
+def load_linked_data(prefix, dist, rec=None, skip_channel_prefix=False):
     schannel, dname = dist2pair(dist)
     meta_file = join(prefix, 'conda-meta', dname + '.json')
     if rec is None:
@@ -895,8 +895,11 @@ def load_linked_data(prefix, dist, rec=None):
     rec['channel'] = channel
     rec['schannel'] = schannel
     rec['link'] = rec.get('link') or True
-    cprefix = '' if schannel == 'defaults' else schannel + '::'
-    linked_data_[prefix][str(cprefix + dname)] = rec
+    if skip_channel_prefix:
+        linked_data_[prefix][dname] = rec
+    else:
+        cprefix = '' if schannel == 'defaults' else schannel + '::'
+        linked_data_[prefix][str(cprefix + dname)] = rec
     return rec
 
 
@@ -934,7 +937,7 @@ def load_meta(prefix, dist):
     return linked_data(prefix).get(dist)
 
 
-def linked_data(prefix):
+def linked_data(prefix, skip_channel_prefix=False):
     """
     Return a dictionary of the linked packages in prefix.
     """
@@ -946,14 +949,17 @@ def linked_data(prefix):
         if isdir(meta_dir):
             for fn in os.listdir(meta_dir):
                 if fn.endswith('.json'):
-                    load_linked_data(prefix, fn[:-5])
+                    load_linked_data(prefix, fn[:-5],
+                                     skip_channel_prefix=skip_channel_prefix)
     return recs
 
-def linked(prefix):
+
+def linked(prefix, skip_channel_prefix=False):
     """
     Return the set of canonical names of linked packages in prefix.
     """
-    return set(linked_data(prefix).keys())
+    return set(linked_data(prefix,
+                           skip_channel_prefix=skip_channel_prefix).keys())
 
 
 def is_linked(prefix, dist):


### PR DESCRIPTION
Needs a test. Something like this gets me back to a place where I can use environments. I wonder if it shouldn't be skipped by default given that the change to use the channels was a breaking one AFAICT.

I wouldn't say this closes #2800 because there's still the issue that these environments aren't exactly reproducible but maybe this is good enough for now?