### PR TITLE
Minor bug fixes for new Solve code

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -143,8 +143,12 @@ class Solver(object):
             specs_map = odict((d.name, MatchSpec(d.name)) for d in solution)
 
         # add in historically-requested specs
+        # Conda hasn't always been good about recording when specs have been removed from
+        # environments.  If the package isn't installed in the current environment, then we
+        # shouldn't try to force it here.
         specs_from_history_map = History(self.prefix).get_requested_specs_map()
-        specs_map.update(specs_from_history_map)
+        specs_map.update((name, spec) for name, spec in iteritems(specs_from_history_map)
+                         if any(spec.match(dist) for dist in solution))
 
         if specs_to_remove:
             # Rather than invoking SAT for removal, we can use the DAG and simple tree traversal

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -143,12 +143,8 @@ class Solver(object):
             specs_map = odict((d.name, MatchSpec(d.name)) for d in solution)
 
         # add in historically-requested specs
-        # Conda hasn't always been good about recording when specs have been removed from
-        # environments.  If the package isn't installed in the current environment, then we
-        # shouldn't try to force it here.
         specs_from_history_map = History(self.prefix).get_requested_specs_map()
-        specs_map.update((name, spec) for name, spec in iteritems(specs_from_history_map)
-                         if any(spec.match(dist) for dist in solution))
+        specs_map.update(specs_from_history_map)
 
         if specs_to_remove:
             # Rather than invoking SAT for removal, we can use the DAG and simple tree traversal

--- a/conda/history.py
+++ b/conda/history.py
@@ -163,6 +163,7 @@ class History(object):
                         specs = literal_eval(specs)
                     elif '[' not in specs:
                         specs = specs.split(',')
+                    specs = tuple(spec for spec in specs if not spec.endswith('@'))
                     if specs and action in ('update', 'install', 'create'):
                         item['update_specs'] = item['specs'] = specs
                     elif specs and action in ('remove', 'uninstall'):
@@ -175,20 +176,20 @@ class History(object):
             item['link_dists'] = dists.get('+', ())
         return res
 
-    def get_requested_specs(self):
-        spec_map = {}
-        for request in self.get_user_requests():
-            axn = request.get('action', '')
-            if axn.startswith('install'):
-                link_dists = tuple(Dist(d[1:]) for d in request.get('link_dists', ()))
-                specs = tuple(MatchSpec(s) for s in request['specs'] if s)
-                match = lambda spec: next((d for d in link_dists if spec.match(d)), None)
-                dists = tuple(match(s) for s in specs)
-                spec_map.update({s.name: (s, d) for (s, d) in zip(specs, dists)})
-            elif axn.startswith('remove'):
-                for name in (MatchSpec(s).name for s in request['specs']):
-                    spec_map.pop(name, None)
-        return set(itervalues(spec_map))
+    # def get_requested_specs(self):
+    #     spec_map = {}
+    #     for request in self.get_user_requests():
+    #         axn = request.get('action', '')
+    #         if axn.startswith('install'):
+    #             link_dists = tuple(Dist(d[1:]) for d in request.get('link_dists', ()))
+    #             specs = tuple(MatchSpec(s) for s in request['specs'] if s)
+    #             match = lambda spec: next((d for d in link_dists if spec.match(d)), None)
+    #             dists = tuple(match(s) for s in specs)
+    #             spec_map.update({s.name: (s, d) for (s, d) in zip(specs, dists)})
+    #         elif axn.startswith('remove'):
+    #             for name in (MatchSpec(s).name for s in request['specs']):
+    #                 spec_map.pop(name, None)
+    #     return set(itervalues(spec_map))
 
     def get_requested_specs_map(self):
         spec_map = {}

--- a/conda/history.py
+++ b/conda/history.py
@@ -189,9 +189,9 @@ class History(object):
         # Conda hasn't always been good about recording when specs have been removed from
         # environments.  If the package isn't installed in the current environment, then we
         # shouldn't try to force it here.
