### PR TITLE
Do not consider dists that are not in the index

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -118,15 +118,7 @@ def display_actions(actions, index, show_channel_urls=None):
         features[pkg][1] = rec.get('features', '')
     for arg in actions.get(UNLINK, []):
         dist = Dist(arg)
-        rec = index.get(dist)
-        if rec is None:
-            package_name, version, build, schannel = dist.quad
-            rec = dict(name=package_name,
-                       version=version,
-                       build=build,
-                       channel=None,
-                       schannel=UNKNOWN_CHANNEL,
-                       build_number=int(build) if build.isdigit() else 0)
+        rec = index[dist]
         pkg = rec['name']
         channels[pkg][0] = channel_str(rec)
         packages[pkg][0] = rec['version'] + '-' + rec['build']

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -470,9 +470,12 @@ class Resolve(object):
         n, v, b = rec['name'], rec['version'], rec['build']
         return any(n == ms.name and ms.match_fast(v, b) for ms in mss)
 
-    def match(self, ms, dist):
+    def match(self, ms, fkey):
         # type: (MatchSpec, Dist) -> bool
-        return MatchSpec(ms).match(dist)
+        rec = self.index[fkey]
+        ms = MatchSpec(ms)
+        return (ms.name == rec['name'] and
+                ms.match_fast(rec['version'], rec['build']))
 
     def match_fast(self, ms, fkey):
         rec = self.index[fkey]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -31,7 +31,7 @@ class ExportIntegrationTests(TestCase):
             output2, error= run_command(Commands.LIST, prefix2, "-e")
             self.assertEqual(output, output2)
 
-    @pytest.mark.xfail(datetime.now() < datetime(2017, 1, 1), reason="Bring back `conda list --export` #3445",
+    @pytest.mark.xfail(datetime.now() < datetime(2017, 2, 1), reason="Bring back `conda list --export` #3445",
                        strict = True)
     def test_multi_channel_export(self):
         """

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -814,50 +814,6 @@ The following packages will be UPDATED:
 """
 
 
-def test_display_actions_no_index():
-    # Test removing a package that is not in the index. This issue
-    # should only come up for removing.
-    actions = defaultdict(list, {'UNLINK': ['notinstalled-1.0-py33_0']})
-
-    with captured() as c:
-        display_actions(actions, index)
-
-    assert c.stdout == """
-The following packages will be REMOVED:
-
-    notinstalled: 1.0-py33_0 <unknown>
-
-"""
-
-    actions = defaultdict(list, {"LINK": ['numpy-1.7.1-py33_0'], "UNLINK":
-        ['numpy-2.0.0-py33_1']})
-
-    with captured() as c:
-        display_actions(actions, index)
-
-    assert c.stdout == """
-The following packages will be DOWNGRADED due to dependency conflicts:
-
-    numpy: 2.0.0-py33_1 <unknown> --> 1.7.1-py33_0 <unknown>
-
-"""
-
-    # tk-8.5.13-1 is not in the index. Test that it guesses the build number
-    # correctly.
-    actions = defaultdict(list, {"LINK": ['tk-8.5.13-0'], "UNLINK":
-        ['tk-8.5.13-1']})
-
-    with captured() as c:
-        display_actions(actions, index)
-
-    assert c.stdout == """
-The following packages will be DOWNGRADED due to dependency conflicts:
-
-    tk: 8.5.13-1 <unknown> --> 8.5.13-0 <unknown>
-
-"""
-
-
 class TestDeprecatedExecutePlan(unittest.TestCase):
 
     def test_update_old_plan(self):


### PR DESCRIPTION
It doesn't make sense for there to be an UNLINK instruction for packages that are not in the index, now that all installed packages are included _in_ the index when constructing any plan.

Similarly, Resolve.match should never be called for a package that is not in the index.

More generally: `Dist` should move towards being nothing more than a record key, and should not assume to contain information like package name, version, etc. This will become much more important when namespaces come out.