### PR TITLE
Further refine conda channels specification

### DIFF
--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -401,7 +401,7 @@ def fetch_index(channel_urls, use_cache=False, index=None):
                 continue
             canonical_name, priority = channel_urls[channel_url]
             channel = Channel(channel_url)
-            for fn, info in iteritems(repodata['packages']):
+            for fn, info in iteritems(repodata.get('packages', {})):
                 rec = IndexRecord.from_objects(info,
                                                fn=fn,
                                                schannel=canonical_name,

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -193,8 +193,9 @@ def fetch_repodata_remote_request(session, url, etag, mod_stamp):
         def maybe_decompress(filename, resp_content):
             return ensure_text_type(bz2.decompress(resp_content)
                                     if filename.endswith('.bz2')
-                                    else resp_content)
-        fetched_repodata = json.loads(maybe_decompress(filename, resp.content))
+                                    else resp_content).strip()
+        json_str = maybe_decompress(filename, resp.content)
+        fetched_repodata = json.loads(json_str) if json_str else {}
         fetched_repodata['_url'] = url
         add_http_value_to_dict(resp, 'Etag', fetched_repodata, '_etag')
         add_http_value_to_dict(resp, 'Last-Modified', fetched_repodata, '_mod')
@@ -207,23 +208,31 @@ def fetch_repodata_remote_request(session, url, etag, mod_stamp):
         # status_code might not exist on SSLError
         status_code = getattr(e.response, 'status_code', None)
         if status_code == 404:
-            if url.endswith('/noarch'):  # noarch directory might not exist
+            if not url.endswith('/noarch'):
                 return None
+            else:
+                help_message = dals("""
+                The remote server could not find the channel you requested.
 
-            help_message = dals("""
-            The remote server could not find the channel you requested.
+                As of conda 4.3, a valid channel *must* contain a `noarch/repodata.json` and
+                associated `noarch/repodata.json.bz2` file, even if `noarch/repodata.json` is
+                empty.
 
-            You will need to adjust your conda configuration to proceed.
-            Use `conda config --show` to view your configuration's current state.
-            Further configuration help can be found at <%s>.
-            """ % join_url(CONDA_HOMEPAGE_URL, 'docs/config.html'))
+                You will need to adjust your conda configuration to proceed.
+                Use `conda config --show` to view your configuration's current state.
+                Further configuration help can be found at <%s>.
+                """ % join_url(CONDA_HOMEPAGE_URL, 'docs/config.html'))
 
         elif status_code == 403:
-            if url.endswith('/noarch'):
+            if not url.endswith('/noarch'):
                 return None
             else:
                 help_message = dals("""
                 The channel you requested is not available on the remote server.
+
+                As of conda 4.3, a valid channel *must* contain a `noarch/repodata.json` and
+                associated `noarch/repodata.json.bz2` file, even if `noarch/repodata.json` is
+                empty.
 
                 You will need to adjust your conda configuration to proceed.
                 Use `conda config --show` to view your configuration's current state.

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -397,7 +397,7 @@ def fetch_index(channel_urls, use_cache=False, index=None):
         result = dict()
 
         for channel_url, repodata in repodatas:
-            if repodata is None:
+            if not repodata:
                 continue
             canonical_name, priority = channel_urls[channel_url]
             channel = Channel(channel_url)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -305,12 +305,17 @@ class IntegrationTests(TestCase):
             repodata = {'info': {}, 'packages': {flask_fname: IndexRecord(**flask_data)}}
             with make_temp_env() as channel:
                 subchan = join(channel, context.subdir)
+                noarch_dir = join(channel, 'noarch')
                 channel = path_to_url(channel)
                 os.makedirs(subchan)
+                os.makedirs(noarch_dir)
                 tar_new_path = join(subchan, flask_fname)
                 copyfile(tar_old_path, tar_new_path)
                 with bz2.BZ2File(join(subchan, 'repodata.json.bz2'), 'w') as f:
                     f.write(json.dumps(repodata, cls=EntityEncoder).encode('utf-8'))
+                with bz2.BZ2File(join(noarch_dir, 'repodata.json.bz2'), 'w') as f:
+                    f.write(json.dumps({}, cls=EntityEncoder).encode('utf-8'))
+
                 run_command(Commands.INSTALL, prefix, '-c', channel, 'flask', '--json')
                 assert_package_is_installed(prefix, channel + '::' + 'flask-')
 


### PR DESCRIPTION
addresses #3708 

A valid repo must minimally contain a file (even if blank) `noarch/repodata.json` and `noarch/repodata.json.bz2`.  Right now, conda assumes that the platform directory for a channel always exists, and it causes errors when it doesn't.  We'll likely be adding new platforms soon, and noarch is/should be in all cases the common `subdir`.  anaconda.org is already compatible:
- https://conda.anaconda.org/kalefranz/noarch/repodata.json
- https://conda.anaconda.org/kalefranz/label/main/noarch/repodata.json
- https://conda.anaconda.org/kalefranz/label/NOPE/noarch/repodata.json

The changes needed to be made will mostly affect `conda/core/index.py` and `fetch_repodata`.  Right now, we assume a `404` response on `/noarch/repodata.json` is ok.  We simply need to flip the assumption, and also make sure we have good error messaging for people with their own repos.

I want to stress that this change is to enable easier expansion of conda's supported platforms and architectures.
