### PR TITLE
version: Fix comparision of multi-part bits

### DIFF
--- a/conda/version.py
+++ b/conda/version.py
@@ -126,9 +126,6 @@ class VersionOrder(object):
       1.0.1a  =>  1.0.1post.a      # ensure correct ordering for openssl
     '''
     def __init__(self, version):
-        # when fillvalue ==  0  =>  1.1 == 1.1.0
-        # when fillvalue == -1  =>  1.1  < 1.1.0
-        self.fillvalue = 0
 
         message = "Malformed version string '%s': " % version
         # version comparison is case-insensitive
@@ -194,22 +191,42 @@ class VersionOrder(object):
                     v[k] = c
                 else:
                     # components shall start with a number to keep numbers and
-                    # strings in phase => prepend fillvalue
-                    v[k] = [self.fillvalue] + c
+                    # strings in phase => prepend 0
+                    v[k] = [0] + c
+        return self
 
     def __str__(self):
         return self.norm_version
 
-    def _eq(self, t1, t2):
-        for v1, v2 in zip_longest(t1, t2, fillvalue=[]):
-            for c1, c2 in zip_longest(v1, v2, fillvalue=self.fillvalue):
-                if c1 != c2:
-                    return False
-        return True
-
     def __eq__(self, other):
-        return (self._eq(self.version, other.version) and
-                self._eq(self.local, other.local))
+        return (not (self.version < other.version) and
+                not (self.version > other.version))
+
+    def _lt(self, t1, t2):
+        min_per_type = {str: 'DEV', int: 0}
+        for v1, v2 in zip_longest(t1, t2, fillvalue=[]):
+            for c1, c2 in zip_longest(v1, v2):
+                if c1 is None:
+                    c1 = min_per_type[type(c2)]
+                elif c2 is None:
+                    c2 = min_per_type[type(c1)]
+                if c1 == c2:
+                    continue
+                elif isinstance(c1, string_types):
+                    if not isinstance(c2, string_types):
+                        # str < int
+                        return True
+                elif isinstance(c2, string_types):
+                        # not (int < str)
+                        return False
+                # c1 and c2 have the same type
+                return c1 < c2
+        # self == other
+        return False
+
+    def _eq(self, t1, t2):
+        return (not self._lt(t1, t2) and
+                not self._lt(t2, t1))
 
     def startswith(self, other):
         # Tests if the version lists match up to the last element in "other".
@@ -231,7 +248,7 @@ class VersionOrder(object):
         nt = len(v2) - 1
         if not self._eq([v1[:nt]], [v2[:nt]]):
             return False
-        c1 = self.fillvalue if len(v1) <= nt else v1[nt]
+        c1 = 0 if len(v1) <= nt else v1[nt]
         c2 = v2[nt]
         if isinstance(c2, string_types):
             return isinstance(c1, string_types) and c1.startswith(c2)
@@ -241,21 +258,9 @@ class VersionOrder(object):
         return not (self == other)
 
     def __lt__(self, other):
-        for t1, t2 in zip([self.version, self.local], [other.version, other.local]):
-            for v1, v2 in zip_longest(t1, t2, fillvalue=[]):
-                for c1, c2 in zip_longest(v1, v2, fillvalue=self.fillvalue):
-                    if c1 == c2:
-                        continue
-                    elif isinstance(c1, string_types):
-                        if not isinstance(c2, string_types):
-                            # str < int
-                            return True
-                    elif isinstance(c2, string_types):
-                            # not (int < str)
-                            return False
-                    # c1 and c2 have the same type
-                    return c1 < c2
-        # self == other
+        if self._lt(self.version, other.version):
+            if self._lt(self.local, other.local):
+                return True
         return False
 
     def __gt__(self, other):


### PR DESCRIPTION
```
if VersionOrder('4.3.2.dev2+38bb992b') < VersionOrder('4.3.2'):
    raise RuntimeError("Non-native subdir support only in conda >= 4.3.2")
```

The problem here was that each part of [0,'DEV',2] was being compared
against 0 and strings ('DEV') are considered less than ints (0).

Also re-implement __eq__ in terms of __lt__ only to prevent repeated logic
and remove the self.fillvalue thing (we always use 0 or 'DEV' now). Though
if anyone cares it could be supported.