### PR TITLE
Fix history tracking

### DIFF
--- a/conda/history.py
+++ b/conda/history.py
@@ -89,12 +89,12 @@ class History(object):
         try:
             self.init_log_file()
             try:
-                last = self.get_state()
+                last = set(self.get_state())
             except CondaHistoryError as e:
                 warnings.warn("Error in %s: %s" % (self.path, e),
                               CondaHistoryWarning)
                 return
-            curr = set(linked(self.prefix))
+            curr = set(map(str, linked(self.prefix)))
             if last == curr:
                 # print a head when a blank env is first created to preserve history
                 if enter_or_exit == 'exit' and self.file_is_empty():
@@ -269,5 +269,6 @@ class History(object):
 
 if __name__ == '__main__':
     from pprint import pprint
-    with History(sys.prefix) as h:
-        pprint(h.get_user_requests())
+    # Don't use in context manager mode---it augments the history every time
+    h = History(sys.prefix)
+    pprint(h.get_user_requests())

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -285,7 +285,7 @@ class NewIntegrationTest(unittest.TestCase):
             Test conda env export
         """
 
-        run_conda_command(Commands.CREATE, test_env_name_2, "python")
+        run_conda_command(Commands.CREATE, test_env_name_2, "python=3.5")
         self.assertTrue(env_is_created(test_env_name_2))
 
         # install something from other channel not in config file

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -189,7 +189,7 @@ class IntegrationTests(TestCase):
 
     @pytest.mark.timeout(900)
     def test_create_install_update_remove(self):
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 
@@ -263,7 +263,7 @@ class IntegrationTests(TestCase):
 
     @pytest.mark.timeout(300)
     def test_list_with_pip_egg(self):
-        with make_temp_env("python=3 pip") as prefix:
+        with make_temp_env("python=3.5 pip") as prefix:
             check_call(PYTHON_BINARY + " -m pip install --egg --no-binary flask flask==0.10.1",
                        cwd=prefix, shell=True)
             stdout, stderr = run_command(Commands.LIST, prefix)
@@ -273,7 +273,7 @@ class IntegrationTests(TestCase):
 
     @pytest.mark.timeout(300)
     def test_list_with_pip_wheel(self):
-        with make_temp_env("python=3 pip") as prefix:
+        with make_temp_env("python=3.5 pip") as prefix:
             check_call(PYTHON_BINARY + " -m pip install flask==0.10.1",
                        cwd=prefix, shell=True)
             stdout, stderr = run_command(Commands.LIST, prefix)
@@ -463,7 +463,7 @@ class IntegrationTests(TestCase):
     @pytest.mark.skipif(on_win, reason="r packages aren't prime-time on windows just yet")
     @pytest.mark.timeout(600)
     def test_clone_offline_multichannel_with_untracked(self):
-        with make_temp_env("python") as prefix:
+        with make_temp_env("python=3.5") as prefix:
 
             run_command(Commands.CONFIG, prefix, "--add channels https://repo.continuum.io/pkgs/free")
             run_command(Commands.CONFIG, prefix, "--remove channels defaults")
@@ -884,7 +884,7 @@ class IntegrationTests(TestCase):
                 assert not package_is_installed(prefix, 'openssl')
 
     def test_transactional_rollback_upgrade_downgrade(self):
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -13,7 +13,7 @@ class ExportIntegrationTests(TestCase):
 
     @pytest.mark.timeout(900)
     def test_basic(self):
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 
@@ -38,7 +38,7 @@ class ExportIntegrationTests(TestCase):
             When try to import from txt
             every package should come from same channel
         """
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 
@@ -66,7 +66,7 @@ class ExportIntegrationTests(TestCase):
             When try to import from txt
             every package should come from same channel
         """
-        with make_temp_env("python=3") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
             assert_package_is_installed(prefix, 'python-3')
 

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -10,7 +10,7 @@ from .test_create import (make_temp_env, assert_package_is_installed,
 class PriorityTest(TestCase):
 
     def test_channel_order_channel_priority_true(self):
-        with make_temp_env("python=3 pycosat==0.6.1") as prefix:
+        with make_temp_env("python=3.5 pycosat==0.6.1") as prefix:
             assert_package_is_installed(prefix, 'python')
             assert_package_is_installed(prefix, 'pycosat')
 
@@ -38,7 +38,7 @@ class PriorityTest(TestCase):
         """
             This case will fail now
         """
-        with make_temp_env("python=3 ") as prefix:
+        with make_temp_env("python=3.5") as prefix:
             assert_package_is_installed(prefix, 'python')
 
             # add conda-forge channel


### PR DESCRIPTION
`linked` returns `Dist` objects, while `get_state` returns strings, and neither will be unordered, so it will never be true (except in empty environments) that `last == cur`.