### PR TITLE
Fix deactivate on mingw64

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -147,13 +147,17 @@ def main():
     elif sys_argv[1] == '..deactivate.path':
         activation_path = get_activate_path(sys_argv[3], shell)
 
+        shelldict = shells[shell]
+        curr_path = shelldict['path_to'](os.environ[str('PATH')])
+        pathsep = shelldict['pathsep']
+
         if os.getenv('_CONDA_HOLD'):
-            new_path = regex.sub(r'%s(:?)' % regex.escape(activation_path),
+            new_path = regex.sub(r'%s(%s?)' % (regex.escape(activation_path), pathsep),
                                  r'CONDA_PATH_PLACEHOLDER\1',
-                                 os.environ[str('PATH')], 1)
+                                 curr_path, 1)
         else:
-            new_path = regex.sub(r'%s(:?)' % regex.escape(activation_path), r'',
-                                 os.environ[str('PATH')], 1)
+            new_path = regex.sub(r'%s(%s?)' % (regex.escape(activation_path), pathsep), r'',
+                                 curr_path, 1)
 
         print(new_path)
         sys.exit(0)


### PR DESCRIPTION
https://github.com/conda/conda/issues/5036

Write the PATH style based on the shell when deactivating. Fixes
deactivate in mingw64 on windows to write the PATH in Posix style
instead of Windows style.