### PR TITLE
Check link 2

### DIFF
--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -292,10 +292,8 @@ def execute_instructions(plan, index=None, verbose=False, _commands=None):
 
         # check commands require the plan
         if 'CHECK' in instruction:
-            # print('running check command: %s' % instruction)
             cmd(state, plan)
         else:
-            # print('running non-check command: %s' % instruction)
             cmd(state, arg)
 
         if (state['i'] is not None and instruction in progress_cmds and

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -3,9 +3,17 @@ from __future__ import absolute_import, division, print_function
 from logging import getLogger
 
 from .base.context import context
+
+from .exceptions import CondaIOError, CondaFileIOError
 from .fetch import fetch_pkg
-from .install import (LINK_HARD, extract, is_extracted, link, messages, name_dist, rm_extracted,
-                      rm_fetched, symlink_conda, unlink)
+from .install import (is_extracted, messages, extract, rm_extracted, rm_fetched, LINK_HARD,
+                      link, unlink, symlink_conda, name_dist, yield_lines, load_meta, islink)
+from .utils import on_win, Once
+from os.path import isdir, join, dirname, exists, isfile
+from os import access, W_OK
+import os
+import tarfile
+import ctypes
 
 
 log = getLogger(__name__)
@@ -21,7 +29,6 @@ PREFIX = 'PREFIX'
 PRINT = 'PRINT'
 PROGRESS = 'PROGRESS'
 SYMLINK_CONDA = 'SYMLINK_CONDA'
-
 
 progress_cmds = set([EXTRACT, RM_EXTRACTED, LINK, UNLINK])
 action_codes = (
@@ -84,6 +91,7 @@ def UNLINK_CMD(state, arg):
 def SYMLINK_CONDA_CMD(state, arg):
     symlink_conda(state['prefix'], arg)
 
+
 # Map instruction to command (a python function)
 commands = {
     PREFIX: PREFIX_CMD,
@@ -97,6 +105,150 @@ commands = {
     UNLINK: UNLINK_CMD,
     SYMLINK_CONDA: SYMLINK_CONDA_CMD,
 }
+
+
+def get_package(plan, instruction):
+    """
+        get the package list based on command
+    :param plan: the plan for action
+    :param instruction : the command
+    :return:
+    """
+    link_list = []
+    for inst, arg in plan:
+        if inst == instruction:
+            link_list.append(arg)
+    return link_list
+
+
+@Once
+def check_link_unlink(state, plan):
+    """
+        check permission issue before link and unlink
+    :param state: the state of plan
+    :param plan: the plan from action
+    :return: the result of permission checking
+    """
+    link_list = get_package(plan, LINK)
+    unlink_list = get_package(plan, UNLINK)
+
+    # check for permission
+    # the folder may not exist now, just check whether can write to prefix
+    prefix = state['prefix']
+    assert isdir(prefix), "prefix is not exist {0}".format(prefix)
+    check_write_permission(prefix)
+
+    # check for link package
+    for arg in link_list:
+        dist, lt = split_linkarg(arg)
+        source_dir = is_extracted(dist)
+        assert source_dir is not None
+        info_dir = join(source_dir, 'info')
+        files = list(yield_lines(join(info_dir, 'files')))
+        # check write permission for every file
+        for f in files:
+            dst = join(prefix, f)
+            check_write_permission(dst)
+
+    # check for unlink
+    for dist in unlink_list:
+        meta = load_meta(prefix, dist)
+        for f in meta['files']:
+            dst = join(prefix, f)
+            # make sure the dst is something
+            if islink(dst) or isfile(dst) or isdir(dst):
+                check_write_permission(dst)
+
+
+def check_write_permission(path):
+    """
+        Check write permission for path
+        If path not exist, go up and check for that path
+    Args:
+        path: the path to check permission
+
+    Returns: True : able to write
+             False : unable to write
+    """
+    while not exists(path):
+        path = dirname(path)
+
+    w_permission = access(path, W_OK)
+    if not w_permission:
+        raise CondaFileIOError(path)
+    return True
+
+
+def get_free_space(dir_name):
+    """
+        Return folder/drive free space (in bytes).
+    :param dir_name: the dir name need to check
+    :return: amount of free space
+    """
+    if on_win:
+        free_bytes = ctypes.c_ulonglong(0)
+        ctypes.windll.kernel32.GetDiskFreeSpaceExW(
+            ctypes.c_wchar_p(dir_name), None, None, ctypes.pointer(free_bytes))
+        return free_bytes.value
+    else:
+        st = os.statvfs(dir_name)
+        return st.f_bavail * st.f_frsize
+
+
+def check_size(path, size):
+    """
+        check whether has enough space
+    :param path:    the directory to check
+    :param size:    whether has that size
+    :return:    True or False
+    """
+    free = get_free_space(path)
+    # print("The free is {0},
+    # and the required is {1}".format(free, size))
+    if free < size:
+        raise CondaIOError("Not enough space in {}".format(path))
+
+
+@Once
+def check_download_space(state, plan):
+    """
+        Check whether there is enough space for download packages
+    :param state: the state of plan
+    :param plan: the plan for the action
+    :return:
+    """
+    arg_list = get_package(plan, FETCH)
+    size = 0
+    for arg in arg_list:
+        if 'size' in state['index'][arg + '.tar.bz2']:
+            size += state['index'][arg + '.tar.bz2']['size']
+
+    prefix = state['prefix']
+    assert isdir(prefix)
+    check_size(prefix, size)
+
+
+@Once
+def check_extract_space(state, plan):
+    """
+        check whether there is enough space for extract packages
+    :param plan: the plan for the action
+    :param state : the state of plan
+    :return:
+    """
+    arg_list = get_package(plan, EXTRACT)
+    size = 0
+    for arg in arg_list:
+        from .install import package_cache
+        rec = package_cache()[arg]
+        fname = rec['files'][0]
+        with tarfile.open(fname) as t:
+            for m in t.getmembers():
+                size += m.size
+
+    prefix = state['prefix']
+    assert isdir(prefix)
+    check_size(prefix, size)
 
 
 def execute_instructions(plan, index=None, verbose=False, _commands=None):
@@ -117,6 +269,14 @@ def execute_instructions(plan, index=None, verbose=False, _commands=None):
 
     log.debug("executing plan %s", plan)
 
+    # Map command to check_command
+    check_cmd = {
+        FETCH_CMD: check_download_space,
+        LINK_CMD: check_link_unlink,
+        UNLINK_CMD: check_link_unlink,
+        EXTRACT_CMD: check_extract_space
+    }
+
     state = {'i': None, 'prefix': context.root_dir, 'index': index}
 
     for instruction, arg in plan:
@@ -129,10 +289,15 @@ def execute_instructions(plan, index=None, verbose=False, _commands=None):
                                                state['i'] - 1))
         cmd = _commands[instruction]
 
+        # perform check
+        c_cmd = check_cmd.get(cmd, None)
+        if c_cmd:
+            c_cmd(state, plan)
+
         cmd(state, arg)
 
         if (state['i'] is not None and instruction in progress_cmds and
-                state['maxval'] == state['i']):
+                    state['maxval'] == state['i']):
             state['i'] = None
             getLogger('progress.stop').info(None)
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -252,21 +252,6 @@ def add_unlink(actions, dist):
     actions[inst.UNLINK].append(dist)
 
 
