### PR TITLE
Reduce excessive error messages

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -57,7 +57,7 @@ class TooManyArgumentsError(ArgumentError):
         self.optional_message = optional_message
 
         suffix = 's' if received - expected > 1 else ''
-        msg = ('Too many arguments: %s Got %s argument%s (%s) but expected %s.' %
+        msg = ('%s Got %s argument%s (%s) but expected %s.' %
                (optional_message, received, suffix, ', '.join(offending_arguments), expected))
         super(TooManyArgumentsError, self).__init__(msg, *args)
 
@@ -181,21 +181,21 @@ class CommandNotFoundError(CondaError):
             Did you mean 'source %(command)s'?
             """)
         else:
-            message = "Conda could not find the command: '%(command)s'"
+            message = "'%(command)s'"
         super(CommandNotFoundError, self).__init__(message, command=command)
 
 
 class CondaFileNotFoundError(CondaError, OSError):
     def __init__(self, filename, *args):
         self.filename = filename
-        message = " '%s'." % filename
+        message = "'%s'." % filename
         super(CondaFileNotFoundError, self).__init__(message, *args)
 
 
 class DirectoryNotFoundError(CondaError):
     def __init__(self, directory):
         self.directory = directory
-        msg = "%s." % directory
+        msg = "'%s'" % directory
         super(DirectoryNotFoundError, self).__init__(msg)
 
 
@@ -371,7 +371,7 @@ class CondaHTTPError(CondaError):
 
 class CondaRevisionError(CondaError):
     def __init__(self, message):
-        msg = "Revision Error: %s." % message
+        msg = "%s." % message
         super(CondaRevisionError, self).__init__(msg)
 
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 class LockError(CondaError):
     def __init__(self, message):
-        msg = "Lock error: %s" % message
+        msg = "%s" % message
         super(LockError, self).__init__(msg)
 
 
@@ -68,7 +68,7 @@ class TooFewArgumentsError(ArgumentError):
         self.received = received
         self.optional_message = optional_message
 
-        msg = ('Too few arguments: %s Got %s arguments but expected %s.' %
+        msg = ('%s Got %s arguments but expected %s.' %
                (optional_message, received, expected))
         super(TooFewArgumentsError, self).__init__(msg, *args)
 
@@ -188,14 +188,14 @@ class CommandNotFoundError(CondaError):
 class CondaFileNotFoundError(CondaError, OSError):
     def __init__(self, filename, *args):
         self.filename = filename
-        message = "File not found: '%s'." % filename
+        message = " '%s'." % filename
         super(CondaFileNotFoundError, self).__init__(message, *args)
 
 
 class DirectoryNotFoundError(CondaError):
     def __init__(self, directory):
         self.directory = directory
-        msg = "Directory not found: '%s'." % directory
+        msg = "%s." % directory
         super(DirectoryNotFoundError, self).__init__(msg)
 
 
@@ -207,7 +207,7 @@ class CondaEnvironmentNotFoundError(CondaError, EnvironmentError):
     """
 
     def __init__(self, environment_name_or_prefix, *args, **kwargs):
-        msg = ("Could not find environment: %s .\n"
+        msg = ("%s .\n"
                "You can list all discoverable environments with `conda info --envs`."
                % environment_name_or_prefix)
         self.environment_name_or_prefix = environment_name_or_prefix
@@ -216,7 +216,7 @@ class CondaEnvironmentNotFoundError(CondaError, EnvironmentError):
 
 class CondaEnvironmentError(CondaError, EnvironmentError):
     def __init__(self, message, *args):
-        msg = 'Environment error: %s' % message
+        msg = '%s' % message
         super(CondaEnvironmentError, self).__init__(msg, *args)
 
 
@@ -251,19 +251,19 @@ class LinkError(CondaError):
 
 class CondaOSError(CondaError, OSError):
     def __init__(self, message):
-        msg = 'OS error: %s' % message
+        msg = '%s' % message
         super(CondaOSError, self).__init__(msg)
 
 
 class ProxyError(CondaError):
     def __init__(self, message):
-        msg = 'Proxy error: %s' % message
+        msg = '%s' % message
         super(ProxyError, self).__init__(msg)
 
 
 class CondaIOError(CondaError, IOError):
     def __init__(self, message, *args):
-        msg = 'IO error: %s' % message
+        msg = '%s' % message
         super(CondaIOError, self).__init__(msg)
 
 
@@ -271,38 +271,38 @@ class CondaFileIOError(CondaIOError):
     def __init__(self, filepath, message, *args):
         self.filepath = filepath
 
-        msg = "Couldn't read or write to file. '%s'. %s" % (filepath, message)
+        msg = "'%s'. %s" % (filepath, message)
         super(CondaFileIOError, self).__init__(msg, *args)
 
 
 class CondaKeyError(CondaError, KeyError):
     def __init__(self, key, message, *args):
         self.key = key
-        self.msg = "Error with key '%s': %s" % (key, message)
+        self.msg = "'%s': %s" % (key, message)
         super(CondaKeyError, self).__init__(self.msg, *args)
 
 
 class ChannelError(CondaError):
     def __init__(self, message, *args):
-        msg = 'Channel Error: %s' % message
+        msg = '%s' % message
         super(ChannelError, self).__init__(msg)
 
 
 class ChannelNotAllowed(ChannelError):
     def __init__(self, message, *args):
-        msg = 'Channel not allowed: %s' % message
+        msg = '%s' % message
         super(ChannelNotAllowed, self).__init__(msg, *args)
 
 
 class CondaImportError(CondaError, ImportError):
     def __init__(self, message):
-        msg = 'Import error: %s' % message
+        msg = '%s' % message
         super(CondaImportError, self).__init__(msg)
 
 
 class ParseError(CondaError):
     def __init__(self, message):
-        msg = 'Parse error: %s' % message
+        msg = '%s' % message
         super(ParseError, self).__init__(msg)
 
 
@@ -470,43 +470,43 @@ Use "conda info <package>" to see the dependencies for each package.'''
 
 class InstallError(CondaError):
     def __init__(self, message):
-        msg = 'Install error: %s' % message
+        msg = '%s' % message
         super(InstallError, self).__init__(msg)
 
 
 class RemoveError(CondaError):
     def __init__(self, message):
-        msg = 'Remove Error: %s' % message
+        msg = '%s' % message
         super(RemoveError, self).__init__(msg)
 
 
 class CondaIndexError(CondaError, IndexError):
     def __init__(self, message):
-        msg = 'Index error: %s' % message
+        msg = '%s' % message
         super(CondaIndexError, self).__init__(msg)
 
 
 class CondaValueError(CondaError, ValueError):
     def __init__(self, message, *args):
-        msg = 'Value error: %s' % message
+        msg = '%s' % message
         super(CondaValueError, self).__init__(msg)
 
 
 class CondaTypeError(CondaError, TypeError):
     def __init__(self, expected_type, received_type, optional_message):
-        msg = "Type error: expected type '%s' and got type '%s'. %s"
+        msg = "Expected type '%s' and got type '%s'. %s"
         super(CondaTypeError, self).__init__(msg)
 
 
 class CondaHistoryError(CondaError):
     def __init__(self, message):
-        msg = 'History error: %s' % message
+        msg = '%s' % message
         super(CondaHistoryError, self).__init__(msg)
 
 
 class CondaUpgradeError(CondaError):
     def __init__(self, message):
-        msg = "Conda upgrade error: %s" % message
+        msg = "%s" % message
         super(CondaUpgradeError, self).__init__(msg)
 
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -207,7 +207,7 @@ class CondaEnvironmentNotFoundError(CondaError, EnvironmentError):
     """
 
     def __init__(self, environment_name_or_prefix, *args, **kwargs):
-        msg = ("%s .\n"
+        msg = ("Could not find environment: %s .\n"
                "You can list all discoverable environments with `conda info --envs`."
                % environment_name_or_prefix)
         self.environment_name_or_prefix = environment_name_or_prefix

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -368,7 +368,7 @@ channels:
                                                   'channels', 'defaults',
                                                   use_exception_handler=True)
         assert stdout == ''
-        assert "CondaKeyError: Error with key 'channels': 'defaults' is not in the 'channels' " \
+        assert "CondaKeyError: 'channels': 'defaults' is not in the 'channels' " \
                "key of the config file" in stderr
 
     # Test creating a new file with --set
@@ -597,13 +597,13 @@ def test_config_command_remove_force():
         stdout, stderr, return_code = run_command(Commands.CONFIG, '--file', rc,
                                            '--remove', 'channels', 'test', use_exception_handler=True)
         assert stdout == ''
-        assert "CondaKeyError: Error with key 'channels': 'test' is not in the 'channels' " \
+        assert "CondaKeyError: 'channels': 'test' is not in the 'channels' " \
                "key of the config file" in stderr
 
         stdout, stderr, return_code = run_command(Commands.CONFIG, '--file', rc,
                                            '--remove', 'disallow', 'python', use_exception_handler=True)
         assert stdout == ''
-        assert "CondaKeyError: Error with key 'disallow': key 'disallow' " \
+        assert "CondaKeyError: 'disallow': key 'disallow' " \
                "is not in the config file" in stderr
 
         stdout, stderr, return_code = run_command(Commands.CONFIG, '--file', rc,
@@ -615,7 +615,7 @@ def test_config_command_remove_force():
                                            '--remove-key', 'always_yes', use_exception_handler=True)
 
         assert stdout == ''
-        assert "CondaKeyError: Error with key 'always_yes': key 'always_yes' " \
+        assert "CondaKeyError: 'always_yes': key 'always_yes' " \
                "is not in the config file" in stderr
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -376,7 +376,7 @@ class ExceptionTests(TestCase):
         assert not c.stdout
 
         if on_win:
-            message = "CommandNotFoundError: Conda could not find the command: 'activate'"
+            message = "CommandNotFoundError: 'activate'"
         else:
             message = ("CommandNotFoundError: 'activate is not a conda command.\n"
                        "Did you mean 'source activate'?")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -43,7 +43,7 @@ class ExceptionTests(TestCase):
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
-        assert c.stderr.strip() == "TooManyArgumentsError: Too many arguments:  Got 5 arguments (g, r, o, o, t) but expected 2."
+        assert c.stderr.strip() == "TooManyArgumentsError:  Got 5 arguments (g, r, o, o, t) but expected 2."
 
     def test_TooFewArgumentsError(self):
         expected = 5
@@ -67,7 +67,7 @@ class ExceptionTests(TestCase):
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
-        assert c.stderr.strip() == "TooFewArgumentsError: Too few arguments:  Got 2 arguments but expected 5."
+        assert c.stderr.strip() == "TooFewArgumentsError:  Got 2 arguments but expected 5."
 
     def test_BasicClobberError(self):
         source_path = "some/path/on/goodwin.ave"
@@ -154,7 +154,7 @@ class ExceptionTests(TestCase):
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
-        assert c.stderr.strip() == "CondaFileNotFoundError: File not found: 'Groot'."
+        assert c.stderr.strip() == "CondaFileNotFoundError: 'Groot'."
 
     def test_DirectoryNotFoundError(self):
         directory = "Groot"
@@ -176,7 +176,7 @@ class ExceptionTests(TestCase):
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
-        assert c.stderr.strip() == "DirectoryNotFoundError: Directory not found: 'Groot'."
+        assert c.stderr.strip() == "DirectoryNotFoundError: 'Groot'"
 
     def test_MD5MismatchError(self):
         url = "https://download.url/path/to/file.tar.bz2"
@@ -252,7 +252,7 @@ class ExceptionTests(TestCase):
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
-        assert c.stderr.strip() == "CondaRevisionError: Revision Error: Groot."
+        assert c.stderr.strip() == "CondaRevisionError: Groot."
 
     def test_CondaKeyError(self):
         key = "Groot"
@@ -275,7 +275,7 @@ class ExceptionTests(TestCase):
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
-        assert c.stderr.strip() == "CondaKeyError: Error with key 'Groot': Groot is not a key."
+        assert c.stderr.strip() == "CondaKeyError: 'Groot': Groot is not a key."
 
     def test_CondaHTTPError(self):
         msg = "Groot"
@@ -331,7 +331,7 @@ class ExceptionTests(TestCase):
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
-        assert c.stderr.strip() == "CommandNotFoundError: Conda could not find the command: 'instate'"
+        assert c.stderr.strip() == "CommandNotFoundError: 'instate'"
 
     def test_CommandNotFoundError_conda_build(self):
         cmd = "build"


### PR DESCRIPTION
addresses #3470 

Not sure if this should be added to 4.4.x but here we go.

This PR reduces somewhat redundunt error messages that are self-explanatory from the their names.

e.g.

```
Before:

- CondaValueError: Value error: Key 'ssl-verify' is not a known primitive parameter.

- TooManyArgumentsError: Too many arguments:  Got 5 arguments ....

After:

- CondaValueError: Key 'ssl-verify' is not a known primitive parameter.

- TooManyArgumentsError: Got 5 arguments ... 
```
