### PR TITLE
Add DumpRecord action.

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1042,3 +1042,34 @@ class ExtractPackageAction(PathAction):
     def __str__(self):
         return ('ExtractPackageAction<source_full_path=%r, target_full_path=%r>'
                 % (self.source_full_path, self.target_full_path))
+
+
+class DumpRecordAction(PathAction):
+
+    def __init__(self, target_pkgs_dir, target_extracted_dirname, record):
+        self.target_pkgs_dir = target_pkgs_dir
+        self.target_extracted_dirname = target_extracted_dirname
+        self.record = record
+
+    def verify(self):
+        self._verified = True
+
+    def execute(self):
+
+        meta = join(self.target_full_path, 'info', 'record.json')
+        log.trace("writing record to %s", meta)
+        with open(meta, 'w') as out:
+            out.write(self.record.pretty_json())
+
+    def reverse(self):
+        return
+
+    def cleanup(self):
+        return
+
+    @property
+    def target_full_path(self):
+        return join(self.target_pkgs_dir, self.target_extracted_dirname)
+
+    def __str__(self):
+        return ('DumpRecordAction<target_full_path=%r>'%self.target_full_path)


### PR DESCRIPTION
This PR generates a "record.json" file with the following content for the "progressbar2" package:

```
{                                                                                                                                                            
  "arch": "x86_64",                                                                                                                                          
  "build": "py27_0",                                                                                                                                         
  "build_number": 0,                                                                                                                                         
  "constrains": null,                                                                                                                                        
  "date": "2017-04-18",                                                                                                                                      
  "depends": [                                                                                                                                               
    "pytest",                                                                                                                                                
    "pytest-runner",                                                                                                                                         
    "python 2.7*",                                                                                                                                           
    "python-utils >=2.0.0"                                                                                                                                   
  ],                                                                                                                                                         
  "license": "BSD License",                                                                                                                                  
  "license_family": "BSD",
  "md5": "39ed982bf8510e8b7bc38990f76c0d26",
  "name": "progressbar2",
  "noarch": null,
  "platform": "linux",
  "size": 33432,
  "version": "3.18.1",
  "fn": "progressbar2-3.18.1-py27_0.tar.bz2",
  "schannel": "defaults",
  "channel": "https://repo.continuum.io/pkgs/free/linux-64",
  "priority": 3,
  "url": "https://repo.continuum.io/pkgs/free/linux-64/progressbar2-3.18.1-py27_0.tar.bz2",
  "auth": null,
  "files": [],
  "preferred_env": null,
  "leased_paths": null
}
```

It addresses https://github.com/conda/conda/issues/5078.
(This may still require some work, notably to implement the `reverse()` and `cleanup()` methods.)