### PR TITLE
Detect and remove stale lock files

### DIFF
--- a/conda/lock.py
+++ b/conda/lock.py
@@ -59,7 +59,8 @@ def _pid_possibly_running(pid):
     operating system.
     """
     if platform.system() == 'Windows':
-        import sys, ctypes
+        import ctypes
+        import sys
         kernel32 = ctypes.windll.kernel32
 
         # TODO: below Vista, PROCESS_QUERY_LIMITED_INFORMATION is not supported:
@@ -167,7 +168,8 @@ class FileLock(object):
         # e.g. if locking path `/conda`, lock file will be `/conda.pidXXXX.conda_lock`
         self.lock_file_glob_str = "%s.pid*.host*.%s" % (self.path_to_lock, LOCK_EXTENSION)
         self.lock_file_regex = re.compile(r"%s\.pid([0-9]+)\.host([\w_]+)\.%s" %
-                                          (re.escape(self.path_to_lock), re.escape(LOCK_EXTENSION)))
+                                          (re.escape(self.path_to_lock),
+                                           re.escape(LOCK_EXTENSION)))
         assert isdir(dirname(self.path_to_lock)), "{0} doesn't exist".format(self.path_to_lock)
         assert "::" not in self.path_to_lock, self.path_to_lock
 
@@ -233,7 +235,8 @@ class DirectoryLock(FileLock):
         # e.g. if locking directory `/conda`, lock file will be `/conda/conda.pidXXXX.conda_lock`
         self.lock_file_glob_str = "%s.pid*.host*.%s" % (lock_path_pre, LOCK_EXTENSION)
         self.lock_file_regex = re.compile(r"%s\.pid([0-9]+)\.host([\w_]+)\.%s" %
-                                          (re.escape(lock_path_pre), re.escape(LOCK_EXTENSION)))
+                                          (re.escape(lock_path_pre),
+                                           re.escape(LOCK_EXTENSION)))
         # make sure '/' exists
         assert isdir(dirname(self.directory_path)), "{0} doesn't exist".format(self.directory_path)
         if not isdir(self.directory_path):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,4 +1,5 @@
 import pytest
+from glob import glob
 from os.path import basename, join, exists, isfile
 from conda.lock import FileLock, LockError, DirectoryLock
 
@@ -110,6 +111,47 @@ def test_lock_retries(tmpdir):
     t.join()
     # lock should clean up after itself
     assert not tmpdir.join(path).exists()
+
+
+def _lock_process(tmpdir, file_path):
+    """
+        Helper function for test_stale_lock_file. Can't be local
+        because it needs to be pickled so it can be executed by
+        another process using the multiprocessing module.
+    """
+    import os
+    with FileLock(file_path):
+        # Use os._exit to prevent cleanup
+        os._exit(1)
+
+
+def test_stale_lock_file(tmpdir):
+    """
+        Test that if a process leaves a lock file behind it
+        gets cleaned up
+    """
+    from multiprocessing import Process
+    package_name = "conda_file_4"
+    tmpfile = join(tmpdir.strpath, package_name)
+    p = Process(target=_lock_process, args=(tmpdir, tmpfile))
+    p.start()
+    p.join()
+
+    # Find the conda lock file left behind:
+    lock_files = glob(join(tmpdir.strpath, "*.conda_lock"))
+    assert len(lock_files) == 1
+    stale_path = basename(lock_files[0])
+
+    with FileLock(tmpfile, retries=0) as lock1:
+        # Stale lock should have been cleared
+        assert not tmpdir.join(stale_path).exists()
+
+        path = basename(lock1.lock_file_path)
+        assert tmpdir.join(path).exists()
+
+    # lock should clean up after itself
+    assert not tmpdir.join(path).exists()
+    assert not tmpdir.join(stale_path).exists()
 
 
 def test_permission_file():


### PR DESCRIPTION
This fixes the problem described in #4862. First, add a test that demonstrates the problem. Then, change the locking logic to attempt to remove stale lock files when it is safe to do so. This simplifies using conda programmatically/non-interactively.

This works by adding the name of the host that created the file into the filename of the lock file in addition to the PID of the process that created it. When a lock file is encountered and the host name in
the filename matches the current host name, and a process with the PID found in the lock filename is not running on the local system, then declare the lock stale and remove it.

This makes conda clean up stale lock files automatically in the majority of cases, while in other cases (reused PID numbers, shared file system), one can still run conda lock --clean manually.