### PR TITLE
Pickle object-ified repodata for performance

### DIFF
--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -363,6 +363,7 @@ def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod
         yield repodata.get('_add_pip') == context.add_pip_as_python_dependency
         yield repodata.get('_mod') == mod_stamp
         yield repodata.get('_etag') == etag
+        yield repodata.get('_pickle_version') == REPODATA_PICKLE_VERSION
 
     if not all(_check_pickled_valid()):
         return None

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -370,6 +370,7 @@ def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod
     if repodata['_priority'] != priority:
         for rec in itervalues(repodata.get('packages', {})):
             rec.priority = priority
+        write_pickled_repodata(cache_path, repodata)
 
     return repodata
 

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -371,7 +371,6 @@ def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod
     if repodata['_priority'] != priority:
         for rec in itervalues(repodata.get('packages', {})):
             rec.priority = priority
-        write_pickled_repodata(cache_path, repodata)
 
     return repodata
 

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -369,7 +369,8 @@ def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod
         return None
 
     if repodata['_priority'] != priority:
-        repodata['_priority']._priority = priority
+        for rec in itervalues(repodata.get('packages', {})):
+            rec.priority = priority
 
     return repodata
 

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -35,7 +35,7 @@ from ..gateways.disk.read import read_index_json
 from ..gateways.disk.update import touch
 from ..models.channel import Channel, prioritize_channels
 from ..models.dist import Dist
-from ..models.index_record import EMPTY_LINK, IndexRecord
+from ..models.index_record import EMPTY_LINK, IndexRecord, Priority
 
 try:
     from cytoolz.itertoolz import take
@@ -369,8 +369,7 @@ def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod
         return None
 
     if repodata['_priority'] != priority:
-        for rec in itervalues(repodata.get('packages', {})):
-            rec.priority = priority
+        repodata['_priority']._priority = priority
 
     return repodata
 
@@ -405,7 +404,7 @@ def process_repodata(repodata, channel_url, schannel, priority):
 
     repodata['_add_pip'] = add_pip = context.add_pip_as_python_dependency
     repodata['_pickle_version'] = REPODATA_PICKLE_VERSION
-    repodata['_priority'] = priority
+    repodata['_priority'] = priority = Priority(priority)
     repodata['_schannel'] = schannel
 
     meta_in_common = {  # just need to make this once, then apply with .update()

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -35,7 +35,7 @@ from ..gateways.disk.read import read_index_json
 from ..gateways.disk.update import touch
 from ..models.channel import Channel, prioritize_channels
 from ..models.dist import Dist
-from ..models.index_record import EMPTY_LINK, IndexRecord, Priority
+from ..models.index_record import EMPTY_LINK, IndexRecord
 
 try:
     from cytoolz.itertoolz import take
@@ -368,7 +368,8 @@ def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod
         return None
 
     if repodata['_priority'] != priority:
-        repodata['_priority']._priority = priority
+        for rec in itervalues(repodata.get('packages', {})):
+            rec.priority = priority
 
     return repodata
 
@@ -403,7 +404,7 @@ def process_repodata(repodata, channel_url, schannel, priority):
 
     repodata['_add_pip'] = add_pip = context.add_pip_as_python_dependency
     repodata['_pickle_version'] = REPODATA_PICKLE_VERSION
-    repodata['_priority'] = priority = Priority(priority)
+    repodata['_priority'] = priority
     repodata['_schannel'] = schannel
 
     meta_in_common = {  # just need to make this once, then apply with .update()

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .enums import LinkType, NoarchType, Platform
-from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin, Entity,
-                                     EnumField, IntegerField, ListField,
+from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin,
+                                     Entity, EnumField, IntegerField, ListField,
                                      MapField, StringField)
 from ..common.compat import string_types
 
@@ -52,7 +52,11 @@ EMPTY_LINK = Link(source='')
 #     version = StringField()
 
 
+<<<<<<< HEAD
 class IndexRecord(DictSafeMixin, Entity):
+=======
+class IndexRecord(DictSafeMixin, Entity):  # rename to IndexRecord
+>>>>>>> Move IndexRecord generation into concurrent tasks
     _lazy_validate = True
 
     arch = StringField(required=False, nullable=True)

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -52,11 +52,7 @@ EMPTY_LINK = Link(source='')
 #     version = StringField()
 
 
-<<<<<<< HEAD
 class IndexRecord(DictSafeMixin, Entity):
-=======
-class IndexRecord(DictSafeMixin, Entity):  # rename to IndexRecord
->>>>>>> Move IndexRecord generation into concurrent tasks
     _lazy_validate = True
 
     arch = StringField(required=False, nullable=True)

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -5,36 +5,9 @@ from functools import total_ordering
 
 from .enums import LinkType, NoarchType, Platform
 from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin, Entity,
-                                     EnumField, Field, IntegerField, ListField, MapField,
+                                     EnumField, IntegerField, ListField, MapField,
                                      StringField)
 from ..common.compat import string_types
-
-
-@total_ordering
-class Priority(object):
-    __slots__ = ('_priority',)
-
-    def __init__(self, priority):
-        self._priority = priority
-
-    def __int__(self):
-        return self._priority
-
-    def __lt__(self, other):
-        return self._priority < int(other)
-
-    def __eq__(self, other):
-        return self._priority == int(other)
-
-    def __repr__(self):
-        return "Priority(%d)" % self._priority
-
-
-class PriorityField(Field):
-    _type = (int, Priority)
-
-    def unbox(self, instance, instance_type, val):
-        return int(val)
 
 
 class LinkTypeField(EnumField):
