### PR TITLE
fix UnicodeDecodeError for ensure_text_type

### DIFF
--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -10,6 +10,7 @@ from operator import methodcaller
 from os import chmod, lstat
 from os.path import islink
 import sys
+import chardet
 
 on_win = bool(sys.platform == "win32")
 
@@ -152,7 +153,11 @@ def ensure_binary(value):
 
 
 def ensure_text_type(value):
-    return value.decode('utf-8') if hasattr(value, 'decode') else value
+    if isinstance(value, text_type):
+        encoding = 'utf-8'
+    else:
+        encoding = chardet.detect(value).get('encoding') or 'utf-8'
+    return value.decode(encoding) if hasattr(value, 'decode') else value
 
 
 def ensure_unicode(value):

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -6,12 +6,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from itertools import chain
+from logging import getLogger
 from operator import methodcaller
 from os import chmod, lstat
 from os.path import islink
 import sys
-import chardet
 
+log = getLogger(__name__)
 on_win = bool(sys.platform == "win32")
 
 PY2 = sys.version_info[0] == 2
@@ -153,11 +154,15 @@ def ensure_binary(value):
 
 
 def ensure_text_type(value):
-    if isinstance(value, text_type):
-        encoding = 'utf-8'
+    if hasattr(value, 'decode'):
+        try:
+            return value.decode('utf-8')
+        except UnicodeDecodeError:
+            from requests.packages.chardet import detect
+            encoding = detect(value).get('encoding') or 'utf-8'
+            return value.decode(encoding)
     else:
-        encoding = chardet.detect(value).get('encoding') or 'utf-8'
-    return value.decode(encoding) if hasattr(value, 'decode') else value
+        return value
 
 
 def ensure_unicode(value):

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -6,13 +6,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from itertools import chain
-from logging import getLogger
 from operator import methodcaller
 from os import chmod, lstat
 from os.path import islink
 import sys
 
-log = getLogger(__name__)
 on_win = bool(sys.platform == "win32")
 
 PY2 = sys.version_info[0] == 2


### PR DESCRIPTION
resolves #4567
supersedes #4583 
target is 4.3.x

------

On new environment creation, subprocess_call function is called:
https://github.com/conda/conda/blob/33303158f070c0eda1ce0bbcb7807ddc7a4972d6/conda/gateways/subprocess.py#L62

Inside, this function calls ensure_text_type to validate standard output:
https://github.com/conda/conda/blob/7005e366a2a7dcd19430114c4a3d30f2eb735995/conda/common/compat.py#L154

However, ensure_text_type raises a Unicode error if the standard output includes not-encoded-in-utf-8 string.

I fixed this error by using chardet package.