### PR TITLE
check revision

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -288,7 +288,7 @@ environment does not exist: %s
 
     try:
         if isinstall and args.revision:
-            actions = revert_actions(prefix, get_revision(args.revision))
+            actions = revert_actions(prefix, get_revision(args.revision), index)
         else:
             with common.json_progress_bars(json=args.json and not args.quiet):
                 actions = install_actions(prefix, index, specs,

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -192,6 +192,11 @@ class CondaHTTPError(CondaError):
         super(CondaHTTPError, self).__init__(msg, *args, **kwargs)
 
 
+class CondaRevisionError(CondaError):
+    def __init__(self, message, *args, **kwargs):
+        msg = 'Revision Error :%s\n' % message
+        super(CondaRevisionError, self).__init__(msg, *args, **kwargs)
+
 class AuthenticationError(CondaError):
     pass
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -618,10 +618,10 @@ def revert_actions(prefix, revision=-1, index=None):
         add_unlink(actions, dist)
 
     # check whether it is a safe revision
-    from .instructions import split_linkarg
+    from .instructions import split_linkarg, LINK, UNLINK, FETCH
     from .exceptions import CondaRevisionError
-    for arg in set(actions.get(inst.LINK, []) + actions.get(inst.UNLINK, [])
-                   + actions.get(inst.FETCH, [])):
+    for arg in set(actions.get(LINK,
+                               []) + actions.get(UNLINK, []) + actions.get(FETCH, [])):
         dist, lt = split_linkarg(arg)
         fkey = dist + '.tar.bz2'
         if fkey not in index:

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -599,7 +599,9 @@ def remove_features_actions(prefix, index, features):
     return actions
 
 
-def revert_actions(prefix, revision=-1):
+def revert_actions(prefix, revision=-1, index=None):
+    # TODO: If revision raise a revision error, should always go back to a safe revision
+    # change
     h = History(prefix)
     h.update()
     try:
@@ -614,6 +616,17 @@ def revert_actions(prefix, revision=-1):
     actions = ensure_linked_actions(state, prefix)
     for dist in curr - state:
         add_unlink(actions, dist)
+
+    # check whether it is a safe revision
+    from .instructions import split_linkarg
+    from .exceptions import CondaRevisionError
+    for arg in set(actions.get(inst.LINK, []) + actions.get(inst.UNLINK, [])
+                   + actions.get(inst.FETCH, [])):
+        dist, lt = split_linkarg(arg)
+        fkey = dist + '.tar.bz2'
+        if fkey not in index:
+            msg = "Cannot revert to {}, since {} is not in repodata".format(revision, dist)
+            raise CondaRevisionError(msg)
 
     return actions
 


### PR DESCRIPTION
Conda install --revision number, when the packages in old state is no long available in repodata, it will raise a keyError, which is not good. 

Now a CondaRevisionError will be raised if there is potential keyError in future. However, still need to improve this one, and tell user to revert to a most recent stable version.

#3158 