### PR TITLE
utils: Add sys_prefix_unfollowed

### DIFF
--- a/conda/cli/find_commands.py
+++ b/conda/cli/find_commands.py
@@ -3,21 +3,25 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 import os
 import re
 import sys
-from os.path import isdir, isfile, join, expanduser
-
+import sysconfig
 from ..common.compat import on_win
-from ..utils import memoized
+from os.path import isdir, isfile, join, expanduser, basename
+
+from ..utils import memoized, sys_prefix_unfollowed
 
 def find_executable(executable, include_others=True):
     # backwards compatibility
     global dir_paths
 
     if include_others:
+        prefixes = [sys_prefix_unfollowed()]
+        if sys.prefix != prefixes[0]:
+            prefixes.append(sys.prefix)
+        dir_paths = [join(p, basename(sysconfig.get_path('scripts')))
+                     for p in prefixes]
+        # Is this still needed?
         if on_win:
-            dir_paths = [join(sys.prefix, 'Scripts'),
-                         'C:\\cygwin\\bin']
-        else:
-            dir_paths = [join(sys.prefix, 'bin')]
+            dir_paths.append('C:\\cygwin\\bin')
     else:
         dir_paths = []
 
@@ -37,12 +41,16 @@ def find_executable(executable, include_others=True):
 
 @memoized
 def find_commands(include_others=True):
+
     if include_others:
+        prefixes = [sys_prefix_unfollowed()]
+        if sys.prefix != prefixes[0]:
+            prefixes.append(sys.prefix)
+        dir_paths = [join(p, basename(sysconfig.get_path('scripts')))
+                     for p in prefixes]
+        # Is this still needed?
         if on_win:
-            dir_paths = [join(sys.prefix, 'Scripts'),
-                         'C:\\cygwin\\bin']
-        else:
-            dir_paths = [join(sys.prefix, 'bin')]
+            dir_paths.append('C:\\cygwin\\bin')
     else:
         dir_paths = []
 

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -7,6 +7,7 @@ import re
 import sys
 import threading
 from functools import partial
+from os.path import dirname
 
 from .common.compat import on_win
 from .common.url import path_to_url
@@ -297,3 +298,25 @@ else:
 
 # put back because of conda build
 urlpath = url_path = path_to_url
+
+
+@memoized
+def sys_prefix_unfollowed():
+    """Since conda is installed into non-root environments as a symlink only
+    and because sys.prefix follows symlinks, this function can be used to
+    get the 'unfollowed' sys.prefix.
+
+    This value is usually the same as the prefix of the environment into
+    which conda has been symlinked. An example of when this is necessary
+    is when conda looks for external sub-commands in find_commands.py
+    """
+    try:
+        frame = sys._current_frames().values()[0]
+        while frame.f_back:
+            frame = frame.f_back
+        code = frame.f_code
+        filename = code.co_filename
+        unfollowed = dirname(dirname(filename))
+    except:
+        return sys.prefix
+    return unfollowed


### PR DESCRIPTION
.. and use it in find_commands.py to account for the fact that conda
is installed into sub-environments as a symlink only and that sys.prefix
follows those symlinks meaning it does not give the environment's prefix

There may be other parts of the codebase that need to use this function
but find_commands.py fails to find external programs without this. It is
necessary to search both sys_prefix_unfollowed *and* sys.prefix in this
case as conda-build will often not be installed into the environment.

The failure here was seen when trying to run the test for conda-build-all
while building it through conda-build.

Do we really need to add C:\cygwin\bin here too? I hope not, at least not
in the non-'backwards compatibility' function.