### PR TITLE
Dist simplification

### DIFF
--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -51,7 +51,7 @@ stderrlog = getLogger('stderrlog')
 fail_unknown_host = False
 
 
-REPODATA_PICKLE_VERSION = 1
+REPODATA_PICKLE_VERSION = 2
 REPODATA_HEADER_RE = b'"(_etag|_mod|_cache_control)":[ ]?"(.*)"'
 
 
@@ -99,7 +99,7 @@ def supplement_index_with_cache(index, channels):
         index_json_record.fn = dist.to_filename()
         index_json_record.schannel = dist.channel
         index_json_record.priority = priority
-        index_json_record.url = dist.to_url()
+        index_json_record.url = pc_entry.get_urls_txt_value()
         index[dist] = index_json_record
 
 

--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -82,7 +82,7 @@ class PackageCacheEntry(object):
         self.dist = dist
         self.package_tarball_full_path = package_tarball_full_path
         self.extracted_package_dir = extracted_package_dir
-        self.channel = Channel(dist.to_url()) if dist.is_channel else Channel(None)
+        self.channel = Channel(dist.channel)
 
     @property
     def is_fetched(self):
@@ -411,7 +411,7 @@ class ProgressiveFetchExtract(object):
         # if we got here, we couldn't find a matching package in the caches
         #   we'll have to download one; fetch and extract
         cache_axn = CacheUrlAction(
-            url=record.get('url') or dist.to_url(),
+            url=record.get('url'),
             target_pkgs_dir=first_writable_cache.pkgs_dir,
             target_package_basename=dist.to_filename(),
             md5sum=md5,

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -75,7 +75,7 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
                     raise CondaFileNotFoundError(path)
                 pc_entry = PackageCache.tarball_file_in_cache(path)
                 dist = pc_entry.dist
-                url = dist.to_url() or pc_entry.get_urls_txt_value()
+                url = pc_entry.get_urls_txt_value()
                 md5sum = md5sum or pc_entry.md5sum
         dist = dist or Dist(url)
         fetch_recs[dist] = {'md5': md5sum, 'url': url}

--- a/conda/models/dist.py
+++ b/conda/models/dist.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import namedtuple
 from logging import getLogger
 import re
 
@@ -9,17 +8,13 @@ from .channel import Channel
 from .index_record import IndexRecord
 from .package_info import PackageInfo
 from .. import CondaError
-from .._vendor.auxlib.entity import Entity, EntityType, IntegerField, StringField
+from .._vendor.auxlib.entity import Entity, EntityType, StringField
 from ..base.constants import CONDA_TARBALL_EXTENSION, DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
-from ..base.context import context
 from ..common.compat import ensure_text_type, text_type, with_metaclass
 from ..common.constants import NULL
-from ..common.url import has_platform, is_url, join_url
+from ..common.url import has_platform, is_url
 
 log = getLogger(__name__)
-DistDetails = namedtuple('DistDetails', ('name', 'version', 'build_string', 'build_number',
-                                         'dist_name'))
-
 
 class DistType(EntityType):
 
@@ -48,46 +43,56 @@ class Dist(Entity):
     _lazy_validate = True
 
     channel = StringField(required=False, nullable=True, immutable=True)
-
     dist_name = StringField(immutable=True)
-    name = StringField(immutable=True)
-    version = StringField(immutable=True)
-    build_string = StringField(immutable=True)
-    build_number = IntegerField(immutable=True)
-
     with_features_depends = StringField(required=False, nullable=True, immutable=True)
-    base_url = StringField(required=False, nullable=True, immutable=True)
-    platform = StringField(required=False, nullable=True, immutable=True)
 
-    def __init__(self, channel, dist_name=None, name=None, version=None, build_string=None,
-                 build_number=None, with_features_depends=None, base_url=None, platform=None):
+    def __init__(self, channel, dist_name=None, with_features_depends=None):
+        # if name is None:
+        #     import pdb; pdb.set_trace()
         super(Dist, self).__init__(channel=channel,
                                    dist_name=dist_name,
-                                   name=name,
-                                   version=version,
-                                   build_string=build_string,
-                                   build_number=build_number,
-                                   with_features_depends=with_features_depends,
-                                   base_url=base_url,
-                                   platform=platform)
+                                   with_features_depends=with_features_depends)
 
     @property
     def full_name(self):
         return self.__str__()
 
     @property
-    def build(self):
-        return self.build_string
-
-    @property
     def pair(self):
         return self.channel or DEFAULTS_CHANNEL_NAME, self.dist_name
 
     @property
