### PR TITLE
Fix json dump on conda config --show --json

### DIFF
--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -13,6 +13,7 @@ import sys
 from .common import (Completer, add_parser_json, stdout_json_success)
 from .. import CondaError
 from .._vendor.auxlib.compat import isiterable
+from .._vendor.auxlib.entity import EntityEncoder
 from .._vendor.auxlib.type_coercion import boolify
 from ..base.context import context
 from ..common.configuration import pretty_list, pretty_map
@@ -303,7 +304,8 @@ def execute_config(args, parser):
                                            'verbosity',
                                            )))
         if context.json:
-            print(json.dumps(d, sort_keys=True, indent=2, separators=(',', ': ')))
+            print(json.dumps(d, sort_keys=True, indent=2, separators=(',', ': '),
+                  cls=EntityEncoder))
         else:
             print('\n'.join(format_dict(d)))
         context.validate_configuration()

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -335,6 +335,9 @@ class Channel(object):
     def __bool__(self):
         return self.__nonzero__()
 
+    def __json__(self):
+        return self.__dict__
+
     @property
     def url_channel_wtf(self):
         return self.base_url, self.canonical_name


### PR DESCRIPTION
- Add method `__json__` to class 'Channel'
- Use EntityDecoder in execute_config to serialize output

Fixes #3807 