### PR TITLE
Clean the pid based lock on exception

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -160,7 +160,7 @@ class CrossPlatformStLink(object):
             cls._st_nlink = cls._windows_st_nlink
 
 
-def find_lock(file_ending=LOCK_EXTENSION):
+def find_lock(file_ending=LOCK_EXTENSION, extra_path=None):
     from os.path import join
     lock_dirs = context.pkgs_dirs[:]
     lock_dirs += [context.root_dir]
@@ -176,7 +176,7 @@ def find_lock(file_ending=LOCK_EXTENSION):
     except ImportError:
         pass
 
-    for dir in lock_dirs:
+    for dir in lock_dirs + list(extra_path):
         if not os.path.exists(dir):
             continue
         for dn in os.listdir(dir):

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -176,7 +176,8 @@ def find_lock(file_ending=LOCK_EXTENSION, extra_path=None):
     except ImportError:
         pass
 
-    for dir in lock_dirs + list(extra_path):
+    lock_dirs = lock_dirs + list(extra_path) if extra_path else lock_dirs
+    for dir in lock_dirs:
         if not os.path.exists(dir):
             continue
         for dn in os.listdir(dir):

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -16,7 +16,7 @@ from ..base.context import context
 from ..install import rm_rf
 from ..utils import human_bytes, backoff_unlink
 from ..exceptions import ArgumentError
-
+from conda.lock import LOCK_EXTENSION
 descr = """
 Remove unused packages and caches.
 """
@@ -160,11 +160,8 @@ class CrossPlatformStLink(object):
             cls._st_nlink = cls._windows_st_nlink
 
 
-def find_lock():
+def find_lock(file_ending=LOCK_EXTENSION):
     from os.path import join
-
-    from conda.lock import LOCK_EXTENSION
-
     lock_dirs = context.pkgs_dirs[:]
     lock_dirs += [context.root_dir]
     for envs_dir in context.envs_dirs:
@@ -183,7 +180,7 @@ def find_lock():
         if not os.path.exists(dir):
             continue
         for dn in os.listdir(dir):
-            if os.path.exists(join(dir, dn)) and dn.endswith(LOCK_EXTENSION):
+            if os.path.exists(join(dir, dn)) and dn.endswith(file_ending):
                 path = join(dir, dn)
                 yield path
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -7,7 +7,6 @@ from logging import getLogger
 from traceback import format_exc
 from . import CondaError, text_type
 from .compat import iteritems, iterkeys
-from conda.cli.main_clean import find_lock
 log = logging.getLogger(__name__)
 
 class LockError(CondaError, RuntimeError):
@@ -438,19 +437,24 @@ conda GitHub issue tracker at:
         stderrlogger.info('\n'.join('    ' + line for line in traceback.splitlines()))
 
 
-def delete_lock():
+def delete_lock(extra_path=None):
     """
         Delete lock on exception accoding to pid
         log warning when delete fails
+
+        Args:
+            extra_path : The extra path that you want to search and
+            delete locks
     """
+    from conda.cli.main_clean import find_lock
     from .lock import LOCK_EXTENSION
     import os
     pid = os.getpid()
     file_end = text_type(pid) + "." + LOCK_EXTENSION
-    locks = list(find_lock(file_ending=file_end))
+    locks = list(find_lock(file_ending=file_end, extra_path=extra_path))
     failed_delete = []
     for path in locks:
-        assert os.path.exists(path)
+        assert os.path.exists(path), path
         try:
             os.unlink(path)
         except (OSError, IOError) as e:

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -106,3 +106,9 @@ def test_lock_retries(tmpdir):
     t.join()
     # lock should clean up after itself
     assert not tmpdir.join(path).exists()
+
+def test_delete_lock(tmpdir):
+    from .test_create import make_temp_env
+    from conda.base.context import context
+    with make_temp_env() as prefix:
+        assert False, context.pkgs_dirs

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -115,7 +115,7 @@ def test_delete_lock():
         try:
             with DirectoryLock(prefix) as lock:
                 path = basename(lock.lock_file_path)
-                assert isfile(join(prefix,path))
+                assert isfile(join(prefix, path))
                 raise TypeError
         except TypeError:
             delete_lock(extra_path=prefix)


### PR DESCRIPTION
This PR clean the lock on finally block in exception handler

1. add delete lock function
2. add extra parameter for find_lock, give extra input of path, and lock file extension
3. add test cases for  delete_lock
