### PR TITLE
Config --add back to prepend behavior

### DIFF
--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -320,11 +320,11 @@ def execute_config(args, parser):
                 # recreate the same file
                 items = rc_config.get(key, [])
                 numitems = len(items)
-                for q, item in enumerate(items):
+                for q, item in enumerate(reversed(items)):
                     # Use repr so that it can be pasted back in to conda config --add
                     if key == "channels" and q in (0, numitems-1):
                         print("--add", key, repr(item),
-                              "  # highest priority" if q == 0 else "  # lowest priority")
+                              "  # lowest priority" if q == 0 else "  # highest priority")
                     else:
                         print("--add", key, repr(item))
 

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -167,7 +167,7 @@ or the file path given by the 'CONDARC' environment variable, if it is set
         choices=BoolOrListKey()
     )
     action.add_argument(
-        "--append", "--add",
+        "--append",
         nargs=2,
         action="append",
         help="""Add one configuration value to the end of a list key.""",
@@ -176,7 +176,7 @@ or the file path given by the 'CONDARC' environment variable, if it is set
         metavar=('KEY', 'VALUE'),
     )
     action.add_argument(
-        "--prepend",
+        "--prepend", "--add",
         nargs=2,
         action="append",
         help="""Add one configuration value to the beginning of a list key.""",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -402,10 +402,10 @@ channel_alias: http://alpha.conda.anaconda.org
 --set always_yes True
 --set changeps1 False
 --set channel_alias http://alpha.conda.anaconda.org
---add channels 'test'   # highest priority
 --add channels 'defaults'   # lowest priority
---add create_default_packages 'ipython'
---add create_default_packages 'numpy'\
+--add channels 'test'   # highest priority
+--add create_default_packages 'numpy'
+--add create_default_packages 'ipython'\
 """
         assert stderr == "unknown key invalid_key"
 
@@ -413,8 +413,8 @@ channel_alias: http://alpha.conda.anaconda.org
                                            '--get', 'channels')
 
         assert stdout == """\
---add channels 'test'   # highest priority
---add channels 'defaults'   # lowest priority\
+--add channels 'defaults'   # lowest priority
+--add channels 'test'   # highest priority\
 """
         assert stderr == ""
 
@@ -431,8 +431,8 @@ channel_alias: http://alpha.conda.anaconda.org
 
         assert stdout == """\
 --set changeps1 False
---add channels 'test'   # highest priority
---add channels 'defaults'   # lowest priority\
+--add channels 'defaults'   # lowest priority
+--add channels 'test'   # highest priority\
 """
         assert stderr == ""
 
@@ -489,10 +489,10 @@ always_yes: true
         assert stdout == """\
 --set always_yes True
 --set changeps1 False
---add channels 'test'   # highest priority
 --add channels 'defaults'   # lowest priority
---add create_default_packages 'ipython'
---add create_default_packages 'numpy'\
+--add channels 'test'   # highest priority
+--add create_default_packages 'numpy'
+--add create_default_packages 'ipython'\
 """
         with open(rc, 'r') as fh:
             print(fh.read())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -274,6 +274,7 @@ class TestConfig(unittest.TestCase):
     #       'https://conda.anaconda.org/username/noarch/'
     #     ]
 
+
 @contextmanager
 def make_temp_condarc(value=None):
     try:
@@ -288,6 +289,7 @@ def make_temp_condarc(value=None):
     finally:
         backoff_unlink(temp_path)
 
+
 def _read_test_condarc(rc):
     with open(rc) as f:
         return f.read()
@@ -300,12 +302,12 @@ def test_config_command_basics():
         # Test that creating the file adds the defaults channel
     with make_temp_condarc() as rc:
         stdout, stderr = run_conda_command('config', '--file', rc, '--add',
-          'channels', 'test')
+                                           'channels', 'test')
         assert stdout == stderr == ''
         assert _read_test_condarc(rc) == """\
 channels:
-  - defaults
   - test
+  - defaults
 """
         print(_read_test_condarc(rc))
         print(_read_test_condarc(rc))
@@ -314,36 +316,36 @@ channels:
     with make_temp_condarc() as rc:
         # When defaults is explicitly given, it should not be added
         stdout, stderr = run_conda_command('config', '--file', rc, '--add',
-            'channels', 'test', '--add', 'channels', 'defaults')
+                                           'channels', 'test', '--add', 'channels', 'defaults')
         assert stdout == ''
-        assert stderr == "Warning: 'defaults' already in 'channels' list, moving to the bottom"
+        assert stderr == "Warning: 'defaults' already in 'channels' list, moving to the top"
         assert _read_test_condarc(rc) == """\
 channels:
-  - test
   - defaults
+  - test
 """
     # Duplicate keys should not be added twice
     with make_temp_condarc() as rc:
         stdout, stderr = run_conda_command('config', '--file', rc, '--add',
-            'channels', 'test')
+                                           'channels', 'test')
         assert stdout == stderr == ''
         stdout, stderr = run_conda_command('config', '--file', rc, '--add',
-            'channels', 'test')
+                                           'channels', 'test')
         assert stdout == ''
-        assert stderr == "Warning: 'test' already in 'channels' list, moving to the bottom"
+        assert stderr == "Warning: 'test' already in 'channels' list, moving to the top"
         assert _read_test_condarc(rc) == """\
 channels:
-  - defaults
   - test
+  - defaults
 """
 
     # Test append
     with make_temp_condarc() as rc:
         stdout, stderr = run_conda_command('config', '--file', rc, '--add',
-            'channels', 'test')
+                                           'channels', 'test')
         assert stdout == stderr == ''
         stdout, stderr = run_conda_command('config', '--file', rc, '--append',
-            'channels', 'test')
+                                           'channels', 'test')
         assert stdout == ''
         assert stderr == "Warning: 'test' already in 'channels' list, moving to the bottom"
         assert _read_test_condarc(rc) == """\
@@ -408,7 +410,7 @@ channel_alias: http://alpha.conda.anaconda.org
         assert stderr == "unknown key invalid_key"
 
         stdout, stderr = run_conda_command('config', '--file', rc,
-        '--get', 'channels')
+                                           '--get', 'channels')
 
         assert stdout == """\
 --add channels 'test'   # highest priority
@@ -417,7 +419,7 @@ channel_alias: http://alpha.conda.anaconda.org
         assert stderr == ""
 
         stdout, stderr = run_conda_command('config', '--file', rc,
-        '--get', 'changeps1')
+                                           '--get', 'changeps1')
 
         assert stdout == """\
 --set changeps1 False\
