### PR TITLE
Additional pre-transaction validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
   conda package, with the following additional features
   1. conda maps the `site-packages` directory to the correct location for the python version
      in the environment,
-  2. conda maps the python-scripts to either $PREFIX/bin or $PREFIX/Scripts depending on platform,
+  2. conda maps the python-scripts directory to either $PREFIX/bin or $PREFIX/Scripts depending
+     on platform,
   3. conda creates the python entry points specified in the conda-build recipe, and
   4. conda compiles pyc files at install time when prefix write permissions are guaranteed.
 

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -35,7 +35,7 @@ SEARCH_PATH = (
 )
 
 DEFAULT_CHANNEL_ALIAS = 'https://conda.anaconda.org'
-CONDA_HOMEPAGE_URL = 'http://conda.pydata.org'
+CONDA_HOMEPAGE_URL = 'https://conda.pydata.org'
 DEFAULTS = 'defaults'
 
 PLATFORM_DIRECTORIES = ("linux-64",

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -207,8 +207,15 @@ class UnlinkLinkTransaction(object):
         link_paths_dict = defaultdict(list)
         for axn in create_lpr_actions:
             for path in axn.linked_package_record.files:
-                link_paths_dict[path].append(axn)
+                link_paths_dict[path.lower()].append(axn)
                 if path not in unlink_paths and lexists(join(target_prefix, path)):
+                    if on_win and any(path.lower() == unlink_path.lower()
+                                      for unlink_path in unlink_paths):
+                        # python doesn't care about case sensitivity on windows apparently
+                        #   I really don't know how this hack is going to affect environment
+                        #   safety and correctness
+                        continue
+
                     # we have a collision; at least try to figure out where it came from
                     linked_data = get_linked_data(target_prefix)
                     colliding_linked_package_record = first(

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from functools import reduce
 from logging import getLogger
 import os
 from os.path import join
@@ -10,11 +9,9 @@ import sys
 from traceback import format_exc
 import warnings
 
+from conda import CondaMultiError
 from conda._vendor.auxlib.collection import first
-
 from conda.exceptions import CondaVerificationError
-
-from conda import CondaMultiError, CondaError
 from .linked_data import (get_python_version_for_prefix, linked_data as get_linked_data,
                           load_meta)
 from .package_cache import PackageCache
@@ -25,7 +22,7 @@ from .path_actions import (CompilePycAction, CreateApplicationEntryPointAction,
                            RemovePrivateEnvMetaAction, UnlinkPathAction)
 from .._vendor.auxlib.ish import dals
 from ..base.context import context
-from ..common.compat import on_win, text_type, itervalues
+from ..common.compat import itervalues, on_win, text_type
 from ..common.path import (explode_directories, get_all_directories, get_bin_directory_short_path,
                            get_major_minor_version,
                            get_python_site_packages_short_path)
@@ -162,7 +159,7 @@ class UnlinkLinkTransaction(object):
         link_actions = (
             (pkg_info, self.make_link_actions(transaction_context, pkg_info,
                                               self.target_prefix, lt))
-             for pkg_info, lt in zip(self.packages_info_to_link, link_types)
+            for pkg_info, lt in zip(self.packages_info_to_link, link_types)
         )
 
         self.all_actions = tuple(per_pkg_actions for per_pkg_actions in

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -221,7 +221,7 @@ class UnlinkLinkTransaction(object):
                         an uninstall action in this transaction. The path appears to be coming from
                         the package '%s', which is already installed in the prefix. If you'd like
                         to proceed anyway, re-run the command with the `--force` flag.
-                        """ % (axn.index_json_record.name,
+                        """ % (axn.linked_package_record.name,
                                axn.target_short_path,
                                Dist(colliding_linked_package_record))))
                     else:
@@ -233,7 +233,7 @@ class UnlinkLinkTransaction(object):
                         doesn't recognize. It may have been created by another package manager.
                         If you'd like to proceed anyway, re-run the command with the `--force`
                         flag.
-                        """ % (axn.index_json_record.name,
+                        """ % (axn.linked_package_record.name,
                                axn.target_short_path)))
 
     def verify(self):
@@ -246,8 +246,10 @@ class UnlinkLinkTransaction(object):
                                            self.num_unlink_pkgs),
         ) if exc)
 
-        if exceptions:
+        if exceptions and not context.force:
             raise CondaMultiError(exceptions)
