### PR TITLE
remove remote_site from binstar get_config

### DIFF
--- a/conda/connection.py
+++ b/conda/connection.py
@@ -97,8 +97,7 @@ class BinstarAuth(AuthBase):
             if DEFAULT_CHANNEL_ALIAS.startswith(base_url):
                 base_url = binstar_default_url
 
-            # chatty 'binstar' logger
-            config = get_config(remote_site=base_url)
+            config = get_config()  # remote_site is site name, not url
             url_from_bs_config = config.get('url', base_url)
             token = load_token(url_from_bs_config)
 


### PR DESCRIPTION
Making this change after chatting with @dsludwig working to address #3442.  Much more work needs to be done here.  But this changes clearly incorrect code to something that might possibly be closer.