### PR TITLE
Move IndexRecord generation into concurrent tasks

### DIFF
--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -125,8 +125,6 @@ def get_index(channel_urls=(), prepend=True, platform=None,
         supplement_index_with_prefix(index, prefix, known_channels)
     if unknown:
         supplement_index_with_cache(index, known_channels)
-    if context.add_pip_as_python_dependency:
-        add_pip_dependency(index)
     return index
 
 
@@ -348,9 +346,44 @@ def read_local_repodata(cache_path):
             return local_repodata
 
 
+def process_repodata(channel_url, channel_map, repodata):
+    add_pip = context.add_pip_as_python_dependency
+    opackages = repodata.setdefault('packages', {})
+    if not opackages:
+        return repodata
+    if channel_map and channel_url in channel_map:
+        schannel, priority = channel_map[channel_url]
+    else:
+        schannel = Channel(channel_url).canonical_name
+        priority = 0
+    repodata_info = repodata.get('info', {})
+    arch = repodata_info.get('arch')
+    platform = repodata_info.get('platform')
+    packages = {}
+    repodata['_schannel'] = schannel
+    repodata['_priority'] = priority
+    repodata['_add_pip'] = add_pip
+    for fn, info in iteritems(opackages):
+        info['fn'] = fn
+        info['url'] = join_url(channel_url, fn)
+        info['arch'] = arch
+        info['platform'] = platform
+        info['channel'] = channel_url
+        info['schannel'] = schannel
+        info['priority'] = priority
+        if (add_pip and (info['name'] == 'python' and
+                         info['version'].startswith(('2.', '3.')))):
+            info['depends'].append('pip')
+        rec = IndexRecord(**info)
+        packages[Dist(rec)] = rec
+    repodata['packages'] = packages
+
+
 @dotlog_on_return("fetching repodata:")
-def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
+def fetch_repodata(url, cache_dir=None, use_cache=False,
+                   session=None, channel_map=None):
     cache_path = join(cache_dir or create_cache_dir(), cache_fn_url(url))
+    repodata = None
 
     try:
         mtime = getmtime(cache_path)
@@ -374,64 +407,63 @@ def fetch_repodata(url, cache_dir=None, use_cache=False, session=None):
         if (timeout > 0 or context.offline) and not url.startswith('file://'):
             log.debug("Using cached repodata for %s at %s. Timeout in %d sec",
                       url, cache_path, timeout)
-            return read_local_repodata(cache_path)
+            repodata = read_local_repodata(cache_path)
 
         log.debug("Locally invalidating cached repodata for %s at %s", url, cache_path)
 
-    try:
-        assert url is not None, url
-        fetched_repodata = fetch_repodata_remote_request(session, url,
-                                                         mod_etag_headers.get('_etag'),
-                                                         mod_etag_headers.get('_mod'))
-    except Response304ContentUnchanged:
-        log.debug("304 NOT MODIFIED for '%s'. Updating mtime and loading from disk", url)
-        touch(cache_path)
-        return read_local_repodata(cache_path)
+    if repodata is None:
+        try:
+            assert url is not None, url
+            repodata = fetch_repodata_remote_request(session, url,
+                                                     mod_etag_headers.get('_etag'),
+                                                     mod_etag_headers.get('_mod'))
+        except Response304ContentUnchanged:
+            log.debug("304 NOT MODIFIED for '%s'. Updating mtime and loading from disk", url)
+            touch(cache_path)
+            repodata = read_local_repodata(cache_path)
+        else:
+            with open(cache_path, 'w') as fo:
+                json.dump(repodata, fo, indent=2, sort_keys=True, cls=EntityEncoder)
 
-    with open(cache_path, 'w') as fo:
-        json.dump(fetched_repodata, fo, indent=2, sort_keys=True, cls=EntityEncoder)
+    if not repodata:
+        return None
+    process_repodata(url, channel_map, repodata)
+    return repodata
 
-    return fetched_repodata or None
 
-
-def _collect_repodatas_serial(use_cache, urls):
+def _collect_repodatas_serial(use_cache, urls, ch_map):
     # type: (bool, List[str]) -> List[Sequence[str, Option[Dict[Dist, IndexRecord]]]]
     session = CondaSession()
-    repodatas = [(url, fetch_repodata(url, use_cache=use_cache, session=session))
+    repodatas = [(url, fetch_repodata(url, use_cache=use_cache,
+                                      session=session, channel_map=ch_map))
                  for url in urls]
     return repodatas
 
 
-def _collect_repodatas_concurrent(executor, use_cache, urls):
-    futures = tuple(executor.submit(fetch_repodata, url, use_cache=use_cache,
+def _collect_repodatas_concurrent(executor, use_cache, urls, ch_map):
+    futures = tuple(executor.submit(fetch_repodata, url,
+                                    channel_map=ch_map,
+                                    use_cache=use_cache,
                                     session=CondaSession()) for url in urls)
     repodatas = [(u, f.result()) for u, f in zip(urls, futures)]
     return repodatas
 
 
-def _collect_repodatas(use_cache, urls):
-    # TODO: there HAS to be a way to clean up this logic
+def _collect_repodatas(use_cache, urls, ch_map):
+    repodatas = executor = None
     if context.concurrent:
         try:
             import concurrent.futures
             executor = concurrent.futures.ThreadPoolExecutor(10)
+            repodatas = _collect_repodatas_concurrent(executor, use_cache, urls, ch_map)
         except (ImportError, RuntimeError) as e:
-            log.debug(repr(e))
             # concurrent.futures is only available in Python >= 3.2 or if futures is installed
             # RuntimeError is thrown if number of threads are limited by OS
-            repodatas = _collect_repodatas_serial(use_cache, urls)
-        else:
-            try:
-                repodatas = _collect_repodatas_concurrent(executor, use_cache, urls)
-            except RuntimeError as e:
-                # Cannot start new thread, then give up parallel execution
-                log.debug(repr(e))
-                repodatas = _collect_repodatas_serial(use_cache, urls)
-            finally:
-                executor.shutdown(wait=True)
-    else:
-        repodatas = _collect_repodatas_serial(use_cache, urls)
-
+            log.debug(repr(e))
+    if executor:
+        executor.shutdown(wait=True)
+    if repodatas is None:
+        repodatas = _collect_repodatas_serial(use_cache, urls, ch_map)
     return repodatas
 
 
@@ -442,35 +474,15 @@ def fetch_index(channel_urls, use_cache=False, index=None):
         stdoutlog.info("Fetching package metadata ...")
 
     urls = tuple(iterkeys(channel_urls))
-    repodatas = _collect_repodatas(use_cache, urls)
+    repodatas = _collect_repodatas(use_cache, urls, channel_urls)
     # type: List[Sequence[str, Option[Dict[Dist, IndexRecord]]]]
     #   this is sorta a lie; actually more primitve types
 
-    def make_index(repodatas):
-        result = dict()
-
-        for channel_url, repodata in repodatas:
-            if not repodata or not repodata.get('packages', {}):
-                continue
-            canonical_name, priority = channel_urls[channel_url]
-            channel = Channel(channel_url)
-            repodata_info = repodata.get('info', {})
-            arch = repodata_info.get('arch')
-            platform = repodata_info.get('platform')
-            for fn, info in iteritems(repodata['packages']):
-                rec = IndexRecord.from_objects(info,
-                                               fn=fn,
-                                               arch=arch,
-                                               platform=platform,
-                                               schannel=canonical_name,
-                                               channel=channel_url,
-                                               priority=priority,
-                                               url=join_url(channel_url, fn),
-                                               auth=channel.auth)
-                result[Dist(rec)] = rec
-        return result
-
-    index = make_index(repodatas)
+    if index is None:
+        index = dict()
+    for _, repodata in repodatas:
+        if repodata:
+            index.update(repodata.get('packages', {}))
 
     if not context.json:
         stdoutlog.info('\n')
@@ -491,13 +503,6 @@ def add_http_value_to_dict(resp, http_key, d, dict_key):
     value = resp.headers.get(http_key)
     if value:
         d[dict_key] = value
-
-
-def add_pip_dependency(index):
-    # TODO: discuss with @mcg1969 and document
-    for dist, info in iteritems(index):
-        if info['name'] == 'python' and info['version'].startswith(('2.', '3.')):
-            index[dist] = IndexRecord.from_objects(info, depends=info['depends'] + ('pip',))
 
 
 def create_cache_dir():

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .enums import LinkType, NoarchType, Platform
-from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin, Entity,
-                                     EnumField, ImmutableEntity, IntegerField, ListField,
+from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin,
+                                     Entity, EnumField, IntegerField, ListField,
                                      MapField, StringField)
 from ..common.compat import string_types
 
@@ -52,7 +52,7 @@ EMPTY_LINK = Link(source='')
 #     version = StringField()
 
 
-class IndexRecord(DictSafeMixin, ImmutableEntity):  # rename to IndexRecord
+class IndexRecord(DictSafeMixin, Entity):  # rename to IndexRecord
     _lazy_validate = True
 
     arch = StringField(required=False, nullable=True)


### PR DESCRIPTION
I'm breaking up the pieces of #4456 for better understanding and safety. Note that this overlaps a lot with #4461, but since I was close to being done here I went head and submitted it.

This rearranges the index operation so that `fetch_index` has little to do but merge dictionaries together. The conversion of repodata data to `Dist/IndexRecord` dictionaries is done in a new function, `process_repodata`, that is run within each separate `_fetch_repodata` task. There is the potential therefore to run these tasks concurrently. Furthermore, by merging `add_pip_as_python_dependency` into this function, we save on some linear scans.

`process_repodata` can certainly be tweaked but I wanted to minimize change here.

One wrinkle to this approach is that the channel priorities needed to be communicated somehow to `process_repodata`. I took the approach of passing in the `channel_urls` map (channel_url -> (schannel, priority)), but this is actually a bit redundant. I didn't want to modify the calling sequences of the fetch functions too much, yet. But logically, that's what seems should happen.