### PR TITLE
Bugfix: include aliases for first argument

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -132,7 +132,7 @@ def _main(*args):
     # when using sys.argv, first argument is generally conda or __main__.py.  Ignore it.
     if (any(sname in args[0] for sname in ('conda', 'conda.exe',
                                            '__main__.py', 'conda-script.py')) and
-            (args[1] in main_modules + find_commands() or args[1].startswith('-'))):
+            (args[1] in list(sub_parsers.choices.keys()) + find_commands() or args[1].startswith('-'))):
         log.debug("Ignoring first argument (%s), as it is not a subcommand", args[0])
         args = args[1:]
 


### PR DESCRIPTION
`main_modules` does not have the 'upgrade' and 'uninstall' aliases.