### PR TITLE
add timestamp metadata for tiebreaking conda-build 3 hashed packages

### DIFF
--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -99,6 +99,7 @@ class IndexRecord(DictSafeMixin, Entity):
     requires = ListField(string_types, required=False)
     size = IntegerField(required=False)
     subdir = StringField(required=False)
+    timestamp = IntegerField(required=False)
     track_features = StringField(required=False)
     version = StringField()
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -532,8 +532,9 @@ class Resolve(object):
         ver = normalized_version(rec.get('version', ''))
         bld = rec.get('build_number', 0)
         bs = rec.get('build_string')
-        return ((valid, -cpri, ver, bld, bs) if context.channel_priority else
-                (valid, ver, -cpri, bld, bs))
+        ts = rec.get('timestamp', 0)
+        return ((valid, -cpri, ver, bld, bs, ts) if context.channel_priority else
+                (valid, ver, -cpri, bld, bs, ts))
 
     def features(self, dist):
         return set(self.index[dist].get('features', '').split())
@@ -654,15 +655,23 @@ class Resolve(object):
         for name, targets in iteritems(sdict):
             pkgs = [(self.version_key(p), p) for p in self.groups.get(name, [])]
             pkey = None
+            # keep in mind that pkgs is already sorted according to version_key (a tuple,
+            #    so composite sort key).  Later entries in the list are, by definition,
+            #    greater in some way, so simply comparing with != suffices.
             for version_key, dist in pkgs:
                 if targets and any(dist == t for t in targets):
                     continue
                 if pkey is None:
                     iv = ib = 0
+                # any version number mismatch (each character compared one by one)
                 elif any(pk != vk for pk, vk in zip(pkey[:3], version_key[:3])):
                     iv += 1
                     ib = 0
+                # build number
                 elif pkey[3] != version_key[3]:
+                    ib += 1
+                # last field is timestamp. Use it as differentiator when build numbers are similar
+                elif pkey[5] != version_key[5]:
                     ib += 1
 
                 if iv or include0:


### PR DESCRIPTION
target is 4.3.x
supersedes #5015 
closes #5017

---

@kalefranz, I'd really like if this could be merged into 4.3.  However, I'll settle for 4.4 if you deem necessary (but then conda-build 3 will require a release of conda 4.4).

@mcg1969 please take a look.  I think I've done what you and I talked about.  This works locally for me.