### PR TITLE
Solver: clean up optional spec behavior

### DIFF
--- a/conda/logic.py
+++ b/conda/logic.py
@@ -72,9 +72,6 @@ class Clauses(object):
     def from_index(self, m):
         return self.indices.get(m)
 
-    def varnum(self, x):
-        return self.names[x] if isinstance(x, string_types) else x
-
     def Assign_(self, vals, name=None):
         tvals = type(vals)
         if tvals is tuple:
@@ -89,12 +86,10 @@ class Clauses(object):
         return self.name_var(x, name) if name else x
 
     def Convert_(self, x):
-        if isinstance(x, string_types):
-            return self.names[x]
         tx = type(x)
         if tx in (tuple, list):
             return tx(map(self.Convert_, x))
-        return x
+        return self.names.get(x, x)
 
     def Eval_(self, func, args, polarity, name, conv=True):
         if conv:
@@ -324,7 +319,7 @@ class Clauses(object):
 
     def LB_Preprocess_(self, equation):
         if type(equation) is dict:
-            equation = [(c, self.varnum(a)) for a, c in iteritems(equation)]
+            equation = [(c, self.names.get(a, a)) for a, c in iteritems(equation)]
         if any(c <= 0 or type(a) is bool for c, a in equation):
             offset = sum(c for c, a in equation if a is True or a is not False and c <= 0)
             equation = [(c, a) if c > 0 else (-c, -a) for c, a in equation
@@ -416,11 +411,29 @@ class Clauses(object):
             return None
         if not self.m:
             return set() if names else []
+        clauses = self.clauses
         if additional:
-            additional = list(map(lambda x: tuple(map(self.varnum, x)), additional))
-            clauses = chain(self.clauses, additional)
-        else:
-            clauses = self.clauses
+            def preproc(eqs):
+                def preproc_(cc):
+                    for c in cc:
+                        c = self.names.get(c, c)
+                        if c is False:
+                            continue
+                        yield c
+                        if c is True:
+                            break
+                for cc in eqs:
+                    cc = tuple(preproc_(cc))
+                    if not cc:
+                        yield cc
+                        break
+                    if cc[-1] is not True:
+                        yield cc
+            additional = list(preproc(additional))
+            if additional:
+                if not additional[-1]:
+                    return None
+                clauses = chain(clauses, additional)
         try:
             solution = pycosat.solve(clauses, vars=self.m, prop_limit=limit)
         except TypeError:
@@ -470,7 +483,7 @@ class Clauses(object):
             return bestsol, sum(abs(c) for c, a in objective) + 1
 
         if type(objective) is dict:
-            objective = [(v, self.varnum(k)) for k, v in iteritems(objective)]
+            objective = [(v, self.names.get(k, k)) for k, v in iteritems(objective)]
 
         objective, offset = self.LB_Preprocess_(objective)
         maxval = max(c for c, a in objective)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -383,7 +383,6 @@ class Resolve(object):
         filter = {}
         touched = {}
         snames = set()
-        nspecs = set()
         unsat = set()
 
         def filter_group(matches, chains=None):
@@ -443,8 +442,6 @@ class Resolve(object):
             # not have a particular dependency, it must be ignored in this pass.
             if first:
                 snames.add(name)
-                if match1 not in specs:
-                    nspecs.add(MatchSpec(name))
             cdeps = defaultdict(list)
             for fkey in group:
                 if filter[fkey]:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -509,7 +509,7 @@ class Resolve(object):
             raise UnsatisfiableError(save_unsat)
 
         dists = {fkey: self.index[fkey] for fkey, val in iteritems(touched) if val}
-        return dists, list(map(MatchSpec, snames - {ms.name for ms in specs}))
+        return dists
 
     def match_any(self, mss, fkey):
         rec = self.index[fkey]
@@ -881,7 +881,7 @@ class Resolve(object):
             # Find the compliant packages
             len0 = len(specs)
             specs = list(map(MatchSpec, specs))
-            dists, new_specs = self.get_dists(specs)
+            dists = self.get_dists(specs)
             if not dists:
                 return False if dists is None else ([[]] if returnall else [])
 
@@ -905,7 +905,7 @@ class Resolve(object):
             specr = []  # requested packages
             speca = []  # all other packages
             specm = set(r2.groups)  # missing from specs
-            for k, s in enumerate(chain(specs, new_specs)):
+            for k, s in enumerate(specs):
                 if s.name in specm:
                     specm.remove(s.name)
                 if not s.optional:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -243,12 +243,20 @@ def test_sat():
     C = Clauses()
     C.new_var('x1')
     C.new_var('x2')
-    assert C.sat([(+1,),(+2,)], names=True) == {'x1','x2'}
-    assert C.sat([(-1,),(+2,)], names=True) == {'x2'}
-    assert C.sat([(-1,),(-2,)], names=True) == set()
-    assert C.sat([(+1,),(-1,)], names=True) is None
+    assert C.sat() is not None
+    assert C.sat([]) is not None
+    assert C.sat([()]) is None
+    assert C.sat([(False,)]) is None
+    assert C.sat([(True,),()]) is None
+    assert C.sat([(True,False,-1)]) is not None
+    assert C.sat([(+1,False),(+2,),(True,)], names=True) == {'x1','x2'}
+    assert C.sat([(-1,False),(True,),(+2,)], names=True) == {'x2'}
+    assert C.sat([(True,),(-1,),(-2,False)], names=True) == set()
+    assert C.sat([(+1,),(-1,False)], names=True) is None
     C.unsat = True
     assert C.sat() is None
+    assert C.sat([]) is None
+    assert C.sat([(True,)]) is None
     assert len(Clauses(10).sat([[1]])) == 10
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -261,19 +261,25 @@ def test_sat():
 
 
 def test_minimize():
-    # minimize    x1 + 2 x2 + 3 x3 + ... + 10 x10
+    # minimize    x1 + 2 x2 + 3 x3 + 4 x4 + 5 x5
     # subject to  x1 + x2 + x3 + x4 + x5  == 1
-    #             x6 + x7 + x8 + x9 + x10 == 1
-    C = Clauses(10)
+    C = Clauses(15)
     C.Require(C.ExactlyOne, range(1,6))
-    C.Require(C.ExactlyOne, range(6,11))
-    objective = [(k,k) for k in range(1,11)]
     sol = C.sat()
     C.unsat = True
-    assert C.minimize(objective, sol)[1] == 56
+    # Unsatisfiable constraints
+    assert C.minimize([(k,k) for k in range(1,6)], sol)[1] == 16
     C.unsat = False
-    sol2, sval = C.minimize(objective, sol)
-    assert C.minimize(objective, sol)[1] == 7, (objective, sol2, sval)
+    sol, sval = C.minimize([(k,k) for k in range(1,6)], sol)
+    assert sval == 1
+    C.Require(C.ExactlyOne, range(6,11))
+    # Supply an initial vector that is too short, forcing recalculation
+    sol, sval = C.minimize([(k,k) for k in range(6,11)], sol)
+    assert sval == 6
+    C.Require(C.ExactlyOne, range(11,16))
+    # Don't supply an initial vector
+    sol, sval = C.minimize([(k,k) for k in range(11,16)])
+    assert sval == 11
 
 
 def test_minimal_unsatisfiable_subset():

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -282,7 +282,7 @@ def test_generate_eq():
     specs = ['anaconda']
     dists, specs = r.get_dists(specs)
     r2 = Resolve(dists, True, True)
-    C = r2.gen_clauses(specs)
+    C = r2.gen_clauses()
     eqv, eqb = r2.generate_version_metrics(C, specs)
     # Should satisfy the following criteria:
     # - lower versions of the same package should should have higher

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -273,17 +273,16 @@ def test_pseudo_boolean():
 
 
 def test_get_dists():
-    dists = r.get_dists(["anaconda 1.5.0"])[0]
+    dists = r.get_dists(["anaconda 1.5.0"])
     assert 'anaconda-1.5.0-np17py27_0.tar.bz2' in dists
     assert 'dynd-python-0.3.0-np17py33_0.tar.bz2' in dists
 
 
 def test_generate_eq():
-    specs = ['anaconda']
-    dists, specs = r.get_dists(specs)
+    dists = r.get_dists(['anaconda'])
     r2 = Resolve(dists, True, True)
     C = r2.gen_clauses()
-    eqv, eqb = r2.generate_version_metrics(C, specs)
+    eqv, eqb = r2.generate_version_metrics(C, list(r2.groups.keys()))
     # Should satisfy the following criteria:
     # - lower versions of the same package should should have higher
     #   coefficients.
@@ -293,16 +292,26 @@ def test_generate_eq():
     #   include=True as it will have a 0 coefficient. The same is true of the
     #   latest version of a package.
     assert eqv == {
+        'anaconda-1.4.0-np15py26_0.tar.bz2': 1,
+        'anaconda-1.4.0-np16py26_0.tar.bz2': 1,
+        'anaconda-1.4.0-np17py26_0.tar.bz2': 1,
+        'anaconda-1.4.0-np17py33_0.tar.bz2': 1,
         'astropy-0.2-np15py26_0.tar.bz2': 1,
         'astropy-0.2-np16py26_0.tar.bz2': 1,
         'astropy-0.2-np17py26_0.tar.bz2': 1,
         'astropy-0.2-np17py33_0.tar.bz2': 1,
+        'biopython-1.60-np15py26_0.tar.bz2': 1,
+        'biopython-1.60-np16py26_0.tar.bz2': 1,
+        'biopython-1.60-np17py26_0.tar.bz2': 1,
         'bitarray-0.8.0-py26_0.tar.bz2': 1,
         'bitarray-0.8.0-py33_0.tar.bz2': 1,
+        'boto-2.8.0-py26_0.tar.bz2': 1,
         'cython-0.18-py26_0.tar.bz2': 1,
         'cython-0.18-py33_0.tar.bz2': 1,
         'distribute-0.6.34-py26_1.tar.bz2': 1,
         'distribute-0.6.34-py33_1.tar.bz2': 1,
+        'gevent-0.13.7-py26_0.tar.bz2': 1,
+        'gevent-0.13.7-py27_0.tar.bz2': 1,
         'ipython-0.13.1-py26_1.tar.bz2': 1,
         'ipython-0.13.1-py33_1.tar.bz2': 1,
         'llvmpy-0.11.1-py26_0.tar.bz2': 1,
@@ -315,12 +324,35 @@ def test_generate_eq():
         'matplotlib-1.2.0-np17py33_1.tar.bz2': 1,
         'nose-1.2.1-py26_0.tar.bz2': 1,
         'nose-1.2.1-py33_0.tar.bz2': 1,
+        'numba-0.7.0-np16py26_1.tar.bz2': 1,
+        'numba-0.7.0-np17py26_1.tar.bz2': 1,
         'numpy-1.5.1-py26_3.tar.bz2': 3,
         'numpy-1.6.2-py26_3.tar.bz2': 2,
         'numpy-1.6.2-py26_4.tar.bz2': 2,
         'numpy-1.6.2-py27_4.tar.bz2': 2,
         'numpy-1.7.0-py26_0.tar.bz2': 1,
         'numpy-1.7.0-py33_0.tar.bz2': 1,
+        'pandas-0.10.0-np16py26_0.tar.bz2': 2,
+        'pandas-0.10.0-np16py27_0.tar.bz2': 2,
+        'pandas-0.10.0-np17py26_0.tar.bz2': 2,
+        'pandas-0.10.0-np17py27_0.tar.bz2': 2,
+        'pandas-0.10.1-np16py26_0.tar.bz2': 1,
+        'pandas-0.10.1-np16py27_0.tar.bz2': 1,
+        'pandas-0.10.1-np17py26_0.tar.bz2': 1,
+        'pandas-0.10.1-np17py27_0.tar.bz2': 1,
+        'pandas-0.10.1-np17py33_0.tar.bz2': 1,
+        'pandas-0.8.1-np16py26_0.tar.bz2': 5,
+        'pandas-0.8.1-np16py27_0.tar.bz2': 5,
+        'pandas-0.8.1-np17py26_0.tar.bz2': 5,
+        'pandas-0.8.1-np17py27_0.tar.bz2': 5,
+        'pandas-0.9.0-np16py26_0.tar.bz2': 4,
+        'pandas-0.9.0-np16py27_0.tar.bz2': 4,
+        'pandas-0.9.0-np17py26_0.tar.bz2': 4,
+        'pandas-0.9.0-np17py27_0.tar.bz2': 4,
+        'pandas-0.9.1-np16py26_0.tar.bz2': 3,
+        'pandas-0.9.1-np16py27_0.tar.bz2': 3,
+        'pandas-0.9.1-np17py26_0.tar.bz2': 3,
+        'pandas-0.9.1-np17py27_0.tar.bz2': 3,
         'pip-1.2.1-py26_1.tar.bz2': 1,
         'pip-1.2.1-py33_1.tar.bz2': 1,
         'psutil-0.6.1-py26_0.tar.bz2': 1,
@@ -334,6 +366,9 @@ def test_generate_eq():
         'pytz-2012j-py33_0.tar.bz2': 1,
         'requests-0.13.9-py26_0.tar.bz2': 1,
         'requests-0.13.9-py33_0.tar.bz2': 1,
+        'scikit-learn-0.13-np15py26_1.tar.bz2': 1,
+        'scikit-learn-0.13-np16py26_1.tar.bz2': 1,
+        'scikit-learn-0.13-np17py26_1.tar.bz2': 1,
         'scipy-0.11.0-np15py26_3.tar.bz2': 1,
         'scipy-0.11.0-np16py26_3.tar.bz2': 1,
         'scipy-0.11.0-np17py26_3.tar.bz2': 1,
@@ -342,21 +377,62 @@ def test_generate_eq():
         'six-1.2.0-py33_0.tar.bz2': 1,
         'sqlalchemy-0.7.8-py26_0.tar.bz2': 1,
         'sqlalchemy-0.7.8-py33_0.tar.bz2': 1,
+        'sympy-0.7.1-py26_0.tar.bz2': 1,
         'tornado-2.4.1-py26_0.tar.bz2': 1,
         'tornado-2.4.1-py33_0.tar.bz2': 1,
         'xlrd-0.9.0-py26_0.tar.bz2': 1,
-        'xlrd-0.9.0-py33_0.tar.bz2': 1}
+        'xlrd-0.9.0-py33_0.tar.bz2': 1,
+        'xlwt-0.7.4-py26_0.tar.bz2': 1}
     assert eqb == {
+        'cairo-1.12.2-0.tar.bz2': 1,
         'dateutil-2.1-py26_0.tar.bz2': 1,
         'dateutil-2.1-py33_0.tar.bz2': 1,
+        'gevent-websocket-0.3.6-py26_1.tar.bz2': 1,
+        'gevent_zeromq-0.2.5-py26_1.tar.bz2': 1,
+        'libnetcdf-4.2.1.1-0.tar.bz2': 1,
+        'numexpr-2.0.1-np16py26_1.tar.bz2': 2,
+        'numexpr-2.0.1-np16py26_2.tar.bz2': 1,
+        'numexpr-2.0.1-np16py26_ce0.tar.bz2': 3,
+        'numexpr-2.0.1-np16py26_p1.tar.bz2': 2,
+        'numexpr-2.0.1-np16py26_p2.tar.bz2': 1,
+        'numexpr-2.0.1-np16py26_pro0.tar.bz2': 3,
+        'numexpr-2.0.1-np16py27_1.tar.bz2': 2,
+        'numexpr-2.0.1-np16py27_2.tar.bz2': 1,
+        'numexpr-2.0.1-np16py27_ce0.tar.bz2': 3,
+        'numexpr-2.0.1-np16py27_p1.tar.bz2': 2,
+        'numexpr-2.0.1-np16py27_p2.tar.bz2': 1,
+        'numexpr-2.0.1-np16py27_pro0.tar.bz2': 3,
+        'numexpr-2.0.1-np17py26_1.tar.bz2': 2,
+        'numexpr-2.0.1-np17py26_2.tar.bz2': 1,
+        'numexpr-2.0.1-np17py26_ce0.tar.bz2': 3,
+        'numexpr-2.0.1-np17py26_p1.tar.bz2': 2,
+        'numexpr-2.0.1-np17py26_p2.tar.bz2': 1,
+        'numexpr-2.0.1-np17py26_pro0.tar.bz2': 3,
+        'numexpr-2.0.1-np17py27_1.tar.bz2': 2,
+        'numexpr-2.0.1-np17py27_2.tar.bz2': 1,
+        'numexpr-2.0.1-np17py27_ce0.tar.bz2': 3,
+        'numexpr-2.0.1-np17py27_p1.tar.bz2': 2,
+        'numexpr-2.0.1-np17py27_p2.tar.bz2': 1,
+        'numexpr-2.0.1-np17py27_pro0.tar.bz2': 3,
         'numpy-1.6.2-py26_3.tar.bz2': 1,
+        'py2cairo-1.10.0-py26_0.tar.bz2': 1,
+        'py2cairo-1.10.0-py27_0.tar.bz2': 1,
+        'pycurl-7.19.0-py26_0.tar.bz2': 1,
+        'pytest-2.3.4-py26_0.tar.bz2': 1,
         'pyzmq-2.2.0.1-py26_0.tar.bz2': 1,
         'pyzmq-2.2.0.1-py33_0.tar.bz2': 1,
+        'scikit-image-0.8.2-np16py26_0.tar.bz2': 1,
+        'scikit-image-0.8.2-np17py26_0.tar.bz2': 1,
+        'scikit-image-0.8.2-np17py33_0.tar.bz2': 1,
         'sphinx-1.1.3-py26_2.tar.bz2': 1,
         'sphinx-1.1.3-py33_2.tar.bz2': 1,
+        'statsmodels-0.4.3-np16py26_0.tar.bz2': 1,
+        'statsmodels-0.4.3-np17py26_0.tar.bz2': 1,
         'system-5.8-0.tar.bz2': 1,
+        'theano-0.5.0-np15py26_0.tar.bz2': 1,
+        'theano-0.5.0-np16py26_0.tar.bz2': 1,
+        'theano-0.5.0-np17py26_0.tar.bz2': 1,
         'zeromq-2.2.0-0.tar.bz2': 1}
