### PR TITLE
Fix #3307 Add try/except block for touch lock

### DIFF
--- a/conda/lock.py
+++ b/conda/lock.py
@@ -114,11 +114,15 @@ class DirectoryLock(FileLock):
         self.lock_file_path = "%s.pid{0}.%s" % (lock_path_pre, LOCK_EXTENSION)
         # e.g. if locking directory `/conda`, lock file will be `/conda/conda.pidXXXX.conda_lock`
         self.lock_file_glob_str = "%s.pid*.%s" % (lock_path_pre, LOCK_EXTENSION)
+        # make sure '/' exists
         assert isdir(dirname(self.directory_path)), "{0} doesn't exist".format(self.directory_path)
         if not isdir(self.directory_path):
-            os.makedirs(self.directory_path, exist_ok=True)
-            log.debug("forced to create %s", self.directory_path)
-        assert os.access(self.directory_path, os.W_OK), "%s not writable" % self.directory_path
+            try:
+                os.makedirs(self.directory_path)
+                log.debug("forced to create %s", self.directory_path)
+            except (OSError, IOError) as e:
+                log.warn("Failed to create")
+
 
 
 Locked = DirectoryLock

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -121,7 +121,7 @@ class DirectoryLock(FileLock):
                 os.makedirs(self.directory_path)
                 log.debug("forced to create %s", self.directory_path)
             except (OSError, IOError) as e:
-                log.warn("Failed to create")
+                log.warn("Failed to create directory %s" % self.directory_path)
 
 
 

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -123,6 +123,4 @@ class DirectoryLock(FileLock):
             except (OSError, IOError) as e:
                 log.warn("Failed to create directory %s" % self.directory_path)
 
-
-
 Locked = DirectoryLock

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -49,7 +49,7 @@ def touch(file_name, times=None):
         with open(file_name, 'a'):
             os.utime(file_name, times)
     except (OSError, IOError) as e:
-        log.debug(repr(e))
+        log.warn("Failed to create lock, do not run conda in parallel process\n")
 
 
 class FileLock(object):

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -45,8 +45,11 @@ def touch(file_name, times=None):
     Examples:
         touch("hello_world.py")
     """
-    with open(file_name, 'a'):
-        os.utime(file_name, times)
+    try:
+        with open(file_name, 'a'):
+            os.utime(file_name, times)
+    except (OSError, IOError) as e:
+        log.debug(repr(e))
 
 
 class FileLock(object):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -118,7 +118,11 @@ def test_permission_file():
         Make sure no exception raised
     """
     import tempfile
-    with tempfile.TemporaryFile(mode='r') as f:
+    from conda.compat import text_type
+    with tempfile.NamedTemporaryFile(mode='r') as f:
+        if not isinstance(f.name, text_type):
+            return
         with FileLock(f.name) as lock:
+
             path = basename(lock.lock_file_path)
             assert not exists(join(f.name, path))

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,9 +1,12 @@
 import pytest
-from os.path import basename, join
-from conda.lock import FileLock, LOCKSTR, LOCK_EXTENSION, LockError
-from conda.install import on_win
+from os.path import basename, join, exists, isfile
+from conda.lock import FileLock, DirectoryLock, LockError
+
 
 def test_filelock_passes(tmpdir):
+    """
+        Normal test on file lock
+    """
     package_name = "conda_file1"
     tmpfile = join(tmpdir.strpath, package_name)
     with FileLock(tmpfile) as lock:
@@ -15,7 +18,10 @@ def test_filelock_passes(tmpdir):
 
 
 def test_filelock_locks(tmpdir):
-
+    """
+        Test on file lock, multiple lock on same file
+        Lock error should raised
+    """
     package_name = "conda_file_2"
     tmpfile = join(tmpdir.strpath, package_name)
     with FileLock(tmpfile) as lock1:
@@ -27,48 +33,42 @@ def test_filelock_locks(tmpdir):
                 assert False  # this should never happen
             assert lock2.path_to_lock == lock1.path_to_lock
 
