### PR TITLE
fix #5356 (additions): skip root/conda logger init for cli.python_api

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -9,7 +9,6 @@ import sys
 from ..common.compat import ensure_text_type, on_win, text_type
 from ..exceptions import (ArgumentError, CondaEnvironmentError, CondaSystemExit, CondaValueError,
                           TooFewArgumentsError, TooManyArgumentsError)
-from ..gateways import initialize_logging
 from ..utils import shells
 
 
@@ -108,7 +107,7 @@ def get_activate_path(prefix, shell):
 
 def main():
     from ..base.constants import ROOT_ENV_NAME
-
+    from ..gateways.logging import initialize_logging
     initialize_logging()
 
     sys_argv = tuple(ensure_text_type(s) for s in sys.argv)

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -80,17 +80,17 @@ def generate_parser():
     return p, sub_parsers
 
 
-def init_loggers(context):
+def init_loggers(context=None):
     from ..gateways.logging import initialize_logging, set_all_logger_level, set_verbosity
     initialize_logging()
-    if context.json:
+    if context and context.json:
         # Silence logging info to avoid interfering with JSON output
         for logger in ('print', 'dotupdate', 'stdoutlog', 'stderrlog'):
             getLogger(logger).setLevel(CRITICAL + 1)
 
-    if context.debug:
+    if context and context.debug:
         set_all_logger_level(DEBUG)
-    elif context.verbosity:
+    elif context and context.verbosity:
         set_verbosity(context.verbosity)
         log.debug("verbosity set to %s", context.verbosity)
 
@@ -171,9 +171,8 @@ def main(*args):
                 from ..exceptions import CommandNotFoundError
                 raise CommandNotFoundError(argv1)
         except Exception as e:
-            from ..base.context import context
             from ..exceptions import handle_exception
-            init_loggers(context)
+            init_loggers()
             return handle_exception(e)
 
     from ..exceptions import conda_exception_handler

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -43,7 +43,6 @@ from argparse import SUPPRESS
 from logging import CRITICAL, DEBUG, getLogger
 
 from .. import __version__
-from ..gateways import initialize_logging
 
 log = getLogger(__name__)
 
@@ -82,7 +81,8 @@ def generate_parser():
 
 
 def init_loggers(context):
-    from ..gateways.logging import set_all_logger_level, set_verbosity
+    from ..gateways.logging import initialize_logging, set_all_logger_level, set_verbosity
+    initialize_logging()
     if context.json:
         # Silence logging info to avoid interfering with JSON output
         for logger in ('print', 'dotupdate', 'stdoutlog', 'stderrlog'):
@@ -154,7 +154,6 @@ def _ensure_text_type(value):
 
 
 def main(*args):
-    initialize_logging()
     if not args:
         args = sys.argv
 
@@ -168,11 +167,13 @@ def main(*args):
                 import conda.cli.activate as activate
                 activate.main()
                 return
-            if argv1 in ('activate', 'deactivate'):
+            elif argv1 in ('activate', 'deactivate'):
                 from ..exceptions import CommandNotFoundError
                 raise CommandNotFoundError(argv1)
         except Exception as e:
+            from ..base.context import context
             from ..exceptions import handle_exception
+            init_loggers(context)
             return handle_exception(e)
 
     from ..exceptions import conda_exception_handler

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -11,9 +11,9 @@ from ..cli.main import generate_parser
 from ..common.io import captured, replace_log_streams
 from ..common.path import win_path_double_escape
 from ..exceptions import conda_exception_handler
-from ..gateways import initialize_logging
+from ..gateways import initialize_std_loggers
 
-initialize_logging()
+initialize_std_loggers()
 log = getLogger(__name__)
 
 

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -11,7 +11,7 @@ from ..cli.main import generate_parser
 from ..common.io import captured, replace_log_streams
 from ..common.path import win_path_double_escape
 from ..exceptions import conda_exception_handler
-from ..gateways import initialize_std_loggers
+from ..gateways.logging import initialize_std_loggers
 
 log = getLogger(__name__)
 

