### PR TITLE
`activate`/`deactivate` with install prefix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,22 +5,19 @@
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 import os
 import sys
-if 'develop' in sys.argv:
-    from setuptools import setup
-else:
-    from distutils.core import setup
+from textwrap import dedent
 
 if not (sys.version_info[:2] == (2, 7) or sys.version_info[:2] >= (3, 3)):
-    sys.exit("conda is only meant for Python 2.7 or 3.3 and up.  "
-             "current version: %d.%d" % sys.version_info[:2])
+    sys.exit(dedent("""\
+        conda is only meant for Python 2.7 or 3.3 and up.
+        current version: {}.{}""").format(*sys.version_info[:2]))
 
 if os.environ.get('CONDA_DEFAULT_ENV'):
     # Try to prevent accidentally installing conda into a non-root conda environment
-    sys.exit("""
-You appear to be in a non-root conda environment. Conda is only supported in
-the root environment. Deactivate and try again.  If you believe this message
-is in error, run CONDA_DEFAULT_ENV='' python setup.py.
-""")
+    sys.exit(dedent("""\
+        You appear to be in a non-root conda environment. Conda is only supported in
+        the root environment. Deactivate and try again.  If you believe this message
+        is in error, run CONDA_DEFAULT_ENV='' python setup.py."""))
 
 # When executing the setup.py, we need to be able to import ourselves, this
 # means that we need to add the src directory to the sys.path.
@@ -30,26 +27,33 @@ sys.path.insert(0, src_dir)
 
 import conda  # NOQA
 from conda._vendor.auxlib import packaging  # NOQA
+if packaging.is_develop:
+    from setuptools import setup
+else:
+    from distutils.core import setup
 
 with open(os.path.join(here, "README.rst")) as f:
     long_description = f.read()
 
-scripts = ['shell/activate',
-           'shell/activate.sh',
-           'shell/activate.csh',
-           'shell/deactivate',
-           'shell/deactivate.sh',
-           'shell/deactivate.csh',
-           'shell/whichshell_args.bash',
-           'shell/whichshell_ps.bash',
-           'shell/whichshell.awk',
-           'shell/envvar_cleanup.bash',
-           ]
+scripts = [
+    'shell/activate',
+    'shell/activate.sh',
+    'shell/activate.csh',
+    'shell/deactivate',
+    'shell/deactivate.sh',
+    'shell/deactivate.csh',
+    'shell/whichshell_args.bash',
+    'shell/whichshell_ps.bash',
+    'shell/whichshell.awk',
+    'shell/envvar_cleanup.bash',
+]
 if sys.platform == 'win32':
     # Powershell scripts should go here
