### PR TITLE
Add support for client TLS certificates

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -66,6 +66,7 @@ class Context(Configuration):
     create_default_packages = SequenceParameter(string_types)
     disallow = SequenceParameter(string_types)
     ssl_verify = PrimitiveParameter(True, parameter_type=string_types + (bool,))
+    client_cert = MapParameter(string_types)
     track_features = SequenceParameter(string_types)
     use_pip = PrimitiveParameter(True)
     proxy_servers = MapParameter(string_types)
@@ -234,6 +235,11 @@ def get_help_dict():
             """),
         'ssl_verify': dals("""
             # ssl_verify can be a boolean value or a filename string
+            """),
+        'client_cert': dals("""
+            # client_cert can have a 'cert' key pointing to a single file
+            # (containing the private key and the certificate) or both 'cert'
+            # and 'key' keys pointing to the individual files
             """),
         'track_features': dals("""
             """),

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -294,6 +294,7 @@ def execute_config(args, parser):
                                            'shortcuts',
                                            'show_channel_urls',
                                            'ssl_verify',
+                                           'client_cert',
                                            'track_features',
                                            'update_dependencies',
                                            'use_pip',

--- a/conda/config.py
+++ b/conda/config.py
@@ -58,6 +58,7 @@ rc_string_keys = [
 # Not supported by conda config yet
 rc_other = [
     'proxy_servers',
+    'client_cert',
 ]
 
 root_dir = context.root_prefix

--- a/conda/connection.py
+++ b/conda/connection.py
@@ -147,6 +147,13 @@ class CondaSession(requests.Session):
 
         self.verify = context.ssl_verify
 
+        client_cert = context.client_cert
+        if 'cert' in client_cert:
+            if 'key' in client_cert:
+                self.cert = (client_cert['cert'], client_cert['key'])
+            else:
+                self.cert = client_cert['cert']
+
 
 class S3Adapter(requests.adapters.BaseAdapter):
 


### PR DESCRIPTION
Required by some proxies or custom repos for authentication. This an updated version of [this change](https://github.com/groutr/conda/commit/a710a473bcb65cd66ffc10d8658bace3cb2c46d2) by @groutr, which wasn't actually needed for #1387, but which I have a need for now.

I tested locally and it seems to work - here's what I did (requires `openssl` and `nginx`):

1. Generate certificates

        mkdir tls
        
        # root ca
        openssl genrsa -out tls/ca.key 2048
        openssl req -x509 -new -nodes -key tls/ca.key -sha256 -days 356 -out tls/ca.pem
        # server
        openssl genrsa -out tls/server.key 2048
        openssl req -new -key tls/server.key -out tls/server.csr
        openssl x509 -req -in tls/server.csr -CA tls/ca.pem -CAkey tls/ca.key -CAcreateserial -out tls/server.crt -days 365  -subj '/C=US/ST=California/O=Conda/OU=Conda/CN=localhost' -sha256
        # client
        openssl genrsa -out tls/client.key 2048
        openssl req -new -key tls/client.key -out tls/client.csr
        openssl x509 -req -in tls/client.csr -CA tls/ca.pem -CAkey tls/ca.key -CAcreateserial -out tls/client.crt -days 365 -subj '/C=US/ST=California/O=Conda/OU=Conda/CN=localhost' -sha256
   
2. Add a new server block to nginx configuration

        server {
            listen 6543 ssl;
        
            ssl on;
            ssl_certificate     /path/to/tls/server.crt; 
            ssl_certificate_key /path/to/tls/server.key; 
        
            ssl_client_certificate /path/to/tls/ca.pem;
            ssl_verify_client on;
        
            location / {
                proxy_pass https://repo.continuum.io/pkgs/;
                proxy_set_header Host repo.continuum.io;
            }
        }

3. Modify `.condarc`

        ssl_verify: /path/to/tls/ca.pem
        channels:
          - https://localhost:6543/free/linux-64/
          - https://localhost:6543/r/linux-64/
        client_cert:
            key: /path/to/tls/client.key
            cert: /path/to/tls/client.crt

4. `conda install` something

You might see a warning about a missing `subjectAltName`, which can be ignored (I couldn't find a quick way to generate local certs with this field.) If you remove the `client_cert` property, requests should fail with a 400 error.