### PR TITLE
update MatchSpec docstring

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -21,6 +21,7 @@ try:
 except ImportError:  # pragma: no cover
     from .._vendor.toolz.itertoolz import concat  # NOQA
 
+
 class MatchSpecType(type):
 
     def __call__(cls, spec_arg=None, **kwargs):
@@ -68,25 +69,73 @@ class MatchSpecType(type):
 @with_metaclass(MatchSpecType)
 class MatchSpec(object):
     """
-    The easiest way to build `MatchSpec` objects that match to arbitrary fields is to
-    use a keyword syntax.  For instance,
-        MatchSpec(name='foo', build='py2*', channel='conda-forge')
-    matches any package named `foo` built with a Python 2 build string in the
-    `conda-forge` channel.  Available keywords to be matched against are fields of
-    the `IndexRecord` model object.
-    Strings are interpreted using the following conventions:
+    :class:`MatchSpec` is, fundamentally, a query language for conda packages.  Any of the fields
+    that comprise a :class:`PackageRecord` can be used to compose a :class:`MatchSpec`.
+
+    :class:`MatchSpec` can be composed with keyword arguments, where keys are any of the
+    attributes of :class:`PackageRecord`.  Values for keyword arguments are the exact values the
+    attribute should match against.  Many fields can also be matched against non-exact values--by
+    including wildcard `*` and `>`/`<` ranges--where supported.  Any non-specified field is
+    the equivalent of a full wildcard match.
+
+    :class:`MatchSpec` can also be composed using a single positional argument, with optional
+    keyword arguments.  Keyword arguments also override any conflicting information provided in
+    the positional argument.  The positional argument can be either an existing :class:`MatchSpec`
+    instance or a string.  Conda has historically had several string representations for equivalent
+    :class:`MatchSpec`s.  This :class:`MatchSpec` should accept any existing valid spec string, and
+    correctly compose a :class:`MatchSpec` instance.
+
+    A series of rules are now followed for creating the canonical string representation of a
+    :class:`MatchSpec` instance.  The canonical string representation can generically be
+    represented by
+
+        (channel(/subdir):(namespace):)name(version(build))[key1=value1,key2=value2]
+
+    where `()` indicate optional fields.  The rules for constructing a canonical string
+    representation are:
+
+    1. `name` (i.e. "package name") is required, but its value can be '*'.  Its position is always
+       outside the key-value brackets.
+    2. If `version` is an exact version, it goes outside the key-value brackets and is prepended
+       by `==`. If `version` is a "fuzzy" value (e.g. `1.11.*`), it goes outside the key-value
+       brackets with the `.*` left off and is prepended by `=`.  Otherwise `version` is included
+       inside key-value brackets.
+    3. If `version` is an exact version, and `build` is an exact value, `build` goes outside
+       key-value brackets prepended by a `=`.  Otherwise, `build` goes inside key-value brackets.
+       `build_string` is an alias for `build`.
+    4. The `namespace` position is being held for a future conda feature.
+    5. If `channel` is included and is an exact value, a `::` separator is ued between `channel`
+       and `name`.  `channel` can either be a canonical channel name or a channel url.  In the
+       canonical string representation, the canonical channel name will always be used.
+    6. If `channel` is an exact value and `subdir` is an exact value, `subdir` is appended to
+       `channel` with a `/` separator.  Otherwise, `subdir` is included in the key-value brackets.
+    7. Key-value brackets can be delimited by comma, space, or comma+space.  Value can optionally
+       be wrapped in single or double quotes, but must be wrapped if `value` contains a comma,
+       space, or equal sign.  The canonical format uses comma delimiters and single quotes.
+    8. When constructing a :class:`MatchSpec` instance from a string, any key-value pair given
+       inside the key-value brackets overrides any matching parameter given outside the brackets.
+
+    When :class:`MatchSpec` attribute values are simple strings, the are interpreted using the
+    following conventions:
+
       - If the string begins with `^` and ends with `$`, it is converted to a regex.
       - If the string contains an asterisk (`*`), it is transformed from a glob to a regex.
       - Otherwise, an exact match to the string is sought.
-    The `.match()` method accepts an `IndexRecord` or dictionary, and matches can pull
-    from any field in that record.
-    Great pain has been taken to preserve back-compatibility with the standard
-    `name version build` syntax. But strictly speaking it is not necessary. Now, the
-    following are all equivalent:
-      - `MatchSpec('foo 1.0 py27_0', optional=True)`
-      - `MatchSpec("* [name='foo',version='1.0',build='py27_0']", optional=True)`
-      - `MatchSpec("foo[version='1.0',optional,build='py27_0']")`
-      - `MatchSpec(name='foo', optional=True, version='1.0', build='py27_0')`
+
+
+    Examples:
+
+        >>> str(MatchSpec(name='foo', build='py2*', channel='conda-forge'))
+        'conda-forge::foo[build=py2*]'
+        >>> str(MatchSpec('foo 1.0 py27_0'))
+        'foo==1.0=py27_0'
+        >>> str(MatchSpec('foo=1.0=py27_0'))
+        'foo==1.0=py27_0'
+        >>> str(MatchSpec('conda-forge::foo[version=1.0.*]'))
+        'conda-forge::foo=1.0'
+        >>> str(MatchSpec('conda-forge/linux-64::foo>=1.0'))
+        "conda-forge/linux-64::foo[version='>=1.0']"
+
     """
 
     FIELD_NAMES = (
@@ -113,12 +162,6 @@ class MatchSpec(object):
         v = self._match_components.get(field_name)
         return v and v.raw_value
 
-    def _is_simple(self):
-        return len(self._match_components) == 1 and self.get_exact_value('name') is not None
-
-    def _is_single(self):
-        return len(self._match_components) == 1
-
     def match(self, rec):
         """f
         Accepts an `IndexRecord` or a dict, and matches can pull from any field
@@ -129,6 +172,12 @@ class MatchSpec(object):
             if not (v.match(val) if hasattr(v, 'match') else v == val):
                 return False
         return True
+
+    def _is_simple(self):
+        return len(self._match_components) == 1 and self.get_exact_value('name') is not None
+
+    def _is_single(self):
+        return len(self._match_components) == 1
 
     def _to_filename_do_not_use(self):
         # WARNING: this is potentially unreliable and use should probably be limited

--- a/tests/conda_env/test_env.py
+++ b/tests/conda_env/test_env.py
@@ -76,8 +76,8 @@ class EnvironmentTestCase(unittest.TestCase):
 
     def test_builds_spec_from_line_raw_dependency(self):
         # TODO Refactor this inside conda to not be a raw string
-        e = env.Environment(dependencies=['nltk=3.0.0=np18py27'])
-        expected = OrderedDict([('conda', ['nltk==3.0.0[build=np18py27]'])])
+        e = env.Environment(dependencies=['nltk=3.0.0=np18py27_0'])
+        expected = OrderedDict([('conda', ['nltk==3.0.0=np18py27_0'])])
         self.assertEqual(e.dependencies, expected)
 
     def test_args_are_wildcarded(self):

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -12,7 +12,7 @@ from conda.common.url import path_to_url
 from conda.exceptions import CondaValueError
 from conda.models.channel import Channel
 from conda.models.dist import Dist
-from conda.models.index_record import IndexRecord, RepodataRecord
+from conda.models.index_record import IndexRecord, PackageRecord
 from conda.models.match_spec import ChannelMatch, MatchSpec, _parse_spec_str
 from conda.models.version import VersionSpec
 
@@ -198,13 +198,25 @@ class MatchSpecTests(TestCase):
         assert m("numpy[build=py3*_2, track_features=mkl]") == "numpy[build=py3*_2,track_features=mkl]"
         assert m("numpy[build=py3*_2, track_features='mkl debug']") == "numpy[build=py3*_2,track_features='debug mkl']"
         assert m("numpy[track_features='mkl,debug', build=py3*_2]") == "numpy[build=py3*_2,track_features='debug mkl']"
+        assert m("numpy[track_features='mkl,debug' build=py3*_2]") == "numpy[build=py3*_2,track_features='debug mkl']"
+
+        assert m("numpy=1.10=py38_0") == "numpy==1.10=py38_0"
+        assert m("numpy==1.10=py38_0") == "numpy==1.10=py38_0"
+        assert m("numpy[version=1.10 build=py38_0]") == "numpy==1.10=py38_0"
+
+        # # a full, exact spec looks like 'defaults/linux-64::numpy==1.8=py26_0'
+        # # can we take an old dist str and reliably parse it with MatchSpec?
+        # assert m("numpy-1.10-py38_0") == "numpy==1.10=py38_0"
+        # assert m("numpy-1.10-py38_0[channel=defaults]") == "defaults::numpy==1.10=py38_0"
+        # assert m("*/win-32::numpy-1.10-py38_0[channel=defaults]") == "defaults/win-32::numpy==1.10=py38_0"
 
     def test_tarball_match_specs(self):
         def m(string):
             return text_type(MatchSpec(string))
 
         url = "https://conda.anaconda.org/conda-canary/linux-64/conda-4.3.21.post699+1dab973-py36h4a561cd_0.tar.bz2"
-        assert m(url) == "conda-canary/linux-64::conda==4.3.21.post699+1dab973[build=py36h4a561cd_0]"
+        assert m(url) == "conda-canary/linux-64::conda==4.3.21.post699+1dab973=py36h4a561cd_0"
+        assert m("conda-canary/linux-64::conda==4.3.21.post699+1dab973=py36h4a561cd_0") == "conda-canary/linux-64::conda==4.3.21.post699+1dab973=py36h4a561cd_0"
 
     def test_exact_values(self):
         assert MatchSpec("*").get_exact_value('name') is None
@@ -277,17 +289,17 @@ class MatchSpecTests(TestCase):
         assert p.match(Dist(channel='defaults', dist_name='python-3.5.1-0', name='python',
                             version='3.5.1', build_string='0', build_number=0, base_url=None,
                             platform=None))
-        assert p.match(RepodataRecord(name='python', version='3.5.1', build='0', build_number=0,
-                                      depends=('openssl 1.0.2*', 'readline 6.2*', 'sqlite',
+        assert p.match(PackageRecord(name='python', version='3.5.1', build='0', build_number=0,
+                                     depends=('openssl 1.0.2*', 'readline 6.2*', 'sqlite',
                                                'tk 8.5*', 'xz 5.0.5', 'zlib 1.2*', 'pip'),
-                                      channel=Channel(scheme='https', auth=None,
+                                     channel=Channel(scheme='https', auth=None,
                                                       location='repo.continuum.io', token=None,
                                                       name='pkgs/free', platform='osx-64',
                                                       package_filename=None),
-                                      subdir='osx-64', fn='python-3.5.1-0.tar.bz2',
-                                      md5='a813bc0a32691ab3331ac9f37125164c', size=14678857,
-                                      priority=0,
-                                      url='https://repo.continuum.io/pkgs/free/osx-64/python-3.5.1-0.tar.bz2'))
+                                     subdir='osx-64', fn='python-3.5.1-0.tar.bz2',
+                                     md5='a813bc0a32691ab3331ac9f37125164c', size=14678857,
+                                     priority=0,
+                                     url='https://repo.continuum.io/pkgs/free/osx-64/python-3.5.1-0.tar.bz2'))
 
 
     def test_index_record(self):
@@ -334,7 +346,7 @@ class TestArg2Spec(TestCase):
         assert arg2spec('ipython=0.13.2') == 'ipython=0.13.2'
         assert arg2spec('ipython=0.13.0') == 'ipython=0.13.0'
         assert arg2spec('ipython==0.13.0') == 'ipython==0.13.0'
-        assert arg2spec('foo=1.3.0=3') == 'foo==1.3.0[build=3]'
+        assert arg2spec('foo=1.3.0=3') == 'foo==1.3.0=3'
 
     def test_pip_style(self):
         assert arg2spec('foo>=1.3') == "foo[version='>=1.3']"
@@ -404,6 +416,26 @@ class SpecStrParsingTests(TestCase):
             "build": "py36h4a561cd_0",
             "fn": "conda-4.3.21.post699+1dab973-py36h4a561cd_0.tar.bz2",
         }
+
+    # def test_parse_spec_str_legacy_dist_format(self):
+    #     assert _parse_spec_str("numpy-1.8-py26_0") == {
+    #         "name": "numpy",
+    #         "version": "1.8",
+    #         "build": "py26_0",
+    #     }
+    #     assert _parse_spec_str("numpy-1.8-py26_0[channel=defaults]") == {
+    #         "channel": "defaults",
+    #         "name": "numpy",
+    #         "version": "1.8",
+    #         "build": "py26_0",
+    #     }
+    #     assert _parse_spec_str("*/win-32::numpy-1.8-py26_0[channel=defaults]") == {
+    #         "channel": "defaults",
+    #         "subdir": "win-32",
+    #         "name": "numpy",
+    #         "version": "1.8",
+    #         "build": "py26_0",
+    #     }
 
     def test_parse_spec_str_no_brackets(self):
         assert _parse_spec_str("numpy") == {
@@ -515,4 +547,3 @@ class SpecStrParsingTests(TestCase):
     def test_parse_errors(self):
         with pytest.raises(CondaValueError):
             _parse_spec_str('!xyz 1.3')
-


### PR DESCRIPTION
The MatchSpec docstring is now

```
:class:`MatchSpec` is, fundamentally, a query language for conda packages.  Any of the fields
that comprise a :class:`PackageRecord` can be used to compose a :class:`MatchSpec`.

:class:`MatchSpec` can be composed with keyword arguments, where keys are any of the
attributes of :class:`PackageRecord`.  Values for keyword arguments are the exact values the
attribute should match against.  Many fields can also be matched against non-exact values--by
including wildcard `*` and `>`/`<` ranges--where supported.  Any non-specified field is
the equivalent of a full wildcard match.

:class:`MatchSpec` can also be composed using a single positional argument, with optional
keyword arguments.  Keyword arguments also override any conflicting information provided in
the positional argument.  The positional argument can be either an existing :class:`MatchSpec`
instance or a string.  Conda has historically had several string representations for equivalent
:class:`MatchSpec`s.  This :class:`MatchSpec` should accept any existing valid spec string, and
correctly compose a :class:`MatchSpec` instance.

A series of rules are now followed for creating the canonical string representation of a
:class:`MatchSpec` instance.  The canonical string representation can generically be
represented by

    (channel(/subdir):(namespace):)name(version(build))[key1=value1,key2=value2]

where `()` indicate optional fields.  The rules for constructing a canonical string
representation are:

1. `name` (i.e. "package name") is required, but its value can be '*'.  Its position is always
   outside the key-value brackets.
2. If `version` is an exact version, it goes outside the key-value brackets and is prepended
   by `==`. If `version` is a "fuzzy" value (e.g. `1.11.*`), it goes outside the key-value
   brackets with the `.*` left off and is prepended by `=`.  Otherwise `version` is included
   inside key-value brackets.
3. If `version` is an exact version, and `build` is an exact value, `build` goes outside
   key-value brackets prepended by a `=`.  Otherwise, `build` goes inside key-value brackets.
   `build_string` is an alias for `build`.
4. The `namespace` position is being held for a future conda feature.
5. If `channel` is included and is an exact value, a `::` separator is ued between `channel`
   and `name`.  `channel` can either be a canonical channel name or a channel url.  In the
   canonical string representation, the canonical channel name will always be used.
6. If `channel` is an exact value and `subdir` is an exact value, `subdir` is appended to
   `channel` with a `/` separator.  Otherwise, `subdir` is included in the key-value brackets.
7. Key-value brackets can be delimited by comma, space, or comma+space.  Value can optionally
   be wrapped in single or double quotes, but must be wrapped if `value` contains a comma,
   space, or equal sign.  The canonical format uses comma delimiters and single quotes.
8. When constructing a :class:`MatchSpec` instance from a string, any key-value pair given
   inside the key-value brackets overrides any matching parameter given outside the brackets.

When :class:`MatchSpec` attribute values are simple strings, the are interpreted using the
following conventions:

  - If the string begins with `^` and ends with `$`, it is converted to a regex.
  - If the string contains an asterisk (`*`), it is transformed from a glob to a regex.
  - Otherwise, an exact match to the string is sought.

Examples:

    >>> str(MatchSpec(name='foo', build='py2*', channel='conda-forge'))
    'conda-forge::foo[build=py2*]'
    >>> str(MatchSpec('foo 1.0 py27_0'))
    'foo==1.0=py27_0'
    >>> str(MatchSpec('foo=1.0=py27_0'))
    'foo==1.0=py27_0'
    >>> str(MatchSpec('conda-forge::foo[version=1.0.*]'))
    'conda-forge::foo=1.0'
    >>> str(MatchSpec('conda-forge/linux-64::foo>=1.0'))
    "conda-forge/linux-64::foo[version='>=1.0']"
    >>> str(MatchSpec('*/linux-64::foo>=1.0'))
    "foo[subdir=linux-64,version='>=1.0']"
```

More examples of the "canonical MatchSpec string form" to review are at https://github.com/kalefranz/conda/blob/cdaca60211d2ff79cf29f51de251a9946d63ad09/tests/models/test_match_spec.py#L151-L203