-def add_link_unlink_check(actions):
-    if inst.CHECK_LINK_UNLINK not in actions:
-        actions[inst.CHECK_LINK_UNLINK] = [True]
-
-
-def add_fetch_check(actions):
-    if inst.CHECK_FETCH not in actions:
-        actions[inst.CHECK_FETCH] = [True]
-
-
-def add_extract_check(actions):
-    if inst.CHECK_EXTRACT not in actions:
-        actions[inst.CHECK_EXTRACT] = [True]
-
-
 def add_checks(actions):
     """
     Adds appropriate checks to a given dict of actions. For example, if arg 'actions'
@@ -279,12 +264,13 @@ def add_checks(actions):
     Returns:
         the actions dict with the appropriate checks added
     """
+
     if inst.LINK in actions or inst.UNLINK in actions:
-        add_link_unlink_check(actions)
+        actions.setdefault(inst.CHECK_LINK_UNLINK, [True])
     if inst.FETCH in actions:
-        add_fetch_check(actions)
+        actions.setdefault(inst.CHECK_FETCH, [True])
     if inst.EXTRACT in actions:
-        add_extract_check(actions)
+        actions.setdefault(inst.CHECK_EXTRACT, [True])
 
 
 def plan_from_actions(actions):

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -19,6 +19,20 @@ stderrlog = logging.getLogger('stderrlog')
 on_win = bool(sys.platform == "win32")
 
 
+class Once(object):
+    """
+        A decorator class let function just do once
+    """
+    def __init__(self, func):
+        self.func = func
+        self.implemented = False
+
+    def __call__(self, *args, **kwargs):
+        if not self.implemented:
+            self.func(*args, **kwargs)
+            self.implemented = True
+
+
 class memoized(object):
     """Decorator. Caches a function's return value each time it is called.
     If called later with the same arguments, the cached value is returned

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -10,8 +10,11 @@ from conda.instructions import execute_instructions, commands, PROGRESS_CMD
 def test_expected_operation_order():
     """Ensure expected order of operations"""
     expected = (
+        instructions.CHECK_FETCH,
         instructions.FETCH,
+        instructions.CHECK_EXTRACT,
         instructions.EXTRACT,
+        instructions.CHECK_LINK_UNLINK,
         instructions.UNLINK,
         instructions.LINK,
         instructions.SYMLINK_CONDA,


### PR DESCRIPTION
Supercedes #3034 "Check link". Modified checks into instructions that are now a part of the operation order. 

Possible solution to #1733 by always checking permissions before linking and unlinking.  