### PR TITLE
Remove pyyaml dependency in tests and update instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,6 @@ separate instance of `Miniconda <http://conda.pydata.org/miniconda.html>`_ and
 work off it. This is also the only way to test conda in both Python 2 and
 Python 3, as conda can only be installed into a root environment.
 
-Run the conda tests by ``conda install pytest pytest-cov pytest-timeout mock responses``
+Run the conda tests by ``conda install pytest pytest-cov pytest-timeout mock responses pyyaml``
 and then running ``py.test`` in the conda directory. The tests are also run by Travis
 CI when you make a pull request.

--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,10 @@ separate instance of `Miniconda <http://conda.pydata.org/miniconda.html>`_ and
 work off it. This is also the only way to test conda in both Python 2 and
 Python 3, as conda can only be installed into a root environment.
 
-Run the conda tests by ``conda install pytest pytest-cov pytest-timeout mock responses pyyaml``
-and then running ``py.test`` in the conda directory. The tests are also run by Travis
-CI when you make a pull request.
+To run the tests, set up a testing environment by running
+
+* ``$CONDA/bin/python -m pip install -r utils/requirements-test.txt``.
+* ``$CONDA/bin/python utils/setup-testing.py develop``
+
+and then running ``py.test`` in the conda directory. The tests are also run by
+various CI systems when you make a pull request.

--- a/tests/conda_env/test_env.py
+++ b/tests/conda_env/test_env.py
@@ -4,7 +4,9 @@ import sys
 import random
 import textwrap
 import unittest
-import yaml
+
+from conda.common.yaml import get_yaml
+yaml = get_yaml()
 
 try:
     from io import StringIO


### PR DESCRIPTION
Without `pyyaml`, the following error occurs when running tests:

```
=================================== ERRORS ====================================
________________ ERROR collecting tests/conda_env/test_env.py _________________
tests\conda_env\test_env.py:7: in <module>
    import yaml
E   ImportError: No module named yaml
________________ ERROR collecting tests/conda_env/test_env.py _________________
ImportError while importing test module 'C:\Users\traveler\AppData\Local\conda\conda\tests\conda_env\test_env.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests\conda_env\test_env.py:7: in <module>
    import yaml
E   ImportError: No module named yaml
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!
```