### PR TITLE
fix #5298 record has 'build', not 'build_string'

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -531,7 +531,7 @@ class Resolve(object):
         valid = 1 if cpri < MAX_CHANNEL_PRIORITY else 0
         ver = normalized_version(rec.get('version', ''))
         bld = rec.get('build_number', 0)
-        bs = rec.get('build_string')
+        bs = rec.get('build')
         ts = rec.get('timestamp', 0)
         return ((valid, -cpri, ver, bld, bs, ts) if context.channel_priority else
                 (valid, ver, -cpri, bld, bs, ts))


### PR DESCRIPTION
fix #5298

@mcg1969 Could this be the cause (and fix) for #5298?