### PR TITLE
Activate trims environment for prompt

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -89,7 +89,7 @@ def _main():
     log.debug("conda.cli.main called with %s", sys.argv)
     if len(sys.argv) > 1:
         argv1 = sys.argv[1].strip()
-        if argv1 in ('..activate', '..deactivate', '..checkenv', '..changeps1'):
+        if argv1 in ('..activate', '..deactivate', '..checkenv', '..trimmedenv', '..changeps1'):
             import conda.cli.activate as activate
             activate.main()
             return

--- a/shell/activate.bat
+++ b/shell/activate.bat
@@ -305,13 +305,7 @@
 @REM # the shortest representation of how conda recognizes your env      #
 @REM # can be an env name, or a full path [if the string contains \ it's #
 @REM # a path]                                                           #
-@IF /I NOT "%CONDA_ENVNAME:\=%"=="%CONDA_ENVNAME%" (
-	@FOR /F "delims=" %%i IN ("%CONDA_ENVNAME%") DO @SET "d=%%~dpi"
-	@FOR /F "delims=" %%i IN ("%CONDA_ENVNAME%") DO @SET "f=%%~ni"
-	@SET "CONDA_DEFAULT_ENV=!d!!f!"
-) ELSE (
-	@SET "CONDA_DEFAULT_ENV=%CONDA_ENVNAME%"
-)
+@FOR /F "delims=" %%i IN ('@CALL "conda" "..trimmedenv" "%WHAT_SHELL_AM_I%" "%CONDA_ENVNAME%"') DO @SET "CONDA_DEFAULT_ENV=%%i"
 @REM # END CONDA_DEFAULT_ENV                                             #
 @REM #####################################################################
 

--- a/shell/activate.csh
+++ b/shell/activate.csh
@@ -262,7 +262,6 @@ if ( $status != 0 ) then
     unset FALSE
     exit 1
 endif
-unset WHAT_SHELL_AM_I
 # END CHECK ENV AND DEACTIVATE OLD ENV                                    #
 ###########################################################################
 
@@ -307,20 +306,12 @@ unset _CONDA_BIN
 # the shortest representation of how conda recognizes your env            #
 # can be an env name, or a full path (if the string contains / it's a     #
 # path)                                                                   #
-if ( `echo "${CONDA_ENVNAME}" | awk '{exit(match($0,/.*\/.*/) != 0)}'` ) then
-    set d=`dirname "${CONDA_ENVNAME}"`
-    set d=`cd "${d}" && pwd`
-    set f=`basename "${CONDA_ENVNAME}"`
-    setenv CONDA_DEFAULT_ENV "${d}/${f}"
-    unset d
-    unset f
-else
-    setenv CONDA_DEFAULT_ENV "${CONDA_ENVNAME}"
-endif
+set CONDA_DEFAULT_ENV=`conda "..trimmedenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}" | sed 's| |\ |g'`
 if ( "${IS_ENV_CONDA_ENVNAME}" == "${FALSE}" ) then
     unset CONDA_ENVNAME
 endif
 unset IS_ENV_CONDA_ENVNAME
+unset WHAT_SHELL_AM_I
 # END CONDA_DEFAULT_ENV                                                   #
 ###########################################################################
 

--- a/shell/activate.ps1
+++ b/shell/activate.ps1
@@ -206,7 +206,6 @@ if ( $lastexitcode -ne 0 ) {
     Remove-Variable IS_ENV_CONDA_VERBOSE
     exit 1
 }
-Remove-Variable WHAT_SHELL_AM_I
 # END CHECK ENV AND DEACTIVATE OLD ENV                                    #
 ###########################################################################
 
@@ -231,20 +230,11 @@ Remove-Variable _CONDA_BIN
 # the shortest representation of how conda recognizes your env            #
 # can be an env name, or a full path (if the string contains \ it's a     #
 # path)                                                                   #
-if ( ${CONDA_ENVNAME} -match '\\' ) {
-    # $d=Split-Path -Path "${CONDA_ENVNAME}"
-    # $d=Resolve-Path "${d}"
-    # $f=Split-Path -Leaf "${CONDA_ENVNAME}"
-    # $env:CONDA_DEFAULT_ENV="${d}\${f}"
-    # Remove-Variable d
-    # Remove-Variable f
-    $env:CONDA_DEFAULT_ENV=Resolve-Path "${CONDA_ENVNAME}"
-} else {
-    $env:CONDA_DEFAULT_ENV="${CONDA_ENVNAME}"
-}
+$env:CONDA_DEFAULT_ENV=conda "..trimmedenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}"
 if ( "${IS_ENV_CONDA_ENVNAME}" -eq "${TRUE}" ) { $env:CONDA_ENVNAME="${CONDA_ENVNAME}" }
 Remove-Variable CONDA_ENVNAME
 Remove-Variable IS_ENV_CONDA_ENVNAME
+Remove-Variable WHAT_SHELL_AM_I
 # END CONDA_DEFAULT_ENV                                                   #
 ###########################################################################
 

--- a/shell/activate.sh
+++ b/shell/activate.sh
@@ -222,7 +222,6 @@ if [ $? != 0 ]; then
     unset FALSE
     return 1
 fi
-unset WHAT_SHELL_AM_I
 # END CHECK ENV AND DEACTIVATE OLD ENV                                    #
 ###########################################################################
 
@@ -249,19 +248,11 @@ unset _CONDA_BIN
 # the shortest representation of how conda recognizes your env            #
 # can be an env name, or a full path (if the string contains / it's a     #
 # path)                                                                   #
-if [ "$(echo ${CONDA_ENVNAME} | awk '{exit(match($0,/.*\/.*/) != 0)}')" ]; then
-    d=$(dirname "${CONDA_ENVNAME}")
-    d=$(cd "${d}" && pwd)
-    f=$(basename "${CONDA_ENVNAME}")
-    CONDA_DEFAULT_ENV="${d}/${f}"
-    unset d
-    unset f
-else
-    CONDA_DEFAULT_ENV="${CONDA_ENVNAME}"
-fi
+CONDA_DEFAULT_ENV=$(conda "..trimmedenv" "${WHAT_SHELL_AM_I}" "${CONDA_ENVNAME}" | sed 's| |\ |')
 export CONDA_DEFAULT_ENV
 [ "${IS_ENV_CONDA_ENVNAME}" = "${FALSE}" ] && unset CONDA_ENVNAME
 unset IS_ENV_CONDA_ENVNAME
+unset WHAT_SHELL_AM_I
 # END CONDA_DEFAULT_ENV                                                   #
 ###########################################################################
 


### PR DESCRIPTION
Address a concern mentioned in #3992 by @traff. And in a far fetched way addresses #3808.

This fix has every `activate` check if an activating environment is in env_dirs and if it is then only the environment name (the path basename) is used to prefix the prompt. If an activating environment is not in env_dirs then it is absoluted and the full path is used for the prompt prefix. This feature was added as a new conda function: `conda ..trimmedenv <SHELL> <ENV>`

As far as I can tell this has no conflicts with my updates to the PowerShell PR #3960 but does extend this new feature to PS.

Yay for less shell scripting!

I am fully aware that this has broken several unittests because previously conda activate would not absolute relative paths (which is what the unittests currently test for).

Just want to confirm that this is a good idea before fixing the tests.