### PR TITLE
SystemExit with user choice 'no'

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -406,7 +406,7 @@ def confirm_yn(args, message="Proceed", default='yes', exit_no=True):
     if choice == 'yes':
         return True
     if exit_no:
-        raise CondaSystemExit('Exiting')
+        raise SystemExit('Exiting\n')
     return False
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
If user say no, may be there is no need to raise a condaSystemExitError(condaError). If so, when in debug mode, it will show the trace back info