### PR TITLE
[conda clean] filter cache directories

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -77,7 +77,8 @@ def find_tarballs():
     for pkgs_dir in context.pkgs_dirs:
         if not isdir(pkgs_dir):
             continue
-        for fn in os.listdir(pkgs_dir):
+        _, _, filenames = next(os.walk(pkgs_dir))
+        for fn in filenames:
             if fn.endswith('.tar.bz2') or fn.endswith('.tar.bz2.part'):
                 pkgs_dirs[pkgs_dir].append(fn)
 

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from errno import EEXIST, ENOENT
 import json
 from logging import getLogger
-from os import listdir, makedirs, removedirs, rename, unlink, walk
+from os import access, listdir, makedirs, removedirs, rename, unlink, walk, W_OK, X_OK
 from os.path import abspath, dirname, isdir, isfile, islink, join, lexists
 from shutil import rmtree
 from uuid import uuid4
@@ -191,3 +191,10 @@ def remove_private_envs_meta(pkg):
     else:
         with open(context.private_envs_json_path, "w") as f:
             json.dump(private_envs_json, f)
+
+def is_deletable(path):
+    """
+    Test if path is removable by the user
+    """
+    parent = dirname(abspath(path))
+    return access(parent, W_OK) and access(parent, X_OK)


### PR DESCRIPTION
This PR attempts to filter out cache directories that the user cannot clean from.  With the new multi-user cache features, running `conda clean -a` plans to remove packages from a global read-only cache.  This is somewhat spooky to a user, even though the operation ultimately fails due to permissions errors.

PR also includes two other minor improvements.  First, `find_tarballs` now scans only files in the pkgs_dir instead of files and directories.  Second, the total size calculation happens while the dictionary is being constructed rather than in a separate loop.

Finally, a new method is added to gateways/disk/delete.py to test if a path is deletable by checking the write and execute permissions of the parent directory.  I'm pretty sure those are the minimum permissions required to remove a path.  I'll double check tomorrow.