### PR TITLE
resolve #5530 add ability for users to choose to post unexpected errors to core maintainers

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -265,6 +265,13 @@ class Activator(object):
     def build_deactivate(self):
         # query environment
         old_conda_shlvl = int(os.getenv('CONDA_SHLVL', 0))
+        if old_conda_shlvl <= 0:
+            return {
+                'unset_vars': (),
+                'set_vars': {},
+                'deactivate_scripts': (),
+                'activate_scripts': (),
+            }
         old_conda_prefix = os.environ['CONDA_PREFIX']
         deactivate_scripts = self._get_deactivate_scripts(old_conda_prefix)
 

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -44,6 +44,7 @@ SEARCH_PATH = (
 
 DEFAULT_CHANNEL_ALIAS = 'https://conda.anaconda.org'
 CONDA_HOMEPAGE_URL = 'https://conda.io'
+ERROR_UPLOAD_URL = 'https://conda.io/conda-post/unexpected-error'
 DEFAULTS_CHANNEL_NAME = 'defaults'
 
 PLATFORM_DIRECTORIES = ("linux-64",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -152,7 +152,7 @@ class Context(Configuration):
                                         validation=default_python_validation)
     always_softlink = PrimitiveParameter(False, aliases=('softlink',))
     always_copy = PrimitiveParameter(False, aliases=('copy',))
-    always_yes = PrimitiveParameter(False, aliases=('yes',))
+    always_yes = PrimitiveParameter(None, aliases=('yes',), element_type=(bool, NoneType))
     channel_priority = PrimitiveParameter(True)
     debug = PrimitiveParameter(False)
     dry_run = PrimitiveParameter(False)
@@ -163,6 +163,7 @@ class Context(Configuration):
     only_dependencies = PrimitiveParameter(False, aliases=('only_deps',))
     quiet = PrimitiveParameter(False)
     prune = PrimitiveParameter(False)
+    report_errors = PrimitiveParameter(None, element_type=(bool, NoneType))
     respect_pinned = PrimitiveParameter(True)
     shortcuts = PrimitiveParameter(True)
     show_channel_urls = PrimitiveParameter(None, element_type=(bool, NoneType))
@@ -691,6 +692,11 @@ def get_help_dict():
             Once conda has connected to a remote resource and sent an HTTP request, the
             read timeout is the number of seconds conda will wait for the server to send
             a response.
+            """),
+        'report_errors': dals("""
+            Opt in, or opt out, of automatic error reporting to core maintainers. Error
+            reports are anonymous, with only the error stack trace and information given
+            by `conda info` being sent.
             """),
         'rollback_enabled': dals("""
             Should any error occur during an unlink/link transaction, revert any disk

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -462,7 +462,7 @@ class Context(Configuration):
             argparse_channels = tuple(self._argparse_args['channel'] or ())
             if argparse_channels and argparse_channels == self._channels:
                 return argparse_channels + (DEFAULTS_CHANNEL_NAME,)
-        return self._channels
+        return self._channels or ()
 
     def get_descriptions(self):
         return get_help_dict()

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -9,8 +9,8 @@ from platform import machine
 import sys
 
 from .constants import (APP_NAME, DEFAULTS_CHANNEL_NAME, DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS,
-                        PLATFORM_DIRECTORIES, PathConflict, ROOT_ENV_NAME, SEARCH_PATH,
-                        ERROR_UPLOAD_URL)
+                        ERROR_UPLOAD_URL, PLATFORM_DIRECTORIES, PathConflict, ROOT_ENV_NAME,
+                        SEARCH_PATH)
 from .. import __version__ as CONDA_VERSION
 from .._vendor.appdirs import user_data_dir
 from .._vendor.auxlib.collection import frozendict
@@ -477,7 +477,7 @@ class Context(Configuration):
             'default_python',
             'dry_run',
             'enable_private_envs',
