### PR TITLE
fix #3433 rm_rf fails to remove broken symlinks

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -478,7 +478,7 @@ def conda_exception_handler(func, *args, **kwargs):
         return 1
     except CondaError as e:
         from conda.base.context import context
-        if context.debug:
+        if context.debug or context.verbosity > 0:
             print_unexpected_error_message(e)
         else:
             print_conda_exception(e)

--- a/conda/install.py
+++ b/conda/install.py
@@ -481,7 +481,7 @@ def run_script(prefix, dist, action='post-link', env_prefix=None):
     else:
         shell_path = '/bin/sh' if 'bsd' in sys.platform else '/bin/bash'
         args = [shell_path, path]
-    env = os.environ
+    env = os.environ.copy()
     env[str('ROOT_PREFIX')] = sys.prefix
     env[str('PREFIX')] = str(env_prefix or prefix)
     env[str('PKG_NAME')], env[str('PKG_VERSION')], env[str('PKG_BUILDNUM')], _ = dist2quad(dist)

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -74,10 +74,12 @@ def split_linkarg(arg):
 
 def LINK_CMD(state, arg):
     dist, lt = split_linkarg(arg)
+    log.debug("=======> LINKING %s <=======", dist)
     link(state['prefix'], dist, lt, index=state['index'])
 
 
 def UNLINK_CMD(state, arg):
+    log.debug("=======> UNLINKING %s <=======", arg)
     unlink(state['prefix'], arg)
 
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -258,6 +258,10 @@ class IntegrationTests(TestCase):
             assert any(line.endswith("<pip>") for line in stdout_lines
                        if line.lower().startswith("flask"))
 
+            # regression test for #3433
+            run_command(Commands.INSTALL, prefix, "python=3.4")
+            assert_package_is_installed(prefix, 'python-3.4.')
+
     @pytest.mark.timeout(300)
     def test_tarball_install_and_bad_metadata(self):
         with make_temp_env("python flask=0.10.1") as prefix:


### PR DESCRIPTION
resolves #3433

@msarahan can you review?

So this really was a bug with the new `rm_rf` code.  The issue was using `os.exists` and `os.stat` instead of `os.lexists` and `os.lstat`.