### PR TITLE
fix 5356 (additions): skip root/conda logger init for cli.python_api

### DIFF
--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -11,9 +11,9 @@ from ..cli.main import generate_parser
 from ..common.io import captured, replace_log_streams, argv
 from ..common.path import win_path_double_escape
 from ..exceptions import conda_exception_handler
-from ..gateways import initialize_logging
+from ..gateways import initialize_std_loggers
 
-initialize_logging()
+initialize_std_loggers()
 log = getLogger(__name__)
 
 

--- a/conda/gateways/__init__.py
+++ b/conda/gateways/__init__.py
@@ -27,5 +27,6 @@ Conda modules strictly prohibited from importing ``conda.gateways`` are
 """
 from __future__ import absolute_import, division, print_function
 
-from .logging import initialize_logging
-initialize_logging()
+from .logging import initialize_logging, initialize_std_loggers
+initialize_logging = initialize_logging
+initialize_std_loggers = initialize_std_loggers

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -37,9 +37,13 @@ class TokenURLFilter(Filter):
 
 @memoize
 def initialize_logging():
-    # initialize_root_logger()  # probably don't need to touch the root logger per #5356
+    initialize_root_logger()
     initialize_conda_logger()
+    initialize_std_loggers()
 
+
+@memoize
+def initialize_std_loggers():
     formatter = Formatter("%(message)s\n")
 
     stdout = getLogger('stdout')
@@ -71,7 +75,7 @@ def initialize_conda_logger(level=WARN):
 
 def set_all_logger_level(level=DEBUG):
     formatter = Formatter("%(message)s\n") if level >= INFO else None
-    # attach_stderr_handler(level, formatter=formatter)  # probably don't need to touch the root logger per #5356  # NOQA
+    attach_stderr_handler(level, formatter=formatter)
     attach_stderr_handler(level, 'conda', formatter=formatter)
     attach_stderr_handler(level, 'requests')
     attach_stderr_handler(level, 'requests.packages.urllib3')

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -35,8 +35,14 @@ class TokenURLFilter(Filter):
         return True
 
 
+# Don't use initialize_logging/initialize_root_logger/initialize_conda_logger in
+# cli.python_api! There we want the user to have control over their logging,
+# e.g., using their own levels, handlers, formatters and propagation settings.
+
 @memoize
 def initialize_logging():
+    # root and 'conda' logger both get their own separate sys.stderr stream handlers.
+    # root gets level ERROR; 'conda' gets level WARN and does not propagate to root.
     initialize_root_logger()
     initialize_conda_logger()
     initialize_std_loggers()
@@ -44,6 +50,10 @@ def initialize_logging():
 
 @memoize
 def initialize_std_loggers():
+    # Set up special loggers 'stdout'/'stderr' which output directly to the corresponding
+    # sys streams, filter token urls and don't propagate.
+    # TODO: To avoid clashes with user loggers when cli.python_api is used, these loggers
+    #       should most likely be renamed to 'conda.stdout'/'conda.stderr' in the future!
     formatter = Formatter("%(message)s\n")
 
     stdout = getLogger('stdout')
@@ -75,8 +85,11 @@ def initialize_conda_logger(level=WARN):
 
 def set_all_logger_level(level=DEBUG):
     formatter = Formatter("%(message)s\n") if level >= INFO else None
+    # root and 'conda' loggers use separate handlers but behave the same wrt level and formatting
     attach_stderr_handler(level, formatter=formatter)
     attach_stderr_handler(level, 'conda', formatter=formatter)
+    # 'requests' loggers get their own handlers so that they always output messages in long format
+    # regardless of the level.
     attach_stderr_handler(level, 'requests')
     attach_stderr_handler(level, 'requests.packages.urllib3')
 


### PR DESCRIPTION
#5380 removed the execution of `initialize_logging` on module initialization, which has been necessary.
It also removed the root logger configuration in `initialize_logging` and `set_all_logger_level` which is a behavioral change, since:
- root logger's default level no longer gets set to `ERROR` in `initialize_logging`
- root logger's level and handler/format do not change in `set_all_logger_level` (and thus also in `set_verbosity`). Notice this is a more subtle change since this would only concern log messages from loggers other than `"conda"` and `"requests"` since those get treated separately and don't propagate to the root logger.

This PR restores the old behavior and avoids configuring root/`"conda"` loggers only in `cli.python_api`.
(Also adds some comments describing the current logging configuration in `common.io`.)