### PR TITLE
Allow to link packages from extracted tarballs when tarball is gone

### DIFF
--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -244,11 +244,12 @@ class PackageCache(object):
         raise CondaError("No package '%s' found in cache directories." % dist)
 
     @classmethod
-    def tarball_file_in_cache(cls, tarball_path, md5sum=None):
+    def tarball_file_in_cache(cls, tarball_path, md5sum=None, exclude_caches=[]):
         tarball_full_path, md5sum = cls._clean_tarball_path_and_get_md5sum(tarball_path, md5sum)
         pc_entry = first(cls(pkgs_dir).tarball_file_in_this_cache(tarball_full_path,
                                                                   md5sum)
-                         for pkgs_dir in context.pkgs_dirs)
+                         for pkgs_dir in context.pkgs_dirs
+                         if pkgs_dir not in exclude_caches)
         return pc_entry
 
     @classmethod

--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -244,7 +244,7 @@ class PackageCache(object):
         raise CondaError("No package '%s' found in cache directories." % dist)
 
     @classmethod
-    def tarball_file_in_cache(cls, tarball_path, md5sum=None, exclude_caches=[]):
+    def tarball_file_in_cache(cls, tarball_path, md5sum=None, exclude_caches=()):
         tarball_full_path, md5sum = cls._clean_tarball_path_and_get_md5sum(tarball_path, md5sum)
         pc_entry = first(cls(pkgs_dir).tarball_file_in_this_cache(tarball_full_path,
                                                                   md5sum)

--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import errno
+from errno import ENOENT
 from functools import reduce
 from logging import getLogger
 from os import listdir
@@ -130,7 +130,7 @@ class PackageCacheEntry(object):
         try:
             return read_repodata_json(epd)
         except (IOError, OSError) as ex:
-            if ex.errno == errno.ENOENT:
+            if ex.errno == ENOENT:
                 return None
             raise  # pragma: no cover
 

--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import errno
 from functools import reduce
 from logging import getLogger
 from os import listdir
@@ -19,7 +20,7 @@ from ..common.path import url_to_path
 from ..common.signals import signal_handler
 from ..common.url import path_to_url
 from ..gateways.disk.create import create_package_cache_directory
-from ..gateways.disk.read import compute_md5sum, isdir, isfile, islink
+from ..gateways.disk.read import read_repodata_json, compute_md5sum, isdir, isfile, islink
 from ..gateways.disk.test import file_path_is_writable
 from ..models.channel import Channel
 from ..models.dist import Dist
@@ -96,6 +97,18 @@ class PackageCacheEntry(object):
         return isdir(epd) and isfile(join(epd, 'info', 'index.json'))
 
     @property
+    @memoizemethod
+    def repodata_record(self):
+        epd = self.extracted_package_dir
+
+        try:
+            return read_repodata_json(epd)
+        except (IOError, OSError) as ex:
+            if ex.errno == errno.ENOENT:
+                return None
+            raise
+
+    @property
     def tarball_basename(self):
         return basename(self.package_tarball_full_path)
 
@@ -111,7 +124,12 @@ class PackageCacheEntry(object):
 
     @property
     def md5sum(self):
-        return self._calculate_md5sum() if self.is_fetched else None
+        if self.repodata_record is not None and self.repodata_record.md5:
+            return self.repodata_record.md5
+        elif self.is_fetched:
+            return self._calculate_md5sum()
+        else:
+            return None
 
     def get_urls_txt_value(self):
         return PackageCache(self.pkgs_dir).urls_data.get_url(self.package_tarball_full_path)

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1077,8 +1077,14 @@ class CacheUrlAction(PathAction):
                 #   record that url as the remote source url in urls.txt
                 # we do the search part of this operation before the create_link so that we
                 #   don't md5sum-match the file created by 'create_link'
+                # there is no point in looking for the tarball in the cache that we are writing
+                #   this file into because we have already removed the previous file if there was any.
+                #   this also makes sure that we ignore the md5sum of a possible extracted
+                #   directory that might exist in this cache because we are going to overwrite it
+                #   anyway when we extract the tarball.
                 source_md5sum = compute_md5sum(source_path)
-                pc_entry = PackageCache.tarball_file_in_cache(source_path, source_md5sum)
+                pc_entry = PackageCache.tarball_file_in_cache(source_path, source_md5sum,
+                                                              exclude_caches=[self.target_pkgs_dir])
                 origin_url = pc_entry.get_urls_txt_value() if pc_entry else None
 
                 # copy the tarball to the writable cache

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1078,13 +1078,14 @@ class CacheUrlAction(PathAction):
                 # we do the search part of this operation before the create_link so that we
                 #   don't md5sum-match the file created by 'create_link'
                 # there is no point in looking for the tarball in the cache that we are writing
-                #   this file into because we have already removed the previous file if there was any.
-                #   this also makes sure that we ignore the md5sum of a possible extracted
+                #   this file into because we have already removed the previous file if there was
+                #   any. This also makes sure that we ignore the md5sum of a possible extracted
                 #   directory that might exist in this cache because we are going to overwrite it
                 #   anyway when we extract the tarball.
                 source_md5sum = compute_md5sum(source_path)
+                exclude_caches = [self.target_pkgs_dir]
                 pc_entry = PackageCache.tarball_file_in_cache(source_path, source_md5sum,
-                                                              exclude_caches=[self.target_pkgs_dir])
+                                                              exclude_caches=exclude_caches)
                 origin_url = pc_entry.get_urls_txt_value() if pc_entry else None
 
                 # copy the tarball to the writable cache

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1083,7 +1083,7 @@ class CacheUrlAction(PathAction):
                 #   directory that might exist in this cache because we are going to overwrite it
                 #   anyway when we extract the tarball.
                 source_md5sum = compute_md5sum(source_path)
