### PR TITLE
fix #3287 activate in 4.1-4.2.3 clobbers non-conda PATH changes

### DIFF
--- a/shell/activate
+++ b/shell/activate
@@ -56,7 +56,9 @@ if (( $? != 0 )); then
 fi
 
 # Ensure we deactivate any scripts from the old env
+_CONDA_HOLD=true
 source "$_CONDA_DIR/deactivate"
+unset _CONDA_HOLD
 
 _NEW_PART=$("$_CONDA_DIR/conda" ..activate $_SHELL$EXT "$args")
 if (( $? == 0 )); then
@@ -64,7 +66,14 @@ if (( $? == 0 )); then
     # export this to restore it upon deactivation
     export CONDA_PS1_BACKUP="$PS1"
 
-    export PATH="$_NEW_PART:$PATH"
+    # look if the deactivate script left a placeholder for us
+    if [[ $PATH == *"CONDA_PATH_PLACEHOLDER"* ]]; then
+        # If it did, replace it with our _NEW_PART
+        export PATH="$(echo "$PATH" | sed -E "s|CONDA_PATH_PLACEHOLDER|$_NEW_PART|g")"
+    else
+        export PATH="$_NEW_PART:$PATH"
+    fi
+
     # CONDA_DEFAULT_ENV is the shortest representation of how conda recognizes your env.
     #    It can be an env name, or a full path.
     #    Last date of change: 2016-06-21

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -67,9 +67,22 @@ if (( $? == 0 )); then
         IFS=$(echo -en "\n\b") && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
     fi
 
+    # get the activation path that would have been provided for this prefix
+    _LAST_ACTIVATE_PATH=$("$_CONDA_DIR/conda" ..activate $_SHELL$EXT "$CONDA_PREFIX")
+
+    # in activate, we replace a placeholder so that conda keeps its place in the PATH order
+    # The activate script sets _CONDA_HOLD here to activate that behavior.
+    #   Otherwise, PATH is simply removed.
+    if [ -n "$_CONDA_HOLD" ]; then
+        export PATH="$(echo "$PATH" | sed -E "s|$_LAST_ACTIVATE_PATH(:?)|CONDA_PATH_PLACEHOLDER\1|g")"
+    else
+        export PATH="$(echo "$PATH" | sed -E "s|$_LAST_ACTIVATE_PATH(:?)||g")"
+    fi
+
+    unset _LAST_ACTIVATE_PATH
+
     unset CONDA_DEFAULT_ENV
     unset CONDA_PREFIX
-    export PATH="$CONDA_PATH_BACKUP"
     unset CONDA_PATH_BACKUP
     export PS1="$CONDA_PS1_BACKUP"
     unset CONDA_PS1_BACKUP


### PR DESCRIPTION
Might go with this instead of #4211 to get it out quickly.  QA tests seem to be messed up in 4.1.x right now.