### PR TITLE
Towards conditional dependencies in specs

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -390,11 +390,12 @@ class UnsatisfiableError(CondaError, RuntimeError):
     def __init__(self, bad_deps, chains=True):
         from .resolve import dashlist, MatchSpec
 
-        bad_deps = [list(map(lambda x: x.spec, dep)) for dep in bad_deps]
+        # Remove any target values from the MatchSpecs, convert to strings
+        bad_deps = [list(map(lambda x: str(MatchSpec(x, target=None)), dep)) for dep in bad_deps]
         if chains:
             chains = {}
             for dep in sorted(bad_deps, key=len, reverse=True):
-                dep1 = [str(MatchSpec(s)).partition(' ') for s in dep[1:]]
+                dep1 = [s.partition(' ') for s in dep[1:]]
                 key = (dep[0],) + tuple(v[0] for v in dep1)
                 vals = ('',) + tuple(v[2] for v in dep1)
                 found = False

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -235,7 +235,8 @@ class Resolve(object):
             return v_ms_(spec) if isinstance(spec, MatchSpec) else v_fkey_(spec)
 
         def v_ms_(ms):
-            return (optional and ms.optional) or any(v_fkey_(fkey) for fkey in self.find_matches(ms))
+            return ((optional and ms.optional) or
+                    any(v_fkey_(fkey) for fkey in self.find_matches(ms)))
 
         def v_fkey_(dist):
             assert isinstance(dist, Dist)
@@ -268,7 +269,10 @@ class Resolve(object):
             A generator of tuples, empty if the MatchSpec is valid.
         """
         def chains_(spec, names):
-            if self.valid(spec, filter, optional) or spec.name in names:
+            if spec.name in names:
+                return
+            names.add(spec.name)
+            if self.valid(spec, filter, optional):
                 return
             dists = self.find_matches(spec) if isinstance(spec, MatchSpec) else [Dist(spec)]
             found = False
@@ -560,6 +564,9 @@ class Resolve(object):
 
     def package_name(self, dist):
         return self.package_quad(dist)[0]
+
+    def is_superceded(self, dist):
+        return dist in self.index or self.index.get('superceded', '')
 
     def get_pkgs(self, ms, emptyok=False):
         ms = MatchSpec(ms)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -215,7 +215,7 @@ class Resolve(object):
             filter.update({Dist(fstr+'@'): True for fstr in features})
         return filter
 
-    def valid(self, spec_or_dist, filter):
+    def valid(self, spec_or_dist, filter, optional=True):
         """Tests if a package, MatchSpec, or a list of both has satisfiable
         dependencies, assuming cyclic dependencies are always valid.
 
@@ -223,6 +223,8 @@ class Resolve(object):
             spec_or_dist: a package key, a MatchSpec, or an iterable of these.
             filter: a dictionary of (fkey,valid) pairs, used to consider a subset
                 of dependencies, and to eliminate repeated searches.
+            optional: if True (default), do not enforce optional specifications
+                when considering validity. If False, enforce them.
 
         Returns:
             True if the full set of dependencies can be satisfied; False otherwise.
@@ -233,7 +235,7 @@ class Resolve(object):
             return v_ms_(spec) if isinstance(spec, MatchSpec) else v_fkey_(spec)
 
         def v_ms_(ms):
-            return ms.optional or any(v_fkey_(fkey) for fkey in self.find_matches(ms))
+            return (optional and ms.optional) or any(v_fkey_(fkey) for fkey in self.find_matches(ms))
 
         def v_fkey_(dist):
             assert isinstance(dist, Dist)
@@ -246,7 +248,7 @@ class Resolve(object):
         result = v_(spec_or_dist)
         return result
 
-    def invalid_chains(self, spec, filter):
+    def invalid_chains(self, spec, filter, optional=True):
         """Constructs a set of 'dependency chains' for invalid specs.
 
         A dependency chain is a tuple of MatchSpec objects, starting with
@@ -259,12 +261,14 @@ class Resolve(object):
             spec: a package key or MatchSpec
             filter: a dictionary of (dist, valid) pairs to be used when
                 testing for package validity.
+            optional: if True (default), do not enforce optional specifications
+                when considering validity. If False, enforce them.
 
         Returns:
             A generator of tuples, empty if the MatchSpec is valid.
         """
         def chains_(spec, names):
