### PR TITLE
#5210 followup

### DIFF
--- a/shell/Library/bin/conda.bat
+++ b/shell/Library/bin/conda.bat
@@ -17,11 +17,11 @@
 @CALL %_CONDA_EXE% %*
 
 @REM This block should really be the equivalent of
-@REM   if "install" in %* GOTO :DO_DEACTIVATE
-@IF "%1"=="install" GOTO :DO_DEACTIVATE
-@IF "%1"=="update" GOTO :DO_DEACTIVATE
-@IF "%1"=="remove" GOTO :DO_DEACTIVATE
-@IF "%1"=="uninstall" GOTO :DO_DEACTIVATE
+@REM   if "install" in %* GOTO :DO_REACTIVATE
+@IF "%1"=="install" GOTO :DO_REACTIVATE
+@IF "%1"=="update" GOTO :DO_REACTIVATE
+@IF "%1"=="remove" GOTO :DO_REACTIVATE
+@IF "%1"=="uninstall" GOTO :DO_REACTIVATE
 
 @GOTO :End
 

--- a/shell/Scripts/activate.bat
+++ b/shell/Scripts/activate.bat
@@ -1,1 +1,1 @@
-@CALL %~dp0..\Library\bin\conda.bat activate "%~1" "%~2"
+@CALL "%~dp0..\Library\bin\conda.bat" activate "%~1" "%~2"

--- a/shell/Scripts/activate.bat
+++ b/shell/Scripts/activate.bat
@@ -1,1 +1,1 @@
-@CALL "%~dp0..\Library\bin\conda.bat" activate "%~1" "%~2"
+@CALL "%~dp0..\Library\bin\conda.bat" activate %*

--- a/shell/Scripts/deactivate.bat
+++ b/shell/Scripts/deactivate.bat
@@ -1,1 +1,1 @@
-@CALL "%~dp0..\Library\bin\conda.bat" deactivate
+@CALL "%~dp0..\Library\bin\conda.bat" deactivate "%~1"

--- a/shell/Scripts/deactivate.bat
+++ b/shell/Scripts/deactivate.bat
@@ -1,1 +1,1 @@
-@CALL %~dp0..\Library\bin\conda.bat deactivate
+@CALL "%~dp0..\Library\bin\conda.bat" deactivate

--- a/shell/Scripts/deactivate.bat
+++ b/shell/Scripts/deactivate.bat
@@ -1,1 +1,1 @@
-@CALL "%~dp0..\Library\bin\conda.bat" deactivate "%~1"
+@CALL "%~dp0..\Library\bin\conda.bat" deactivate %*


### PR DESCRIPTION
Congrats for the progress in #5210!
These are some minor modification on the `.bat` files.
- added quotes since `%~dp0` can contain spaces and stuff
- reactivate instead of deactivate environments for install commands
- added argument passing to deactivate so that it behaves like `conda deactivate`, i.e., let `conda.activate` complain if there are additional arguments
- made activate/deactivate pass along all arguments to make them behave more like `conda.bat (de)activate`
