### PR TITLE
Add support for the linux-aarch64 platform

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -52,6 +52,7 @@ PLATFORM_DIRECTORIES = ("linux-64",
                         "linux-ppc64le",
                         "linux-armv6l",
                         "linux-armv7l",
+                        "linux-aarch64",
                         "zos-z",
                         "noarch",
                         )

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -46,6 +46,7 @@ _platform_map = {
 non_x86_linux_machines = {
     'armv6l',
     'armv7l',
+    'aarch64',
     'ppc64le',
 }
 _arch_names = {

--- a/conda/models/enums.py
+++ b/conda/models/enums.py
@@ -17,6 +17,7 @@ class Arch(Enum):
     x86_64 = 'x86_64'
     armv6l = 'armv6l'
     armv7l = 'armv7l'
+    aarch64 = 'aarch64'
     ppc64le = 'ppc64le'
     z = 'z'
 


### PR DESCRIPTION
closes #5125
supersedes #5187 
target is 4.3.x

-------

This is a different, more direct approach to fixing #5125 than #4809.  I've built a minimal aarch64 installer and some [basic packages](https://anaconda.org/aarch64_gbox/) using this patch and did not run into any issue.