### PR TITLE
revert json output for leaky plan

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -593,6 +593,14 @@ def json_progress_bars(json=False):
 
 def stdout_json_success(success=True, **kwargs):
     result = {'success': success}
+
+    # this code reverts json output for plan back to previous behavior
+    #   relied on by Anaconda Navigator and nb_conda
+    if 'LINK' in kwargs:
+        kwargs['LINK'] = [str(d) for d in kwargs['LINK']]
+    if 'UNLINK' in kwargs:
+        kwargs['UNLINK'] = [str(d) for d in kwargs['UNLINK']]
+
     result.update(kwargs)
     stdout_json(result)
 


### PR DESCRIPTION
@goanpeca, this should fix https://github.com/ContinuumIO/navigator/issues/831.  I'm going to need you to test.

@quasiben as described [here](https://github.com/ContinuumIO/navigator/issues/831#issuecomment-272980569), this reverts conda to previous behavior.  Is this going to mess up something you've already changed to be compatible with 4.3?