### PR TITLE
Add an `always_softlink` option to condarc to force softlinks even on filesystems that support hardlinks

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -77,6 +77,7 @@ class Context(Configuration):
     default_channels = SequenceParameter(string_types, DEFAULT_CHANNELS)
 
     # command line
+    always_softlink = PrimitiveParameter(False, aliases=('softlink',))
     always_copy = PrimitiveParameter(False, aliases=('copy',))
     always_yes = PrimitiveParameter(False, aliases=('yes',))
     channel_priority = PrimitiveParameter(True)
@@ -211,6 +212,8 @@ def get_help_dict():
         'always_yes': dals("""
             """),
         'always_copy': dals("""
+            """),
+        'always_softlink': dals("""
             """),
         'changeps1': dals("""
             """),

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -247,6 +247,7 @@ def execute_config(args, parser):
                              'add_pip_as_python_dependency',
                              'allow_softlinks',
                              'always_copy',
+                             'always_softlink',
                              'always_yes',
                              'binstar_upload',
                              'auto_update_conda',

--- a/conda/config.py
+++ b/conda/config.py
@@ -37,6 +37,7 @@ rc_bool_keys = [
     'always_yes',
     'always_copy',
     'allow_softlinks',
+    'always_softlink',
     'auto_update_conda',
     'changeps1',
     'use_pip',

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -146,7 +146,7 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
                     pass
             if context.always_copy:
                 lt = LINK_COPY
-            elif context.always_symlink:
+            elif context.always_softlink:
                 lt = LINK_SOFT
             elif try_hard_link(fetched_dir, prefix, dist):
                 lt = LINK_HARD

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -146,6 +146,8 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
                     pass
             if context.always_copy:
                 lt = LINK_COPY
+            elif context.always_symlink:
+                lt = LINK_SOFT
             elif try_hard_link(fetched_dir, prefix, dist):
                 lt = LINK_HARD
             elif context.allow_softlinks and not on_win:

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -357,6 +357,8 @@ def ensure_linked_actions(dists, prefix, index=None, force=False,
                     pass
             if context.always_copy or always_copy:
                 lt = LINK_COPY
+            elif context.always_softlink:
+                lt = LINK_SOFT
             elif try_hard_link(fetched_dir, prefix, dist):
                 lt = LINK_HARD
             elif context.allow_softlinks and not on_win:

--- a/tests/condarc
+++ b/tests/condarc
@@ -34,6 +34,9 @@ always_yes: True
 #                        i.e. soft-link when possible)
 allow_softlinks: False
 
+# always use soft-links instead of hard-links (default False)
+always_softlink: True
+
 # change ps1 when using activate (default True)
 changeps1: False
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -441,6 +441,11 @@ channel_alias: http://alpha.conda.anaconda.org
         assert stdout == ""
         assert stderr == ""
 
+        stdout, stderr = run_conda_command('config', '--file', rc, '--get', 'always_softlink')
+
+        assert stdout == ""
+        assert stderr == ""
+
         stdout, stderr = run_conda_command('config', '--file', rc, '--get', 'track_features')
 
         assert stdout == ""


### PR DESCRIPTION
This addresses #3308.

One question: I made it a condarc option like allow_softlinks, should it also (or only?) be a command line argument?

And one TODO: `always_copy` and `always_softlink` should be made mutually exclusive, where's the best place to do this?

I'll PR a change to the docs if this is accepted.
