### PR TITLE
allow args passed to cli.main()

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -671,7 +671,6 @@ def package_cache():
         return package_cache_
     # Stops recursion
     package_cache_['@'] = None
-    # import pdb; pdb.set_trace()
     for pdir in context.pkgs_dirs:
         try:
             data = open(join(pdir, 'urls.txt')).read()


### PR DESCRIPTION
The purpose here is to be able to call cli.main to run conda from within an existing process.  It's an alternative to the API that is present in conda 4.3.