### PR TITLE
fix sys_prefix_unfollowed for Python 3

### DIFF
--- a/conda/utils.py
+++ b/conda/utils.py
@@ -289,7 +289,7 @@ def sys_prefix_unfollowed():
     is when conda looks for external sub-commands in find_commands.py
     """
     try:
-        frame = list(sys._current_frames().values())[0]
+        frame = next(iter(sys._current_frames().values()))
         while frame.f_back:
             frame = frame.f_back
         code = frame.f_code

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -289,7 +289,7 @@ def sys_prefix_unfollowed():
     is when conda looks for external sub-commands in find_commands.py
     """
     try:
-        frame = sys._current_frames().values()[0]
+        frame = list(sys._current_frames().values())[0]
         while frame.f_back:
             frame = frame.f_back
         code = frame.f_code


### PR DESCRIPTION
target is 4.3.x
supersedes #5317 and #5318 