### PR TITLE
resolve #5147 add 'config files' to conda info

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -198,6 +198,9 @@ def get_info_dict(system=False):
                     for c in channels]
     channels = [mask_anaconda_token(c) for c in channels]
 
+    config_files = tuple(path for path in context.collect_all()
+                         if path not in ('envvars', 'cmd_line'))
+
     info_dict = dict(
         platform=context.subdir,
         conda_version=conda_version,
@@ -221,6 +224,7 @@ def get_info_dict(system=False):
         requests_version=requests_version,
         user_agent=context.user_agent,
         conda_location=CONDA_PACKAGE_ROOT,
+        config_files=config_files,
     )
     if on_win:
         from ..common.platform import is_admin_on_windows
@@ -252,7 +256,7 @@ def get_info_dict(system=False):
 def get_main_info_str(info_dict):
     from .._vendor.auxlib.ish import dals
 
-    for key in 'pkgs_dirs', 'envs_dirs', 'channels':
+    for key in 'pkgs_dirs', 'envs_dirs', 'channels', 'config_files':
         info_dict['_' + key] = ('\n' + 26 * ' ').join(info_dict[key])
     info_dict['_rtwro'] = ('writable' if info_dict['root_writable'] else 'read only')
 
@@ -273,6 +277,7 @@ def get_main_info_str(info_dict):
               package cache : %(_pkgs_dirs)s
                channel URLs : %(_channels)s
                 config file : %(rc_path)s
+               config files : %(_config_files)s
                offline mode : %(offline)s
                  user-agent : %(user_agent)s\
     """) % info_dict)


### PR DESCRIPTION
resolve #5147 

```
$ python -m conda info
Current conda install:

               platform : osx-64
          conda version : None
       conda is private : False
      conda-env version : None
    conda-build version : 2.1.10+6.g99aaa148
         python version : 3.5.2.final.0
       requests version : 2.10.0
       root environment : /usr/local/bin/../Cellar/python3/3.5.2_1/bin/../Frameworks/Python.framework/Versions/3.5  (writable)
    default environment : /usr/local/bin/../Cellar/python3/3.5.2_1/bin/../Frameworks/Python.framework/Versions/3.5
       envs directories : /usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/envs
                          /Users/kfranz/.conda/envs
          package cache : /usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/pkgs
                          /Users/kfranz/.conda/pkgs
           channel URLs : https://repo.continuum.io/pkgs/free/osx-64
                          https://repo.continuum.io/pkgs/free/noarch
                          https://repo.continuum.io/pkgs/r/osx-64
                          https://repo.continuum.io/pkgs/r/noarch
                          https://repo.continuum.io/pkgs/pro/osx-64
                          https://repo.continuum.io/pkgs/pro/noarch
            config file : /Users/kfranz/.condarc
           config files : /etc/conda/condarc.d/config.yml
                          /Users/kfranz/.condarc
           offline mode : False
             user-agent : conda/None requests/2.10.0 CPython/3.5.2 Darwin/16.5.0 OSX/10.12.4
                UID:GID : 502:20
```