-        if not on_win:
-            assert "LOCKERROR" in str(execinfo.value)
-            assert "conda is already doing something" in str(execinfo.value)
         assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
 
     # lock should clean up after itself
     assert not tmpdir.join(path).exists()
 
 
-def test_filelock_folderlocks(tmpdir):
-    import os
-    package_name = "conda_file_2"
+def test_folder_locks(tmpdir):
+    """
+        Test on Directory lock
+    """
+    package_name = "dir_1"
     tmpfile = join(tmpdir.strpath, package_name)
-    os.makedirs(tmpfile)
-    with FileLock(tmpfile) as lock1:
-        path = basename(lock1.lock_file_path)
-        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
+    with DirectoryLock(tmpfile) as lock1:
+
+        assert exists(lock1.lock_file_path) and isfile(lock1.lock_file_path)
 
         with pytest.raises(LockError) as execinfo:
-            with FileLock(tmpfile, retries=1) as lock2:
+            with DirectoryLock(tmpfile, retries=1) as lock2:
                 assert False  # this should never happen
-            assert lock2.path_to_lock == lock1.path_to_lock
 
-        if not on_win:
-            assert "LOCKERROR" in str(execinfo.value)
-            assert "conda is already doing something" in str(execinfo.value)
-            assert lock1.path_to_lock in str(execinfo.value)
-
-        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
+        assert exists(lock1.lock_file_path) and isfile(lock1.lock_file_path)
 
     # lock should clean up after itself
-    assert not tmpdir.join(path).exists()
-
-
-def lock_thread(tmpdir, file_path):
-    with FileLock(file_path) as lock1:
-        path = basename(lock1.lock_file_path)
-        assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
-    assert not tmpdir.join(path).exists()
+    assert not exists(lock1.lock_file_path)
 
 
 def test_lock_thread(tmpdir):
+    """
+        2 thread want to lock a file
+        One thread will have LockError Raised
+    """
+    def lock_thread(tmpdir, file_path):
+        with FileLock(file_path) as lock1:
+            path = basename(lock1.lock_file_path)
+            assert tmpdir.join(path).exists() and tmpdir.join(path).isfile()
+        assert not tmpdir.join(path).exists()
 
     from threading import Thread
     package_name = "conda_file_3"
@@ -85,13 +85,17 @@ def test_lock_thread(tmpdir):
     assert not tmpdir.join(path).exists()
 
 
-def lock_thread_retries(tmpdir, file_path):
-    with pytest.raises(LockError) as execinfo:
-        with FileLock(file_path, retries=0):
-            assert False  # should never enter here, since max_tires is 0
-        assert  "LOCKERROR" in str(execinfo.value)
-
 def test_lock_retries(tmpdir):
+    """
+        2 thread want to lock a same file
+        Lock has zero retries
+        One thread will have LockError raised
+    """
+    def lock_thread_retries(tmpdir, file_path):
+        with pytest.raises(LockError) as execinfo:
+            with FileLock(file_path, retries=0):
+                assert False  # should never enter here, since max_tires is 0
+            assert "LOCKERROR" in str(execinfo.value)
 
     from threading import Thread
     package_name = "conda_file_3"
@@ -106,3 +110,15 @@ def test_lock_retries(tmpdir):
     t.join()
     # lock should clean up after itself
     assert not tmpdir.join(path).exists()
+
+
+def test_permission_file():
+    """
+        Test when lock cannot be created due to permission
+        Make sure no exception raised
+    """
+    import tempfile
+    with tempfile.TemporaryFile(mode='r') as f:
+        with FileLock(f.name) as lock:
+            path = basename(lock.lock_file_path)
+            assert not exists(join(f.name, path))


### PR DESCRIPTION
@kalefranz 

This PR will fix #3307 , add try / except block when creating files . Even no lock , as long as not run multiple process at parallel, conda is safe 

Generally, we will add a try/except block when create lock file. That is what we do for conda 4.1 [here](https://github.com/conda/conda/blob/4.1.x/conda/lock.py#L69-L72)