### PR TITLE
enable configuring packaging pinning with condarc

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -82,6 +82,7 @@ class Context(Configuration):
     disallow = SequenceParameter(string_types)
     force_32bit = PrimitiveParameter(False)
     path_conflict = PrimitiveParameter(PathConflict.clobber)
+    pinned_packages = SequenceParameter(string_types, string_delimiter='/')  # TODO: consider a different string delimiter  # NOQA
     rollback_enabled = PrimitiveParameter(True)
     track_features = SequenceParameter(string_types)
     use_pip = PrimitiveParameter(True)
@@ -616,6 +617,9 @@ def get_help_dict():
             create, install, or update operation. The value must be one of 'clobber',
             'warn', or 'prevent'. The '--clobber' command-line flag or clobber
             configuration parameter overrides path_conflict set to 'prevent'.
+            """),
+        'pinned_packages': dals("""
+            A list of package specs to pin for every environment resolution.
             """),
         'pkgs_dirs': dals("""
             The list of directories where locally-available packages are linked from at

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -453,9 +453,6 @@ class Context(Configuration):
             'default_python',
             'force_32bit',
             'migrated_custom_channels',
-# https://conda.io/docs/config.html#configure-conda-for-use-behind-a-proxy-server-proxy-servers # NOQA
-# before adding proxy_servers to this documentation, we should test and verify behavior # NOQA
-            'proxy_servers',
             'root_dir',
             'skip_safety_checks',
             'subdir',
@@ -625,6 +622,14 @@ def get_help_dict():
             The list of directories where locally-available packages are linked from at
             install time. Packages not locally available are downloaded and extracted
             into the first writable directory.
+            """),
+        'proxy_servers': dals("""
+            A mapping to enable proxy settings. Keys can be either (1) a scheme://hostname
+            form, which will match any request to the given scheme and exact hostname, or
+            (2) just a scheme, which will match requests to that scheme. Values are are
+            the actual proxy server, and are of the form
+            'scheme://[user:password@]host[:port]'. The optional 'user:password' inclusion
+            enables HTTP Basic Auth with your proxy.
             """),
         'quiet': dals("""
             Disable progress bar display and other output.

--- a/conda/config.py
+++ b/conda/config.py
@@ -30,6 +30,7 @@ rc_list_keys = [
     'envs_dirs',
     'pkgs_dirs',
     'default_channels',
+    'pinned_packages',
 ]
 
 rc_bool_keys = [

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -419,10 +419,13 @@ def add_defaults_to_specs(r, linked, specs, update=False, prefix=None):
 
 def get_pinned_specs(prefix):
     pinfile = join(prefix, 'conda-meta', 'pinned')
-    if not exists(pinfile):
-        return []
-    with open(pinfile) as f:
-        return [i for i in f.read().strip().splitlines() if i and not i.strip().startswith('#')]
+    if exists(pinfile):
+        with open(pinfile) as f:
+            from_file = (i for i in f.read().strip().splitlines()
+                         if i and not i.strip().startswith('#'))
+    else:
+        from_file = ()
+    return tuple(concatv(context.pinned_packages, from_file))
 
 
 # Has one spec (string) for each env

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -425,7 +425,13 @@ def get_pinned_specs(prefix):
                          if i and not i.strip().startswith('#'))
     else:
         from_file = ()
-    return tuple(concatv(context.pinned_packages, from_file))
+
+    from .cli.common import spec_from_line
+
+    def munge_spec(s):
+        return s if ' ' in s else spec_from_line(s)
+
+    return tuple(munge_spec(s) for s in concatv(context.pinned_packages, from_file))
 
 
 # Has one spec (string) for each env

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -692,7 +692,7 @@ def augment_specs(prefix, specs, pinned=True):
     # get conda-meta/pinned
     if pinned:
         pinned_specs = get_pinned_specs(prefix)
-        log.debug("Pinned specs=%s" % pinned_specs)
+        log.debug("Pinned specs=%s", pinned_specs)
         specs += [MatchSpec(spec) for spec in pinned_specs]
 
     # support aggressive auto-update conda

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -735,7 +735,7 @@ def remove_actions(prefix, specs, index, force=False, pinned=True):
 
     if pinned:
         pinned_specs = get_pinned_specs(prefix)
-        log.debug("Pinned specs=%s" % pinned_specs)
+        log.debug("Pinned specs=%s", pinned_specs)
 
     linked = {r.package_name(dist): dist for dist in linked_dists}
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,6 +10,13 @@ import re
 import json
 from shlex import split
 
+from os.path import join
+from tempfile import gettempdir
+from uuid import uuid4
+
+from conda.gateways.disk.delete import rm_rf
+from conda.gateways.disk.read import lexists
+
 from conda.base.context import reset_context
 from conda.common.io import captured, argv, replace_log_streams
 from conda.gateways.logging import initialize_logging
