### PR TITLE
Expand scope of packages included by bad_installed

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -744,18 +744,13 @@ class Resolve(object):
         log.debug('Checking if the current environment is consistent')
         if not installed:
             return None, []
-        xtra = []  # List[Dist]
         dists = {}  # Dict[Dist, Record]
         specs = []
         for dist in installed:
-            rec = self.index.get(dist)
-            if rec is None:
-                xtra.append(dist)
-            else:
-                dists[dist] = rec
-                specs.append(MatchSpec(' '.join(self.package_quad(dist)[:3])))
-        if xtra:
-            log.debug('Packages missing from index: %s', xtra)
+            dist = Dist(dist)
+            rec = self.index[dist]
+            dists[dist] = rec
+            specs.append(MatchSpec(' '.join(self.package_quad(dist)[:3])))
         r2 = Resolve(dists, True, True)
         C = r2.gen_clauses()
         constraints = r2.generate_spec_constraints(C, specs)
@@ -764,7 +759,7 @@ class Resolve(object):
         except TypeError:
             log.debug('Package set caused an unexpected error, assuming a conflict')
             solution = None
-        limit = None
+        limit = xtra = None
         if not solution or xtra:
             def get_(name, snames):
                 if name not in snames:
@@ -772,14 +767,24 @@ class Resolve(object):
                     for fn in self.groups.get(name, []):
                         for ms in self.ms_depends(fn):
                             get_(ms.name, snames)
+            # New addition: find the largest set of installed packages that
+            # are consistent with each other, and include those in the
+            # list of packages to maintain consistency with
             snames = set()
+            try:
+                eq_optional_c = r2.generate_removal_count(C, specs)
+                solution, _ = C.minimize(eq_optional_c, C.sat())
+                snames.update(dists[Dist(q)]['name']
+                              for q in (C.from_index(s) for s in solution)
+                              if q and q[0] != '!' and '@' not in q)
+            except:
+                pass
+            # Existing behavior: keep all specs and their dependencies
             for spec in new_specs:
                 get_(MatchSpec(spec).name, snames)
-            xtra = [x for x in xtra if x not in snames]
-            if xtra or not (solution or all(s.name in snames for s in specs)):
-                limit = set(s.name for s in specs if s.name in snames)
-                xtra = [dist for dist in (Dist(fn) for fn in installed)
-                        if self.package_name(dist) not in snames]
+            if len(snames) < len(dists):
+                limit = snames
+                xtra = [dist for dist, rec in iteritems(dists) if rec['name'] not in snames]
                 log.debug('Limiting solver to the following packages: %s', ', '.join(limit))
         if xtra:
             log.debug('Packages to be preserved: %s', xtra)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -754,11 +754,7 @@ class Resolve(object):
         r2 = Resolve(dists, True, True)
         C = r2.gen_clauses()
         constraints = r2.generate_spec_constraints(C, specs)
-        try:
-            solution = C.sat(constraints)
-        except TypeError:
-            log.debug('Package set caused an unexpected error, assuming a conflict')
-            solution = None
+        solution = C.sat(constraints)
         limit = xtra = None
         if not solution or xtra:
             def get_(name, snames):
@@ -771,14 +767,11 @@ class Resolve(object):
             # are consistent with each other, and include those in the
             # list of packages to maintain consistency with
             snames = set()
-            try:
-                eq_optional_c = r2.generate_removal_count(C, specs)
-                solution, _ = C.minimize(eq_optional_c, C.sat())
-                snames.update(dists[Dist(q)]['name']
-                              for q in (C.from_index(s) for s in solution)
-                              if q and q[0] != '!' and '@' not in q)
-            except:
-                pass
+            eq_optional_c = r2.generate_removal_count(C, specs)
+            solution, _ = C.minimize(eq_optional_c, C.sat())
+            snames.update(dists[Dist(q)]['name']
+                          for q in (C.from_index(s) for s in solution)
+                          if q and q[0] != '!' and '@' not in q)
             # Existing behavior: keep all specs and their dependencies
             for spec in new_specs:
                 get_(MatchSpec(spec).name, snames)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -913,35 +913,27 @@ def test_broken_install():
         'tk-8.5.13-0.tar.bz2',
         'zlib-1.2.7-0.tar.bz2']]
 
