### PR TITLE
Calculate streamed_bytes correctly

### DIFF
--- a/conda/gateways/download.py
+++ b/conda/gateways/download.py
@@ -97,10 +97,9 @@ def download(url, target_full_path, md5sum):
                       Content-Length: %(content_length)d
                       downloaded bytes: %(downloaded_bytes)d
                     """)
-                    # raise CondaError(message, url=url, target_path=target_full_path,
-                    #                  content_length=content_length,
-                    #                  downloaded_bytes=streamed_bytes)
-                    log.info(message)
+                    raise CondaError(message, url=url, target_path=target_full_path,
+                                     content_length=content_length,
+                                     downloaded_bytes=streamed_bytes)
 
             except (IOError, OSError) as e:
                 if e.errno == 104:

--- a/conda/gateways/download.py
+++ b/conda/gateways/download.py
@@ -73,7 +73,9 @@ def download(url, target_full_path, md5sum):
                 with open(target_full_path, 'wb') as fh:
                     streamed_bytes = 0
                     for chunk in resp.iter_content(2 ** 14):
-                        streamed_bytes += len(chunk)
+                        # chunk could be the decompressed form of the real data
+                        # but we want the exact number of bytes read till now
+                        streamed_bytes = resp.raw.tell()
                         try:
                             fh.write(chunk)
                         except IOError as e:


### PR DESCRIPTION
Since the requests module encapsulates the decoding of data received
over HTTP(S?), the chunk obtained from `iter_content()` could be the
decompressed form of the actual data received over the wire. Now, the
'Content-Length' HTTP header holds the raw length of the HTTP body.
Since `streamed_bytes` always ends up calculating the total length
of the decoded data, it may not match the value present in the header
'Content-Length' received as a response to the initial GET request.
Possible scenarios include cases when the data is compressed using
either gzip or deflate mechanisms.

This patch fixes this by calculating `streamed_bytes` from the method
`requests.packages.urllib3.response.HTTPResponse.tell`, which returns
the number of (undecoded) bytes pulled over the wire so far.

Fixes #4299 