@@ -425,7 +427,7 @@ channel_alias: http://alpha.conda.anaconda.org
         assert stderr == ""
 
         stdout, stderr = run_conda_command('config', '--file', rc,
-            '--get', 'changeps1', 'channels')
+                                           '--get', 'changeps1', 'channels')
 
         assert stdout == """\
 --set changeps1 False
@@ -434,14 +436,12 @@ channel_alias: http://alpha.conda.anaconda.org
 """
         assert stderr == ""
 
-        stdout, stderr = run_conda_command('config', '--file', rc,
-        '--get', 'allow_softlinks')
+        stdout, stderr = run_conda_command('config', '--file', rc, '--get', 'allow_softlinks')
 
         assert stdout == ""
         assert stderr == ""
 
-        stdout, stderr = run_conda_command('config', '--file', rc,
-        '--get', 'track_features')
+        stdout, stderr = run_conda_command('config', '--file', rc, '--get', 'track_features')
 
         assert stdout == ""
         assert stderr == ""
@@ -451,8 +451,7 @@ channel_alias: http://alpha.conda.anaconda.org
         assert stdout == ""
         assert "invalid choice: 'invalid_key'" in stderr
 
-        stdout, stderr = run_conda_command('config', '--file', rc,
-        '--get', 'not_valid_key')
+        stdout, stderr = run_conda_command('config', '--file', rc, '--get', 'not_valid_key')
 
         assert stdout == ""
         assert "invalid choice: 'not_valid_key'" in stderr
@@ -480,8 +479,9 @@ always_yes: true
 """
     # First verify that this itself is valid YAML
     assert yaml_load(condarc) == {'channels': ['test', 'defaults'],
-        'create_default_packages': ['ipython', 'numpy'], 'changeps1':
-        False, 'always_yes': True}
+                                  'create_default_packages': ['ipython', 'numpy'],
+                                  'changeps1': False,
+                                  'always_yes': True}
 
     with make_temp_condarc(condarc) as rc:
         stdout, stderr = run_conda_command('config', '--file', rc, '--get')
@@ -497,7 +497,8 @@ always_yes: true
         with open(rc, 'r') as fh:
             print(fh.read())
 
-        stdout, stderr = run_conda_command('config', '--file', rc, '--prepend', 'channels', 'mychannel')
+        stdout, stderr = run_conda_command('config', '--file', rc, '--prepend',
+                                           'channels', 'mychannel')
         assert stdout == stderr == ''
 
         with open(rc, 'r') as fh:
@@ -520,7 +521,7 @@ always_yes: true
 """
 
         stdout, stderr = run_conda_command('config', '--file', rc,
-            '--set', 'changeps1', 'true')
+                                           '--set', 'changeps1', 'true')
 
         assert stdout == stderr == ''
 
