### PR TITLE
Fix pinned string format.

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -300,7 +300,7 @@ def install(args, parser, command='install'):
             if pinned_specs:
                 path = join(prefix, 'conda-meta', 'pinned')
                 error_message.append("\n\nNote that you have pinned specs in %s:" % path)
-                error_message.append("\n\n    %r" % pinned_specs)
+                error_message.append("\n\n    %r" % (pinned_specs,))
 
             error_message = ''.join(error_message)
             raise PackageNotFoundError(error_message)


### PR DESCRIPTION
Fixes #4998 

---

If the pinned file contains multiple entries, the current code will
traceback. Instead, pack the result into a tuple which will safely
print. Same fix as @pelson made in #2187.