### PR TITLE
Allow path in (de)activate.d

### DIFF
--- a/shell/activate.bat
+++ b/shell/activate.bat
@@ -333,19 +333,6 @@
 @REM # scope                                                             #
 @SET "_CONDA_DIR=%CONDA_PREFIX%\etc\conda\activate.d"
 @ENDLOCAL && (
-	@REM load post-activate scripts
-	@REM scripts found in %CONDA_PREFIX%\etc\conda\activate.d
-	@IF EXIST "%_CONDA_DIR%" (
-		@PUSHD "%_CONDA_DIR%"
-		@FOR %%f IN (*.bat) DO @(
-			@IF "%CONDA_VERBOSE%"=="%TRUE%" (
-				@ECHO [ACTIVATE]: Sourcing %_CONDA_DIR%\%%f.
-			)
-			@CALL "%%f"
-		)
-		@POPD
-	)
-
 	@SET "PATH=%PATH%"
 	@SET "PROMPT=%PROMPT%"
 
@@ -361,6 +348,19 @@
 	)
 	@IF /I "%IS_ENV_CONDA_HELP%"=="%TRUE%" (
 		@SET "CONDA_HELP=%CONDA_HELP%"
+	)
+
+	@REM load post-activate scripts
+	@REM scripts found in %CONDA_PREFIX%\etc\conda\activate.d
+	@IF EXIST "%_CONDA_DIR%" (
+		@PUSHD "%_CONDA_DIR%"
+		@FOR %%f IN (*.bat) DO @(
+			@IF "%CONDA_VERBOSE%"=="%TRUE%" (
+				@ECHO [ACTIVATE]: Sourcing %_CONDA_DIR%\%%f.
+			)
+			@CALL "%%f"
+		)
+		@POPD
 	)
 
 	@REM #################################################################

--- a/shell/deactivate.bat
+++ b/shell/deactivate.bat
@@ -253,19 +253,6 @@
 @REM # scope                                                             #
 @SET "_CONDA_DIR=%CONDA_PREFIX%\etc\conda\deactivate.d"
 @ENDLOCAL && (
-	@REM load post-deactivate scripts
-	@REM scripts found in %CONDA_PREFIX%\etc\conda\deactivate.d
-	@IF EXIST "%_CONDA_DIR%" (
-		@PUSHD "%_CONDA_DIR%"
-		@FOR %%f IN (*.bat) DO @(
-			@IF "%CONDA_VERBOSE%"=="%TRUE%" (
-				@ECHO [DEACTIVATE]: Sourcing %_CONDA_DIR%\%%f.
-			)
-			@CALL "%%f"
-		)
-		@POPD
-	)
-
 	@SET "PATH=%PATH%"
 	@SET "PROMPT=%PROMPT%"
 
@@ -279,6 +266,19 @@
 	)
 	@IF /I "%IS_ENV_CONDA_HELP%"=="%TRUE%" (
 		@SET "CONDA_HELP=%CONDA_HELP%"
+	)
+
+	@REM load post-deactivate scripts
+	@REM scripts found in %CONDA_PREFIX%\etc\conda\deactivate.d
+	@IF EXIST "%_CONDA_DIR%" (
+		@PUSHD "%_CONDA_DIR%"
+		@FOR %%f IN (*.bat) DO @(
+			@IF "%CONDA_VERBOSE%"=="%TRUE%" (
+				@ECHO [DEACTIVATE]: Sourcing %_CONDA_DIR%\%%f.
+			)
+			@CALL "%%f"
+		)
+		@POPD
 	)
 
 	@REM #################################################################


### PR DESCRIPTION
Address #3915 

Moves the post-activate and pre-deactivate script processing to after setting local variables to global scope variables in Windows CMD.exe. This allows the user to customize their %PATH% in the pre-/post- processing.