@@ -552,7 +553,7 @@ always_yes: true
 
     with make_temp_condarc(condarc) as rc:
         stdout, stderr = run_conda_command('config', '--file', rc, '--add',
-            'disallow', 'perl')
+                                           'disallow', 'perl')
         assert stdout == stderr == ''
         assert _read_test_condarc(rc) == condarc + """\
 disallow:
@@ -566,34 +567,34 @@ def test_config_command_remove_force():
     # Finally, test --remove, --remove-key
     with make_temp_condarc() as rc:
         run_conda_command('config', '--file', rc, '--add',
-            'channels', 'test')
+                          'channels', 'test')
         run_conda_command('config', '--file', rc, '--set',
-            'always_yes', 'true')
+                          'always_yes', 'true')
         stdout, stderr = run_conda_command('config', '--file', rc,
-            '--remove', 'channels', 'test')
+                                           '--remove', 'channels', 'test')
         assert stdout == stderr == ''
         assert yaml_load(_read_test_condarc(rc)) == {'channels': ['defaults'],
-            'always_yes': True}
+                                                     'always_yes': True}
 
         stdout, stderr = run_conda_command('config', '--file', rc,
-            '--remove', 'channels', 'test', '--force')
+                                           '--remove', 'channels', 'test', '--force')
         assert stdout == ''
         assert stderr == """\
 CondaKeyError: Error with key 'channels': 'test' is not in the 'channels' key of the config file"""
 
         stdout, stderr = run_conda_command('config', '--file', rc,
-            '--remove', 'disallow', 'python', '--force')
+                                           '--remove', 'disallow', 'python', '--force')
         assert stdout == ''
         assert stderr == """\
 CondaKeyError: Error with key 'disallow': key 'disallow' is not in the config file"""
 
         stdout, stderr = run_conda_command('config', '--file', rc,
-            '--remove-key', 'always_yes', '--force')
+                                           '--remove-key', 'always_yes', '--force')
         assert stdout == stderr == ''
         assert yaml_load(_read_test_condarc(rc)) == {'channels': ['defaults']}
 
         stdout, stderr = run_conda_command('config', '--file', rc,
-            '--remove-key', 'always_yes', '--force')
+                                           '--remove-key', 'always_yes', '--force')
 
         assert stdout == ''
         assert stderr == """\
@@ -605,11 +606,11 @@ CondaKeyError: Error with key 'always_yes': key 'always_yes' is not in the confi
 def test_config_command_bad_args():
     with make_temp_condarc() as rc:
         stdout, stderr = run_conda_command('config', '--file', rc, '--add',
-            'notarealkey', 'test')
+                                           'notarealkey', 'test')
         assert stdout == ''
 
         stdout, stderr = run_conda_command('config', '--file', rc, '--set',
-            'notarealkey', 'true')
+                                           'notarealkey', 'true')
         assert stdout == ''
 
 
@@ -645,6 +646,7 @@ def test_config_set():
 
         assert stdout == ''
         assert stderr == ''
+
 
 def test_set_rc_string():
     # Test setting string keys in .condarc

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -294,7 +294,7 @@ class IntegrationTests(TestCase):
             # install from local channel
             for field in ('url', 'channel', 'schannel'):
                 del flask_data[field]
-            repodata = {'info': {}, 'packages':{flask_fname: flask_data}}
+            repodata = {'info': {}, 'packages': {flask_fname: flask_data}}
             with make_temp_env() as channel:
                 subchan = join(channel, context.subdir)
                 channel = path_to_url(channel)
@@ -474,7 +474,8 @@ class IntegrationTests(TestCase):
     def test_shortcut_not_attempted_with_no_shortcuts_arg(self):
         prefix = make_temp_prefix("_" + str(uuid4())[:7])
         with make_temp_env(prefix=prefix):