--- a/conda/gateways/__init__.py
+++ b/conda/gateways/__init__.py
@@ -25,8 +25,3 @@ Conda modules strictly prohibited from importing ``conda.gateways`` are
 - ``conda.client``
 
 """
-from __future__ import absolute_import, division, print_function
-
-from .logging import initialize_logging, initialize_std_loggers
-initialize_logging = initialize_logging
-initialize_std_loggers = initialize_std_loggers

--- a/conda/gateways/__init__.py
+++ b/conda/gateways/__init__.py
@@ -27,5 +27,6 @@ Conda modules strictly prohibited from importing ``conda.gateways`` are
 """
 from __future__ import absolute_import, division, print_function
 
-from .logging import initialize_logging
-initialize_logging()
+from .logging import initialize_logging, initialize_std_loggers
+initialize_logging = initialize_logging
+initialize_std_loggers = initialize_std_loggers

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -38,7 +38,11 @@ class TokenURLFilter(Filter):
 def initialize_logging():
     initialize_root_logger()
     initialize_conda_logger()
+    initialize_std_loggers()
 
+
+@memoize
+def initialize_std_loggers():
     formatter = Formatter("%(message)s\n")
 
     stdout = getLogger('stdout')

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -34,8 +34,14 @@ class TokenURLFilter(Filter):
         return True
 
 
+# Don't use initialize_logging/initialize_root_logger/initialize_conda_logger in
+# cli.python_api! There we want the user to have control over their logging,
+# e.g., using their own levels, handlers, formatters and propagation settings.
+
 @memoize
 def initialize_logging():
+    # root and 'conda' logger both get their own separate sys.stderr stream handlers.
+    # root gets level ERROR; 'conda' gets level WARN and does not propagate to root.
     initialize_root_logger()
     initialize_conda_logger()
     initialize_std_loggers()
@@ -43,6 +49,10 @@ def initialize_logging():
 
 @memoize
 def initialize_std_loggers():
+    # Set up special loggers 'stdout'/'stderr' which output directly to the corresponding
+    # sys streams, filter token urls and don't propagate.
+    # TODO: To avoid clashes with user loggers when cli.python_api is used, these loggers
+    #       should most likely be renamed to 'conda.stdout'/'conda.stderr' in the future!
     formatter = Formatter("%(message)s\n")
 
     stdout = getLogger('stdout')
@@ -74,8 +84,11 @@ def initialize_conda_logger(level=WARN):
 
 def set_all_logger_level(level=DEBUG):
     formatter = Formatter("%(message)s\n") if level >= INFO else None
+    # root and 'conda' loggers use separate handlers but behave the same wrt level and formatting
     attach_stderr_handler(level, formatter=formatter)
     attach_stderr_handler(level, 'conda', formatter=formatter)
+    # 'requests' loggers get their own handlers so that they always output messages in long format
+    # regardless of the level.
     attach_stderr_handler(level, 'requests')
     attach_stderr_handler(level, 'requests.packages.urllib3')
 

--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -7,7 +7,7 @@ from conda.base.constants import SEARCH_PATH
 from conda.base.context import context
 from conda.cli.conda_argparse import ArgumentParser
 from conda.cli.main import init_loggers
-from conda.gateways import initialize_logging
+from conda.gateways.logging import initialize_logging
 
 try:
     from conda.exceptions import conda_exception_handler


### PR DESCRIPTION
fix #5356
supersedes #5396
targeting 4.3.x

---

#5380 removed the execution of `initialize_logging` on module initialization, which has been necessary.
It also removed the root logger configuration in `initialize_logging` and `set_all_logger_level` which is a behavioral change, since:
- root logger's default level no longer gets set to `ERROR` in `initialize_logging`
- root logger's level and handler/format do not change in `set_all_logger_level` (and thus also in `set_verbosity`). Notice this is a more subtle change since this would only concern log messages from loggers other than `"conda"` and `"requests"` since those get treated separately and don't propagate to the root logger.

This PR restores the old behavior and avoids configuring root/`"conda"` loggers only in `cli.python_api`.
(Also adds some comments describing the current logging configuration in `common.io`.)