### PR TITLE
logging simplifications/improvements

### DIFF
--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -8,7 +8,7 @@ from shlex import split
 from ..base.constants import APP_NAME, SEARCH_PATH
 from ..base.context import context
 from ..cli.main import generate_parser
-from ..common.io import captured, replace_log_streams, argv
+from ..common.io import captured, argv
 from ..common.path import win_path_double_escape
 from ..exceptions import conda_exception_handler
 from ..gateways import initialize_std_loggers
@@ -74,7 +74,7 @@ def run_command(command, *arguments, **kwargs):
     )
     log.debug("executing command >>>  conda %s", command_line)
     try:
-        with argv(['python_api'] + split_command_line), captured() as c, replace_log_streams():
+        with argv(['python_api'] + split_command_line), captured() as c:
             if use_exception_handler:
                 return_code = conda_exception_handler(args.func, args, p)
             else:

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -11,9 +11,9 @@ from ..cli.main import generate_parser
 from ..common.io import captured, replace_log_streams, argv
 from ..common.path import win_path_double_escape
 from ..exceptions import conda_exception_handler
-from ..gateways import initialize_logging
+from ..gateways import initialize_std_loggers
 
-initialize_logging()
+initialize_std_loggers()
 log = getLogger(__name__)
 
 

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -122,16 +122,18 @@ def _logger_lock():
 @contextmanager
 def disable_logger(logger_name):
     logr = getLogger(logger_name)
-    _hndlrs, _lvl, _dsbld, _prpgt = logr.handlers, logr.level, logr.disabled, logr.propagate
+    _lvl, _dsbld, _prpgt = logr.level, logr.disabled, logr.propagate
+    null_handler = NullHandler()
     with _logger_lock():
-        logr.addHandler(NullHandler())
+        logr.addHandler(null_handler)
         logr.setLevel(CRITICAL + 1)
         logr.disabled, logr.propagate = True, False
     try:
         yield
     finally:
         with _logger_lock():
-            logr.handlers, logr.level, logr.disabled = _hndlrs, _lvl, _dsbld
+            logr.removeHandler(null_handler)  # restore list logr.handlers
+            logr.level, logr.disabled = _lvl, _dsbld
             logr.propagate = _prpgt
 
 

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -72,6 +72,19 @@ def cwd(directory):
 def captured():
     # NOTE: This function is not thread-safe.  Using within multi-threading may cause spurious
     # behavior of not returning sys.stdout and sys.stderr back to their 'proper' state
+    # """
+    # Context manager to capture the printed output of the code in the with block
+    #
+    # Bind the context manager to a variable using `as` and the result will be
+    # in the stdout property.
+    #
+    # >>> from conda.common.io import captured
+    # >>> with captured() as c:
+    # ...     print('hello world!')
+    # ...
+    # >>> c.stdout
+    # 'hello world!\n'
+    # """
     class CapturedText(object):
         pass
     saved_stdout, saved_stderr = sys.stdout, sys.stderr

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -89,7 +89,7 @@ def captured():
 
 @contextmanager
 def replace_log_streams():
-    # replace the logger stream handlers with stdout and stderr handlers
+    # for loggers stdout/stderr replace their handlers' streams with current sys.stdout/sys.stderr
     stdout_logger, stderr_logger = getLogger('stdout'), getLogger('stderr')
     saved_stdout_strm = stdout_logger.handlers[0].stream
     saved_stderr_strm = stderr_logger.handlers[0].stream

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -88,22 +88,6 @@ def captured():
 
 
 @contextmanager
-def replace_log_streams():
-    # for loggers stdout/stderr replace their handlers' streams with current sys.stdout/sys.stderr
-    stdout_logger, stderr_logger = getLogger('stdout'), getLogger('stderr')
-    saved_stdout_strm = stdout_logger.handlers[0].stream
-    saved_stderr_strm = stderr_logger.handlers[0].stream
-    stdout_logger.handlers[0].stream = sys.stdout
-    stderr_logger.handlers[0].stream = sys.stderr
-    try:
-        yield
-    finally:
-        # replace the original streams
-        stdout_logger.handlers[0].stream = saved_stdout_strm
-        stderr_logger.handlers[0].stream = saved_stderr_strm
-
-
-@contextmanager
 def argv(args_list):
     saved_args = sys.argv
     sys.argv = args_list

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -580,8 +580,8 @@ class InvalidVersionSpecError(CondaError):
 def print_conda_exception(exception):
     from .base.context import context
 