+    def triple(self):
+        res = self.dist_name.rsplit('-', 2) + ['', '']
+        return tuple(res[:3])
+
+    @property
+    def name(self):
+        return self.triple[0]
+
+    @property
+    def version(self):
+        return self.triple[1]
+
+    @property
+    def build(self):
+        return self.triple[2]
+
+    @property
+    def build_string(self):
+        return self.triple[2]
+
+    @property
+    def build_number(self):
+        try:
+            return int(self.build.rsplit('_', 1)[-1])
+        except ValueError:
+            return 0
+
+    @property
     def quad(self):
         # returns: name, version, build_string, channel
-        parts = self.dist_name.rsplit('-', 2) + ['', '']
-        return parts[0], parts[1], parts[2], self.channel or DEFAULTS_CHANNEL_NAME
+        return self.triple + (self.channel or DEFAULTS_CHANNEL_NAME,)
 
     def __str__(self):
         base = "%s::%s" % (self.channel, self.dist_name) if self.channel else self.dist_name
@@ -99,10 +104,6 @@ class Dist(Entity):
     @property
     def is_feature_package(self):
         return self.dist_name.endswith('@')
-
-    @property
-    def is_channel(self):
-        return bool(self.base_url and self.platform)
 
     def to_filename(self, extension='.tar.bz2'):
         if self.is_feature_package:
@@ -122,10 +123,6 @@ class Dist(Entity):
 
         if string.endswith('@'):
             return cls(channel='@',
-                       name=string,
-                       version="",
-                       build_string="",
-                       build_number=0,
                        dist_name=string,
                        with_features_depends=None)
 
@@ -143,13 +140,7 @@ class Dist(Entity):
         elif channel is None:
             channel = DEFAULTS_CHANNEL_NAME
 
-        # enforce dist format
-        dist_details = cls.parse_dist_name(original_dist)
         return cls(channel=channel,
-                   name=dist_details.name,
-                   version=dist_details.version,
-                   build_string=dist_details.build_string,
-                   build_number=dist_details.build_number,
                    dist_name=original_dist,
                    with_features_depends=w_f_d)
 
@@ -169,18 +160,7 @@ class Dist(Entity):
             else:
                 dist_name = no_tar_bz2_string.rsplit('/', 1)[-1]
 
-            parts = dist_name.rsplit('-', 2)
-
-            name = parts[0]
-            version = parts[1]
-            build_string = parts[2] if len(parts) >= 3 else ''
-            build_number_as_string = ''.join(filter(lambda x: x.isdigit(),
-                                                    (build_string.rsplit('_')[-1]
-                                                     if build_string else '0')))
-            build_number = int(build_number_as_string) if build_number_as_string else 0
-
-            return DistDetails(name, version, build_string, build_number, dist_name)
-
+            return dist_name
         except:
             raise CondaError("dist_name is not a valid conda package: %s" % original_string)
 
@@ -190,10 +170,9 @@ class Dist(Entity):
         if not url.endswith(CONDA_TARBALL_EXTENSION) and '::' not in url:
             raise CondaError("url '%s' is not a conda package" % url)
 
-        dist_details = cls.parse_dist_name(url)
+        dist_name = cls.parse_dist_name(url)
         if '::' in url:
             url_no_tarball = url.rsplit('::', 1)[0]
-            platform = context.subdir
             base_url = url_no_tarball.split('::')[0]
             channel = text_type(Channel(base_url))
         else:
@@ -203,21 +182,7 @@ class Dist(Entity):
             channel = Channel(base_url).canonical_name if platform else UNKNOWN_CHANNEL
 
         return cls(channel=channel,
-                   name=dist_details.name,
-                   version=dist_details.version,
-                   build_string=dist_details.build_string,
-                   build_number=dist_details.build_number,
-                   dist_name=dist_details.dist_name,
-                   base_url=base_url,
-                   platform=platform)
-
-    def to_url(self):
-        if not self.base_url:
-            return None
-        filename = self.dist_name + CONDA_TARBALL_EXTENSION
-        return (join_url(self.base_url, self.platform, filename)
-                if self.platform
-                else join_url(self.base_url, filename))
+                   dist_name=dist_name)
 
     def __key__(self):
         return self.channel, self.dist_name, self.with_features_depends

--- a/tests/models/test_dist.py
+++ b/tests/models/test_dist.py
@@ -52,8 +52,6 @@ class DistTests(TestCase):
         assert d.channel == 's3://some/bucket/name'
         assert d.quad[0] == "spyder-app"
         assert d.dist_name == "spyder-app-2.3.8-py27_0"