+        else:
+            log.info(exceptions)
 
         self._verified = True
 

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -217,26 +217,25 @@ class UnlinkLinkTransaction(object):
                     )
                     if colliding_linked_package_record:
                         yield CondaVerificationError(dals("""
-                        The package '%s' cannot be installed due to a path collision for
-                        '%s'.
+                        The package '%s' cannot be installed due to a
+                        path collision for '%s'.
                         This path already exists in the target prefix, and it won't be removed by
                         an uninstall action in this transaction. The path appears to be coming from
                         the package '%s', which is already installed in the prefix. If you'd like
                         to proceed anyway, re-run the command with the `--force` flag.
                         """ % (Dist(axn.linked_package_record),
-                               axn.target_short_path,
+                               path,
                                Dist(colliding_linked_package_record))))
                     else:
                         yield CondaVerificationError(dals("""
-                        The package '%s' cannot be installed due to a path collision for
-                        '%s'.
+                        The package '%s' cannot be installed due to a
+                        path collision for '%s'.
                         This path already exists in the target prefix, and it won't be removed
                         by an uninstall action in this transaction. The path is one that conda
                         doesn't recognize. It may have been created by another package manager.
                         If you'd like to proceed anyway, re-run the command with the `--force`
                         flag.
-                        """ % (Dist(axn.linked_package_record),
-                               axn.target_short_path)))
+                        """ % (Dist(axn.linked_package_record), path)))
         for path, axns in iteritems(link_paths_dict):
             if len(axns) > 1:
                 yield CondaVerificationError(dals("""

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -248,10 +248,11 @@ class UnlinkLinkTransaction(object):
                 yield CondaVerificationError(dals("""
                 This transaction has incompatible packages due to a shared path.
                   packages: %s
-                  path: %s
+                  path: %s%s
                 If you'd like to proceed anyway, re-run the command with the `--force` flag.
                 """ % (', '.join(text_type(Dist(axn.linked_package_record)) for axn in axns),
-                       path)))
+                       axns[0].target_short_path,
+                       "  (conda looks for paths to be case-insensitive)" if on_win else "")))
 
     def verify(self):
         if not self._prepared:

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -223,7 +223,7 @@ class UnlinkLinkTransaction(object):
                         an uninstall action in this transaction. The path appears to be coming from
                         the package '%s', which is already installed in the prefix. If you'd like
                         to proceed anyway, re-run the command with the `--force` flag.
-                        """ % (axn.linked_package_record.name,
+                        """ % (Dist(axn.linked_package_record),
                                axn.target_short_path,
                                Dist(colliding_linked_package_record))))
                     else:
@@ -235,7 +235,7 @@ class UnlinkLinkTransaction(object):
                         doesn't recognize. It may have been created by another package manager.
                         If you'd like to proceed anyway, re-run the command with the `--force`
                         flag.
-                        """ % (axn.linked_package_record.name,
+                        """ % (Dist(axn.linked_package_record),
                                axn.target_short_path)))
         for path, axns in iteritems(link_paths_dict):
             if len(axns) > 1:

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -224,34 +224,36 @@ class UnlinkLinkTransaction(object):
                     if colliding_linked_package_record:
                         yield CondaVerificationError(dals("""
                         The package '%s' cannot be installed due to a
-                        path collision for '%s'.
+                        %spath collision for '%s'.
                         This path already exists in the target prefix, and it won't be removed by
                         an uninstall action in this transaction. The path appears to be coming from
                         the package '%s', which is already installed in the prefix. If you'd like
                         to proceed anyway, re-run the command with the `--force` flag.
                         """ % (Dist(axn.linked_package_record),
+                               "case-insensitive " if on_win else "",
                                path,
                                Dist(colliding_linked_package_record))))
                     else:
                         yield CondaVerificationError(dals("""
                         The package '%s' cannot be installed due to a
-                        path collision for '%s'.
+                        %spath collision for '%s'.
                         This path already exists in the target prefix, and it won't be removed
                         by an uninstall action in this transaction. The path is one that conda
                         doesn't recognize. It may have been created by another package manager.
                         If you'd like to proceed anyway, re-run the command with the `--force`
                         flag.
-                        """ % (Dist(axn.linked_package_record), path)))
+                        """ % ("case-insensitive " if on_win else "",
+                               Dist(axn.linked_package_record), path)))
         for path, axns in iteritems(link_paths_dict):
             if len(axns) > 1:
                 yield CondaVerificationError(dals("""
                 This transaction has incompatible packages due to a shared path.
                   packages: %s
