### PR TITLE
remove redundant logging setup

### DIFF
--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -11,9 +11,9 @@ from ..cli.main import generate_parser
 from ..common.io import captured, replace_log_streams, argv
 from ..common.path import win_path_double_escape
 from ..exceptions import conda_exception_handler
-from ..gateways import initialize_logging
+from ..gateways import initialize_std_loggers
 
-initialize_logging()
+initialize_std_loggers()
 log = getLogger(__name__)
 
 

--- a/conda/gateways/__init__.py
+++ b/conda/gateways/__init__.py
@@ -27,5 +27,6 @@ Conda modules strictly prohibited from importing ``conda.gateways`` are
 """
 from __future__ import absolute_import, division, print_function
 
-from .logging import initialize_logging
-initialize_logging()
+from .logging import initialize_logging, initialize_std_loggers
+initialize_logging = initialize_logging
+initialize_std_loggers = initialize_std_loggers

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -37,9 +37,13 @@ class TokenURLFilter(Filter):
 
 @memoize
 def initialize_logging():
-    # initialize_root_logger()  # probably don't need to touch the root logger per #5356
+    initialize_root_logger()
     initialize_conda_logger()
+    initialize_std_loggers()
 
+
+@memoize
+def initialize_std_loggers():
     formatter = Formatter("%(message)s\n")
 
     stdout = getLogger('stdout')
@@ -71,7 +75,7 @@ def initialize_conda_logger(level=WARN):
 
 def set_all_logger_level(level=DEBUG):
     formatter = Formatter("%(message)s\n") if level >= INFO else None
-    # attach_stderr_handler(level, formatter=formatter)  # probably don't need to touch the root logger per #5356  # NOQA
+    attach_stderr_handler(level, formatter=formatter)
     attach_stderr_handler(level, 'conda', formatter=formatter)
     attach_stderr_handler(level, 'requests')
     attach_stderr_handler(level, 'requests.packages.urllib3')

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -88,10 +88,8 @@ def set_all_logger_level(level=DEBUG):
     # root and 'conda' loggers use separate handlers but behave the same wrt level and formatting
     attach_stderr_handler(level, formatter=formatter)
     attach_stderr_handler(level, 'conda', formatter=formatter)
-    # 'requests' loggers get their own handlers so that they always output messages in long format
-    # regardless of the level.
+    # 'requests' logger gets its own handler, to ouput messages in long format regardless of level
     attach_stderr_handler(level, 'requests')
-    attach_stderr_handler(level, 'requests.packages.urllib3')
 
 
 def set_verbosity(verbosity_level):

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -35,8 +35,14 @@ class TokenURLFilter(Filter):
         return True
 
 
+# Don't use initialize_logging/initialize_root_logger/initialize_conda_logger in
+# cli.python_api! There we want the user to have control over their logging,
+# e.g., using their own levels, handlers, formatters and propagation settings.
+
 @memoize
 def initialize_logging():
+    # root and 'conda' logger both get their own separate sys.stderr stream handlers.
+    # root gets level ERROR; 'conda' gets level WARN and does not propagate to root.
     initialize_root_logger()
     initialize_conda_logger()
     initialize_std_loggers()
@@ -44,6 +50,10 @@ def initialize_logging():
 
 @memoize
 def initialize_std_loggers():
+    # Set up special loggers 'stdout'/'stderr' which output directly to the corresponding
+    # sys streams, filter token urls and don't propagate.
+    # TODO: To avoid clashes with user loggers when cli.python_api is used, these loggers
+    #       should most likely be renamed to 'conda.stdout'/'conda.stderr' in the future!
     formatter = Formatter("%(message)s\n")
 
     stdout = getLogger('stdout')
@@ -75,8 +85,11 @@ def initialize_conda_logger(level=WARN):
 
 def set_all_logger_level(level=DEBUG):
     formatter = Formatter("%(message)s\n") if level >= INFO else None
+    # root and 'conda' loggers use separate handlers but behave the same wrt level and formatting
     attach_stderr_handler(level, formatter=formatter)
     attach_stderr_handler(level, 'conda', formatter=formatter)
+    # 'requests' loggers get their own handlers so that they always output messages in long format
+    # regardless of the level.
     attach_stderr_handler(level, 'requests')
     attach_stderr_handler(level, 'requests.packages.urllib3')
 


### PR DESCRIPTION
This is based on #5396.
This removes some redundancy in the logging setup:
- remove setup for `'requests.packages.urllib3'`: `'requests'` gets the same setup and thus can also handle (via propagation) those messages. **NOTE**: This assumes `'requests.packages.urllib3'` behaves well and propagates everthing (`level = NOTSET`, `propagate = True`) -- does this not hold or why has `urllib3` been treated specially?? (then fbcbe554e2413dba69c50de13435a5eb07c97b59 shouldn't be applied of course!)
- only set level but do not add handlers and `propagate = False` to `'conda'` logger so that the (equally configured) root logger can handle those messages.