### PR TITLE
Add clobber configuration

### DIFF
--- a/conda/_vendor/auxlib/type_coercion.py
+++ b/conda/_vendor/auxlib/type_coercion.py
@@ -3,6 +3,8 @@ from collections import Mapping
 from itertools import chain
 from re import IGNORECASE, compile
 
+from enum import Enum
+
 from .compat import NoneType, integer_types, isiterable, iteritems, string_types, text_type
 from .decorators import memoize, memoizedproperty
 from .exceptions import AuxlibError
@@ -211,6 +213,11 @@ def typify(value, type_hint=None):
     # now we either have a stripped string, a type hint, or both
     # use the hint if it exists
     if isiterable(type_hint):
+        if issubclass(type_hint, Enum):
+            try:
+                return type_hint(value)
+            except ValueError:
+                return type_hint[value]
         type_hint = set(type_hint)
         if not (type_hint - NUMBER_TYPES_SET):
             return numberify(value)

--- a/conda/_vendor/auxlib/type_coercion.py
+++ b/conda/_vendor/auxlib/type_coercion.py
@@ -213,7 +213,7 @@ def typify(value, type_hint=None):
     # now we either have a stripped string, a type hint, or both
     # use the hint if it exists
     if isiterable(type_hint):
-        if issubclass(type_hint, Enum):
+        if isinstance(type_hint, type) and issubclass(type_hint, Enum):
             try:
                 return type_hint(value)
             except ValueError:

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 from os.path import join
 