-            'error_upload_url',
+            'error_upload_url',  # should remain undocumented
             'force_32bit',
             'max_shlvl',
             'migrated_custom_channels',

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -9,7 +9,8 @@ from platform import machine
 import sys
 
 from .constants import (APP_NAME, DEFAULTS_CHANNEL_NAME, DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS,
-                        PLATFORM_DIRECTORIES, PathConflict, ROOT_ENV_NAME, SEARCH_PATH)
+                        PLATFORM_DIRECTORIES, PathConflict, ROOT_ENV_NAME, SEARCH_PATH,
+                        ERROR_UPLOAD_URL)
 from .. import __version__ as CONDA_VERSION
 from .._vendor.appdirs import user_data_dir
 from .._vendor.auxlib.collection import frozendict
@@ -147,7 +148,6 @@ class Context(Configuration):
     migrated_custom_channels = MapParameter(string_types)  # TODO: also take a list of strings
     _custom_multichannels = MapParameter(list, aliases=('custom_multichannels',))
 
-    # command line
     default_python = PrimitiveParameter(default_python_default(),
                                         validation=default_python_validation)
     always_softlink = PrimitiveParameter(False, aliases=('softlink',))
@@ -156,6 +156,7 @@ class Context(Configuration):
     channel_priority = PrimitiveParameter(True)
     debug = PrimitiveParameter(False)
     dry_run = PrimitiveParameter(False)
+    error_upload_url = PrimitiveParameter(ERROR_UPLOAD_URL)
     force = PrimitiveParameter(False)
     json = PrimitiveParameter(False)
     no_dependencies = PrimitiveParameter(False, aliases=('no_deps',))
@@ -476,6 +477,7 @@ class Context(Configuration):
             'default_python',
             'dry_run',
             'enable_private_envs',
+            'error_upload_url',
             'force_32bit',
             'max_shlvl',
             'migrated_custom_channels',

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -342,7 +342,6 @@ def add_parser_channels(p):
         dest='channel',  # apparently conda-build uses this; someday rename to channels are remove context.channels alias to channel  # NOQA
         # TODO: if you ever change 'channel' to 'channels', make sure you modify the context.channels property accordingly # NOQA
         action="append",