-    # Add a fake package and an incompatible numpy
-    installed2 = list(installed)
-    installed2[1] = Dist('numpy-1.7.1-py33_p0.tar.bz2')
-    installed2.append(Dist('notarealpackage-2.0-0.tar.bz2'))
-    assert r.install([], installed2) == installed2
-    installed3 = r.install(['numpy'], installed2)
-    installed4 = r.remove(['pandas'], installed2)
-    assert set(installed4) == set(installed2[:3] + installed2[4:])
+    # Add an incompatible numpy; installation should be untouched
+    installed1 = list(installed)
+    installed1[1] = Dist('numpy-1.7.1-py33_p0.tar.bz2')
+    assert set(r.install([], installed1)) == set(installed1)
+    assert r.install(['numpy 1.6*'], installed1) == installed
 
-    # Remove the installed version of pandas from the index
-    index2 = index.copy()
-    d = Dist('pandas-0.11.0-np16py27_1.tar.bz2')
-    index2[d] = IndexRecord.from_objects(index2[d], priority=MAX_CHANNEL_PRIORITY)
-    r2 = Resolve(index2)
-    installed2 = r2.install(['pandas', 'python 2.7*', 'numpy 1.6*'], installed)
-    assert installed2 == [Dist(d) for d in [
-        'dateutil-2.1-py27_1.tar.bz2',
-        'numpy-1.6.2-py27_4.tar.bz2',
-        'openssl-1.0.1c-0.tar.bz2',
-        'pandas-0.10.1-np16py27_0.tar.bz2',
-        'python-2.7.5-0.tar.bz2',
-        'pytz-2013b-py27_0.tar.bz2',
-        'readline-6.2-0.tar.bz2',
-        'scipy-0.11.0-np16py27_3.tar.bz2',
-        'six-1.3.0-py27_0.tar.bz2',
-        'sqlite-3.7.13-0.tar.bz2',
-        'system-5.8-1.tar.bz2',
-        'tk-8.5.13-0.tar.bz2',
-        'zlib-1.2.7-0.tar.bz2']]
+    # Add an incompatible pandas; installation should be untouched, then fixed
+    installed2 = list(installed)
+    installed2[3] = Dist('pandas-0.11.0-np17py27_1.tar.bz2')
+    assert set(r.install([], installed2)) == set(installed2)
+    assert r.install(['pandas'], installed2) == installed
+
+    # Removing pandas should fix numpy, since pandas depends on it
+    installed3 = list(installed)
+    installed3[1] = Dist('numpy-1.7.1-py33_p0.tar.bz2')
+    installed3[3] = Dist('pandas-0.11.0-np17py27_1.tar.bz2')
+    installed4 = r.remove(['pandas'], installed)
+    assert r.bad_installed(installed4, [])[0] is None
+
+    # Tests removed involving packages not in the index, because we
+    # always insure installed packages _are_ in the index
 
 
 def test_remove():


### PR DESCRIPTION
I remain bothered by the behavior of `Resolve.bad_installed`; see, for instance, #4394. This modification hopefully improves its behavior.

When a broken environment is found, `bad_installed` limits the set of packages that are considered to a consistent set. Previously, this consisted simply of all the packages specified on the command line, and their dependencies. This addition looks for the the largest subset of the installed packages that are consistent, and includes those as well. This way, we can be sure that `bad_installed` shouldn't make things _worse_.

This new version also makes the assumption that all of the packages passed in `installed` are, in fact, in the index. Given that we include the installed packages in the index before we ever call the solver, this is a reasonable assumption.