### PR TITLE
fix scrambled URL of non-alias channel with token

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -116,8 +116,14 @@ def _read_channel_configuration(scheme, host, port, path):
         _scheme, _auth, _token = 'file', None, None
         return location, name, _scheme, _auth, _token
 
-    # Step 7. fall through to host:port as channel_location and path as channel_name
-    return (Url(host=host, port=port).url.rstrip('/'), path.strip('/') or None,
+    # Step 7. fall through to host:port/path as channel_location and path as channel_name
+    path_parts = path.rsplit('/', 1)
+    if len(path_parts) == 2:
+        path, name = path_parts
+    else:
+        path, name = None, path
+
+    return (Url(host=host, port=port, path=path).url.rstrip('/'), name.strip('/') or None,
             scheme or None, None, None)
 
 

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -228,6 +228,18 @@ class AnacondaServerChannelTests(TestCase):
             "https://10.2.3.4:8080/conda/t/x1029384756/bioconda/noarch",
         ]
 
+    def test_token_in_custom_channel(self):
+        channel = Channel("https://10.2.8.9:8080/conda/t/tk-987-321/bioconda")
+        assert channel.urls() == [
+            "https://10.2.8.9:8080/conda/bioconda/%s" % self.platform,
+            "https://10.2.8.9:8080/conda/bioconda/noarch",
+        ]
+
+        assert channel.urls(with_credentials=True) == [
+            "https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/%s" % self.platform,
+            "https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/noarch",
+        ]
+
 
 class CustomConfigChannelTests(TestCase):
     """


### PR DESCRIPTION
@kalefranz 

The URL parsing would swap around locations of URL parts if passed a `/t/<TOKEN>` URL that was not the `channel_alias`.

Patch includes a test that reproduces the problem, and a possible fix.