### PR TITLE
Unbound var checks in bash

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -83,7 +83,7 @@ if (( $? == 0 )); then
     export CONDA_PREFIX="$(echo ${firstpath} | sed "s|/bin$||")" &>/dev/null
 
     # if CONDA_DEFAULT_ENV not in PS1, prepend it with parentheses
-    if [ $("$_CONDA_DIR/conda" ..changeps1) = "1" ]; then
+    if [ $("$_CONDA_DIR/conda" ..changeps1) = "1" ] && [ -n "${PS1+x}" ]; then
         if ! $(grep -q CONDA_DEFAULT_ENV <<<$PS1); then
             export PS1="(${CONDA_DEFAULT_ENV}) $PS1"
         fi

--- a/bin/activate
+++ b/bin/activate
@@ -62,7 +62,7 @@ _NEW_PART=$("$_CONDA_DIR/conda" ..activate $_SHELL$EXT "$args")
 if (( $? == 0 )); then
     export CONDA_PATH_BACKUP="$PATH"
     # export this to restore it upon deactivation
-    export CONDA_PS1_BACKUP="$PS1"
+    [[ -z ${PS1+x} ]] || export CONDA_PS1_BACKUP="$PS1"
 
     export PATH="$_NEW_PART:$PATH"
     # CONDA_DEFAULT_ENV is the shortest representation of how conda recognizes your env.

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -52,7 +52,7 @@ instead of 'deactivate'.
     exit 1
 fi
 
-if [[ -z "$CONDA_PATH_BACKUP" ]]; then
+if [[ -z "${CONDA_PATH_BACKUP+x}" ]]; then
     if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "deactivate" ]]; then
         exit 0
     else
@@ -71,7 +71,7 @@ if (( $? == 0 )); then
     unset CONDA_PREFIX
     export PATH="$CONDA_PATH_BACKUP"
     unset CONDA_PATH_BACKUP
-    export PS1="$CONDA_PS1_BACKUP"
+    [[ -z ${PS1+x} ]] || export PS1="$CONDA_PS1_BACKUP"
     unset CONDA_PS1_BACKUP
 else
     return $?

--- a/bin/deactivate
+++ b/bin/deactivate
@@ -62,16 +62,18 @@ fi
 
 if (( $? == 0 )); then
     # Inverse of activation: run deactivate scripts prior to deactivating env
-    _CONDA_D="${CONDA_PREFIX}/etc/conda/deactivate.d"
-    if [[ -d $_CONDA_D ]]; then
+    [[ -n ${CONDA_PREFIX+x} ]] && _CONDA_D="${CONDA_PREFIX}/etc/conda/deactivate.d"
+    if [[ -n ${_CONDA_D+x} ]] && [[ -d $_CONDA_D ]]; then
         IFS=$(echo -en "\n\b") && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
     fi
 
     unset CONDA_DEFAULT_ENV
     unset CONDA_PREFIX
-    export PATH="$CONDA_PATH_BACKUP"
+    [[ -n ${CONDA_PATH_BACKUP+x} ]] && export PATH="$CONDA_PATH_BACKUP"
     unset CONDA_PATH_BACKUP
-    [[ -z ${PS1+x} ]] || export PS1="$CONDA_PS1_BACKUP"
+
+    # export PS1 in an interactive shell only
+    [[ -n ${PS1+x} ]] && export PS1="$CONDA_PS1_BACKUP"
     unset CONDA_PS1_BACKUP
 else
     return $?

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -202,9 +202,6 @@ def test_activate_deactivate(shell):
 
 @pytest.mark.slow
 def test_activate_deactivate_with_nounset_errexit(shell):