-                exclude_caches = [self.target_pkgs_dir]
+                exclude_caches = self.target_pkgs_dir,
                 pc_entry = PackageCache.tarball_file_in_cache(source_path, source_md5sum,
                                                               exclude_caches=exclude_caches)
                 origin_url = pc_entry.get_urls_txt_value() if pc_entry else None

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -102,6 +102,12 @@ def read_index_json(extracted_package_directory):
     return record
 
 
+def read_repodata_json(extracted_package_directory):
+    with open(join(extracted_package_directory, 'info', 'repodata_record.json')) as fi:
+        record = IndexRecord(**json.load(fi))
+    return record
+
+
 def read_icondata(extracted_package_directory):
     icon_file_path = join(extracted_package_directory, 'info', 'icon.png')
     if isfile(icon_file_path):

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -84,7 +84,6 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
                                        channel=dist.channel, schannel=dist.channel, fn=dist.fn,
                                        url=url, md5=md5sum)
 
-
     # perform any necessary fetches and extractions
     if verbose:
         from .console import setup_verbose_handlers

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -81,6 +81,7 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
         dist = dist or Dist(url)
         fetch_recs[dist] = IndexRecord(name=dist.name, version=dist.version, build=dist.build,
                                        build_number=dist.build_number, arch=dist.platform,
+                                       channel=dist.channel, schannel=dist.channel, fn=dist.fn,
                                        url=url, md5=md5sum)
 
 

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -79,7 +79,10 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
                 url = dist.to_url() or pc_entry.get_urls_txt_value()
                 md5sum = md5sum or pc_entry.md5sum
         dist = dist or Dist(url)
-        fetch_recs[dist] = {'md5': md5sum, 'url': url}
+        fetch_recs[dist] = IndexRecord(name=dist.name, version=dist.version, build=dist.build,
+                                       build_number=dist.build_number, arch=dist.platform,
+                                       url=url, md5=md5sum)
+
 
     # perform any necessary fetches and extractions
     if verbose:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -26,6 +26,7 @@ import requests
 
 from conda import CondaError, CondaMultiError
 from conda._vendor.auxlib.entity import EntityEncoder
+from conda.base.constants import CONDA_TARBALL_EXTENSION, PACKAGE_CACHE_MAGIC_FILE
 from conda.base.context import Context, context, reset_context
 from conda.cli.main import generate_parser
 from conda.cli.main_clean import configure_parser as clean_configure_parser
@@ -164,6 +165,22 @@ def make_temp_env(*packages, **kwargs):
             yield prefix
         finally:
             rmtree(prefix, ignore_errors=True)
