### PR TITLE
create sudo target for travis-ci test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ matrix:
   allow_failures:
     - env: PYTHON_VERSION=3.6 SUDO=true
 
-
-
 install:
   - which -a python
   - env | sort

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,19 @@ matrix:
   include:
     - env: PYTHON_VERSION=3.6
       os: linux
-    - env: PYTHON_VERSION=3.4
+#    - env: PYTHON_VERSION=3.4
+#      os: linux
+#    - env: PYTHON_VERSION=2.7
+#      os: linux
+#    - env: PYTHON_VERSION=3.6 FLAKE8=true
+#      os: linux
+#    - env: PYTHON_VERSION=3.6
+#      os: osx
+#    - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
+#      os: linux
+    - env: PYTHON_VERSION=3.6 SUDO=true
       os: linux
-    - env: PYTHON_VERSION=2.7
-      os: linux
-    - env: PYTHON_VERSION=3.6 FLAKE8=true
-      os: linux
-    - env: PYTHON_VERSION=3.6
-      os: osx
-    - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
-      os: linux
+      sudo: true
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
     - env: FLAKE8=true
       python: '3.5'
       os: linux
-    - env: PYTHON_VERSION=3.6
-      os: osx
+#    - env: PYTHON_VERSION=3.6
+#      os: osx
     - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
       os: linux
     - env: PYTHON_VERSION=3.6 SUDO=true
@@ -31,7 +31,7 @@ matrix:
       sudo: true
   allow_failures:
     - env: PYTHON_VERSION=3.6 SUDO=true
-    - os: osx
+#    - os: osx
 
 install:
   - which -a python

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,24 @@ addons:
 
 matrix:
   include:
-#    - env: PYTHON_VERSION=3.6
-#      os: linux
-#    - env: PYTHON_VERSION=3.4
-#      os: linux
-#    - env: PYTHON_VERSION=2.7
-#      os: linux
-#    - env: PYTHON_VERSION=3.6 FLAKE8=true
-#      os: linux
-#    - env: PYTHON_VERSION=3.6
-#      os: osx
-#    - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
-#      os: linux
+    - env: PYTHON_VERSION=3.6
+      os: linux
+    - env: PYTHON_VERSION=3.4
+      os: linux
+    - env: PYTHON_VERSION=2.7
+      os: linux
+    - env: PYTHON_VERSION=3.6 FLAKE8=true
+      os: linux
+    - env: PYTHON_VERSION=3.6
+      os: osx
+    - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
+      os: linux
     - env: PYTHON_VERSION=3.6 SUDO=true
       os: linux
       sudo: true
+  allow_failures:
+    - env: PYTHON_VERSION=3.6 SUDO=true
+
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 
 matrix:
   include:
-    - env: PYTHON_VERSION=3.6
+    - env: PYTHON_VERSION=3.6 SUDO=true
       sudo: true
       language: generic
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
-language: generic
 os: linux
 
 env:
@@ -16,14 +15,19 @@ matrix:
   include:
     - env: PYTHON_VERSION=3.6
       sudo: true
+      language: generic
     - env: PYTHON_VERSION=3.4
+      language: generic
     - env: PYTHON_VERSION=2.7
+      language: generic
     - env: FLAKE8=true
       language: python
       python: '3.5'
     - env: PYTHON_VERSION=3.6
       os: osx
+      language: generic
     - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
+      language: generic
   allow_failures:
     - os: osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-sudo: false
-os: linux
-
 env:
   global:
     - PYTHONUNBUFFERED=yes
@@ -16,18 +13,28 @@ matrix:
     - env: PYTHON_VERSION=3.6
       sudo: true
       language: generic
+      os: linux
     - env: PYTHON_VERSION=3.4
+      sudo: false
       language: generic
+      os: linux
     - env: PYTHON_VERSION=2.7
+      sudo: false
       language: generic
+      os: linux
     - env: FLAKE8=true
+      sudo: false
       language: python
       python: '3.5'
+      os: linux
     - env: PYTHON_VERSION=3.6
+      sudo: false
+      language: generic
       os: osx
-      language: generic
     - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
+      sudo: false
       language: generic
+      os: linux
   allow_failures:
     - os: osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,18 @@ addons:
 
 matrix:
   include:
-    - env: PYTHON_VERSION=3.6
-      os: linux
-    - env: PYTHON_VERSION=3.4
-      os: linux
-    - env: PYTHON_VERSION=2.7
-      os: linux
-    - env: PYTHON_VERSION=3.6 FLAKE8=true
-      os: linux
-    - env: PYTHON_VERSION=3.6
-      os: osx
-    - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
-      os: linux
+#    - env: PYTHON_VERSION=3.6
+#      os: linux
+#    - env: PYTHON_VERSION=3.4
+#      os: linux
+#    - env: PYTHON_VERSION=2.7
+#      os: linux
+#    - env: PYTHON_VERSION=3.6 FLAKE8=true
+#      os: linux
+#    - env: PYTHON_VERSION=3.6
+#      os: osx
+#    - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
+#      os: linux
     - env: PYTHON_VERSION=3.6 SUDO=true
       os: linux
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,18 @@ matrix:
 #      os: linux
 #    - env: PYTHON_VERSION=2.7
 #      os: linux
-    - env: FLAKE8=true
-      language: python
-      python: '3.5'
-      os: linux
+#    - env: FLAKE8=true
+#      language: python
+#      python: '3.5'
+#      os: linux
 #    - env: PYTHON_VERSION=3.6
 #      os: osx
     - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
       os: linux
-    - env: PYTHON_VERSION=3.6 SUDO=true
-      os: linux
-      sudo: true
-  allow_failures:
-    - env: PYTHON_VERSION=3.6 SUDO=true
+#    - env: PYTHON_VERSION=3.6 SUDO=true
+#      os: linux
+#      sudo: true
+#  allow_failures:
 #    - os: osx
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
 
 matrix:
   include:
-    - env: PYTHON_VERSION=3.6
-      os: linux
+#    - env: PYTHON_VERSION=3.6
+#      os: linux
 #    - env: PYTHON_VERSION=3.4
 #      os: linux
 #    - env: PYTHON_VERSION=2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,3 @@ script:
   - source ./utils/travis-run-script.sh
 
 sudo: false
-
-after_success:
-  - ~/miniconda/bin/pip install codecov coveralls scrutinizer-ocular
-  - codecov --env PYTHON_VERSION
-  - coveralls || true
-  - ocular || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ addons:
       - zsh
 
 matrix:
-  allow_failures:
-    - os: osx
   include:
     - env: PYTHON_VERSION=3.6
       sudo: true
@@ -26,6 +24,8 @@ matrix:
     - env: PYTHON_VERSION=3.6
       os: osx
     - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
+  allow_failures:
+    - os: osx
 
 install:
   - which -a python

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 #    - env: PYTHON_VERSION=2.7
 #      os: linux
     - env: FLAKE8=true
+      language: python
       python: '3.5'
       os: linux
 #    - env: PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
     - env: PYTHON_VERSION=3.6 FLAKE8=true
       python: 3.6
       os: linux
-#    - env: PYTHON_VERSION=3.6
-#      os: osx
+    - env: PYTHON_VERSION=3.6
+      os: osx
     - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
       os: linux
     - env: PYTHON_VERSION=3.6 SUDO=true
@@ -31,6 +31,7 @@ matrix:
       sudo: true
   allow_failures:
     - env: PYTHON_VERSION=3.6 SUDO=true
+    - os: osx
 
 install:
   - which -a python
@@ -39,5 +40,3 @@ install:
 
 script:
   - source ./utils/travis-run-script.sh
-
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: generic
+os: linux
 
 env:
   global:
@@ -12,26 +13,19 @@ addons:
       - zsh
 
 matrix:
+  allow_failures:
+    - os: osx
   include:
-#    - env: PYTHON_VERSION=3.6
-#      os: linux
-#    - env: PYTHON_VERSION=3.4
-#      os: linux
-#    - env: PYTHON_VERSION=2.7
-#      os: linux
-#    - env: FLAKE8=true
-#      language: python
-#      python: '3.5'
-#      os: linux
-#    - env: PYTHON_VERSION=3.6
-#      os: osx
+    - env: PYTHON_VERSION=3.6
+      sudo: true
+    - env: PYTHON_VERSION=3.4
+    - env: PYTHON_VERSION=2.7
+    - env: FLAKE8=true
+      language: python
+      python: '3.5'
+    - env: PYTHON_VERSION=3.6
+      os: osx
     - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
-      os: linux
-#    - env: PYTHON_VERSION=3.6 SUDO=true
-#      os: linux
-#      sudo: true
-#  allow_failures:
-#    - os: osx
 
 install:
   - which -a python

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
 #      os: linux
 #    - env: PYTHON_VERSION=2.7
 #      os: linux
