### PR TITLE
fix conda-build local channel bug

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -22,7 +22,7 @@ def get_conda_build_local_url():
         import traceback
         log.debug(traceback.format_exc())
         return None
-    return path_to_url(croot) if exists(croot) else None
+    return [path_to_url(croot)] if exists(croot) else None
 
 
 def has_scheme(value):


### PR DESCRIPTION
fix bug for --use-local, 

in https://github.com/conda/conda/blob/master/conda/models/channel.py#L74, the code will iterate through self._local_url, which is return of get_conda_build_local_url(). However , that function will return a str instead of a list, so it will never match for 'local' channel.