### PR TITLE
fix #4671 backoff for package validate race condition

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -6,7 +6,9 @@ from errno import EXDEV
 import json
 from logging import getLogger
 from os.path import dirname, join
+from random import random
 import re
+from time import sleep
 
 from .linked_data import delete_linked_data, get_python_version_for_prefix, load_linked_data
 from .portability import _PaddingError, update_prefix
@@ -213,13 +215,22 @@ class LinkPathAction(CreateInPrefixPathAction):
     def verify(self):
         # TODO: consider checking hashsums
         if self.link_type != LinkType.directory and not lexists(self.source_full_path):
-            return CondaVerificationError(dals("""
-            The package for %s located at %s
-            appears to be corrupted. The path '%s'
-            specified in the package manifest cannot be found.
-            """ % (self.package_info.index_json_record.name,
-                   self.package_info.extracted_package_dir,
-                   self.source_short_path)))
+            # This backoff loop is added because of some weird race condition conda-build
+            # experiences. Would be nice at some point to get to the bottom of why it happens.
+            for n in range(6):  # with retries = 6, max total time ~= 3.2 sec
+                sleep_time = ((2 ** n) + random()) * 0.1
+                log.trace("retrying lexists(%s) in %g sec", self.source_full_path, sleep_time)
+                sleep(sleep_time)
+                if lexists(self.source_full_path):
+                    break
+            else:
+                return CondaVerificationError(dals("""
+                The package for %s located at %s
+                appears to be corrupted. The path '%s'
+                specified in the package manifest cannot be found.
+                """ % (self.package_info.index_json_record.name,
+                       self.package_info.extracted_package_dir,
+                       self.source_short_path)))
         self._verified = True
 
     def execute(self):


### PR DESCRIPTION
The 4.4 branch ended up having even more of these race conditions happen for whatever reason than the 4.3 branch.  I caught them in basically every test run with conda-build.  This is a backport of the solution that seemed to work for now in the 4.4 branch.

CC @msarahan 