-            if self.valid(spec, filter) or spec.name in names:
+            if self.valid(spec, filter, optional) or spec.name in names:
                 return
             dists = self.find_matches(spec) if isinstance(spec, MatchSpec) else [Dist(spec)]
             found = False
@@ -358,11 +362,11 @@ class Resolve(object):
             filter = {}
             for mn, v in sdep.items():
                 if mn != ms.name and mn in commkeys:
-                    # Mark this package's "unique" dependencies as invali
+                    # Mark this package's "unique" dependencies as invalid
                     for fkey in v - commkeys[mn]:
                         filter[fkey] = False
             # Find the dependencies that lead to those invalid choices
-            ndeps = set(self.invalid_chains(ms, filter))
+            ndeps = set(self.invalid_chains(ms, filter, False))
             # This may produce some additional invalid chains that we
             # don't care about. Select only those that terminate in our
             # predetermined set of "common" keys.
@@ -585,9 +589,9 @@ class Resolve(object):
             elif not ms.is_simple():
                 m = C.from_name(self.push_MatchSpec(C, ms.name))
         if m is None:
+            libs = [dist.full_name for dist in libs]
             if ms.optional:
                 libs.append('!@s@'+ms.name)
-            libs = [dist.full_name for dist in libs]
             m = C.Any(libs)
         C.name_var(m, name)
         return name

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -842,6 +842,69 @@ def test_optional_dependencies():
     assert raises(UnsatisfiableError, lambda: r.install(['package1', 'package2 1.0']))
 
 
+def test_superceded():
+    index2 = index.copy()
+    index2['package1-1.0-0.tar.bz2'] = IndexRecord(**{
+        'build': '0',
+        'build_number': 0,
+        'depends': ['package2'],
+        'name': 'package1',
+        'requires': ['package2'],
+        'version': '1.0',
+    })
+    index2['package1-2.0-0.tar.bz2'] = IndexRecord(**{
+        'build': '0',
+        'build_number': 0,
+        'depends': ['package2 >=2.0 (optional)'],
+        'name': 'package1',
+        'requires': ['package2'],
+        'version': '2.0',
+    })
+    index2['package2-1.0-0.tar.bz2'] = IndexRecord(**{
+        'build': '0',
+        'build_number': 0,
+        'depends': [],
+        'name': 'package2',
+        'requires': [],
+        'version': '1.0',
+    })
+    index2['package2-2.0-0.tar.bz2'] = IndexRecord(**{
+        'build': '0',
+        'build_number': 0,
+        'depends': ['package1 >=2.0'],
+        'superceded': 'package1 >=2.0',
+        'name': 'package2',
+        'requires': [],
+        'version': '2.0',
+    })
+    index2 = {Dist(key): value for key, value in iteritems(index2)}
+    r = Resolve(index2)
+
+    assert set(r.find_matches(MatchSpec('package1'))) == {
+        Dist('package1-1.0-0.tar.bz2'),
+        Dist('package1-2.0-0.tar.bz2'),
+    }
+    assert set(r.get_reduced_index(['package1']).keys()) == {
+        Dist('package1-1.0-0.tar.bz2'),
+        Dist('package1-2.0-0.tar.bz2'),
+        Dist('package2-1.0-0.tar.bz2'),
+        Dist('package2-2.0-0.tar.bz2'),
+    }
+    installed = r.install(['package1 1.0'])
+    assert installed == [
+        Dist('package1-1.0-0.tar.bz2'),
+        Dist('package2-1.0-0.tar.bz2'),
+    ]
+    assert r.install(['package1 2.0']) == [
+        Dist('package1-2.0-0.tar.bz2'),
+    ]
+    assert r.install(['package1 2.0'], installed) == [
+        Dist('package1-2.0-0.tar.bz2'),
+        Dist('package2-2.0-0.tar.bz2'),
+    ]
+    assert raises(UnsatisfiableError, lambda: r.install(['package1 1.0', 'package2 2.0']))
+
+
 def test_package_ordering():
     sympy_071 = Package('sympy-0.7.1-py27_0.tar.bz2', r.index[Dist('sympy-0.7.1-py27_0.tar.bz2')])
     sympy_072 = Package('sympy-0.7.2-py27_0.tar.bz2', r.index[Dist('sympy-0.7.2-py27_0.tar.bz2')])

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -73,9 +73,11 @@ class TestMatchSpec(unittest.TestCase):
         m2 = MatchSpec(m, optional=False)
         m3 = MatchSpec(m2, target='blas-1.0-0.tar.bz2')
         m4 = MatchSpec(m3, target=None, optional=True)
