### PR TITLE
Use --format=json to parse list of pip packages

### DIFF
--- a/conda_env/pip_util.py
+++ b/conda_env/pip_util.py
@@ -5,7 +5,7 @@ NOTE: This modules used to in conda, as conda/pip.py
 """
 from __future__ import absolute_import, print_function
 from os.path import isfile, join
-import re
+import json
 import subprocess
 import sys
 
@@ -51,50 +51,33 @@ def installed(prefix, output=True):
     args = pip_args(prefix)
     if args is None:
         return
-    args.append('list')
+    args += ['list', '--format', 'json']
     try:
-        pipinst = subprocess.check_output(
-            args, universal_newlines=True
-        ).splitlines()
+        s = subprocess.check_output(args, universal_newlines=True)
     except Exception:
         # Any error should just be ignored
         if output:
             print("# Warning: subprocess call to pip failed")
         return
+    pkgs = json.loads(s)
 
     # For every package in pipinst that is not already represented
     # in installed append a fake name to installed with 'pip'
     # as the build string
-    pat = re.compile('([\w.-]+)\s+\((.+)\)')
-    for line in pipinst:
-        line = line.strip()
-        if not line:
-            continue
-        m = pat.match(line)
-        if m is None:
-            if output:
-                print('Could not extract name and version from: %r' % line)
-            continue
-        name, version = m.groups()
-        name = name.lower()
-        kwargs = {
-            'name': name,
-            'version': version,
-        }
-        if ', ' in version:
+    for kwargs in pkgs:
+        kwargs['name'] = kwargs['name'].lower()
+        if ', ' in kwargs['version']:
             # Packages installed with setup.py develop will include a path in
             # the version. They should be included here, even if they are
             # installed with conda, as they are preferred over the conda
             # version. We still include the conda version, though, because it
             # is still installed.
 
-            version, path = version.split(', ')
+            version, path = kwargs['version'].split(', ')
             # We do this because the code below uses rsplit('-', 2)
             version = version.replace('-', ' ')
-            kwargs.update({
-                'path': path,
-                'version': version,
-            })
+            kwargs['version'] = version
+            kwargs['path'] = path
         yield PipPackage(**kwargs)
 
 


### PR DESCRIPTION
supersedes #4330
targeting 4.4.x

-------

Makes pip package discovery more robust by forcing pip list to output
json, overriding any settings in user's pip.conf.