### PR TITLE
rm_rf: Remove incorrect elision of delete_prefix_from_linked_data()

### DIFF
--- a/conda/common/disk.py
+++ b/conda/common/disk.py
@@ -6,7 +6,7 @@ from errno import EACCES, EEXIST, ENOENT, EPERM
 from itertools import chain
 from logging import getLogger
 from os import W_OK, access, chmod, getpid, listdir, lstat, makedirs, rename, unlink, walk
-from os.path import abspath, basename, dirname, isdir, isfile, islink, join, lexists
+from os.path import abspath, basename, dirname, isdir, islink, join, lexists
 from shutil import rmtree
 from stat import S_IEXEC, S_IMODE, S_ISDIR, S_ISLNK, S_ISREG, S_IWRITE
 from time import sleep
@@ -204,10 +204,8 @@ def rm_rf(path, max_retries=5, trash=True):
                         return True
                 backoff_rmdir(path)
             finally:
-                # If path was removed, ensure it's not in linked_data_
-                if islink(path) or isfile(path):
-                    from conda.install import delete_linked_data_any
-                    delete_linked_data_any(path)
+                from conda.install import delete_linked_data_any
+                delete_linked_data_any(path)
         if lexists(path):
             try:
                 backoff_unlink(path)


### PR DESCRIPTION
The `if` statement was wrong. If `path` was deleted correctly, it would never call
`delete_prefix_from_linked_data(path)` because at that stage it is neither a link
nor a file.

This bug turned up when trying to use `conda-build` variants. The build prefix did
not contain any packages for subsequent variants because `conda` thought they were
already installed.

If the `rmdir` fails, perhaps we could make a best effort fixup of marking the env
as 'ok to be trivially clobbered' or something like that? Here I have elected to
remove `path` from `linked_data` regardless of the (complete) success of `rmdir`.

The commit that introduced this bug was a1b79e58:

```
@@ -192,10 +192,10 @@ def rm_rf(path, max_retries=5, trash=True):
                 backoff_rmdir(path)
             finally:
                 # If path was removed, ensure it's not in linked_data_
-                if not isdir(path):
+                if islink(path) or isfile(path):
                     from conda.install import delete_linked_data_any
                     delete_linked_data_any(path)
-        elif lexists(path):
+        if lexists(path):
             try:
                 backoff_unlink(path)
                 return True
```