### PR TITLE
Add a test for an explicit package install with two package caches

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1079,31 +1079,10 @@ class CacheUrlAction(PathAction):
                 if origin_url and Dist(origin_url).is_channel:
                     target_package_cache.urls_data.add_url(origin_url)
             else:
-                # so our tarball source isn't a package cache, but that doesn't mean it's not
-                #   in another package cache somewhere
-                # let's try to find the actual, remote source url by matching md5sums, and then
-                #   record that url as the remote source url in urls.txt
-                # we do the search part of this operation before the create_link so that we
-                #   don't md5sum-match the file created by 'create_link'
-                # there is no point in looking for the tarball in the cache that we are writing
-                #   this file into because we have already removed the previous file if there was
-                #   any. This also makes sure that we ignore the md5sum of a possible extracted
-                #   directory that might exist in this cache because we are going to overwrite it
-                #   anyway when we extract the tarball.
-                source_md5sum = compute_md5sum(source_path)
-                exclude_caches = self.target_pkgs_dir,
-                pc_entry = PackageCache.tarball_file_in_cache(source_path, source_md5sum,
-                                                              exclude_caches=exclude_caches)
-                origin_url = pc_entry.get_urls_txt_value() if pc_entry else None
-
                 # copy the tarball to the writable cache
                 create_link(source_path, self.target_full_path, link_type=LinkType.copy,
                             force=context.force)
-
-                if origin_url and Dist(origin_url).is_channel:
-                    target_package_cache.urls_data.add_url(origin_url)
-                else:
-                    target_package_cache.urls_data.add_url(self.url)
+                target_package_cache.urls_data.add_url(self.url)
 
         else:
             download(self.url, self.target_full_path, self.md5sum)


### PR DESCRIPTION
This is basically the scenario that I was mentioning in https://github.com/conda/conda/pull/5289#issuecomment-300973286. It would fail both with and without #5289 merged.

The problem is that when running an `conda install` with an explicit `tar.bz2` file, the logic in `conda/misc.py` creates a `Dist` object for the tarball. The `Dist` object is identified by `channel` and `dist_name`. It then runs an `ProgressiveFetchExtract` on that tarball which ultimately writes an entry for the file in `urls.txt`. When doing that, it tries to match the tarball with an existing tarball in a package cache, and if it finds one, it adds the path to that cache as the channel instead of the path where the explicitly given `.tar.bz2` file was located.

Now, when linking the package, conda creates a pseudo index based only on package caches, and since it just added the new package into a package cache, expects to find the package in this index. The index is basically a dictionary with `Dist` objects as keys. However, the `Dist` object that is in this index now has a different channel than the explicit package location because it was recorded into `urls.txt` with a different location if a match was found in the logic described above.

In this PR, this is fixed by removing the logic that matches an explicitly specified package with packages from a package cache. It's not clear to me whether this was just some sort of optimization or actually important logic in some case, so be careful. It doesn't seem to cause other test failures, though.

I guess the whole explicit-package-install logic is somewhat fragile and could possibly need some refactoring, but I just wanted to write up this particular issue while it is still fresh in my mind.