### PR TITLE
Modest local caching of repodata without remote server calls

### DIFF
--- a/conda/_vendor/auxlib/logz.py
+++ b/conda/_vendor/auxlib/logz.py
@@ -110,7 +110,7 @@ def stringify(obj):
         if request_object.body:
             builder.append(request_object.body)
 
-    def requests_models_Response_builder(builder, response_object):
+    def requests_models_Response_builder(builder, response_object, include_content=False):
         builder.append("<<{0} {1} {2}".format(response_object.url.split(':', 1)[0].upper(),
                                               response_object.status_code, response_object.reason))
         builder.extend("< {0}: {1}".format(key, value)
@@ -118,13 +118,14 @@ def stringify(obj):
                                                 key=response_header_sort_key))
         elapsed = text_type(response_object.elapsed).split(':', 1)[-1]
         builder.append('< Elapsed: {0}'.format(elapsed))
-        builder.append('')
-        content_type = response_object.headers.get('Content-Type')
-        if content_type == 'application/json':
-            builder.append(pformat(response_object.json, indent=2))
+        if include_content:
             builder.append('')
-        elif content_type is not None and content_type.startswith('text/'):
-            builder.append(response_object.text)
+            content_type = response_object.headers.get('Content-Type')
+            if content_type == 'application/json':
+                builder.append(pformat(response_object.json(), indent=2))
+                builder.append('')
+            elif content_type is not None and content_type.startswith('text/'):
+                builder.append(response_object.text)
 
     try:
         name = fullname(obj)

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -69,7 +69,7 @@ class Context(Configuration):
     use_pip = PrimitiveParameter(True)
     concurrent = PrimitiveParameter(False)
     rollback_enabled = PrimitiveParameter(True)
