### PR TITLE
Print correct activate/deactivate message for fish shell

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -91,15 +91,27 @@ def print_activate(arg):
         #
         """)
     else:
-        message = dals("""
-        #
-        # To activate this environment, use:
-        # > source activate %s
-        #
-        # To deactivate this environment, use:
-        # > source deactivate %s
-        #
-        """)
+        shell = os.path.split(os.environ.get('SHELL', ''))[-1]
+        if 'fish' == shell:
+            message = dals("""
+            #
+            # To activate this environment, use:
+            # > conda activate %s
+            #
+            # To deactivate this environment, use:
+            # > conda deactivate %s
+            #
+            """)
+        else:
+            message = dals("""
+            #
+            # To activate this environment, use:
+            # > source activate %s
+            #
+            # To deactivate this environment, use:
+            # > source deactivate %s
+            #
+            """)
 
     return message % (arg, arg)
 


### PR DESCRIPTION
supersedes #4417 
target is 4.3.x

------

Under `fish`, every `conda create` command produces this unvalid usage message. A correct suggestion would be `conda activate/deactivate`, and that's what I try to address here. I realize that there are plans to change all `source activate/deactivate` commands into `conda *` ones, but for the time being, I think this does not hurt anybody!

Also, I don't know if this way of checking the shell in use is the most elegant, but at least it works in my system. Further testing would be appreciated.