-            stdout, stderr = run_command(Commands.INSTALL, prefix, "console_shortcut", "--no-shortcuts")
+            stdout, stderr = run_command(Commands.INSTALL, prefix, "console_shortcut",
+                                         "--no-shortcuts")
             # This test is sufficient, because it effectively verifies that the code
             #  path was not visited.
             assert ("Environment name starts with underscore '_'.  Skipping menu installation."

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,12 +1,13 @@
-from .test_create import (make_temp_env, package_is_installed, PYTHON_BINARY,
+from .test_create import (make_temp_env, PYTHON_BINARY,
                           assert_package_is_installed, run_command, Commands,
                           make_temp_prefix)
-from os.path import (exists, join, basename)
+from os.path import (exists, join)
 from unittest import TestCase
 import tempfile
 import pytest
 
 from conda.install import rm_rf
+
 
 class ExportIntegrationTests(TestCase):
 
@@ -58,7 +59,6 @@ class ExportIntegrationTests(TestCase):
             finally:
                 rm_rf(env_txt.name)
 
-
     def test_multi_channel_explicit(self):
         """
             When try to import from txt
@@ -87,4 +87,3 @@ class ExportIntegrationTests(TestCase):
                 self.assertEqual(output, output2)
             finally:
                 rm_rf(env_txt.name)
-

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -11,8 +11,8 @@ def test_info():
     conda_info_out, conda_info_err = run_conda_command('info')
     assert_equals(conda_info_err, '')
     for name in ['platform', 'conda version', 'root environment',
-        'default environment', 'envs directories', 'package cache',
-        'channel URLs', 'config file', 'offline mode']:
+                 'default environment', 'envs directories', 'package cache',
+                 'channel URLs', 'config file', 'offline mode']:
         assert_in(name, conda_info_out)
 
     conda_info_e_out, conda_info_e_err = run_conda_command('info', '-e')
@@ -22,7 +22,7 @@ def test_info():
     conda_info_s_out, conda_info_s_err = run_conda_command('info', '-s')
     assert_equals(conda_info_s_err, '')
     for name in ['sys.version', 'sys.prefix', 'sys.executable', 'conda location',
-        'conda-build', 'CIO_TEST', 'CONDA_DEFAULT_ENV', 'PATH', 'PYTHONPATH']:
+                 'conda-build', 'CIO_TEST', 'CONDA_DEFAULT_ENV', 'PATH', 'PYTHONPATH']:
         assert_in(name, conda_info_s_out)
     if config.platform == 'linux':
         assert_in('LD_LIBRARY_PATH', conda_info_s_out)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -487,7 +487,8 @@ def test_dist2():
     for name in ('python', 'python-hyphen', ''):
         for version in ('2.7.0', '2.7.0rc1', ''):
             for build in ('0', 'py27_0', 'py35_0+g34fe21', ''):
-                for channel in ('defaults', 'test', 'test-hyphen', 'http://bremen', 'https://anaconda.org/mcg', '<unknown>'):
+                for channel in ('defaults', 'test', 'test-hyphen', 'http://bremen',
+                                'https://anaconda.org/mcg', '<unknown>'):
                     dist_noprefix = name + '-' + version + '-' + build
                     quad = (name, version, build, channel)
                     dist = dist_noprefix if channel == 'defaults' else channel + '::' + dist_noprefix

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -1,8 +1,6 @@
-from logging import getLogger, Handler, DEBUG
 import unittest
+from logging import getLogger, Handler, DEBUG
 
-
-from conda import exceptions
 from conda import instructions
 from conda.instructions import execute_instructions, commands, PROGRESS_CMD
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,7 +1,10 @@
-import pytest
 from os.path import basename, join
-from conda.lock import FileLock, LOCKSTR, LOCK_EXTENSION, LockError
+
+import pytest
+
 from conda.install import on_win
+from conda.lock import FileLock, LockError
+
 
 def test_filelock_passes(tmpdir):
     package_name = "conda_file1"
@@ -89,7 +92,8 @@ def lock_thread_retries(tmpdir, file_path):
     with pytest.raises(LockError) as execinfo:
         with FileLock(file_path, retries=0):
             assert False  # should never enter here, since max_tires is 0
-        assert  "LOCKERROR" in str(execinfo.value)
+        assert "LOCKERROR" in str(execinfo.value)
+
 
 def test_lock_retries(tmpdir):
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -17,6 +17,7 @@ from conda.compat import string_types, iteritems
 # directly are NOT and OR. The rest are implemented in terms of these.
 # Peformance is not an issue.
 
+
 def my_NOT(x):
     if isinstance(x, bool):
         return not x
@@ -26,6 +27,7 @@ def my_NOT(x):
         return x[1:] if x[0] == '!' else '!' + x
     return None
 
+
 def my_ABS(x):
     if isinstance(x, bool):
         return True
@@ -34,6 +36,7 @@ def my_ABS(x):
     if isinstance(x, string_types):
         return x[1:] if x[0] == '!' else x
     return None
+
 
 def my_OR(*args):
     '''Implements a logical OR according to the logic:
@@ -56,25 +59,32 @@ def my_OR(*args):
         return True
     return None
 
+
 def my_AND(*args):
     args = list(map(my_NOT,args))
     return my_NOT(my_OR(*args))
 
+
 def my_XOR(i,j):
     return my_OR(my_AND(i,my_NOT(j)),my_AND(my_NOT(i),j))
 
+
 def my_ITE(c,t,f):
     return my_OR(my_AND(c,t),my_AND(my_NOT(c),f))
+
 
 def my_AMONE(*args):
     args = [my_NOT(v) for v in args]
     return my_AND(*[my_OR(v1,v2) for v1,v2 in combinations(args,2)])
 
+
 def my_XONE(*args):
     return my_AND(my_OR(*args),my_AMONE(*args))
 
+
 def my_SOL(ij, sol):
     return (v if type(v) is bool else (True if v in sol else False) for v in ij)
+
 
 def my_EVAL(eq, sol):
     # evaluate_eq doesn't handle True/False entries
@@ -84,6 +94,7 @@ def my_EVAL(eq, sol):
 # True, False, variables from 1 to m, and their negations, in order to exercise
 # all logical branches of the function. Test negative, positive, and full
 # polarities for each.
+
 
 def my_TEST(Mfunc, Cfunc, mmin, mmax, is_iter):
     for m in range(mmin,mmax+1):
@@ -129,26 +140,34 @@ def my_TEST(Mfunc, Cfunc, mmin, mmax, is_iter):
                 qsol = Mfunc(*my_SOL(ij,sol))
                 assert qsol is False, (ij, sol,'Prevent(%s)' % Cfunc.__name__, Cneg.clauses)
 
+
 def test_NOT():
     my_TEST(my_NOT, Clauses.Not, 1, 1, False)
+
 
 def test_AND():
     my_TEST(my_AND, Clauses.And, 2,2, False)
 
+
 def test_ALL():
     my_TEST(my_AND, Clauses.All, 0, 4, True)
+
 
 def test_OR():
     my_TEST(my_OR,  Clauses.Or,  2,2, False)
 
+
 def test_ANY():
     my_TEST(my_OR,  Clauses.Any, 0,4, True)
+
 
 def test_XOR():
     my_TEST(my_XOR, Clauses.Xor, 2,2, False)
 
+
 def test_ITE():
     my_TEST(my_ITE, Clauses.ITE, 3,3, False)
+
 
 def test_AMONE():
     my_TEST(my_AMONE, Clauses.AtMostOne_NSQ, 0,3, True)
@@ -160,10 +179,12 @@ def test_AMONE():
     x2 = C2.AtMostOne((1,2,3,4,5,6,7,8,9,10))
     assert x1 == x2 and C1.clauses == C2.clauses
 
+
 def test_XONE():
     my_TEST(my_XONE, Clauses.ExactlyOne_NSQ, 0,3, True)
     my_TEST(my_XONE, Clauses.ExactlyOne_BDD, 0,3, True)
     my_TEST(my_XONE, Clauses.ExactlyOne, 0,3, True)
+
 
 def test_LinearBound():
     L = [
@@ -217,6 +238,7 @@ def test_LinearBound():
         for _, sol in zip(range(max_iter), Cneg.itersolve([],N)):
             assert not(rhs[0] <= my_EVAL(eq2,sol) <= rhs[1]), ('Cneg',Cneg.clauses)
 
+
 def test_sat():
     C = Clauses()
     C.new_var('x1')
@@ -228,6 +250,7 @@ def test_sat():
     C.unsat = True
     assert C.sat() is None
     assert len(Clauses(10).sat([[1]])) == 10
+
 
 def test_minimize():
     # minimize    x1 + 2 x2 + 3 x3 + ... + 10 x10
@@ -243,6 +266,7 @@ def test_minimize():
     C.unsat = False
     sol2, sval = C.minimize(objective, sol)
     assert C.minimize(objective, sol)[1] == 7, (objective, sol2, sval)
+
 
 def test_minimal_unsatisfiable_subset():
     def sat(val):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -37,6 +37,7 @@ def make_mock_directory(tmpdir, mock_directory):
         else:
             make_mock_directory(tmpdir.mkdir(key), value)
 
+
 def test_walk_prefix(tmpdir):  # tmpdir is a py.test utility
     # Each directory is a dict whose keys are names. If the value is
     # None, then that key represents a file. If it's another dict, that key is

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -135,6 +135,7 @@ class TestAddDeaultsToSpec(unittest.TestCase):
             ]:
             self.check(specs, added)
 
+
 def test_display_actions():
     os.environ['CONDA_SHOW_CHANNEL_URLS'] = 'False'
     reset_context(())
@@ -182,7 +183,6 @@ The following NEW packages will be INSTALLED:
     with captured() as c:
         display_actions(actions, index)
 
-
     assert c.stdout == """
 The following packages will be REMOVED:
 
@@ -193,7 +193,6 @@ The following packages will be REMOVED:
     zlib:     1.2.7-0 \n\
 
 """
-
 
     actions = defaultdict(list, {'LINK': ['cython-0.19.1-py33_0'], 'UNLINK':
     ['cython-0.19-py33_0']})
@@ -246,7 +245,6 @@ The following packages will be DOWNGRADED due to dependency conflicts:
 
 """
 
-
     actions = defaultdict(list, {'LINK': ['cython-0.19.1-py33_0',
         'dateutil-2.1-py33_1'], 'UNLINK':  ['cython-0.19-py33_0',
             'dateutil-1.5-py33_0']})
@@ -264,7 +262,6 @@ The following packages will be UPDATED:
 
     actions['LINK'], actions['UNLINK'] = actions['UNLINK'], actions['LINK']
 
-
     with captured() as c:
         display_actions(actions, index)
 
@@ -275,7 +272,6 @@ The following packages will be DOWNGRADED due to dependency conflicts:
     dateutil: 2.1-py33_1    --> 1.5-py33_0 \n\
 
 """
-
 
 
 def test_display_actions_show_channel_urls():
@@ -302,7 +298,6 @@ The following packages will be downloaded:
 
 """
 
-
     actions = defaultdict(list, {'PREFIX':
     '/Users/aaronmeurer/anaconda/envs/test', 'SYMLINK_CONDA':
     ['/Users/aaronmeurer/anaconda'], 'LINK': ['python-3.3.2-0', 'readline-6.2-0 1', 'sqlite-3.7.13-0 1', 'tk-8.5.13-0 1', 'zlib-1.2.7-0 1']})
@@ -327,7 +322,6 @@ The following NEW packages will be INSTALLED:
     with captured() as c:
         display_actions(actions, index)
 
-
     assert c.stdout == """
 The following packages will be REMOVED:
 
@@ -338,7 +332,6 @@ The following packages will be REMOVED:
     zlib:     1.2.7-0  <unknown>
 
 """
-
 
     actions = defaultdict(list, {'LINK': ['cython-0.19.1-py33_0'], 'UNLINK':
     ['cython-0.19-py33_0']})
@@ -355,7 +348,6 @@ The following packages will be UPDATED:
 
     actions['LINK'], actions['UNLINK'] = actions['UNLINK'], actions['LINK']
 
-
     with captured() as c:
         display_actions(actions, index)
 
@@ -365,7 +357,6 @@ The following packages will be DOWNGRADED due to dependency conflicts:
     cython: 0.19.1-py33_0 <unknown> --> 0.19-py33_0 <unknown>
 
 """
-
 
     actions = defaultdict(list, {'LINK': ['cython-0.19.1-py33_0',
         'dateutil-1.5-py33_0', 'numpy-1.7.1-py33_0'], 'UNLINK':
@@ -392,7 +383,6 @@ The following packages will be DOWNGRADED due to dependency conflicts:
     dateutil: 2.1-py33_1   <unknown> --> 1.5-py33_0    <unknown>
 
 """
-
 
     actions = defaultdict(list, {'LINK': ['cython-0.19.1-py33_0',
         'dateutil-2.1-py33_1'], 'UNLINK':  ['cython-0.19-py33_0',
@@ -439,7 +429,6 @@ The following packages will be UPDATED:
 """
 
     actions['LINK'], actions['UNLINK'] = actions['UNLINK'], actions['LINK']
-
 
     with captured() as c:
         display_actions(actions, index)
@@ -662,6 +651,7 @@ The following packages will be DOWNGRADED due to dependency conflicts:
 
 """
 
+
 def test_display_actions_features():
     os.environ['CONDA_SHOW_CHANNEL_URLS'] = 'False'
     reset_context(())
@@ -756,7 +746,6 @@ The following NEW packages will be INSTALLED:
 
 """
 
-
     actions = defaultdict(list, {'UNLINK': ['numpy-1.7.1-py33_p0', 'cython-0.19-py33_0']})
 
     with captured() as c:
@@ -794,7 +783,6 @@ The following packages will be UPDATED:
 
 """
 
-
     actions = defaultdict(list, {'LINK': ['numpy-1.7.1-py33_p0'], 'UNLINK': ['numpy-1.7.1-py33_0']})
 
     with captured() as c:
@@ -819,6 +807,7 @@ The following packages will be UPDATED:
     numpy: 1.7.1-py33_p0 <unknown> [mkl] --> 1.7.1-py33_0 <unknown>
 
 """
+
 
 def test_display_actions_no_index():
     # Test removing a package that is not in the index. This issue
@@ -863,6 +852,7 @@ The following packages will be DOWNGRADED due to dependency conflicts:
 
 """
 
+
 class TestDeprecatedExecutePlan(unittest.TestCase):
 
     def test_update_old_plan(self):
@@ -886,17 +876,14 @@ class TestDeprecatedExecutePlan(unittest.TestCase):
             INSTRUCTION_CMD.called = True
             INSTRUCTION_CMD.arg = arg
 
-
         set_commands({'INSTRUCTION': INSTRUCTION_CMD})
 
         old_plan = ['# plan', 'INSTRUCTION arg']
 
         plan.execute_plan(old_plan)
 
-
         self.assertTrue(INSTRUCTION_CMD.called)
         self.assertEqual(INSTRUCTION_CMD.arg, 'arg')
-
 
 
 class PlanFromActionsTests(unittest.TestCase):

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -1,8 +1,11 @@
 from unittest import TestCase
+
 import pytest
-from .test_create import (make_temp_env, assert_package_is_installed
-    , run_command, Commands, get_conda_list_tuple)
+
 from conda.base.context import context
+from .test_create import (make_temp_env, assert_package_is_installed,
+                          run_command, Commands, get_conda_list_tuple)
+
 
 class PriorityTest(TestCase):
 
@@ -30,7 +33,6 @@ class PriorityTest(TestCase):
             # conda list should show pycosat coming from conda-forge
             pycosat_tuple = get_conda_list_tuple(prefix, "pycosat")
             assert pycosat_tuple[3] == 'conda-forge'
-
 
     @pytest.mark.timeout(300)
     def test_channel_priority_update(self):

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -18,6 +18,7 @@ r = Resolve(index)
 
 f_mkl = set(['mkl'])
 
+
 class TestMatchSpec(unittest.TestCase):
 
     def test_match(self):
@@ -270,10 +271,12 @@ def test_pseudo_boolean():
         'zlib-1.2.7-0.tar.bz2',
     ]]
 
+
 def test_get_dists():
     dists = r.get_dists(["anaconda 1.5.0"])[0]
     assert 'anaconda-1.5.0-np17py27_0.tar.bz2' in dists
     assert 'dynd-python-0.3.0-np17py33_0.tar.bz2' in dists
+
 
 def test_generate_eq():
     specs = ['anaconda']
@@ -354,6 +357,7 @@ def test_generate_eq():
         'system-5.8-0.tar.bz2': 1,
         'zeromq-2.2.0-0.tar.bz2': 1}
 
+
 def test_unsat():
     # scipy 0.12.0b1 is not built for numpy 1.5, only 1.6 and 1.7
     assert raises(UnsatisfiableError, lambda: r.install(['numpy 1.5*', 'scipy 0.12.0b1']))
@@ -361,11 +365,13 @@ def test_unsat():
     assert raises(UnsatisfiableError, lambda: r.install(['numpy 1.5*', 'python 3*']))
     assert raises(UnsatisfiableError, lambda: r.install(['numpy 1.5*', 'numpy 1.6*']))
 
+
 def test_nonexistent():
     assert raises(NoPackagesFoundError, lambda: r.get_pkgs('notarealpackage 2.0*'))
     assert raises(NoPackagesFoundError, lambda: r.install(['notarealpackage 2.0*']))
     # This exact version of NumPy does not exist
     assert raises(NoPackagesFoundError, lambda: r.install(['numpy 1.5']))
+
 
 def test_nonexistent_deps():
     index2 = index.copy()
@@ -540,7 +546,6 @@ def test_nonexistent_deps():
     ]
     assert raises(NoPackagesFoundError, lambda: r.install(['mypackage 1.1']))
 
-
     assert r.install(['anotherpackage 1.0']) == [
         'anotherpackage-1.0-py33_0.tar.bz2',
         'mypackage-1.0-py33_0.tar.bz2',
@@ -674,6 +679,7 @@ def test_package_ordering():
     assert (numpy != numpy_mkl) is True
     assert (numpy == numpy_mkl) is False
 
+
 def test_irrational_version():
     assert r.install(['pytz 2012d', 'python 3*'], returnall=True) == [[
         'openssl-1.0.1c-0.tar.bz2',
@@ -685,6 +691,7 @@ def test_irrational_version():
         'tk-8.5.13-0.tar.bz2',
         'zlib-1.2.7-0.tar.bz2'
     ]]
+
 
 def test_no_features():
     # Without this, there would be another solution including 'scipy-0.11.0-np16py26_p3.tar.bz2'.
@@ -791,6 +798,7 @@ def test_no_features():
             'zlib-1.2.7-0.tar.bz2',
             ]][0]
 
