### PR TITLE
Fix empty environment issue in conda and conda-env

### DIFF
--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -121,11 +121,9 @@ def get_packages(installed, regex):
 
 def list_packages(prefix, installed, regex=None, format='human',
                   show_channel_urls=context.show_channel_urls):
-    res = 1
-
+    res = 0
     result = []
     for dist in get_packages(installed, regex):
-        res = 0
         if format == 'canonical':
             result.append(dist)
             continue

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -99,6 +99,12 @@ def execute(args, parser):
     # common.ensure_override_channels_requires_channel(args)
     # channel_urls = args.channel or ()
 
+    # special case for empty environment
+    if not env.dependencies:
+        from conda.install import symlink_conda
+        from conda.base.context import context
+        symlink_conda(prefix, context.root_dir)
+
     for installer_type, pkg_specs in env.dependencies.items():
         try:
             installer = get_installer(installer_type)


### PR DESCRIPTION
This PR solves 2 issue related to empty environment

1. conda list -n empty-environment should not return 1 as return code

2. conda env create -f empty-environment.yml cannot handle empty environment