### PR TITLE
never symlink executables

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -179,7 +179,9 @@ def create_hard_link_or_copy(src, dst):
 
 
 def _do_softlink(src, dst):
-    if is_executable(src):
+    if islink(src):
+        symlink(src, dst)
+    elif is_executable(src):
         # for extra details, see https://github.com/conda/conda/pull/4625#issuecomment-280696371
         # We only need to do this copy for executables which have an RPATH containing $ORIGIN
         #   on Linux, so `is_executable()` is currently overly aggressive.

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -15,7 +15,7 @@ import traceback
 
 from .delete import rm_rf
 from .link import islink, link, readlink, symlink
-from .permissions import make_executable
+from .permissions import is_executable, make_executable
 from .read import get_json_content
 from .update import touch
 from ..subprocess import subprocess_call
@@ -178,6 +178,28 @@ def create_hard_link_or_copy(src, dst):
         shutil.copy2(src, dst)
 
 
+def _do_softlink(src, dst):
+    if is_executable(src):
+        # for extra details, see https://github.com/conda/conda/pull/4625#issuecomment-280696371
+        # We only need to do this copy for executables which have an RPATH containing $ORIGIN
+        #   on Linux, so `is_executable()` is currently overly aggressive.
+        # A future optimization will be to copy code from @mingwandroid's virtualenv patch.
+        _do_copy(src, dst)
+    else:
+        symlink(src, dst)
+
+
+def _do_copy(src, dst):
+    # on unix, make sure relative symlinks stay symlinks
+    if not on_win and islink(src):
+        src_points_to = readlink(src)
+        if not src_points_to.startswith('/'):
+            # copy relative symlinks as symlinks
+            symlink(src_points_to, dst)
+            return
+    shutil.copy2(src, dst)
+
+
 def create_link(src, dst, link_type=LinkType.hardlink, force=False):
     if link_type == LinkType.directory:
         # A directory is technically not a link.  So link_type is a misnomer.
@@ -199,16 +221,9 @@ def create_link(src, dst, link_type=LinkType.hardlink, force=False):
             raise CondaError("Cannot hard link a directory. %s" % src)
         link(src, dst)
     elif link_type == LinkType.softlink:
-        symlink(src, dst)
+        _do_softlink(src, dst)
     elif link_type == LinkType.copy:
-        # on unix, make sure relative symlinks stay symlinks
-        if not on_win and islink(src):
-            src_points_to = readlink(src)
-            if not src_points_to.startswith('/'):
-                # copy relative symlinks as symlinks
-                symlink(src_points_to, dst)
-                return
-        shutil.copy2(src, dst)
+        _do_copy(src, dst)
     else:
         raise CondaError("Did not expect linktype=%r" % link_type)
 

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -68,4 +68,6 @@ def make_executable(path):
 
 
 def is_executable(path):
-    return isfile(path) and (access(path, X_OK) or (on_win and path.endswith(('.exe', '.bat'))))
+    if isfile(path):  # for now, leave out `and not islink(path)`
+        return path.endswith(('.exe', '.bat')) if on_win else access(path, X_OK)
+    return False

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -4,12 +4,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from errno import EACCES, ENOENT, EPERM
 from itertools import chain
 from logging import getLogger
-from os import chmod, lstat, walk
+from os import X_OK, access, chmod, lstat, walk
 from os.path import isdir, isfile, join
 from stat import S_IEXEC, S_IMODE, S_ISDIR, S_ISLNK, S_ISREG, S_IWRITE, S_IXGRP, S_IXOTH, S_IXUSR
 
 from . import MAX_TRIES, exp_backoff_fn
 from .link import lchmod
+from ...common.compat import on_win
 
 log = getLogger(__name__)
 
@@ -64,3 +65,7 @@ def make_executable(path):
         chmod(path, S_IMODE(mode) | S_IXUSR | S_IXGRP | S_IXOTH)
     else:
         log.error("Cannot make path '%s' executable", path)
+
+
+def is_executable(path):
+    return isfile(path) and (access(path, X_OK) or (on_win and path.endswith(('.exe', '.bat'))))

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -11,7 +11,7 @@ from itertools import chain
 import json
 from logging import getLogger
 from os import listdir
-from os.path import isdir, isfile, islink, join, lexists
+from os.path import isdir, isfile, join, lexists
 import shlex
 
 from .link import islink
@@ -27,7 +27,7 @@ from ...models.package_info import PackageInfo, PackageMetadata, PathData, PathD
 log = getLogger(__name__)
 
 listdir = listdir
-lexists, isdir, isfile, islink = lexists, isdir, isfile, islink
+lexists, isdir, isfile = lexists, isdir, isfile
 
 
 def yield_lines(path):

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -10,15 +10,14 @@ import hashlib
 from itertools import chain
 import json
 from logging import getLogger
-from os import X_OK, access, listdir
-from os.path import isdir, isfile, join, lexists
+from os import listdir
+from os.path import isdir, isfile, islink, join, lexists
 import shlex
 
 from .link import islink
 from ..._vendor.auxlib.collection import first
 from ..._vendor.auxlib.ish import dals
 from ...base.constants import PREFIX_PLACEHOLDER
