### PR TITLE
Fix help string of --update-dependencies option.

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -290,7 +290,7 @@ def add_parser_install(p):
         action="store_true",
         dest="update_deps",
         default=NULL,
-        help="Don't update dependencies (default: %s)." % context.update_dependencies,
+        help="Update dependencies (default: %s)." % context.update_dependencies,
     )
     p.add_argument(
         "--no-update-dependencies", "--no-update-deps",


### PR DESCRIPTION
Before, it was the same as for --no-update-dependencies, which doesn't make sense, see [here](https://github.com/conda/conda/compare/master...bilderbuchi:patch-1#diff-ae6ced2baf06e49bf278c2c66aa0d7d0R300).

Ping @asmeurer who originally wrote the original, correct string, which was changed at some point.