### PR TITLE
fix #5466 scrambled URL of non-alias channel with token #5456

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -16,10 +16,10 @@ from ..common.url import (Url, has_scheme, is_url, join_url, path_to_url,
 
 try:
     from cytoolz.functoolz import excepts
-    from cytoolz.itertoolz import concatv, topk
+    from cytoolz.itertoolz import concatv, drop
 except ImportError:  # pragma: no cover
     from .._vendor.toolz.functoolz import excepts  # NOQA
-    from .._vendor.toolz.itertoolz import concatv, topk  # NOQA
+    from .._vendor.toolz.itertoolz import concatv, drop  # NOQA
 
 log = getLogger(__name__)
 
@@ -419,14 +419,14 @@ def _read_channel_configuration(scheme, host, port, path):
         _scheme, _auth, _token = 'file', None, None
         return location, name, _scheme, _auth, _token
 
-    # Step 7. fall through to host:port/path as channel_location and path as channel_name
-    path_parts = path.rsplit('/', 1)
-    if len(path_parts) == 2:
-        path, name = path_parts
-    else:
-        path, name = None, path
-
-    return (Url(host=host, port=port, path=path).url.rstrip('/'), name.strip('/') or None,
+    # Step 7. fall through to host:port as channel_location and path as channel_name
+    #  but bump the first token of paths starting with /conda for compatibility with
+    #  Anaconda Enterprise Repository software.
+    bump = None
+    path_parts = path.strip('/').split('/')
+    if path_parts and path_parts[0] == 'conda':
+        bump, path = 'conda', '/'.join(drop(1, path_parts))
+    return (Url(host=host, port=port, path=bump).url.rstrip('/'), path.strip('/') or None,
             scheme or None, None, None)
 
 

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -419,8 +419,14 @@ def _read_channel_configuration(scheme, host, port, path):
         _scheme, _auth, _token = 'file', None, None
         return location, name, _scheme, _auth, _token
 
-    # Step 7. fall through to host:port as channel_location and path as channel_name
-    return (Url(host=host, port=port).url.rstrip('/'), path.strip('/') or None,
+    # Step 7. fall through to host:port/path as channel_location and path as channel_name
+    path_parts = path.rsplit('/', 1)
+    if len(path_parts) == 2:
+        path, name = path_parts
+    else:
+        path, name = None, path
+
+    return (Url(host=host, port=port, path=path).url.rstrip('/'), name.strip('/') or None,
             scheme or None, None, None)
 
 

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -20,7 +20,6 @@ from conda.models.channel import Channel, prioritize_channels
 from conda.utils import on_win
 from logging import getLogger
 from unittest import TestCase
-import conda.models.channel
 
 try:
     from unittest.mock import patch
@@ -249,12 +248,25 @@ class AnacondaServerChannelTests(TestCase):
         ]
 
     def test_token_in_custom_channel(self):
+        channel = Channel("https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/label/dev")
+        assert channel.name == "bioconda/label/dev"
+        assert channel.location == "10.2.8.9:8080/conda"
+        assert channel.urls() == [
+            "https://10.2.8.9:8080/conda/bioconda/label/dev/%s" % self.platform,
+            "https://10.2.8.9:8080/conda/bioconda/label/dev/noarch",
+        ]
+        assert channel.urls(with_credentials=True) == [
+            "https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/label/dev/%s" % self.platform,
+            "https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/label/dev/noarch",
+        ]
+
         channel = Channel("https://10.2.8.9:8080/conda/t/tk-987-321/bioconda")
+        assert channel.name == "bioconda"
+        assert channel.location == "10.2.8.9:8080/conda"
         assert channel.urls() == [
             "https://10.2.8.9:8080/conda/bioconda/%s" % self.platform,
             "https://10.2.8.9:8080/conda/bioconda/noarch",
         ]
-
         assert channel.urls(with_credentials=True) == [
             "https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/%s" % self.platform,
             "https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/noarch",

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -248,6 +248,18 @@ class AnacondaServerChannelTests(TestCase):
             "https://10.2.3.4:8080/conda/t/x1029384756/bioconda/noarch",
         ]
 
+    def test_token_in_custom_channel(self):
+        channel = Channel("https://10.2.8.9:8080/conda/t/tk-987-321/bioconda")
+        assert channel.urls() == [
+            "https://10.2.8.9:8080/conda/bioconda/%s" % self.platform,
+            "https://10.2.8.9:8080/conda/bioconda/noarch",
+        ]
+
+        assert channel.urls(with_credentials=True) == [
+            "https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/%s" % self.platform,
+            "https://10.2.8.9:8080/conda/t/tk-987-321/bioconda/noarch",
+        ]
+
 
 class CustomConfigChannelTests(TestCase):
     """


### PR DESCRIPTION
resolves #5466
supersedes #5456
target is 4.4.x

----

The URL parsing would swap around locations of URL parts if passed a `/t/<TOKEN>` URL that was not the `channel_alias`.

Patch includes a test that reproduces the problem, and a possible fix.