-        default=NULL,
         help="""Additional channel to search for packages. These are URLs searched in the order
         they are given (including file:// for local directories).  Then, the defaults
         or channels from .condarc are searched (unless --override-channels is given).  You can use

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -342,6 +342,7 @@ def add_parser_channels(p):
         dest='channel',  # apparently conda-build uses this; someday rename to channels are remove context.channels alias to channel  # NOQA
         # TODO: if you ever change 'channel' to 'channels', make sure you modify the context.channels property accordingly # NOQA
         action="append",
+        default=NULL,
         help="""Additional channel to search for packages. These are URLs searched in the order
         they are given (including file:// for local directories).  Then, the defaults
         or channels from .condarc are searched (unless --override-channels is given).  You can use

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -812,8 +812,13 @@ class Configuration(object):
 
             if match is not None:
                 try:
-                    typed_value = typify_data_structure(match.value(parameter),
-                                                        parameter._element_type)
+                    untyped_value = match.value(parameter)
+                    if untyped_value is None:
+                        if isinstance(parameter, SequenceParameter):
+                            untyped_value = ()
+                        elif isinstance(parameter, MapParameter):
+                            untyped_value = {}
+                    typed_value = typify_data_structure(untyped_value, parameter._element_type)
                 except TypeCoercionError as e:
                     validation_errors.append(CustomValidationError(match.key, e.value,
                                                                    match.source, text_type(e)))

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -10,7 +10,7 @@ import sys
 
 from enum import Enum
 
-from .compat import StringIO, iteritems
+from .compat import StringIO, iteritems, on_win
 from .constants import NULL
 from .._vendor.auxlib.logz import NullHandler
 
@@ -221,6 +221,10 @@ def attach_stderr_handler(level=WARN, logger_name=None, propagate=False, formatt
 
 def timeout(timeout_secs, func, *args, **kwargs):
     default_return = kwargs.pop('default_return', None)
+    if on_win:
+        # Why does Windows have to be so difficult all the time? Kind of gets old.
+        # Guess we'll bypass Windows timeouts for now.
+        return func(*args, **kwargs)
 
     class TimeoutException(Exception):
         pass

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -226,7 +226,7 @@ def timeout(timeout_secs, func, *args, **kwargs):
         # Guess we'll bypass Windows timeouts for now.
         try:
             return func(*args, **kwargs)
-        except KeyboardInterrupt:
+        except KeyboardInterrupt:  # pragma: no cover
             return default_return
     else:
         class TimeoutException(Exception):
@@ -242,5 +242,5 @@ def timeout(timeout_secs, func, *args, **kwargs):
             ret = func(*args, **kwargs)
             signal.alarm(0)
             return ret
-        except (TimeoutException,  KeyboardInterrupt):
+        except (TimeoutException,  KeyboardInterrupt):  # pragma: no cover
             return default_return

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import logging
 from logging import CRITICAL, Formatter, NOTSET, StreamHandler, WARN, getLogger
 import os
+import signal
 import sys
 
 from enum import Enum
@@ -216,3 +217,23 @@ def attach_stderr_handler(level=WARN, logger_name=None, propagate=False, formatt
         logr.addHandler(new_stderr_handler)
         logr.setLevel(level)
         logr.propagate = propagate
+
+
+def timeout(timeout_secs, func, *args, **kwargs):
+    default_return = kwargs.pop('default_return', None)
+
+    class TimeoutException(Exception):
+        pass
+
+    def interrupt(signum, frame):
+        raise TimeoutException()
+
+    signal.signal(signal.SIGALRM, interrupt)
+    signal.alarm(timeout_secs)
+
+    try:
+        ret = func(*args, **kwargs)
+        signal.alarm(0)
+        return ret
+    except (TimeoutException,  KeyboardInterrupt):
+        return default_return

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -12,7 +12,7 @@ from . import CondaError, CondaExitZero, CondaMultiError, text_type
 from ._vendor.auxlib.entity import EntityEncoder
 from ._vendor.auxlib.ish import dals
 from ._vendor.auxlib.type_coercion import boolify
-from .base.constants import ERROR_UPLOAD_URL, PathConflict
+from .base.constants import PathConflict
 from .common.compat import ensure_text_type, input, iteritems, iterkeys, on_win, string_types
 from .common.io import timeout
 from .common.signals import get_signal_name
@@ -689,8 +689,8 @@ def print_unexpected_error_message(e):
             # That is, when following a 301 or 302, it turns a POST into a GET.
             # And no way to disable.  WTF
             import requests
-            response = requests.head(ERROR_UPLOAD_URL, headers=headers, timeout=_timeout)
-            location = response.headers.get('Location', ERROR_UPLOAD_URL)
+            response = requests.head(context.error_upload_url, headers=headers, timeout=_timeout)
+            location = response.headers.get('Location', context.error_upload_url)
             response = requests.post(location, headers=headers, timeout=_timeout, data=data)
             log.debug("upload response status: %s", response and response.status_code)
         except Exception as e:  # pragma: no cover

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -664,17 +664,6 @@ def print_unexpected_error_message(e):
             try:
                 stdin = timeout(40, input)
                 do_upload = stdin and boolify(stdin)
-                if stdin is None:
-                    # means timeout was reached
-                    sys.stderr.write('\nTimeout reached. No report sent.\n')
-                if stdin and do_upload is False:
-                    sys.stderr.write(
-                        "\n"
-                        "No report sent. To permanently opt-out, use\n"
-                        "\n"
-                        "    $ conda config --set report_errors false\n"
-                        "\n"
-                    )
 
             except Exception as e:  # pragma: no cover
                 log.debug('%r', e)
@@ -698,14 +687,25 @@ def print_unexpected_error_message(e):
         except Exception as e:  # pragma: no cover
             log.info('%r', e)
 
-    if stdin and do_upload is True:
+        if stdin:
+            sys.stderr.write(
+                "\n"
+                "Thank you for helping to improve conda.\n"
+                "Opt-in to automatically sending reports (and not see this message again)\n"
+                "by running\n"
+                "\n"
+                "    $ conda config --set report_errors true\n"
+                "\n"
+            )
+    elif ask_for_upload and stdin is None:
+        # means timeout was reached for `input`
+        sys.stderr.write('\nTimeout reached. No report sent.\n')
+    elif ask_for_upload:
         sys.stderr.write(
             "\n"
-            "Thank you for helping to improve conda.\n"
-            "Opt-in to automatically sending reports (and not see this message again)\n"
-            "by running\n"
+            "No report sent. To permanently opt-out, use\n"
             "\n"
-            "    $ conda config --set report_errors true\n"
+            "    $ conda config --set report_errors false\n"
             "\n"
         )
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -594,7 +594,15 @@ def print_conda_exception(exception):
 
 
 def print_unexpected_error_message(e):
-    traceback = format_exc()
+    try:
+        traceback = format_exc()
+    except AttributeError:  # pragma: no cover
+        if sys.version_info[:2] == (3, 4):
+            # AttributeError: 'NoneType' object has no attribute '__context__'
+            traceback = ''
+        else:
+            raise
+
     from .base.context import context
 
     # bomb = "\U0001F4A3 "

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from datetime import timedelta
 import json
 from logging import getLogger
+import os
 import sys
 from traceback import format_exc
 
@@ -615,6 +616,13 @@ def print_unexpected_error_message(e):
         'conda_info': info_dict,
     }
 
+    try:
+        isatty = os.isatty(0)
+    except Exception as e:
+        log.debug('%r', e)
+        # given how the rest of this function is constructed, better to assume True here
+        isatty = True
+
     if context.report_errors is False:
         ask_for_upload = False
         do_upload = False
@@ -622,6 +630,9 @@ def print_unexpected_error_message(e):
         ask_for_upload = False
         do_upload = True
     elif context.json or context.quiet:
+        ask_for_upload = False
+        do_upload = not context.offline and context.always_yes
+    elif not isatty:
         ask_for_upload = False
         do_upload = not context.offline and context.always_yes
     else:

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -633,7 +633,7 @@ def print_unexpected_error_message(e):
     }
 
     try:
-        isatty = os.isatty(0)
+        isatty = os.isatty(0) or on_win
     except Exception as e:
         log.debug('%r', e)
         # given how the rest of this function is constructed, better to assume True here
@@ -672,8 +672,13 @@ def print_unexpected_error_message(e):
         message_builder.append('')
         if info_dict:
             from .cli.main_info import get_main_info_str
-            message_builder.append(get_main_info_str(info_dict))
-            message_builder.append('')
+            try:
+                message_builder.append(get_main_info_str(info_dict))
+            except Exception as e:
+                message_builder.append('conda info could not be constructed.')
+                message_builder.append('%r' % e)
+        message_builder.append('')
+
         if ask_for_upload:
             message_builder.append(
                 "An unexpected error has occurred. Conda has prepared the above report."

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -721,7 +721,7 @@ def print_unexpected_error_message(e):
             sys.stderr.write(
                 "\n"
                 "Thank you for helping to improve conda.\n"
-                "Opt-in to automatically sending reports (and not see this message again)\n"
+                "Opt-in to always sending reports (and not see this message again)\n"
                 "by running\n"
                 "\n"
                 "    $ conda config --set report_errors true\n"

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -630,6 +630,7 @@ def print_unexpected_error_message(e):
         ask_for_upload = True
         do_upload = False
 
+    stdin = None
     if context.json:
         from .cli.common import stdout_json
         stdout_json(error_report)
@@ -665,7 +666,16 @@ def print_unexpected_error_message(e):
                 do_upload = stdin and boolify(stdin)
                 if stdin is None:
                     # means timeout was reached
-                    sys.stderr.write('\nTimeout reached. No report uploaded.\n')
+                    sys.stderr.write('\nTimeout reached. No report sent.\n')
+                if stdin and do_upload is False:
+                    sys.stderr.write(
+                        "\n"
+                        "No report sent. To permanently opt-out, use\n"
+                        "\n"
+                        "    $ conda config --set report_errors false\n"
+                        "\n"
+                    )
+
             except Exception as e:  # pragma: no cover
                 log.debug('%r', e)
                 do_upload = False
@@ -688,15 +698,14 @@ def print_unexpected_error_message(e):
         except Exception as e:  # pragma: no cover
             log.info('%r', e)
 
-        if not (context.json or context.quiet):
-            sys.stderr.write("\nThank you for helping to improve conda.\n")
-
-    if context.report_errors is None and not (context.json or context.quiet):
+    if stdin and do_upload is True:
         sys.stderr.write(
-            "If you'd like to opt-in to automatically sending reports (and not\n"
-            "see this message again), run\n"
             "\n"
-            "    conda config --set report_errors true\n"
+            "Thank you for helping to improve conda.\n"
+            "Opt-in to automatically sending reports (and not see this message again)\n"
+            "by running\n"
+            "\n"
+            "    $ conda config --set report_errors true\n"
             "\n"
         )
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -676,6 +676,7 @@ def _execute_upload(context, error_report):
     }
     _timeout = context.remote_connect_timeout_secs, context.remote_read_timeout_secs
     data = json.dumps(error_report, sort_keys=True, cls=EntityEncoder) + '\n'
+    response = None
     try:
         # requests does not follow HTTP standards for redirects of non-GET methods
         # That is, when following a 301 or 302, it turns a POST into a GET.
@@ -695,6 +696,16 @@ def _execute_upload(context, error_report):
         log.debug("upload response status: %s", response and response.status_code)
     except Exception as e:  # pragma: no cover
         log.info('%r', e)
+    try:
+        if response and response.ok:
+            sys.stderr.write("Upload successful.\n")
+        else:
+            sys.stderr.write("Upload did not complete.")
+            if response and response.status_code:
+                sys.stderr.write(" HTTP %s" % response.status_code)
+            sys.stderr.write("\n")
+    except Exception as e:
+        log.debug("%r" % e)
 
 
 def print_unexpected_error_message(e):

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -605,8 +605,16 @@ def print_unexpected_error_message(e):
     command = ' '.join(ensure_text_type(s) for s in sys.argv)
     info_dict = {}
     if ' info' not in command:
-        from .cli.main_info import get_info_dict
-        info_dict = get_info_dict()
+        try:
+            from .cli.main_info import get_info_dict
+            info_dict = get_info_dict()
+        except Exception as info_e:
+            info_traceback = format_exc()
+            info_dict = {
+                'error': repr(info_e),
+                'error_type': info_e.__class__.__name__,
+                'traceback': info_traceback,
+            }
 
     error_report = {
         'error': repr(e),

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -608,22 +608,20 @@ def print_unexpected_error_message(e):
         info_dict = get_info_dict()
 
     error_report = {
-            'error': repr(e),
-            'error_type': '%s' % type(e),
-            'command': command,
-            'traceback': traceback,
-            'conda_info': info_dict,
-        }
+        'error': repr(e),
+        'error_type': e.__class__.__name__,
+        'command': command,
+        'traceback': traceback,
+        'conda_info': info_dict,
+    }
 
     if context.report_errors is False:
-        #
         ask_for_upload = False
         do_upload = False
     elif context.report_errors is True or context.always_yes:
         ask_for_upload = False
         do_upload = True
     elif context.json or context.quiet:
-        #
         ask_for_upload = False
         do_upload = not context.offline and context.always_yes
     else:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -735,7 +735,8 @@ class Resolve(object):
     def solve(self, specs, returnall=False, _remove=False):
         # type: (List[str], bool) -> List[Dist]
         try:
-            stdoutlog.info("Solving package specifications: ")
+            if not context.json:
+                stdoutlog.info("Solving package specifications: ")
             log.debug("Solving for %s", specs)
 
             # Find the compliant packages
@@ -845,16 +846,18 @@ class Resolve(object):
                 psols2 = list(map(set, psolutions))
                 common = set.intersection(*psols2)
                 diffs = [sorted(set(sol) - common) for sol in psols2]
-                stdoutlog.info(
-                    '\nWarning: %s possible package resolutions '
-                    '(only showing differing packages):%s%s' %
-                    ('>10' if nsol > 10 else nsol,
-                     dashlist(', '.join(diff) for diff in diffs),
-                     '\n  ... and others' if nsol > 10 else ''))
+                if not context.json:
+                    stdoutlog.info(
+                        '\nWarning: %s possible package resolutions '
+                        '(only showing differing packages):%s%s' %
+                        ('>10' if nsol > 10 else nsol,
+                         dashlist(', '.join(diff) for diff in diffs),
+                         '\n  ... and others' if nsol > 10 else ''))
 
             def stripfeat(sol):
                 return sol.split('[')[0]
-            stdoutlog.info('\n')
+            if not context.json:
+                stdoutlog.info('\n')
 
             if returnall:
                 return [sorted(Dist(stripfeat(dname)) for dname in psol) for psol in psolutions]
@@ -862,5 +865,6 @@ class Resolve(object):
                 return sorted(Dist(stripfeat(dname)) for dname in psolutions[0])
 
         except:
-            stdoutlog.info('\n')
+            if not context.json:
+                stdoutlog.info('\n')
             raise

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -389,7 +389,7 @@ class ExceptionTests(TestCase):
 
     @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
-    def test_print_unexpected_error_message_1(self, head_mock, post_mock):
+    def test_print_unexpected_error_message_upload_1(self, post_mock, head_mock):
         with env_var('CONDA_REPORT_ERRORS', 'true', reset_context):
             e = AssertionError()
             with captured() as c:
@@ -402,7 +402,7 @@ class ExceptionTests(TestCase):
 
     @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
-    def test_print_unexpected_error_message_2(self, head_mock, post_mock):
+    def test_print_unexpected_error_message_upload_2(self, post_mock, head_mock):
         with env_var('CONDA_JSON', 'true', reset_context):
             with env_var('CONDA_YES', 'yes', reset_context):
                 e = AssertionError()
@@ -417,7 +417,7 @@ class ExceptionTests(TestCase):
     @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
     @patch('conda.exceptions.input', return_value='y')
-    def test_print_unexpected_error_message_3(self, head_mock, post_mock, input_mock):
+    def test_print_unexpected_error_message_upload_3(self, input_mock, post_mock, head_mock):
         e = AssertionError()
         with captured() as c:
             print_unexpected_error_message(e)
@@ -425,6 +425,35 @@ class ExceptionTests(TestCase):
         assert input_mock.call_count == 1
         assert head_mock.call_count == 1
         assert post_mock.call_count == 1
+        assert c.stdout == ''
+        assert "conda is private" in c.stderr
+
+    @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
+    @patch('requests.post', return_value=None)
+    @patch('conda.exceptions.input', return_value='n')
+    def test_print_unexpected_error_message_opt_out_1(self, input_mock, post_mock, head_mock):
+        with env_var('CONDA_REPORT_ERRORS', 'false', reset_context):
+            e = AssertionError()
+            with captured() as c:
+                print_unexpected_error_message(e)
+
+            assert input_mock.call_count == 0
+            assert head_mock.call_count == 0
+            assert post_mock.call_count == 0
+            assert c.stdout == ''
+            assert "conda is private" in c.stderr
+
+    @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
+    @patch('requests.post', return_value=None)
+    @patch('conda.exceptions.input', return_value='n')
+    def test_print_unexpected_error_message_opt_out_2(self, input_mock, post_mock, head_mock):
+        e = AssertionError()
+        with captured() as c:
+            print_unexpected_error_message(e)
+
+        assert input_mock.call_count == 1
+        assert head_mock.call_count == 0
+        assert post_mock.call_count == 0
         assert c.stdout == ''
         assert "conda is private" in c.stderr
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -425,7 +425,8 @@ class ExceptionTests(TestCase):
     @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
     @patch('conda.exceptions.input', return_value='y')
-    def test_print_unexpected_error_message_upload_3(self, input_mock, post_mock, head_mock):
+    @patch('conda.exceptions.os.isatty', return_value=True)
+    def test_print_unexpected_error_message_upload_3(self, isatty_mock, input_mock, post_mock, head_mock):
         try:
             assert 0
         except AssertionError:
@@ -462,7 +463,8 @@ class ExceptionTests(TestCase):
     @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
     @patch('conda.exceptions.input', return_value='n')
-    def test_print_unexpected_error_message_opt_out_2(self, input_mock, post_mock, head_mock):
+    @patch('conda.exceptions.os.isatty', return_value=True)
+    def test_print_unexpected_error_message_opt_out_2(self, isatty_mock, input_mock, post_mock, head_mock):
         try:
             assert 0
         except AssertionError:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -390,6 +390,10 @@ class ExceptionTests(TestCase):
     @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
     def test_print_unexpected_error_message_upload_1(self, post_mock, head_mock):
+        try:
+            assert 0
+        except AssertionError:
+            pass
         with env_var('CONDA_REPORT_ERRORS', 'true', reset_context):
             e = AssertionError()
             with captured() as c:
@@ -403,6 +407,10 @@ class ExceptionTests(TestCase):
     @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
     def test_print_unexpected_error_message_upload_2(self, post_mock, head_mock):
+        try:
+            assert 0
+        except AssertionError:
+            pass
         with env_var('CONDA_JSON', 'true', reset_context):
             with env_var('CONDA_YES', 'yes', reset_context):
                 e = AssertionError()
@@ -418,6 +426,10 @@ class ExceptionTests(TestCase):
     @patch('requests.post', return_value=None)
     @patch('conda.exceptions.input', return_value='y')
     def test_print_unexpected_error_message_upload_3(self, input_mock, post_mock, head_mock):
+        try:
+            assert 0
+        except AssertionError:
+            pass
         e = AssertionError()
         with captured() as c:
             print_unexpected_error_message(e)
@@ -432,6 +444,10 @@ class ExceptionTests(TestCase):
     @patch('requests.post', return_value=None)
     @patch('conda.exceptions.input', return_value='n')
     def test_print_unexpected_error_message_opt_out_1(self, input_mock, post_mock, head_mock):
+        try:
+            assert 0
+        except AssertionError:
+            pass
         with env_var('CONDA_REPORT_ERRORS', 'false', reset_context):
             e = AssertionError()
             with captured() as c:
@@ -447,6 +463,10 @@ class ExceptionTests(TestCase):
     @patch('requests.post', return_value=None)
     @patch('conda.exceptions.input', return_value='n')
     def test_print_unexpected_error_message_opt_out_2(self, input_mock, post_mock, head_mock):
+        try:
+            assert 0
+        except AssertionError:
+            pass
         e = AssertionError()
         with captured() as c:
             print_unexpected_error_message(e)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -449,10 +449,9 @@ class ExceptionTests(TestCase):
         assert c.stdout == ''
         assert "conda is private" in c.stderr
 
-    @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
     @patch('conda.exceptions.input', return_value='n')
-    def test_print_unexpected_error_message_opt_out_1(self, input_mock, post_mock, head_mock):
+    def test_print_unexpected_error_message_opt_out_1(self, input_mock, post_mock):
         try:
             assert 0
         except AssertionError:
@@ -463,16 +462,14 @@ class ExceptionTests(TestCase):
                 print_unexpected_error_message(e)
 
             assert input_mock.call_count == 0
-            assert head_mock.call_count == 0
             assert post_mock.call_count == 0
             assert c.stdout == ''
             assert "conda is private" in c.stderr
 
-    @patch('requests.head', return_value=AttrDict(headers=AttrDict(Location='')))
     @patch('requests.post', return_value=None)
     @patch('conda.exceptions.input', return_value='n')
     @patch('conda.exceptions.os.isatty', return_value=True)
-    def test_print_unexpected_error_message_opt_out_2(self, isatty_mock, input_mock, post_mock, head_mock):
+    def test_print_unexpected_error_message_opt_out_2(self, isatty_mock, input_mock, post_mock):
         try:
             assert 0
         except AssertionError:
@@ -482,7 +479,6 @@ class ExceptionTests(TestCase):
             print_unexpected_error_message(e)
 
         assert input_mock.call_count == 1
-        assert head_mock.call_count == 0
         assert post_mock.call_count == 0
         assert c.stdout == ''
         assert "conda is private" in c.stderr


### PR DESCRIPTION
resolve #5530

This PR also adds a new configuration parameter, `report_errors`.  The default value is `None`, which means conda will prompt and ask if the user wants to send the error report or not.  With

    conda config --set report_errors true

there won't be any prompt, and the error will automatically be sent.  This is equivalent to an opt-in always.  While

    conda config --set report_errors false

is equivalent to "always opt out."