### PR TITLE
Eliminate distkey string parsing

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -93,6 +93,8 @@ PRIVATE_ENVS = join(sys.prefix, "conda-meta/private_envs")
 
 UNKNOWN_CHANNEL = "<unknown>"
 
+PIP_PSEUDOCHANNEL = "<pip>"
+
 INTERRUPT_SIGNALS = (
     'SIGABRT',
     'SIGINT',

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -21,6 +21,7 @@ from ..exceptions import (CondaFileIOError, CondaRuntimeError, CondaSystemExit, 
                           DryRunExit)
 from ..resolve import MatchSpec
 from ..utils import memoize
+from ..compat import itervalues
 get_prefix = partial(context_get_prefix, context)
 
 
@@ -107,7 +108,7 @@ class InstalledPackages(Completer):
     def _get_items(self):
         from conda.core.linked_data import linked
         packages = linked(context.prefix_w_legacy_search)
-        return [dist.quad[0] for dist in packages]
+        return [rec['name'] for rec in itervalues(packages)]
 
 def add_parser_help(p):
     """

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -12,7 +12,7 @@ from .common import (Completer, Packages, add_parser_channels, add_parser_json, 
                      ensure_override_channels_requires_channel, ensure_use_local, stdout_json)
 from ..api import get_index
 from ..base.context import context
-from ..common.compat import text_type
+from ..common.compat import text_type, itervalues
 from ..exceptions import CommandArgumentError, PackageNotFoundError
 from ..misc import make_icon_url
 from ..resolve import MatchSpec, NoPackagesFoundError
@@ -158,7 +158,7 @@ def execute_search(args, parser):
     from ..core.package_cache import PackageCache
 
     linked = linked_data(prefix)
-    extracted = set(pc_entry.dist.name for pc_entry in PackageCache.get_all_extracted_entries())
+    extracted = set(pc_entry.dist for pc_entry in PackageCache.get_all_extracted_entries())
 
     # XXX: Make this work with more than one platform
     platform = args.platform or ''
@@ -205,7 +205,8 @@ def execute_search(args, parser):
             json[name] = []
 
         if args.outdated:
-            vers_inst = [dist.quad[1] for dist in linked if dist.quad[0] == name]
+            vers_inst = [rec['version'] for rec in itervalues(linked)
+                         if rec['name'] == name]
             if not vers_inst:
                 continue
             assert len(vers_inst) == 1, name

--- a/conda/core/linked_data.py
+++ b/conda/core/linked_data.py
@@ -44,7 +44,8 @@ def load_linked_data(prefix, dist_name, rec=None, ignore_channels=False):
     fn = rec.get('fn')
     if not fn:
         fn = rec['fn'] = url.rsplit('/', 1)[-1] if url else dist_name + '.tar.bz2'
-    if fn[:-8] != dist_name:
+    if fn[:-8] != dist_name or any(x not in rec for x in
+                                   ('name', 'version', 'build', 'build_number')):
         log.debug('Ignoring invalid package metadata file: %s' % meta_file)
         return None
     channel = rec.get('channel')

--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from logging import getLogger
 from os import listdir
-from os.path import basename, isdir, isfile, islink, join
+from os.path import basename, dirname, isdir, isfile, islink, join
 from traceback import format_exc
 
 from .path_actions import CacheUrlAction, ExtractPackageAction
@@ -233,9 +233,14 @@ class PackageCache(object):
     @classmethod
     def tarball_file_in_cache(cls, tarball_path, md5sum=None):
         tarball_full_path, md5sum = cls._clean_tarball_path_and_get_md5sum(tarball_path, md5sum)
+        tarball_dir = dirname(tarball_full_path)
+        if tarball_dir in context.pkgs_dirs:
+            pkgs_dirs = (tarball_dir,)
+        else:
+            pkgs_dirs = context.pkgs_dirs
         pc_entry = first(PackageCache(pkgs_dir).tarball_file_in_this_cache(tarball_full_path,
                                                                            md5sum)
-                         for pkgs_dir in context.pkgs_dirs)
+                         for pkgs_dir in pkgs_dirs)
         return pc_entry
 
     @classmethod

--- a/conda/history.py
+++ b/conda/history.py
@@ -35,9 +35,13 @@ def pretty_diff(diff):
     added = {}
     removed = {}
     for s in diff:
-        fn = s[1:]
-        dist = Dist(fn)
-        name, version, _, channel = dist.quad
+        parts = s[1:].rsplit(' ')
+        dist = Dist(parts[0])
+        channel, fn = dist.pair
+        if len(parts) == 4:
+            _, name, version, _ = parts
+        else:
+            name, version, _ = fn.rsplit('-', 2)
         if channel != DEFAULTS:
             version += ' (%s)' % channel
         if s.startswith('-'):
@@ -46,11 +50,11 @@ def pretty_diff(diff):
             added[name.lower()] = version
     changed = set(added) & set(removed)
     for name in sorted(changed):
-        yield ' %s  {%s -> %s}' % (name, removed[name], added[name])
+        yield ' %s {%s -> %s}' % (name, removed[name], added[name])
     for name in sorted(set(removed) - changed):
-        yield '-%s-%s' % (name, removed[name])
+        yield '-%s %s' % (name, removed[name])
     for name in sorted(set(added) - changed):
-        yield '+%s-%s' % (name, added[name])
+        yield '+%s %s' % (name, added[name])
 
 
 def pretty_content(content):

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -62,6 +62,7 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
             raise ParseError('Could not parse explicit URL: %s' % spec)
         url_p, fn, md5sum = m.group('url_p'), m.group('fn'), m.group('md5')
         url = join_url(url_p, fn)
+
         # url_p is everything but the tarball_basename and the md5sum
 
         # If the path points to a file in the package cache, we need to use
@@ -265,7 +266,7 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
 
     if r is None:
         r = Resolve(index)
-    dists = r.dependency_sort({d.quad[0]: d for d in urls.keys()})
+    dists = r.dependency_sort({index[d]['name']: d for d in urls.keys()})
     urls = [urls[d] for d in dists]
 
     if verbose:

--- a/conda_env/pip_util.py
+++ b/conda_env/pip_util.py
@@ -98,7 +98,7 @@ def installed(prefix, output=True):
         yield PipPackage(**kwargs)
 
 
-def add_pip_installed(prefix, installed_pkgs, json=None, output=True):
+def pip_installed(prefix, conda_pkgs, json=None, output=True):
     # Defer to json for backwards compatibility
     if isinstance(json, bool):
         output = not json
@@ -106,8 +106,11 @@ def add_pip_installed(prefix, installed_pkgs, json=None, output=True):
     # TODO Refactor so installed is a real list of objects/dicts
     #      instead of strings allowing for direct comparison
     # split :: to get rid of channel info
-    conda_names = {d.quad[0] for d in installed_pkgs}
+    installed_pkgs = set()
     for pip_pkg in installed(prefix, output=output):
-        if pip_pkg['name'] in conda_names and 'path' not in pip_pkg:
+        if ((pip_pkg['name'] in conda_pkgs or
+             pip_pkg['name'].replace('-', '_') in conda_pkgs) and
+           'path' not in pip_pkg):
             continue
         installed_pkgs.add(str(pip_pkg))
+    return installed_pkgs

--- a/tests/models/test_dist.py
+++ b/tests/models/test_dist.py
@@ -15,10 +15,6 @@ class DistTests(TestCase):
     def test_dist(self):
         d = Dist.from_string("spyder-app-2.3.8-py27_0.tar.bz2")
         assert d.channel == 'defaults'
-        assert d.quad[0] == "spyder-app"
-        assert d.quad[1] == "2.3.8"
-        assert d.quad[2] == "py27_0"
-        assert d.build_number == 0
         assert d.dist_name == "spyder-app-2.3.8-py27_0"
 
         assert d == Dist.from_string("spyder-app-2.3.8-py27_0")
@@ -36,21 +32,16 @@ class DistTests(TestCase):
 
         d = Dist("mkl@")
         assert d.channel == "@"
-        assert d.quad[0] == "mkl@"
-        assert d.quad[1] == ""
-        assert d.quad[2] == ""
         assert d.with_features_depends is None
         assert d.is_feature_package
 
     def test_channel(self):
         d = Dist.from_string("conda-forge::spyder-app-2.3.8-py27_0.tar.bz2")
         assert d.channel == 'conda-forge'
-        assert d.quad[0] == "spyder-app"
         assert d.dist_name == "spyder-app-2.3.8-py27_0"
 
         d = Dist.from_string("s3://some/bucket/name::spyder-app-2.3.8-py27_0.tar.bz2")
         assert d.channel == 's3://some/bucket/name'
-        assert d.quad[0] == "spyder-app"
         assert d.dist_name == "spyder-app-2.3.8-py27_0"
         assert d.to_url() == join_url("s3://some/bucket/name", context.subdir,
                                       "spyder-app-2.3.8-py27_0.tar.bz2")
@@ -63,9 +54,6 @@ class UrlDistTests(TestCase):
         url = "https://repo.continuum.io/pkgs/free/win-64/spyder-app-2.3.8-py27_0.tar.bz2"
         d = Dist(url)
         assert d.channel == 'defaults'
-        assert d.name == 'spyder-app'
-        assert d.version == '2.3.8'
-        assert d.build_string == 'py27_0'
 
         assert d.to_url() == url
         assert d.is_channel is True
@@ -74,9 +62,6 @@ class UrlDistTests(TestCase):
         url = "https://not.real.continuum.io/pkgs/free/win-64/spyder-app-2.3.8-py27_0.tar.bz2"
         d = Dist(url)
         assert d.channel == 'defaults'  # because pkgs/free is in defaults
-        assert d.name == 'spyder-app'
-        assert d.version == '2.3.8'
-        assert d.build_string == 'py27_0'
 
         assert d.to_url() == url
         assert d.is_channel is True
@@ -85,9 +70,6 @@ class UrlDistTests(TestCase):
         url = "https://not.real.continuum.io/not/free/win-64/spyder-app-2.3.8-py27_0.tar.bz2"
         d = Dist(url)
         assert d.channel == 'https://not.real.continuum.io/not/free'
-        assert d.name == 'spyder-app'
-        assert d.version == '2.3.8'
-        assert d.build_string == 'py27_0'
 
         assert d.to_url() == url
         assert d.is_channel is True
@@ -96,9 +78,6 @@ class UrlDistTests(TestCase):
         url = path_to_url(join_url(context.croot, 'osx-64', 'bcrypt-3.1.1-py35_2.tar.bz2'))
         d = Dist(url)
         assert d.channel == 'local'
-        assert d.name == 'bcrypt'
-        assert d.version == '3.1.1'
-        assert d.build_string == 'py35_2'
 
         assert d.to_url() == url
         assert d.is_channel is True
@@ -107,9 +86,6 @@ class UrlDistTests(TestCase):
         url = join_url('file:///some/location/on/disk', 'osx-64', 'bcrypt-3.1.1-py35_2.tar.bz2')
         d = Dist(url)
         assert d.channel == 'file:///some/location/on/disk'
-        assert d.name == 'bcrypt'
-        assert d.version == '3.1.1'
-        assert d.build_string == 'py35_2'
 
         assert d.to_url() == url
         assert d.is_channel is True
@@ -119,9 +95,6 @@ class UrlDistTests(TestCase):
         url = "https://repo.continuum.io/pkgs/free/cffi-1.9.1-py34_0.tar.bz2"
         d = Dist(url)
         assert d.channel == '<unknown>'
-        assert d.name == 'cffi'
-        assert d.version == '1.9.1'
-        assert d.build_string == 'py34_0'
 
         assert d.to_url() == url
         assert d.is_channel is False
@@ -130,9 +103,6 @@ class UrlDistTests(TestCase):
         url = path_to_url(join_url(context.croot, 'cffi-1.9.1-py34_0.tar.bz2'))
         d = Dist(url)
         assert d.channel == '<unknown>'
-        assert d.name == 'cffi'
-        assert d.version == '1.9.1'
-        assert d.build_string == 'py34_0'
 
         assert d.to_url() == url
         assert d.is_channel is False
@@ -142,9 +112,6 @@ class UrlDistTests(TestCase):
         url = join_url(path_to_url(context.pkgs_dirs[0]), 'cffi-1.9.1-py34_0.tar.bz2')
         d = Dist(url)
         assert d.channel == '<unknown>'
-        assert d.name == 'cffi'
-        assert d.version == '1.9.1'
-        assert d.build_string == 'py34_0'
 
         assert d.to_url() == url
         assert d.is_channel is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,7 @@ class TestJson(unittest.TestCase):
         with captured():
             res = capture_json_with_argv('conda search --json')
         self.assertIsInstance(res, dict)
+        assert 'conda' in res
         self.assertIsInstance(res['conda'], list)
         self.assertIsInstance(res['conda'][0], dict)
         keys = ('build', 'channel', 'extracted', 'features', 'fn',

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -48,6 +48,21 @@ def solve(specs):
     return [Dist.from_string(fn) for fn in r.solve(specs)]
 
 
+def IndexRecord_from_dist(d, **rec):
+    channel, dist_name = Dist(d).pair
+    name, version, build = dist_name.rsplit('-', 2)
+    try:
+        build_number = int(build.rsplit('_', 1)[-1])
+    except:
+        build_number = 0
+    rec.update({'name': name,
+                'version': version,
+                'build': build,
+                'build_number': build_number})
+    rec.setdefault('channel', channel)
+    return IndexRecord.from_objects(rec)
+
+
 class add_unlink_TestCase(unittest.TestCase):
     def generate_random_dist(self):
         return "foobar-%s-0" % random.randint(100, 200)
@@ -277,9 +292,9 @@ def test_display_actions_show_channel_urls():
         "numpy-1.7.1-py27_0"]})
     # The older test index doesn't have the size metadata
     d = Dist('sympy-0.7.2-py27_0.tar.bz2')
-    index[d] = IndexRecord.from_objects(d, size=4374752)
+    index[d] = IndexRecord_from_dist(d, size=4374752)
     d = Dist('numpy-1.7.1-py27_0.tar.bz2')
-    index[d] = IndexRecord.from_objects(d, size=5994338)
+    index[d] = IndexRecord_from_dist(d, size=5994338)
 
     with captured() as c:
         display_actions(actions, index)
@@ -413,9 +428,9 @@ The following packages will be DOWNGRADED due to dependency conflicts:
     actions['LINK'], actions['UNLINK'] = actions['UNLINK'], actions['LINK']
 
     d = Dist('cython-0.19.1-py33_0.tar.bz2')
-    index[d] = IndexRecord.from_objects(d, channel='my_channel')
+    index[d] = IndexRecord_from_dist(d, channel='my_channel')
     d = Dist('dateutil-1.5-py33_0.tar.bz2')
-    index[d] = IndexRecord.from_objects(d, channel='my_channel')
+    index[d] = IndexRecord_from_dist(d, channel='my_channel')
 
     with captured() as c:
         display_actions(actions, index)
@@ -852,9 +867,9 @@ class PlanFromActionsTests(unittest.TestCase):
 
     def test_plan_link_menuinst(self):
         menuinst = Dist('menuinst-1.4.2-py27_0')
-        menuinst_record = IndexRecord.from_objects(menuinst)
+        menuinst_record = IndexRecord_from_dist(menuinst)
         ipython = Dist('ipython-5.1.0-py27_1')
-        ipython_record = IndexRecord.from_objects(ipython)
+        ipython_record = IndexRecord_from_dist(ipython)
         actions = {
             'PREFIX': 'aprefix',
             'LINK': [ipython, menuinst],
@@ -890,20 +905,20 @@ class PlanFromActionsTests(unittest.TestCase):
         assert expected_plan[2] == conda_plan[2]
 
 
+
 def generate_mocked_resolve(pkgs, install=None):
-    mock_package = namedtuple("IndexRecord",
-                              ["preferred_env", "name", "schannel", "version", "fn"])
-    mock_resolve = namedtuple("Resolve", ["get_dists_for_spec", "index", "explicit", "install",
-                                          "package_name", "dependency_sort"])
+    mock_package = namedtuple("IndexRecord", ["preferred_env", "name", "schannel",
+                                              "version", "build", "fn"])
+    mock_resolve = namedtuple("Resolve", ["index", "get_dists_for_spec", "explicit", 
+                                          "install", "package_name", 
+                                          "dependency_sort", "match"])
 
     index = {}
     groups = defaultdict(list)
     for preferred_env, name, schannel, version in pkgs:
         dist = Dist.from_string('%s-%s-0' % (name, version), channel_override=schannel)
-        pkg = mock_package(preferred_env=preferred_env, name=name, schannel=schannel,
-                           version=version, fn=name)
         groups[name].append(dist)
-        index[dist] = pkg
+        index[dist] = IndexRecord_from_dist(dist, preferred_env=preferred_env)
 
     def get_dists_for_spec(spec, emptyok=False):
         # Here, spec should be a MatchSpec
@@ -918,15 +933,26 @@ def generate_mocked_resolve(pkgs, install=None):
     def get_install(spec, installed, update_deps=None):
         return install
 
+    def get_record(dist):
+        rec = index.get(dist)
+        if rec is None:
+            rec = IndexRecord_from_dist(dist)
+        return rec
+
     def get_package_name(dist):
-        return dist.name
+        return get_record(dist)['name']
 
     def get_dependency_sort(specs):
         return tuple(spec for spec in specs.values())
 
-    return mock_resolve(get_dists_for_spec=get_dists_for_spec, index=index, explicit=get_explicit,
-                        install=get_install, package_name=get_package_name,
-                        dependency_sort=get_dependency_sort)
+    def get_match(ms, dist):
+        ms = MatchSpec(ms)
+        rec = get_record(dist)
+        return (ms.name == rec['name'] and
+                ms.match_fast(rec['version'], rec['build']))
+
+    return mock_resolve(index, get_dists_for_spec, get_explicit, get_install,
+                        get_package_name, get_dependency_sort, get_match)
 
 
 def generate_mocked_record(dist_name):
@@ -1201,7 +1227,7 @@ class TestAddUnlinkOptionsForUpdate(unittest.TestCase):
 
         test_link_data = {context.root_prefix: {Dist("test1-2.1.4-1"): True}}
         with patch("conda.core.linked_data.linked_data_", test_link_data):
-            plan.add_unlink_options_for_update(actions, required_solves, self.res.index)
+            plan.add_unlink_options_for_update(actions, required_solves, self.res)
 
         expected_output = [action, generate_remove_action("root/prefix", [Dist("test1-2.1.4-1")])]
         self.assertEquals(actions, expected_output)
@@ -1224,7 +1250,7 @@ class TestAddUnlinkOptionsForUpdate(unittest.TestCase):
 
         test_link_data = {context.root_prefix: {Dist("test1-2.1.4-1"): True}}
         with patch("conda.core.linked_data.linked_data_", test_link_data):
-            plan.add_unlink_options_for_update(actions, required_solves, self.res.index)
+            plan.add_unlink_options_for_update(actions, required_solves, self.res)
 
         aug_action_root = defaultdict(list)
         aug_action_root["PREFIX"] = context.root_prefix
@@ -1243,7 +1269,7 @@ class TestAddUnlinkOptionsForUpdate(unittest.TestCase):
         action["PREFIX"] = "root/prefix"
         action["LINK"] = [Dist("test3-1.2.0"), Dist("test4-1.2.1")]
         actions = [action]
-        plan.add_unlink_options_for_update(actions, required_solves, self.res.index)
+        plan.add_unlink_options_for_update(actions, required_solves, self.res)
         expected_output = [action, generate_remove_action(
             "some/prefix/envs/_env_", [Dist("test3-1.2.0"), Dist("test4-2.1.0-22")])]
         self.assertEquals(actions, expected_output)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -25,6 +25,10 @@ r = Resolve(index)
 f_mkl = set(['mkl'])
 
 
+def triple_(dstr):
+    return dstr[:-8].rsplit('-',2)
+
+
 class TestMatchSpec(unittest.TestCase):
 
     def test_match(self):
@@ -45,20 +49,20 @@ class TestMatchSpec(unittest.TestCase):
             ('python', False),
             ]:
             m = MatchSpec(spec)
-            self.assertEqual(m.match(Dist('numpy-1.7.1-py27_0.tar.bz2')), res)
+            self.assertEqual(m.match(*triple_('numpy-1.7.1-py27_0.tar.bz2')), res)
 
         # both version numbers conforming to PEP 440
-        self.assertFalse(MatchSpec('numpy >=1.0.1').match(Dist('numpy-1.0.1a-0.tar.bz2')))
+        self.assertFalse(MatchSpec('numpy >=1.0.1').match(*triple_('numpy-1.0.1a-0.tar.bz2')))
         # both version numbers non-conforming to PEP 440
-        self.assertFalse(MatchSpec('numpy >=1.0.1.vc11').match(Dist('numpy-1.0.1a.vc11-0.tar.bz2')))
-        self.assertTrue(MatchSpec('numpy >=1.0.1*.vc11').match(Dist('numpy-1.0.1a.vc11-0.tar.bz2')))
+        self.assertFalse(MatchSpec('numpy >=1.0.1.vc11').match(*triple_('numpy-1.0.1a.vc11-0.tar.bz2')))
+        self.assertTrue(MatchSpec('numpy >=1.0.1*.vc11').match(*triple_('numpy-1.0.1a.vc11-0.tar.bz2')))
         # one conforming, other non-conforming to PEP 440
-        self.assertTrue(MatchSpec('numpy <1.0.1').match(Dist('numpy-1.0.1.vc11-0.tar.bz2')))
-        self.assertTrue(MatchSpec('numpy <1.0.1').match(Dist('numpy-1.0.1a.vc11-0.tar.bz2')))
-        self.assertFalse(MatchSpec('numpy >=1.0.1.vc11').match(Dist('numpy-1.0.1a-0.tar.bz2')))
-        self.assertTrue(MatchSpec('numpy >=1.0.1a').match(Dist('numpy-1.0.1z-0.tar.bz2')))
-        self.assertTrue(MatchSpec('numpy >=1.0.1a py27*').match(Dist('numpy-1.0.1z-py27_1.tar.bz2')))
-        self.assertTrue(MatchSpec('blas * openblas').match(Dist('blas-1.0-openblas.tar.bz2')))
+        self.assertTrue(MatchSpec('numpy <1.0.1').match(*triple_('numpy-1.0.1.vc11-0.tar.bz2')))
+        self.assertTrue(MatchSpec('numpy <1.0.1').match(*triple_('numpy-1.0.1a.vc11-0.tar.bz2')))
+        self.assertFalse(MatchSpec('numpy >=1.0.1.vc11').match(*triple_('numpy-1.0.1a-0.tar.bz2')))
+        self.assertTrue(MatchSpec('numpy >=1.0.1a').match(*triple_('numpy-1.0.1z-0.tar.bz2')))
+        self.assertTrue(MatchSpec('numpy >=1.0.1a py27*').match(*triple_('numpy-1.0.1z-py27_1.tar.bz2')))
+        self.assertTrue(MatchSpec('blas * openblas').match(*triple_('blas-1.0-openblas.tar.bz2')))
 
         self.assertTrue(MatchSpec('blas').is_simple())
         self.assertFalse(MatchSpec('blas').is_exact())
@@ -112,7 +116,7 @@ class TestSolve(unittest.TestCase):
 
     def assert_have_mkl(self, dists, names):
         for dist in dists:
-            if dist.quad[0] in names:
+            if r.package_name(dist) in names:
                 self.assertEqual(r.features(dist), f_mkl)
 
     def test_explicit0(self):
@@ -917,10 +921,10 @@ def test_broken_install():
     installed2 = list(installed)
     installed2[1] = Dist('numpy-1.7.1-py33_p0.tar.bz2')
     installed2.append(Dist('notarealpackage-2.0-0.tar.bz2'))
-    assert r.install([], installed2) == installed2
+    assert r.install([], installed2) == installed2[:-1]
     installed3 = r.install(['numpy'], installed2)
     installed4 = r.remove(['pandas'], installed2)
-    assert set(installed4) == set(installed2[:3] + installed2[4:])
+    assert set(installed4) == set(installed2[:3] + installed2[4:-1])
 
     # Remove the installed version of pandas from the index
     index2 = index.copy()


### PR DESCRIPTION
Builds on #4130. Removed `name`, `version`, `build_number`, and `build` from the `Dist` object, so that it becomes just a key into an index of, say, `IndexRecord` objects, which already have all of that information.

Requiring that filenames obey a very specific format, and parsing them to retrieve information such as this, prevents us from considering alternatives as may be needed in the future; e.g., for namespaces. And reliable `build_number` extraction requires reliance on an undocumented assumption that the build number is `int(build.rsplit('_', 1)[-1]`.