-    stdoutlogger = getLogger('stdout')
-    stderrlogger = getLogger('stderr')
+    stdoutlogger = getLogger('conda.stdout')
+    stderrlogger = getLogger('conda.stderr')
     if context.json:
         import json
         stdoutlogger.info(json.dumps(exception.dump_map(), indent=2, sort_keys=True,
@@ -597,7 +597,7 @@ def print_unexpected_error_message(e):
     # print("%s  %s  %s" % (3*bomb, 3*explosion, 3*fire))
     traceback = format_exc()
 
-    stderrlogger = getLogger('stderr')
+    stderrlogger = getLogger('conda.stderr')
 
     from .base.context import context
     if context.json:

--- a/conda/gateways/__init__.py
+++ b/conda/gateways/__init__.py
@@ -27,5 +27,6 @@ Conda modules strictly prohibited from importing ``conda.gateways`` are
 """
 from __future__ import absolute_import, division, print_function
 
-from .logging import initialize_logging
-initialize_logging()
+from .logging import initialize_logging, initialize_std_loggers
+initialize_logging = initialize_logging
+initialize_std_loggers = initialize_std_loggers

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -37,9 +37,13 @@ class TokenURLFilter(Filter):
 
 @memoize
 def initialize_logging():
-    # initialize_root_logger()  # probably don't need to touch the root logger per #5356
+    initialize_root_logger()
     initialize_conda_logger()
+    initialize_std_loggers()
 
+
+@memoize
+def initialize_std_loggers():
     formatter = Formatter("%(message)s\n")
 
     stdout = getLogger('stdout')
@@ -71,7 +75,7 @@ def initialize_conda_logger(level=WARN):
 
 def set_all_logger_level(level=DEBUG):
     formatter = Formatter("%(message)s\n") if level >= INFO else None
-    # attach_stderr_handler(level, formatter=formatter)  # probably don't need to touch the root logger per #5356  # NOQA
+    attach_stderr_handler(level, formatter=formatter)
     attach_stderr_handler(level, 'conda', formatter=formatter)
     attach_stderr_handler(level, 'requests')
     attach_stderr_handler(level, 'requests.packages.urllib3')

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -35,8 +35,14 @@ class TokenURLFilter(Filter):
         return True
 
 
+# Don't use initialize_logging/initialize_root_logger/initialize_conda_logger in
+# cli.python_api! There we want the user to have control over their logging,
+# e.g., using their own levels, handlers, formatters and propagation settings.
+
 @memoize
 def initialize_logging():
+    # root and 'conda' logger both get their own separate sys.stderr stream handlers.
+    # root gets level ERROR; 'conda' gets level WARN and does not propagate to root.
     initialize_root_logger()
     initialize_conda_logger()
     initialize_std_loggers()
@@ -44,6 +50,10 @@ def initialize_logging():
 
 @memoize
 def initialize_std_loggers():
+    # Set up special loggers 'stdout'/'stderr' which output directly to the corresponding
+    # sys streams, filter token urls and don't propagate.
+    # TODO: To avoid clashes with user loggers when cli.python_api is used, these loggers
+    #       should most likely be renamed to 'conda.stdout'/'conda.stderr' in the future!
     formatter = Formatter("%(message)s\n")
 
     stdout = getLogger('stdout')
@@ -75,8 +85,11 @@ def initialize_conda_logger(level=WARN):
 
 def set_all_logger_level(level=DEBUG):
     formatter = Formatter("%(message)s\n") if level >= INFO else None
+    # root and 'conda' loggers use separate handlers but behave the same wrt level and formatting
     attach_stderr_handler(level, formatter=formatter)
     attach_stderr_handler(level, 'conda', formatter=formatter)
+    # 'requests' loggers get their own handlers so that they always output messages in long format
+    # regardless of the level.
     attach_stderr_handler(level, 'requests')
     attach_stderr_handler(level, 'requests.packages.urllib3')
 

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -67,13 +67,11 @@ def initialize_logging():
 
 @memoize
 def initialize_std_loggers():
-    # Set up special loggers 'stdout'/'stderr' which output directly to the corresponding
-    # sys streams, filter token urls and don't propagate.
-    # TODO: To avoid clashes with user loggers when cli.python_api is used, these loggers
-    #       should most likely be renamed to 'conda.stdout'/'conda.stderr' in the future!
+    # Set up special loggers 'conda.stdout'/'conda.stderr' which output directly to the
+    # corresponding sys streams, filter token urls and don't propagate.
     formatter = Formatter("%(message)s\n")
 
-    stdout = getLogger('stdout')
+    stdout = getLogger('conda.stdout')
     stdout.setLevel(INFO)
     stdouthandler = StdStreamHandler('stdout')
     stdouthandler.setLevel(INFO)
@@ -82,7 +80,7 @@ def initialize_std_loggers():
     stdout.addFilter(TokenURLFilter())
     stdout.propagate = False
 
-    stderr = getLogger('stderr')
+    stderr = getLogger('conda.stderr')
     stderr.setLevel(INFO)
     stderrhandler = StdStreamHandler('stderr')
     stderrhandler.setLevel(INFO)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -53,19 +53,7 @@ def raises(exception, func, string=None):
 
 @contextmanager
 def captured(disallow_stderr=True):
-    # """
-    # Context manager to capture the printed output of the code in the with block
-    #
-    # Bind the context manager to a variable using `as` and the result will be
-    # in the stdout property.
-    #
-    # >>> from tests.helpers import captured
-    # >>> with captured() as c:
-    # ...     print('hello world!')
-    # ...
-    # >>> c.stdout
-    # 'hello world!\n'
-    # """
+    # same as common.io.captured but raises Exception if unexpected output was written to stderr
     try:
         with common_io_captured() as c:
             yield c

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -18,7 +18,7 @@ from conda.gateways.disk.delete import rm_rf
 from conda.gateways.disk.read import lexists
 
 from conda.base.context import reset_context
-from conda.common.io import captured, argv, replace_log_streams
+from conda.common.io import captured, argv
 from conda.gateways.logging import initialize_logging
 from conda import cli
 
@@ -119,7 +119,7 @@ def assert_in(a, b, output=""):
 def run_inprocess_conda_command(command):
     # anything that uses this function is an integration test
     reset_context(())
-    with argv(split(command)), captured() as c, replace_log_streams():
+    with argv(split(command)), captured() as c:
         initialize_logging()
         try:
             exit_code = cli.main()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -39,8 +39,7 @@ from conda.cli.main_remove import configure_parser as remove_configure_parser
 from conda.cli.main_search import configure_parser as search_configure_parser
 from conda.cli.main_update import configure_parser as update_configure_parser
 from conda.common.compat import PY2, iteritems, itervalues, text_type
-from conda.common.io import argv, captured, disable_logger, env_var, replace_log_streams, \
-    stderr_log_level
+from conda.common.io import argv, captured, disable_logger, env_var, stderr_log_level
 from conda.common.path import get_bin_directory_short_path, get_python_site_packages_short_path, \
     pyc_path
 from conda.common.url import path_to_url
@@ -142,7 +141,7 @@ def run_command(command, prefix, *arguments, **kwargs):
     context._set_argparse_args(args)
     print("\n\nEXECUTING COMMAND >>> $ conda %s\n\n" % command_line, file=sys.stderr)
     with stderr_log_level(TEST_LOG_LEVEL, 'conda'), stderr_log_level(TEST_LOG_LEVEL, 'requests'):
-        with argv(['python_api'] + split_command_line), captured() as c, replace_log_streams():
+        with argv(['python_api'] + split_command_line), captured() as c:
             if use_exception_handler:
                 conda_exception_handler(args.func, args, p)
             else:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -6,7 +6,7 @@ from conda.common.compat import on_win
 from conda import text_type
 from conda._vendor.auxlib.ish import dals
 from conda.base.context import reset_context, context
-from conda.common.io import captured, env_var, replace_log_streams
+from conda.common.io import captured, env_var
 from conda.exceptions import CommandNotFoundError, FileNotFoundError, CondaHTTPError, CondaKeyError, \
     CondaRevisionError, DirectoryNotFoundError, MD5MismatchError, PackageNotFoundError, TooFewArgumentsError, \
     TooManyArgumentsError, conda_exception_handler, BasicClobberError, KnownPackageClobberError, \
@@ -25,7 +25,7 @@ class ExceptionTests(TestCase):
         offending_arguments = "groot"
         exc = TooManyArgumentsError(expected, received, offending_arguments)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -39,7 +39,7 @@ class ExceptionTests(TestCase):
         assert json_obj['offending_arguments'] == "groot"
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -50,7 +50,7 @@ class ExceptionTests(TestCase):
         received = 2
         exc = TooFewArgumentsError(expected, received)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -63,7 +63,7 @@ class ExceptionTests(TestCase):
         assert json_obj['received'] == 2
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -74,7 +74,7 @@ class ExceptionTests(TestCase):
         target_path = "some/path/to/wright.st"
         exc = BasicClobberError(source_path, target_path, context)
         with env_var("CONDA_PATH_CONFLICT", "prevent", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -90,7 +90,7 @@ class ExceptionTests(TestCase):
         colliding_linked_dist = "Liquid"
         exc = KnownPackageClobberError(target_path, colliding_dist_being_linked, colliding_linked_dist, context)
         with env_var("CONDA_PATH_CONFLICT", "prevent", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -107,7 +107,7 @@ class ExceptionTests(TestCase):
         colliding_dist_being_linked = "Groot"
         exc = UnknownPackageClobberError(target_path, colliding_dist_being_linked, context)
         with env_var("CONDA_PATH_CONFLICT", "prevent", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -124,7 +124,7 @@ class ExceptionTests(TestCase):
         incompatible_package_dists = "Groot"
         exc = SharedLinkPathClobberError(target_path, incompatible_package_dists, context)
         with env_var("CONDA_PATH_CONFLICT", "prevent", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -139,7 +139,7 @@ class ExceptionTests(TestCase):
         filename = "Groot"
         exc = FileNotFoundError(filename)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -150,7 +150,7 @@ class ExceptionTests(TestCase):
         assert json_obj['error'] == repr(exc)
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -160,7 +160,7 @@ class ExceptionTests(TestCase):
         directory = "Groot"
         exc = DirectoryNotFoundError(directory)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -172,7 +172,7 @@ class ExceptionTests(TestCase):
         assert json_obj['path'] == "Groot"
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -185,7 +185,7 @@ class ExceptionTests(TestCase):
         actual_md5sum = "deadbeef"
         exc = MD5MismatchError(url, target_full_path, expected_md5sum, actual_md5sum)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -200,7 +200,7 @@ class ExceptionTests(TestCase):
         assert json_obj['actual_md5sum'] == actual_md5sum
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -216,7 +216,7 @@ class ExceptionTests(TestCase):
         package = "Groot"
         exc = PackageNotFoundError(package)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -227,7 +227,7 @@ class ExceptionTests(TestCase):
         assert json_obj['error'] == repr(exc)
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -237,7 +237,7 @@ class ExceptionTests(TestCase):
         message = "Groot"
         exc = CondaRevisionError(message)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -248,7 +248,7 @@ class ExceptionTests(TestCase):
         assert json_obj['error'] == repr(exc)
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -259,7 +259,7 @@ class ExceptionTests(TestCase):
         message = "Groot is not a key."
         exc = CondaKeyError(key, message)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -271,7 +271,7 @@ class ExceptionTests(TestCase):
         assert json_obj['key'] == "Groot"
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -286,7 +286,7 @@ class ExceptionTests(TestCase):
         exc = CondaHTTPError(msg, url, status_code, reason, elapsed_time)
 
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
             json_obj = json.loads(c.stdout)
@@ -301,7 +301,7 @@ class ExceptionTests(TestCase):
             assert json_obj['elapsed_time'] == elapsed_time
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -317,7 +317,7 @@ class ExceptionTests(TestCase):
         exc = CommandNotFoundError(cmd)
 
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -327,7 +327,7 @@ class ExceptionTests(TestCase):
         assert json_obj['error'] == repr(exc)
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -338,7 +338,7 @@ class ExceptionTests(TestCase):
         exc = CommandNotFoundError(cmd)
 
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -348,7 +348,7 @@ class ExceptionTests(TestCase):
         assert json_obj['error'] == repr(exc)
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -360,7 +360,7 @@ class ExceptionTests(TestCase):
         exc = CommandNotFoundError(cmd)
 
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -370,7 +370,7 @@ class ExceptionTests(TestCase):
         assert json_obj['error'] == repr(exc)
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout
@@ -391,7 +391,7 @@ class ExceptionTests(TestCase):
         exc = BinaryPrefixReplacementError(path, placeholder, new_prefix,
                                            original_data_length, new_data_length)
         with env_var("CONDA_JSON", "yes", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         json_obj = json.loads(c.stdout)
@@ -407,7 +407,7 @@ class ExceptionTests(TestCase):
         assert json_obj['placeholder'] == placeholder
 
         with env_var("CONDA_JSON", "no", reset_context):
-            with captured() as c, replace_log_streams():
+            with captured() as c:
                 conda_exception_handler(_raise_helper, exc)
 
         assert not c.stdout


### PR DESCRIPTION
This is based on #5396.

This does:
- remove `replace_log_streams` and instead make the handlers of `"stdout"`/`"stderr "` loggers always output to the current `sys.stdout`/`sys.stderr`.
- rename loggers `"stdout"`/`"stderr"` to `"conda.stdout"`/`"conda.stderr "`; that way they won't clash if some external code (e.g., caller of `cli.python_api`) uses equally named loggers.

Also includes these minor changes:
- use `common.io.captured` in `test.helpers` instead of having the code duplicated.
- properly remove `NullHandler` in `common.io.disable_logger` (which is only used by tests)