### PR TITLE
don't show root env name in activate prompt modifier

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -37,7 +37,9 @@ class Activator(object):
     # information to the __init__ method of this class.
 
     def __init__(self, shell, arguments=None):
+        from .base.constants import ROOT_ENV_NAME
         from .base.context import context
+        self._root_env_name = ROOT_ENV_NAME
         self.context = context
         self.shell = shell
         self._raw_arguments = arguments
@@ -172,7 +174,7 @@ class Activator(object):
                                 % (command, remainder_args))
 
         if command == 'activate':
-            self.env_name_or_prefix = remainder_args and remainder_args[0] or 'root'
+            self.env_name_or_prefix = remainder_args and remainder_args[0] or self._root_env_name
 
         self.command = command
 
@@ -399,11 +401,14 @@ class Activator(object):
 
     def _default_env(self, prefix):
         if prefix == self.context.root_prefix:
-            return 'base'
+            return self._root_env_name
         return basename(prefix) if basename(dirname(prefix)) == 'envs' else prefix
 
     def _prompt_modifier(self, conda_default_env):
-        return "(%s) " % conda_default_env if self.context.changeps1 else ""
+        if conda_default_env == self._root_env_name or not self.context.changeps1:
+            return ""
+        else:
+            return "(%s) " % conda_default_env
 
     def _get_activate_scripts(self, prefix):
         return self.path_conversion(glob(join(

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -77,7 +77,7 @@ DEFAULT_CHANNELS_WIN = ('https://repo.continuum.io/pkgs/free',
 # use the bool(sys.platform == "win32") definition here so we don't import .compat.on_win
 DEFAULT_CHANNELS = DEFAULT_CHANNELS_WIN if bool(sys.platform == "win32") else DEFAULT_CHANNELS_UNIX
 
-ROOT_ENV_NAME = 'base'
+ROOT_ENV_NAME = 'root'
 
 ROOT_NO_RM = (
     'python',

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -57,10 +57,13 @@ class ActivatorUnitTests(TestCase):
     def test_PS1(self):
         with env_var("CONDA_CHANGEPS1", "yes", reset_context):
             activator = Activator('posix')
-            assert activator._prompt_modifier(ROOT_ENV_NAME) == '(%s) ' % ROOT_ENV_NAME
+            assert activator._prompt_modifier(ROOT_ENV_NAME) == ''
 
-            instructions = activator.build_activate("root")
-            assert instructions['set_vars']['CONDA_PROMPT_MODIFIER'] == '(%s) ' % ROOT_ENV_NAME
+            instructions = activator.build_activate(ROOT_ENV_NAME)
+            assert instructions['set_vars']['CONDA_PROMPT_MODIFIER'] == ''
+
+            activator = Activator('posix')
+            assert activator._prompt_modifier('test-env') == '(test-env) '
 
     def test_PS1_no_changeps1(self):
         with env_var("CONDA_CHANGEPS1", "no", reset_context):


### PR DESCRIPTION
Related discussion at https://github.com/conda/conda/issues/1609#issuecomment-310531315