-from ...common.compat import on_win
 from ...exceptions import CondaFileNotFoundError, CondaUpgradeError
 from ...models.channel import Channel
 from ...models.enums import FileMode, PathType
@@ -64,10 +63,6 @@ def compute_md5sum(file_full_path):
         for chunk in iter(partial(fh.read, 4096), b''):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
-
-
-def is_exe(path):
-    return isfile(path) and (access(path, X_OK) or (on_win and path.endswith(('.exe', '.bat'))))
 
 
 def find_first_existing(*globs):

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -22,6 +22,7 @@ from conda.common.path import get_python_site_packages_short_path, get_python_no
 from conda.core.path_actions import LinkPathAction, CompilePycAction, CreatePythonEntryPointAction
 from conda.gateways.disk.create import mkdir_p, create_link
 from conda.gateways.disk.delete import rm_rf
+from conda.gateways.disk.link import symlink
 from conda.gateways.disk.read import compute_md5sum
 from conda.gateways.disk.permissions import is_executable
 from conda.gateways.disk.link import islink, stat_nlink
@@ -125,7 +126,7 @@ class PathActionsTests(TestCase):
         # symlink the current python
         python_full_path = join(self.prefix, get_python_short_path(target_python_version))
         mkdir_p(dirname(python_full_path))
-        create_link(sys.executable, python_full_path, LinkType.softlink)
+        symlink(sys.executable, python_full_path)
 
         axn.execute()
         assert isfile(axn.target_full_path)

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -126,7 +126,11 @@ class PathActionsTests(TestCase):
         # symlink the current python
         python_full_path = join(self.prefix, get_python_short_path(target_python_version))
         mkdir_p(dirname(python_full_path))
-        symlink(sys.executable, python_full_path)
+        create_link(sys.executable, python_full_path, LinkType.softlink)
+        # if on_win:
+        #     copy()
+        # else:
+        #     symlink(sys.executable, python_full_path)
 
         axn.execute()
         assert isfile(axn.target_full_path)

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -127,10 +127,6 @@ class PathActionsTests(TestCase):
         python_full_path = join(self.prefix, get_python_short_path(target_python_version))
         mkdir_p(dirname(python_full_path))
         create_link(sys.executable, python_full_path, LinkType.softlink)
-        # if on_win:
-        #     copy()
-        # else:
-        #     symlink(sys.executable, python_full_path)
 
         axn.execute()
         assert isfile(axn.target_full_path)

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -184,7 +184,8 @@ class PathActionsTests(TestCase):
         mkdir_p(dirname(py_ep_axn.target_full_path))
         py_ep_axn.execute()
         assert isfile(py_ep_axn.target_full_path)
-        assert is_executable(py_ep_axn.target_full_path)
+        if not on_win:
+            assert is_executable(py_ep_axn.target_full_path)
         with open(py_ep_axn.target_full_path) as fh:
             lines = fh.readlines()
             first_line = lines[0].strip()

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -22,7 +22,8 @@ from conda.common.path import get_python_site_packages_short_path, get_python_no
 from conda.core.path_actions import LinkPathAction, CompilePycAction, CreatePythonEntryPointAction
 from conda.gateways.disk.create import mkdir_p, create_link
 from conda.gateways.disk.delete import rm_rf
-from conda.gateways.disk.read import is_exe, compute_md5sum
+from conda.gateways.disk.read import compute_md5sum
+from conda.gateways.disk.permissions import is_executable
 from conda.gateways.disk.link import islink, stat_nlink
 from conda.models.enums import LinkType, NoarchType
 from conda.common.compat import PY2, on_win
@@ -182,7 +183,7 @@ class PathActionsTests(TestCase):
         mkdir_p(dirname(py_ep_axn.target_full_path))
         py_ep_axn.execute()
         assert isfile(py_ep_axn.target_full_path)
-        assert is_exe(py_ep_axn.target_full_path)
+        assert is_executable(py_ep_axn.target_full_path)
         with open(py_ep_axn.target_full_path) as fh:
             lines = fh.readlines()
             first_line = lines[0].strip()
@@ -204,7 +205,7 @@ class PathActionsTests(TestCase):
             windows_exe_axn.verify()
             windows_exe_axn.execute()
             assert isfile(windows_exe_axn.target_full_path)
-            assert is_exe(windows_exe_axn.target_full_path)
+            assert is_executable(windows_exe_axn.target_full_path)
 
             src = compute_md5sum(join(context.conda_prefix, 'Scripts/conda.exe'))
             assert src == compute_md5sum(windows_exe_axn.target_full_path)


### PR DESCRIPTION
A low-level response to https://github.com/conda/conda/issues/3974 and https://github.com/ContinuumIO/anaconda-issues/issues/1392.

This is targeted for 4.4.0 because I'd prefer a change like this go through a full feature canary cycle.

CC @mingwandroid 