### PR TITLE
{de,}activate: Do not use `IFS` to find scripts to source

### DIFF
--- a/shell/activate
+++ b/shell/activate
@@ -101,7 +101,7 @@ if (( $? == 0 )); then
     # Load any of the scripts found $PREFIX/etc/conda/activate.d AFTER activation
     _CONDA_D="${CONDA_PREFIX}/etc/conda/activate.d"
     if [[ -d "$_CONDA_D" ]]; then
-        IFS=$(echo -en "\n\b")&>/dev/null  && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
+        eval $(find "$_CONDA_D" -iname "*.sh" -exec echo source \'{}\'';' \;)
     fi
 else
     return $?

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -64,7 +64,7 @@ if (( $? == 0 )); then
     # Inverse of activation: run deactivate scripts prior to deactivating env
     _CONDA_D="${CONDA_PREFIX}/etc/conda/deactivate.d"
     if [[ -d $_CONDA_D ]]; then
-        IFS=$(echo -en "\n\b") && for f in $(find "$_CONDA_D" -iname "*.sh"); do source "$f"; done
+        eval $(find "$_CONDA_D" -iname "*.sh" -exec echo source \'{}\'';' \;)
     fi
 
     # get the activation path that would have been provided for this prefix


### PR DESCRIPTION
Unfortunately this change would remain active afterwards and
this meant that normal variable delimiting did not work, so if a
script set CFLAGS="flag1 flag2", that value would be treated as
a single argument when passed to the compiler.

Instead `eval` and `find -exec echo` are used

{de,}activate