### PR TITLE
fix #3200 on 4.3.x by checking variables properly

### DIFF
--- a/shell/activate
+++ b/shell/activate
@@ -66,6 +66,9 @@ _NEW_PART=$("$_CONDA_DIR/conda" ..activate $_SHELL$EXT "$args")
 if (( $? == 0 )); then
     export CONDA_PATH_BACKUP="$PATH"
     # export this to restore it upon deactivation
+    if [[ -z ${PS1+x} ]]; then
+        PS1="";
+    fi;
     export CONDA_PS1_BACKUP="$PS1"
 
     # look if the deactivate script left a placeholder for us

--- a/shell/deactivate
+++ b/shell/deactivate
@@ -52,7 +52,7 @@ instead of 'deactivate'.
     exit 1
 fi
 
-if [[ -z "$CONDA_PATH_BACKUP" ]]; then
+if [[ -z ${CONDA_PATH_BACKUP+x} ]]; then
     if [[ -n $BASH_VERSION ]] && [[ "$(basename "$0" 2> /dev/null)" == "deactivate" ]]; then
         exit 0
     else


### PR DESCRIPTION
This PR checks for the existence of CONDA_PATH_BACKUP and PS1 in the case that set -eu is specified in the bash script for issue #3200. I think the structure of these scripts are changed in the upcoming 4.4 and 5.0 but this fixes it for the current version. 