### PR TITLE
fix 5321: ensure variable PROMPT is set in activate.bat

### DIFF
--- a/shell/activate.bat
+++ b/shell/activate.bat
@@ -44,6 +44,8 @@
 @IF errorlevel 1 exit /b 1
 
 @REM take a snapshot of pristine state for later
+@REM if PROMPT is not set at all, explicitly set it to the default, i.e. current path followed by greater sign
+@IF NOT DEFINED PROMPT SET PROMPT=$P$G
 @SET "CONDA_PS1_BACKUP=%PROMPT%"
 @FOR /F "delims=" %%i IN ('@call "%CONDA_EXE%" ..changeps1') DO @SET "CHANGE_PROMPT=%%i"
 @IF errorlevel 1 exit /b 1


### PR DESCRIPTION
fix #5321

If `PROMPT` is not set, subsequent commands will not work as expected, e.g.,
```batch
@SET "CONDA_PS1_BACKUP=%PROMPT%"
```
and
```batch
@IF "%CHANGE_PROMPT%" == "1" @IF "x%PROMPT:CONDA_DEFAULT_ENV=%" == "x%PROMPT%" (
    SET "PROMPT=(%CONDA_NEW_ENV%) %PROMPT%"
)
```
Note though, I'm not sure how/why a user's `PROMPT` environment variable would not be set, but it happened in #5321. This might just be misconfigured user settings which wouldn't necessarily need to be supported -- this PR handles it nonetheless.