### PR TITLE
Quote prefix paths for locations with spaces.

### DIFF
--- a/conda/cli/help.py
+++ b/conda/cli/help.py
@@ -35,7 +35,7 @@ Missing write permissions in: ${root_dir}
 # then make changes to it.
 # This may be done using the command:
 #
-# $ conda create -n my_${name} --clone=${prefix}
+# $ conda create -n my_${name} --clone="${prefix}"
 """
     msg = msg.replace('${root_dir}', context.root_prefix)
     msg = msg.replace('${prefix}', prefix)


### PR DESCRIPTION
The prefix location may contain spaces in the path -- quote the path
to handle this case. Fixes #5006.