### PR TITLE
conda-build compatibility work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       sudo: false
       language: generic
       os: linux
-    - env: PYTHON_VERSION=3.6 CONDA_BUILD=3.0.0rc1
+    - env: PYTHON_VERSION=3.6 CONDA_BUILD=3.0.0
       sudo: false
       language: generic
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
       os: osx
   allow_failures:
     - os: osx
-    - env: PYTHON_VERSION=3.6 CONDA_BUILD=3.0.0rc1
+    - env: PYTHON_VERSION=3.6 CONDA_BUILD=3.0.0
 
 install:
   - source utils/functions.sh && run_setup

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -459,6 +459,8 @@ class PrefixReplaceLinkAction(LinkPathAction):
         self._verified = True
 
     def execute(self):
+        if not self._verified:
+            self.verify()
         source_path = self.intermediate_path or self.source_full_path
         log.trace("linking %s => %s", source_path, self.target_full_path)
         create_link(source_path, self.target_full_path, LinkType.hardlink)

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -374,7 +374,7 @@ conda_build_test() {
     . $prefix/etc/profile.d/conda.sh
     conda activate root
     conda info
-    # echo "skip_safety_checks: true" >> ~/.condarc
+    echo "skip_safety_checks: true" >> ~/.condarc
 
     pushd conda-build
 


### PR DESCRIPTION
Bug fix for conda 4.4.x compatibility (including `skip_safety_checks: false`) with conda-build 2.1.x.