-    repodata_timeout_secs = PrimitiveParameter(60)
+    repodata_timeout_secs = PrimitiveParameter(300)
 
     _root_dir = PrimitiveParameter("", aliases=('root_dir',))
     _envs_dirs = SequenceParameter(string_types, aliases=('envs_dirs', 'envs_path'),

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -69,6 +69,7 @@ class Context(Configuration):
     use_pip = PrimitiveParameter(True)
     concurrent = PrimitiveParameter(False)
     rollback_enabled = PrimitiveParameter(True)
+    repodata_timeout_secs = PrimitiveParameter(60)
 
     _root_dir = PrimitiveParameter("", aliases=('root_dir',))
     _envs_dirs = SequenceParameter(string_types, aliases=('envs_dirs', 'envs_path'),

--- a/conda/common/disk.py
+++ b/conda/common/disk.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from contextlib import contextmanager
 from logging import getLogger
-from os import makedirs
+from os import makedirs, unlink
 from os.path import isdir
+from tempfile import NamedTemporaryFile
 
 log = getLogger(__name__)
 
@@ -16,3 +18,22 @@ def conda_bld_ensure_dir(path):
             makedirs(path)
         except OSError:
             pass
+
+
+@contextmanager
+def temporary_content_in_file(content, suffix=""):
+    # content returns temporary file path with contents
+    fh = None
+    path = None
+    try:
+        fh = NamedTemporaryFile(mode="w", delete=False, suffix=suffix)
+        path = fh.name
+        fh.write(content)
+        fh.flush()
+        fh.close()
+        yield path
+    finally:
+        if fh is not None:
+            fh.close()
+        if path is not None:
+            unlink(path)

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -29,7 +29,7 @@ from ..common.url import join_url
 from ..connection import CondaSession
 from ..exceptions import CondaHTTPError, CondaRuntimeError
 from ..gateways.disk.update import touch
-from ..models.channel import Channel, offline_keep, prioritize_channels
+from ..models.channel import Channel, prioritize_channels
 from ..models.dist import Dist
 from ..models.index_record import EMPTY_LINK, IndexRecord
 
@@ -267,8 +267,6 @@ def read_local_repodata(cache_path):
 
 @dotlog_on_return("fetching repodata:")
 def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
-    # if not offline_keep(url):
-    #     return {'packages': {}}
     cache_path = join(cache_dir or create_cache_dir(), cache_fn_url(url))
 
     try:

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -128,6 +128,13 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
 
     try:
         mtime = getmtime(cache_path)
+    except (IOError, OSError):
+        log.debug("No local cache found for %s at %s", url, cache_path)
+        if use_cache:
+            return {'packages': {}}
+        else:
+            mod_etag_headers = {}
+    else:
         timeout = mtime + context.repodata_timeout_secs - time()
         if timeout > 0:
             log.debug("Using cached repodata for %s at %s. Timeout in %d sec",
@@ -138,13 +145,6 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
         else:
             mod_etag_headers = read_mod_and_etag(cache_path)
             log.debug("Locally invalidating cached repodata for %s at %s", url, cache_path)
-
-    except (IOError, ValueError):
-        log.debug("No local cache found for %s at %s", url, cache_path)
-        if use_cache:
-            return {'packages': {}}
-        else:
-            mod_etag_headers = {}
 
     if not context.ssl_verify:
         warnings.simplefilter('ignore', InsecureRequestWarning)

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -452,8 +452,7 @@ def add_pip_dependency(index):
 
 
 def create_cache_dir():
-    from .package_cache import PackageCache
-    cache_dir = join(PackageCache.first_writable().pkgs_dir, 'cache')
+    cache_dir = join(context.pkgs_dirs[0], 'cache')
     try:
         makedirs(cache_dir)
     except OSError:

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -21,10 +21,10 @@ from .linked_data import linked_data
 from .._vendor.auxlib.entity import EntityEncoder
 from .._vendor.auxlib.ish import dals
 from .._vendor.auxlib.logz import stringify
-from ..base.constants import CONDA_HOMEPAGE_URL, DEFAULTS, MAX_CHANNEL_PRIORITY, \
-    PLATFORM_DIRECTORIES
+from ..base.constants import (CONDA_HOMEPAGE_URL, DEFAULTS, MAX_CHANNEL_PRIORITY,
+                              PLATFORM_DIRECTORIES)
 from ..base.context import context
-from ..common.compat import ensure_text_type, iteritems, itervalues, text_type, iterkeys
+from ..common.compat import ensure_text_type, iteritems, iterkeys, itervalues
 from ..common.url import join_url
 from ..connection import CondaSession
 from ..exceptions import CondaHTTPError, CondaRuntimeError

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -112,10 +112,9 @@ class dotlog_on_return(object):
 
 
 def read_mod_and_etag(path):
-    with open(path, 'r') as f:
+    with open(path, 'rb') as f:
         with closing(mmap(f.fileno(), 0, access=ACCESS_READ)) as m:
-            regex_str = r'"(_etag|_mod)":[ ]?"(.*)"'
-            match_objects = take(2, re.finditer(regex_str, m))
+            match_objects = take(2, re.finditer(b'"(_etag|_mod)":[ ]?"(.*)"', m))
             result = dict(mo.groups() for mo in match_objects)
             return result
 

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -17,17 +17,17 @@ import warnings
 from requests.exceptions import ConnectionError, HTTPError, SSLError
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
-from conda.gateways.disk.update import touch
 from .linked_data import linked_data
 from .._vendor.auxlib.entity import EntityEncoder
 from .._vendor.auxlib.ish import dals
 from .._vendor.auxlib.logz import stringify
 from ..base.constants import CONDA_HOMEPAGE_URL, DEFAULTS, MAX_CHANNEL_PRIORITY
 from ..base.context import context
-from ..common.compat import iteritems, itervalues, ensure_text_type
+from ..common.compat import ensure_text_type, iteritems, itervalues
 from ..common.url import join_url
 from ..connection import CondaSession
 from ..exceptions import CondaHTTPError, CondaRuntimeError
+from ..gateways.disk.update import touch
 from ..models.channel import Channel, offline_keep, prioritize_channels
 from ..models.dist import Dist
 from ..models.index_record import EMPTY_LINK, IndexRecord

--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -249,6 +249,8 @@ class PackageCache(object):
 
     def _init_dir(self):
         pkgs_dir = self.pkgs_dir
+        if not isdir(pkgs_dir):
+            return
         pkgs_dir_contents = listdir(pkgs_dir)
         while pkgs_dir_contents:
             base_name = pkgs_dir_contents.pop(0)

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -2,15 +2,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from logging import getLogger
-from os import rename
+from os import rename, utime
 from os.path import lexists
 import re
+
+from conda._vendor.auxlib.path import expand
 
 from . import exp_backoff_fn
 
 log = getLogger(__name__)
 
-# in the rest of conda's code, os.rename is preferrably imported from here
+# in the rest of conda's code, os.rename is preferably imported from here
 rename = rename
 
 SHEBANG_REGEX = re.compile(br'^(#!((?:\\ |[^ \n\r])+)(.*))')
@@ -27,6 +29,7 @@ def update_file_in_place_as_binary(file_full_path, callback):
     fh = None
     try:
         fh = exp_backoff_fn(open, file_full_path, 'rb+')
+        log.trace("in-place update path locked for %s", file_full_path)
         data = fh.read()
         fh.seek(0)
         try:
@@ -43,3 +46,12 @@ def backoff_rename(source_path, destination_path):
     if lexists(source_path):
         exp_backoff_fn(rename, source_path, destination_path)
     return
+
+
+def touch(path):
+    path = expand(path)
+    log.trace("touching path %s", path)
+    if lexists(path):
+        utime(path, None)
+    else:
+        open(path, 'a').close()

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -422,6 +422,9 @@ class MultiChannel(Channel):
 
 
 def prioritize_channels(channels, with_credentials=True, platform=None):
+    # prioritize_channels returns and OrderedDict with platform-specific channel
+    #   urls as the key, and a tuple of canonical channel name and channel priority
+    #   number as the value
     # ('https://conda.anaconda.org/conda-forge/osx-64/', ('conda-forge', 1))
     result = odict()
     for q, chn in enumerate(channels):

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from logging import getLogger
+from time import time
+from unittest import TestCase
+
+from conda.connection import CondaSession
+
+from conda.common.io import env_var
+
+from conda.base.context import context, reset_context
+from conda.common.compat import iteritems
+from conda.common.disk import temporary_content_in_file
+from conda.core.index import get_index, read_mod_and_etag, cache_fn_url, \
+    Response304ContentUnchanged
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+log = getLogger(__name__)
+
+
+def platform_in_record(platform, record):
+    return ("/%s/" % platform in record.url) or ("/noarch/" in record.url)
+
+
+class GetIndexIntegrationTests(TestCase):
+
+    def test_get_index_no_platform_with_offline_cache(self):
+        import conda.core.index
+        with env_var('CONDA_REPODATA_TIMEOUT_SECS', '0', reset_context):
+            with patch.object(conda.core.index, 'read_mod_and_etag') as read_mod_and_etag:
+                read_mod_and_etag.return_value = {}
+                channel_urls = ('https://repo.continuum.io/pkgs/pro',)
+                with env_var('CONDA_REPODATA_TIMEOUT_SECS', '0', reset_context):
+                    this_platform = context.subdir
+                    index = get_index(channel_urls=channel_urls, prepend=False)
+                    for dist, record in iteritems(index):
+                        assert platform_in_record(this_platform, record), (this_platform, record.url)
+
+        with env_var('CONDA_OFFLINE', 'yes', reset_context):
+            with patch.object(conda.core.index, 'fetch_repodata_remote_request') as remote_request:
+                index2 = get_index(channel_urls=channel_urls, prepend=False)
+                assert index2 == index
+                assert remote_request.call_count == 0
+
+        with env_var('CONDA_REPODATA_TIMEOUT_SECS', '0', reset_context):
+            with patch.object(conda.core.index, 'fetch_repodata_remote_request') as remote_request:
+                remote_request.side_effect = Response304ContentUnchanged()
+                index3 = get_index(channel_urls=channel_urls, prepend=False)
+                assert index3 == index
+
+    def test_get_index_linux64_platform(self):
+        linux64 = 'linux-64'
+        index = get_index(platform=linux64)
+        for dist, record in iteritems(index):
+            assert platform_in_record(linux64, record), (linux64, record.url)
+
+    def test_get_index_osx64_platform(self):
+        osx64 = 'osx-64'
+        index = get_index(platform=osx64)
+        for dist, record in iteritems(index):
+            assert platform_in_record(osx64, record), (osx64, record.url)
+
+    def test_get_index_win64_platform(self):
+        win64 = 'win-64'
+        index = get_index(platform=win64)
+        for dist, record in iteritems(index):
+            assert platform_in_record(win64, record), (win64, record.url)
+
+
+class StaticFunctionTests(TestCase):
+
+    def test_read_mod_and_etag_mod_only(self):
+        mod_only_str = """
+        {
+          "_mod": "Wed, 14 Dec 2016 18:49:16 GMT",
+          "_url": "https://conda.anaconda.org/conda-canary/noarch",
+          "info": {
+            "arch": null,
+            "default_numpy_version": "1.7",
+            "default_python_version": "2.7",
+            "platform": null,
+            "subdir": "noarch"
+          },
+          "packages": {}
+        }
+        """.strip()
+        with temporary_content_in_file(mod_only_str) as path:
+            mod_etag_dict = read_mod_and_etag(path)
+            assert "_etag" not in mod_etag_dict
+            assert mod_etag_dict["_mod"] == "Wed, 14 Dec 2016 18:49:16 GMT"
+
+    def test_read_mod_and_etag_etag_only(self):
+        etag_only_str = """
+        {
+          "_url": "https://repo.continuum.io/pkgs/r/noarch",
+          "info": {},
+          "_etag": "\"569c0ecb-48\"",
+          "packages": {}
+        }
+        """.strip()
+        with temporary_content_in_file(etag_only_str) as path:
+            mod_etag_dict = read_mod_and_etag(path)
+            assert "_mod" not in mod_etag_dict
+            assert mod_etag_dict["_etag"] == "\"569c0ecb-48\""
+
+    def test_read_mod_and_etag_etag_mod(self):
+        etag_mod_str = """
+        {
+          "_etag": "\"569c0ecb-48\"",
+          "_mod": "Sun, 17 Jan 2016 21:59:39 GMT",
+          "_url": "https://repo.continuum.io/pkgs/r/noarch",
+          "info": {},
+          "packages": {}
+        }
+        """.strip()
+        with temporary_content_in_file(etag_mod_str) as path:
+            mod_etag_dict = read_mod_and_etag(path)
+            assert mod_etag_dict["_mod"] == "Sun, 17 Jan 2016 21:59:39 GMT"
+            assert mod_etag_dict["_etag"] == "\"569c0ecb-48\""
+
+    def test_read_mod_and_etag_mod_etag(self):
+        mod_etag_str = """
+        {
+          "_mod": "Sun, 17 Jan 2016 21:59:39 GMT",
+          "_url": "https://repo.continuum.io/pkgs/r/noarch",
+          "info": {},
+          "_etag": "\"569c0ecb-48\"",
+          "packages": {}
+        }
+        """.strip()
+        with temporary_content_in_file(mod_etag_str) as path:
+            mod_etag_dict = read_mod_and_etag(path)
+            assert mod_etag_dict["_mod"] == "Sun, 17 Jan 2016 21:59:39 GMT"
+            assert mod_etag_dict["_etag"] == "\"569c0ecb-48\""
+
+    def test_cache_fn_url(self):
+        hash1 = cache_fn_url("http://repo.continuum.io/pkgs/free/osx-64/")
+        hash2 = cache_fn_url("http://repo.continuum.io/pkgs/free/osx-64")
+        assert "87c17da0.json" == hash1 == hash2
+
+        hash3 = cache_fn_url("https://repo.continuum.io/pkgs/free/osx-64/")
+        hash4 = cache_fn_url("https://repo.continuum.io/pkgs/free/osx-64")
+        assert "840cf1fb.json" == hash3 == hash4 != hash1
+
+        hash5 = cache_fn_url("https://repo.continuum.io/pkgs/free/linux-64/")
+        assert hash4 != hash5
+
+        hash6 = cache_fn_url("https://repo.continuum.io/pkgs/r/osx-64")
+        assert hash4 != hash6
+

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2,14 +2,26 @@
 from __future__ import absolute_import, division, print_function
 
 import bz2
+from contextlib import contextmanager
+from glob import glob
 import json
+from json import loads as json_loads
+from logging import DEBUG, getLogger
 import os
+from os.path import basename, exists, isdir, isfile, join, relpath
+from shlex import split
+from shutil import copyfile, rmtree
+from subprocess import check_call
+import sys
+from tempfile import gettempdir
+from unittest import TestCase
+from uuid import uuid4
+
 import pytest
 import requests
-import sys
-from conda import CondaError, plan, CondaMultiError
+
+from conda import CondaError, CondaMultiError, plan
 from conda._vendor.auxlib.entity import EntityEncoder
-from conda._vendor.auxlib.ish import dals
 from conda.base.context import context, reset_context
 from conda.cli.common import get_index_trap
 from conda.cli.main import generate_parser
@@ -22,36 +34,20 @@ from conda.cli.main_list import configure_parser as list_configure_parser
 from conda.cli.main_remove import configure_parser as remove_configure_parser
 from conda.cli.main_search import configure_parser as search_configure_parser
 from conda.cli.main_update import configure_parser as update_configure_parser
+from conda.common.compat import itervalues, text_type
 from conda.common.io import captured, disable_logger, replace_log_streams, stderr_log_level
-from conda.common.path import get_bin_directory_short_path, missing_pyc_files, \
-    get_python_site_packages_short_path, pyc_path
+from conda.common.path import get_bin_directory_short_path, get_python_site_packages_short_path, pyc_path
 from conda.common.url import path_to_url
 from conda.common.yaml import yaml_load
-from conda.common.compat import itervalues, text_type
-from conda.connection import LocalFSAdapter, CondaSession
 from conda.core.index import create_cache_dir
 from conda.core.linked_data import get_python_version_for_prefix, \
     linked as install_linked, linked_data, linked_data_
+from conda.core.package_cache import PackageCache
 from conda.exceptions import CondaHTTPError, DryRunExit, RemoveError, conda_exception_handler
 from conda.gateways.disk.delete import rm_rf
 from conda.gateways.logging import TRACE
-from conda.core.package_cache import PackageCache
 from conda.models.index_record import IndexRecord
 from conda.utils import on_win
-from contextlib import contextmanager
-from datetime import datetime
-from glob import glob
-from json import loads as json_loads
-from logging import DEBUG, getLogger
-from os.path import basename, exists, isdir, isfile, join, relpath
-from requests import Session
-from requests.adapters import BaseAdapter
-from shlex import split
-from shutil import copyfile, rmtree
-from subprocess import check_call
-from tempfile import gettempdir
-from unittest import TestCase
-from uuid import uuid4
 
 try:
     from unittest.mock import patch

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -34,7 +34,7 @@ class TestConnectionWithShortTimeouts(TestCase):
             with env_var('CONDA_REMOTE_READ_TIMEOUT_SECS', 1, reset_context):
                 with env_var('CONDA_REMOTE_MAX_RETRIES', 1, reset_context):
                     with pytest.raises(CondaHTTPError) as execinfo:
-                        url = "http://240.0.0.0/"
+                        url = "http://240.0.0.0/channel/osx-64"
                         msg = "Connection error:"
                         fetch_repodata(url)
                         assert msg in str(execinfo)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -9,7 +9,7 @@ from conda.misc import url_pat, walk_prefix
 class TestMisc(unittest.TestCase):
 
     def test_cache_fn_url(self):
-        url = "http://repo.continuum.io/pkgs/pro/osx-64/"
+        url = "http://repo.continuum.io/pkgs/pro/osx-64"
         self.assertEqual(cache_fn_url(url), '7618c8b6.json')
 
     def test_url_pat_1(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -9,8 +9,8 @@ from conda.misc import url_pat, walk_prefix
 class TestMisc(unittest.TestCase):
 
     def test_cache_fn_url(self):
-        url = "http://repo.continuum.io/pkgs/pro/osx-64"
-        self.assertEqual(cache_fn_url(url), '7618c8b6.json')
+        url = "http://repo.continuum.io/pkgs/pro/osx-64/"
+        self.assertEqual(cache_fn_url(url), 'd9525757.json')
 
     def test_url_pat_1(self):
         m = url_pat.match('http://www.cont.io/pkgs/linux-64/foo.tar.bz2'


### PR DESCRIPTION
As users add more and more channels, just the process of getting `304` responses from remove servers can really slow down the experience.  Configurable local caching of repodata information with a modest timeout seems reasonable.  I've implemented it here, with a default timeout of 5 minutes.  Really all I'm doing is taking the `mtime` of the locally cached file into account (and updating it when the server tells us to with a `304`).