@@ -106,7 +79,7 @@ class IndexRecord(DictSafeMixin, Entity):
     fn = StringField(required=False, nullable=True)
     schannel = StringField(required=False, nullable=True)
     channel = StringField(required=False, nullable=True)
-    priority = PriorityField(required=False)
+    priority = IntegerField(required=False)
     url = StringField(required=False, nullable=True)
     auth = StringField(required=False, nullable=True)
 

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -5,9 +5,36 @@ from functools import total_ordering
 
 from .enums import LinkType, NoarchType, Platform
 from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin, Entity,
-                                     EnumField, IntegerField, ListField, MapField,
+                                     EnumField, Field, IntegerField, ListField, MapField,
                                      StringField)
 from ..common.compat import string_types
+
+
+@total_ordering
+class Priority(object):
+    __slots__ = ('_priority',)
+
+    def __init__(self, priority):
+        self._priority = priority
+
+    def __int__(self):
+        return self._priority
+
+    def __lt__(self, other):
+        return self._priority < int(other)
+
+    def __eq__(self, other):
+        return self._priority == int(other)
+
+    def __repr__(self):
+        return "Priority(%d)" % self._priority
+
+
+class PriorityField(Field):
+    _type = (int, Priority)
+
+    def unbox(self, instance, instance_type, val):
+        return int(val)
 
 
 class LinkTypeField(EnumField):
@@ -79,7 +106,7 @@ class IndexRecord(DictSafeMixin, Entity):
     fn = StringField(required=False, nullable=True)
     schannel = StringField(required=False, nullable=True)
     channel = StringField(required=False, nullable=True)
-    priority = IntegerField(required=False)
+    priority = PriorityField(required=False)
     url = StringField(required=False, nullable=True)
     auth = StringField(required=False, nullable=True)
 

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -1,11 +1,40 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from functools import total_ordering
+
 from .enums import LinkType, NoarchType, Platform
-from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin,
-                                     Entity, EnumField, IntegerField, ListField,
-                                     MapField, StringField)
+from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin, Entity,
+                                     EnumField, Field, IntegerField, ListField, MapField,
+                                     StringField)
 from ..common.compat import string_types
+
+
+@total_ordering
+class Priority(object):
+    __slots__ = ('_priority',)
+
+    def __init__(self, priority):
+        self._priority = priority
+
+    def __int__(self):
+        return self._priority
+
+    def __lt__(self, other):
+        return self._priority < int(other)
+
+    def __eq__(self, other):
+        return self._priority == int(other)
+
+    def __repr__(self):
+        return "Priority(%d)" % self._priority
+
+
+class PriorityField(Field):
+    _type = (int, Priority)
+
+    def unbox(self, instance, instance_type, val):
+        return int(val)
 
 
 class LinkTypeField(EnumField):
@@ -77,7 +106,7 @@ class IndexRecord(DictSafeMixin, Entity):
     fn = StringField(required=False, nullable=True)
     schannel = StringField(required=False, nullable=True)
     channel = StringField(required=False, nullable=True)
-    priority = IntegerField(required=False)
+    priority = PriorityField(required=False)
     url = StringField(required=False, nullable=True)
     auth = StringField(required=False, nullable=True)
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -36,7 +36,7 @@ class TestConnectionWithShortTimeouts(TestCase):
                     with pytest.raises(CondaHTTPError) as execinfo:
                         url = "http://240.0.0.0/channel/osx-64"
                         msg = "Connection error:"
-                        fetch_repodata(url)
+                        fetch_repodata(url, 'channel', 0)
                         assert msg in str(execinfo)
 
     def test_tmpDownload(self):

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -72,8 +72,8 @@ miniconda_install() {
     export PATH=~/miniconda/bin:$PATH
     hash -r
     which -a conda
+    conda install -y -q pip conda python
     conda info
-    conda install -y -q pip
     which -a pip
     which -a python
     conda config --set auto_update_conda false

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -72,7 +72,7 @@ miniconda_install() {
     export PATH=~/miniconda/bin:$PATH
     hash -r
     which -a conda
-    conda install -y -q pip conda python
+    conda install -y -q pip conda 'python>=3.6'
     conda info
     which -a pip
     which -a python

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -55,6 +55,7 @@ conda_build_unit_test() {
     echo
     echo ">>>>>>>>>>>> running conda-build unit tests >>>>>>>>>>>>>>>>>>>>>"
     echo
+    ~/miniconda/bin/python -m conda info
     ~/miniconda/bin/python -m pytest --basetemp /tmp/cb -v tests
     popd
 }
@@ -67,8 +68,6 @@ if [[ $FLAKE8 == true ]]; then
 elif [[ -n $CONDA_BUILD ]]; then
     conda_build_smoke_test
     conda_build_unit_test
-    # if [[ $CONDA_BUILD == 1.21.11 || $CONDA_BUILD == master ]]; then
-    # fi
 else
     main_test
     if [[ "$(uname -s)" == "Linux" ]]; then


### PR DESCRIPTION
Builds on #4473. By moving the IndexRecord wrapping into the fetch_repodata tasks, we can cache those objects. Significant improvements in speed result for subsequent loads of the same channels.

For `defaults` and `conda-forge`: first call to `get_index`, no pickled data:
```
CPU times: user 7.5 s, sys: 209 ms, total: 7.71 s
Wall time: 7.79 s
```
Second call:
```
CPU times: user 834 ms, sys: 86.6 ms, total: 921 ms
Wall time: 1.11 s
```
The cost is, in my view, reasonable. Here is the equivalent call prior to this PR:
```
CPU times: user 6.6 s, sys: 127 ms, total: 6.73 s
Wall time: 6.94 s
```