### PR TITLE
Fix Channel Priority issue with duplicated channel

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -186,6 +186,8 @@ def prioritize_channels(channels):
     for q, chn in enumerate(channels):
         channel = Channel(chn)
         for url in channel.urls:
+            if url in result:
+                continue
             result[url] = channel.canonical_name, q
     return result
 


### PR DESCRIPTION
When duplicated channel in channel_urls list, priority of channel may be wrong.

Fix with a check