### PR TITLE
fix/improve traceback formatting (4.3.x)

### DIFF
--- a/conda/core/package_cache.py
+++ b/conda/core/package_cache.py
@@ -5,7 +5,6 @@ from functools import reduce
 from logging import getLogger
 from os import listdir
 from os.path import basename, join
-from traceback import format_exc
 
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler
@@ -504,8 +503,7 @@ class ProgressiveFetchExtract(object):
             try:
                 action.execute()
             except Exception as e:
-                log.debug("Error in action %s", action)
-                log.debug(format_exc())
+                log.debug("Error in action %s", action, exc_info=True)
                 action.reverse()
                 exceptions.append(CondaError(repr(e)))
             else:

--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -325,8 +325,7 @@ def write_pickled_repodata(cache_path, repodata):
         with open(get_pickle_path(cache_path), 'wb') as f:
             pickle.dump(repodata, f)
     except Exception as e:
-        import traceback
-        log.debug("Failed to dump pickled repodata.\n%s", traceback.format_exc())
+        log.debug("Failed to dump pickled repodata.", exc_info=True)
 
 
 def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod_stamp):
@@ -340,8 +339,7 @@ def read_pickled_repodata(cache_path, channel_url, schannel, priority, etag, mod
         with open(pickle_path, 'rb') as f:
             repodata = pickle.load(f)
     except Exception as e:
-        import traceback
-        log.debug("Failed to load pickled repodata.\n%s", traceback.format_exc())
+        log.debug("Failed to load pickled repodata.", exc_info=True)
         rm_rf(pickle_path)
         return None
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -11,7 +11,6 @@ from os.path import basename, isdir, isfile, join, lexists
 from shutil import copy as shutil_copy, copystat
 import sys
 import tarfile
-import traceback
 
 from .delete import rm_rf
 from .link import islink, link, readlink, symlink
@@ -149,8 +148,7 @@ def make_menu(prefix, file_path, remove=False):
         import menuinst
         menuinst.install(join(prefix, win_path_ok(file_path)), remove, prefix)
     except:
-        stdoutlog.error("menuinst Exception:")
-        stdoutlog.error(traceback.format_exc())
+        stdoutlog.error("menuinst Exception", exc_info=True)
 
 
 def mkdir_p(path):


### PR DESCRIPTION
This backports a commit from #5578 which might fix #5574.

Notable changes:
 - where possible, used `exc_info` argument instead of manually calling `traceback.format_exc`

Other behavioral changes:
 - for `make_menu`/`menuinst` exception: use standard newline instead of ":" as separator