### PR TITLE
Fix possibly repodata fetch with the `--offline` flag

### DIFF
--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -413,7 +413,7 @@ def fetch_repodata(url, schannel, priority,
         mtime = getmtime(cache_path)
     except (IOError, OSError):
         log.debug("No local cache found for %s at %s", url, cache_path)
-        if context.offline or use_cache:
+        if use_cache or (context.offline and not url.startswith('file://')):
             return {'packages': {}}
         else:
             mod_etag_headers = {}

--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -413,7 +413,7 @@ def fetch_repodata(url, schannel, priority,
         mtime = getmtime(cache_path)
     except (IOError, OSError):
         log.debug("No local cache found for %s at %s", url, cache_path)
-        if use_cache:
+        if context.offline or use_cache:
             return {'packages': {}}
         else:
             mod_etag_headers = {}

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -162,6 +162,48 @@ def make_temp_env(*packages, **kwargs):
         finally:
             rmtree(prefix, ignore_errors=True)
 
+@contextmanager
+def make_temp_channel(packages):
+    package_reqs = [pkg.replace('-', '=') for pkg in packages]
+    package_names = [pkg.split('-')[0] for pkg in packages]
+
+    with make_temp_env(*package_reqs) as prefix:
+        for package in packages:
+            assert_package_is_installed(prefix, package)
+        data = [p for p in itervalues(linked_data(prefix)) if p['name'] in package_names]
+        run_command(Commands.REMOVE, prefix, *package_names)
+        for package in packages:
+            assert not package_is_installed(prefix, package)
+        assert_package_is_installed(prefix, 'python')
+
+    repodata = {'info': {}, 'packages': {}}
+    tarfiles = {}
+    for package_data in data:
+        pkg_data = package_data
+        fname = pkg_data['fn']
+        tarfiles[fname] = join(PackageCache.first_writable().pkgs_dir, fname)
+
+        pkg_data = pkg_data.dump()
+        for field in ('url', 'channel', 'schannel'):
+            del pkg_data[field]
+        repodata['packages'][fname] = IndexRecord(**pkg_data)
+
+    with make_temp_env() as channel:
+        subchan = join(channel, context.subdir)
+        noarch_dir = join(channel, 'noarch')
+        channel = path_to_url(channel)
+        os.makedirs(subchan)
+        os.makedirs(noarch_dir)
+        for fname, tar_old_path in tarfiles.items():
+            tar_new_path = join(subchan, fname)
+            copyfile(tar_old_path, tar_new_path)
+
+        with bz2.BZ2File(join(subchan, 'repodata.json.bz2'), 'w') as f:
+            f.write(json.dumps(repodata, cls=EntityEncoder).encode('utf-8'))
+        with bz2.BZ2File(join(noarch_dir, 'repodata.json.bz2'), 'w') as f:
+            f.write(json.dumps({}, cls=EntityEncoder).encode('utf-8'))
+
+        yield channel
 
 def reload_config(prefix):
     prefix_condarc = join(prefix+os.sep, 'condarc')
@@ -324,52 +366,28 @@ class IntegrationTests(TestCase):
             assert_package_is_installed(prefix, 'python-3.4.')
 
     def test_install_tarball_from_local_channel(self):
-        with make_temp_env("flask=0.10.1") as prefix:
-            assert_package_is_installed(prefix, 'flask-0.10.1')
-            flask_data = [p for p in itervalues(linked_data(prefix)) if p['name'] == 'flask'][0]
+        # Regression test for #2812
+        # install from local channel
+        with make_temp_env() as prefix, make_temp_channel(["flask-0.10.1"]) as channel:
+            run_command(Commands.INSTALL, prefix, '-c', channel, 'flask=0.10.1', '--json')
+            assert_package_is_installed(prefix, channel + '::' + 'flask-')
+            flask_fname = [p for p in itervalues(linked_data(prefix)) if p['name'] == 'flask'][0]['fn']
+
             run_command(Commands.REMOVE, prefix, 'flask')
-            assert not package_is_installed(prefix, 'flask-0.10.1')
-            assert_package_is_installed(prefix, 'python')
+            assert not package_is_installed(prefix, 'flask-0')
 
-            flask_fname = flask_data['fn']
-            tar_old_path = join(PackageCache.first_writable().pkgs_dir, flask_fname)
-
-            # Regression test for #2812
-            # install from local channel
-            flask_data = flask_data.dump()
-            for field in ('url', 'channel', 'schannel'):
-                del flask_data[field]
-            repodata = {'info': {}, 'packages': {flask_fname: IndexRecord(**flask_data)}}
-            with make_temp_env() as channel:
-                subchan = join(channel, context.subdir)
-                noarch_dir = join(channel, 'noarch')
-                channel = path_to_url(channel)
-                os.makedirs(subchan)
-                os.makedirs(noarch_dir)
-                tar_new_path = join(subchan, flask_fname)
-                copyfile(tar_old_path, tar_new_path)
-                with bz2.BZ2File(join(subchan, 'repodata.json.bz2'), 'w') as f:
-                    f.write(json.dumps(repodata, cls=EntityEncoder).encode('utf-8'))
-                with bz2.BZ2File(join(noarch_dir, 'repodata.json.bz2'), 'w') as f:
-                    f.write(json.dumps({}, cls=EntityEncoder).encode('utf-8'))
-
-                run_command(Commands.INSTALL, prefix, '-c', channel, 'flask', '--json')
-                assert_package_is_installed(prefix, channel + '::' + 'flask-')
-
-                run_command(Commands.REMOVE, prefix, 'flask')
-                assert not package_is_installed(prefix, 'flask-0')
-
-                # Regression test for 2970
-                # install from build channel as a tarball
-                conda_bld = join(dirname(PackageCache.first_writable().pkgs_dir), 'conda-bld')
-                conda_bld_sub = join(conda_bld, context.subdir)
-                if not isdir(conda_bld_sub):
-                    os.makedirs(conda_bld_sub)
-                tar_bld_path = join(conda_bld_sub, flask_fname)
-                copyfile(tar_new_path, tar_bld_path)
-                # CondaFileNotFoundError: '/home/travis/virtualenv/python2.7.9/conda-bld/linux-64/flask-0.10.1-py27_2.tar.bz2'.
-                run_command(Commands.INSTALL, prefix, tar_bld_path)
-                assert_package_is_installed(prefix, 'flask-')
+            # Regression test for 2970
+            # install from build channel as a tarball
+            tar_path = join(PackageCache.first_writable().pkgs_dir, flask_fname)
+            conda_bld = join(dirname(PackageCache.first_writable().pkgs_dir), 'conda-bld')
+            conda_bld_sub = join(conda_bld, context.subdir)
+            if not isdir(conda_bld_sub):
+                os.makedirs(conda_bld_sub)
+            tar_bld_path = join(conda_bld_sub, basename(tar_path))
+            copyfile(tar_path, tar_bld_path)
+            # CondaFileNotFoundError: '/home/travis/virtualenv/python2.7.9/conda-bld/linux-64/flask-0.10.1-py27_2.tar.bz2'.
+            run_command(Commands.INSTALL, prefix, tar_bld_path)
+            assert_package_is_installed(prefix, 'flask-')
 
     def test_tarball_install_and_bad_metadata(self):
         with make_temp_env("python flask=0.10.1 --json") as prefix:


### PR DESCRIPTION
Add a test and fix a scenario where conda would attempt to fetch repodata remotely despite the `--offline` flag given. Mentioned originally in [this comment](https://github.com/conda/conda/pull/5134#issuecomment-297115358).