-        assert d.to_url() == join_url("s3://some/bucket/name", context.subdir,
-                                      "spyder-app-2.3.8-py27_0.tar.bz2")
 
 
 class UrlDistTests(TestCase):
@@ -67,9 +65,6 @@ class UrlDistTests(TestCase):
         assert d.version == '2.3.8'
         assert d.build_string == 'py27_0'
 
-        assert d.to_url() == url
-        assert d.is_channel is True
-
         # standard url channel
         url = "https://not.real.continuum.io/pkgs/free/win-64/spyder-app-2.3.8-py27_0.tar.bz2"
         d = Dist(url)
@@ -77,9 +72,6 @@ class UrlDistTests(TestCase):
         assert d.name == 'spyder-app'
         assert d.version == '2.3.8'
         assert d.build_string == 'py27_0'
-
-        assert d.to_url() == url
-        assert d.is_channel is True
 
         # another standard url channel
         url = "https://not.real.continuum.io/not/free/win-64/spyder-app-2.3.8-py27_0.tar.bz2"
@@ -89,9 +81,6 @@ class UrlDistTests(TestCase):
         assert d.version == '2.3.8'
         assert d.build_string == 'py27_0'
 
-        assert d.to_url() == url
-        assert d.is_channel is True
-
         # local file url that is a named channel
         url = path_to_url(join_url(context.croot, 'osx-64', 'bcrypt-3.1.1-py35_2.tar.bz2'))
         d = Dist(url)
@@ -100,9 +89,6 @@ class UrlDistTests(TestCase):
         assert d.version == '3.1.1'
         assert d.build_string == 'py35_2'
 
-        assert d.to_url() == url
-        assert d.is_channel is True
-
         # local file url that is not a named channel
         url = join_url('file:///some/location/on/disk', 'osx-64', 'bcrypt-3.1.1-py35_2.tar.bz2')
         d = Dist(url)
@@ -110,9 +96,6 @@ class UrlDistTests(TestCase):
         assert d.name == 'bcrypt'
         assert d.version == '3.1.1'
         assert d.build_string == 'py35_2'
-
-        assert d.to_url() == url
-        assert d.is_channel is True
 
     def test_dist_with_non_channel_url(self):
         # contrived url
@@ -123,9 +106,6 @@ class UrlDistTests(TestCase):
         assert d.version == '1.9.1'
         assert d.build_string == 'py34_0'
 
-        assert d.to_url() == url
-        assert d.is_channel is False
-
         # file url that is not a channel
         url = path_to_url(join_url(context.croot, 'cffi-1.9.1-py34_0.tar.bz2'))
         d = Dist(url)
@@ -133,9 +113,6 @@ class UrlDistTests(TestCase):
         assert d.name == 'cffi'
         assert d.version == '1.9.1'
         assert d.build_string == 'py34_0'
-
-        assert d.to_url() == url
-        assert d.is_channel is False
 
         # file url that is a package cache
         # TODO: maybe this should look up the channel in urls.txt?  or maybe that's too coupled?
@@ -145,6 +122,3 @@ class UrlDistTests(TestCase):
         assert d.name == 'cffi'
         assert d.version == '1.9.1'
         assert d.build_string == 'py34_0'
-
-        assert d.to_url() == url
-        assert d.is_channel is False

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -276,7 +276,7 @@ class IntegrationTests(TestCase):
                        cwd=prefix, shell=True)
             stdout, stderr = run_command(Commands.LIST, prefix)
             stdout_lines = stdout.split('\n')
-            assert any(line.endswith("<pip>") for line in stdout_lines
+            assert any(line.rstrip().endswith("<pip>") for line in stdout_lines
                        if line.lower().startswith("flask"))
 
     @pytest.mark.timeout(300)
@@ -286,7 +286,7 @@ class IntegrationTests(TestCase):
                        cwd=prefix, shell=True)
             stdout, stderr = run_command(Commands.LIST, prefix)
             stdout_lines = stdout.split('\n')
-            assert any(line.endswith("<pip>") for line in stdout_lines
+            assert any(line.rstrip().endswith("<pip>") for line in stdout_lines
                        if line.lower().startswith("flask"))
 
             # regression test for #3433


### PR DESCRIPTION
@kalefranz it looks like we're both experimenting with roughly the same thing. But hey, I've already tried doing this 2-3 times already, so why not.

This is not a _removal_ of Dist, just a simplification to channel/distname/w_f_d. To accomplish the simplest such change, I introduce properties to replace most of the missing fields, except `platform` and `base_url`.