### PR TITLE
Minor change to regex to avoid Python bug

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -128,7 +128,7 @@ def split_platform(value):
             return value, None
 
 
-TOKEN_RE = re.compile(r'(/t/[a-z0-9A-Z-]+)?(\S*)?')
+TOKEN_RE = re.compile(r'(/t/[a-z0-9A-Z-]+)?(\S*)')
 def split_token(value):  # NOQA
     token, path = TOKEN_RE.match(value).groups()
     return token, path or '/'


### PR DESCRIPTION
Apparently there is a bug in the regex implementation on some systems that makes an expression of the type `(\S*)?` invalid (fails with sre_constants.error: nothing to repeat). I experienced the bug on Windows with py2.7.11 and on Red Hat with py2.7.3, but not on windows with py2.7.12 in a virtualenv. It might be related to this:
http://stackoverflow.com/questions/3675144/regex-error-nothing-to-repeat
In this case, the `?` shouldn't be necessary, so I propose removing it, which solves the problem.