### PR TITLE
change check for placeholder to be more friendly to long PATH

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -53,14 +53,18 @@
 @REM always store the full path to the environment, since CONDA_DEFAULT_ENV varies
 @FOR /F "tokens=1 delims=;" %%i in ("%NEW_PATH%") DO @SET "CONDA_PREFIX=%%i"
 
+@REM Do we have CONDA_PATH_PLACEHOLDER in PATH?
+@SET "CHECK_PLACEHOLDER=import os; print('CONDA_PATH_PLACEHOLDER' in os.environ['PATH'])"
+@FOR /F "tokens=1 delims=;" %%i in ('@call python -c "%CHECK_PLACEHOLDER%"') DO @SET "HAS_PLACEHOLDER=%%i"
+
 @REM look if the deactivate script left a placeholder for us.
-@IF "x%PATH%" == "x%PATH:CONDA_PATH_PLACEHOLDER=%" (
-    @REM If it did not, prepend NEW_PATH
-    @SET "PATH=%NEW_PATH%;%PATH%"
-) ELSE (
+@IF "%HAS_PLACEHOLDER%" == "True" (
     @REM If it did, replace it with our NEW_PATH
     @REM    Delayed expansion used here to do replacement with value of NEW_PATH
     @CALL SET "PATH=%%PATH:CONDA_PATH_PLACEHOLDER=!NEW_PATH!%%"
+) ELSE (
+    @REM If it did not, prepend NEW_PATH
+    @SET "PATH=%NEW_PATH%;%PATH%"
 )
 
 @REM This persists env variables, which are otherwise local to this script right now.


### PR DESCRIPTION
We have a problem with the activate scripts where if PATH is too long, there is one particular command in activate.bat that barfs because the command is too long.  This replaces that command with a similar way of doing it in Python that does not violate these length constraints.

Further explanation from chat with @mingwandroid:

that bit in activate.bat is saying basically "is the placeholder in PATH", but batch is awkward, and so it has to fully expand the original PATH, and the modified PATH to do the comparison.  So for long PATH, we have a very, very long command line: PATH x2 + a bit

See example error at https://ci.appveyor.com/project/ContinuumAnalyticsFOSS/conda-build/build/1.0.504/job/470lesgbhsj9ixt9#L999

CC @mingwandroid @kalefranz 