-        linked_dists = tuple(Dist(d) for d in PrefixData(self.prefix).iter_records())
+        prefix_recs = tuple(PrefixData(self.prefix).iter_records())
         return dict((name, spec) for name, spec in iteritems(spec_map)
-                    if any(spec.match(dist) for dist in linked_dists))
+                    if any(spec.match(dist) for dist in prefix_recs))
 
     def construct_states(self):
         """

--- a/conda/history.py
+++ b/conda/history.py
@@ -163,7 +163,7 @@ class History(object):
                         specs = literal_eval(specs)
                     elif '[' not in specs:
                         specs = specs.split(',')
-                    specs = tuple(spec for spec in specs if not spec.endswith('@'))
+                    specs = [spec for spec in specs if not spec.endswith('@')]
                     if specs and action in ('update', 'install', 'create'):
                         item['update_specs'] = item['specs'] = specs
                     elif specs and action in ('remove', 'uninstall'):

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -477,28 +477,41 @@ def _parse_spec_str(spec_str):
 
     # Step 3. strip off brackets portion
     brackets = {}
-    m1 = re.match(r'^(.*)(?:\[(.*)\])$', spec_str)
-    if m1:
-        spec_str, brackets_str = m1.groups()
+    m3 = re.match(r'^(.*)(?:\[(.*)\])$', spec_str)
+    if m3:
+        spec_str, brackets_str = m3.groups()
         brackets_str = brackets_str.strip("[]\n\r\t ")
 
-        m5 = re.finditer(r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)', brackets_str)
-        for match in m5:
+        m3b = re.finditer(r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)', brackets_str)
+        for match in m3b:
             key, _, value, _ = match.groups()
             if not key or not value:
                 raise CondaValueError("Invalid MatchSpec: %s" % spec_str)
             brackets[key] = value
 
-    # Step 4. strip off '::' channel and namespace
-    m2 = spec_str.rsplit(':', 2)
-    m2_len = len(m2)
-    if m2_len == 3:
-        channel_str, namespace, spec_str = m2
-    elif m2_len == 2:
-        namespace, spec_str = m2
+    # Step 4. strip off parens portion
+    m4 = re.match(r'^(.*)(?:\((.*)\))$', spec_str)
+    parens = {}
+    if m4:
+        spec_str, parens_str = m4.groups()
+        parens_str = parens_str.strip("[]\n\r\t ")
+        m4b = re.finditer(r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)', parens_str)
+        for match in m4b:
+            key, _, value, _ = match.groups()
+            parens[key] = value
+        if 'optional' in parens_str:
+            parens['optional'] = True
+
+    # Step 5. strip off '::' channel and namespace
+    m5 = spec_str.rsplit(':', 2)
+    m5_len = len(m5)
+    if m5_len == 3:
+        channel_str, namespace, spec_str = m5
+    elif m5_len == 2:
+        namespace, spec_str = m5
         channel_str = None
-    elif m2_len:
-        spec_str = m2[0]
+    elif m5_len:
+        spec_str = m5[0]
         channel_str, namespace = None, None
     else:
         raise NotImplementedError()
@@ -512,7 +525,7 @@ def _parse_spec_str(spec_str):
     if 'subdir' in brackets:
         subdir = brackets.pop('subdir')
 
-    # Step 5. strip off package name from remaining version + build
+    # Step 6. strip off package name from remaining version + build
     m3 = re.match(r'([^ =<>!]+)?([><!= ].+)?', spec_str)
     if m3:
         name, spec_str = m3.groups()
@@ -521,7 +534,7 @@ def _parse_spec_str(spec_str):
     else:
         raise CondaValueError("Invalid MatchSpec: %s" % spec_str)
 
-    # Step 6. otherwise sort out version + build
+    # Step 7. otherwise sort out version + build
     spec_str = spec_str and spec_str.strip()
     # This was an attempt to make MatchSpec('numpy-1.11.0-py27_0') work like we'd want. It's
     # not possible though because plenty of packages have names with more than one '-'.
@@ -547,7 +560,7 @@ def _parse_spec_str(spec_str):
     else:
         version, build = None, None
 
-    # Step 7. now compile components together
+    # Step 8. now compile components together
     components = {}
     components['name'] = name if name else '*'
 

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -477,11 +477,11 @@ def _parse_spec_str(spec_str):
 
     # Step 3. strip off brackets portion
     brackets = {}
-    m3 = re.match(r'^(.*)(?:\[(.*)\])$', spec_str)
+    m3 = re.match(r'.*(?:(\[.*\]))', spec_str)
     if m3:
-        spec_str, brackets_str = m3.groups()
-        brackets_str = brackets_str.strip("[]\n\r\t ")
-
+        brackets_str = m3.groups()[0]
+        spec_str = spec_str.replace(brackets_str, '')
+        brackets_str = brackets_str[1:-1]
         m3b = re.finditer(r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)', brackets_str)
         for match in m3b:
             key, _, value, _ = match.groups()
@@ -490,11 +490,12 @@ def _parse_spec_str(spec_str):
             brackets[key] = value
 
     # Step 4. strip off parens portion
-    m4 = re.match(r'^(.*)(?:\((.*)\))$', spec_str)
+    m4 = re.match(r'.*(?:(\(.*\)))', spec_str)
     parens = {}
     if m4:
-        spec_str, parens_str = m4.groups()
-        parens_str = parens_str.strip("[]\n\r\t ")
+        parens_str = m4.groups()[0]
+        spec_str = spec_str.replace(parens_str, '')
+        parens_str = parens_str[1:-1]
         m4b = re.finditer(r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)', parens_str)
         for match in m4b:
             key, _, value, _ = match.groups()

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -18,7 +18,7 @@ from conda.core.index import _supplement_index_with_prefix
 from ._vendor.boltons.setutils import IndexedSet
 from .base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
 from .base.context import context
-from .common.compat import on_win
+from .common.compat import on_win, itervalues
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.linked_data import is_linked, linked_data
 from .core.package_cache import ProgressiveFetchExtract
@@ -584,8 +584,7 @@ def revert_actions(prefix, revision=-1, index=None):
     # change
     h = History(prefix)
     h.update()
-    user_requested_specs_and_dists = h.get_requested_specs()
-    user_requested_specs = tuple(x[0] for x in user_requested_specs_and_dists)
+    user_requested_specs = itervalues(h.get_requested_specs_map())
     try:
         state = h.get_state(revision)
     except IndexError:

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -195,15 +195,6 @@ def test_prune_1():
         assert tuple(final_state_2) == tuple(solver._index[Dist(d)] for d in order)
 
 
-def test_prune_2():
-    specs_to_remove = MatchSpec("python=2"),
-    history_specs = MatchSpec("sqlite=3"),
-    with get_solver(specs_to_remove=specs_to_remove, history_specs=history_specs) as solver:
-        final_state = solver.solve_final_state(prune=True)
-        print(final_state)
-        assert len(final_state) == 1
-
-
 def test_force_remove_1():
     specs = MatchSpec("numpy[build=*py27*]"),
     with get_solver(specs) as solver:

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -590,3 +590,12 @@ class SpecStrParsingTests(TestCase):
             "name": "foo",
             "version": ">=1.0",
         }
+
+    def test_parse_parens(self):
+        assert _parse_spec_str("conda-forge::foo[build=3](target=blarg,optional)") == {
+            "channel": "conda-forge",
+            "name": "foo",
+            "build": "3",
+            # "target": "blarg",  # suppressing these for now
+            # "optional": True,
+        }


### PR DESCRIPTION
* handles the case when a spec was recorded in the history file with something like `(target=fn,optional)`
* doesn't force specs into the returned history specs if a spec doesn't actually match a package in the current environment