### PR TITLE
Fix #3253: conda env create from a txt file, handle comments carefully

### DIFF
--- a/conda_env/specs/requirements.py
+++ b/conda_env/specs/requirements.py
@@ -37,6 +37,9 @@ class RequirementsSpec(object):
         dependencies = []
         with open(self.filename) as reqfile:
             for line in reqfile:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
                 dependencies.append(line)
         return env.Environment(
             name=self.name,


### PR DESCRIPTION
conda env create --file xxx.txt does not handle whole-line comments very carefully.

Should skip if line.strip() is None to line start with "#"

Fix issue #3253 