### PR TITLE
4.2.x

### DIFF
--- a/conda/_vendor/auxlib/packaging.py
+++ b/conda/_vendor/auxlib/packaging.py
@@ -92,7 +92,7 @@ log = getLogger(__name__)
 Response = namedtuple('Response', ['stdout', 'stderr', 'rc'])
 GIT_DESCRIBE_REGEX = compile(r"(?:[_-a-zA-Z]*)"
                              r"(?P<version>\d+\.\d+\.\d+)"
-                             r"(?:-(?P<dev>\d+)-g(?P<hash>[0-9a-f]{7}))$")
+                             r"(?:-(?P<dev>\d+)-g(?P<hash>[0-9a-f]{7,9}))")
 
 
 def call(path, command, raise_on_error=True):

--- a/conda/_vendor/auxlib/packaging.py
+++ b/conda/_vendor/auxlib/packaging.py
@@ -92,7 +92,7 @@ log = getLogger(__name__)
 Response = namedtuple('Response', ['stdout', 'stderr', 'rc'])
 GIT_DESCRIBE_REGEX = compile(r"(?:[_-a-zA-Z]*)"
                              r"(?P<version>\d+\.\d+\.\d+)"
-                             r"(?:-(?P<dev>\d+)-g(?P<hash>[0-9a-f]{7,9}))")
+                             r"(?:-(?P<dev>\d+)-g(?P<hash>[0-9a-f]{7,}))")
 
 
 def call(path, command, raise_on_error=True):


### PR DESCRIPTION
Same again, this time for the 4.2.x branch with a necessary previous backport.