### PR TITLE
enable binary prefix replacement on windows; add support for fixing prefixes in distlib-generated exes

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -427,6 +427,10 @@ def replace_entry_point_shebang(all_data, placeholder, new_prefix):
                     launcher = all_data[:pos]
 
         if data and shebang and launcher:
+            if hasattr(placeholder, 'encode'):
+                placeholder = placeholder.encode('utf-8')
+            if hasattr(new_prefix, 'encode'):
+                new_prefix = new_prefix.encode('utf-8')
             shebang = shebang.replace(placeholder, new_prefix)
             all_data = b"".join([launcher, shebang, data])
     return all_data

--- a/conda/install.py
+++ b/conda/install.py
@@ -410,6 +410,26 @@ def replace_entry_point_shebang(all_data, placeholder, new_prefix):
     consist of a launcher, then a shebang, then a zip archive of the entry point code to run.  We need to change
     the shebang.
     https://bitbucket.org/vinay.sajip/pyzzer/src/5d5740cb04308f067d5844a56fbe91e7a27efccc/pyzzer/__init__.py?at=default&fileviewer=file-view-default#__init__.py-112  # NOQA
+
+    Copyright (c) 2013 Vinay Sajip.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
     """
 
     launcher = shebang = data = None

--- a/conda/install.py
+++ b/conda/install.py
@@ -36,6 +36,7 @@ import re
 import shlex
 import shutil
 import stat
+import struct
 import subprocess
 import sys
 import tarfile
@@ -370,16 +371,23 @@ def binary_replace(data, a, b):
     All input arguments are expected to be bytes objects.
     """
 
-    def replace(match):
-        occurances = match.group().count(a)
-        padding = (len(a) - len(b))*occurances
-        if padding < 0:
-            raise PaddingError(a, b, padding)
-        return match.group().replace(a, b) + b'\0' * padding
-    pat = re.compile(re.escape(a) + b'([^\0]*?)\0')
-    res = pat.sub(replace, data)
-    assert len(res) == len(data)
-    return res
+    original_data = data
+
+    if on_win:
+        # This is a no-op if the data is not a distlib-created launcher.
+        data = replace_entry_point_shebang(data, a, b)
+
+    if original_data == data:
+        def replace(match):
+            occurances = match.group().count(a)
+            padding = (len(a) - len(b))*occurances
+            if padding < 0:
+                raise PaddingError(a, b, padding)
+            return match.group().replace(a, b) + b'\0' * padding
+        pat = re.compile(re.escape(a) + b'([^\0]*?)\0')
+        data = pat.sub(replace, data)
+        assert len(data) == len(original_data)
+    return data
 
 
 def replace_long_shebang(mode, data):
@@ -397,23 +405,45 @@ def replace_long_shebang(mode, data):
     return data
 
 