+from enum import Enum
+
 on_win = bool(sys.platform == "win32")
 PREFIX_PLACEHOLDER = ('/opt/anaconda1anaconda2'
                       # this is intentionally split into parts, such that running
@@ -95,3 +97,9 @@ INTERRUPT_SIGNALS = (
     'SIGQUIT',
     'SIGBREAK',
 )
+
+
+class PathConflict(Enum):
+    clobber = 'clobber'
+    warn = 'warn'
+    prevent = 'prevent'

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -52,10 +52,10 @@ _arch_names = {
 }
 
 
-class ClobberBehavior(Enum):
-    enforcing = 'enforcing'
-    permissive = 'permissive'
-    disabled = 'disabled'
+class PathConflict(Enum):
+    clobber = 'clobber'
+    warn = 'warn'
+    prevent = 'prevent'
 
 
 def channel_alias_validation(value):
@@ -70,7 +70,7 @@ class Context(Configuration):
     allow_softlinks = PrimitiveParameter(True)
     auto_update_conda = PrimitiveParameter(True, aliases=('self_update',))
     changeps1 = PrimitiveParameter(True)
-    clobber_behavior = PrimitiveParameter(ClobberBehavior.disabled)
+    path_conflict = PrimitiveParameter(PathConflict.clobber)
     create_default_packages = SequenceParameter(string_types)
     disallow = SequenceParameter(string_types)
     force_32bit = PrimitiveParameter(False)

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -9,6 +9,8 @@ from os.path import abspath, basename, dirname, expanduser, isdir, join
 from platform import machine
 import sys
 
+from enum import Enum
+
 from .constants import (APP_NAME, DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS, ROOT_ENV_NAME,
                         SEARCH_PATH)
 from .._vendor.auxlib.decorators import memoizedproperty
@@ -50,6 +52,12 @@ _arch_names = {
 }
 
 
+class ClobberBehavior(Enum):
+    enforcing = 'enforcing'
+    permissive = 'permissive'
+    disabled = 'disabled'
+
+
 def channel_alias_validation(value):
     if value and not has_scheme(value):
         return "channel_alias value '%s' must have scheme/protocol." % value
@@ -62,6 +70,7 @@ class Context(Configuration):
     allow_softlinks = PrimitiveParameter(True)
     auto_update_conda = PrimitiveParameter(True, aliases=('self_update',))
     changeps1 = PrimitiveParameter(True)
+    clobber_behavior = PrimitiveParameter(ClobberBehavior.disabled)
     create_default_packages = SequenceParameter(string_types)
     disallow = SequenceParameter(string_types)
     force_32bit = PrimitiveParameter(False)

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -9,8 +9,7 @@ from os.path import abspath, basename, dirname, expanduser, isdir, join
 from platform import machine
 import sys
 
-from enum import Enum
-
+from conda.base.constants import PathConflict
 from .constants import (APP_NAME, DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS, ROOT_ENV_NAME,
                         SEARCH_PATH)
 from .._vendor.auxlib.decorators import memoizedproperty
@@ -52,12 +51,6 @@ _arch_names = {
 }
 
 
-class PathConflict(Enum):
-    clobber = 'clobber'
-    warn = 'warn'
-    prevent = 'prevent'
-
-
 def channel_alias_validation(value):
     if value and not has_scheme(value):
         return "channel_alias value '%s' must have scheme/protocol." % value
@@ -69,16 +62,17 @@ class Context(Configuration):
     add_pip_as_python_dependency = PrimitiveParameter(True)
     allow_softlinks = PrimitiveParameter(True)
     auto_update_conda = PrimitiveParameter(True, aliases=('self_update',))
+    clobber = PrimitiveParameter(False)
     changeps1 = PrimitiveParameter(True)
-    path_conflict = PrimitiveParameter(PathConflict.clobber)
+    concurrent = PrimitiveParameter(False)
     create_default_packages = SequenceParameter(string_types)
     disallow = SequenceParameter(string_types)
     force_32bit = PrimitiveParameter(False)
+    path_conflict = PrimitiveParameter(PathConflict.clobber)
+    repodata_timeout_secs = PrimitiveParameter(300)
+    rollback_enabled = PrimitiveParameter(True)
     track_features = SequenceParameter(string_types)
     use_pip = PrimitiveParameter(True)
-    concurrent = PrimitiveParameter(False)
-    rollback_enabled = PrimitiveParameter(True)
-    repodata_timeout_secs = PrimitiveParameter(300)
 
     _root_dir = PrimitiveParameter("", aliases=('root_dir',))
     _envs_dirs = SequenceParameter(string_types, aliases=('envs_dirs', 'envs_path'),

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -384,6 +384,17 @@ def add_parser_show_channel_urls(p):
         help="Don't show channel urls.",
     )
 
+
+def add_parser_create_install_update(p):
+    p.add_argument(
+        "--clobber",
+        action="store_true",
+        default=NULL,
+        help="Allow clobbering of overlapping file paths within packages, "
+             "and suppress related warnings.",
+    )
+
+
 def ensure_use_local(args):
     if not args.use_local:
         return

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -75,10 +75,9 @@ class TooFewArgumentsError(ArgumentError):
         self.received = received
         self.optional_message = optional_message
 
-        msg = 'Too few arguments: %s. Got %s arguments and expected %s.' %\
-              (optional_message, received, expected)
+        msg = ('Too few arguments: %s. Got %s arguments and expected %s.' %
+               (optional_message, received, expected))
         super(TooFewArgumentsError, self).__init__(msg, *args)
-
 
 
 class ClobberError(CondaError):

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -604,7 +604,7 @@ def maybe_raise(error, context):
                 print_conda_exception(CondaMultiError(clobber_errors))
             if non_clobber_errors:
                 raise CondaMultiError(non_clobber_errors)
-    if isinstance(error, ClobberError):
+    elif isinstance(error, ClobberError):
         if context.path_conflict == PathConflict.prevent and not context.clobber:
             raise error
         elif context.path_conflict == PathConflict.warn and not context.clobber:

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -26,7 +26,7 @@ from ...common.compat import on_win
 from ...common.path import win_path_ok
 from ...exceptions import BasicClobberError, CondaOSError, maybe_raise
 from ...models.dist import Dist
-from ...models.enums import LinkType, PathType
+from ...models.enums import LinkType
 
 log = getLogger(__name__)
 stdoutlog = getLogger('stdoutlog')

--- a/conda/gateways/download.py
+++ b/conda/gateways/download.py
@@ -13,7 +13,7 @@ from .. import CondaError
 from .._vendor.auxlib.ish import dals
 from ..base.context import context
 from ..connection import CondaSession
-from ..exceptions import ClobberError, CondaHTTPError, MD5MismatchError
+from ..exceptions import BasicClobberError, CondaHTTPError, MD5MismatchError, maybe_raise
 
 log = getLogger(__name__)
 
@@ -52,7 +52,7 @@ def download(url, target_full_path, md5sum):
     content_length = None
 
     if exists(target_full_path):
-        raise ClobberError(target_full_path, url, None)
+        maybe_raise(BasicClobberError(target_full_path, url, context))
 
     if not context.ssl_verify:
         disable_ssl_verify_warning()

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -2,13 +2,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+
+from conda.base.constants import PathConflict
 from conda.common.path import win_path_backout
 from tempfile import gettempdir
 
 import pytest
 from conda._vendor.auxlib.ish import dals
 from conda._vendor.toolz.itertoolz import concat
-from conda.base.context import context, reset_context, ClobberBehavior
+from conda.base.context import context, reset_context
 from conda.common.compat import odict
 from conda.common.configuration import ValidationError, YamlRawParameter
 from conda.common.io import env_var
@@ -149,5 +151,5 @@ class ContextTests(TestCase):
         assert rc.get('conda-build')['root-dir'] == "/some/test/path"
 
     def test_clobber_enum(self):
-        with env_var("CONDA_CLOBBER_BEHAVIOR", 'enforcing', reset_context):
-            assert context.clobber_behavior == ClobberBehavior.enforcing
+        with env_var("CONDA_PATH_CONFLICT", 'prevent', reset_context):
+            assert context.path_conflict == PathConflict.prevent

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -8,7 +8,7 @@ from tempfile import gettempdir
 import pytest
 from conda._vendor.auxlib.ish import dals
 from conda._vendor.toolz.itertoolz import concat
-from conda.base.context import context, reset_context
+from conda.base.context import context, reset_context, ClobberBehavior
 from conda.common.compat import odict
 from conda.common.configuration import ValidationError, YamlRawParameter
 from conda.common.io import env_var
@@ -147,3 +147,7 @@ class ContextTests(TestCase):
         assert context.conda_build['root-dir'] == "/some/test/path"
         from conda.config import rc
         assert rc.get('conda-build')['root-dir'] == "/some/test/path"
+
+    def test_clobber_enum(self):
+        with env_var("CONDA_CLOBBER_BEHAVIOR", 'enforcing', reset_context):
+            assert context.clobber_behavior == ClobberBehavior.enforcing


### PR DESCRIPTION
This PR implements a new configuration option, called `path_conflict`.  It has three possible values: `clobber`, `warn`, and `prevent`.  In 4.3, the default value will be `clobber`.  That will give package maintainers time to correct current incompatibilities within their package ecosystem. In 4.4, the default will switch to `warn`, which means these operations continue to clobber, but the warning messages are displayed.  In `4.5`, the default value will switch to `prevent`.

This PR also implements a `--clobber` command line flag.  Using it overrides the setting for `path_conflict` to effectively be `clobber` for that operation.