### PR TITLE
Add vc to default specs

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -374,6 +374,7 @@ def add_defaults_to_specs(r, linked, specs, update=False, prefix=None):
 
     for name, def_ver in [('python', context.default_python or None),
                           # Default version required, but only used for Python
+                          ('vc', None),
                           ('lua', None)]:
         if any(s.name == name and not s.is_simple() for s in mspecs):
             # if any of the specifications mention the Python/Numpy version,


### PR DESCRIPTION
It looks like many recipes are now using the `vc` metapackages to track vc features instead of the python package. But I am finding that `conda update --all` attempts to update vc from 9 to 14, along with all the packages that have a vc9 and vc14 feature. I don't think this is ever the desired behaviour?

This small change seems to make the vc package behave more like python, pinning the version during `conda update --all`.