### PR TITLE
Bump date to fix test_multi_channel_export

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -31,7 +31,7 @@ class ExportIntegrationTests(TestCase):
             output2, error= run_command(Commands.LIST, prefix2, "-e")
             self.assertEqual(output, output2)
 
-    @pytest.mark.xfail(datetime.now() < datetime(2017, 1, 1), reason="Bring back `conda list --export` #3445",
+    @pytest.mark.xfail(datetime.now() < datetime(2017, 2, 1), reason="Bring back `conda list --export` #3445",
                        strict = True)
     def test_multi_channel_export(self):
         """


### PR DESCRIPTION
We are very close to getting full channel support into conda env. Until then, this test continues to fail.