### PR TITLE
Testcase : add integration test for conda-env

### DIFF
--- a/tests/conda_env/cli.py
+++ b/tests/conda_env/cli.py
@@ -167,6 +167,29 @@ class NewIntegrationTest(unittest.TestCase):
         o, e, s = run("conda env remove --yes --name snowflakes")
         self.assertEqual(0, s, o)
 
+    def test_list(self):
+        """
+            Test conda env
+        """
+        if not env_is_created("snowflakes"):
+            o, e, s = run("conda create --yes --name snowflakes python")
+            self.assertEqual(0, s, e)
+            self.assertTrue(env_is_created("snowflakes"))
+
+        snowflake, e, s = run("conda list -n snowflakes -e")
+        self.assertEqual(0, s, e)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix="txt") as env_txt:
+            env_txt.write(snowflake)
+            env_txt.flush()
+            _, e, s = run("conda env remove --yes --name snowflakes")
+            self.assertEqual(0, s, e)
+            o, e, s = run("conda create -n snowflakes --file " + env_txt.name)
+            self.assertEqual(0, s, e)
+            self.assertTrue(env_is_created("snowflakes"))
+
+        o, e, s = run("conda env remove --yes --name snowflakes")
+        self.assertEqual(0, s, o)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/conda_env/support/notebook.ipynb
+++ b/tests/conda_env/support/notebook.ipynb
@@ -1,1 +1,1 @@
-{"nbformat": 3, "nbformat_minor": 0, "worksheets": [{"cells": []}], "metadata": {"name": "", "signature": ""}}
+{"nbformat": 3, "metadata": {"signature": "", "name": ""}, "nbformat_minor": 0, "worksheets": [{"cells": []}]}

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -559,7 +559,7 @@ class IntegrationTests(TestCase):
 
                 # make sure that cleanup without specifying --shortcuts still removes shortcuts
                 run_command(Commands.REMOVE, prefix, 'console_shortcut')
-
+                assert not package_is_installed(prefix, 'console_shortcut')
                 assert not isfile(shortcut_file)
         finally:
             rmtree(prefix, ignore_errors=True)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -559,7 +559,7 @@ class IntegrationTests(TestCase):
 
                 # make sure that cleanup without specifying --shortcuts still removes shortcuts
                 run_command(Commands.REMOVE, prefix, 'console_shortcut')
-                assert not package_is_installed(prefix, 'console_shortcut')
+
                 assert not isfile(shortcut_file)
         finally:
             rmtree(prefix, ignore_errors=True)


### PR DESCRIPTION
Add more conda env integration test

1. test conda env --help
2. test conda env remove
3. test conda env export and conda env create
4. test conda list -e and conda create --file xxx.txt

Following instruction here : http://conda.pydata.org/docs/using/envs.html#export-the-environment-file