### PR TITLE
Pass positional argument 'context' to BasicClobberError

### DIFF
--- a/conda/gateways/download.py
+++ b/conda/gateways/download.py
@@ -52,7 +52,7 @@ def download(url, target_full_path, md5sum):
     content_length = None
 
     if exists(target_full_path):
-        maybe_raise(BasicClobberError(target_full_path, url, context))
+        maybe_raise(BasicClobberError(target_full_path, url, context), context)
 
     if not context.ssl_verify:
         disable_ssl_verify_warning()


### PR DESCRIPTION
Issue can be reproduced by:

```bash
(root) $ touch /tmp/src.tar.gz
(root) $ python3 -c '
from conda import fetch;
fetch.download(url="file:///tmp/src.tar.gz", dst_path="dest.tar.gz")'
(root) $ python3 -c '
from conda import fetch;
fetch.download(url="file:///tmp/src.tar.gz", dst_path="dest.tar.gz")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/condadev3/lib/python3.5/site-packages/conda/core/package_cache.py", line 514, in download
    gateway_download(url, dst_path, md5)
  File "/tmp/condadev3/lib/python3.5/site-packages/conda/gateways/download.py", line 55, in download
    maybe_raise(BasicClobberError(target_full_path, url, context))
TypeError: maybe_raise() missing 1 required positional argument: 'context'
```

`BasicClobberError()`: 'context' is a _required_ argument