### PR TITLE
Reset Internal Field Seperator after usage in (de)activation scripts

### DIFF
--- a/shell/activate
+++ b/shell/activate
@@ -92,18 +92,9 @@ if (( $? == 0 )); then
     # Load any of the scripts found $PREFIX/etc/conda/activate.d AFTER activation
     _CONDA_D="${CONDA_PREFIX}/etc/conda/activate.d"
     if [[ -d "$_CONDA_D" ]]; then
-        # Save any previous value of IFS used
-        if [[ -n $IFS ]]; then
-            OLD_IFS=$IFS
-        fi
         IFS=$(echo -en "\n\b")&>/dev/null  && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
-        # Reset IFS value to previous value, if any
-        if [[ -n $OLD_IFS ]]; then
-            IFS=$OLD_IFS
-            unset OLD_IFS
-        else
-            unset IFS
-        fi
+        # Reset IFS value to empty
+        unset IFS
     fi
 else
     return $?

--- a/shell/activate
+++ b/shell/activate
@@ -92,7 +92,18 @@ if (( $? == 0 )); then
     # Load any of the scripts found $PREFIX/etc/conda/activate.d AFTER activation
     _CONDA_D="${CONDA_PREFIX}/etc/conda/activate.d"
     if [[ -d "$_CONDA_D" ]]; then
+        # Save any previous value of IFS used
+        if [[ -n $IFS ]]; then
+            OLD_IFS=IFS
+        fi
         IFS=$(echo -en "\n\b")&>/dev/null  && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
+        # Reset IFS value to previous value, if any
+        if [[ -n $OLD_IFS ]]; then
+            IFS=$OLD_IFS
+            unset OLD_IFS
+        else
+            unset IFS
+        fi
     fi
 else
     return $?

--- a/shell/activate
+++ b/shell/activate
@@ -94,7 +94,7 @@ if (( $? == 0 )); then
     if [[ -d "$_CONDA_D" ]]; then
         # Save any previous value of IFS used
         if [[ -n $IFS ]]; then
-            OLD_IFS=IFS
+            OLD_IFS=$IFS
         fi
         IFS=$(echo -en "\n\b")&>/dev/null  && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
         # Reset IFS value to previous value, if any

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -66,7 +66,7 @@ if (( $? == 0 )); then
     if [[ -d $_CONDA_D ]]; then
         # Save any previous value of IFS used
         if [[ -n $IFS ]]; then
-            OLD_IFS=IFS
+            OLD_IFS=$IFS
         fi
         IFS=$(echo -en "\n\b") && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
         # Reset IFS value to previous value, if any

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -64,18 +64,9 @@ if (( $? == 0 )); then
     # Inverse of activation: run deactivate scripts prior to deactivating env
     _CONDA_D="${CONDA_PREFIX}/etc/conda/deactivate.d"
     if [[ -d $_CONDA_D ]]; then
-        # Save any previous value of IFS used
-        if [[ -n $IFS ]]; then
-            OLD_IFS=$IFS
-        fi
         IFS=$(echo -en "\n\b") && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
-        # Reset IFS value to previous value, if any
-        if [[ -n $OLD_IFS ]]; then
-            IFS=$OLD_IFS
-            unset OLD_IFS
-        else
-            unset IFS
-        fi
+        # Reset IFS value to empty
+        unset IFS
     fi
 
     unset CONDA_DEFAULT_ENV

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -64,7 +64,18 @@ if (( $? == 0 )); then
     # Inverse of activation: run deactivate scripts prior to deactivating env
     _CONDA_D="${CONDA_PREFIX}/etc/conda/deactivate.d"
     if [[ -d $_CONDA_D ]]; then
+        # Save any previous value of IFS used
+        if [[ -n $IFS ]]; then
+            OLD_IFS=IFS
+        fi
         IFS=$(echo -en "\n\b") && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
+        # Reset IFS value to previous value, if any
+        if [[ -n $OLD_IFS ]]; then
+            IFS=$OLD_IFS
+            unset OLD_IFS
+        else
+            unset IFS
+        fi
     fi
 
     unset CONDA_DEFAULT_ENV


### PR DESCRIPTION
Sourcing the activation scripts changes the internal field seperator ($IFS) internal variable in bash, but does not unset it.  

Deactivating or activating any environments that have additional activation scripts causes the default behaviour of bash ```for``` loops to change.

Discussed more fully in #3296 
