### PR TITLE
Add/fix supplement_index_with_*

### DIFF
--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -285,7 +285,7 @@ class NewIntegrationTest(unittest.TestCase):
             Test conda env export
         """
 
-        run_conda_command(Commands.CREATE, test_env_name_2, "python")
+        run_conda_command(Commands.CREATE, test_env_name_2, "python=3.5")
         self.assertTrue(env_is_created(test_env_name_2))
 
         # install something from other channel not in config file

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -41,17 +41,28 @@ class GetIndexIntegrationTests(TestCase):
                     for dist, record in iteritems(index):
                         assert platform_in_record(this_platform, record), (this_platform, record.url)
 
-        with env_var('CONDA_OFFLINE', 'yes', reset_context):
-            with patch.object(conda.core.index, 'fetch_repodata_remote_request') as remote_request:
-                index2 = get_index(channel_urls=channel_urls, prepend=False)
-                assert index2 == index
-                assert remote_request.call_count == 0
+        # When unknown=True (which is implicity engaged when context.offline is
+        # True), there may be additional items in the cache that are included in
+        # the index. But where those items coincide with entries already in the
+        # cache, they must not change the record in any way. TODO: add one or
+        # more packages to the cache so these tests affirmatively exercise
+        # supplement_index_from_cache on CI?
 
-        with env_var('CONDA_REPODATA_TIMEOUT_SECS', '0', reset_context):
-            with patch.object(conda.core.index, 'fetch_repodata_remote_request') as remote_request:
-                remote_request.side_effect = Response304ContentUnchanged()
-                index3 = get_index(channel_urls=channel_urls, prepend=False)
-                assert index3 == index
+        for unknown in (None, False, True):
+            with env_var('CONDA_OFFLINE', 'yes', reset_context):
+                with patch.object(conda.core.index, 'fetch_repodata_remote_request') as remote_request:
+                    index2 = get_index(channel_urls=channel_urls, prepend=False, unknown=unknown)
+                    assert all(index2.get(k) == rec for k, rec in iteritems(index))
+                    assert unknown is not False or len(index) == len(index2)
+                    assert remote_request.call_count == 0
+
+        for unknown in (False, True):
+            with env_var('CONDA_REPODATA_TIMEOUT_SECS', '0', reset_context):
+                with patch.object(conda.core.index, 'fetch_repodata_remote_request') as remote_request:
+                    remote_request.side_effect = Response304ContentUnchanged()
+                    index3 = get_index(channel_urls=channel_urls, prepend=False, unknown=unknown)
+                    assert all(index3.get(k) == rec for k, rec in iteritems(index))
+                    assert unknown or len(index) == len(index3)
 
     def test_get_index_linux64_platform(self):
         linux64 = 'linux-64'

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -189,7 +189,7 @@ class IntegrationTests(TestCase):
 
     @pytest.mark.timeout(900)
     def test_create_install_update_remove(self):
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 
@@ -263,7 +263,7 @@ class IntegrationTests(TestCase):
 
     @pytest.mark.timeout(300)
     def test_list_with_pip_egg(self):
-        with make_temp_env("python=3 pip") as prefix:
+        with make_temp_env("python=3.5 pip") as prefix:
             check_call(PYTHON_BINARY + " -m pip install --egg --no-binary flask flask==0.10.1",
                        cwd=prefix, shell=True)
             stdout, stderr = run_command(Commands.LIST, prefix)
@@ -273,7 +273,7 @@ class IntegrationTests(TestCase):
 
     @pytest.mark.timeout(300)
     def test_list_with_pip_wheel(self):
-        with make_temp_env("python=3 pip") as prefix:
+        with make_temp_env("python=3.5 pip") as prefix:
             check_call(PYTHON_BINARY + " -m pip install flask==0.10.1",
                        cwd=prefix, shell=True)
             stdout, stderr = run_command(Commands.LIST, prefix)
@@ -463,7 +463,7 @@ class IntegrationTests(TestCase):
     @pytest.mark.skipif(on_win, reason="r packages aren't prime-time on windows just yet")
     @pytest.mark.timeout(600)
     def test_clone_offline_multichannel_with_untracked(self):
-        with make_temp_env("python") as prefix:
+        with make_temp_env("python=3.5") as prefix:
 
             run_command(Commands.CONFIG, prefix, "--add channels https://repo.continuum.io/pkgs/free")
             run_command(Commands.CONFIG, prefix, "--remove channels defaults")
@@ -884,7 +884,7 @@ class IntegrationTests(TestCase):
                 assert not package_is_installed(prefix, 'openssl')
 
     def test_transactional_rollback_upgrade_downgrade(self):
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -13,7 +13,7 @@ class ExportIntegrationTests(TestCase):
 
     @pytest.mark.timeout(900)
     def test_basic(self):
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 
@@ -38,7 +38,7 @@ class ExportIntegrationTests(TestCase):
             When try to import from txt
             every package should come from same channel
         """
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 
@@ -66,7 +66,7 @@ class ExportIntegrationTests(TestCase):
             When try to import from txt
             every package should come from same channel
         """
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -10,7 +10,7 @@ from .test_create import (make_temp_env, assert_package_is_installed,
 class PriorityTest(TestCase):
 
     def test_channel_order_channel_priority_true(self):
-        with make_temp_env("python=3 pycosat==0.6.1") as prefix:
+        with make_temp_env("python=3.5 pycosat==0.6.1") as prefix:
             assert_package_is_installed(prefix, 'python')
             assert_package_is_installed(prefix, 'pycosat')
 
@@ -38,7 +38,7 @@ class PriorityTest(TestCase):
         """
             This case will fail now
         """
-        with make_temp_env("python=3 ") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert_package_is_installed(prefix, 'python')
 
             # add conda-forge channel


### PR DESCRIPTION
This restores `add_unknown` functionality with a new function `supplement_index_with_cache`, and it simplifies `supplement_index_with_prefix` as well. It also moves `add_pip_dependency` into `get_index`.