### PR TITLE
Fix #4152

### DIFF
--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -57,7 +57,7 @@ def from_environment(name, prefix, no_builds=False, ignore_channels=False):
     # this doesn't dump correctly using pyyaml
     channels = list(context.channels)
     if not ignore_channels:
-        for dist in installed:
+        for dist in conda_pkgs:
             if dist.channel not in channels:
                 channels.insert(0, dist.channel)
     return Environment(name=name, dependencies=dependencies, channels=channels, prefix=prefix)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -36,10 +36,9 @@ def from_environment(name, prefix, no_builds=False, ignore_channels=False):
         name: The name of environment
         prefix: The path of prefix
         no_builds: Whether has build requirement
-        ignore_channels: whether ingore_channels
+        ignore_channels: whether ignore_channels
 
-    Returns:     Environment obejct
-
+    Returns:     Environment object
     """
     installed = linked(prefix, ignore_channels=ignore_channels)
     conda_pkgs = copy(installed)


### PR DESCRIPTION
The `pip_pkgs` are `str`s, so trying to get their `.channel` attribute
raises an error. Only `conda_pkgs` have channels anyways.