### PR TITLE
Remove features properly

### DIFF
--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -136,8 +136,8 @@ def execute(args, parser):
                           prefix=prefix)
     specs = None
     if args.features:
-        features = set(args.package_names)
-        actions = plan.remove_features_actions(prefix, index, features)
+        specs = ['@' + f for f in set(args.package_names)]
+        actions = plan.remove_actions(prefix, specs, index, pinned=args.pinned)
         action_groups = actions,
     elif args.all:
         if plan.is_root_prefix(prefix):

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -787,34 +787,6 @@ def remove_actions(prefix, specs, index, force=False, pinned=True):
     return actions
 
 
-def remove_features_actions(prefix, index, features):
-    r = Resolve(index)
-    linked = r.installed
-
-    actions = defaultdict(list)
-    actions[PREFIX] = prefix
-    _linked = [d + '.tar.bz2' for d in linked]
-    to_link = []
-
-    for dist in sorted(linked):
-        fn = dist.dist_name + '.tar.bz2'
-        if fn not in index:
-            continue
-        if r.track_features(fn).intersection(features):
-            add_unlink(actions, dist)
-        if r.features(fn).intersection(features):
-            add_unlink(actions, dist)
-            subst = r.find_substitute(_linked, features, fn)
-            if subst:
-                to_link.append(subst[:-8])
-
-    if to_link:
-        dists = (Dist(d) for d in to_link)
-        actions.update(ensure_linked_actions(dists, prefix))
-
-    return actions
-
-
 def remove_spec_action_from_prefix(prefix, dist):
     actions = defaultdict(list)
     actions[inst.PREFIX] = prefix

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -392,6 +392,20 @@ class IntegrationTests(TestCase):
             run_command(Commands.REMOVE, prefix, '--all')
             assert not exists(prefix)
 
+    @pytest.mark.skipif(on_win, reason="nomkl not present on windows")
+    @pytest.mark.timeout(300)
+    def test_remove_features(self):
+        with make_temp_env("numpy nomkl") as prefix:
+            assert exists(join(prefix, PYTHON_BINARY))
+            assert_package_is_installed(prefix, 'numpy')
+            assert_package_is_installed(prefix, 'nomkl')
+            assert not package_is_installed(prefix, 'mkl')
+
+            run_command(Commands.REMOVE, prefix, '--features', 'nomkl')
+            assert_package_is_installed(prefix, 'numpy')
+            assert not package_is_installed(prefix, 'nomkl')
+            assert_package_is_installed(prefix, 'mkl')
+
     @pytest.mark.skipif(on_win and context.bits == 32, reason="no 32-bit windows python on conda-forge")
     def test_dash_c_usage_replacing_python(self):
         # Regression test for #2606

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -222,18 +222,6 @@ class TestSolve(unittest.TestCase):
         self.assertEqual(len(dists), 61)
 
 
-class TestFindSubstitute(unittest.TestCase):
-
-    def test1(self):
-        installed = r.install(['anaconda 1.5.0', 'python 2.7*', 'numpy 1.7*', 'mkl@'])
-        for old, new in [('numpy-1.7.1-py27_p0.tar.bz2', 'numpy-1.7.1-py27_0.tar.bz2'),
-                         ('scipy-0.12.0-np17py27_p0.tar.bz2', 'scipy-0.12.0-np17py27_0.tar.bz2'),
-                         ('mkl-rt-11.0-p0.tar.bz2', None)
-                         ]:
-            assert Dist(old) in installed
-            assert r.find_substitute(installed, f_mkl, old) == (Dist(new) if new else None)
-
-
 def test_pseudo_boolean():
     # The latest version of iopro, 1.5.0, was not built against numpy 1.5
     assert r.install(['iopro', 'python 2.7*', 'numpy 1.5*'], returnall=True) == [[Dist(fn) for fn in [


### PR DESCRIPTION
I never did like how we had separate logic for removing features from an environment. The remove logic for normal packages should suffice. And it does suffice, with very minor modifications, as I hope you can see. The benefit here is no more special `remove_features_actions` method, no `find_substitute` method.