### PR TITLE
Don't disable binstar logger

### DIFF
--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -64,7 +64,6 @@ def initialize_logging():
     binstar.setLevel(CRITICAL+1)
     binstar.addHandler(NullHandler())
     binstar.propagate = False
-    binstar.disabled = True
 
 
 def initialize_root_logger(level=ERROR):


### PR DESCRIPTION
If binstar logger is disabled, unhandled exceptions are not shown.
An example for this is https://github.com/Anaconda-Platform/anaconda-client/issues/391