### PR TITLE
Fix location of temporary hard links of index.json

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -75,17 +75,17 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
         # is_local: if the tarball is stored locally (file://)
         # is_cache: if the tarball is sitting in our cache
         is_local = not is_url(url) or url.startswith('file://')
-        prefix = cached_url(url) if is_local else None
-        is_cache = prefix is not None
+        url_prefix = cached_url(url) if is_local else None
+        is_cache = url_prefix is not None
         if is_cache:
             # Channel information from the cache
-            schannel = 'defaults' if prefix == '' else prefix[:-2]
+            schannel = 'defaults' if url_prefix == '' else url_prefix[:-2]
         else:
             # Channel information from the URL
             channel, schannel = Channel(url).url_channel_wtf
-            prefix = '' if schannel == 'defaults' else schannel + '::'
+            url_prefix = '' if schannel == 'defaults' else schannel + '::'
 
-        fn = prefix + fn
+        fn = url_prefix + fn
         dist = fn[:-8]
         # Add explicit file to index so we'll be sure to see it later
         if is_local:


### PR DESCRIPTION
The command:
$ conda install https://repo.continuum.io/pkgs/free/linux-64/affine-1.1.0-py27_0.tar.bz2 --debug

Reveals:
DEBUG conda.common.disk:rm_rf(198): rm_rf /home/wani/conda/.tmp-affine-1.1.0-py27_0

The command:
$ conda install /tmp/affine-1.1.0-py27_0.tar.bz2 --debug

Reveals:
DEBUG conda.common.disk:rm_rf(198): rm_rf /home/wani/conda/file:/tmp::/.tmp-affine-1.1.0-py27_0

As is evident, when the protocol is file://, conda creates a bogus
folder by the name: file:/ + /path/to/folder/of/tar.gz + '::'

The variable 'prefix' is required by the function try_hard_link().
We shouldn't modify it before that. This change ensures that the
file ${prefix}/.tmp-${pkgname} is indeed created inside the folder
${prefix}.