### PR TITLE
Perform strict prefix checking when removing conda env, fixes #3814

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -333,6 +333,10 @@ class Context(Configuration):
         return get_prefix(self, self._argparse_args, False)
 
     @property
+    def strict_prefix(self):
+        return get_prefix(self, self._argparse_args, False, strict=True)
+
+    @property
     def prefix_w_legacy_search(self):
         return get_prefix(self, self._argparse_args, True)
 
@@ -518,7 +522,7 @@ def get_help_dict():
     }
 
 
-def get_prefix(ctx, args, search=True):
+def get_prefix(ctx, args, search=True, strict=False):
     """Get the prefix to operate in
 
     Args:
@@ -528,6 +532,7 @@ def get_prefix(ctx, args, search=True):
 
     Returns: the prefix
     Raises: CondaEnvironmentNotFoundError if the prefix is invalid
+            and strict is set to True
     """
     if getattr(args, 'name', None):
         if '/' in args.name:
@@ -543,7 +548,14 @@ def get_prefix(ctx, args, search=True):
             if not envs_dir:
                 raise CondaError("No writable package envs directories found in\n"
                                  "%s" % text_type(context.envs_dirs))
-            return join(envs_dir, args.name)
+
+            prefix = join(envs_dir, args.name)
+
+            if strict and not isdir(prefix):
+                raise CondaEnvironmentNotFoundError(args.name)
+
+            return prefix
+
     elif getattr(args, 'prefix', None):
         return abspath(expanduser(args.prefix))
     else:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -529,6 +529,7 @@ def get_prefix(ctx, args, search=True, strict=False):
         ctx: the context of conda
         args: the argparse args from the command line
         search: whether search for prefix
+        strict: checks if prefix path exists
 
     Returns: the prefix
     Raises: CondaEnvironmentNotFoundError if the prefix is invalid

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -118,7 +118,7 @@ def execute(args, parser):
         raise CondaValueError('no package names supplied,\n'
                               '       try "conda remove -h" for more details')
 
-    prefix = context.prefix_w_legacy_search
+    prefix = context.strict_prefix
     if args.all and prefix == context.default_prefix:
         msg = "cannot remove current environment. deactivate and run conda remove again"
         raise CondaEnvironmentError(msg)

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -12,6 +12,7 @@ from conda_env.cli.main import create_parser
 from conda.base.context import context
 from conda.base.constants import ROOT_ENV_NAME
 from conda.common.io import captured
+from conda.exceptions import CondaEnvironmentNotFoundError
 from conda.install import rm_rf
 from conda.cli.main_create import configure_parser as conda_create_parser
 from conda.cli.main_list import configure_parser as list_parser
@@ -38,6 +39,7 @@ channels:
 
 test_env_name_1 = "env-1"
 test_env_name_2 = "snowflakes"
+test_env_name_3 = "env_foo"
 
 def escape_for_winpath(p):
     if p:
@@ -236,12 +238,20 @@ class NewIntegrationTests(unittest.TestCase):
             run_env_command(Commands.ENV_REMOVE, test_env_name_2)
             self.assertFalse(env_is_created(test_env_name_2))
 
-    def test_create_env(self):
+    def test_create_remove_env(self):
         """
-            Test conda create env and conda env remove env
+            Test conda create and remove env
         """
-        run_conda_command(Commands.CREATE, test_env_name_2)
-        self.assertTrue(env_is_created(test_env_name_2))
+
+        run_conda_command(Commands.CREATE, test_env_name_3)
+        self.assertTrue(env_is_created(test_env_name_3))
+
+        with pytest.raises(CondaEnvironmentNotFoundError) as execinfo:
+            run_env_command(Commands.ENV_REMOVE, 'does-not-exist')
+
+        run_env_command(Commands.ENV_REMOVE, test_env_name_3)
+        self.assertFalse(env_is_created(test_env_name_3))
+
 
     def test_export(self):
         """


### PR DESCRIPTION
I introducted a new context attribute `context.strict_prefix` to use for `conda env remove` and anywhere else where strict prefix checking is required. Feedback is appreciated.