### PR TITLE
Bring back `conda list --export`

### DIFF
--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -216,8 +216,7 @@ def execute(args, parser):
     if args.canonical:
         format = 'canonical'
     elif args.export:
-        print_explicit(prefix, args.md5)
-        return
+        format = 'export'
     else:
         format = 'human'
 


### PR DESCRIPTION
https://github.com/conda/conda/pull/3291/files#r79096929 made `conda list --export`
do the same thing as `conda list --explicit`, which is inconsistent with the `conda list --help`
string and broke the Julia wrapper Conda.jl