### PR TITLE
Add features/track_features support for MatchSpec

### DIFF
--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -145,7 +145,7 @@ def execute(args, parser):
                           prefix=prefix)
     specs = None
     if args.features:
-        specs = ['@' + f for f in set(args.package_names)]
+        specs = [MatchSpec(track_features=f) for f in set(args.package_names)]
         actions = remove_actions(prefix, specs, index, pinned=context.respect_pinned)
         actions['ACTION'] = 'REMOVE_FEATURE'
         action_groups = (actions, index),

--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -100,7 +100,7 @@ class IndexRecord(DictSafeMixin, Entity):
     size = IntegerField(required=False)
     subdir = StringField(required=False)
     timestamp = IntegerField(required=False)
-    track_features = StringField(required=False)
+    track_features = StringField(default='', required=False)
     version = StringField()
 
     fn = StringField(required=False, nullable=True)

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -125,6 +125,9 @@ class MatchSpec(object):
                         raise CondaValueError("Invalid MatchSpec: %s" % spec)
                     elif field == 'optional':
                         kwargs.setdefault('optional', bool(value) if eq else True)
+                        if bool(_exact_field('name')) + bool(_exact_field('track_features')) != 1:
+                            raise CondaValueError("Optional MatchSpec must be tied"
+                                " to a name or track_feature (and not both): %s" % spec)
                     elif field == 'target':
                         kwargs.setdefault('target', value)
                     else:

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -26,6 +26,8 @@ class SplitSearch(object):
     def __init__(self, value):
         self.exact = value  # ensures this is considered an exact match
         self.match = re.compile(r'(?:^|.* )%s(?:$| )' % value).match
+    def __repr__(self):
+    	return "'%s'" % self.exact
 
 
 _implementors = {
@@ -203,6 +205,9 @@ class MatchSpec(object):
     def is_simple(self):
         return len(self._specs_map) == 1 and self.exact_field('name') is not None
 
+    def is_single(self):
+    	return len(self._specs_map) == 1
+
     def match(self, rec):
         """
         Accepts an `IndexRecord` or a dict, and matches can pull from any field
@@ -271,6 +276,9 @@ class MatchSpec(object):
 
     def __repr__(self):
         return "MatchSpec(%s)" % (self._to_string(args=True, base=False),)
+
+    def __contains__(self, field):
+    	return field in self._specs_map
 
     def __str__(self):
         return self._to_string(args=True, base=True)

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -27,7 +27,7 @@ class SplitSearch(object):
         self.exact = value  # ensures this is considered an exact match
         self.match = re.compile(r'(?:^|.* )%s(?:$| )' % value).match
     def __repr__(self):
-    	return "'%s'" % self.exact
+        return "'%s'" % self.exact
 
 
 _implementors = {
@@ -206,7 +206,7 @@ class MatchSpec(object):
         return len(self._specs_map) == 1 and self.exact_field('name') is not None
 
     def is_single(self):
-    	return len(self._specs_map) == 1
+        return len(self._specs_map) == 1
 
     def match(self, rec):
         """
@@ -278,7 +278,7 @@ class MatchSpec(object):
         return "MatchSpec(%s)" % (self._to_string(args=True, base=False),)
 
     def __contains__(self, field):
-    	return field in self._specs_map
+        return field in self._specs_map
 
     def __str__(self):
         return self._to_string(args=True, base=True)

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -26,6 +26,7 @@ class SplitSearch(object):
     def __init__(self, value):
         self.exact = value  # ensures this is considered an exact match
         self.match = re.compile(r'(?:^|.* )%s(?:$| )' % value).match
+
     def __repr__(self):
         return "'%s'" % self.exact
 
@@ -127,7 +128,8 @@ class MatchSpec(object):
                         kwargs.setdefault('optional', bool(value) if eq else True)
                         if bool(_exact_field('name')) + bool(_exact_field('track_features')) != 1:
                             raise CondaValueError("Optional MatchSpec must be tied"
-                                " to a name or track_feature (and not both): %s" % spec)
+                                                  " to a name or track_feature (and not both): %s"
+                                                  "" % spec)
                     elif field == 'target':
                         kwargs.setdefault('target', value)
                     else:

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -8,7 +8,7 @@ from conda.models.index_record import IndexRecord
 from conda.models.match_spec import MatchSpec
 
 
-def DPkg(s):
+def DPkg(s, **kwargs):
     d = Dist(s)
     return IndexRecord(
         fn=d.to_filename(),
@@ -16,7 +16,8 @@ def DPkg(s):
         version=d.version,
         build=d.build_string,
         build_number=int(d.build_string.rsplit('_', 1)[-1]),
-        schannel=d.channel)
+        schannel=d.channel,
+        **kwargs)
 
 
 class MatchSpecTests(unittest.TestCase):
@@ -174,3 +175,16 @@ class MatchSpecTests(unittest.TestCase):
         # Seems odd, but this is needed for compatibility
         assert MatchSpec('test* 1.2').strictness == 3
         assert MatchSpec('foo', build_number=2).strictness == 3
+
+    def test_features(self):
+        dst = Dist('defaults::foo-1.2.3-4.tar.bz2')
+        a = MatchSpec(features='test')
+        assert a.match(DPkg(dst, features='test'))
+        assert not a.match(DPkg(dst, features='test2'))
+        assert a.match(DPkg(dst, features='test me'))
+        assert a.match(DPkg(dst, features='you test'))
+        assert a.match(DPkg(dst, features='you test me'))
+        assert a.exact_field('features') == 'test'
+
+
+

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -41,6 +41,8 @@ class MatchSpecTests(unittest.TestCase):
         ]:
             m = MatchSpec(spec)
             assert m.match(DPkg('numpy-1.7.1-py27_0.tar.bz2')) == result
+            assert 'name' in m
+            assert m.name == 'python' or 'version' in m
 
         # both version numbers conforming to PEP 440
         assert not MatchSpec('numpy >=1.0.1').match(DPkg('numpy-1.0.1a-0.tar.bz2'))
@@ -185,6 +187,3 @@ class MatchSpecTests(unittest.TestCase):
         assert a.match(DPkg(dst, features='you test'))
         assert a.match(DPkg(dst, features='you test me'))
         assert a.exact_field('features') == 'test'
-
-
-


### PR DESCRIPTION
resolves #5121

@kalefranz check it. I'm not _using_ this yet, but I did at least add tests. This provides the ability to match on `features/track_features` cleanly even when there are multiple values embedded in those strings.

One trick is that I wanted `exact_field('track_features')` to return a non-`None` value even though I needed to use regex matching to accomplish this. So that's the explanation for the new `.exact` convention that you see in the `exact_field` function.