### PR TITLE
resolve #5468 remove --alt-hint from CLI API

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -138,11 +138,6 @@ def add_parser_create_install_update(p):
     add_parser_copy(p)
     add_parser_insecure(p)
     p.add_argument(
-        "--alt-hint",
-        action="store_true",
-        default=False,
-        help="Use an alternate algorithm to generate an unsatisfiability hint.")
-    p.add_argument(
         "--update-dependencies", "--update-deps",
         action="store_true",
         dest="update_deps",

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -249,7 +249,7 @@ def install(args, parser, command='install'):
                 unlink_link_transaction = get_install_transaction(
                     prefix, index, specs, force=args.force, only_names=only_names,
                     pinned=context.respect_pinned, always_copy=context.always_copy,
-                    minimal_hint=args.alt_hint, update_deps=context.update_dependencies,
+                    update_deps=context.update_dependencies,
                     channel_priority_map=_channel_priority_map, is_update=isupdate)
                 progressive_fetch_extract = unlink_link_transaction.get_pfe()
     except NoPackagesFoundError as e:

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -225,7 +225,7 @@ def get_resolve_object(index, prefix):
 
 
 def get_install_transaction(prefix, index, spec_strs, force=False, only_names=None,
-                            always_copy=False, pinned=True, minimal_hint=False, update_deps=True,
+                            always_copy=False, pinned=True, update_deps=True,
                             prune=False, channel_priority_map=None, is_update=False):
     # type: (str, Dict[Dist, Record], List[str], bool, Option[List[str]], bool, bool, bool,
     #        bool, bool, bool, Dict[str, Sequence[str, int]]) -> List[Dict[weird]]
@@ -259,7 +259,7 @@ def get_install_transaction(prefix, index, spec_strs, force=False, only_names=No
         if len(env_add_map) == len(registered_packages) == 0:
             # short-circuit the rest of this logic
             return get_install_transaction_single(prefix, index, spec_strs, force, only_names,
-                                                  always_copy, pinned, minimal_hint, update_deps,
+                                                  always_copy, pinned, update_deps,
                                                   prune, channel_priority_map, is_update)
 
         root_specs_to_remove = set(MatchSpec(s.name) for s in concat(itervalues(env_add_map)))
@@ -332,14 +332,13 @@ def get_install_transaction(prefix, index, spec_strs, force=False, only_names=No
     else:
         # disregard any requested preferred env
         return get_install_transaction_single(prefix, index, spec_strs, force, only_names,
-                                              always_copy, pinned, minimal_hint, update_deps,
+                                              always_copy, pinned, update_deps,
                                               prune, channel_priority_map, is_update)
 
 
 def get_install_transaction_single(prefix, index, specs, force=False, only_names=None,
-                                   always_copy=False, pinned=True, minimal_hint=False,
-                                   update_deps=True, prune=False, channel_priority_map=None,
-                                   is_update=False):
+                                   always_copy=False, pinned=True, update_deps=True,
+                                   prune=False, channel_priority_map=None, is_update=False):
     specs = tuple(MatchSpec(s) for s in specs)
     r = get_resolve_object(index.copy(), prefix)
     unlink_dists, link_dists = solve_for_actions(prefix, r, specs_to_add=specs, prune=prune)

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -439,11 +439,11 @@ def add_defaults_to_specs(r, linked, specs, update=False, prefix=None):
 
 
 def install_actions(prefix, index, specs, force=False, only_names=None, always_copy=False,
-                    pinned=True, minimal_hint=False, update_deps=True, prune=False,
+                    pinned=True, update_deps=True, prune=False,
                     channel_priority_map=None, is_update=False):  # pragma: no cover
     # this is for conda-build
     txn = get_install_transaction_single(prefix, index, specs, force, only_names, always_copy,
-                                         pinned, minimal_hint, update_deps, prune,
+                                         pinned, update_deps, prune,
                                          channel_priority_map, is_update)
     prefix_setup = txn.prefix_setups[prefix]
     actions = get_blank_actions(prefix)


### PR DESCRIPTION
resolves #5468
supersedes #5427
target is 4.4.x

----

I couldn't figure out what `--alt-hint` did, so I looked at the source code only to find that it doesn't do anything. Now I'm removing the option so no one else wastes their time the same way.