### PR TITLE
Fixed "No matches for wildcard '$activate_d/*.fish'" warning.

### DIFF
--- a/shell/conda.fish
+++ b/shell/conda.fish
@@ -145,10 +145,10 @@ end
 # Equivalent to bash version of conda deactivate script
 function deactivate --description 'Deactivate the current conda environment.'
     if set -q CONDA_DEFAULT_ENV  # don't deactivate the root environment
-          # check if there are any *.fish scripts in deactivate.d
-          set -l deactivate_d $CONDA_PREFIX/etc/conda/deactivate.d
-          if test -d "$deactivate_d"
-              source $deactivate_d/*.fish
+          # execute all *.fish scripts in deactivate.d
+          set -l deactivate_scripts $CONDA_PREFIX/etc/conda/deactivate.d/*.fish
+          for script in $deactivate_scripts
+              source $script
           end
           set -gx PATH $CONDA_BACKUP_PATH
           set -e CONDA_DEFAULT_ENV
@@ -193,10 +193,10 @@ function activate --description 'Activate a conda environment.'
         # Always store the full prefix path as CONDA_PREFIX
         set -gx CONDA_PREFIX (echo $PATH[1] | sed 's|/bin$||g')
 
-        # check if there are any *.fish scripts in activate.d
-        set -l activate_d $CONDA_PREFIX/etc/conda/activate.d
-        if test -d "$activate_d"
-            source $activate_d/*.fish
+        # execute all *.fish scripts in activate.d
+        set -l activate_scripts $CONDA_PREFIX/etc/conda/activate.d/*.fish
+        for script in $activate_scripts
+            source $script
         end
 
         if [ (conda '..changeps1') = "1" ]


### PR DESCRIPTION
supersedes #4033

CC @zzag

targeting 4.3.x branch for next patch release

-----


While activating or deactivating an environment with `conda activate some-cool-env` or `conda deactivate` in fish shell, a warning is popping out, like 
```
No matches for wildcard '$activate_d/*.fish'.  (Tip: empty matches are allowed in 'set', 'count', 'for'.)
~/Apps/Anaconda/etc/fish/conf.d/conda.fish (line 35):             source $activate_d/*.fish
                                                                         ^
```
or
```
No matches for wildcard '$deactivate_d/*.fish'.  (Tip: empty matches are allowed in 'set', 'count', 'for'.)
~/Apps/Anaconda/etc/fish/conf.d/conda.fish (line 5):               source $deactivate_d/*.fish
                                                                          ^
```

We cannot source multiple scripts with a wildcard(usage is `source filename [arguments ...]`)! So, we have to source each script in a loop.