### PR TITLE
fix exceptions triggered during activate

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -145,20 +145,24 @@ def main(*args):
 
     log.debug("conda.cli.main called with %s", args)
     if len(args) > 1:
-        argv1 = args[1].strip()
-        if argv1.startswith('..'):
-            import conda.cli.activate as activate
-            activate.main()
-            return
-        if argv1 in ('activate', 'deactivate'):
+        try:
+            argv1 = args[1].strip()
+            if argv1.startswith('..'):
+                import conda.cli.activate as activate
+                activate.main()
+                return
+            if argv1 in ('activate', 'deactivate'):
 
-            message = "'%s' is not a conda command.\n" % argv1
-            from ..common.compat import on_win
-            if not on_win:
-                message += ' Did you mean "source %s" ?\n' % ' '.join(args[1:])
+                message = "'%s' is not a conda command.\n" % argv1
+                from ..common.compat import on_win
+                if not on_win:
+                    message += ' Did you mean "source %s" ?\n' % ' '.join(args[1:])
 
-            from ..exceptions import CommandNotFoundError
-            raise CommandNotFoundError(argv1, message)
+                from ..exceptions import CommandNotFoundError
+                raise CommandNotFoundError(argv1, message)
+        except Exception as e:
+            from ..exceptions import handle_exception
+            return handle_exception(e)
 
     from ..exceptions import conda_exception_handler
     return conda_exception_handler(_main, *args)

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -568,23 +568,28 @@ def maybe_raise(error, context):
         raise NotImplementedError()
 
 
-def conda_exception_handler(func, *args, **kwargs):
-    try:
-        return_value = func(*args, **kwargs)
-        if isinstance(return_value, int):
-            return return_value
-    except CondaExitZero:
+def handle_exception(e):
+    if isinstance(e, CondaExitZero):
         return 0
-    except CondaRuntimeError as e:
+    elif isinstance(e, CondaRuntimeError):
         print_unexpected_error_message(e)
         return 1
-    except CondaError as e:
+    elif isinstance(e, CondaError):
         from conda.base.context import context
         if context.debug or context.verbosity > 0:
             print_unexpected_error_message(e)
         else:
             print_conda_exception(e)
         return 1
-    except Exception as e:
+    else:
         print_unexpected_error_message(e)
         return 1
+
+
+def conda_exception_handler(func, *args, **kwargs):
+    try:
+        return_value = func(*args, **kwargs)
+        if isinstance(return_value, int):
+            return return_value
+    except Exception as e:
+        return handle_exception(e)


### PR DESCRIPTION
This PR pulls some logic out of `conda_exception_handler` and into its own function so that it can be used to prevent full stack traces that happen under expected circumstances during activate and deactivate.

CC @goanpeca