### PR TITLE
{de,}activate: Remove BSD-ism from sed calls

### DIFF
--- a/shell/activate
+++ b/shell/activate
@@ -69,7 +69,7 @@ if (( $? == 0 )); then
     # look if the deactivate script left a placeholder for us
     if [[ $PATH == *"CONDA_PATH_PLACEHOLDER"* ]]; then
         # If it did, replace it with our _NEW_PART
-        export PATH="$(echo "$PATH" | sed -E "s|CONDA_PATH_PLACEHOLDER|$_NEW_PART|g")"
+        export PATH="$(echo "$PATH" | sed "s|CONDA_PATH_PLACEHOLDER|$_NEW_PART|g")"
     else
         export PATH="$_NEW_PART:$PATH"
     fi

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -74,9 +74,9 @@ if (( $? == 0 )); then
     # The activate script sets _CONDA_HOLD here to activate that behavior.
     #   Otherwise, PATH is simply removed.
     if [ -n "$_CONDA_HOLD" ]; then
-        export PATH="$(echo "$PATH" | sed -E "s|$_LAST_ACTIVATE_PATH(:?)|CONDA_PATH_PLACEHOLDER\1|")"
+        export PATH="$(echo "$PATH" | sed "s|$_LAST_ACTIVATE_PATH|CONDA_PATH_PLACEHOLDER|")"
     else
-        export PATH="$(echo "$PATH" | sed -E "s|$_LAST_ACTIVATE_PATH(:?)||")"
+        export PATH="$(echo "$PATH" | sed -e "s|$_LAST_ACTIVATE_PATH:||" -e "s|$_LAST_ACTIVATE_PATH||")"
     fi
 
     unset _LAST_ACTIVATE_PATH


### PR DESCRIPTION
The `-E` flag only works on macOS (and some *BSD I guess). In GNU sed, the flag is
`-r`. These flags turn on 'extended regular expressions'.

Extended regular expressions were only needed in one of the three invocations (the
other case where initially it looked like it serves a purpose removed the `:` only
to put it back again).

The case that did make use of extended regular expressions is rewritten to use sed
'chaining' instead. I could've added code to determine which sed is being used but
macOS sed does not provide a `--version` flag and even if it did, calling it twice
would add the overhead of another process invocation.