### PR TITLE
fix #5214 install messages for 'nothing_to_do' case

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -311,20 +311,20 @@ def install(args, parser, command='install'):
             raise CondaImportError(text_type(e))
         raise
 
-    if not context.json:
-        if any(nothing_to_do(actions) for actions in action_set) and not newenv:
+    if any(nothing_to_do(actions) for actions in action_set) and not newenv:
+        if not context.json:
             from .main_list import print_packages
 
-            if not context.json:
-                spec_regex = r'^(%s)$' % re.escape('|'.join(s.split()[0] for s in ospecs))
-                print('\n# All requested packages already installed.')
-                for action in action_set:
-                    print_packages(action["PREFIX"], spec_regex)
-            else:
-                common.stdout_json_success(
-                    message='All requested packages already installed.')
-            return
+            spec_regex = r'^(%s)$' % re.escape('|'.join(s.split()[0] for s in ospecs))
+            print('\n# All requested packages already installed.')
+            for action in action_set:
+                print_packages(action["PREFIX"], spec_regex)
+        else:
+            common.stdout_json_success(
+                message='All requested packages already installed.')
+        return
 
+    if not context.json:
         for actions in action_set:
             print()
             print("Package plan for installation in environment %s:" % actions["PREFIX"])

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -315,7 +315,7 @@ def install(args, parser, command='install'):
         if not context.json:
             from .main_list import print_packages
 
-            spec_regex = r'^(%s)$' % re.escape('|'.join(s.split()[0] for s in ospecs))
+            spec_regex = r'^(%s)$' % '|'.join(re.escape(s.split()[0]) for s in ospecs)
             print('\n# All requested packages already installed.')
             for action in action_set:
                 print_packages(action["PREFIX"], spec_regex)


### PR DESCRIPTION
fixes #5214

This also applies to branch `4.4.x`!

Running any install command with `--json` could never execute
```python
common.stdout_json_success(
    message='All requested packages already installed.')
```
due to the top `if not context.json:`.
Furthermore this fixes #5214 which was caused by escaping the conditional `|`.