### PR TITLE
resolve #5411 add 'conda config --write-default'

### DIFF
--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -9,7 +9,7 @@ from argparse import SUPPRESS
 import collections
 import json
 import os
-from os.path import join, isfile
+from os.path import isfile, join
 import sys
 from textwrap import wrap
 
@@ -271,9 +271,9 @@ def parameter_description_builder(name):
 
 def execute_config(args, parser):
     try:
-        from cytoolz.itertoolz import chain, groupby
+        from cytoolz.itertoolz import concat, groupby
     except ImportError:  # pragma: no cover
-        from .._vendor.toolz.itertoolz import chain, groupby  # NOQA
+        from .._vendor.toolz.itertoolz import concat, groupby  # NOQA
     from .._vendor.auxlib.entity import EntityEncoder
 
     json_warnings = []
@@ -319,8 +319,8 @@ def execute_config(args, parser):
                              sort_keys=True, indent=2, separators=(',', ': '),
                              cls=EntityEncoder))
         else:
-            print('\n'.join(chain.from_iterable(parameter_description_builder(name)
-                                                for name in paramater_names)))
+            print('\n'.join(concat(parameter_description_builder(name)
+                                   for name in paramater_names)))
         return
 
     if args.write_default:
@@ -336,8 +336,8 @@ def execute_config(args, parser):
 
         with open(user_rc_path, 'w') as fh:
             paramater_names = context.list_parameters()
-            fh.write('\n'.join(chain(parameter_description_builder(name)
-                                     for name in paramater_names)))
+            fh.write('\n'.join(concat(parameter_description_builder(name)
+                                      for name in paramater_names)))
         return
 
     if args.validate:

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -288,26 +288,33 @@ def execute_config(args, parser):
                 element_types = details['element_types']
                 default_value_str = json.dumps(details['default_value'], cls=EntityEncoder)
 
-                builder.extend(yaml_dump({name: json.loads(default_value_str)}).strip().split('\n'))
+                # builder.extend(yaml_dump({name: json.loads(default_value_str)}).strip().split('\n'))
 
 
                 if details['parameter_type'] == 'primitive':
-                    builder[0] += "  # (%s)" % ', '.join(sorted(set(et for et in element_types)))
+                    builder.append("%s (%s)" % (name, ', '.join(sorted(set(et for et in element_types)))))
                 else:
-                    builder[0] += "  # (%s: %s)" % (details['parameter_type'], ', '.join(sorted(set(et for et in element_types))))
+                    builder.append("%s (%s: %s)" % (name, details['parameter_type'], ', '.join(sorted(set(et for et in element_types)))))
 
-                builder.extend(' ' + line for line in wrap(details['description'], 70))
 
                 if aliases:
-                    builder.append(" aliases: %s" % ', '.join(aliases))
+                    builder.append("  aliases: %s" % ', '.join(aliases))
                 if string_delimiter:
-                    builder.append(" string delimiter: '%s'" % string_delimiter)
+                    builder.append("  string delimiter: '%s'" % string_delimiter)
+
+                builder.extend('  ' + line for line in wrap(details['description'], 70))
+
+                builder.append('')
+
+                builder.extend(yaml_dump({name: json.loads(default_value_str)}).strip().split('\n'))
+
                 # print('\n  '.join(wrap('  ' + details['description'], 70)))
 
-                sys.stdout.write('# ')
-                print('\n# '.join(builder))
+                # sys.stdout.write('# ')
+                print('\n'.join('# ' + line for line in builder))
                 print()
-                
+                print()
+
         return
 
     # if args.write_default:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -610,7 +610,7 @@ class IntegrationTests(TestCase):
             stdout, stderr = run_command(Commands.CONFIG, prefix, "--describe")
             assert not stderr
             for param_name in context.list_parameters():
-                assert re.search(r'^%s \(' % param_name, stdout, re.MULTILINE)
+                assert re.search(r'^# %s \(' % param_name, stdout, re.MULTILINE)
 
             stdout, stderr = run_command(Commands.CONFIG, prefix, "--describe --json")
             assert not stderr
@@ -628,6 +628,19 @@ class IntegrationTests(TestCase):
                 json_obj = json.loads(stdout.strip())
                 assert json_obj['envvars'] == {'quiet': True}
                 assert json_obj['cmd_line'] == {'json': True}
+
+            run_command(Commands.CONFIG, prefix, "--set changeps1 false")
+            with pytest.raises(CondaError):
+                run_command(Commands.CONFIG, prefix, "--write-default")
+
+            rm_rf(join(prefix, 'condarc'))
+            run_command(Commands.CONFIG, prefix, "--write-default")
+
+            with open(join(prefix, 'condarc')) as fh:
+                data = fh.read()
+
+            for param_name in context.list_parameters():
+                assert re.search(r'^# %s \(' % param_name, data, re.MULTILINE)
 
     def test_conda_config_validate(self):
         with make_temp_env() as prefix:


### PR DESCRIPTION
resolve #5411 

Adds a command `conda config --write-defaults` that creates a default, descriptive `~/.condarc` file.  The contents of the file are identical to `conda config --describe`.