-    - env: PYTHON_VERSION=3.6 FLAKE8=true
-      python: 3.6
+    - env: FLAKE8=true
+      python: '3.5'
       os: linux
     - env: PYTHON_VERSION=3.6
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ matrix:
 #      os: linux
 #    - env: PYTHON_VERSION=2.7
 #      os: linux
-#    - env: PYTHON_VERSION=3.6 FLAKE8=true
-#      os: linux
+    - env: PYTHON_VERSION=3.6 FLAKE8=true
+      os: linux
 #    - env: PYTHON_VERSION=3.6
 #      os: osx
-#    - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
-#      os: linux
+    - env: PYTHON_VERSION=3.6 CONDA_BUILD=2.1.3
+      os: linux
     - env: PYTHON_VERSION=3.6 SUDO=true
       os: linux
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 #    - env: PYTHON_VERSION=2.7
 #      os: linux
     - env: PYTHON_VERSION=3.6 FLAKE8=true
+      python: 3.6
       os: linux
 #    - env: PYTHON_VERSION=3.6
 #      os: osx

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTEST_EXE ?= $(shell which py.test)
-PYTHON_EXE ?= $(shell echo $(PYTEST_EXE) | xargs head -1 | sed 's/^\#!//')
+PYTHON_EXE ?= $(shell cat $(PYTEST_EXE) | xargs head -1 | sed 's/^\#!//')
 PYTHON_MAJOR_VERSION := $(shell $(PYTHON_EXE) -c "import sys; print(sys.version_info[0])")
 TEST_PLATFORM := $(shell $(PYTHON_EXE) -c "import sys; print('win' if sys.platform.startswith('win') else 'unix')")
 PYTHONHASHSEED := $(shell python -c "import random as r; print(r.randint(0,4294967296))")

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 PYTEST_EXE ?= $(shell which py.test)
-PYTHON_EXE ?= $(shell sed 's/^\#!//' $(PYTEST_EXE) | head -1)
+PYTHON_EXE ?= $(shell sed 's/^\#!//' $(PYTEST_EXE) | head -1 | sed "s|$HOME|~|")
 PYTHON_MAJOR_VERSION := $(shell $(PYTHON_EXE) -c "import sys; print(sys.version_info[0])")
 TEST_PLATFORM := $(shell $(PYTHON_EXE) -c "import sys; print('win' if sys.platform.startswith('win') else 'unix')")
 PYTHONHASHSEED := $(shell python -c "import random as r; print(r.randint(0,4294967296))")
-TIME := $(shell which time)
 
 
 PYTEST_VARS := PYTHONHASHSEED=$(PYTHONHASHSEED) PYTHON_MAJOR_VERSION=$(PYTHON_MAJOR_VERSION) TEST_PLATFORM=$(TEST_PLATFORM)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTEST_EXE ?= $(shell which py.test)
-PYTHON_EXE ?= $(shell cat $(PYTEST_EXE) | xargs head -1 | sed 's/^\#!//')
+PYTHON_EXE ?= $(shell sed 's/^\#!//' $(PYTEST_EXE) | head -1)
 PYTHON_MAJOR_VERSION := $(shell $(PYTHON_EXE) -c "import sys; print(sys.version_info[0])")
 TEST_PLATFORM := $(shell $(PYTHON_EXE) -c "import sys; print('win' if sys.platform.startswith('win') else 'unix')")
 PYTHONHASHSEED := $(shell python -c "import random as r; print(r.randint(0,4294967296))")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,10 +74,10 @@ install:
 build: false
 
 test_script:
-  - py.test --cov conda --cov-report term-missing conda tests --shell=cmd.exe --shell=bash.exe
+  - py.test --cov-report xml --cov-report term-missing --cov-append --cov conda -m "not integration and not installed" --shell=cmd.exe --shell=bash.exe
+  - py.test --cov-report xml --cov-report term-missing --cov-append --cov conda -m "integration and not installed" --shell=cmd.exe --shell=bash.exe
+  - py.test --cov-report xml --cov-report term-missing --cov-append --cov conda -m "installed" --shell=cmd.exe --shell=bash.exe
 
 on_success:
   - pip install codecov coveralls scrutinizer-ocular
   - codecov --env PYTHON_VERSION
-  # - coveralls && exit 0  # coveralls is a piece of crap and doesn't merge tests runs from Appveyor and Travis CI with the same commit hashes
-  # - ocular && exit 0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,8 +74,8 @@ install:
 build: false
 
 test_script:
-  - py.test --cov-report xml --cov-report term-missing --cov-append --cov conda -m "not integration and not installed" --shell=cmd.exe --shell=bash.exe
-  - py.test --cov-report xml --cov-report term-missing --cov-append --cov conda -m "integration and not installed" --shell=cmd.exe --shell=bash.exe
+  - py.test --cov-report xml --cov-report term-missing --cov-append --cov conda -m "not integration and not installed"
+  - py.test --cov-report xml --cov-report term-missing --cov-append --cov conda -m "integration and not installed"
   - py.test --cov-report xml --cov-report term-missing --cov-append --cov conda -m "installed" --shell=cmd.exe --shell=bash.exe
 
 on_success:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -4,19 +4,21 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import Sequence
 from logging import getLogger
 import os
-from os.path import (abspath, basename, expanduser, isdir, isfile, join, normpath,
-                     split as path_split, dirname)
+from os.path import (abspath, basename, dirname, expanduser, isdir, isfile, join, normpath,
+                     split as path_split)
 from platform import machine
 import sys
 
 from .constants import (APP_NAME, DEFAULTS_CHANNEL_NAME, DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS,
                         PathConflict, ROOT_ENV_NAME, SEARCH_PATH)
+from .. import CondaError
 from .._vendor.appdirs import user_data_dir
+from .._vendor.auxlib.collection import first
 from .._vendor.auxlib.decorators import memoizedproperty
 from .._vendor.auxlib.ish import dals
 from .._vendor.auxlib.path import expand
 from .._vendor.boltons.setutils import IndexedSet
-from ..common.compat import NoneType, iteritems, itervalues, odict, on_win, string_types
+from ..common.compat import NoneType, iteritems, itervalues, odict, on_win, string_types, text_type
 from ..common.configuration import (Configuration, LoadError, MapParameter, PrimitiveParameter,
                                     SequenceParameter, ValidationError)
 from ..common.disk import conda_bld_ensure_dir
@@ -525,12 +527,21 @@ def get_prefix(ctx, args, search=True):
         if search:
             return locate_prefix_by_name(ctx, args.name)
         else:
-            from ..core.package_cache import PackageCache
-            return join(dirname(PackageCache.first_writable().pkgs_dir), 'envs', args.name)
+            # need first writable envs_dir
+            envs_dir = first(ctx.envs_dirs, envs_dir_has_writable_pkg_cache)
+            if not envs_dir:
+                raise CondaError("No writable package envs directories found in\n"
+                                 "%s" % text_type(context.envs_dirs))
+            return join(envs_dir, args.name)
     elif getattr(args, 'prefix', None):
         return abspath(expanduser(args.prefix))
     else:
         return ctx.default_prefix
+
+
+def envs_dir_has_writable_pkg_cache(envs_dir):
+    from ..core.package_cache import PackageCache
+    return PackageCache(join(dirname(envs_dir), 'pkgs')).is_writable
 
 
 def locate_prefix_by_name(ctx, name):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -5,7 +5,7 @@ from collections import Sequence
 from logging import getLogger
 import os
 from os.path import (abspath, basename, expanduser, isdir, isfile, join, normpath,
-                     split as path_split)
+                     split as path_split, dirname)
 from platform import machine
 import sys
 
@@ -525,7 +525,8 @@ def get_prefix(ctx, args, search=True):
         if search:
             return locate_prefix_by_name(ctx, args.name)
         else:
-            return join(ctx.envs_dirs[0], args.name)
+            from ..core.package_cache import PackageCache
+            return join(dirname(PackageCache.first_writable().pkgs_dir), 'envs', args.name)
     elif getattr(args, 'prefix', None):
         return abspath(expanduser(args.prefix))
     else:

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -343,7 +343,8 @@ def load_file_configs(search_path):
         yield fullpath, YamlRawParameter.make_raw_parameters_from_file(fullpath)
 
     def _dir_yaml_loader(fullpath):
-        for filepath in glob(join(fullpath, "*.yml")):
+        for filepath in sorted(concatv(glob(join(fullpath, "*.yml")),
+                                       glob(join(fullpath, "*.yaml")))):
             yield filepath, YamlRawParameter.make_raw_parameters_from_file(filepath)
 
     # map a stat result to a file loader or a directory loader

--- a/conda_env/cli/common.py
+++ b/conda_env/cli/common.py
@@ -3,12 +3,11 @@ import os
 import sys
 
 from conda._vendor.auxlib.entity import EntityEncoder
