### PR TITLE
Separate http auth management

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -20,8 +20,9 @@ def get_index(channel_urls=(), prepend=True, platform=None,
         channel_urls = ['local'] + list(channel_urls)
     if prepend:
         channel_urls += context.channels
-    channel_urls = prioritize_channels(channel_urls)
-    index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
+    channel_urls, channel_auth = prioritize_channels(channel_urls)
+    index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown,
+                        channel_auths=channel_auth)
     if prefix:
         priorities = {c: p for c, p in itervalues(channel_urls)}
         maxp = max(itervalues(priorities)) + 1 if priorities else 1

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -221,7 +221,7 @@ def execute(args, parser):
             print(json.dumps({"channels": channels}))
         return 0
 
-    channels = list(prioritize_channels(channels).keys())
+    channels = list(prioritize_channels(channels)[0].keys())
     if not context.json:
         channels = [c + ('' if offline_keep(c) else '  (offline)')
                     for c in channels]

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -147,6 +147,7 @@ class UrlChannel(Channel):
         parsed = urlparse(url)
         self._scheme = parsed.scheme
         self._netloc = parsed.netloc
+        self._auth = parsed.auth
         _path, self._platform = split_platform(parsed.path)
         self._token, self._path = split_token(_path)
 
@@ -168,6 +169,7 @@ class NamedChannel(Channel):
             parsed = urlparse(context.channel_alias)
         self._scheme = parsed.scheme
         self._netloc = parsed.netloc
+        self._auth = parsed.auth
         self._token = None
         self._path = join(parsed.path or '/', name)
         self._platform = None
@@ -180,7 +182,7 @@ class NoneChannel(NamedChannel):
 
     def __init__(self, value):
         self._raw_value = value
-        self._scheme = self._netloc = self._token = self._path = self._platform = None
+        self._scheme = self._netloc = self._auth = self._token = self._path = self._platform = None
 
     @property
     def canonical_name(self):
@@ -194,13 +196,15 @@ class NoneChannel(NamedChannel):
 def prioritize_channels(channels):
     # ('https://conda.anaconda.org/conda-forge/osx-64/', ('conda-forge', 1))
     result = odict()
+    auths = odict()
     for q, chn in enumerate(channels):
         channel = Channel(chn)
         for url in channel.urls:
             if url in result:
                 continue
             result[url] = channel.canonical_name, q
-    return result
+            auths[url] = tuple(channel._auth.split(':')) if channel._auth else None
+    return result, auths
 
 
 def offline_keep(url):

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -146,3 +146,10 @@ class ChannelTests(TestCase):
         assert c.canonical_name == "https://some.other.com/pkgs/free"
         assert c.urls == ["https://some.other.com/pkgs/free/%s/" % platform,
                           "https://some.other.com/pkgs/free/noarch/"]
+
+    def test_auth(self):
+        assert Channel('http://user:pass@conda.anaconda.org/t/tk-abc-123-456/bioconda/win-64').canonical_name == "bioconda"
+        assert Channel('http://conda.anaconda.org/bioconda/label/main/osx-64')._auth == None
+        assert Channel('http://user:pass@conda.anaconda.org/bioconda/label/main/osx-64')._auth == 'user:pass'
+        assert Channel('http://user:pass@path/to/repo')._auth == 'user:pass'
+        assert Channel('http://user:pass@path/to/repo').canonical_name == 'http://path/to/repo'


### PR DESCRIPTION
Fixes #3459 and #2804

- Changed prioritize_channel to return also channel authorizations
- Added `auth` field in the info dictionary, so that subsequent get requests to urls (like in `download` function) can retrieve auth information
- Added tests