### PR TITLE
auxlib/packaging: Git hashes are not limited to 9 characters

### DIFF
--- a/conda/_vendor/auxlib/packaging.py
+++ b/conda/_vendor/auxlib/packaging.py
@@ -92,7 +92,7 @@ log = getLogger(__name__)
 Response = namedtuple('Response', ['stdout', 'stderr', 'rc'])
 GIT_DESCRIBE_REGEX = compile(r"(?:[_-a-zA-Z]*)"
                              r"(?P<version>\d+\.\d+\.\d+)"
-                             r"(?:-(?P<dev>\d+)-g(?P<hash>[0-9a-f]{7,9}))")
+                             r"(?:-(?P<dev>\d+)-g(?P<hash>[0-9a-f]{7,}))")
 
 
 def call(command, path=None, raise_on_error=True):


### PR DESCRIPTION
They are unlimited. https://git-scm.com/docs/git-describe states:
".. or as many digits as needed to form a unique object name."