### PR TITLE
rm_rf: Remove incorrect elision of delete_prefix_from_linked_data()

### DIFF
--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -5,7 +5,7 @@ from errno import ENOENT
 import json
 from logging import getLogger
 from os import listdir, removedirs, rename, unlink, walk
-from os.path import abspath, dirname, isdir, isfile, join, lexists
+from os.path import abspath, dirname, isdir, join, lexists
 from shutil import rmtree
 from uuid import uuid4
 
@@ -38,10 +38,8 @@ def rm_rf(path, max_retries=5, trash=True):
                         return True
                 backoff_rmdir(path)
             finally:
-                # If path was removed, ensure it's not in linked_data_
-                if islink(path) or isfile(path):
-                    from ...core.linked_data import delete_prefix_from_linked_data
-                    delete_prefix_from_linked_data(path)
+                from ...core.linked_data import delete_prefix_from_linked_data
+                delete_prefix_from_linked_data(path)
         elif lexists(path):
             try:
                 backoff_unlink(path)


### PR DESCRIPTION
The `if` statement was wrong. If `path` was deleted correctly, it would never call
`delete_prefix_from_linked_data(path)` because at that stage it is neither a link
nor a file.

This bug turned up when trying to use `conda-build` variants. The build prefix did
not contain any packages for subsequent variants because `conda` thought they were
already installed.

If the `rmdir` fails, perhaps we could make a best effort fixup of marking the env
as 'ok to be trivially clobbered' or something like that? Here I have elected to
remove `path` from `linked_data` regardless of the (complete) success of `rmdir`.

The commit that introduced this bug was a1b79e58:

```
@@ -192,10 +192,10 @@ def rm_rf(path, max_retries=5, trash=True):
                 backoff_rmdir(path)
             finally:
                 # If path was removed, ensure it's not in linked_data_
-                if not isdir(path):
+                if islink(path) or isfile(path):
                     from conda.install import delete_linked_data_any
                     delete_linked_data_any(path)
-        elif lexists(path):
+        if lexists(path):
             try:
                 backoff_unlink(path)
                 return True
```