### PR TITLE
version: Fix comparision of multi-part bits

### DIFF
--- a/shell/activate
+++ b/shell/activate
@@ -101,7 +101,7 @@ if (( $? == 0 )); then
     # Load any of the scripts found $PREFIX/etc/conda/activate.d AFTER activation
     _CONDA_D="${CONDA_PREFIX}/etc/conda/activate.d"
     if [[ -d "$_CONDA_D" ]]; then
-        IFS=$(echo -en "\n\b")&>/dev/null  && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
+        for f in $(IFS=$(echo -en "\n\b") find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
     fi
 else
     return $?

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -64,7 +64,7 @@ if (( $? == 0 )); then
     # Inverse of activation: run deactivate scripts prior to deactivating env
     _CONDA_D="${CONDA_PREFIX}/etc/conda/deactivate.d"
     if [[ -d $_CONDA_D ]]; then
-        IFS=$(echo -en "\n\b") && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
+        for f in $(IFS=$(echo -en "\n\b") find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
     fi
 
     # get the activation path that would have been provided for this prefix


### PR DESCRIPTION
```
if VersionOrder('4.3.2.dev2+38bb992b') < VersionOrder('4.3.2'):
    raise RuntimeError("Non-native subdir support only in conda >= 4.3.2")
```

The problem here was that each part of [0,'DEV',2] was being compared
against 0 and strings ('DEV') are considered less than ints (0).

Also re-implement __eq__ in terms of __lt__ only to prevent repeated logic
and remove the self.fillvalue thing (we always use 0 or 'DEV' now). Though
if anyone cares it could be supported.