### PR TITLE
Fix exception when generating JSON output

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -186,15 +186,15 @@ def stdout_json_success(success=True, **kwargs):
 
     # this code reverts json output for plan back to previous behavior
     #   relied on by Anaconda Navigator and nb_conda
-    unlink_link_transaction = kwargs.get('unlink_link_transaction')
+    unlink_link_transaction = kwargs.pop('unlink_link_transaction', None)
     if unlink_link_transaction:
         from .._vendor.toolz.itertoolz import concat
         actions = kwargs.setdefault('actions', {})
-        actions['LINK'] = tuple(str(d) for d in concat(
-            stp.link_dists for stp in itervalues(unlink_link_transaction.prefix_setups)
+        actions['LINK'] = tuple(d.dist_str() for d in concat(
+            stp.link_precs for stp in itervalues(unlink_link_transaction.prefix_setups)
         ))
-        actions['UNLINK'] = tuple(str(d) for d in concat(
-            stp.unlink_dists for stp in itervalues(unlink_link_transaction.prefix_setups)
+        actions['UNLINK'] = tuple(d.dist_str() for d in concat(
+            stp.unlink_precs for stp in itervalues(unlink_link_transaction.prefix_setups)
         ))
     result.update(kwargs)
     stdout_json(result)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1017,6 +1017,16 @@ class IntegrationTests(TestCase):
         assert "python:" in stdout
         assert join('another', 'place') in stdout
 
+    def test_create_dry_run_json(self):
+        prefix = '/some/place'
+        with pytest.raises(DryRunExit):
+            run_command(Commands.CREATE, prefix, "flask", "--dry-run", "--json")
+        stdout, stderr = run_command(Commands.CREATE, prefix, "flask", "--dry-run", "--json", use_exception_handler=True)
+
+        loaded = json.loads(stdout)
+        assert "python" in "\n".join(loaded['actions']['LINK'])
+        assert "flask" in "\n".join(loaded['actions']['LINK'])
+
     def test_packages_not_found(self):
         with make_temp_env() as prefix:
             with pytest.raises(PackagesNotFoundError) as exc:


### PR DESCRIPTION
This looks like a regression in the current 4.4.x beta release: When running the command `conda create -n <env> --dry --json python`, the command would fail with `AttributeError("'PrefixSetup' object has no attribute 'link_dists')`.

This PR fixes this by using the `link_precs` and `unlink_precs` attributes instead. It also removes the `unlink_link_transaction` key from `kwargs` because otherwise the JSON serializer would complain that "an object of type `UnlinkLinkTransaction` is not JSON serializable."

It's not fully clear to me what the desired JSON output should be. In conda 4.2.x, it used to be

```
"actions": {
  "LINK": [
    "defaults::vs2015_runtime-14.00.23026.0-0 1",
    ...
  ]
}
```

In conda 4.3.x, it used to be

```
"actions": [
  {
    "LINK": [
      {
        "base_url": null,
        "build_number": 0,
        "build_string": "0",
        "channel": "defaults",
        "dist_name": "vs2008_runtime-9.00.30729.5054-0",
        "name": "vs2008_runtime",
        "platform": null,
        "version": "9.00.30729.5054",
        "with_features_depends": null
      },
      ...
    ]
  }
]
```

Now in conda 4.4.x, the output is back to what it was in conda 4.2.x. From the code that generates the JSON output it looks like this is intended and not a byproduct of this PR.