-
 
 def test_unsat():
     # scipy 0.12.0b1 is not built for numpy 1.5, only 1.6 and 1.7
@@ -413,7 +489,7 @@ def test_nonexistent_deps():
         'mypackage-1.0-py33_0.tar.bz2',
         'mypackage-1.1-py33_0.tar.bz2',
     }
-    assert set(r.get_dists(['mypackage'])[0].keys()) == {
+    assert set(r.get_dists(['mypackage']).keys()) == {
         'mypackage-1.1-py33_0.tar.bz2',
         'nose-1.1.2-py33_0.tar.bz2',
         'nose-1.2.1-py33_0.tar.bz2',
@@ -513,7 +589,7 @@ def test_nonexistent_deps():
         'mypackage-1.0-py33_0.tar.bz2',
         'mypackage-1.1-py33_0.tar.bz2',
         }
-    assert set(r.get_dists(['mypackage'])[0].keys()) == {
+    assert set(r.get_dists(['mypackage']).keys()) == {
         'mypackage-1.0-py33_0.tar.bz2',
         'nose-1.1.2-py33_0.tar.bz2',
         'nose-1.2.1-py33_0.tar.bz2',
@@ -623,7 +699,7 @@ def test_circular_dependencies():
     assert set(r.find_matches(MatchSpec('package1'))) == {
         'package1-1.0-0.tar.bz2',
     }
-    assert set(r.get_dists(['package1'])[0].keys()) == {
+    assert set(r.get_dists(['package1']).keys()) == {
         'package1-1.0-0.tar.bz2',
         'package2-1.0-0.tar.bz2',
     }


### PR DESCRIPTION
This is the first in a sequence of PRs designed to simplify solver logic, with a view towards making the hints provide actually useful information.

In this PR, we modify `verify_specs` we come up with a proper view of optional specifications that allow us to eliminate the separation of optional and non-optional specs in `verify_specs`, `filter_group`, `solve`, etc.

The fundamental concept is this: an optional specification is actually the _logical negation_ of a corresponding non-optional spec.

Let's start with the simple one: `MatchSpec('foo', optional=True)` means: match any version of `foo`, but also accept a scenario when no match occurs. This is the negation of `MatchSpec('foo @ @')`, which by construction matches *no* packages, and would always fail. 

This seems like a contrived example, but now consider this: `MatchSpec('foo @ @', optional=True)`. This won't match any valid package, but because it has the `optional` flag, it is still true if no `foo` package is installed. This *prevents* `foo` from being a part of the package set. This is used for *exactly* this purpose: `conda remove foo` causes the passes exactly that `MatchSpec` to the solver.

Now consider a version constraint: `MatchSpec('foo >=2.0', optional=True)`. This specification means: *install `foo` if you can obtain version 2.0 or later; but if not, install nothing.* It is the logical negation of `MatchSpec('foo <2.0')`! Again, `conda remove` makes use of this logic to ensure that installed packages are not downgraded. 

For a complete example: consider an environment with `foo 1.0` and `bar 2.0` installed. Suppose further that `bar 2.0`  and all later versions depend on `foo`, but `bar 1.0` does not. Now suppose the command `conda remove foo` produced the following two specifications (among others): 
```
MatchSpec('foo @ @', optional=True), MatchSpec('bar', optional=True)
```
The first specification ensures that `foo` will not appear in the new package set. Because `bar 2.0` depends on `foo`, it will have to be removed. But the solver will see that `bar 1.0` can be installed in its place, and schedule a downgrade. Some time ago we decided this was undesirable behavior; and now conda produces these specs:
```
MatchSpec('foo @ @', optional=True), MatchSpec('bar >=2.0', optional=True)
```
Again, `bar 2.0` will have to be removed, but because all *later* versions of `bar` depend on `foo` as well, there is no valid replacement for it. Therefore, `conda` will schedule the *removal* of `bar` altogether.

While we currently do not expose this functionality to conda packages themselves, it would have a useful purpose for specifying *optional dependencies* for a package. Of course, if a dependency is optional, it should not be installed unless a user explicitly asks to do so. The real benefit comes if the optional dependency has a version constraint, because it can be used to *exclude* versions of the dependency that might be incompatible with your package.