### PR TITLE
MNT: Elevate message about conda lock to warning

### DIFF
--- a/conda/lock.py
+++ b/conda/lock.py
@@ -82,8 +82,8 @@ class FileLock(object):
             # search, whether there is process already locked on this file
             glob_result = glob(self.lock_file_glob_str)
             if glob_result:
-                log.debug(LOCKSTR.format(glob_result))
-                log.debug("Sleeping for %s seconds", sleep_time)
+                log.warning(LOCKSTR.format(glob_result))
+                log.warning("Sleeping for %s seconds", sleep_time)
 
                 time.sleep(sleep_time / 10)
                 sleep_time *= 2


### PR DESCRIPTION
It is frustrating to sit at an empty command prompt whenever conda
detects a lock file.  It is rarely obvious why conda is stalled out.
That sometimes become clear when you ctrl+c and see the stack trace is
sitting at a time.sleep call.  Is there any reason *not* to tell the
user that you're just waiting for a lock file? That way the user knows
(1) why conda is stalled and (2) what they can do to resolve the
problem.  I regularly hit this 'stalled conda' problem after I ctrl+c
during file downloads.

Whether or not it *needs* to be elevated to logger.warning is up for debate,
but having this "hey there's a lock file" message shown in the console would be
useful