+
+@contextmanager
+def make_temp_package_cache():
+    prefix = make_temp_prefix()
+    pkgs_dir = join(prefix, 'pkgs')
+    mkdir_p(pkgs_dir)
+    touch(join(pkgs_dir, PACKAGE_CACHE_MAGIC_FILE))
+
+    try:
+        with env_var('CONDA_PKGS_DIRS', pkgs_dir, reset_context):
+            assert context.pkgs_dirs == (pkgs_dir,)
+            yield pkgs_dir
+    finally:
+        rmtree(prefix, ignore_errors=True)
+        if pkgs_dir in PackageCache._cache_:
+            del PackageCache._cache_[pkgs_dir]
 
 @contextmanager
 def make_temp_channel(packages):
@@ -1064,40 +1081,30 @@ class IntegrationTests(TestCase):
                 assert result_dict.get('local_channel_seen')
 
     def test_create_from_extracted(self):
-        # Test that we can link a package from its extracted directory
-        # even if the tarball is no longer available.
-        pkgs_dir = PackageCache.first_writable().pkgs_dir
-        mkdir_p(pkgs_dir)
-        pkgs_dir_hold = pkgs_dir + '_hold'
+        with make_temp_env() as prefix:
+            with make_temp_package_cache() as pkgs_dir:
+                assert context.pkgs_dirs == (pkgs_dir,)
+                def pkgs_dir_has_tarball(tarball_prefix):
+                    return any(f.startswith(tarball_prefix) and f.endswith(CONDA_TARBALL_EXTENSION)
+                               for f in os.listdir(pkgs_dir))
 
-        try:
-            shutil.move(pkgs_dir, pkgs_dir_hold)
+                # First, make sure the openssl package is present in the cache,
+                # downloading it if needed
+                assert not pkgs_dir_has_tarball('openssl-')
+                run_command(Commands.INSTALL, prefix, 'openssl')
+                run_command(Commands.REMOVE, prefix, 'openssl')
+                assert pkgs_dir_has_tarball('openssl-')
 
-            # First, make sure the python package is present
-            with make_temp_env('python') as prefix:
-                pkgs_dir_contents = [join(pkgs_dir, d) for d in os.listdir(pkgs_dir)]
-                pkgs_dir_tarballs = [f for f in pkgs_dir_contents if f.endswith('.tar.bz2')]
-                assert any(basename(d).startswith('python-') for d in pkgs_dir_tarballs)
+                # Then, remove the tarball but keep the extracted directory around
+                run_command(Commands.CLEAN, prefix, '--tarballs --yes')
+                assert not pkgs_dir_has_tarball('openssl-')
 
-            # Then, remove the tarball but keep the extracted directory around
-            run_command(Commands.CLEAN, prefix, "--tarballs --yes")
-            pkgs_dir_contents = [join(pkgs_dir, d) for d in os.listdir(pkgs_dir)]
-            pkgs_dir_tarballs = [f for f in pkgs_dir_contents if f.endswith('.tar.bz2')]
-            assert not any(basename(d).startswith('python-') for d in pkgs_dir_tarballs)
-
-            # Finally, create a new environment with python in it. We expect that the
-            # tarball did not appear again because we simply linked the environment from
-            # the extracted directory. If the tarball appeared again, we decided to
-            # re-download the package for some reason.
-            with make_temp_env('python') as prefix:
-                pkgs_dir_contents = [join(pkgs_dir, d) for d in os.listdir(pkgs_dir)]
-                pkgs_dir_tarballs = [f for f in pkgs_dir_contents if f.endswith('.tar.bz2')]
-                assert not any(basename(d).startswith('python-') for d in pkgs_dir_tarballs)
-
-        finally:
-            rm_rf(pkgs_dir)
-            shutil.move(pkgs_dir_hold, pkgs_dir)
-            PackageCache.clear()
+                # Finally, install openssl, enforcing the use of the extracted package.
+                # We expect that the tarball does not appear again because we simply
+                # linked the package from the extracted directory. If the tarball
+                # appeared again, we decided to re-download the package for some reason.
+                run_command(Commands.INSTALL, prefix, 'openssl --offline')
+                assert not pkgs_dir_has_tarball('openssl-')
 
     def test_clean_tarballs_and_packages(self):
         pkgs_dir = PackageCache.first_writable().pkgs_dir

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1081,24 +1081,24 @@ class IntegrationTests(TestCase):
                 assert result_dict.get('local_channel_seen')
 
     def test_create_from_extracted(self):
