### PR TITLE
Include OS specific defaults listings

### DIFF
--- a/conda/exports.py
+++ b/conda/exports.py
@@ -74,7 +74,7 @@ import conda.base.context  # NOQA
 from conda.base.context import get_prefix as context_get_prefix, non_x86_linux_machines  # NOQA
 non_x86_linux_machines = non_x86_linux_machines
 
-from .base.constants import DEFAULT_CHANNELS       # NOQA
+from .base.constants import DEFAULT_CHANNELS, DEFAULT_CHANNELS_WIN, DEFAULT_CHANNELS_UNIX  # NOQA
 from ._vendor.auxlib.entity import EntityEncoder        # NOQA
 EntityEncoder = EntityEncoder
 get_prefix = partial(context_get_prefix, conda.base.context.context)


### PR DESCRIPTION
Adds `DEFAULT_CHANNELS_WIN` and `DEFAULT_CHANNELS_UNIX` to `conda.exports` so that both are available for inspection. This is a step towards determining the contents of `defaults` for an OS that may be different from the one `conda` is installed on.

cc @kalefranz

xref: https://github.com/conda/conda/issues/3348