### PR TITLE
Two sat()/minimize() fixes

### DIFF
--- a/conda/logic.py
+++ b/conda/logic.py
@@ -72,9 +72,6 @@ class Clauses(object):
     def from_index(self, m):
         return self.indices.get(m)
 
-    def varnum(self, x):
-        return self.names[x] if isinstance(x, string_types) else x
-
     def Assign_(self, vals, name=None):
         tvals = type(vals)
         if tvals is tuple:
@@ -89,12 +86,10 @@ class Clauses(object):
         return self.name_var(x, name) if name else x
 
     def Convert_(self, x):
-        if isinstance(x, string_types):
-            return self.names[x]
         tx = type(x)
         if tx in (tuple, list):
             return tx(map(self.Convert_, x))
-        return x
+        return self.names.get(x, x)
 
     def Eval_(self, func, args, polarity, name, conv=True):
         if conv:
@@ -324,7 +319,7 @@ class Clauses(object):
 
     def LB_Preprocess_(self, equation):
         if type(equation) is dict:
-            equation = [(c, self.varnum(a)) for a, c in iteritems(equation)]
+            equation = [(c, self.names.get(a, a)) for a, c in iteritems(equation)]
         if any(c <= 0 or type(a) is bool for c, a in equation):
             offset = sum(c for c, a in equation if a is True or a is not False and c <= 0)
             equation = [(c, a) if c > 0 else (-c, -a) for c, a in equation
@@ -416,11 +411,29 @@ class Clauses(object):
             return None
         if not self.m:
             return set() if names else []
+        clauses = self.clauses
         if additional:
-            additional = list(map(lambda x: tuple(map(self.varnum, x)), additional))
-            clauses = chain(self.clauses, additional)
-        else:
-            clauses = self.clauses
+            def preproc(eqs):
+                def preproc_(cc):
+                    for c in cc:
+                        c = self.names.get(c, c)
+                        if c is False:
+                            continue
+                        yield c
+                        if c is True:
+                            break
+                for cc in eqs:
+                    cc = tuple(preproc_(cc))
+                    if not cc:
+                        yield cc
+                        break
+                    if cc[-1] is not True:
+                        yield cc
+            additional = list(preproc(additional))
+            if additional:
+                if not additional[-1]:
+                    return None
+                clauses = chain(clauses, additional)
         try:
             solution = pycosat.solve(clauses, vars=self.m, prop_limit=limit)
         except TypeError:
@@ -470,7 +483,7 @@ class Clauses(object):
             return bestsol, sum(abs(c) for c, a in objective) + 1
 
         if type(objective) is dict:
-            objective = [(v, self.varnum(k)) for k, v in iteritems(objective)]
+            objective = [(v, self.names.get(k, k)) for k, v in iteritems(objective)]
 
         objective, offset = self.LB_Preprocess_(objective)
         maxval = max(c for c, a in objective)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -243,12 +243,20 @@ def test_sat():
     C = Clauses()
     C.new_var('x1')
     C.new_var('x2')
-    assert C.sat([(+1,),(+2,)], names=True) == {'x1','x2'}
-    assert C.sat([(-1,),(+2,)], names=True) == {'x2'}
-    assert C.sat([(-1,),(-2,)], names=True) == set()
-    assert C.sat([(+1,),(-1,)], names=True) is None
+    assert C.sat() is not None
+    assert C.sat([]) is not None
+    assert C.sat([()]) is None
+    assert C.sat([(False,)]) is None
+    assert C.sat([(True,),()]) is None
+    assert C.sat([(True,False,-1)]) is not None
+    assert C.sat([(+1,False),(+2,),(True,)], names=True) == {'x1','x2'}
+    assert C.sat([(-1,False),(True,),(+2,)], names=True) == {'x2'}
+    assert C.sat([(True,),(-1,),(-2,False)], names=True) == set()
+    assert C.sat([(+1,),(-1,False)], names=True) is None
     C.unsat = True
     assert C.sat() is None
+    assert C.sat([]) is None
+    assert C.sat([(True,)]) is None
     assert len(Clauses(10).sat([[1]])) == 10
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -261,19 +261,25 @@ def test_sat():
 
 
 def test_minimize():
-    # minimize    x1 + 2 x2 + 3 x3 + ... + 10 x10
+    # minimize    x1 + 2 x2 + 3 x3 + 4 x4 + 5 x5
     # subject to  x1 + x2 + x3 + x4 + x5  == 1
-    #             x6 + x7 + x8 + x9 + x10 == 1
-    C = Clauses(10)
+    C = Clauses(15)
     C.Require(C.ExactlyOne, range(1,6))
-    C.Require(C.ExactlyOne, range(6,11))
-    objective = [(k,k) for k in range(1,11)]
     sol = C.sat()
     C.unsat = True
-    assert C.minimize(objective, sol)[1] == 56
+    # Unsatisfiable constraints
+    assert C.minimize([(k,k) for k in range(1,6)], sol)[1] == 16
     C.unsat = False
-    sol2, sval = C.minimize(objective, sol)
-    assert C.minimize(objective, sol)[1] == 7, (objective, sol2, sval)
+    sol, sval = C.minimize([(k,k) for k in range(1,6)], sol)
+    assert sval == 1
+    C.Require(C.ExactlyOne, range(6,11))
+    # Supply an initial vector that is too short, forcing recalculation
+    sol, sval = C.minimize([(k,k) for k in range(6,11)], sol)
+    assert sval == 6
+    C.Require(C.ExactlyOne, range(11,16))
+    # Don't supply an initial vector
+    sol, sval = C.minimize([(k,k) for k in range(11,16)])
+    assert sval == 11
 
 
 def test_minimal_unsatisfiable_subset():


### PR DESCRIPTION
Under certain uncommon (I think) circumstances, some of the specifications passed to the SAT logic include boolean `True` or `False` values. Care must be taken to distinguish booleans from integers in the SAT logic, because 0 and 1 are not equivalent: `0` is an illegal index altogether, and `1` means variable 1.

Previous versions of the logic module created special boolean wrapper objects that would prevent accidental confusion of the two, but that code was jettisoned for the purposes of code simplification and profile-driven performance improvement. The test suite attempts to exhaustively verify that True/False are not ever confused with 1/0, but unfortunately some cases were not covered, specifically in the `sat()` function.

This fix can---and, in my opinion, should---be cherry picked into 4.1 and 4.2. Since it is isolated to `logic.py` and `test_logic.py`, there should be no merge conflicts. I do believe its occurrence in practice is rare, but it's definitely possible that it will come up. And it is _is_ exercised by the solver improvements I'm working on.