### PR TITLE
make python entry point format match pip entry points

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -22,8 +22,7 @@ from ..common.url import path_to_url
 from ..exceptions import CondaUpgradeError, CondaVerificationError, PaddingError
 from ..gateways.disk.create import (compile_pyc, create_hard_link_or_copy, create_link,
                                     create_private_envs_meta, create_private_pkg_entry_point,
-                                    create_unix_python_entry_point,
-                                    create_windows_python_entry_point, extract_tarball,
+                                    create_python_entry_point, extract_tarball,
                                     make_menu, write_linked_package_record)
 from ..gateways.disk.delete import remove_private_envs_meta, rm_rf, try_rmdir_all_empty
 from ..gateways.disk.read import compute_md5sum, isfile, islink, lexists
@@ -418,13 +417,14 @@ class CreatePythonEntryPointAction(CreateInPrefixPathAction):
     def execute(self):
         log.trace("creating python entry point %s", self.target_full_path)
         if on_win:
-            create_windows_python_entry_point(self.target_full_path, self.module, self.func)
+            python_full_path = None
         else:
             target_python_version = self.transaction_context['target_python_version']
             python_short_path = get_python_short_path(target_python_version)
             python_full_path = join(self.target_prefix, win_path_ok(python_short_path))
-            create_unix_python_entry_point(self.target_full_path, python_full_path,
-                                           self.module, self.func)
+
+        create_python_entry_point(self.target_full_path, python_full_path,
+                                  self.module, self.func)
         self._execute_successful = True
 
     def reverse(self):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -36,10 +36,14 @@ stdoutlog = getLogger('stdoutlog')
 
 python_entry_point_template = dals("""
 # -*- coding: utf-8 -*-
+import re
+import sys
+
+from %(module)s import %(import_name)s
+
 if __name__ == '__main__':
-    from sys import exit
-    from %(module)s import %(func)s
-    exit(%(func)s())
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(%(func)s())
 """)
 
 application_entry_point_template = dals("""
@@ -67,7 +71,9 @@ def create_unix_python_entry_point(target_full_path, python_full_path, module, f
             context=context,
         ), context)
 
-    pyscript = python_entry_point_template % {'module': module, 'func': func}
+    import_name = func.split('.')[0]
+    pyscript = python_entry_point_template % {
+        'module': module, 'func': func, 'import_name': import_name}
     with open(target_full_path, str('w')) as fo:
         shebang = '#!%s\n' % python_full_path
         if hasattr(shebang, 'encode'):
@@ -90,7 +96,9 @@ def create_windows_python_entry_point(target_full_path, module, func):
             context=context,
         ), context)
 
-    pyscript = python_entry_point_template % {'module': module, 'func': func}
+    import_name = func.split('.')[0]
+    pyscript = python_entry_point_template % {
+        'module': module, 'func': func, import_name: 'import_name'}
     with open(target_full_path, str('w')) as fo:
         fo.write(pyscript)
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -73,7 +73,10 @@ def create_unix_python_entry_point(target_full_path, python_full_path, module, f
 
     import_name = func.split('.')[0]
     pyscript = python_entry_point_template % {
-        'module': module, 'func': func, 'import_name': import_name}
+        'module': module,
+        'func': func,
+        'import_name': import_name,
+    }
     with open(target_full_path, str('w')) as fo:
         shebang = '#!%s\n' % python_full_path
         if hasattr(shebang, 'encode'):
@@ -98,7 +101,10 @@ def create_windows_python_entry_point(target_full_path, module, func):
 
     import_name = func.split('.')[0]
     pyscript = python_entry_point_template % {
-        'module': module, 'func': func, import_name: 'import_name'}
+        'module': module,
+        'func': func,
+        'import_name': import_name,
+    }
     with open(target_full_path, str('w')) as fo:
         fo.write(pyscript)
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -63,7 +63,7 @@ def write_as_json_to_file(file_path, obj):
         fo.write(ensure_binary(json_str))
 
 
-def create_unix_python_entry_point(target_full_path, python_full_path, module, func):
+def create_python_entry_point(target_full_path, python_full_path, module, func):
     if lexists(target_full_path):
         maybe_raise(BasicClobberError(
             source_path=None,
@@ -77,36 +77,24 @@ def create_unix_python_entry_point(target_full_path, python_full_path, module, f
         'func': func,
         'import_name': import_name,
     }
-    with open(target_full_path, str('w')) as fo:
+
+    if python_full_path is not None:
         shebang = '#!%s\n' % python_full_path
         if hasattr(shebang, 'encode'):
             shebang = shebang.encode()
         shebang = replace_long_shebang(FileMode.text, shebang)
         if hasattr(shebang, 'decode'):
             shebang = shebang.decode()
-        fo.write(shebang)
-        fo.write(pyscript)
-    make_executable(target_full_path)
+    else:
+        shebang = None
 
-    return target_full_path
-
-
-def create_windows_python_entry_point(target_full_path, module, func):
-    if lexists(target_full_path):
-        maybe_raise(BasicClobberError(
-            source_path=None,
-            target_path=target_full_path,
-            context=context,
-        ), context)
-
-    import_name = func.split('.')[0]
-    pyscript = python_entry_point_template % {
-        'module': module,
-        'func': func,
-        'import_name': import_name,
-    }
     with open(target_full_path, str('w')) as fo:
+        if shebang is not None:
+            fo.write(shebang)
         fo.write(pyscript)
+
+    if shebang is not None:
+        make_executable(target_full_path)
 
     return target_full_path
 


### PR DESCRIPTION
target is 4.4.x
supersedes #5005
closes #5001

---

When creating entry point script use the template used by pip for creating
entry points for wheels.