### PR TITLE
Fix arg name typo from "verison" to "version"

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -88,7 +88,7 @@ class MatchSpec(object):
     def is_simple(self):
         return self.match_fast == self._match_any
 
-    def _match_any(self, verison, build):
+    def _match_any(self, version, build):
         return True
 
     def _match_version(self, version, build):


### PR DESCRIPTION
target is 4.3.x
supersedes #4830