### PR TITLE
Fix Conda install No package specified

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -154,6 +154,9 @@ def install(args, parser, command='install'):
 # $ conda update --prefix %s anaconda
 """ % prefix)
 
+    if isinstall and not (args.file or args.packages):
+        raise CondaValueError("no package names supplied")
+
     linked = install_linked(prefix)
     lnames = {name_dist(d) for d in linked}
     if isupdate and not args.all:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -154,9 +154,6 @@ def install(args, parser, command='install'):
 # $ conda update --prefix %s anaconda
 """ % prefix)
 
-    if isinstall and not (args.file or args.packages):
-        raise CondaValueError("no package names supplied")
-
     linked = install_linked(prefix)
     lnames = {name_dist(d) for d in linked}
     if isupdate and not args.all:
@@ -202,6 +199,9 @@ def install(args, parser, command='install'):
 
     if isinstall and args.revision:
         get_revision(args.revision, json=args.json)
+    elif isinstall and not (args.file or args.packages):
+        raise CondaValueError("too few arguments, "
+                              "must supply command line package specs or --file")
 
     num_cp = sum(s.endswith('.tar.bz2') for s in args.packages)
     if num_cp:


### PR DESCRIPTION
"Conda install "  should raise error .

ToDo:

1. Change conda install --help, a package or file name is required 
2. Empty environment should not fetching index
3. Better error message. 
4. Optional : 2 new line below conda error message. too much \n !