+        m5 = MatchSpec('blas 1.0 (optional)')
         self.assertTrue(m.spec == m2.spec and m.optional != m2.optional)
         self.assertTrue(m2.spec == m3.spec and m2.optional == m3.optional and m2.target != m3.target)
         self.assertTrue(m == m4)
+        self.assertTrue(m == m5)
 
         self.assertRaises(ValueError, MatchSpec, 'blas (optional')
         self.assertRaises(ValueError, MatchSpec, 'blas (optional,test)')
@@ -791,6 +793,53 @@ def test_circular_dependencies():
         Dist('package1-1.0-0.tar.bz2'),
         Dist('package2-1.0-0.tar.bz2'),
     ]
+
+
+def test_optional_dependencies():
+    index2 = index.copy()
+    index2['package1-1.0-0.tar.bz2'] = IndexRecord(**{
+        'build': '0',
+        'build_number': 0,
+        'depends': ['package2 >1.0 (optional)'],
+        'name': 'package1',
+        'requires': ['package2'],
+        'version': '1.0',
+    })
+    index2['package2-1.0-0.tar.bz2'] = IndexRecord(**{
+        'build': '0',
+        'build_number': 0,
+        'depends': [],
+        'name': 'package2',
+        'requires': [],
+        'version': '1.0',
+    })
+    index2['package2-2.0-0.tar.bz2'] = IndexRecord(**{
+        'build': '0',
+        'build_number': 0,
+        'depends': [],
+        'name': 'package2',
+        'requires': [],
+        'version': '2.0',
+    })
+    index2 = {Dist(key): value for key, value in iteritems(index2)}
+    r = Resolve(index2)
+
+    assert set(r.find_matches(MatchSpec('package1'))) == {
+        Dist('package1-1.0-0.tar.bz2'),
+    }
+    assert set(r.get_reduced_index(['package1']).keys()) == {
+        Dist('package1-1.0-0.tar.bz2'),
+        Dist('package2-2.0-0.tar.bz2'),
+    }
+    assert r.install(['package1']) == [
+        Dist('package1-1.0-0.tar.bz2'),
+    ]
+    assert r.install(['package1', 'package2']) == r.install(['package1', 'package2 >1.0']) == [
+        Dist('package1-1.0-0.tar.bz2'),
+        Dist('package2-2.0-0.tar.bz2'),
+    ]
+    assert raises(UnsatisfiableError, lambda: r.install(['package1', 'package2 <2.0']))
+    assert raises(UnsatisfiableError, lambda: r.install(['package1', 'package2 1.0']))
 
 
 def test_package_ordering():


### PR DESCRIPTION
Improves the support for optional dependencies:
- Introduces a `test_optional_dependencies` test
- Fixes `UnsatisfiableSpecification` exceptions so that the `optional` MatchSpec flag is preserved in the output
- Fixes `find_conflicts` so that optional specs can be treated as conflicts

The result gives us errors like this:
```
conda.exceptions.UnsatisfiableError: The following specifications were found to be in conflict:
  - package1 -> package2 >1.0 (optional)
  - package2 <2.0
```
The `(optional)` keyword, including the parentheses, was already supported by the MatchSpec object.

If this works, we should be able to support optional dependencies in the repodata and in `conda build` with little or no changes.