### PR TITLE
fix appending to tuple

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -108,7 +108,7 @@ def _main(*args):
             raise CommandNotFoundError(argv1, message)
 
     if len(args) == 1:
-        args.append('-h')
+        args = args + ('-h',)
 
     p, sub_parsers = generate_parser()
 


### PR DESCRIPTION
with the 4.3.5 release typing `conda` on the cli with no args produces the following error:

```
ubuntu@ubuntu-xenial:~$ conda
An unexpected error has occurred.
Please consider posting the following information to the
conda GitHub issue tracker at:

    https://github.com/conda/conda/issues



Current conda install:

               platform : linux-64
          conda version : 4.3.5
       conda is private : False
      conda-env version : 4.3.5
    conda-build version : not installed
         python version : 3.5.2.final.0
       requests version : 2.12.4
       root environment : /opt/anaconda  (writable)
    default environment : /opt/anaconda
       envs directories : /opt/anaconda/envs
          package cache : /opt/anaconda/pkgs
           channel URLs : https://repo.continuum.io/pkgs/free/linux-64
                          https://repo.continuum.io/pkgs/free/noarch
                          https://repo.continuum.io/pkgs/r/linux-64
                          https://repo.continuum.io/pkgs/r/noarch
                          https://repo.continuum.io/pkgs/pro/linux-64
                          https://repo.continuum.io/pkgs/pro/noarch
            config file : None
           offline mode : False
             user-agent : conda/4.3.5 requests/2.12.4 CPython/3.5.2 Linux/4.4.0-38-generic debian/stretch/sid glibc/2.23
                UID:GID : 1000:1000



`$ /opt/anaconda/bin/conda`




    Traceback (most recent call last):
      File "/opt/anaconda/lib/python3.5/site-packages/conda/exceptions.py", line 617, in conda_exception_handler
        return_value = func(*args, **kwargs)
      File "/opt/anaconda/lib/python3.5/site-packages/conda/cli/main.py", line 90, in _main
        args.append('-h')
    AttributeError: 'tuple' object has no attribute 'append'
```

PR resolves the issue by concatenating two 1-element tuples