### PR TITLE
Fix spelling: superceded -> superseded.

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -230,7 +230,7 @@ def display_actions(actions, index, show_channel_urls=None):
             print(format(oldfmt[pkg] + arrow + newfmt[pkg], pkg))
 
     if channeled:
-        print("\nThe following packages will be SUPERCEDED by a higher-priority channel:\n")
+        print("\nThe following packages will be SUPERSEDED by a higher-priority channel:\n")
         for pkg in sorted(channeled):
             print(format(oldfmt[pkg] + arrow + newfmt[pkg], pkg))
 

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -22,8 +22,8 @@ class PriorityIntegrationTests(TestCase):
             # update --all
             update_stdout, _ = run_command(Commands.UPDATE, prefix, '--all')
 
-            # pycosat should be in the SUPERCEDED list
-            superceded_split = update_stdout.split('SUPERCEDED')
+            # pycosat should be in the SUPERSEDED list
+            superceded_split = update_stdout.split('SUPERSEDED')
             assert len(superceded_split) == 2
             assert 'pycosat' in superceded_split[1]
 
@@ -48,7 +48,7 @@ class PriorityIntegrationTests(TestCase):
             # update python
             update_stdout, _ = run_command(Commands.UPDATE, prefix, 'python')
 
-            # pycosat should be in the SUPERCEDED list
+            # pycosat should be in the SUPERSEDED list
             superceded_split = update_stdout.split('UPDATED')
             assert len(superceded_split) == 2
             assert 'conda-forge' in superceded_split[1]


### PR DESCRIPTION
Fixes #3857.
see https://en.wiktionary.org/wiki/supercede, http://www.merriam-webster.com/dictionary/supercede