+
 def test_multiple_solution():
     index2 = index.copy()
     fn = 'pandas-0.11.0-np16py27_1.tar.bz2'
@@ -803,6 +811,7 @@ def test_multiple_solution():
     res = r.solve(['pandas', 'python 2.7*', 'numpy 1.6*'], returnall=True)
     res = set([y for x in res for y in x if y.startswith('pandas')])
     assert res <= res1
+
 
 def test_broken_install():
     installed = r.install(['pandas', 'python 2.7*', 'numpy 1.6*'])
@@ -826,6 +835,7 @@ def test_broken_install():
     installed2 = r.install(['numpy'], installed)
     installed3 = r.remove(['pandas'], installed)
     assert set(installed3) == set(installed[:3] + installed[4:])
+
 
 def test_remove():
     installed = r.install(['pandas', 'python 2.7*'])
@@ -871,6 +881,7 @@ def test_remove():
         'tk-8.5.13-0.tar.bz2',
         'zlib-1.2.7-0.tar.bz2']
 
+
 def test_channel_priority():
     fn1 = 'pandas-0.10.1-np17py27_0.tar.bz2'
     fn2 = 'other::' + fn1
@@ -903,6 +914,7 @@ def test_channel_priority():
     assert installed1 != installed3
     assert installed2 == installed3
 
