### PR TITLE
Fix --use-index-cache actually hitting the index cache

### DIFF
--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -420,6 +420,12 @@ def fetch_repodata(url, schannel, priority,
     else:
         mod_etag_headers = read_mod_and_etag(cache_path)
 
+        if use_cache:
+            log.debug("Using cached repodata for %s at %s because use_cache=True",
+                      url, cache_path)
+            return read_local_repodata(cache_path, url, schannel, priority,
+                                       mod_etag_headers.get('_etag'), mod_etag_headers.get('_mod'))
+
         if context.local_repodata_ttl > 1:
             max_age = context.local_repodata_ttl
         elif context.local_repodata_ttl == 1:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -898,7 +898,7 @@ class IntegrationTests(TestCase):
 
                 mock_method.side_effect = side_effect
                 stdout, stderr = run_command(Commands.INFO, prefix, "flask --json")
-                mock_method.assert_called()
+                assert mock_method.called
 
             # Next run with --use-index-cache and make sure it actually hits the cache
             # and does not go out fetching index data remotely.

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -873,6 +873,45 @@ class IntegrationTests(TestCase):
         run_command(Commands.CLEAN, prefix, "--index-cache")
         assert not glob(join(index_cache_dir, "*.json"))
 
+    def test_use_index_cache(self):
+        from conda.connection import CondaSession
+
+        prefix = make_temp_prefix("_" + str(uuid4())[:7])
+        with make_temp_env(prefix=prefix):
+            # First, clear the index cache to make sure we start with an empty cache.
+            index_cache_dir = create_cache_dir()
+            run_command(Commands.CLEAN, '', "--index-cache")
+            assert not glob(join(index_cache_dir, "*.json"))
+
+            # Then, populate the index cache.
+            orig_get = CondaSession.get
+            with patch.object(CondaSession, 'get', autospec=True) as mock_method:
+                def side_effect(self, url, **kwargs):
+                    # Make sure that we don't use the cache because of the
+                    # corresponding HTTP header. This test is supposed to test
+                    # whether the --use-index-cache causes the cache to be used.
+                    result = orig_get(self, url, **kwargs)
+                    for header in ['Etag', 'Last-Modified', 'Cache-Control']:
+                        if header in result.headers:
+                            del result.headers[header]
+                    return result
+
+                mock_method.side_effect = side_effect
+                stdout, stderr = run_command(Commands.INFO, prefix, "flask --json")
+                mock_method.assert_called()
+
+            # Next run with --use-index-cache and make sure it actually hits the cache
+            # and does not go out fetching index data remotely.
+            with patch.object(CondaSession, 'get', autospec=True) as mock_method:
+                def side_effect(self, url, **kwargs):
+                    if url.endswith('/repodata.json') or url.endswith('/repodata.json.bz2'):
+                        raise AssertionError('Index cache was not hit')
+                    else:
+                        return orig_get(self, url, **kwargs)
+
+                mock_method.side_effect = side_effect
+                run_command(Commands.INSTALL, prefix, "flask", "--json", "--use-index-cache")
+
     def test_clean_tarballs_and_packages(self):
         pkgs_dir = PackageCache.first_writable().pkgs_dir
         mkdir_p(pkgs_dir)


### PR DESCRIPTION
In conda 4.2.x, I had a workflow where I would run `conda install ... --use-index-cache` and rely on the fact that it actually uses the local cache, i.e. does not try to go online to update any index. If all packages that are in the local index cache are also available on disk, this allows creating new environments without connectivity.

Now I might be missing something as to what the intention of the  `--use-index-cache` flag is, but this behavior broke in conda 4.3.x. It looks somewhat unintentional because in the case that there is no index cache, the behavior still is to return an empty index instead of updating the index remotely if `--use-index-cache` is set.

This PR adds a test that makes sure that if a local cache exists and `--use-index-cache` is set, the cache is actually hit, and then fixes the case described above.