### PR TITLE
Add a flag for installing dependencies only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.3.0 (unreleased)
 
+### Improvements
+* add `--deps-only` command line flag for `conda install`
+
 ### Bug Fixes
 * account for the Windows Python 2.7 os.environ unicode aversion (#3363)
 * fix link field in record object (#3424)

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -270,7 +270,7 @@ def add_parser_install(p):
     p.add_argument(
         "--deps-only",
         action="store_true",
-        help="Install dependencies but not the specified packages "
+        help="Install all dependencies excepted the specified packages "
              "(useful for development purposes).",
     )
     p.add_argument(

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -268,6 +268,12 @@ def add_parser_install(p):
         help="Do not install dependencies.",
     )
     p.add_argument(
+        "--deps-only",
+        action="store_true",
+        help="Install dependencies but not the specified packages "
+             "(useful for development purposes).",
+    )
+    p.add_argument(
         '-m', "--mkdir",
         action="store_true",
         help="Create the environment directory if necessary.",

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -285,6 +285,11 @@ def install(args, parser, command='install'):
     else:
         only_names = None
 
+    if args.deps_only:
+        skip_names = set(s.split()[0] for s in ospecs)
+    else:
+        skip_names = None
+
     if not isdir(prefix) and not newenv:
         if args.mkdir:
             try:
@@ -302,6 +307,7 @@ def install(args, parser, command='install'):
                 actions = install_actions(prefix, index, specs,
                                           force=args.force,
                                           only_names=only_names,
+                                          skip_names=skip_names,
                                           pinned=args.pinned,
                                           always_copy=context.always_copy,
                                           minimal_hint=args.alt_hint,

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -448,8 +448,9 @@ def get_pinned_specs(prefix):
         return [i for i in f.read().strip().splitlines() if i and not i.strip().startswith('#')]
 
 
-def install_actions(prefix, index, specs, force=False, only_names=None, always_copy=False,
-                    pinned=True, minimal_hint=False, update_deps=True, prune=False):
+def install_actions(prefix, index, specs, force=False, only_names=None,
+                    skip_names=None, always_copy=False, pinned=True,
+                    minimal_hint=False, update_deps=True, prune=False):
     r = Resolve(index)
     linked = r.installed
 
@@ -487,6 +488,8 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
         dist = fn[:-8]
         name = name_dist(dist)
         if not name or only_names and name not in only_names:
+            continue
+        if skip_names and name in skip_names:
             continue
         must_have[name] = dist
 


### PR DESCRIPTION
Fixes #1543 by adding a `--deps-only` flag.

After checking it behaves as expected, but as this is my first PR to Conda maybe I'm missing some use cases or implementation guidelines? Also not sure how to handle tests here.

A possible issue is when we specify both a package and one or several of its dependencies. For example, the command below would be very handy to quickly create a development environment for the `xarray` package, excepted that it wouldn't install the specified version of Python.

```
$ conda create -n test_env python=3.5 xarray --deps-only

Package plan for installation in environment /home/bovy/miniconda3/envs/test_env:

The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    mkl-11.3.3                 |                0       122.1 MB
    numpy-1.11.1               |           py35_0         6.1 MB
    pytz-2016.6.1              |           py35_0         177 KB
    six-1.10.0                 |           py35_0          17 KB
    python-dateutil-2.5.3      |           py35_0         237 KB
    pandas-0.18.1              |      np111py35_0        14.1 MB
    ------------------------------------------------------------
                                           Total:       142.6 MB

The following NEW packages will be INSTALLED:

    mkl:             11.3.3-0          
    numpy:           1.11.1-py35_0     
    openssl:         1.0.2i-0          
    pandas:          0.18.1-np111py35_0
    pip:             8.1.2-py35_0      
    python-dateutil: 2.5.3-py35_0      
    pytz:            2016.6.1-py35_0   
    readline:        6.2-2             
    setuptools:      27.2.0-py35_0     
    six:             1.10.0-py35_0     
    sqlite:          3.13.0-0          
    tk:              8.5.18-0          
    wheel:           0.29.0-py35_0     
    xz:              5.2.2-0           
    zlib:            1.2.8-3           
```
