### PR TITLE
 logging simplifications/improvements: #5547 followup

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -29,7 +29,7 @@ from ..misc import append_env, clone_env, explicit, touch_nonadmin
 from ..plan import revert_actions
 
 log = getLogger(__name__)
-stderr = getLogger('stderr')
+stderrlog = getLogger('conda.stderr')
 
 
 def check_prefix(prefix, json=False):
@@ -46,9 +46,9 @@ def check_prefix(prefix, json=False):
         raise CondaValueError(error, json)
 
     if ' ' in prefix:
-        stderr.warn("WARNING: A space was detected in your requested environment path\n"
-                    "'%s'\n"
-                    "Spaces in paths can sometimes be problematic." % prefix)
+        stderrlog.warn("WARNING: A space was detected in your requested environment path\n"
+                       "'%s'\n"
+                       "Spaces in paths can sometimes be problematic." % prefix)
 
 
 def clone(src_arg, dst_prefix, json=False, quiet=False, index_args=None):

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -113,7 +113,7 @@ def init_loggers(context=None):
     initialize_logging()
     if context and context.json:
         # Silence logging info to avoid interfering with JSON output
-        for logger in ('conda.stdout.verbose', 'conda.stdout.raw', 'conda.stderr.raw'):
+        for logger in ('conda.stdout.verbose', 'conda.stdoutlog', 'conda.stderrlog'):
             getLogger(logger).setLevel(CRITICAL + 1)
 
     if context and context.verbosity:

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -113,7 +113,7 @@ def init_loggers(context=None):
     initialize_logging()
     if context and context.json:
         # Silence logging info to avoid interfering with JSON output
-        for logger in ('print', 'conda.stdout.raw', 'conda.stderr.raw'):
+        for logger in ('conda.stdout.verbose', 'conda.stdout.raw', 'conda.stderr.raw'):
             getLogger(logger).setLevel(CRITICAL + 1)
 
     if context and context.verbosity:

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -113,7 +113,7 @@ def init_loggers(context=None):
     initialize_logging()
     if context and context.json:
         # Silence logging info to avoid interfering with JSON output
-        for logger in ('print', 'stdoutlog', 'stderrlog'):
+        for logger in ('print', 'conda.stdout.raw', 'conda.stderr.raw'):
             getLogger(logger).setLevel(CRITICAL + 1)
 
     if context and context.verbosity:

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -10,9 +10,8 @@ from ..cli.main import generate_parser
 from ..common.io import CaptureTarget, argv, captured
 from ..common.path import win_path_double_escape
 from ..exceptions import conda_exception_handler
-from ..gateways import initialize_std_loggers
+from ..gateways.logging import initialize_std_loggers
 
-initialize_std_loggers()
 log = getLogger(__name__)
 
 

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -22,7 +22,6 @@ except ImportError:  # pragma: no cover
     from .._vendor.toolz.itertoolz import take  # NOQA
 
 log = getLogger(__name__)
-stdoutlog = getLogger('stdoutlog')
 
 
 def get_index(channel_urls=(), prepend=True, platform=None,

--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -36,7 +36,6 @@ except ImportError:  # pragma: no cover
 
 
 log = getLogger(__name__)
-stderrlog = getLogger('stderrlog')
 
 
 class PackageCacheType(type):

--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
 __all__ = ('RepoData',)
 
 log = getLogger(__name__)
-stderrlog = getLogger('conda.stderr.raw')
+stderrlog = getLogger('conda.stderrlog')
 
 REPODATA_PICKLE_VERSION = 3
 REPODATA_HEADER_RE = b'"(_etag|_mod|_cache_control)":[ ]?"(.*)"'

--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
 __all__ = ('RepoData',)
 
 log = getLogger(__name__)
-stderrlog = getLogger('stderrlog')
+stderrlog = getLogger('conda.stderr.raw')
 
 REPODATA_PICKLE_VERSION = 3
 REPODATA_HEADER_RE = b'"(_etag|_mod|_cache_control)":[ ]?"(.*)"'

--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -386,8 +386,7 @@ def write_pickled_repodata(cache_path, repodata):
         with open(get_pickle_path(cache_path), 'wb') as f:
             pickle.dump(repodata, f)
     except Exception as e:
-        import traceback
-        log.debug("Failed to dump pickled repodata.\n%s", traceback.format_exc())
+        log.debug("Failed to dump pickled repodata.", exc_info=True)
 
 
 def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod_stamp):
