### PR TITLE
Allow proxy_servers to be of type None

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -107,7 +107,7 @@ class Context(Configuration):
                                          element_type=string_types + (NoneType,))
     client_ssl_cert_key = PrimitiveParameter(None, aliases=('client_cert_key',),
                                              element_type=string_types + (NoneType,))
-    proxy_servers = MapParameter(string_types)
+    proxy_servers = MapParameter(string_types + (NoneType,))
     remote_connect_timeout_secs = PrimitiveParameter(9.15)
     remote_read_timeout_secs = PrimitiveParameter(60.)
     remote_max_retries = PrimitiveParameter(3)

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -45,6 +45,13 @@ class ContextCustomRcTests(TestCase):
         channel_alias: ftp://new.url:8082
         conda-build:
           root-dir: /some/test/path
+        proxy_servers:
+          http: http://user:pass@corp.com:8080
+          https: none
+          ftp:
+          sftp: ''
+          ftps: false
+          rsync: 'false'
         """)
         reset_context()
         rd = odict(testdata=YamlRawParameter.make_raw_parameters('testdata', yaml_load(string)))
@@ -156,6 +163,14 @@ class ContextCustomRcTests(TestCase):
             Channel('passion'),
             Channel('learn_from_every_thing'),
         )
+
+    def test_proxy_servers(self):
+        assert context.proxy_servers['http'] == 'http://user:pass@corp.com:8080'
+        assert context.proxy_servers['https'] is None
+        assert context.proxy_servers['ftp'] is None
+        assert context.proxy_servers['sftp'] == ''
+        assert context.proxy_servers['ftps'] == 'False'
+        assert context.proxy_servers['rsync'] == 'False'
 
     def test_conda_build_root_dir(self):
         assert context.conda_build['root-dir'] == "/some/test/path"


### PR DESCRIPTION
Don't interpret proxy_servers as the string: "None" if param is
specified without any value. Similar to b517e48b

Fixes #5102 