### PR TITLE
fix PS1 backup in activate script

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -62,7 +62,7 @@ _NEW_PART=$("$_CONDA_DIR/conda" ..activate $_SHELL$EXT "$args")
 if (( $? == 0 )); then
     export CONDA_PATH_BACKUP="$PATH"
     # export this to restore it upon deactivation
-    export CONDA_PS1_BACKUP=$PS1
+    export CONDA_PS1_BACKUP="$PS1"
 
     export PATH="$_NEW_PART:$PATH"
     # CONDA_DEFAULT_ENV is the shortest representation of how conda recognizes your env.


### PR DESCRIPTION
When using a more sophisticated shell prompt the `activate` script does not work properly.

The error in my zsh is:
```
13:16:17 conda                                                                        proper_ps1_backup_when_activate_env✓
‣ source activate foobar
/Users/blindgaenger/anaconda/bin/activate:export:65: not valid in this context: "+%T"`%{$reset_color%}
```

I'm using the fix by @Zibi92 described in #3042 👍 