### PR TITLE
modify LICENSE.txt so that github recognizes it as BSD 3-Clause

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,37 +1,27 @@
-Conda is released under the following terms:
+BSD 3-Clause License
 
-(c) 2012 Continuum Analytics, Inc. / http://continuum.io
-All Rights Reserved
+Copyright (c) 2012, Continuum Analytics, Inc.
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of Continuum Analytics, Inc. nor the
-      names of its contributors may be used to endorse or promote products
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
 DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-Dependencies
-============
-
-versioneer.py is Public Domain
-
-The ProgressBar package is redistributed under the BSD 3-clause license
-as per the terms of its license.
-(see conda/progressbar/LICENSE.txt)
-


### PR DESCRIPTION
Github is supposed to [recognize license files now](https://github.com/blog/2252-license-now-displayed-on-repository-overview), but it apparently doesn't recognize conda's LICENSE.txt as BSD 3-Clause.  

This PR should fix that.  The text is copied directly from 
http://choosealicense.com/licenses/bsd-3-clause/