### PR TITLE
Issue #2611: update documentation about how to source conda.fish

### DIFF
--- a/shell/conda.fish
+++ b/shell/conda.fish
@@ -11,7 +11,7 @@
 #     Source this file from the fish shell to enable activate / deactivate functions.
 #     In order to automatically load these functions on fish startup, append
 #
-#         source (conda info --root)/bin/conda.fish
+#         source (conda info --root)/etc/fish/conf.d/conda.fish
 #
 #     to the end of your ~/.config/config.fish file.
 #


### PR DESCRIPTION
`conda.fish` was apparently moved from `bin/conda.fish` to `etc\fish\conf.d\conda.fish` by eb4368c7:

```
commit eb4368c7238af61d2a1d47029062304d1b11b93b
Author: Kale Franz <kfranz@continuum.io>
Date:   Wed Jun 15 16:53:02 2016 -0500

    move conda.fish to etc/fish/conf.d```