### PR TITLE
use install.rm_rf for TemporaryDirectory cleanup

### DIFF
--- a/conda/compat.py
+++ b/conda/compat.py
@@ -8,6 +8,8 @@ import sys
 import types
 import os
 
+from .install import rm_rf as _rm_rf
+
 # True if we are running on Python 3.
 PY3 = sys.version_info[0] == 3
 
@@ -32,9 +34,25 @@ if PY3:
     from urllib.parse import quote as urllib_quote
     from itertools import zip_longest
     from shlex import quote
-    from tempfile import TemporaryDirectory
+    from tempfile import TemporaryDirectory as _TemporaryDirectory
+    import warnings as _warnings
     range = range
     zip = zip
+
+    class TemporaryDirectory(_TemporaryDirectory):
+        def cleanup(self, _warn=False, _warnings=_warnings):
+            if self.name and not self._closed:
+                try:
+                    _rm_rf(self.name)
+                except (TypeError, AttributeError) as ex:
+                    if "None" not in '%s' % (ex,):
+                        raise
+                    self._rm_rf(self.name)
+                self._closed = True
+                if _warn and _warnings.warn:
+                    _warnings.warn("Implicitly cleaning up {!r}".format(self),
+                                   _warnings.ResourceWarning)
+
 else:
     import ConfigParser as configparser
     from cStringIO import StringIO
@@ -60,11 +78,10 @@ else:
 
     # Modified from http://hg.python.org/cpython/file/3.3/Lib/tempfile.py. Don't
     # use the 3.4 one. It uses the new weakref.finalize feature.
-    import shutil as _shutil
     import warnings as _warnings
-    import os as _os
     from tempfile import mkdtemp
     range = xrange
+    # used elsewhere - do not remove
     from itertools import izip as zip
 
     class TemporaryDirectory(object):
@@ -95,15 +112,15 @@ else:
         def cleanup(self, _warn=False, _warnings=_warnings):
             if self.name and not self._closed:
                 try:
-                    _shutil.rmtree(self.name)
+                    _rm_rf(self.name)
                 except (TypeError, AttributeError) as ex:
                     if "None" not in '%s' % (ex,):
                         raise
-                    self._rmtree(self.name)
+                    _rm_rf(self.name)
                 self._closed = True
                 if _warn and _warnings.warn:
                     _warnings.warn("Implicitly cleaning up {!r}".format(self),
-                                   ResourceWarning)
+                                   _warnings.ResourceWarning)
 
         def __exit__(self, exc, value, tb):
             self.cleanup()
@@ -112,22 +129,6 @@ else:
             # Issue a ResourceWarning if implicit cleanup needed
             self.cleanup(_warn=True)
 
-        def _rmtree(self, path, _OSError=OSError, _sep=_os.path.sep,
-                    _listdir=_os.listdir, _remove=_os.remove, _rmdir=_os.rmdir):
-            # Essentially a stripped down version of shutil.rmtree.  We can't
-            # use globals because they may be None'ed out at shutdown.
-            if not isinstance(path, str):
-                _sep = _sep.encode()
-            try:
-                for name in _listdir(path):
-                    fullname = path + _sep + name
-                    try:
-                        _remove(fullname)
-                    except _OSError:
-                        self._rmtree(fullname)
-                _rmdir(path)
-            except _OSError:
-                pass
 
 if PY3:
     _iterkeys = "keys"


### PR DESCRIPTION
This tries to put our backoff logic in the cleanup code path for TemporaryDirectory, which is a python3 builtin, and which we backport to 2.7.

Note that rm_rf will eventually take the windows move_path_to_trash code path.

Example error: https://ci.appveyor.com/project/ContinuumAnalyticsFOSS/conda-build/build/1.0.508/job/9ymue76656g31d9p#L1183