### PR TITLE
use cPickle in place of pickle for repodata

### DIFF
--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -11,7 +11,6 @@ from logging import DEBUG, getLogger
 from mmap import ACCESS_READ, mmap
 from os import makedirs
 from os.path import dirname, join, split as path_split
-import pickle
 import re
 from textwrap import dedent
 from time import time
@@ -42,6 +41,11 @@ try:
     from cytoolz.itertoolz import take
 except ImportError:
     from .._vendor.toolz.itertoolz import take
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 __all__ = ('collect_all_repodata',)
 


### PR DESCRIPTION
This is roughly 2x faster for me on win with python 2.7.

It may be worthwhile to also investigate ujson for this serialization: https://github.com/esnme/ultrajson

There are some very interesting benchmarks at https://blog.hartleybrody.com/python-serialize/

CC @mcg1969 @kalefranz 