### PR TITLE
remove pycrypto as requirement on windows

### DIFF
--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,6 +1,7 @@
 enum34; python_version < '3.3'
 futures; python_version < '3'
+menuinst; sys.platform == 'win32'
 pycosat
-pycrypto
+pycrypto; sys.platform != 'win32'
 requests>=2.14.2
 ruamel.yaml


### PR DESCRIPTION
Something going on with appveyor not being able to pip install pycrypto.  It's not used in 4.3, so just remove it as a requirement.