### PR TITLE
tmp fix for empty env

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -371,7 +371,9 @@ environment does not exist: %s
             common.stdout_json_success(
                 message='All requested packages already installed.')
         return
-
+    from ..instructions import LINK, UNLINK, SYMLINK_CONDA
+    if not actions[LINK] and not actions[UNLINK]:
+        actions[SYMLINK_CONDA] = [context.root_dir]
     if not args.json:
         print()
         print("Package plan for installation in environment %s:" % prefix)

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -360,6 +360,7 @@ environment does not exist: %s
         if e.args and 'could not import' in e.args[0]:
             raise CondaImportError('', e, args.json)
         raise CondaError('UnsatisfiableSpecifications', e, args.json)
+
     if nothing_to_do(actions) and not newenv:
         from .main_list import print_packages
 
@@ -371,9 +372,12 @@ environment does not exist: %s
             common.stdout_json_success(
                 message='All requested packages already installed.')
         return
-    from ..instructions import LINK, UNLINK, SYMLINK_CONDA
-    if not actions[LINK] and not actions[UNLINK]:
-        actions[SYMLINK_CONDA] = [context.root_dir]
+    elif newenv:
+        # needed in the case of creating an empty env
+        from ..instructions import LINK, UNLINK, SYMLINK_CONDA
+        if not actions[LINK] and not actions[UNLINK]:
+            actions[SYMLINK_CONDA] = [context.root_dir]
+
     if not args.json:
         print()
         print("Package plan for installation in environment %s:" % prefix)

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -360,7 +360,7 @@ environment does not exist: %s
         if e.args and 'could not import' in e.args[0]:
             raise CondaImportError('', e, args.json)
         raise CondaError('UnsatisfiableSpecifications', e, args.json)
-    if nothing_to_do(actions):
+    if nothing_to_do(actions) and not newenv:
         from .main_list import print_packages
 
         if not args.json:

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -137,6 +137,7 @@ def display_actions(actions, index, show_channel_urls=None):
         maxnewchannels = max(len(channel_filt(p[1])) for p in channels.values())
     else:
         empty = True
+        actions[inst.SYMLINK_CONDA] = [context.root_dir]
     updated = set()
     downgraded = set()
     channeled = set()
@@ -522,7 +523,8 @@ These packages need to be removed before conda can proceed.""" % (' '.join(linke
         force=force, always_copy=always_copy)
 
     # always symlink to create empty dirs
-    actions[inst.SYMLINK_CONDA] = [context.root_dir]
+    if actions[inst.LINK]:
+        actions[inst.SYMLINK_CONDA] = [context.root_dir]
 
     for fkey in sorted(linked):
         dist = fkey[:-8]

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -137,7 +137,7 @@ def display_actions(actions, index, show_channel_urls=None):
         maxnewchannels = max(len(channel_filt(p[1])) for p in channels.values())
     else:
         empty = True
-        actions[inst.SYMLINK_CONDA] = [context.root_dir]
+
     updated = set()
     downgraded = set()
     channeled = set()

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -522,7 +522,6 @@ These packages need to be removed before conda can proceed.""" % (' '.join(linke
         index=index if force else None,
         force=force, always_copy=always_copy)
 
-    # always symlink to create empty dirs
     if actions[inst.LINK]:
         actions[inst.SYMLINK_CONDA] = [context.root_dir]
 


### PR DESCRIPTION
fix the bug for empty environment

In original code, if it is a install-action, and everything is already installed, the program however will create a empty environment. This is caused by https://github.com/conda/conda/blob/master/conda/plan.py#L525. Now, there is always symlink in action, which means it cannot pass nothing_to_do function in https://github.com/conda/conda/blob/master/conda/cli/install.py#L363.

Here is a tmp fix
@kalefranz  @dorzel 