### PR TITLE
support stacking environments

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -91,8 +91,9 @@ class Context(Configuration):
     default_python = PrimitiveParameter('%d.%d' % sys.version_info[:2],
                                         element_type=string_types + (NoneType,))
     disallow = SequenceParameter(string_types)
-    force_32bit = PrimitiveParameter(False)
     enable_private_envs = PrimitiveParameter(False)
+    force_32bit = PrimitiveParameter(False)
+    max_shlvl = PrimitiveParameter(2)
     path_conflict = PrimitiveParameter(PathConflict.clobber)
     pinned_packages = SequenceParameter(string_types, string_delimiter='/')  # TODO: consider a different string delimiter  # NOQA
     rollback_enabled = PrimitiveParameter(True)
@@ -471,6 +472,7 @@ class Context(Configuration):
             'default_python',
             'enable_private_envs',
             'force_32bit',
+            'max_shlvl',
             'migrated_custom_channels',
             'prune',
             'respect_pinned',


### PR DESCRIPTION
**Conda will not stack multiple levels of environments by default.**  This PR does not do that.

This PR implements environment stacking via an opt-in configuration parameter.  For now it will be undocumented.  Many people think this feature is dangerous.  However, as trivial as it is was now to implement, there's no reason it can't live behind a feature switch that users can opt in to.

resolves #3580
supersedes #3924 