### PR TITLE
Do not replace \ with / in file:// URLs on Windows

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -52,8 +52,6 @@ def url_to_path(url):  # NOQA
 
 @memoize
 def urlparse(url):
-    if on_win and url.startswith('file:'):
-        url.replace('\\', '/')
     return parse_url(url)
 
 

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -211,8 +211,6 @@ class Channel(object):
         if hasattr(value, 'decode'):
             value = value.decode(UTF8)
         if has_scheme(value):
-            if value.startswith('file:') and on_win:
-                value = value.replace('\\', '/')
             return Channel.from_url(value)
         elif value.startswith(('./', '..', '~', '/')) or is_windows_path(value):
             return Channel.from_url(path_to_url(value))


### PR DESCRIPTION
This makes channel URLs of the type

    file://\server\share\dir

and

    file://\\server\share\dir  # Windows uses this form internally

work again on Windows after it stopped working in the 4.2.x branch after version 4.2.9. More precisely, the last good commit was 63c67adc0fd9cd187bec79abdd5ca23f8ff73297 and the first bad commit is 027ee0dc94c5d6d21e8ce5585d778859d11a8313. The intermediate commits are savepoints where conda install does not run.

It was mentioned in issue #3779 that some instances of `value = value.replace('\\', '/')` could be the cause of the URLs not working anymore.

This is a fix for the 4.2.x branch only, and relevant only if there will be more 4.2.x releases. The proper fix for Windows UNC network paths was already merged into 4.3.x in PR #4190. This 4.2.x fix does not attempt to include support for the actual standard compliant URL `file://server/share/dir`, only to restore the forms that worked in 4.2.9 and earlier.