@@ -121,3 +128,16 @@ def run_inprocess_conda_command(command):
     print(c.stderr, file=sys.stderr)
     print(c.stdout)
     return c.stdout, c.stderr, exit_code
+
+
+@contextmanager
+def tempdir():
+    tempdirdir = gettempdir()
+    dirname = str(uuid4())[:8]
+    prefix = join(tempdirdir, dirname)
+    try:
+        os.makedirs(prefix)
+        yield prefix
+    finally:
+        if lexists(prefix):
+            rm_rf(prefix)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,4 +1,9 @@
 import os
+
+from conda.gateways.disk.create import mkdir_p
+
+from conda.common.io import env_var
+
 from conda._vendor.boltons.setutils import IndexedSet
 
 from conda.cli import common
@@ -28,7 +33,7 @@ from conda.utils import on_win
 from conda.common.compat import iteritems
 
 # FIXME This should be a relative import
-from tests.helpers import captured
+from tests.helpers import captured, tempdir
 from conda import CondaError
 
 from .decorators import skip_if_no_mock
@@ -1247,6 +1252,33 @@ class TestAddUnlinkOptionsForUpdate(unittest.TestCase):
         expected_output = [action, generate_remove_action(
             "some/prefix/envs/_env_", [Dist("test3-1.2.0"), Dist("test4-2.1.0-22")])]
         self.assertEquals(actions, expected_output)
+
+
+def test_pinned_specs():
+    specs_1 = ("numpy 1.11", "python >3")
+    with env_var('CONDA_PINNED_PACKAGES', '/'.join(specs_1), reset_context):
+        pinned = plan.get_pinned_specs("/none")
+        assert pinned == specs_1
+
+    specs_2 = ("scipy ==0.14.2", "openjdk >=8")
+    with tempdir() as td:
+        mkdir_p(join(td, 'conda-meta'))
+        with open(join(td, 'conda-meta', 'pinned'), 'w') as fh:
+            fh.write("\n".join(specs_2))
+            fh.write("\n")
+        pinned = plan.get_pinned_specs(td)
+        assert pinned == specs_2
+
+    with env_var('CONDA_PINNED_PACKAGES', '/'.join(specs_2), reset_context):
+        with tempdir() as td:
+            mkdir_p(join(td, 'conda-meta'))
+            with open(join(td, 'conda-meta', 'pinned'), 'w') as fh:
+                fh.write("\n".join(specs_1))
+                fh.write("\n")
+
+            pinned = plan.get_pinned_specs(td)
+            assert pinned == specs_2 + specs_1
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -7,6 +7,7 @@ from conda.common.io import env_var
 from conda._vendor.boltons.setutils import IndexedSet
 
 from conda.cli import common
+from conda.cli.python_api import run_command, Commands
 from conda.core import linked_data
 from conda.core.package_cache import ProgressiveFetchExtract
 from conda.exceptions import NoPackagesFoundError, InstallError
@@ -1269,15 +1270,19 @@ def test_pinned_specs():
         pinned = plan.get_pinned_specs(td)
         assert pinned == specs_2
 
-    with env_var('CONDA_PINNED_PACKAGES', '/'.join(specs_2), reset_context):
-        with tempdir() as td:
-            mkdir_p(join(td, 'conda-meta'))
-            with open(join(td, 'conda-meta', 'pinned'), 'w') as fh:
-                fh.write("\n".join(specs_1))
-                fh.write("\n")
+    with tempdir() as td:
+        mkdir_p(join(td, 'conda-meta'))
+        with open(join(td, 'conda-meta', 'pinned'), 'w') as fh:
+            fh.write("\n".join(specs_1))
+            fh.write("\n")
 
-            pinned = plan.get_pinned_specs(td)
-            assert pinned == specs_2 + specs_1
+        with env_var('CONDA_PREFIX', td, reset_context):
+            run_command(Commands.CONFIG, "--env --add pinned_packages requests=2.13")
+            with env_var('CONDA_PINNED_PACKAGES', '/'.join(specs_2), reset_context):
+                pinned = plan.get_pinned_specs(td)
+                assert pinned == specs_2 + ("requests 2.13",) + specs_1
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@electronwill This will soon be merged, and while it's a new feature, I'm still going to break the rule and merge it into 4.3.  It'll probably be included in 4.3.16.

With this PR, packages can be pinned with configuration in a condarc file, rather than as currently documented [here](https://conda.io/docs/faq.html#pinning-packages).

Within a condarc file, users can add something like:

```
pinned_packages:
  - python >3
  - numpy 1.11
```

From the command line, you could do something like

    conda config --env --add pinned_packages python=2.7

Notice the new `--env` flag there.  That's being added as part of https://github.com/conda/conda/pull/4913.  It just specifies that that config should be written to the active environment's condarc file--if there is one active--otherwise it'll fall back to the user condarc file.  It's analogous to the `--system` flag for `conda config`.

So the takeaway, and actually new feature, is that packages can be pinned for the whole system, per user, or per environment, based on the condarc file that the configuration is written to.