### PR TITLE
Trick Codecov to ignore site-packages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,3 +10,6 @@ ignore:
   - conda/gateways/adapters/ftp.py
   - conda/gateways/adapters/s3.py
   - tests/.*
+
+fixes:
+  - ".*/Lib/site-packages/.*::"


### PR DESCRIPTION
This is in the `fixes` section because we are fixing a path from `C:/Python35_64/Lib/site-packages/conda/fetch.py` to an empty string and therefore be ignored by Codecov.

CC discussion with @kalefranz