### PR TITLE
[DO NOT MERGE] Hack: Work around (maybe broken?) LocalFSAdapter

### DIFF
--- a/conda/fetch.py
+++ b/conda/fetch.py
@@ -18,6 +18,7 @@ from logging import DEBUG, getLogger
 from os.path import basename, dirname, join
 from requests.exceptions import ConnectionError, HTTPError, SSLError
 from requests.packages.urllib3.connectionpool import InsecureRequestWarning
+from requests_file import FileAdapter
 from warnings import warn
 
 from ._vendor.auxlib.ish import dals
@@ -105,6 +106,7 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
         headers["If-Modified-Since"] = cache["_mod"]
 
     if 'repo.continuum.io' in url or url.startswith("file://"):
+        session.mount('file://', FileAdapter())
         filename = 'repodata.json.bz2'
         headers['Accept-Encoding'] = 'identity'
     else:


### PR DESCRIPTION
Since https://github.com/kennethreitz/requests/commit/34af72c87d79bd8852e8564c050dd7711c6a08d6 requests no longer handles `file://`.

Although we *have* our own LocalFSAdapter, to me, it looks incomplete and doesn't seem to be working:

```
$ /home/ray/mc-x64-3.5/bin/conda install -c file:///home/ray/gd.cio/r-language/r-3.3.2 r-essentials

    Traceback (most recent call last):
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/exceptions.py", line 479, in conda_exception_handler
        return_value = func(*args, **kwargs)
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/cli/main.py", line 145, in _main
        exit_code = args.func(args, p)
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/cli/main_install.py", line 80, in execute
        install(args, parser, 'install')
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/cli/install.py", line 238, in install
        prefix=prefix)
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/api.py", line 24, in get_index
        index = fetch_index(channel_urls, use_cache=use_cache, unknown=unknown)
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/fetch.py", line 301, in fetch_index
        repodatas = [(u, f.result()) for u, f in zip(urls, futures)]
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/fetch.py", line 301, in <listcomp>
        repodatas = [(u, f.result()) for u, f in zip(urls, futures)]
      File "/home/ray/mc-x64-3.5/lib/python3.5/concurrent/futures/_base.py", line 398, in result
        return self.__get_result()
      File "/home/ray/mc-x64-3.5/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
        raise self._exception
      File "/home/ray/mc-x64-3.5/lib/python3.5/concurrent/futures/thread.py", line 55, in run
        result = self.fn(*self.args, **self.kwargs)
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/fetch.py", line 75, in func
        res = f(*args, **kwargs)
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/conda/fetch.py", line 118, in fetch_repodata
        timeout=(6.1, 60))
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/requests/sessions.py", line 501, in get
        return self.request('GET', url, **kwargs)
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/requests/sessions.py", line 488, in request
        resp = self.send(prep, **send_kwargs)
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/requests/sessions.py", line 641, in send
        r.content
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/requests/models.py", line 781, in content
        self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
      File "/home/ray/mc-x64-3.5/lib/python3.5/site-packages/requests/models.py", line 714, in generate
        chunk = self.raw.read(chunk_size)
    AttributeError: 'FileNotFoundError' object has no attribute 'read'
```

I have 'fixed' this by using a different adapter, from the requests-file project in a very hacky way. Using this, I get:

```
$ /home/ray/mc-x64-3.5/bin/conda install -c file:///home/ray/gd.cio/r-language/r-3.3.2 r-essentials

Fetching package metadata ...........
Solving package specifications: ..........

# All requested packages already installed.
# packages in environment at /home/ray/mc-x64-3.5:
#
r-essentials              1.5.0                         0    file:///home/ray/gd.cio/r-language/r-3.3.2
```