### PR TITLE
workaround for symlink race conditions

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -561,6 +561,10 @@ def symlink_conda_hlp(prefix, root_dir, where, symlink_fn):
                     (e.errno in (errno.EPERM, errno.EACCES, errno.EROFS, errno.EEXIST))):
                 log.debug("Cannot symlink {0} to {1}. Ignoring since link already exists."
                           .format(root_file, prefix_file))
+            elif (e.errno == errno.ENOENT):
+                log.debug("Problem with symlink management {0} {1}. File may have been removed by another concurrent process." .format(root_file, prefix_file))
+            elif (e.errno == errno.EEXIST)):
+                log.debug("Problem with symlink management {0} {1}. File may have been created by another concurrent process." .format(root_file, prefix_file))
             else:
                 raise
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -558,13 +558,15 @@ def symlink_conda_hlp(prefix, root_dir, where, symlink_fn):
                 symlink_fn(root_file, prefix_file)
         except (IOError, OSError) as e:
             if (os.path.lexists(prefix_file) and
-                    (e.errno in (errno.EPERM, errno.EACCES, errno.EROFS, errno.EEXIST))):
+                    e.errno in (errno.EPERM, errno.EACCES, errno.EROFS, errno.EEXIST)):
                 log.debug("Cannot symlink {0} to {1}. Ignoring since link already exists."
                           .format(root_file, prefix_file))
-            elif (e.errno == errno.ENOENT):
-                log.debug("Problem with symlink management {0} {1}. File may have been removed by another concurrent process." .format(root_file, prefix_file))
-            elif (e.errno == errno.EEXIST)):
-                log.debug("Problem with symlink management {0} {1}. File may have been created by another concurrent process." .format(root_file, prefix_file))
+            elif e.errno == errno.ENOENT:
+                log.debug("Problem with symlink management {0} {1}. File may have been removed by "
+                          "another concurrent process." .format(root_file, prefix_file))
+            elif e.errno == errno.EEXIST:
+                log.debug("Problem with symlink management {0} {1}. File may have been created by "
+                          "another concurrent process." .format(root_file, prefix_file))
             else:
                 raise
 


### PR DESCRIPTION
See: https://github.com/conda/conda/issues/3001
This should fix a bug related to symlink race conditions on cluster shared filesystems.

Supersedes #4345.
Target is 4.2.x branch.  Will get merged up into 4.3.x for all future releases.