### PR TITLE
fix api->conda regex substitution for Anaconda API channels

### DIFF
--- a/conda/gateways/anaconda_client.py
+++ b/conda/gateways/anaconda_client.py
@@ -121,7 +121,7 @@ log = getLogger(__name__)
 
 def replace_first_api_with_conda(url):
     # replace first occurrence of 'api' with 'conda' in url
-    return re.sub(r'([./])api([./])', r'\1conda\2', url, count=1)
+    return re.sub(r'([./])api([./]|$)', r'\1conda\2', url, count=1)
 
 
 def read_binstar_tokens():


### PR DESCRIPTION
fixes https://github.com/conda/conda/issues/5101

The current regex substitutor fails when the Anaconda Client URL ends in `/api` (which is, unfortunately, always). This needs to be cherry picked to 4.2, 4.3, and 4.4.