### PR TITLE
fetch: Timeout tuples do not work for ftp

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -375,7 +375,10 @@ def download(url, dst_path, session=None, md5=None, urlstxt=False, retries=None)
     with FileLock(dst_path):
         rm_rf(dst_path)
         try:
-            resp = session.get(url, stream=True, proxies=session.proxies, timeout=(3.05, 27))
+            timeout=(3.05, 27)
+            if url.startswith('ftp'):
+                timeout=10
+            resp = session.get(url, stream=True, proxies=session.proxies, timeout=timeout)
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 407:  # Proxy Authentication Required


### PR DESCRIPTION
This is a bug in the interaction between requests and ftplib but
we can work around it anyway.

Before this change, ftp downloads would fail on Python 3.5 with:

  File ../conda/conda/conda/fetch.py, line 378, in download
    resp = session.get(url, stream=True, proxies=session.proxies, timeout=(3.05, 27))
  File ../lib/python3.5/site-packages/requests/sessions.py, line 487, in get
    return self.request('GET', url, **kwargs)
  File ../lib/python3.5/site-packages/requests/sessions.py, line 475, in request
    resp = self.send(prep, **send_kwargs)
  File ../lib/python3.5/site-packages/requests/sessions.py, line 585, in send
    r = adapter.send(request, **kwargs)
  File ../conda/conda/conda/connection.py, line 306, in send
    self.conn.connect(host, port, timeout)
  File ../lib/python3.5/ftplib.py, line 153, in connect
    source_address=self.source_address)
  File ../lib/python3.5/socket.py, line 699, in create_connection
    sock.settimeout(timeout)
TypeError: an integer is required (got type tuple)