### PR TITLE
make configuration SEARCH_PATH more consistent

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -21,20 +21,21 @@ machine_bits = 8 * tuple.__itemsize__
 APP_NAME = 'conda'
 
 SEARCH_PATH = (
+    '/etc/conda/.condarc',
     '/etc/conda/condarc',
     '/etc/conda/condarc.d/',
+    '/var/lib/conda/.condarc',
     '/var/lib/conda/condarc',
     '/var/lib/conda/condarc.d/',
-    '%s/condarc' % sys.prefix,
-    '%s/.condarc' % sys.prefix,
-    '%s/condarc.d/' % sys.prefix,
-    '$CONDA_ROOT/condarc',
     '$CONDA_ROOT/.condarc',
+    '$CONDA_ROOT/condarc',
     '$CONDA_ROOT/condarc.d/',
+    '~/.conda/.condarc',
     '~/.conda/condarc',
     '~/.conda/condarc.d/',
     '~/.condarc',
     '$CONDA_PREFIX/.condarc',
+    '$CONDA_PREFIX/condarc',
     '$CONDA_PREFIX/condarc.d/',
     '$CONDARC',
 )


### PR DESCRIPTION
Slight modification to make conda configuration SEARCH_PATH more consistent.  The complete search path is now

```python
SEARCH_PATH = (
    '/etc/conda/.condarc',
    '/etc/conda/condarc',
    '/etc/conda/condarc.d/',
    '/var/lib/conda/.condarc',
    '/var/lib/conda/condarc',
    '/var/lib/conda/condarc.d/',
    '$CONDA_ROOT/.condarc',
    '$CONDA_ROOT/condarc',
    '$CONDA_ROOT/condarc.d/',
    '~/.conda/.condarc',
    '~/.conda/condarc',
    '~/.conda/condarc.d/',
    '~/.condarc',
    '$CONDA_PREFIX/.condarc',
    '$CONDA_PREFIX/condarc',
    '$CONDA_PREFIX/condarc.d/',
    '$CONDARC',
)
```