### PR TITLE
revert boto patch from #2380

### DIFF
--- a/conda/connection.py
+++ b/conda/connection.py
@@ -209,21 +209,6 @@ class S3Adapter(requests.adapters.BaseAdapter):
 
         try:
             import boto
-
-            # silly patch for AWS because
-            # TODO: remove or change to warning once boto >2.39.0 is released
-            # https://github.com/boto/boto/issues/2617
-            from boto.pyami.config import Config, ConfigParser
-
-            def get(self, section, name, default=None, **kw):
-                try:
-                    val = ConfigParser.get(self, section, name, **kw)
-                except:
-                    val = default
-                return val
-
-            Config.get = get
-
         except ImportError:
             stderrlog.info('\nError: boto is required for S3 channels. '
                            'Please install it with `conda install boto`\n'


### PR DESCRIPTION
This PR reverts #2380.  boto 2.42.0 is now available in the defaults channel.

@jseabold ok with you now?