@@ -401,8 +400,7 @@ def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod
         with open(pickle_path, 'rb') as f:
             repodata = pickle.load(f)
     except Exception as e:
-        import traceback
-        log.debug("Failed to load pickled repodata.\n%s", traceback.format_exc())
+        log.debug("Failed to load pickled repodata.", exc_info=True)
         rm_rf(pickle_path)
         return None
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -592,7 +592,7 @@ def print_conda_exception(exception):
     if context.json:
         import json
         map_dump = exception.dump_map()
-        json_exception = json.dumps(map_dump, indent=2, sort_keys=True, cls=EntityEncoder) 
+        json_exception = json.dumps(map_dump, indent=2, sort_keys=True, cls=EntityEncoder)
         stdoutlog.info("%s\n" % json_exception)
     else:
         stderrlog.info("\n%r\n", exception)

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -587,14 +587,14 @@ class InvalidVersionSpecError(CondaError):
 def print_conda_exception(exception):
     from .base.context import context
 
-    stdoutlogger = getLogger('conda.stdout')
-    stderrlogger = getLogger('conda.stderr')
+    stdoutlog = getLogger('conda.stdout')
+    stderrlog = getLogger('conda.stderr')
     if context.json:
         import json
-        stdoutlogger.info(json.dumps(exception.dump_map(), indent=2, sort_keys=True,
+        stdoutlog.info(json.dumps(exception.dump_map(), indent=2, sort_keys=True,
                                      cls=EntityEncoder))
     else:
-        stderrlogger.info("\n%r", exception)
+        stderrlog.info("\n%r", exception)
 
 
 def _calculate_ask_do_upload(context):

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -591,10 +591,11 @@ def print_conda_exception(exception):
     stderrlog = getLogger('conda.stderr')
     if context.json:
         import json
-        stdoutlog.info(json.dumps(exception.dump_map(), indent=2, sort_keys=True,
-                                     cls=EntityEncoder))
+        map_dump = exception.dump_map()
+        json_exception = json.dumps(map_dump, indent=2, sort_keys=True, cls=EntityEncoder) 
+        stdoutlog.info("%s\n" % json_exception)
     else:
-        stderrlog.info("\n%r", exception)
+        stderrlog.info("\n%r\n", exception)
 
 
 def _calculate_ask_do_upload(context):

--- a/conda/gateways/__init__.py
+++ b/conda/gateways/__init__.py
@@ -25,8 +25,3 @@ Conda modules strictly prohibited from importing ``conda.gateways`` are
 - ``conda.client``
 
 """
-from __future__ import absolute_import, division, print_function
-
-from .logging import initialize_logging, initialize_std_loggers
-initialize_logging = initialize_logging
-initialize_std_loggers = initialize_std_loggers

--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -9,7 +9,7 @@ from ...disk.delete import rm_rf
 from ....common.url import url_to_s3_info
 
 log = getLogger(__name__)
-stderrlog = getLogger('stderrlog')
+stderrlog = getLogger('conda.stderr.raw')
 
 
 class S3Adapter(BaseAdapter):

--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from logging import getLogger
+from logging import getLogger, LoggingAdapter
 from tempfile import mkstemp
 
 from .. import BaseAdapter, CaseInsensitiveDict, Response
@@ -9,7 +9,7 @@ from ...disk.delete import rm_rf
 from ....common.url import url_to_s3_info
 
 log = getLogger(__name__)
-stderrlog = getLogger('conda.stderr')
+stderrlog = LoggingAdapter(getLogger('conda.stderrlog'), extra=dict(terminator="\n"))
 
 
 class S3Adapter(BaseAdapter):

--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from logging import getLogger, LoggingAdapter
+from logging import getLogger, LoggerAdapter
 from tempfile import mkstemp
 
 from .. import BaseAdapter, CaseInsensitiveDict, Response
@@ -9,7 +9,7 @@ from ...disk.delete import rm_rf
 from ....common.url import url_to_s3_info
 
 log = getLogger(__name__)
-stderrlog = LoggingAdapter(getLogger('conda.stderrlog'), extra=dict(terminator="\n"))
+stderrlog = LoggerAdapter(getLogger('conda.stderrlog'), extra=dict(terminator="\n"))
 
 
 class S3Adapter(BaseAdapter):

--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -9,7 +9,7 @@ from ...disk.delete import rm_rf
 from ....common.url import url_to_s3_info
 
 log = getLogger(__name__)
-stderrlog = getLogger('conda.stderr.raw')
+stderrlog = getLogger('conda.stderr')
 
 
 class S3Adapter(BaseAdapter):
@@ -30,7 +30,7 @@ class S3Adapter(BaseAdapter):
             stderrlog.info('\nError: boto is required for S3 channels. '
                            'Please install it with `conda install boto`\n'
                            'Make sure to run `source deactivate` if you '
-                           'are in a conda environment.\n')
+                           'are in a conda environment.')
             resp.status_code = 404
             return resp
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -28,7 +28,7 @@ from ...exceptions import BasicClobberError, CondaOSError, maybe_raise
 from ...models.enums import FileMode, LinkType
 
 log = getLogger(__name__)
-stdoutlog = getLogger('conda.stdout')
+stdoutlog = getLogger('conda.stdoutlog')
 
 mkdir_p = mkdir_p  # in __init__.py to help with circular imports
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -29,7 +29,7 @@ from ...exceptions import BasicClobberError, CondaOSError, maybe_raise
 from ...models.enums import FileMode, LinkType
 
 log = getLogger(__name__)
-stdoutlog = getLogger('conda.stdout.raw')
+stdoutlog = getLogger('conda.stdout')
 
 mkdir_p = mkdir_p  # in __init__.py to help with circular imports
 
@@ -172,8 +172,7 @@ def make_menu(prefix, file_path, remove=False):
         import menuinst
         menuinst.install(join(prefix, win_path_ok(file_path)), remove, prefix)
     except:
-        stdoutlog.error("menuinst Exception:")
-        stdoutlog.error(traceback.format_exc())
+        stdoutlog.error("menuinst Exception", exc_info=True)
 
 
 def create_hard_link_or_copy(src, dst):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -10,7 +10,6 @@ from os.path import basename, dirname, isdir, isfile, join, splitext
 from shutil import copy as shutil_copy, copystat
 import sys
 import tarfile
-import traceback
 
 from . import mkdir_p
 from .delete import rm_rf

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -29,7 +29,7 @@ from ...exceptions import BasicClobberError, CondaOSError, maybe_raise
 from ...models.enums import FileMode, LinkType
 
 log = getLogger(__name__)
-stdoutlog = getLogger('stdoutlog')
+stdoutlog = getLogger('conda.stdout.raw')
 
 mkdir_p = mkdir_p  # in __init__.py to help with circular imports
 

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -53,11 +53,6 @@ class StdStreamHandler(StreamHandler):
         return super(StdStreamHandler, self).__getattribute__(attr)
 
 
-class RawFormatter(Formatter):
-    def format(self, record):
-        return record.msg
-
-
 # Don't use initialize_logging/initialize_root_logger/set_conda_log_level in
 # cli.python_api! There we want the user to have control over their logging,
 # e.g., using their own levels, handlers, formatters and propagation settings.
@@ -75,7 +70,7 @@ def initialize_std_loggers():
     # Set up special loggers 'conda.stdout'/'conda.stderr' which output directly to the
     # corresponding sys streams, filter token urls and don't propagate.
     formatter = Formatter("%(message)s\n")
-    raw_formatter = RawFormatter()
+    raw_formatter = Formatter('%(message)s')
 
     for stream in 'stdout', 'stderr'):
         logger = getLogger('conda.%s' % stream)

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -57,12 +57,15 @@ class StdStreamHandler(StreamHandler):
 
     def emit(self, record):
         # in contrast to the Python 2.7 StreamHandler, this has no special Unicode handling;
-        # however, this backports the Python >3.2 terminator attribute.
+        # however, this backports the Python >=3.2 terminator attribute and additionally makes it
+        # further customizable by giving record an identically named attribute, e.g., via
+        # logger.log(..., extra={"terminator": ""}) or LoggerAdapter(logger, {"terminator": ""}).
         try:
             msg = self.format(record)
+            terminator = getattr(record, "terminator", self.terminator)
             stream = self.stream
             stream.write(msg)
-            stream.write(self.terminator)
+            stream.write(terminator)
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -92,8 +92,10 @@ def initialize_std_loggers():
     verbose_logger = getLogger('conda.stdout.verbose')
     verbose_logger.setLevel(INFO)
     verbose_handler = StdStreamHandler('stdout')
+    verbose_handler.setLevel(INFO)
     verbose_handler.setFormatter(formatter)
     verbose_logger.addHandler(verbose_handler)
+    verbose_logger.propagate = False
 
 
 def initialize_root_logger(level=ERROR):

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -74,41 +74,25 @@ def initialize_std_loggers():
     # Set up special loggers 'conda.stdout'/'conda.stderr' which output directly to the
     # corresponding sys streams, filter token urls and don't propagate.
     formatter = Formatter("%(message)s\n")
-
-    stdout = getLogger('conda.stdout')
-    stdout.setLevel(INFO)
-    stdouthandler = StdStreamHandler('stdout')
-    stdouthandler.setLevel(INFO)
-    stdouthandler.setFormatter(formatter)
-    stdout.addHandler(stdouthandler)
-    stdout.addFilter(TokenURLFilter())
-    stdout.propagate = False
-
-    stderr = getLogger('conda.stderr')
-    stderr.setLevel(INFO)
-    stderrhandler = StdStreamHandler('stderr')
-    stderrhandler.setLevel(INFO)
-    stderrhandler.setFormatter(formatter)
-    stderr.addHandler(stderrhandler)
-    stderr.addFilter(TokenURLFilter())
-    stderr.propagate = False
-
     raw_formatter = RawFormatter()
-    stdout_raw = getLogger('conda.stdout.raw')
-    stdout_raw.setLevel(DEBUG)
-    stdout_raw_handler = StdStreamHandler('stdout', terminator='')
-    stdout_raw_handler.setLevel(DEBUG)
-    stdout_raw_handler.setFormatter(raw_formatter)
-    stdout_raw.addHandler(stdout_raw_handler)
-    stdout_raw.propagate = False
 
-    stderr_raw = getLogger('conda.stderr.raw')
-    stderr_raw.setLevel(DEBUG)
-    stderr_raw_handler = StdStreamHandler('stderr', terminator='')
-    stderr_raw_handler.setLevel(DEBUG)
-    stderr_raw_handler.setFormatter(raw_formatter)
-    stderr_raw.addHandler(stderr_raw_handler)
-    stderr_raw.propagate = False
+    for stream in 'stdout', 'stderr'):
+        logger = getLogger('conda.%s' % stream)
+        logger.setLevel(INFO)
+        handler = StdStreamHandler(stream)
+        handler.setLevel(INFO)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.addFilter(TokenURLFilter())
+        logger.propagate = False
+
+        raw_logger = getLogger('conda.%s.raw' % stream)
+        raw_logger.setLevel(DEBUG)
+        raw_handler = StdStreamHandler(stream, terminator='')
+        raw_handler.setLevel(DEBUG)
+        raw_handler.setFormatter(raw_formatter)
+        raw_logger.addHandler(raw_handler)
+        raw_logger.propagate = False
 
 
 def initialize_root_logger(level=ERROR):

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -101,14 +101,14 @@ def initialize_std_loggers():
         logger.addFilter(TokenURLFilter())
         logger.propagate = False
 
-        raw_logger = getLogger('conda.%s.raw' % stream)
-        raw_logger.setLevel(DEBUG)
-        raw_handler = StdStreamHandler(stream)
-        raw_handler.terminator = ''
-        raw_handler.setLevel(DEBUG)
-        raw_handler.setFormatter(formatter)
-        raw_logger.addHandler(raw_handler)
-        raw_logger.propagate = False
+        stdlog_logger = getLogger('conda.%slog' % stream)
+        stdlog_logger.setLevel(DEBUG)
+        stdlog_handler = StdStreamHandler(stream)
+        stdlog_handler.terminator = ''
+        stdlog_handler.setLevel(DEBUG)
+        stdlog_handler.setFormatter(formatter)
+        stdlog_logger.addHandler(stdlog_handler)
+        stdlog_logger.propagate = False
 
     verbose_logger = getLogger('conda.stdout.verbose')
     verbose_logger.setLevel(INFO)

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -69,8 +69,7 @@ def initialize_logging():
 def initialize_std_loggers():
     # Set up special loggers 'conda.stdout'/'conda.stderr' which output directly to the
     # corresponding sys streams, filter token urls and don't propagate.
-    formatter = Formatter("%(message)s\n")
-    raw_formatter = Formatter('%(message)s')
+    formatter = Formatter("%(message)s")
 
     for stream in 'stdout', 'stderr'):
         logger = getLogger('conda.%s' % stream)
@@ -86,15 +85,14 @@ def initialize_std_loggers():
         raw_logger.setLevel(DEBUG)
         raw_handler = StdStreamHandler(stream, terminator='')
         raw_handler.setLevel(DEBUG)
-        raw_handler.setFormatter(raw_formatter)
+        raw_handler.setFormatter(formatter)
         raw_logger.addHandler(raw_handler)
         raw_logger.propagate = False
 
     verbose_logger = getLogger('conda.stdout.verbose')
     verbose_logger.setLevel(INFO)
     verbose_handler = StdStreamHandler('stdout')
-    verbose_formatter = Formatter('%(message)s')
-    verbose_handler.setFormatter(verbose_formatter)
+    verbose_handler.setFormatter(formatter)
     verbose_logger.addHandler(verbose_handler)
 
 

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -95,6 +95,13 @@ def initialize_std_loggers():
         raw_logger.addHandler(raw_handler)
         raw_logger.propagate = False
 
+    verbose_logger = getLogger('conda.stdout.verbose')
+    verbose_logger.setLevel(INFO)
+    verbose_handler = StdStreamHandler('stdout')
+    verbose_formatter = Formatter('%(message)s')
+    verbose_handler.setFormatter(verbose_formatter)
+    verbose_logger.addHandler(verbose_handler)
+
 
 def initialize_root_logger(level=ERROR):
     attach_stderr_handler(level)

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -42,14 +42,15 @@ class StdStreamHandler(StreamHandler):
         Args:
             sys_stream: stream name, either "stdout" or "stderr" (attribute of module sys)
         """
-        assert hasattr(sys, sys_stream)
-        self._sys_stream = sys_stream
-        super(StreamHandler, self).__init__()  # skip StreamHandler.__init__ which sets self.stream
+        super(StdStreamHandler, self).__init__(getattr(sys, sys_stream))
+        self.sys_stream = sys_stream
+        del self.stream
 
-    @property
-    def stream(self):
-        # always get current stdout/stderr, removes the need to replace self.stream when needed
-        return getattr(sys, self._sys_stream)
+    def __getattr__(self, attr):
+        # always get current sys.stdout/sys.stderr, unless self.stream has been set explicitly
+        if attr == 'stream':
+            return getattr(sys, self.sys_stream)
+        return super(StdStreamHandler, self).__getattribute__(attr)
 
 
 class RawFormatter(Formatter):

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -52,6 +52,11 @@ class StdStreamHandler(StreamHandler):
         return getattr(sys, self._sys_stream)
 
 
+class RawFormatter(Formatter):
+    def format(self, record):
+        return record.msg
+
+
 # Don't use initialize_logging/initialize_root_logger/set_conda_log_level in
 # cli.python_api! There we want the user to have control over their logging,
 # e.g., using their own levels, handlers, formatters and propagation settings.
@@ -87,6 +92,23 @@ def initialize_std_loggers():
     stderr.addHandler(stderrhandler)
     stderr.addFilter(TokenURLFilter())
     stderr.propagate = False
+
+    raw_formatter = RawFormatter()
+    stdout_raw = getLogger('conda.stdout.raw')
+    stdout_raw.setLevel(DEBUG)
+    stdout_raw_handler = StdStreamHandler('stdout', terminator='')
+    stdout_raw_handler.setLevel(DEBUG)
+    stdout_raw_handler.setFormatter(raw_formatter)
+    stdout_raw.addHandler(stdout_raw_handler)
+    stdout_raw.propagate = False
+
+    stderr_raw = getLogger('conda.stderr.raw')
+    stderr_raw.setLevel(DEBUG)
+    stderr_raw_handler = StdStreamHandler('stderr', terminator='')
+    stderr_raw_handler.setLevel(DEBUG)
+    stderr_raw_handler.setFormatter(raw_formatter)
+    stderr_raw.addHandler(stderr_raw_handler)
+    stderr_raw.propagate = False
 
 
 def initialize_root_logger(level=ERROR):

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -71,7 +71,7 @@ def initialize_std_loggers():
     # corresponding sys streams, filter token urls and don't propagate.
     formatter = Formatter("%(message)s")
 
-    for stream in 'stdout', 'stderr'):
+    for stream in ('stdout', 'stderr'):
         logger = getLogger('conda.%s' % stream)
         logger.setLevel(INFO)
         handler = StdStreamHandler(stream)

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -52,16 +52,15 @@ class StdStreamHandler(StreamHandler):
         return getattr(sys, self._sys_stream)
 
 
-# Don't use initialize_logging/initialize_root_logger/initialize_conda_logger in
+# Don't use initialize_logging/initialize_root_logger/set_conda_log_level in
 # cli.python_api! There we want the user to have control over their logging,
 # e.g., using their own levels, handlers, formatters and propagation settings.
 
 @memoize
 def initialize_logging():
-    # root and 'conda' logger both get their own separate sys.stderr stream handlers.
-    # root gets level ERROR; 'conda' gets level WARN and does not propagate to root.
+    # root gets level ERROR; 'conda' gets level WARN and propagates to root.
     initialize_root_logger()
-    initialize_conda_logger()
+    set_conda_log_level()
     initialize_std_loggers()
 
 
@@ -94,15 +93,16 @@ def initialize_root_logger(level=ERROR):
     attach_stderr_handler(level)
 
 
-def initialize_conda_logger(level=WARN):
-    attach_stderr_handler(level, 'conda')
+def set_conda_log_level(level=WARN):
+    conda_logger = getLogger('conda')
+    conda_logger.setLevel(level)
+    conda_logger.propagate = True  # let root logger's handler format/output message
 
 
 def set_all_logger_level(level=DEBUG):
     formatter = Formatter("%(message)s\n") if level >= INFO else None
-    # root and 'conda' loggers use separate handlers but behave the same wrt level and formatting
     attach_stderr_handler(level, formatter=formatter)
-    attach_stderr_handler(level, 'conda', formatter=formatter)
+    set_conda_log_level(level)  # only set level and use root's handler/formatter
     # 'requests' loggers get their own handlers so that they always output messages in long format
     # regardless of the level.
     attach_stderr_handler(level, 'requests')

--- a/conda/install.py
+++ b/conda/install.py
@@ -38,7 +38,6 @@ from .core.package_cache import rm_fetched  # NOQA
 rm_fetched = rm_fetched
 
 log = logging.getLogger(__name__)
-stdoutlog = logging.getLogger('stdoutlog')
 
 # backwards compatibility for conda-build
 prefix_placeholder = PREFIX_PLACEHOLDER

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -50,7 +50,7 @@ def PREFIX_CMD(state, prefix):
 def PRINT_CMD(state, arg):
     if arg.startswith(('Unlinking packages', 'Linking packages')):
         return
-    getLogger('print').info(arg)
+    getLogger('conda.stdout.verbose').info(arg)
 
 
 def FETCH_CMD(state, package_cache_entry):

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -37,8 +37,8 @@ If you are sure that conda is not running, remove it and try again.
 You can also use: $ conda clean --lock
 """
 
-stdoutlog = logging.getLogger('stdoutlog')
 log = logging.getLogger(__name__)
+stdoutlog = logging.getLogger('conda.stdout.raw')
 
 def touch(file_name, times=None):
     """ Touch function like touch in Unix shell

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -38,7 +38,7 @@ You can also use: $ conda clean --lock
 """
 
 log = logging.getLogger(__name__)
-stdoutlog = logging.getLogger('conda.stdout.raw')
+stdoutlog = logging.getLogger('conda.stdoutlog')
 
 def touch(file_name, times=None):
     """ Touch function like touch in Unix shell

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -15,7 +15,6 @@ from .models.version import normalized_version
 
 log = logging.getLogger(__name__)
 stdoutlog = logging.getLogger('stdoutlog')
-stderrlog = logging.getLogger('stderrlog')
 
 
 # used in conda build

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -14,7 +14,7 @@ from .models.match_spec import MatchSpec
 from .models.version import normalized_version
 
 log = logging.getLogger(__name__)
-stdoutlog = logging.getLogger('conda.stdout.raw')
+stdoutlog = logging.getLogger('conda.stdoutlog')
 
 
 # used in conda build

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -14,7 +14,7 @@ from .models.match_spec import MatchSpec
 from .models.version import normalized_version
 
 log = logging.getLogger(__name__)
-stdoutlog = logging.getLogger('stdoutlog')
+stdoutlog = logging.getLogger('conda.stdout.raw')
 
 
 # used in conda build


### PR DESCRIPTION
Notable changes:
 - cherry-picked "remove redundant log handler/formatter, propagate instead" from #5397
 - merge conflicts fixed
 - replaced loggers `"stdoutlog"`/`"stderrlog"` with `"conda.stdoutlog"`/`"conda.stderrlog"`~~`"conda.stdout.raw"`/`"conda.stderr.raw"`~~
 - replaced logger `"print"` with `"conda.stdout.verbose"`
 - where possible, used `exc_info` argument instead of manually calling `traceback.format_exc`

In contrast to the previous `"stdoutlog"`/`"stderrlog"` loggers, which output record messages directly without formatting, `"conda.stdoutlog"`/`"conda.stderrlog"` do normal log formatting.~~The loggers `"conda.stdout.raw"`/`"conda.stderr.raw"` are named that way since they previously output record messages directly without formatting.~~ I changed that in 83e3fdde66b0ed4143a0a6f251e959d4cb7fbe94 since I can't think of a good reason why we should do that ~~-- I didn't change their names, though~~. Different from the non-`"*log"`~~`"*.raw"`~~ loggers, they don't add a newline after the message (via `StdStreamHandler.terminator=""`). Maybe they should be aptly named to reflect that? Apart from that the only other difference is that their default logging level is `DEBUG` -- as has been for `"stdoutlog"`/`"stderrlog"` before they were removed in #5546 (but, IMO, it really does not make sense to have different levels here).

Other behavioral changes:
 - for `make_menu`/`menuinst` exception: use standard newline instead of ":" as separator
 - in `UnlinkLinkTransaction._verify_individual_level` format the actual processed error (w/o traceback, which should be non-existent anyway, I think)
 - add trailing/additional newline explicitly in `print_conda_exception` instead of doing it via formatter
 - use traceback-less exception formatting for Python 3.4 if traceback is not available

I haven't looked into the progress indicator stuff or any other `print` and `sys.[stream].write` calls which could/should/shouldn't be replaced by logger calls.