-    scripts.extend(['shell/activate.bat',
-                    'shell/deactivate.bat',
-                    'shell/envvar_cleanup.bat'])
+    scripts += [
+        'shell/activate.bat',
+        'shell/deactivate.bat',
+        'shell/envvar_cleanup.bat',
+    ]
 
 install_requires = [
     'pycosat >=0.6.1',
@@ -59,6 +63,14 @@ install_requires = [
 if sys.version_info < (3, 4):
     install_requires.append('enum34')
 
+cmdclass = {
+    'build_py': packaging.BuildPyCommand,
+    'sdist': packaging.SDistCommand,
+}
+if packaging.is_develop:
+    cmdclass['develop'] = packaging.DevelopCommand
+else:
+    cmdclass['install_scripts'] = packaging.InstallScriptsCommand
 
 setup(
     name=conda.__name__,
@@ -84,10 +96,7 @@ setup(
                                               "build",
                                               "utils",
                                               ".tox")),
-    cmdclass={
-        'build_py': packaging.BuildPyCommand,
-        'sdist': packaging.SDistCommand,
-    },
+    cmdclass=cmdclass,
     install_requires=[],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if os.environ.get('CONDA_DEFAULT_ENV'):
     # Try to prevent accidentally installing conda into a non-root conda environment
     sys.exit(dedent("""\
         You appear to be in a non-root conda environment. Conda is only supported in
-        the root environment. Deactivate and try again.  If you believe this message
+        the root environment. Deactivate and try again. If you believe this message
         is in error, run CONDA_DEFAULT_ENV='' python setup.py."""))
 
 # When executing the setup.py, we need to be able to import ourselves, this
@@ -63,6 +63,16 @@ install_requires = [
 if sys.version_info < (3, 4):
     install_requires.append('enum34')
 
+packages = packaging.find_packages(
+    exclude=(
+        "tests",
+        "tests.*",
+        "build",
+        "utils",
+        ".tox",
+    )
+)
+
 cmdclass = {
     'build_py': packaging.BuildPyCommand,
     'sdist': packaging.SDistCommand,
@@ -91,11 +101,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
     ],
-    packages=packaging.find_packages(exclude=("tests",
-                                              "tests.*",
-                                              "build",
-                                              "utils",
-                                              ".tox")),
+    packages=packages,
     cmdclass=cmdclass,
     install_requires=[],
     entry_points={

--- a/shell/README.md
+++ b/shell/README.md
@@ -2,7 +2,7 @@
 
 The `activate` and `deactivate` scripts are the core programs that effectively enable and disable conda virtual environments.
 
-The majority of these files are expected to be installed into the Anaconda bin directory (on Unix) and Anaconda Script directory (on Windows) and effectively available on the user's `$PATH`.
+Many of these scripts utilize each other. These dependencies are hardcoded as `${CONDA_INSTALL_PREFIX}`, this value is substituted accordingly when installing conda. This also means we can do some creative unittesting without actually installing the conda package by setting the `${CONDA_INSTALL_PREFIX}`.
 
 There are three code families for activate and deactivate:
 
@@ -16,7 +16,19 @@ All of the codes have been designed to reflect the greatest similarity in their 
 
 This family contains the bulk of the logic and code. Within POSIX unix shells we support two sub-families; bourne shell and c-shell. Both the activate and deactivate branches described below consult the `whichshell.awk`, `whichshell_args.bash`, and `whichshell_ps.bash` scripts.
 
-For testing and debugging use `test_whichshell` to see how the `whichshell*` codes respond in certain unix shell configurations (e.g. `csh` vs. `bash -l` vs. `dash` etc.). The various conditionals that are detected there can be used to modify the logic in `whichshell.awk`.
+For testing and debugging use `test_whichshell` to see how the `whichshell*` codes respond in certain unix shell configurations (e.g. `csh` vs. `bash -l` vs. `dash` etc.). Make sure that you first set the `${CONDA_INSTALL_PREFIX}`:
+
+```
+# for bourne shells
+CONDA_INSTALL_PREFIX=$(pwd)
+. ./test_whichshell
+
+# for c shells
+set CONDA_INSTALL_PREFIX=`pwd`
+source ./test_whichshell
+```
+
+The various conditionals that are detected there can be used to modify the logic in `whichshell.awk`.
 
 Users interact directly with the `activate` and `deactivate` programs:
 

--- a/shell/activate
+++ b/shell/activate
@@ -11,35 +11,48 @@
 # # ACTIVATE                                                            # #
 # # if tree that determined which activate script to run                # #
 # #                                                                     # #
-# # assumes that activate*/deactivate*/whichshell*/envvar_cleanup*      # #
-# # exists on the user's $PATH                                          # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
 # #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 ###########################################################################
 # ERROR CLAUSE                                                            #
-whichshell_args.bash "activate" "error-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
-awk -f "`which whichshell.awk`" || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "activate"                                                            \
+    "error-clause"                                                        \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    : ||                                                                  \
+    :
 # END ERROR CLAUSE                                                        #
 ###########################################################################
 
 ###########################################################################
 # BOURNE SHELL CLAUSE                                                     #
 # bash/zsh/dash/posh/ksh                                                  #
-whichshell_args.bash "activate" "bourne-shell-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
-awk -f "`which whichshell.awk`" && . activate.sh || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "activate"                                                            \
+    "bourne-shell-clause"                                                 \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    . ${CONDA_INSTALL_PREFIX}/activate.sh ||                              \
+    :
 # END BOURNE SHELL CLAUSE                                                 #
 ###########################################################################
 
 ###########################################################################
 # C-SHELL CLAUSE                                                          #
 # tcsh/csh                                                                #
-whichshell_args.bash "activate" "c-shell-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
-awk -f "`which whichshell.awk`" && source "`which activate.csh`" || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "activate"                                                            \
+    "c-shell-clause"                                                      \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    source "${CONDA_INSTALL_PREFIX}/activate.csh" ||                      \
+    :
 # END C-SHELL CLAUSE                                                      #
 ###########################################################################
 

--- a/shell/activate.bat
+++ b/shell/activate.bat
@@ -10,6 +10,10 @@
 @REM # # this file is also indented using TABS instead of SPACES to    # #
 @REM # # avoid very odd syntax errors                                  # #
 @REM # #                                                               # #
+@REM # # the setuptools will properly substitute the                   # #
+@REM # # CONDA_INSTALL_PREFIX upon install into the conda              # #
+@REM # # executable bin [see the install_scripts function of setup.py] # #
+@REM # #                                                               # #
 @REM # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 @REM # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -195,7 +199,7 @@
 @REM #####################################################################
 @REM # HELP DIALOG                                                       #
 @IF /I "%CONDA_HELP%"=="%TRUE%" (
-	@CALL "conda" "..activate" "%WHAT_SHELL_AM_I%" "-h" "%UNKNOWN%"
+	@CALL "%CONDA_INSTALL_PREFIX%\conda" "..activate" "%WHAT_SHELL_AM_I%" "-h" "%UNKNOWN%"
 
 	@ENDLOCAL && (
 		@IF /I "%IS_ENV_CONDA_ENVNAME%"=="%TRUE%" (
@@ -220,7 +224,7 @@
 
 @REM #####################################################################
 @REM # CHECK ENV AND DEACTIVATE OLD ENV                                  #
-@CALL "conda" "..checkenv" "%WHAT_SHELL_AM_I%" "%CONDA_ENVNAME%"
+@CALL "%CONDA_INSTALL_PREFIX%\conda" "..checkenv" "%WHAT_SHELL_AM_I%" "%CONDA_ENVNAME%"
 @IF errorlevel 1 (
 	@ENDLOCAL && (
 		@IF /I "%IS_ENV_CONDA_ENVNAME%"=="%TRUE%" (
@@ -242,7 +246,7 @@
 @SET "_IS_ENV_CONDA_VERBOSE=%IS_ENV_CONDA_VERBOSE%"
 
 @REM # ensure we deactivate any scripts from the old env                 #
-@CALL "deactivate.bat"
+@CALL "%CONDA_INSTALL_PREFIX%\deactivate.bat"
 @IF NOT errorlevel 0 (
 	@ENDLOCAL && (
 		@IF /I "%IS_ENV_CONDA_ENVNAME%"=="1" (
@@ -267,7 +271,7 @@
 @SET "CONDA_VERBOSE=%_CONDA_VERBOSE%"
 @SET "WHAT_SHELL_AM_I=%_CONDA_WHAT_SHELL_AM_I%"
 
-@FOR /F "delims=" %%i IN ('@CALL "conda" "..activate" "%WHAT_SHELL_AM_I%" "%CONDA_ENVNAME%"') DO @SET "_CONDA_BIN=%%i"
+@FOR /F "delims=" %%i IN ('@CALL "%CONDA_INSTALL_PREFIX%\conda" "..activate" "%WHAT_SHELL_AM_I%" "%CONDA_ENVNAME%"') DO @SET "_CONDA_BIN=%%i"
 @IF NOT errorlevel 0 (
 	@ENDLOCAL && (
 		@IF /I "%IS_ENV_CONDA_ENVNAME%"=="%TRUE%" (
@@ -319,7 +323,7 @@
 @REM # PROMPT & CONDA_PS1_BACKUP                                         #
 @REM # export PROMPT to restore upon deactivation                        #
 @REM # customize the PROMPT to show what environment has been activated  #
-@FOR /F "delims=" %%i IN ('@CALL "conda" "..changeps1"') DO @SET "_CONDA_CHANGEPS1=%%i"
+@FOR /F "delims=" %%i IN ('@CALL "%CONDA_INSTALL_PREFIX%\conda" "..changeps1"') DO @SET "_CONDA_CHANGEPS1=%%i"
 @IF /I "!_CONDA_CHANGEPS1!"=="1" @IF /I NOT "%PROMPT%"=="" (
 	@SET "CONDA_PS1_BACKUP=%PROMPT%"
 	@SET "PROMPT=(!CONDA_DEFAULT_ENV!) %PROMPT%"

--- a/shell/activate.csh
+++ b/shell/activate.csh
@@ -8,6 +8,10 @@
 # # use == "" instead of -z test (and != "" for -n) for robust support  # #
 # # across different platforms (especially Ubuntu)                      # #
 # #                                                                     # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
+# #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -35,7 +39,7 @@ switch ( `uname -s` )
                 setenv MSYS2_ENV_CONV_EXCL "CONDA_PATH"
             else
                 if ( "${MSYS2_ENV_CONV_EXCL}" != "CONDA_PATH" ) then
-                    setenv MSYS2_ENV_CONV_EXCL `envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL};CONDA_PATH" --delim=";" -d`
+                    setenv MSYS2_ENV_CONV_EXCL `${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL};CONDA_PATH" --delim=";" -d`
                 endif
             endif
         endif
@@ -151,7 +155,7 @@ endif
 ###########################################################################
 # HELP DIALOG                                                             #
 if ( "${CONDA_HELP}" == "${TRUE}" ) then
-    conda "..activate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
+    ${CONDA_INSTALL_PREFIX}/conda "..activate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
 
     unset WHAT_SHELL_AM_I
     if ( "${IS_ENV_CONDA_ENVNAME}" == "${FALSE}" ) then
@@ -187,7 +191,7 @@ unset UNKNOWN
 
 ###########################################################################
 # CHECK ENV AND DEACTIVATE OLD ENV                                        #
-conda "..checkenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
+${CONDA_INSTALL_PREFIX}/conda "..checkenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
 if ( $status != 0 ) then
     unset WHAT_SHELL_AM_I
     if ( "${IS_ENV_CONDA_ENVNAME}" == "${FALSE}" ) then
@@ -212,10 +216,7 @@ if ( $?MSYS2_ENV_CONV_EXCL ) then
 endif
 
 # ensure we deactivate any scripts from the old env                       #
-# beware of csh's `which` checking $PATH and aliases for matches          #
-# by using \deactivate we will refer to the "root" deactivate not the     #
-# aliased deactivate if it exists                                         #
-source "`which \deactivate.csh`" ""
+source "${CONDA_INSTALL_PREFIX}/deactivate.csh" ""
 if ( $status != 0 ) then
     unset _CONDA_WHAT_SHELL_AM_I
     if ( "${IS_ENV_CONDA_ENVNAME}" == "0" ) then
@@ -246,7 +247,7 @@ unset _IS_ENV_CONDA_VERBOSE
 unset _CONDA_VERBOSE
 unset _CONDA_WHAT_SHELL_AM_I
 
-set _CONDA_BIN=`conda "..activate" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}" | sed 's| |\ |g'`
+set _CONDA_BIN=`${CONDA_INSTALL_PREFIX}/conda "..activate" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}" | sed 's| |\ |g'`
 if ( $status != 0 ) then
     unset WHAT_SHELL_AM_I
     unset _CONDA_BIN
@@ -328,7 +329,7 @@ unset IS_ENV_CONDA_ENVNAME
 # PS1 & CONDA_PS1_BACKUP                                                  #
 # export PS1 to restore upon deactivation                                 #
 # customize the PS1 to show what environment has been activated           #
-if ( `conda "..changeps1"` == 1 && $?prompt ) then
+if ( `${CONDA_INSTALL_PREFIX}/conda "..changeps1"` == 1 && $?prompt ) then
     setenv CONDA_PS1_BACKUP "${prompt}"
     set prompt="(${CONDA_DEFAULT_ENV}) ${prompt}"
 endif

--- a/shell/activate.ps1
+++ b/shell/activate.ps1
@@ -3,6 +3,10 @@
 # #                                                                     # #
 # # ACTIVATE FOR WINDOWS POWERSHELL.EXE                                 # #
 # #                                                                     # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
+# #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -127,7 +131,7 @@ if ( "${CONDA_ENVNAME}" -eq "" ) { $CONDA_ENVNAME="root" }
 ###########################################################################
 # HELP DIALOG                                                             #
 if ( "${CONDA_HELP}" -eq "${TRUE}" ) {
-    conda "..activate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
+    ${CONDA_INSTALL_PREFIX}\conda "..activate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
 
     Remove-Variable WHAT_SHELL_AM_I
     if ( "${IS_ENV_CONDA_ENVNAME}" -eq "${TRUE}" ) { $env:CONDA_ENVNAME="${CONDA_ENVNAME}" }
@@ -157,7 +161,7 @@ Remove-Variable UNKNOWN
 
 ###########################################################################
 # CHECK ENV AND DEACTIVATE OLD ENV                                        #
-conda "..checkenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
+${CONDA_INSTALL_PREFIX}\conda "..checkenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
 if ( $lastexitcode -ne 0 ) {
     Remove-Variable WHAT_SHELL_AM_I
     if ( "${IS_ENV_CONDA_ENVNAME}" -eq "${TRUE}" ) { $env:CONDA_ENVNAME="${CONDA_ENVNAME}" }
@@ -175,7 +179,7 @@ $_CONDA_VERBOSE="${CONDA_VERBOSE}"
 $_IS_ENV_CONDA_VERBOSE="${IS_ENV_CONDA_VERBOSE}"
 
 # ensure we deactivate any scripts from the old env                       #
-. (Get-Command deactivate.ps1).path
+. "${CONDA_INSTALL_PREFIX}\deactivate.ps1"
 if ( $lastexitcode -ne 0 ) {
     Remove-Variable _CONDA_WHAT_SHELL_AM_I
     if ( "${IS_ENV_CONDA_ENVNAME}" -eq "${TRUE}" ) { $env:CONDA_ENVNAME="${CONDA_ENVNAME}" }
@@ -194,7 +198,7 @@ Remove-Variable _IS_ENV_CONDA_VERBOSE
 Remove-Variable _CONDA_VERBOSE
 Remove-Variable _CONDA_WHAT_SHELL_AM_I
 
-$_CONDA_BIN=conda "..activate" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
+$_CONDA_BIN=${CONDA_INSTALL_PREFIX}\conda "..activate" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
 if ( $lastexitcode -ne 0 ) {
     Remove-Variable WHAT_SHELL_AM_I
     Remove-Variable _CONDA_BIN
@@ -255,7 +259,7 @@ Remove-Variable IS_ENV_CONDA_ENVNAME
 #                                                                         #
 # TODO: this is much too complex to do here, delegate to Python           #
 # TODO: redesign conda ..changeps1 to actually return the new prompt      #
-if ( conda "..changeps1" -eq 1 -and (Get-Command Prompt).definition -ne "" ) {
+if ( ${CONDA_INSTALL_PREFIX}\conda "..changeps1" -eq 1 -and (Get-Command Prompt).definition -ne "" ) {
     $env:CONDA_PS1_BACKUP=Get-Content function:\Prompt
     # Set-Content function:\Prompt $env:CONDA_PS1_BACKUP
 }

--- a/shell/activate.sh
+++ b/shell/activate.sh
@@ -5,6 +5,10 @@
 # #                                                                     # #
 # # ACTIVATE FOR BOURNE-SHELL                                           # #
 # #                                                                     # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
+# #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -35,7 +39,7 @@ case "$(uname -s)" in
         # exclude CONDA_PATH from the Windows -> MSYS2 path
         # conversion and vice versa
         if [ -n "${MSYS2_ENV_CONV_EXCL+x}" ] && ! [ "${MSYS2_ENV_CONV_EXCL}" = "" ] && ! [ "${MSYS2_ENV_CONV_EXCL}" = "CONDA_PATH" ]; then
-            MSYS2_ENV_CONV_EXCL=$(envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL};CONDA_PATH" --delim=";" -d)
+            MSYS2_ENV_CONV_EXCL=$(${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL};CONDA_PATH" --delim=";" -d)
         else
             MSYS2_ENV_CONV_EXCL="CONDA_PATH"
         fi
@@ -131,7 +135,7 @@ unset is_envname_set
 ###########################################################################
 # HELP DIALOG                                                             #
 if [ "${CONDA_HELP}" = "${TRUE}" ]; then
-    conda "..activate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
+    ${CONDA_INSTALL_PREFIX}/conda "..activate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
 
     unset WHAT_SHELL_AM_I
     [ "${IS_ENV_CONDA_ENVNAME}" = "${FALSE}" ] && unset CONDA_ENVNAME
@@ -159,7 +163,7 @@ unset UNKNOWN
 
 ###########################################################################
 # CHECK ENV AND DEACTIVATE OLD ENV                                        #
-conda "..checkenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
+${CONDA_INSTALL_PREFIX}/conda "..checkenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
 if [ $? != 0 ]; then
     unset WHAT_SHELL_AM_I
     [ "${IS_ENV_CONDA_ENVNAME}" = "${FALSE}" ] && unset CONDA_ENVNAME
@@ -180,7 +184,7 @@ if [ -n "${MSYS2_ENV_CONV_EXCL+x}" ]; then
 fi
 
 # ensure we deactivate any scripts from the old env                       #
-. deactivate.sh ""
+. "${CONDA_INSTALL_PREFIX}/deactivate.sh" ""
 if [ $? != 0 ]; then
     unset _CONDA_WHAT_SHELL_AM_I
     [ "${IS_ENV_CONDA_ENVNAME}" = "0" ] && unset CONDA_ENVNAME
@@ -210,7 +214,7 @@ unset _IS_ENV_CONDA_VERBOSE
 unset _CONDA_VERBOSE
 unset _CONDA_WHAT_SHELL_AM_I
 
-_CONDA_BIN=$(conda "..activate" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}" | sed 's| |\ |')
+_CONDA_BIN=$(${CONDA_INSTALL_PREFIX}/conda "..activate" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}" | sed 's| |\ |')
 if [ $? != 0 ]; then
     unset WHAT_SHELL_AM_I
     unset _CONDA_BIN
@@ -269,7 +273,7 @@ unset IS_ENV_CONDA_ENVNAME
 # PS1 & CONDA_PS1_BACKUP                                                  #
 # export PS1 to restore upon deactivation                                 #
 # customize the PS1 to show what environment has been activated           #
-if [ "$(conda "..changeps1")" = "1" ] && [ -n "${PS1+x}" ]; then
+if [ "$(${CONDA_INSTALL_PREFIX}/conda "..changeps1")" = "1" ] && [ -n "${PS1+x}" ]; then
     CONDA_PS1_BACKUP="${PS1}"
     PS1="(${CONDA_DEFAULT_ENV}) ${PS1}"
     export CONDA_PS1_BACKUP

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -11,35 +11,48 @@
 # # DEACTIVATE                                                          # #
 # # if tree that determined which deactivate script to run              # #
 # #                                                                     # #
-# # assumes that activate*/deactivate*/whichshell*/envvar_cleanup*      # #
-# # exists on the user's $PATH                                          # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
 # #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 ###########################################################################
 # ERROR CLAUSE                                                            #
-whichshell_args.bash "deactivate" "error-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
-awk -f "`which whichshell.awk`" || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "deactivate"                                                          \
+    "error-clause"                                                        \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    : ||                                                                  \
+    :
 # END ERROR CLAUSE                                                        #
 ###########################################################################
 
 ###########################################################################
 # BOURNE SHELL CLAUSE                                                     #
 # bash/zsh/dash/posh/ksh                                                  #
-whichshell_args.bash "deactivate" "bourne-shell-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
-awk -f "`which whichshell.awk`" && . deactivate.sh || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "deactivate"                                                          \
+    "bourne-shell-clause"                                                 \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    . ${CONDA_INSTALL_PREFIX}/deactivate.sh ||                            \
+    :
 # END BOURNE SHELL CLAUSE                                                 #
 ###########################################################################
 
 ###########################################################################
 # C-SHELL CLAUSE                                                          #
 # tcsh/csh                                                                #
-whichshell_args.bash "deactivate" "c-shell-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
-awk -f "`which whichshell.awk`" && source "`which deactivate.csh`" || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "deactivate"                                                          \
+    "c-shell-clause"                                                      \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo 'csh'` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    source "${CONDA_INSTALL_PREFIX}/deactivate.csh" ||                    \
+    :
 # END C-SHELL CLAUSE                                                      #
 ###########################################################################
 

--- a/shell/deactivate.bat
+++ b/shell/deactivate.bat
@@ -10,6 +10,10 @@
 @REM # # this file is also indented using TABS instead of SPACES to    # #
 @REM # # avoid very odd syntax errors                                  # #
 @REM # #                                                               # #
+@REM # # the setuptools will properly substitute the                   # #
+@REM # # CONDA_INSTALL_PREFIX upon install into the conda              # #
+@REM # # executable bin [see the install_scripts function of setup.py] # #
+@REM # #                                                               # #
 @REM # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 @REM # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -181,7 +185,7 @@
 @REM #####################################################################
 @REM # HELP DIALOG                                                       #
 @IF /I "%CONDA_HELP%"=="%TRUE%" (
-	@CALL "conda" "..deactivate" "%WHAT_SHELL_AM_I%" "-h" "%UNKNOWN%"
+	@CALL "%CONDA_INSTALL_PREFIX%\conda" "..deactivate" "%WHAT_SHELL_AM_I%" "-h" "%UNKNOWN%"
 
 	@ENDLOCAL && (
 		@IF /I "%IS_ENV_CONDA_HELP%"=="%TRUE%" (
@@ -224,7 +228,7 @@
 @REM # removed but they will all start with the same %CONDA_PREFIX%,     #
 @REM # consequently we will use fuzzy matching [/f] to get all of the    #
 @REM # relevant removals                                                 #
-@FOR /F "delims=" %%i IN ('@CALL "envvar_cleanup.bat" "%PATH%" /delim=";" /u /f "%CONDA_PREFIX%"') DO @SET "PATH=%%i"
+@FOR /F "delims=" %%i IN ('@CALL "%CONDA_INSTALL_PREFIX%\envvar_cleanup.bat" "%PATH%" /delim=";" /u /f "%CONDA_PREFIX%"') DO @SET "PATH=%%i"
 @IF NOT errorlevel 0 (
 	@ENDLOCAL && (
 		@IF /I "%IS_ENV_CONDA_VERBOSE%"=="%TRUE%" (

--- a/shell/deactivate.csh
+++ b/shell/deactivate.csh
@@ -8,6 +8,10 @@
 # # use == "" instead of -z test (and != "" for -n) for robust support  # #
 # # across different platforms (especially Ubuntu)                      # #
 # #                                                                     # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
+# #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -35,7 +39,7 @@ switch ( `uname -s` )
                 setenv MSYS2_ENV_CONV_EXCL "CONDA_PATH"
             else
                 if ( "${MSYS2_ENV_CONV_EXCL}" != "CONDA_PATH" ) then
-                    setenv MSYS2_ENV_CONV_EXCL `envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL};CONDA_PATH" --delim=";" -d`
+                    setenv MSYS2_ENV_CONV_EXCL `${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL};CONDA_PATH" --delim=";" -d`
                 endif
             endif
         endif
@@ -131,7 +135,7 @@ endif
 ###########################################################################
 # HELP DIALOG                                                             #
 if ( "${CONDA_HELP}" == "${TRUE}" ) then
-    conda "..deactivate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
+    ${CONDA_INSTALL_PREFIX}/conda "..deactivate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
 
     unset WHAT_SHELL_AM_I
     if ( "${IS_ENV_CONDA_HELP}" == "${FALSE}" ) then
@@ -178,7 +182,7 @@ if ( "${BAD_DEACTIVATE}" == "${TRUE}" ) then
     endif
     unset IS_ENV_CONDA_VERBOSE
     if ( $?MSYS2_ENV_CONV_EXCL ) then
-        setenv MSYS2_ENV_CONV_EXCL=`envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL}" --delim=";" -r "CONDA_PATH"`
+        setenv MSYS2_ENV_CONV_EXCL=`${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL}" --delim=";" -r "CONDA_PATH"`
         if ( "${MSYS2_ENV_CONV_EXCL}" == "" ) then
             unsetenv MSYS2_ENV_CONV_EXCL
         endif
@@ -196,7 +200,7 @@ endif
 # to avoid cases when path setting succeeds and is parsed correctly from  #
 # one to the other                                                        #
 set tmp_PATH="${PATH}"
-set PATH=(`envvar_cleanup.bash "${tmp_PATH}" --delim=":" -u -f "${CONDA_PREFIX}"`)
+set PATH=(`${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${tmp_PATH}" --delim=":" -u -f "${CONDA_PREFIX}"`)
 if ( $status != 0 ) then
     unset tmp_PATH
     if ( "${IS_ENV_CONDA_VERBOSE}" == "${FALSE}" ) then
@@ -263,7 +267,7 @@ rehash
 ###########################################################################
 # CLEANUP VARS FOR THIS SCOPE                                             #
 if ( $?MSYS2_ENV_CONV_EXCL ) then
-    setenv MSYS2_ENV_CONV_EXCL=`envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL}" --delim=";" -r "CONDA_PATH"`
+    setenv MSYS2_ENV_CONV_EXCL=`${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL}" --delim=";" -r "CONDA_PATH"`
     if ( "${MSYS2_ENV_CONV_EXCL}" == "" ) then
         unsetenv MSYS2_ENV_CONV_EXCL
     endif

--- a/shell/deactivate.ps1
+++ b/shell/deactivate.ps1
@@ -3,6 +3,10 @@
 # #                                                                     # #
 # # DEACTIVATE FOR WINDOWS POWERSHELL.EXE                               # #
 # #                                                                     # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
+# #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -104,7 +108,7 @@ if ( "${CONDA_VERBOSE}" -eq "" ) { $CONDA_VERBOSE="${FALSE}" }
 ###########################################################################
 # HELP DIALOG                                                             #
 if ( "${CONDA_HELP}" -eq "${TRUE}" ) {
-    conda "..deactivate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
+    ${CONDA_INSTALL_PREFIX}\conda "..deactivate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
 
     Remove-Variable WHAT_SHELL_AM_I
     if ( "${IS_ENV_CONDA_HELP}" -eq "${TRUE}" ) { $env:CONDA_HELP="${CONDA_HELP}" }
@@ -151,7 +155,7 @@ if ( -not ((Get-ChildItem env:).Name | Select-String -pattern CONDA_PREFIX) -or 
 #                                                                         #
 # replace ; with ? before calling batch program since powershell to batch #
 # converts ; to linebreaks without explicit escaping \;                   #
-$env:Path=(envvar_cleanup.bat ${env:PATH}.replace(";","?") --delim="?" -u -f "${env:CONDA_PREFIX}").replace("?",";")
+$env:Path=(${CONDA_INSTALL_PREFIX}\envvar_cleanup.bat ${env:PATH}.replace(";","?") --delim="?" -u -f "${env:CONDA_PREFIX}").replace("?",";")
 if ( $lastexitcode -ne 0 ) {
     if ( "${IS_ENV_CONDA_VERBOSE}" -eq "${TRUE}" ) { $env:CONDA_VERBOSE="${CONDA_VERBOSE}" }
     Remove-Variable CONDA_VERBOSE

--- a/shell/deactivate.sh
+++ b/shell/deactivate.sh
@@ -5,6 +5,10 @@
 # #                                                                     # #
 # # DEACTIVATE FOR BOURNE-SHELL                                         # #
 # #                                                                     # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
+# #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -35,7 +39,7 @@ case "$(uname -s)" in
         # exclude CONDA_PATH from the Windows -> Cygwin Et Al. path
         # conversion and vice versa
         if [ -n "${MSYS2_ENV_CONV_EXCL+x}" ] && ! [ "${MSYS2_ENV_CONV_EXCL}" = "" ] && ! [ "${MSYS2_ENV_CONV_EXCL}" = "CONDA_PATH" ]; then
-            MSYS2_ENV_CONV_EXCL=$(envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL};CONDA_PATH" --delim=";" -d)
+            MSYS2_ENV_CONV_EXCL=$(${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL};CONDA_PATH" --delim=";" -d)
         else
             MSYS2_ENV_CONV_EXCL="CONDA_PATH"
         fi
@@ -116,7 +120,7 @@ unset arg
 ###########################################################################
 # HELP DIALOG                                                             #
 if [ "${CONDA_HELP}" = "${TRUE}" ]; then
-    conda "..deactivate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
+    ${CONDA_INSTALL_PREFIX}/conda "..deactivate" "${WHAT_SHELL_AM_I}" "-h" ${UNKNOWN}
 
     unset WHAT_SHELL_AM_I
     [ "${IS_ENV_CONDA_HELP}" = "${FALSE}" ]    && unset CONDA_HELP
@@ -147,7 +151,7 @@ if [ -z "${CONDA_PREFIX+x}" ] || [ -z "${CONDA_PREFIX}" ]; then
     [ "${IS_ENV_CONDA_VERBOSE}" = "${FALSE}" ] && unset CONDA_VERBOSE
     unset IS_ENV_CONDA_VERBOSE
     if [ -n "${MSYS2_ENV_CONV_EXCL+x}" ]; then
-        MSYS2_ENV_CONV_EXCL=$(envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL}" --delim=";" -r "CONDA_PATH")
+        MSYS2_ENV_CONV_EXCL=$(${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL}" --delim=";" -r "CONDA_PATH")
         [ "${MSYS2_ENV_CONV_EXCL}" = "" ] && unset MSYS2_ENV_CONV_EXCL
     fi
     unset TRUE
@@ -163,7 +167,7 @@ fi
 # Unix we will only expect a single path that need to be removed, for     #
 # simplicity and consistency with the Windows *.bat scripts we will use   #
 # fuzzy matching (/f) to get all of the relevant removals                 #
-PATH=$(envvar_cleanup.bash "${PATH}" --delim=":" -u -f "${CONDA_PREFIX}")
+PATH=$(${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${PATH}" --delim=":" -u -f "${CONDA_PREFIX}")
 if [ $? != 0 ]; then
     [ "${IS_ENV_CONDA_VERBOSE}" = "${FALSE}" ] && unset CONDA_VERBOSE
     unset IS_ENV_CONDA_VERBOSE
@@ -240,7 +244,7 @@ fi
 ###########################################################################
 # CLEANUP VARS FOR THIS SCOPE                                             #
 if [ -n "${MSYS2_ENV_CONV_EXCL+x}" ]; then
-    MSYS2_ENV_CONV_EXCL=$(envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL}" --delim=";" -r "CONDA_PATH")
+    MSYS2_ENV_CONV_EXCL=$(${CONDA_INSTALL_PREFIX}/envvar_cleanup.bash "${MSYS2_ENV_CONV_EXCL}" --delim=";" -r "CONDA_PATH")
     [ "${MSYS2_ENV_CONV_EXCL}" = "" ] && unset MSYS2_ENV_CONV_EXCL
 fi
 unset TRUE

--- a/shell/test_whichshell
+++ b/shell/test_whichshell
@@ -12,7 +12,9 @@
 # # interact with the whichshell* scripts to see how they respond in    # #
 # # certain scenarios                                                   # #
 # #                                                                     # #
-# # assumes that whichshell*/envvar_cleanup* exists on the user's $PATH # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
 # #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -21,45 +23,63 @@ echo "TEST_WHICHSHELL"
 echo ""
 
 echo "WHICHSHELL_PS.BASH"
-whichshell_ps.bash && echo "NOT (t)csh" || echo "IS (t)csh"
-whichshell_ps.bash && eval 'echo $0' || echo "csh"
+${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && echo "NOT (t)csh" || echo "IS (t)csh"
+${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo "csh"
 echo ""
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 echo "WHICHSHELL_ARGS.BASH: ERROR-CLAUSE"
-whichshell_args.bash "test_whichshell" "error-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo "csh"`
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "test_whichshell"                                                     \
+    "error-clause"                                                        \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo "csh"`
 echo ""
 
 echo "WHICHSHELL_ARGS.BASH: BOURNE-SHELL-CLAUSE"
-whichshell_args.bash "test_whichshell" "bourne-shell-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo "csh"`
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "test_whichshell"                                                     \
+    "bourne-shell-clause"                                                 \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo "csh"`
 echo ""
 
 echo "WHICHSHELL_ARGS.BASH: C-SHELL-CLAUSE"
-whichshell_args.bash "test_whichshell" "c-shell-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo "csh"`
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "test_whichshell"                                                     \
+    "c-shell-clause"                                                      \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo "csh"`
 echo ""
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 echo "WHICHSHELL.AWK: ERROR-CLAUSE"
-whichshell_args.bash "test_whichshell" "error-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo "csh"` | \
-awk -f "`which whichshell.awk`" && echo "++ SELECTED ++" || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "test_whichshell"                                                     \
+    "error-clause"                                                        \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo "csh"` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    echo "++ SELECTED ++" ||                                              \
+    :
 echo ""
 
 echo "WHICHSHELL.AWK: BOURNE-SHELL-CLAUSE"
-whichshell_args.bash "test_whichshell" "bourne-shell-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo "csh"` | \
-awk -f "`which whichshell.awk`" && echo "++ SELECTED ++" || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "test_whichshell"                                                     \
+    "bourne-shell-clause"                                                 \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo "csh"` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    echo "++ SELECTED ++" ||                                              \
+    :
 echo ""
 
 echo "WHICHSHELL.AWK: C-SHELL-CLAUSE"
-whichshell_args.bash "test_whichshell" "c-shell-clause" \
-`whichshell_ps.bash && eval 'echo $0' || echo "csh"` | \
-awk -f "`which whichshell.awk`" && echo "++ SELECTED ++" || :
+${CONDA_INSTALL_PREFIX}/whichshell_args.bash                              \
+    "test_whichshell"                                                     \
+    "c-shell-clause"                                                      \
+    `${CONDA_INSTALL_PREFIX}/whichshell_ps.bash && eval 'echo $0' || echo "csh"` | \
+awk -f "${CONDA_INSTALL_PREFIX}/whichshell.awk" &&                        \
+    echo "++ SELECTED ++" ||                                              \
+    :
 echo ""

--- a/shell/whichshell_args.bash
+++ b/shell/whichshell_args.bash
@@ -9,13 +9,17 @@
 # #                                                                     # #
 # # this works in conjunction with the other whichshell*                # #
 # #                                                                     # #
+# # the setuptools will properly substitute the CONDA_INSTALL_PREFIX    # #
+# # upon install into the conda executable bin (see the install_scripts # #
+# # function of setup.py)                                               # #
+# #                                                                     # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 ###########################################################################
 # DETECT PARENT PROGRAM                                                   #
 # since this is already an executable we need to get this parent          #
-PARENT_PROCESS=$(whichshell_ps.bash $$ -v)
+PARENT_PROCESS=$(${CONDA_INSTALL_PREFIX}/whichshell_ps.bash $$ -v)
 # END DETECT PARENT PROGRAM                                               #
 ###########################################################################
 


### PR DESCRIPTION
A preliminary idea that appears to work correctly and address the issues raised after #3175 was merged.

Prepends the `$CONDA_INSTALL_PREFIX` value to all of the `activate`/`deactivate` (and related) scripts that previously assumed that the scripts could be found on the user's `$PATH`.

As a helpful bonus this fix may result in an option for `activate`/`deactivate` unittests to not require conda to be installed (and instead just set the `$CONDA_INSTALL_PREFIX` environment variable prior to running the unittests).