### PR TITLE
add skip_safety_checks configuration parameter

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -85,6 +85,7 @@ class Context(Configuration):
     rollback_enabled = PrimitiveParameter(True)
     track_features = SequenceParameter(string_types)
     use_pip = PrimitiveParameter(True)
+    skip_safety_checks = PrimitiveParameter(False)
 
     _root_dir = PrimitiveParameter("", aliases=('root_dir',))
     _envs_dirs = SequenceParameter(string_types, aliases=('envs_dirs', 'envs_path'),

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -240,6 +240,10 @@ class UnlinkLinkTransaction(object):
         if not self._prepared:
             self.prepare()
 
+        if context.skip_safety_checks:
+            self._verified = True
+            return
+
         exceptions = tuple(exc for exc in concatv(
             self._verify_individual_level(self.all_actions),
             self._verify_transaction_level(self.target_prefix, self.all_actions,


### PR DESCRIPTION
@mingwandroid This could help with your install time benchmark.  It'll be included in 4.3.14.