-from conda.base.context import context
+from conda.base.context import context, get_prefix as context_get_prefix
 from conda.config import root_dir, default_prefix
 from conda.exceptions import CondaValueError
 
 root_env_name = 'root'
-envs_dirs = context.envs_dirs
 
 
 def stdout_json(d):
@@ -19,29 +18,14 @@ def stdout_json(d):
 
 
 def get_prefix(args, search=True):
-    if args.name:
-        if '/' in args.name:
-            raise CondaValueError("'/' not allowed in environment name: %s" %
-                                  args.name, getattr(args, 'json', False))
-        if args.name == root_env_name:
-            return root_dir
-        if search:
-            prefix = find_prefix_name(args.name)
-            if prefix:
-                return prefix
-        return join(envs_dirs[0], args.name)
-
-    if args.prefix:
-        return abspath(expanduser(args.prefix))
-
-    return default_prefix
+    return context_get_prefix(context, args, search)
 
 
 def find_prefix_name(name):
     if name == root_env_name:
         return root_dir
     # always search cwd in addition to envs dirs (for relative path access)
-    for envs_dir in list(envs_dirs) + [os.getcwd(), ]:
+    for envs_dir in list(context.envs_dirs) + [os.getcwd(), ]:
         prefix = join(envs_dir, name)
         if isdir(prefix):
             return prefix

--- a/conda_env/cli/common.py
+++ b/conda_env/cli/common.py
@@ -1,11 +1,10 @@
-from os.path import abspath, join, isdir, expanduser
 import os
+from os.path import isdir, join
 import sys
 
 from conda._vendor.auxlib.entity import EntityEncoder
 from conda.base.context import context, get_prefix as context_get_prefix
-from conda.config import root_dir, default_prefix
-from conda.exceptions import CondaValueError
+from conda.config import root_dir
 
 root_env_name = 'root'
 

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -1,19 +1,18 @@
 from __future__ import print_function
+
 from argparse import RawDescriptionHelpFormatter
 import os
 import sys
 import textwrap
 
-
-from conda.cli import common
-from conda.cli import install as cli_install
+from conda.cli import common, install as cli_install
 from conda.gateways.disk.delete import rm_rf
 from conda.misc import touch_nonadmin
 from conda.plan import is_root_prefix
 
-from ..installers.base import get_installer, InvalidInstaller
-from .. import exceptions
-from .. import specs
+from .common import get_prefix
+from .. import exceptions, specs
+from ..installers.base import InvalidInstaller, get_installer
 
 description = """
 Create an environment based on an environment file
@@ -87,8 +86,7 @@ def execute(args, parser):
     except exceptions.SpecNotFound:
         raise
 
-    from conda.base.context import context, get_prefix
-    prefix = get_prefix(context, args, search=False)
+    prefix = get_prefix(args, search=False)
 
     if args.force and not is_root_prefix(prefix) and os.path.exists(prefix):
         rm_rf(prefix)

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -15,9 +15,6 @@ from ..installers.base import get_installer, InvalidInstaller
 from .. import exceptions
 from .. import specs
 
-# for conda env import
-from conda_env.cli.common import get_prefix
-
 description = """
 Create an environment based on an environment file
 """
@@ -90,7 +87,8 @@ def execute(args, parser):
     except exceptions.SpecNotFound:
         raise
 
-    prefix = get_prefix(args, search=False)
+    from conda.base.context import context, get_prefix
+    prefix = get_prefix(context, args, search=False)
 
     if args.force and not is_root_prefix(prefix) and os.path.exists(prefix):
         rm_rf(prefix)

--- a/tests/common/test_configuration.py
+++ b/tests/common/test_configuration.py
@@ -270,7 +270,6 @@ class ConfigurationTests(TestCase):
                 pprint(val)
             assert config.channels == ('wile', 'porky', 'bugs', 'elmer', 'daffy',
                                        'tweety', 'foghorn')
-
         finally:
             rmtree(tempdir, ignore_errors=True)
 

--- a/tests/common/test_configuration.py
+++ b/tests/common/test_configuration.py
@@ -263,6 +263,11 @@ class ConfigurationTests(TestCase):
             assert raw_data[f2]['proxy_servers'].value(None)['http'] == "marv"
 
             config = SampleConfiguration(search_path)
+
+            from pprint import pprint
+            for key, val in config.collect_all().items():
+                print(key)
+                pprint(val)
             assert config.channels == ('wile', 'porky', 'bugs', 'elmer', 'daffy',
                                        'tweety', 'foghorn')
 

--- a/tests/conda_env/test_create.py
+++ b/tests/conda_env/test_create.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+from conda.base.context import reset_context
+from conda.common.io import env_var
+
 from conda.exports import text_type
 from contextlib import contextmanager
 from logging import getLogger, Handler
@@ -66,8 +69,7 @@ def run_command(command, envs_dir, env_name, *arguments):
     command_line = "{0} -n {1} -f {2}".format(command, env_name, " ".join(arguments))
 
     args = p.parse_args(split(command_line))
-    with mock.patch('conda_env.cli.common.envs_dirs', new=(envs_dir,)):
-        args.func(args, p)
+    args.func(args, p)
 
 
 @contextmanager
@@ -105,14 +107,15 @@ class IntegrationTests(TestCase):
 
     def test_create_update(self):
         with make_temp_envs_dir() as envs_dir:
-            env_name = str(uuid4())[:8]
-            prefix = join(envs_dir, env_name)
-            python_path = join(prefix, PYTHON_BINARY)
+            with env_var('CONDA_ENVS_DIRS', envs_dir, reset_context):
+                env_name = str(uuid4())[:8]
+                prefix = join(envs_dir, env_name)
+                python_path = join(prefix, PYTHON_BINARY)
 
-            run_command(Commands.CREATE, envs_dir, env_name, utils.support_file('example/environment_pinned.yml'))
-            assert exists(python_path)
-            assert_package_is_installed(prefix, 'flask-0.9')
+                run_command(Commands.CREATE, envs_dir, env_name, utils.support_file('example/environment_pinned.yml'))
+                assert exists(python_path)
+                assert_package_is_installed(prefix, 'flask-0.9')
 
-            run_command(Commands.UPDATE, envs_dir, env_name, utils.support_file('example/environment_pinned_updated.yml'))
-            assert_package_is_installed(prefix, 'flask-0.10.1')
-            assert not package_is_installed(prefix, 'flask-0.9')
+                run_command(Commands.UPDATE, envs_dir, env_name, utils.support_file('example/environment_pinned_updated.yml'))
+                assert_package_is_installed(prefix, 'flask-0.10.1')
+                assert not package_is_installed(prefix, 'flask-0.9')

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -414,6 +414,7 @@ def test_PS1(shell, bash_profile):
         assert_equals(stdout, shell_vars['raw_ps'], stderr)
 
 
+@pytest.mark.installed
 def test_PS1_no_changeps1(shell, bash_profile):
     """Ensure that people's PS1 remains unchanged if they have that setting in their RC file."""
     shell_vars = _format_vars(shell)
@@ -557,6 +558,7 @@ def test_activate_from_env(shell):
         assert_equals(stdout.rstrip(), env_dirs[1], stderr)
 
 
+@pytest.mark.installed
 def test_deactivate_from_env(shell):
     """Tests whether the deactivate bat file or link in the activated environment works OK"""
     shell_vars = _format_vars(shell)
@@ -667,6 +669,7 @@ def test_activate_has_extra_env_vars(shell):
 
 
 @pytest.mark.slow
+@pytest.mark.installed
 def test_activate_keeps_PATH_order(shell):
     if not on_win or shell != "cmd.exe":
         pytest.xfail("test only implemented for cmd.exe on win")
@@ -681,6 +684,7 @@ def test_activate_keeps_PATH_order(shell):
         assert stdout.startswith("somepath;" + sys.prefix)
 
 @pytest.mark.slow
+@pytest.mark.installed
 def test_deactivate_placeholder(shell):
     if not on_win or shell != "cmd.exe":
         pytest.xfail("test only implemented for cmd.exe on win")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import json
 
 import unittest
 
+from conda.base.context import context
 from conda.gateways.disk.delete import rm_rf
 import pytest
 
@@ -85,8 +86,9 @@ class TestJson(unittest.TestCase):
         res = capture_json_with_argv('conda config --get channels --json')
         self.assertJsonSuccess(res)
 
-        res = capture_json_with_argv('conda config --get channels --system --json')
-        self.assertJsonSuccess(res)
+        if context.root_writable:
+            res = capture_json_with_argv('conda config --get channels --system --json')
+            self.assertJsonSuccess(res)
 
         res = capture_json_with_argv('conda config --get channels --file tempfile.rc --json')
         self.assertJsonSuccess(res)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -857,7 +857,7 @@ class IntegrationTests(TestCase):
         assert not glob(join(index_cache_dir, "*.json"))
 
     def test_clean_tarballs_and_packages(self):
