### PR TITLE
Fix prune option when installing packages

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -463,7 +463,10 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
     if track_features:
         specs.extend(x + '@' for x in track_features)
 
-    pkgs = r.install(specs, linked, update_deps=update_deps)
+    installed = linked
+    if prune:
+        installed = []
+    pkgs = r.install(specs, installed, update_deps=update_deps)
 
     for fn in pkgs:
         dist = fn[:-8]

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -22,7 +22,9 @@ from requests import Session
 from requests.adapters import BaseAdapter
 
 from conda import config
+from conda import plan
 from conda.cli import conda_argparse
+from conda.cli.common import get_index_trap
 from conda.cli.main_config import configure_parser as config_configure_parser
 from conda.cli.main_create import configure_parser as create_configure_parser
 from conda.cli.main_install import configure_parser as install_configure_parser
@@ -399,6 +401,23 @@ class IntegrationTests(TestCase):
         with make_temp_env("python=2 pandas") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'numpy')
+
+    @pytest.mark.timeout(300)
+    def test_install_prune(self):
+        with make_temp_env("python=2 decorator") as prefix:
+            assert_package_is_installed(prefix, 'decorator')
+
+            # prune is a feature used by conda-env
+            # conda itself does not provide a public API for it
+            index = get_index_trap(prefix=prefix)
+            actions = plan.install_actions(prefix,
+                                           index,
+                                           specs=['flask'],
+                                           prune=True)
+            plan.execute_actions(actions, index, verbose=True)
+
+            assert_package_is_installed(prefix, 'flask')
+            assert not package_is_installed(prefix, 'decorator')
 
     @pytest.mark.skipif(on_win, reason="mkl package not available on Windows")
     @pytest.mark.timeout(300)


### PR DESCRIPTION
The prune option is used only by conda-env and it was not being tested
neither by conda nor conda-env.