### PR TITLE
Trick Codecov to ignore site-packages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,3 +10,6 @@ ignore:
   - conda/gateways/adapters/ftp.py
   - conda/gateways/adapters/s3.py
   - tests/.*
+
+fixes:
+  - ".*/Lib/site-packages/.*::"


### PR DESCRIPTION
@stevepeak let's use this PR.  Pointed at the 4.3.x branch with is the current release branch, and also passing tests.  I'll post links to Travis Appveyor, and Codecov runs for each commit.