-        pkgs_dir = join(PackageCache.first_writable().pkgs_dir, 'pkgs')
+        pkgs_dir = PackageCache.first_writable().pkgs_dir
         mkdir_p(pkgs_dir)
         pkgs_dir_hold = pkgs_dir + '_hold'
         try:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -324,7 +324,7 @@ class IntegrationTests(TestCase):
             assert_package_is_installed(prefix, 'python')
 
             flask_fname = flask_data['fn']
-            tar_old_path = join(context.pkgs_dirs[0], flask_fname)
+            tar_old_path = join(PackageCache.first_writable().pkgs_dir, flask_fname)
 
             # Regression test for #2812
             # install from local channel
@@ -372,7 +372,8 @@ class IntegrationTests(TestCase):
             assert_package_is_installed(prefix, 'python')
 
             flask_fname = flask_data['fn']
-            tar_old_path = join(context.pkgs_dirs[0], flask_fname)
+            tar_old_path = join(PackageCache.first_writable().pkgs_dir, flask_fname)
+
             assert isfile(tar_old_path)
 
             # regression test for #2886 (part 1 of 2)
@@ -856,7 +857,7 @@ class IntegrationTests(TestCase):
         assert not glob(join(index_cache_dir, "*.json"))
 
     def test_clean_tarballs_and_packages(self):
-        pkgs_dir = context.pkgs_dirs[0]
+        pkgs_dir = join(PackageCache.first_writable().pkgs_dir, 'pkgs')
         mkdir_p(pkgs_dir)
         pkgs_dir_hold = pkgs_dir + '_hold'
         try:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -8,7 +8,7 @@ import json
 from json import loads as json_loads
 from logging import DEBUG, getLogger
 import os
-from os.path import basename, exists, isdir, isfile, join, relpath
+from os.path import basename, exists, isdir, isfile, join, relpath, dirname
 from shlex import split
 from shutil import copyfile, rmtree
 from subprocess import check_call
@@ -353,7 +353,7 @@ class IntegrationTests(TestCase):
 
                 # Regression test for 2970
                 # install from build channel as a tarball
-                conda_bld = join(sys.prefix, 'conda-bld')
+                conda_bld = join(dirname(PackageCache.first_writable().pkgs_dir), 'conda-bld')
                 conda_bld_sub = join(conda_bld, context.subdir)
                 if not isdir(conda_bld_sub):
                     os.makedirs(conda_bld_sub)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from datetime import datetime
+
 from conda.base.context import context
 from conda.common.compat import text_type
 from conda.core.package_cache import download
@@ -76,6 +78,7 @@ class TestBinaryReplace(unittest.TestCase):
         self.assertRaises(_PaddingError, binary_replace,
                           b'aaaacaaaa\x00', b'aaaa', b'bbbbb')
 
