### PR TITLE
link: Pass target_prefix as env_prefix regardless of is_unlink

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -302,7 +302,7 @@ class UnlinkLinkTransaction(object):
             run_script(target_prefix if is_unlink else pkg_data.extracted_package_dir,
                        Dist(pkg_data),
                        'pre-unlink' if is_unlink else 'pre-link',
-                       target_prefix if is_unlink else None)
+                       target_prefix)
             for axn_idx, action in enumerate(actions):
                 action.execute()
             run_script(target_prefix, Dist(pkg_data), 'post-unlink' if is_unlink else 'post-link')


### PR DESCRIPTION
Existing pre-link scripts expect $PREFIX to be the destination
prefix into which the package is being installed.

In 4.3 that code changed, None gets passed as env_prefix so
prefix gets used instead which is now the package cache and
not the destination. The commit which made this change is:
95241d2c6e19fd8a3223e3c703a39db8a9dcdb8f

This bug can be reproduced by:

```
conda install conda=4.3
conda install -c continuumcrew anaconda-navigator
```

resulting in:

```
/home/ray/mc-x64-3.5/pkgs/anaconda-navigator-1.4rc2-py_1/bin/.anaconda-navigator-pre-link.sh: line 3: /home/ray/mc-x64-3.5/pkgs/anaconda-navigator-1.4rc2-py_1/bin/python: No such file or directory
```