### PR TITLE
Get install actions for requrired specs

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -474,18 +474,20 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
                     channel_priority_map=None, is_update=False):
     # type: (str, Dict[Dist, Record], List[str], bool, Option[List[str]], bool, bool, bool,
     #        bool, bool, bool, Dict[str, Sequence[str, int]]) -> Dict[weird]
+    str_specs = specs
     specs = [MatchSpec(spec) for spec in specs]
     r = get_resolve_object(index.copy(), prefix)
 
     linked_in_root = linked_data(context.root_prefix)
 
+    # Ensure that there is only on prefix to install into
     dists_for_envs = determine_all_envs(r, specs, channel_priority_map=channel_priority_map)
     ensure_packge_not_duplicated_in_private_env_root(dists_for_envs, linked_in_root)
     preferred_envs = set(d.env for d in dists_for_envs)
-
     assert len(preferred_envs) == 1
+
     specs_for_prefix = SpecsForPrefix(
-        prefix=prefix, specs=tuple(sp.spec for sp in dists_for_envs), r=r
+        prefix=prefix, specs=tuple(str_specs), r=r
     )
     actions = get_actions_for_dists(specs_for_prefix, only_names, index, force, always_copy, prune,
                                     update_deps, pinned)


### PR DESCRIPTION
Previously it was choosing specs from dists_for_envs which, without
matching to original specs, causing spec specifiers to be ignored