+
 def test_dependency_sort():
     specs = ['pandas','python 2.7*','numpy 1.6*']
     installed = r.install(specs)
@@ -922,6 +934,7 @@ def test_dependency_sort():
         'dateutil-2.1-py27_1',
         'scipy-0.12.0-np16py27_0',
         'pandas-0.11.0-np16py27_1']
+
 
 def test_update_deps():
     installed = r.install(['python 2.7*', 'numpy 1.6*', 'pandas 0.10.1'])

--- a/tests/test_toposort.py
+++ b/tests/test_toposort.py
@@ -1,6 +1,7 @@
 import unittest
 from conda.toposort import toposort, pop_key
 
+
 class TopoSortTests(unittest.TestCase):
 
     def test_pop_key(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,7 @@ def test_path_translations():
         assert utils.win_path_to_cygwin(windows_path) == cygwin_path
         assert utils.cygwin_path_to_win(cygwin_path) == windows_path
 
+
 def test_text_translations():
     test_win_text = "prepending z:\\msarahan\\code\\conda\\tests\\envsk5_b4i\\test 1 and z:\\msarahan\\code\\conda\\tests\\envsk5_b4i\\test 1\\scripts to path"
     test_unix_text = "prepending /z/msarahan/code/conda/tests/envsk5_b4i/test 1 and /z/msarahan/code/conda/tests/envsk5_b4i/test 1/scripts to path"


### PR DESCRIPTION
Changes 'conda config --add' back to prepending behavior. Now aliases with 
--prepend

response to #3336 