-    if shell not in ("bash", "bash.exe"):
-        pytest.skip("test only relevant for bash")
-
     shell_vars = _format_vars(shell)
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
         commands = (shell_vars['command_setup'] + """
@@ -221,9 +218,6 @@ def test_activate_deactivate_with_nounset_errexit(shell):
 
 @pytest.mark.slow
 def test_activate_deactivate_noninteractive(shell):
-    if shell not in ("bash", "bash.exe"):
-        pytest.skip("test only relevant for bash")
-
     shell_vars = _format_vars(shell)
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
         commands = (shell_vars['command_setup'] + """

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -201,39 +201,6 @@ def test_activate_deactivate(shell):
 
 
 @pytest.mark.slow
-def test_activate_deactivate_with_nounset_errexit(shell):
-    shell_vars = _format_vars(shell)
-    with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
-        commands = (shell_vars['command_setup'] + """
-        set -o nounset
-        set -o errexit
-        {source} "{syspath}{binpath}activate" "{env_dirs[0]}" {nul}
-        {source} "{syspath}{binpath}deactivate"
-        {printpath}
-        """).format(envs=envs, env_dirs=gen_test_env_paths(envs, shell), **shell_vars)
-
-        stdout, stderr = run_in(commands, shell)
-        stdout = strip_leading_library_bin(stdout, shells[shell])
-        assert_equals(stdout, u"%s" % shell_vars['base_path'])
-
-@pytest.mark.slow
-def test_activate_deactivate_noninteractive(shell):
-    shell_vars = _format_vars(shell)
-    with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
-        commands = (shell_vars['command_setup'] + """
-        set -o nounset
-        set -o errexit
-        unset PS1
-        {source} "{syspath}{binpath}activate" "{env_dirs[0]}" {nul}
-        {source} "{syspath}{binpath}deactivate"
-        {printpath}
-        """).format(envs=envs, env_dirs=gen_test_env_paths(envs, shell), **shell_vars)
-
-        stdout, stderr = run_in(commands, shell)
-        stdout = strip_leading_library_bin(stdout, shells[shell])
-        assert_equals(stdout, u"%s" % shell_vars['base_path'])
-
-@pytest.mark.slow
 def test_activate_root(shell):
     shell_vars = _format_vars(shell)
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -201,6 +201,39 @@ def test_activate_deactivate(shell):
 
 
 @pytest.mark.slow
+def test_activate_deactivate_with_nounset_errexit(shell):
+    shell_vars = _format_vars(shell)
+    with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
+        commands = (shell_vars['command_setup'] + """
+        set -o nounset
+        set -o errexit
+        {source} "{syspath}{binpath}activate" "{env_dirs[0]}" {nul}
+        {source} "{syspath}{binpath}deactivate"
+        {printpath}
+        """).format(envs=envs, env_dirs=gen_test_env_paths(envs, shell), **shell_vars)
+
+        stdout, stderr = run_in(commands, shell)
+        stdout = strip_leading_library_bin(stdout, shells[shell])
+        assert_equals(stdout, u"%s" % shell_vars['base_path'])
+
+@pytest.mark.slow
+def test_activate_deactivate_noninteractive(shell):
+    shell_vars = _format_vars(shell)
+    with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
+        commands = (shell_vars['command_setup'] + """
+        set -o nounset
+        set -o errexit
+        unset PS1
+        {source} "{syspath}{binpath}activate" "{env_dirs[0]}" {nul}
+        {source} "{syspath}{binpath}deactivate"
+        {printpath}
+        """).format(envs=envs, env_dirs=gen_test_env_paths(envs, shell), **shell_vars)
+
+        stdout, stderr = run_in(commands, shell)
+        stdout = strip_leading_library_bin(stdout, shells[shell])
+        assert_equals(stdout, u"%s" % shell_vars['base_path'])
+
+@pytest.mark.slow
 def test_activate_root(shell):
     shell_vars = _format_vars(shell)
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -202,6 +202,9 @@ def test_activate_deactivate(shell):
 
 @pytest.mark.slow
 def test_activate_deactivate_with_nounset_errexit(shell):
+    if shell not in ("bash", "bash.exe"):
+        pytest.skip("test only relevant for bash")
+
     shell_vars = _format_vars(shell)
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
         commands = (shell_vars['command_setup'] + """
@@ -218,6 +221,9 @@ def test_activate_deactivate_with_nounset_errexit(shell):
 
 @pytest.mark.slow
 def test_activate_deactivate_noninteractive(shell):
+    if shell not in ("bash", "bash.exe"):
+        pytest.skip("test only relevant for bash")
+
     shell_vars = _format_vars(shell)
     with TemporaryDirectory(prefix='envs', dir=dirname(__file__)) as envs:
         commands = (shell_vars['command_setup'] + """


### PR DESCRIPTION
Re: #3200 

This works for me locally. I'd be grateful for some advice on tests. In particular, tests fail for me locally before and after:

```bash
$ python -m pytest --shell=bash -ktest_activate_deactivate
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.5.2, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /Users/shahin/projects/conda, inifile: setup.cfg
plugins: cov-2.2.1
collected 195 items / 2 errors 

tests/test_activate.py FFF
===================================================================================== ERRORS ======================================================================================
_______________________________________________________________________ ERROR collecting tests/test_cli.py ________________________________________________________________________
tests/test_cli.py:62: in <module>
    class TestJson(unittest.TestCase):
tests/test_cli.py:224: in TestJson
    @pytest.mark.timeout(300)
../../miniconda3/lib/python3.5/site-packages/_pytest/mark.py:184: in __getattr__
    self._check(name)
../../miniconda3/lib/python3.5/site-packages/_pytest/mark.py:199: in _check
    raise AttributeError("%r not a registered marker" % (name,))
E   AttributeError: 'timeout' not a registered marker
______________________________________________________________________ ERROR collecting tests/test_create.py ______________________________________________________________________
tests/test_create.py:200: in <module>
    class IntegrationTests(TestCase):
tests/test_create.py:208: in IntegrationTests
    @pytest.mark.timeout(900)
../../miniconda3/lib/python3.5/site-packages/_pytest/mark.py:184: in __getattr__
    self._check(name)
../../miniconda3/lib/python3.5/site-packages/_pytest/mark.py:199: in _check
    raise AttributeError("%r not a registered marker" % (name,))
E   AttributeError: 'timeout' not a registered marker
==================================================================================== FAILURES =====================================================================================
_________________________________________________________________________ test_activate_deactivate[bash] __________________________________________________________________________
Traceback (most recent call last):
  File "/Users/shahin/projects/conda/tests/test_activate.py", line 200, in test_activate_deactivate
    assert_equals(stdout, u"%s" % shell_vars['base_path'])
  File "/Users/shahin/projects/conda/tests/helpers.py", line 132, in assert_equals
    assert a.lower() == b.lower(), output
AssertionError: '' != '/users/shahin/miniconda3/bin:/users/shahin/local/bin:/usr/local/opt/coreutils/libexec/gnubin:/users/shahin/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:
/users/shahin/miniconda3/bin:/users/shahin/local/bin:/usr/local/opt/coreutils/libexec/gnubin:/users/shahin/bin:/users/shahin/applications/phabricator/arcanist/bin:/users/shahin/ap
plications/phabricator/arcanist/bin'

_______________________________________________________________ test_activate_deactivate_with_nounset_errexit[bash] _______________________________________________________________
Traceback (most recent call last):
  File "/Users/shahin/projects/conda/tests/test_activate.py", line 220, in test_activate_deactivate_with_nounset_errexit
    assert_equals(stdout, u"%s" % shell_vars['base_path'])
  File "/Users/shahin/projects/conda/tests/helpers.py", line 132, in assert_equals
    assert a.lower() == b.lower(), output
AssertionError: '' != '/users/shahin/miniconda3/bin:/users/shahin/local/bin:/usr/local/opt/coreutils/libexec/gnubin:/users/shahin/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:
/users/shahin/miniconda3/bin:/users/shahin/local/bin:/usr/local/opt/coreutils/libexec/gnubin:/users/shahin/bin:/users/shahin/applications/phabricator/arcanist/bin:/users/shahin/ap
plications/phabricator/arcanist/bin'


__________________________________________________________________ test_activate_deactivate_noninteractive[bash] __________________________________________________________________
Traceback (most recent call last):
  File "/Users/shahin/projects/conda/tests/test_activate.py", line 240, in test_activate_deactivate_noninteractive
    assert_equals(stdout, u"%s" % shell_vars['base_path'])
  File "/Users/shahin/projects/conda/tests/helpers.py", line 132, in assert_equals
    assert a.lower() == b.lower(), output
AssertionError: '' != '/users/shahin/miniconda3/bin:/users/shahin/local/bin:/usr/local/opt/coreutils/libexec/gnubin:/users/shahin/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:
/users/shahin/miniconda3/bin:/users/shahin/local/bin:/usr/local/opt/coreutils/libexec/gnubin:/users/shahin/bin:/users/shahin/applications/phabricator/arcanist/bin:/users/shahin/ap
plications/phabricator/arcanist/bin'
```