-        with make_temp_env() as prefix:
-            with make_temp_package_cache() as pkgs_dir:
-                assert context.pkgs_dirs == (pkgs_dir,)
-                def pkgs_dir_has_tarball(tarball_prefix):
-                    return any(f.startswith(tarball_prefix) and f.endswith(CONDA_TARBALL_EXTENSION)
-                               for f in os.listdir(pkgs_dir))
+        with make_temp_package_cache() as pkgs_dir:
+            assert context.pkgs_dirs == (pkgs_dir,)
+            def pkgs_dir_has_tarball(tarball_prefix):
+                return any(f.startswith(tarball_prefix) and f.endswith(CONDA_TARBALL_EXTENSION)
+                           for f in os.listdir(pkgs_dir))
 
+            with make_temp_env() as prefix:
                 # First, make sure the openssl package is present in the cache,
                 # downloading it if needed
                 assert not pkgs_dir_has_tarball('openssl-')
                 run_command(Commands.INSTALL, prefix, 'openssl')
-                run_command(Commands.REMOVE, prefix, 'openssl')
                 assert pkgs_dir_has_tarball('openssl-')
 
                 # Then, remove the tarball but keep the extracted directory around
                 run_command(Commands.CLEAN, prefix, '--tarballs --yes')
                 assert not pkgs_dir_has_tarball('openssl-')
 
+            with make_temp_env() as prefix:
                 # Finally, install openssl, enforcing the use of the extracted package.
                 # We expect that the tarball does not appear again because we simply
                 # linked the package from the extracted directory. If the tarball

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1107,11 +1107,7 @@ class IntegrationTests(TestCase):
                 assert not pkgs_dir_has_tarball('openssl-')
 
     def test_clean_tarballs_and_packages(self):
-        pkgs_dir = PackageCache.first_writable().pkgs_dir
-        mkdir_p(pkgs_dir)
-        pkgs_dir_hold = pkgs_dir + '_hold'
-        try:
-            shutil.move(pkgs_dir, pkgs_dir_hold)
+        with make_temp_package_cache() as pkgs_dir:
             with make_temp_env("flask") as prefix:
                 pkgs_dir_contents = [join(pkgs_dir, d) for d in os.listdir(pkgs_dir)]
                 pkgs_dir_dirs = [d for d in pkgs_dir_contents if isdir(d)]
@@ -1134,10 +1130,6 @@ class IntegrationTests(TestCase):
             pkgs_dir_contents = [join(pkgs_dir, d) for d in os.listdir(pkgs_dir)]
             pkgs_dir_dirs = [d for d in pkgs_dir_contents if isdir(d)]
             assert not any(basename(d).startswith('flask-') for d in pkgs_dir_dirs)
-        finally:
-            rm_rf(pkgs_dir)
-            shutil.move(pkgs_dir_hold, pkgs_dir)
-            PackageCache.clear()
 
     def test_clean_source_cache(self):
         cache_dirs = {


### PR DESCRIPTION
Currently, when linking a package, an already-extracted package is only
used when the corresponding tarball also exists and its md5 checksum
matches what is in the repodata. This means that if the tarball is not
present and only the extracted directory exists, conda always re-downloads
the tarball (and re-extracts it) even if the extracted directory exists
already because it can't compare the checksums otherwise.

This used to be different in previous versions such as 4.2.x where conda
would link a package from an extracted directory even if the tarball was
gone.

The current behavior is somewhat unfortunate in the sense that after a Miniconda
install, the pkgs directory is left with only extracted directories and no
tarballs. Also, `conda clean --tarballs` removes *all* tarballs and so causes
a re-download of all packages next time an environment is being created.

This PR modifies conda's behavior leveraging the newly introduced (in #5148)
`repodata_record.json` file which is written at package extraction time.
Among other things, it contains the md5 checksum of the tarball that was
extracted, and therefore allows us to perform the md5 comparison even in
the absence of the actual tarball.