+def replace_entry_point_shebang(all_data, placeholder, new_prefix):
+    """Code adapted from pyzzer.  This is meant to deal with entry point exe's created by distlib, which
+    consist of a launcher, then a shebang, then a zip archive of the entry point code to run.  We need to change
+    the shebang.
+    https://bitbucket.org/vinay.sajip/pyzzer/src/5d5740cb04308f067d5844a56fbe91e7a27efccc/pyzzer/__init__.py?at=default&fileviewer=file-view-default#__init__.py-112  # NOQA
+    """
+
+    launcher = shebang = data = None
+    pos = all_data.rfind(b'PK\x05\x06')
+    if pos >= 0:
+        end_cdr = all_data[pos + 12:pos + 20]
+        cdr_size, cdr_offset = struct.unpack('<LL', end_cdr)
+        arc_pos = pos - cdr_size - cdr_offset
+        data = all_data[arc_pos:]
+        if arc_pos > 0:
+            pos = all_data.rfind(b'#!', 0, arc_pos)
+            if pos >= 0:
+                shebang = all_data[pos:arc_pos]
+                if pos > 0:
+                    launcher = all_data[:pos]
+
+        if data and shebang and launcher:
+            shebang = shebang.replace(placeholder, new_prefix)
+            all_data = b"".join([launcher, shebang, data])
+    return all_data
+
+
 def replace_prefix(mode, data, placeholder, new_prefix):
     if mode == 'text':
         data = data.replace(placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
-    # Skip binary replacement in Windows.  Some files do have prefix information embedded, but
-    #    this should not matter, as it is not used for things like RPATH.
     elif mode == 'binary':
-        if not on_win:
-            data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
-        else:
-            logging.debug("Skipping prefix replacement in binary on Windows")
+        data = binary_replace(data, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
     else:
         sys.exit("Invalid mode: %s" % mode)
     return data
 
 
 def update_prefix(path, new_prefix, placeholder=prefix_placeholder, mode='text'):
-    if on_win:
+    if on_win and mode == 'text':
         # force all prefix replacements to forward slashes to simplify need to escape backslashes
         # replace with unix-style path separators
         new_prefix = new_prefix.replace('\\', '/')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,10 +2,12 @@ import pytest
 import random
 import shutil
 import stat
+import subprocess
+import sys
 import tempfile
 import unittest
 from contextlib import contextmanager
-from os import makedirs
+from os import makedirs, getcwd, chdir
 from os.path import join, basename, relpath, exists, dirname
 
 from conda import install
@@ -13,8 +15,9 @@ from conda.install import (PaddingError, binary_replace, update_prefix,
                            warn_failed_remove, duplicates_to_remove, dist2quad,
                            dist2name, dist2dirname, dist2filename, dist2pair, name_dist,
                            move_path_to_trash, on_win)
+from conda.fetch import download
 from .decorators import skip_if_no_mock
-from .helpers import mock
+from .helpers import mock, captured
 
 patch = mock.patch if mock else None
 
@@ -63,6 +66,56 @@ class TestBinaryReplace(unittest.TestCase):
             b'bbbcbbb\x00\x00\x00')
         self.assertRaises(PaddingError, binary_replace,
                           b'aaaacaaaa\x00', b'aaaa', b'bbbbb')
+
+    @pytest.mark.skipif(not on_win, reason="exe entry points only necessary on win")
+    def test_windows_entry_point(self):
+        """
+        This emulates pip-created entry point executables on windows.  For more info,
+        refer to conda/install.py::replace_entry_point_shebang
+        """
+        tmp_dir = tempfile.mkdtemp()
+        cwd = getcwd()
+        chdir(tmp_dir)
+        original_prefix = "C:\\BogusPrefix\\python.exe"
+        try:
+            url = 'https://bitbucket.org/vinay.sajip/pyzzer/downloads/pyzzerw.pyz'
+            download(url, 'pyzzerw.pyz')
+            url = 'https://files.pythonhosted.org/packages/source/c/conda/conda-4.1.6.tar.gz'
+            download(url, 'conda-4.1.6.tar.gz')
+            subprocess.check_call([sys.executable, 'pyzzerw.pyz',
+                                   # output file
+                                   '-o', 'conda.exe',
+                                   # entry point
+                                   '-m', 'conda.cli.main:main',
+                                   # initial shebang
+                                   '-s', '#! ' + original_prefix,
+                                   # launcher executable to use (32-bit text should be compatible)
+                                   '-l', 't32',
+                                   # source archive to turn into executable
+                                   'conda-4.1.6.tar.gz',
+                                   ],
+                                  cwd=tmp_dir)
+            # this is the actual test: change the embedded prefix and make sure that the exe runs.
+            data = open('conda.exe', 'rb').read()
+            fixed_data = binary_replace(data, original_prefix, sys.executable)
+            with open("conda.fixed.exe", 'wb') as f:
+                f.write(fixed_data)
+            # without a valid shebang in the exe, this should fail
+            with pytest.raises(subprocess.CalledProcessError):
+                subprocess.check_call(['conda.exe', '-h'])
+
+            process = subprocess.Popen(['conda.fixed.exe', '-h'],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)
+            output, error = process.communicate()
+            output = output.decode('utf-8')
+            error = error.decode('utf-8')
+            assert ("conda is a tool for managing and deploying applications, "
+                    "environments and packages.") in output
+        except:
+            raise
+        finally:
+            chdir(cwd)
 
 
 class FileTests(unittest.TestCase):


### PR DESCRIPTION
Targeting 4.1.x - fast release would be ideal.  Let me know if 4.2 is preferable.

Backstory: pip uses distlib (http://distlib.readthedocs.io/en/latest/) under the covers.  Distlib in turn uses simple_launcher (https://bitbucket.org/vinay.sajip/simple_launcher/) to create executable entry points.  These entry points consist of the launcher itself, plus a shebang, plus a zip archive with the entry point payload.  We need to be able to edit that shebang in order to make entry https://bitbucket.org/vinay.sajip/pyzzer/src/5d5740cb04308f067d5844a56fbe91e7a27efccc/pyzzer/__init__.py?at=default&fileviewer=file-view-default#__init__.py-112) to separate the launcher, shebang, and zip archive, then update the shebang, then reassemble the exe.

This PR depends on a change to conda-build as well, to identify the exe's as files with binary prefixes that need replacement.  This PR re-enables binary prefix replacement on windows.

CC @takluyver 