### PR TITLE
Allow client_ssl_cert{_key} to be of type None

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -103,8 +103,10 @@ class Context(Configuration):
     # remote connection details
     ssl_verify = PrimitiveParameter(True, element_type=string_types + (bool,),
                                     validation=ssl_verify_validation)
-    client_ssl_cert = PrimitiveParameter('', aliases=('client_cert',))
-    client_ssl_cert_key = PrimitiveParameter('', aliases=('client_cert_key',))
+    client_ssl_cert = PrimitiveParameter(None, aliases=('client_cert',),
+                                         element_type=string_types + (NoneType,))
+    client_ssl_cert_key = PrimitiveParameter(None, aliases=('client_cert_key',),
+                                             element_type=string_types + (NoneType,))
     proxy_servers = MapParameter(string_types)
     remote_connect_timeout_secs = PrimitiveParameter(9.15)
     remote_read_timeout_secs = PrimitiveParameter(60.)


### PR DESCRIPTION
If client_ssl_cert{_key} is set to None, or not set, then the value is
literally interpreted as the string "None" in the context of Conda. This
patch fixes this issue by:
  - allowing the datatype for the value to be None
  - setting the default value to None instead of ''

Fixes #5073 