### PR TITLE
change sys.exit to raise LinkError when info/files not found

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -381,6 +381,12 @@ class CondaSignatureError(CondaError):
         super(CondaSignatureError, self).__init__(msg)
 
 
+class CondaUpgradeError(CondaError):
+    def __init__(self, message):
+        msg = "Conda upgrade error: %s" % message
+        super(CondaUpgradeError, self).__init__(msg)
+
+
 def print_conda_exception(exception):
     from conda.base.context import context
 

--- a/conda/install.py
+++ b/conda/install.py
@@ -955,8 +955,7 @@ def link(prefix, dist, linktype=LINK_HARD, index=None):
     info_dir = join(source_dir, 'info')
 
     if not os.path.isfile(join(info_dir, "files")):
-        print("Installing %s requires a minimum conda version of 4.3." % dist, file=sys.stderr)
-        sys.exit(1)
+        raise LinkError("Installing %s requires a minimum conda version of 4.3." % dist)
 
     files = list(yield_lines(join(info_dir, 'files')))
     has_prefix_files = read_has_prefix(join(info_dir, 'has_prefix'))

--- a/conda/install.py
+++ b/conda/install.py
@@ -46,7 +46,7 @@ from .base.constants import UTF8
 from .base.context import context
 from .common.disk import exp_backoff_fn, rm_rf
 from .common.url import path_to_url
-from .exceptions import CondaOSError, LinkError, PaddingError
+from .exceptions import CondaOSError, LinkError, PaddingError, CondaUpgradeError
 from .lock import DirectoryLock, FileLock
 from .models.channel import Channel
 from .utils import on_win
@@ -955,7 +955,7 @@ def link(prefix, dist, linktype=LINK_HARD, index=None):
     info_dir = join(source_dir, 'info')
 
     if not os.path.isfile(join(info_dir, "files")):
-        raise LinkError("Installing %s requires a minimum conda version of 4.3." % dist)
+        raise CondaUpgradeError("Installing %s requires a minimum conda version of 4.3." % dist)
 
     files = list(yield_lines(join(info_dir, 'files')))
     has_prefix_files = read_has_prefix(join(info_dir, 'has_prefix'))


### PR DESCRIPTION
@kalefranz this error is tripping up conda-build.  When I build in parallel, conda (or the OS beneath conda) is still doing some not-quite-synchronous I/O, and conda does not find files that should be there.  I have a retry mechanism in place, but the sys.exit that I replace in this PR is not friendly to that retry mechanism.

Please consider this PR as a more friendly error that will make the retry in conda-build work much better.