-                  path: %s%s
+                  %spath: %s
                 If you'd like to proceed anyway, re-run the command with the `--force` flag.
                 """ % (', '.join(text_type(Dist(axn.linked_package_record)) for axn in axns),
-                       axns[0].target_short_path,
-                       "  (conda looks for paths to be case-insensitive)" if on_win else "")))
+                       "case-insensitive " if on_win else "",
+                       path)))
 
     def verify(self):
         if not self._prepared:

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -192,7 +192,10 @@ class UnlinkLinkTransaction(object):
         # for each path we are creating in link_actions, we need to make sure
         #   1. each path either doesn't already exist in the prefix, or will be unlinked
         #   2. there's only a single instance of each path
-        unlink_paths = set(axn.target_short_path
+
+        # paths are case-insensitive on windows apparently
+        lower_on_win = lambda p: p.lower() if on_win else p
+        unlink_paths = set(lower_on_win(axn.target_short_path)
                            for _, pkg_actions in all_actions[:num_unlink_pkgs]
                            for axn in pkg_actions
                            if isinstance(axn, UnlinkPathAction))
@@ -206,6 +209,7 @@ class UnlinkLinkTransaction(object):
         link_paths_dict = defaultdict(list)
         for axn in create_lpr_actions:
             for path in axn.linked_package_record.files:
+                path = lower_on_win(path)
                 link_paths_dict[path].append(axn)
                 if path not in unlink_paths and lexists(join(target_prefix, path)):
                     # we have a collision; at least try to figure out where it came from

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -338,7 +338,7 @@ class UnlinkLinkTransaction(object):
                     reverse_from_idx=axn_idx
                 )
             raise CondaMultiError(tuple(concatv(
-                (execute_exc,),
+                (e,),
                 reverse_excs,
             )))
 

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -55,6 +55,9 @@ class PathAction(object):
 
     @abstractmethod
     def verify(self):
+        # if verify fails, it should return an exception object rather than raise
+        #  at the end of a verification run, all errors will be raised as a CondaMultiError
+        # after successful verification, the verify method should set self._verified = True
         raise NotImplementedError()
 
     @abstractmethod
@@ -209,7 +212,7 @@ class LinkPathAction(CreateInPrefixPathAction):
     def verify(self):
         # TODO: consider checking hashsums
         if self.link_type != LinkType.directory and not lexists(self.source_full_path):
-            raise CondaVerificationError(dals("""
+            return CondaVerificationError(dals("""
             The package for %s located at %s
             appears to be corrupted. The path '%s'
             specified in the package manifest cannot be found.
@@ -246,7 +249,7 @@ class PrefixReplaceLinkAction(LinkPathAction):
 
     def verify(self):
         if not (self.prefix_placeholder or self.file_mode):
-            raise CondaVerificationError(dals("""
+            return CondaVerificationError(dals("""
             The package for %s located at %s
             appears to be corrupted. For the file at path %s
             a prefix_placeholder and file_mode must be specified. Instead got values
@@ -255,7 +258,7 @@ class PrefixReplaceLinkAction(LinkPathAction):
                    self.package_info.extracted_package_dir,
                    self.source_short_path, self.prefix_placeholder, self.file_mode)))
         if not isfile(self.source_full_path):
-            raise CondaVerificationError(dals("""
+            return CondaVerificationError(dals("""
             The package for %s located at %s
             appears to be corrupted. The path '%s'
             specified in the package manifest is not a file.
@@ -456,6 +459,7 @@ class CreateApplicationEntryPointAction(CreateInPrefixPathAction):
 
 
 class CreateLinkedPackageRecordAction(CreateInPrefixPathAction):
+    # this is the action that creates a packages json file in the conda-meta/ directory
 
     @classmethod
     def create_actions(cls, transaction_context, package_info, target_prefix, requested_link_type,
@@ -482,9 +486,6 @@ class CreateLinkedPackageRecordAction(CreateInPrefixPathAction):
         self.linked_package_record = linked_package_record
         self._record_written_to_disk = False
         self._linked_data_loaded = False
-
-    def verify(self):
-        pass
 
     def execute(self):
         log.trace("creating linked package record %s", self.target_full_path)

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -414,8 +414,7 @@ class CondaUpgradeError(CondaError):
 
 class CondaVerificationError(CondaError):
     def __init__(self, message):
-        msg = "Conda verification error: %s" % message
-        super(CondaVerificationError, self).__init__(msg)
+        super(CondaVerificationError, self).__init__(message)
 
 
 def print_conda_exception(exception):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -212,6 +212,9 @@ def create_link(src, dst, link_type=LinkType.hardlink, force=False):
         mkdir_p(dst)
         return
 
+    if not lexists(src):
+        raise CondaError("Cannot link a source that does not exist. %s" % src)
+
     if lexists(dst):
         if force:
             log.info("file exists, but clobbering: %r" % dst)
@@ -220,6 +223,8 @@ def create_link(src, dst, link_type=LinkType.hardlink, force=False):
             raise ClobberError(dst, src, link_type)
 
     if link_type == LinkType.hardlink:
+        if isdir(src):
+            raise CondaError("Cannot hard link a directory. %s" % src)
         if on_win:
             win_hard_link(src, dst)
         else:

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -41,5 +41,8 @@ def update_file_in_place_as_binary(file_full_path, callback):
 
 def backoff_rename(source_path, destination_path):
     if lexists(source_path):
+        log.trace("renaming %s => %s", source_path, destination_path)
         exp_backoff_fn(rename, source_path, destination_path)
+    else:
+        log.trace("cannot rename; source path does not exist '%s'", source_path)
     return


### PR DESCRIPTION
Add an additional verification step to UnlinkLinkTransaction that
looks at the transaction as a whole, making sure that any
paths being linked are either unlinked first or don't exist
in the prefix.

Addressing more of https://github.com/conda/conda/issues/3494