+    @pytest.mark.integration
     @pytest.mark.skipif(not on_win, reason="exe entry points only necessary on win")
     def test_windows_entry_point(self):
         """
@@ -87,7 +90,7 @@ class TestBinaryReplace(unittest.TestCase):
         chdir(tmp_dir)
         original_prefix = "C:\\BogusPrefix\\python.exe"
         try:
-            url = 'https://bitbucket.org/vinay.sajip/pyzzer/downloads/pyzzerw.pyz'
+            url = 'https://s3.amazonaws.com/conda-dev/pyzzerw.pyz'
             download(url, 'pyzzerw.pyz')
             url = 'https://files.pythonhosted.org/packages/source/c/conda/conda-4.1.6.tar.gz'
             download(url, 'conda-4.1.6.tar.gz')

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -82,4 +82,6 @@ install_conda_dev() {
     hash -r
     $INSTALL_PREFIX/bin/pip install -r utils/requirements-test.txt
     $INSTALL_PREFIX/bin/python utils/setup-testing.py develop
+    mkdir -p $INSTALL_PREFIX/conda-meta
+    touch $INSTALL_PREFIX/conda-meta/history
 }

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -1,0 +1,47 @@
+# Set global variables
+case "$(uname -s)" in
+    'Darwin')
+        export MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-4.2.12-MacOSX-x86_64.sh"
+        ;;
+    'Linux')
+        export MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh"
+        ;;
+    *)  ;;
+esac
+
+install_python() {
+    INSTALL_PREFIX=${1:-~/miniconda}
+
+    # strategy is to use Miniconda to install python, but then remove all vestiges of conda
+   curl -sSL $MINICONDA_URL -o ~/miniconda.sh
+   chmod +x ~/miniconda.sh
+   mkdir -p $INSTALL_PREFIX
+   ~/miniconda.sh -bfp $INSTALL_PREFIX
+   hash -r
+   $INSTALL_PREFIX/bin/conda install -y -q python=$PYTHON_VERSION
+   local site_packages=$($INSTALL_PREFIX/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")
+   rm -rf $INSTALL_PREFIX/bin/activate \
+       $INSTALL_PREFIX/bin/conda \
+       $INSTALL_PREFIX/bin/deactivate \
+       $INSTALL_PREFIX/conda-meta/conda-*.json \
+       $INSTALL_PREFIX/conda-meta/requests-*.json \
+       $INSTALL_PREFIX/conda-meta/pyopenssl-*.json \
+       $INSTALL_PREFIX/conda-meta/cryptography-*.json \
+       $INSTALL_PREFIX/conda-meta/idna-*.json \
+       $INSTALL_PREFIX/conda-meta/ruamel-*.json \
+       $INSTALL_PREFIX/conda-meta/pycrypto-*.json \
+       $INSTALL_PREFIX/conda-meta/pycosat-*.json \
+       $site_packages/conda* \
+       $site_packages/requests* \
+       $site_packages/pyopenssl* \
+       $site_packages/cryptography* \
+       $site_packages/idna* \
+       $site_packages/ruamel* \
+       $site_packages/pycrypto* \
+       $site_packages/pycosat*
+   hash -r
+   which -a python
+   $INSTALL_PREFIX/bin/python --version
+   $INSTALL_PREFIX/bin/pip --version
+
+}

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -13,15 +13,16 @@ install_python() {
     INSTALL_PREFIX=${1:-~/miniconda}
 
     # strategy is to use Miniconda to install python, but then remove all vestiges of conda
-   curl -sSL $MINICONDA_URL -o ~/miniconda.sh
-   chmod +x ~/miniconda.sh
-   mkdir -p $INSTALL_PREFIX
-   ~/miniconda.sh -bfp $INSTALL_PREFIX
-   hash -r
-   $INSTALL_PREFIX/bin/conda install -y -q python=$PYTHON_VERSION
-   local site_packages=$($INSTALL_PREFIX/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")
-   rm -rf $INSTALL_PREFIX/bin/activate \
+    curl -sSL $MINICONDA_URL -o ~/miniconda.sh
+    chmod +x ~/miniconda.sh
+    mkdir -p $INSTALL_PREFIX
+    ~/miniconda.sh -bfp $INSTALL_PREFIX
+    hash -r
+    $INSTALL_PREFIX/bin/conda install -y -q python=$PYTHON_VERSION
+    local site_packages=$($INSTALL_PREFIX/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")
+    rm -rf $INSTALL_PREFIX/bin/activate \
        $INSTALL_PREFIX/bin/conda \
+       $INSTALL_PREFIX/bin/conda-env \
        $INSTALL_PREFIX/bin/deactivate \
        $INSTALL_PREFIX/conda-meta/conda-*.json \
        $INSTALL_PREFIX/conda-meta/requests-*.json \
@@ -39,9 +40,46 @@ install_python() {
        $site_packages/ruamel* \
        $site_packages/pycrypto* \
        $site_packages/pycosat*
-   hash -r
-   which -a python
-   $INSTALL_PREFIX/bin/python --version
-   $INSTALL_PREFIX/bin/pip --version
+    hash -r
+    which -a python
+    $INSTALL_PREFIX/bin/python --version
+    $INSTALL_PREFIX/bin/pip --version
 
+}
+
+
+install_conda_dev() {
+
+    INSTALL_PREFIX=${1:-~/miniconda}
+
+    curl -sSL $MINICONDA_URL -o ~/miniconda.sh
+    chmod +x ~/miniconda.sh
+    mkdir -p $INSTALL_PREFIX
+    ~/miniconda.sh -bfp $INSTALL_PREFIX
+    hash -r
+    $INSTALL_PREFIX/bin/conda install -y -q python=$PYTHON_VERSION
+    local site_packages=$($INSTALL_PREFIX/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")
+    rm -rf $INSTALL_PREFIX/bin/activate \
+       $INSTALL_PREFIX/bin/conda \
+       $INSTALL_PREFIX/bin/conda-env \
+       $INSTALL_PREFIX/bin/deactivate \
+       $INSTALL_PREFIX/conda-meta/conda-*.json \
+       $INSTALL_PREFIX/conda-meta/requests-*.json \
+       $INSTALL_PREFIX/conda-meta/pyopenssl-*.json \
+       $INSTALL_PREFIX/conda-meta/cryptography-*.json \
+       $INSTALL_PREFIX/conda-meta/idna-*.json \
+       $INSTALL_PREFIX/conda-meta/ruamel-*.json \
+       $INSTALL_PREFIX/conda-meta/pycrypto-*.json \
+       $INSTALL_PREFIX/conda-meta/pycosat-*.json \
+       $site_packages/conda* \
+       $site_packages/requests* \
+       $site_packages/pyopenssl* \
+       $site_packages/cryptography* \
+       $site_packages/idna* \
+       $site_packages/ruamel* \
+       $site_packages/pycrypto* \
+       $site_packages/pycosat*
+    hash -r
+    $INSTALL_PREFIX/bin/pip install -r utils/requirements-test.txt
+    $INSTALL_PREFIX/bin/python utils/setup-testing.py develop
 }

--- a/utils/requirements-test.txt
+++ b/utils/requirements-test.txt
@@ -8,3 +8,4 @@ radon
 responses
 anaconda-client
 nbformat
+codecov

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -2,6 +2,8 @@ set -e
 set -x
 
 export INSTALL_PREFIX="~/miniconda"
+export PATH="$INSTALL_PREFIX/bin:$PATH"
+
 
 osx_setup() {
     brew update || brew update

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -21,7 +21,7 @@ install_python() {
    chmod +x ~/miniconda.sh
    ~/miniconda.sh -bfp "$INSTALL_PREFIX"
    hash -r
-   conda install -y -q python=$PYTHON_VERSION
+   $INSTALL_PREFIX/bin/conda install -y -q python=$PYTHON_VERSION
    local site_packages=$($INSTALL_PREFIX/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")
    rm -rf $INSTALL_PREFIX/bin/activate \
        $INSTALL_PREFIX/bin/conda \

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -111,8 +111,6 @@ if [[ $FLAKE8 == true ]]; then
     $INSTALL_PREFIX/bin/pip install flake8
 elif [[ $SUDO == true ]]; then
     sudo -E -u root bash -c "source utils/functions.sh && install_conda_dev /usr/local"
-    ls -al /usr/local
-    ls -al /usr/local/bin
     export INSTALL_PREFIX="/usr/local"
     export PATH=$INSTALL_PREFIX/bin:$PATH
 elif [[ -n $CONDA_BUILD ]]; then

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -26,6 +26,7 @@ install_python() {
    local site_packages=$($INSTALL_PREFIX/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")
    rm -rf $INSTALL_PREFIX/bin/activate \
        $INSTALL_PREFIX/bin/conda \
+       $INSTALL_PREFIX/bin/conda-env \
        $INSTALL_PREFIX/bin/deactivate \
        $INSTALL_PREFIX/conda-meta/conda-*.json \
        $INSTALL_PREFIX/conda-meta/requests-*.json \
@@ -113,11 +114,11 @@ if [[ $FLAKE8 == true ]]; then
     install_python
     $INSTALL_PREFIX/bin/pip install flake8
 elif [[ $SUDO == true ]]; then
-    # export INSTALL_PREFIX="~/miniconda"
-    # export PATH=$INSTALL_PREFIX/bin:$PATH
-    sudo -E -u root bash -c "source utils/functions.sh && install_python /usr/local"
+    sudo -E -u root bash -c "source utils/functions.sh && install_conda_dev /usr/local"
     ls -al /usr/local
     ls -al /usr/local/bin
+    export INSTALL_PREFIX="/usr/local"
+    export PATH=$INSTALL_PREFIX/bin:$PATH
 elif [[ -n $CONDA_BUILD ]]; then
     miniconda_install
     conda_build_install

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -1,41 +1,13 @@
 set -e
 set -x
 
-export PATH="~/miniconda/bin:$PATH"
-
+export INSTALL_PREFIX="~/miniconda"
 
 osx_setup() {
     brew update || brew update
 
     brew outdated openssl || brew upgrade openssl
     brew install zsh
-
-#    # install pyenv
-#    git clone https://github.com/yyuu/pyenv.git ~/.pyenv
-#    PYENV_ROOT="$HOME/.pyenv"
-#    PATH="$PYENV_ROOT/bin:$PATH"
-#    eval "$(pyenv init -)"
-#
-#    case "$PYTHON_VERSION" in
-#        '2.7')
-#            curl -O https://bootstrap.pypa.io/get-pip.py
-#            python get-pip.py --user
-#            ;;
-#        '3.4')
-#            pyenv install 3.4.5
-#            pyenv global 3.4.5
-#            ;;
-#        '3.5')
-#            pyenv install 3.5.2
-#            pyenv global 3.5.2
-#            ;;
-#        '3.6')
-#            pyenv install 3.6.0
-#            pyenv global 3.6.0
-#            ;;
-#    esac
-#    pyenv rehash
-#    export PYTHON_EXE="$(pyenv which python)"
 
     rvm get head
 }
@@ -45,21 +17,21 @@ install_python() {
     # strategy is to use Miniconda to install python, but then remove all vestiges of conda
    curl -sSL $MINICONDA_URL -o ~/miniconda.sh
    chmod +x ~/miniconda.sh
-   ~/miniconda.sh -bfp ~/miniconda
+   ~/miniconda.sh -bfp "$INSTALL_PREFIX"
    hash -r
    conda install -y -q python=$PYTHON_VERSION
-   local site_packages=$(~/miniconda/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")
-   rm -rf ~/miniconda/bin/activate \
-       ~/miniconda/bin/conda \
-       ~/miniconda/bin/deactivate \
-       ~/miniconda/conda-meta/conda-*.json \
-       ~/miniconda/conda-meta/requests-*.json \
-       ~/miniconda/conda-meta/pyopenssl-*.json \
-       ~/miniconda/conda-meta/cryptography-*.json \
-       ~/miniconda/conda-meta/idna-*.json \
-       ~/miniconda/conda-meta/ruamel-*.json \
-       ~/miniconda/conda-meta/pycrypto-*.json \
-       ~/miniconda/conda-meta/pycosat-*.json \
+   local site_packages=$($INSTALL_PREFIX/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")
+   rm -rf $INSTALL_PREFIX/bin/activate \
+       $INSTALL_PREFIX/bin/conda \
+       $INSTALL_PREFIX/bin/deactivate \
+       $INSTALL_PREFIX/conda-meta/conda-*.json \
+       $INSTALL_PREFIX/conda-meta/requests-*.json \
+       $INSTALL_PREFIX/conda-meta/pyopenssl-*.json \
+       $INSTALL_PREFIX/conda-meta/cryptography-*.json \
+       $INSTALL_PREFIX/conda-meta/idna-*.json \
+       $INSTALL_PREFIX/conda-meta/ruamel-*.json \
+       $INSTALL_PREFIX/conda-meta/pycrypto-*.json \
+       $INSTALL_PREFIX/conda-meta/pycosat-*.json \
        $site_packages/conda* \
        $site_packages/requests* \
        $site_packages/pyopenssl* \
@@ -70,15 +42,15 @@ install_python() {
        $site_packages/pycosat*
    hash -r
    which -a python
-   ~/miniconda/bin/python --version
-   ~/miniconda/bin/pip --version
+   $INSTALL_PREFIX/bin/python --version
+   $INSTALL_PREFIX/bin/pip --version
 
 }
 
 miniconda_install() {
     curl -L https://repo.continuum.io/miniconda/Miniconda3-4.0.5-Linux-x86_64.sh -o ~/miniconda.sh
     bash ~/miniconda.sh -bfp ~/miniconda
-    export PATH=~/miniconda/bin:$PATH
+    export PATH=$INSTALL_PREFIX/bin:$PATH
     hash -r
     which -a conda
     conda install -y -q pip conda 'python>=3.6'
@@ -91,8 +63,8 @@ miniconda_install() {
 
 conda_build_install() {
     # install conda
-    rm -rf $(~/miniconda/bin/python -c "import site; print(site.getsitepackages()[0])")/conda
-    ~/miniconda/bin/python utils/setup-testing.py install
+    rm -rf $($INSTALL_PREFIX/bin/python -c "import site; print(site.getsitepackages()[0])")/conda
+    $INSTALL_PREFIX/bin/python utils/setup-testing.py install
     hash -r
     conda info
 
@@ -101,7 +73,7 @@ conda_build_install() {
     conda install -y -q -c conda-forge perl pytest-xdist
     conda install -y -q anaconda-client numpy
 
-    ~/miniconda/bin/python -m pip install pytest-catchlog pytest-mock
+    $INSTALL_PREFIX/bin/python -m pip install pytest-catchlog pytest-mock
 
     conda config --set add_pip_as_python_dependency true
 
@@ -110,9 +82,9 @@ conda_build_install() {
 
     # install conda-build
     git clone -b $CONDA_BUILD --single-branch --depth 1000 https://github.com/conda/conda-build.git
-    rm -rf $(~/miniconda/bin/python -c "import site; print(site.getsitepackages()[0])")/conda_build
+    rm -rf $($INSTALL_PREFIX/bin/python -c "import site; print(site.getsitepackages()[0])")/conda_build
     pushd conda-build
-    ~/miniconda/bin/pip install .
+    $INSTALL_PREFIX/bin/pip install .
     hash -r
     conda info
     popd
@@ -136,11 +108,13 @@ esac
 
 if [[ $FLAKE8 == true ]]; then
     install_python
-    ~/miniconda/bin/pip install flake8
+    $INSTALL_PREFIX/bin/pip install flake8
+elif [[ $SUDO == true ]]; then
+    echo 'hello world'
 elif [[ -n $CONDA_BUILD ]]; then
     miniconda_install
     conda_build_install
 else
     install_python
-    ~/miniconda/bin/pip install -r utils/requirements-test.txt
+    $INSTALL_PREFIX/bin/pip install -r utils/requirements-test.txt
 fi

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -114,8 +114,6 @@ elif [[ $SUDO == true ]]; then
     ls -al ./conda
 elif [[ -n $CONDA_BUILD ]]; then
     install_python
-
-    miniconda_install
     conda_build_install
 else
     install_python

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -113,11 +113,11 @@ if [[ $FLAKE8 == true ]]; then
     install_python
     $INSTALL_PREFIX/bin/pip install flake8
 elif [[ $SUDO == true ]]; then
-    export INSTALL_PREFIX="~/miniconda"
-    export PATH=$INSTALL_PREFIX/bin:$PATH
-    export -f install_python
-    type -a install_python || true
+    # export INSTALL_PREFIX="~/miniconda"
+    # export PATH=$INSTALL_PREFIX/bin:$PATH
     sudo -E -u root bash -c "source utils/functions.sh && install_python /usr/local"
+    ls -al /usr/local
+    ls -al /usr/local/bin
 elif [[ -n $CONDA_BUILD ]]; then
     miniconda_install
     conda_build_install

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -113,7 +113,10 @@ if [[ $FLAKE8 == true ]]; then
     install_python
     $INSTALL_PREFIX/bin/pip install flake8
 elif [[ $SUDO == true ]]; then
-    echo 'hello world'
+    export INSTALL_PREFIX="~/miniconda"
+    export PATH=$INSTALL_PREFIX/bin:$PATH
+    export -f install_python
+    sudo -E -u root install_python
 elif [[ -n $CONDA_BUILD ]]; then
     miniconda_install
     conda_build_install

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -45,7 +45,6 @@ install_python() {
        $site_packages/pycrypto* \
        $site_packages/pycosat*
    hash -r
-   which -a python
    $INSTALL_PREFIX/bin/python --version
    $INSTALL_PREFIX/bin/pip --version
 
@@ -56,11 +55,8 @@ miniconda_install() {
     bash ~/miniconda.sh -bfp ~/miniconda
     export PATH=$INSTALL_PREFIX/bin:$PATH
     hash -r
-    which -a conda
     conda install -y -q pip conda 'python>=3.6'
     conda info
-    which -a pip
-    which -a python
     conda config --set auto_update_conda false
 }
 

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -116,9 +116,8 @@ elif [[ $SUDO == true ]]; then
     export INSTALL_PREFIX="~/miniconda"
     export PATH=$INSTALL_PREFIX/bin:$PATH
     export -f install_python
-    sudo -E -u root env | sort || true
-    sudo -E -u root bash -c "env | sort" || true
-    sudo -E -u root install_python || true
+    type -a install_python || true
+    sudo -E -u root bash -c "source utils/functions.sh && install_python /usr/local"
 elif [[ -n $CONDA_BUILD ]]; then
     miniconda_install
     conda_build_install

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -2,7 +2,7 @@ set -e
 set -x
 
 export INSTALL_PREFIX="~/miniconda"
-export PATH="$INSTALL_PREFIX/bin:$PATH"
+export PATH=$INSTALL_PREFIX/bin:$PATH
 
 
 osx_setup() {
@@ -19,7 +19,8 @@ install_python() {
     # strategy is to use Miniconda to install python, but then remove all vestiges of conda
    curl -sSL $MINICONDA_URL -o ~/miniconda.sh
    chmod +x ~/miniconda.sh
-   ~/miniconda.sh -bfp "$INSTALL_PREFIX"
+   mkdir -p $INSTALL_PREFIX
+   ~/miniconda.sh -bfp $INSTALL_PREFIX
    hash -r
    $INSTALL_PREFIX/bin/conda install -y -q python=$PYTHON_VERSION
    local site_packages=$($INSTALL_PREFIX/bin/python -c "from distutils.sysconfig import get_python_lib as g; print(g())")

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 
-export INSTALL_PREFIX="~/miniconda"
+export INSTALL_PREFIX=~/miniconda
 export PATH=$INSTALL_PREFIX/bin:$PATH
 
 
@@ -52,33 +52,31 @@ install_python() {
 
 miniconda_install() {
     curl -L https://repo.continuum.io/miniconda/Miniconda3-4.0.5-Linux-x86_64.sh -o ~/miniconda.sh
-    bash ~/miniconda.sh -bfp ~/miniconda
-    export PATH=$INSTALL_PREFIX/bin:$PATH
+    bash ~/miniconda.sh -bfp $INSTALL_PREFIX
     hash -r
-    conda install -y -q pip conda 'python>=3.6'
-    conda info
-    conda config --set auto_update_conda false
+    $INSTALL_PREFIX/bin/conda install -y -q pip conda 'python>=3.6'
+    $INSTALL_PREFIX/bin/conda info
+    $INSTALL_PREFIX/bin/conda config --set auto_update_conda false
 }
 
 
 conda_build_install() {
     # install conda
-    rm -rf $($INSTALL_PREFIX/bin/python -c "import site; print(site.getsitepackages()[0])")/conda
+    $INSTALL_PREFIX/bin/pip install -r utils/requirements-test.txt
     $INSTALL_PREFIX/bin/python utils/setup-testing.py install
-    hash -r
-    conda info
+    $INSTALL_PREFIX/bin/conda info
 
     # install conda-build test dependencies
-    conda install -y -q pytest pytest-cov pytest-timeout mock
-    conda install -y -q -c conda-forge perl pytest-xdist
-    conda install -y -q anaconda-client numpy
+    $INSTALL_PREFIX/bin/conda install -y -q pytest pytest-cov pytest-timeout mock
+    $INSTALL_PREFIX/bin/conda install -y -q -c conda-forge perl pytest-xdist
+    $INSTALL_PREFIX/bin/conda install -y -q anaconda-client numpy
 
-    $INSTALL_PREFIX/bin/python -m pip install pytest-catchlog pytest-mock
+    $INSTALL_PREFIX/bin/pip install pytest-catchlog pytest-mock
 
-    conda config --set add_pip_as_python_dependency true
+    $INSTALL_PREFIX/bin/conda config --set add_pip_as_python_dependency true
 
     # install conda-build runtime dependencies
-    conda install -y -q filelock jinja2 patchelf conda-verify setuptools contextlib2 pkginfo
+    $INSTALL_PREFIX/bin/conda install -y -q filelock jinja2 patchelf conda-verify setuptools contextlib2 pkginfo
 
     # install conda-build
     git clone -b $CONDA_BUILD --single-branch --depth 1000 https://github.com/conda/conda-build.git
@@ -115,6 +113,8 @@ elif [[ $SUDO == true ]]; then
     sudo -E -u root chown -R root:root ./conda
     ls -al ./conda
 elif [[ -n $CONDA_BUILD ]]; then
+    install_python
+
     miniconda_install
     conda_build_install
 else

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -106,7 +106,7 @@ esac
 
 if [[ $FLAKE8 == true ]]; then
     pip install flake8
-elif [[ $SUDO == true ]]; then
+elif [[ $TRAVIS_SUDO == true ]]; then
     sudo -E -u root bash -c "source utils/functions.sh && install_conda_dev /usr/local"
     export INSTALL_PREFIX="/usr/local"
     export PATH=$INSTALL_PREFIX/bin:$PATH

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -107,8 +107,7 @@ esac
 
 
 if [[ $FLAKE8 == true ]]; then
-    install_python
-    $INSTALL_PREFIX/bin/pip install flake8
+    pip install flake8
 elif [[ $SUDO == true ]]; then
     sudo -E -u root bash -c "source utils/functions.sh && install_conda_dev /usr/local"
     export INSTALL_PREFIX="/usr/local"

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -113,6 +113,8 @@ elif [[ $SUDO == true ]]; then
     sudo -E -u root bash -c "source utils/functions.sh && install_conda_dev /usr/local"
     export INSTALL_PREFIX="/usr/local"
     export PATH=$INSTALL_PREFIX/bin:$PATH
+    sudo -E -u root chown -R root:root ./conda
+    ls -al ./conda
 elif [[ -n $CONDA_BUILD ]]; then
     miniconda_install
     conda_build_install

--- a/utils/travis-run-install.sh
+++ b/utils/travis-run-install.sh
@@ -116,7 +116,9 @@ elif [[ $SUDO == true ]]; then
     export INSTALL_PREFIX="~/miniconda"
     export PATH=$INSTALL_PREFIX/bin:$PATH
     export -f install_python
-    sudo -E -u root install_python
+    sudo -E -u root env | sort || true
+    sudo -E -u root bash -c "env | sort" || true
+    sudo -E -u root install_python || true
 elif [[ -n $CONDA_BUILD ]]; then
     miniconda_install
     conda_build_install

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -53,6 +53,9 @@ activate_test() {
     # make test-installed
     $PYTEST_EXE $ADD_COV -m "installed"
 
+    $INSTALL_PREFIX/bin/pip install codecov
+    $INSTALL_PREFIX/bin/codecov --env PYTHON_VERSION
+
 #    $INSTALL_PREFIX/bin/python -m pytest --cov-report term-missing --cov-report xml --cov-append --shell=bash --shell=zsh -m "installed" tests
 }
 

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -73,7 +73,9 @@ conda_build_unit_test() {
 }
 
 if [[ $FLAKE8 == true ]]; then
-    flake8 --statistics
+    ls -al $INSTALL_PREFIX/bin
+    ls -al .
+    $INSTALL_PREFIX/bin/flake8 --statistics -v
 elif [[ -n $CONDA_BUILD ]]; then
     conda_build_smoke_test
     conda_build_unit_test

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -20,12 +20,12 @@ make_conda_entrypoint() {
 }
 
 main_test() {
-    export PYTEST_EXE="~/miniconda/bin/py.test"
+    export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
 
     # basic unit tests
     make conda-version
     make integration
-#    ~/miniconda/bin/python -m pytest --cov-report xml --shell=bash --shell=zsh -m "not installed" --doctest-modules conda tests
+#    $INSTALL_PREFIX/bin/python -m pytest --cov-report xml --shell=bash --shell=zsh -m "not installed" --doctest-modules conda tests
 }
 
 activate_test() {
@@ -34,16 +34,16 @@ activate_test() {
 #    ln -sf shell/deactivate $prefix/bin/deactivate
 #    make_conda_entrypoint $prefix/bin/conda $prefix/bin/python pwd
 
-    ~/miniconda/bin/python utils/setup-testing.py develop
-    export PATH="~/miniconda/bin:$PATH"
+    $INSTALL_PREFIX/bin/python utils/setup-testing.py develop
+    export PATH="$INSTALL_PREFIX/bin:$PATH"
     hash -r
-    ~/miniconda/bin/python -c "import conda; print(conda.__version__)"
-    ~/miniconda/bin/python -m conda info
+    $INSTALL_PREFIX/bin/python -c "import conda; print(conda.__version__)"
+    $INSTALL_PREFIX/bin/python -m conda info
 
-    export PYTEST_EXE="~/miniconda/bin/py.test"
+    export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
     make test-installed
 
-#    ~/miniconda/bin/python -m pytest --cov-report term-missing --cov-report xml --cov-append --shell=bash --shell=zsh -m "installed" tests
+#    $INSTALL_PREFIX/bin/python -m pytest --cov-report term-missing --cov-report xml --cov-append --shell=bash --shell=zsh -m "installed" tests
 }
 
 
@@ -57,16 +57,16 @@ conda_build_unit_test() {
     echo
     echo ">>>>>>>>>>>> running conda-build unit tests >>>>>>>>>>>>>>>>>>>>>"
     echo
-    ~/miniconda/bin/python -m conda info
-    ~/miniconda/bin/python -m pytest --basetemp /tmp/cb -v --durations=20 -n 0 -m "serial" tests
-    ~/miniconda/bin/python -m pytest --basetemp /tmp/cb -v --durations=20 -n 2 -m "not serial" tests
+    $INSTALL_PREFIX/bin/python -m conda info
+    $INSTALL_PREFIX/bin/python -m pytest --basetemp /tmp/cb -v --durations=20 -n 0 -m "serial" tests
+    $INSTALL_PREFIX/bin/python -m pytest --basetemp /tmp/cb -v --durations=20 -n 2 -m "not serial" tests
     popd
 }
 
 env | sort
 
 if [[ $FLAKE8 == true ]]; then
-    ~/miniconda/bin/python -m flake8 --statistics
+    $INSTALL_PREFIX/bin/python -m flake8 --statistics
 elif [[ -n $CONDA_BUILD ]]; then
     conda_build_smoke_test
     conda_build_unit_test

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -32,7 +32,7 @@ main_test() {
     $PYTHON_EXE utils/setup-testing.py --version
 
     # make integration
-    $PYTEST_EXE $ADD_COV -m "not integration and not installed" --shell=bash --shell=zsh || true  # TODO: take or true off!
+    $PYTEST_EXE $ADD_COV -m "not integration and not installed" --shell=bash --shell=zsh
     $PYTEST_EXE $ADD_COV -m "integration and not installed" --shell=bash --shell=zsh
 
 }

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -23,21 +23,29 @@ main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
     echo "$PYTEST_EXE"
 
-    # works
-    ls -al "$INSTALL_PREFIX/bin" || true
-    cat "$INSTALL_PREFIX/bin/py.test" || true
-    cat "$INSTALL_PREFIX/bin/pytest" || true
+    $PYTEST_EXE --version || true
+    ~/miniconda/bin/py.test --version || true
+    $HOME/miniconda/bin/py.test --version || true
+    /home/travis/miniconda/bin/py.test --version || true
 
-    # doesn't work
-    cat "$HOME/miniconda/bin/pytest" || true
-    cat "/home/$USER/miniconda/bin/pytest" || true
-    ls -al /home/$USER/miniconda/bin/pytest || true
+    test $HOME = ~ && echo 'yes' || echo 'no'
+    test $HOME = ~/ && echo 'yes' || echo 'no'
 
-    ls -al / || true
-    ls -al /home || true
-    ls -al /home/travis || true
-    ls -al /home/$USER/miniconda || true
-    ls -al ~ || true
+#    # works
+#    ls -al "$INSTALL_PREFIX/bin" || true
+#    cat "$INSTALL_PREFIX/bin/py.test" || true
+#    cat "$INSTALL_PREFIX/bin/pytest" || true
+#
+#    # doesn't work
+#    cat "$HOME/miniconda/bin/pytest" || true
+#    cat "/home/$USER/miniconda/bin/pytest" || true
+#    ls -al /home/$USER/miniconda/bin/pytest || true
+#
+#    ls -al / || true
+#    ls -al /home || true
+#    ls -al /home/travis || true
+#    ls -al /home/$USER/miniconda || true
+#    ls -al ~ || true
 
 
     # basic unit tests

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -53,7 +53,6 @@ activate_test() {
     # make test-installed
     $PYTEST_EXE $ADD_COV -m "installed"
 
-    $INSTALL_PREFIX/bin/pip install codecov
     $INSTALL_PREFIX/bin/codecov --env PYTHON_VERSION
 
 #    $INSTALL_PREFIX/bin/python -m pytest --cov-report term-missing --cov-report xml --cov-append --shell=bash --shell=zsh -m "installed" tests

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -32,8 +32,8 @@ main_test() {
     $PYTHON_EXE utils/setup-testing.py --version
 
     # make integration
-    $PYTEST_EXE $ADD_COV -m "not integration and not installed"
-    $PYTEST_EXE $ADD_COV -m "integration and not installed"
+    $PYTEST_EXE $ADD_COV -m "not integration and not installed" --shell=bash --shell=zsh
+    $PYTEST_EXE $ADD_COV -m "integration and not installed" --shell=bash --shell=zsh
 
 }
 
@@ -51,11 +51,8 @@ activate_test() {
 
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
     # make test-installed
-    $PYTEST_EXE $ADD_COV -m "installed"
+    $PYTEST_EXE $ADD_COV -m "installed" --shell=bash --shell=zsh
 
-    $INSTALL_PREFIX/bin/codecov --env PYTHON_VERSION
-
-#    $INSTALL_PREFIX/bin/python -m pytest --cov-report term-missing --cov-report xml --cov-append --shell=bash --shell=zsh -m "installed" tests
 }
 
 
@@ -75,8 +72,6 @@ conda_build_unit_test() {
     popd
 }
 
-env | sort
-
 if [[ $FLAKE8 == true ]]; then
     flake8 --statistics
 elif [[ -n $CONDA_BUILD ]]; then
@@ -87,6 +82,7 @@ else
     if [[ "$(uname -s)" == "Linux" ]]; then
         activate_test
     fi
+    $INSTALL_PREFIX/bin/codecov --env PYTHON_VERSION
 fi
 
 set +x

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -21,7 +21,7 @@ make_conda_entrypoint() {
 
 main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
-    export PYTHON_EXE=$(sed 's/^\#!//' $(PYTEST_EXE) | head -1 | sed "s|$HOME|~|")
+    export PYTHON_EXE=$(sed 's/^\#!//' $PYTEST_EXE | head -1 | sed "s|$HOME|~|")
     export PYTHON_MAJOR_VERSION=$($PYTHON_EXE -c "import sys; print(sys.version_info[0])")
     export TEST_PLATFORM=$($PYTHON_EXE -c "import sys; print('win' if sys.platform.startswith('win') else 'unix')")
     export PYTHONHASHSEED=$($PYTHON_EXE -c "import random as r; print(r.randint(0,4294967296))")

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -32,7 +32,7 @@ main_test() {
     $PYTHON_EXE utils/setup-testing.py --version
 
     # make integration
-    $PYTEST_EXE $ADD_COV -m "not integration and not installed" --shell=bash --shell=zsh
+    $PYTEST_EXE $ADD_COV -m "not integration and not installed" --shell=bash --shell=zsh || true  # TODO: take or true off!
     $PYTEST_EXE $ADD_COV -m "integration and not installed" --shell=bash --shell=zsh
 
 }

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -21,7 +21,9 @@ make_conda_entrypoint() {
 
 main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
+    echo "$PYTEST_EXE"
     ls -al "$INSTALL_PREFIX/bin"
+    cat /home/travis/miniconda/bin/py.test
 
     # basic unit tests
     make conda-version

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -43,7 +43,12 @@ activate_test() {
 #    ln -sf shell/deactivate $prefix/bin/deactivate
 #    make_conda_entrypoint $prefix/bin/conda $prefix/bin/python pwd
 
-    $INSTALL_PREFIX/bin/python utils/setup-testing.py develop
+    if [[ $TRAVIS_SUDO == true ]]; then
+        sudo $INSTALL_PREFIX/bin/python utils/setup-testing.py develop
+    else
+        $INSTALL_PREFIX/bin/python utils/setup-testing.py develop
+    fi
+
     export PATH="$INSTALL_PREFIX/bin:$PATH"
     hash -r
     $INSTALL_PREFIX/bin/python -c "import conda; print(conda.__version__)"

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -24,14 +24,14 @@ main_test() {
     echo "$PYTEST_EXE"
 
     # works
-    ls -al "$INSTALL_PREFIX/bin"
+    ls -al "$INSTALL_PREFIX/bin" || true
     cat "$INSTALL_PREFIX/bin/py.test" || true
     cat "$INSTALL_PREFIX/bin/pytest" || true
 
     # doesn't work
     cat "$HOME/miniconda/bin/pytest" || true
     cat "/home/$USER/miniconda/bin/pytest" || true
-    ls -al /home/$USER/miniconda/bin/pytest
+    ls -al /home/$USER/miniconda/bin/pytest || true
 
     ls -al / || true
     ls -al /home || true

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -23,8 +23,11 @@ main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
     echo "$PYTEST_EXE"
     ls -al "$INSTALL_PREFIX/bin"
-    cat "$INSTALL_PREFIX/bin/py.test" || true
-    cat "$INSTALL_PREFIX/bin/pytest" || true
+#    cat "$INSTALL_PREFIX/bin/py.test" || true
+#    cat "$INSTALL_PREFIX/bin/pytest" || true
+    cat "$HOME/miniconda/bin/pytest" || true
+    cat "/home/$USER/miniconda/bin/pytest" || true
+    ls -al /home/$USER/miniconda/bin/pytest
 
     # basic unit tests
     make conda-version

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -79,7 +79,7 @@ conda_build_unit_test() {
 env | sort
 
 if [[ $FLAKE8 == true ]]; then
-    $INSTALL_PREFIX/bin/python -m flake8 --statistics
+    flake8 --statistics
 elif [[ -n $CONDA_BUILD ]]; then
     conda_build_smoke_test
     conda_build_unit_test

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -32,8 +32,8 @@ main_test() {
     $PYTHON_EXE utils/setup-testing.py --version
 
     # make integration
-    $PYTEST_EXE $ADD_COV -m "not integration and not installed" --shell=bash --shell=zsh
-    $PYTEST_EXE $ADD_COV -m "integration and not installed" --shell=bash --shell=zsh
+    $PYTEST_EXE $ADD_COV -m "not integration and not installed"
+    $PYTEST_EXE $ADD_COV -m "integration and not installed"
 
 }
 

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -23,7 +23,8 @@ main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
     echo "$PYTEST_EXE"
     ls -al "$INSTALL_PREFIX/bin"
-    cat /home/travis/miniconda/bin/py.test
+    cat "$INSTALL_PREFIX/bin/py.test" || true
+    cat "$INSTALL_PREFIX/bin/pytest" || true
 
     # basic unit tests
     make conda-version

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -21,6 +21,7 @@ make_conda_entrypoint() {
 
 main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
+    ls -al "$INSTALL_PREFIX/bin"
 
     # basic unit tests
     make conda-version

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -73,9 +73,7 @@ conda_build_unit_test() {
 }
 
 if [[ $FLAKE8 == true ]]; then
-    ls -al $INSTALL_PREFIX/bin
-    ls -al .
-    $INSTALL_PREFIX/bin/flake8 --statistics -v
+    flake8 --statistics
 elif [[ -n $CONDA_BUILD ]]; then
     conda_build_smoke_test
     conda_build_unit_test

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -21,7 +21,8 @@ make_conda_entrypoint() {
 
 main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
-    export PYTHON_EXE=$(sed 's/^\#!//' $PYTEST_EXE | head -1 | sed "s|$HOME|~|")
+    export PYTHON_EXE=$(sed 's/^\#!//' $PYTEST_EXE | head -1)
+    # export PYTHON_EXE=$(sed 's/^\#!//' $PYTEST_EXE | head -1 | sed "s|$HOME|~|")
     export PYTHON_MAJOR_VERSION=$($PYTHON_EXE -c "import sys; print(sys.version_info[0])")
     export TEST_PLATFORM=$($PYTHON_EXE -c "import sys; print('win' if sys.platform.startswith('win') else 'unix')")
     export PYTHONHASHSEED=$($PYTHON_EXE -c "import random as r; print(r.randint(0,4294967296))")

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -22,7 +22,6 @@ make_conda_entrypoint() {
 main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
     export PYTHON_EXE=$(sed 's/^\#!//' $PYTEST_EXE | head -1)
-    # export PYTHON_EXE=$(sed 's/^\#!//' $PYTEST_EXE | head -1 | sed "s|$HOME|~|")
     export PYTHON_MAJOR_VERSION=$($PYTHON_EXE -c "import sys; print(sys.version_info[0])")
     export TEST_PLATFORM=$($PYTHON_EXE -c "import sys; print('win' if sys.platform.startswith('win') else 'unix')")
     export PYTHONHASHSEED=$($PYTHON_EXE -c "import random as r; print(r.randint(0,4294967296))")

--- a/utils/travis-run-script.sh
+++ b/utils/travis-run-script.sh
@@ -22,12 +22,23 @@ make_conda_entrypoint() {
 main_test() {
     export PYTEST_EXE="$INSTALL_PREFIX/bin/py.test"
     echo "$PYTEST_EXE"
+
+    # works
     ls -al "$INSTALL_PREFIX/bin"
-#    cat "$INSTALL_PREFIX/bin/py.test" || true
-#    cat "$INSTALL_PREFIX/bin/pytest" || true
+    cat "$INSTALL_PREFIX/bin/py.test" || true
+    cat "$INSTALL_PREFIX/bin/pytest" || true
+
+    # doesn't work
     cat "$HOME/miniconda/bin/pytest" || true
     cat "/home/$USER/miniconda/bin/pytest" || true
     ls -al /home/$USER/miniconda/bin/pytest
+
+    ls -al / || true
+    ls -al /home || true
+    ls -al /home/travis || true
+    ls -al /home/$USER/miniconda || true
+    ls -al ~ || true
+
 
     # basic unit tests
     make conda-version


### PR DESCRIPTION
This PR took a lot of back-and-forth with Travis-CI, but I think the result it worth it.  Besides a few bug fixes to make everything pass, this PR adds a test target where conda is installed into a read-only prefix `/usr/local` so conda's executable is at `/usr/local/bin/conda`, and then the full test-suite is ran with a non-privileged user.

addresses #4649