### PR TITLE
change for copy setting

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -406,7 +406,7 @@ def confirm_yn(args, message="Proceed", default='yes', exit_no=True):
     if choice == 'yes':
         return True
     if exit_no:
-        raise CondaSystemExit('Exiting')
+        raise SystemExit('Exiting\n')
     return False
 
 # --------------------------------------------------------------------

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -122,6 +122,10 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
         if name in linked:
             actions[UNLINK].append(linked[name])
 
+        ######################################
+        # copied from conda/plan.py   TODO: refactor
+        ######################################
+
         # check for link action
         from .install import LINK_COPY, LINK_HARD, LINK_SOFT
         from .install import try_hard_link
@@ -158,6 +162,10 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
                     rm_rf(fetched_dist)
                 except (OSError, IOError):
                     pass
+
+    ######################################
+    # ^^^^^^^^^^ copied from conda/plan.py
+    ######################################
 
     # Pull the repodata for channels we are using
     if channels:

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -120,7 +120,13 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
         name = name_dist(dist)
         if name in linked:
             actions[UNLINK].append(linked[name])
-        actions[LINK].append(dist)
+
+        if context.always_copy:
+            from .install import LINK_COPY
+            lt = LINK_COPY
+            actions[LINK].append('%s %d' % (dist, lt))
+        else:
+            actions[LINK].append(dist)
 
     # Pull the repodata for channels we are using
     if channels:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -277,6 +277,7 @@ class IntegrationTests(TestCase):
 
             # regression test for #2626
             # install tarball with full path, outside channel
+
             tar_new_path = join(prefix, flask_fname)
             copyfile(tar_old_path, tar_new_path)
             run_command(Commands.INSTALL, prefix, tar_new_path)


### PR DESCRIPTION
For install tar from local, it goes to misc/explicit function. In this function, when specify the link action, it will ignore the link type from context or --copy from command line.

Add code to fix this , please refer to issue #3182 