### PR TITLE
Eliminate index modification in Resolve.__init__

### DIFF
--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -5,6 +5,7 @@ import bz2
 from conda import CondaError
 from contextlib import closing
 from functools import wraps
+from itertools import chain
 import hashlib
 import json
 from logging import DEBUG, getLogger
@@ -28,6 +29,7 @@ from ..base.context import context
 from ..common.compat import ensure_text_type, ensure_unicode, iteritems, iterkeys, itervalues
 from ..common.url import join_url
 from ..connection import CondaSession
+from ..resolve import MatchSpec
 from ..exceptions import CondaHTTPError, CondaRuntimeError
 from ..gateways.disk.read import read_index_json
 from ..gateways.disk.update import touch
@@ -100,6 +102,54 @@ def supplement_index_with_cache(index, channels):
         index[dist] = rec
 
 
+def supplement_index_with_repodata(index, repodata, channel, priority):
+    repodata_info = repodata.get('info', {})
+    arch = repodata_info.get('arch')
+    platform = repodata_info.get('platform')
+    schannel = channel.canonical_name
+    channel_url = channel.url()
+    auth = channel.auth
+    for fn, info in iteritems(repodata['packages']):
+        rec = IndexRecord.from_objects(info,
+                                       fn=fn,
+                                       arch=arch,
+                                       platform=platform,
+                                       schannel=schannel,
+                                       channel=channel_url,
+                                       priority=priority,
+                                       url=join_url(channel_url, fn),
+                                       auth=auth)
+        dist = Dist(rec)
+        index[dist] = rec
+        if 'with_features_depends' in info:
+            base_deps = info.get('depends', ())
+            base_feats = set(info.get('features', '').strip().split())
+            for feat, deps in iteritems(info['with_features_depends']):
+                feat = set(feat.strip().split())
+                snames = {MatchSpec(s).name for s in deps}
+                base2 = [s for s in base_deps if MatchSpec(s).name not in snames]
+                feat2 = ' '.join(sorted(base_feats | feat))
+                feat = ' '.join(sorted(feat))
+                deps2 = base2 + deps
+                dist = Dist.from_objects(dist, with_features_depends=feat)
+                rec2 = IndexRecord.from_objects(rec, features=feat2, depends=deps2)
+                index[dist] = rec2
+
+
+def supplement_index_with_features(index, features=()):
+    for feat in chain(context.track_features, features):
+        fname = feat + '@'
+        rec = IndexRecord(
+            name=fname,
+            version='0',
+            build='0',
+            schannel='defaults',
+            track_features=feat,
+            build_number=0,
+            fn=fname)
+        index[Dist(rec)] = rec
+
+
 def get_index(channel_urls=(), prepend=True, platform=None,
               use_local=False, use_cache=False, unknown=None, prefix=None):
     """
@@ -125,6 +175,8 @@ def get_index(channel_urls=(), prepend=True, platform=None,
         supplement_index_with_prefix(index, prefix, known_channels)
     if unknown:
         supplement_index_with_cache(index, known_channels)
+    if context.track_features:
+        supplement_index_with_features(index)
     if context.add_pip_as_python_dependency:
         add_pip_dependency(index)
     return index
@@ -446,31 +498,12 @@ def fetch_index(channel_urls, use_cache=False, index=None):
     # type: List[Sequence[str, Option[Dict[Dist, IndexRecord]]]]
     #   this is sorta a lie; actually more primitve types
 
-    def make_index(repodatas):
-        result = dict()
-
-        for channel_url, repodata in repodatas:
-            if not repodata or not repodata.get('packages', {}):
-                continue
-            canonical_name, priority = channel_urls[channel_url]
+    index = dict()
+    for channel_url, repodata in repodatas:
+        if repodata and repodata.get('packages'):
+            _, priority = channel_urls[channel_url]
             channel = Channel(channel_url)
-            repodata_info = repodata.get('info', {})
-            arch = repodata_info.get('arch')
-            platform = repodata_info.get('platform')
-            for fn, info in iteritems(repodata['packages']):
-                rec = IndexRecord.from_objects(info,
-                                               fn=fn,
-                                               arch=arch,
-                                               platform=platform,
-                                               schannel=canonical_name,
-                                               channel=channel_url,
-                                               priority=priority,
-                                               url=join_url(channel_url, fn),
-                                               auth=channel.auth)
-                result[Dist(rec)] = rec
-        return result
-
-    index = make_index(repodatas)
+            supplement_index_with_repodata(index, repodata, channel, priority)
 
     if not context.json:
         stdoutlog.info('\n')

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from .enums import LinkType, Platform
 from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin, Entity,
                                      EnumField, ImmutableEntity, IntegerField, ListField,
-                                     MapField, StringField)
+                                     StringField)
 from ..common.compat import string_types
 
 

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -75,5 +75,4 @@ class IndexRecord(DictSafeMixin, ImmutableEntity):  # rename to IndexRecord
     files = ListField(string_types, default=(), required=False)
     link = ComposableField(Link, required=False)
 
-    with_features_depends = MapField(required=False)
     preferred_env = StringField(default=None, required=False, nullable=True)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from itertools import chain
 import logging
 import re
 
@@ -11,7 +10,6 @@ from .console import setup_handlers
 from .exceptions import CondaValueError, NoPackagesFoundError, UnsatisfiableError
 from .logic import Clauses, minimal_unsatisfiable_subset
 from .models.dist import Dist
-from .models.index_record import IndexRecord
 from .toposort import toposort
 from .version import VersionSpec, normalized_version
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -8,8 +8,10 @@ from conda.base.context import reset_context
 from conda.common.compat import iteritems, text_type
 from conda.exceptions import NoPackagesFoundError, UnsatisfiableError
 from conda.models.dist import Dist
+from conda.models.channel import Channel
 from conda.models.index_record import IndexRecord
 from conda.resolve import MatchSpec, Resolve
+from conda.core.index import supplement_index_with_repodata, supplement_index_with_features
 from os.path import dirname, join
 
 import pytest
@@ -18,8 +20,12 @@ from conda.resolve import MatchSpec, Resolve, NoPackagesFound, Unsatisfiable
 from tests.helpers import raises
 
 with open(join(dirname(__file__), 'index.json')) as fi:
-    index = {Dist(key): IndexRecord(**value) for key, value in iteritems(json.load(fi))}
+    repodata = json.load(fi)
 
+index = {}
+channel = Channel('defaults')
+supplement_index_with_repodata(index, {'packages': repodata}, channel, 1)
+supplement_index_with_features(index, ('mkl',))
 r = Resolve(index)
 
 f_mkl = set(['mkl'])


### PR DESCRIPTION
This change prevents Resolve from having to copy and modify its index.

To accomplish this, all of the modifications have been moved to `conda.core.index` so they can be done during the `fetch_index`/`get_index` phase. I'll comment more later, for now I'm getting this pushed up for better testing.