### PR TITLE
fix target prefix determination

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -807,6 +807,12 @@ def _get_user_agent(context_platform):
     return user_agent
 
 
+# backward compatibility for conda-build
+def get_prefix(args, search=True):
+    from ..core.envs_manager import determine_target_prefix
+    return determine_target_prefix(context, args)
+
+
 try:
     context = Context(SEARCH_PATH, APP_NAME, None)
 except LoadError as e:  # pragma: no cover

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -352,6 +352,8 @@ class Context(Configuration):
 
     @property
     def default_prefix(self):
+        if self.active_prefix:
+            return self.active_prefix
         _default_env = os.getenv('CONDA_DEFAULT_ENV')
         if _default_env in (None, ROOT_ENV_NAME, 'root'):
             return self.root_prefix
@@ -394,17 +396,11 @@ class Context(Configuration):
             return None
 
     @property
-    def prefix(self):
-        return get_prefix(self, self._argparse_args, False)
-
-    @property
-    def prefix_w_legacy_search(self):
-        return get_prefix(self, self._argparse_args, True)
-
-    @property
-    def clone_src(self):
-        assert self._argparse_args.clone is not None
-        return locate_prefix_by_name(self, self._argparse_args.clone)
+    def target_prefix(self):
+        # used for the prefix that is the target of the command currently being executed
+        # different from the active prefix, which is sometimes given by -p or -n command line flags
+        from ..core.envs_manager import determine_target_prefix
+        return determine_target_prefix(self)
 
     @property
     def root_prefix(self):
@@ -770,16 +766,6 @@ def get_help_dict():
             Sets output log level. 0 is warn. 1 is info. 2 is debug. 3 is trace.
             """),
     })
-
-
-def get_prefix(ctx, args, search=True):
-    from ..core.envs_manager import get_prefix
-    return get_prefix(ctx, args, search)
-
-
-def locate_prefix_by_name(ctx, name):
-    from ..core.envs_manager import EnvsDirectory
-    return EnvsDirectory.locate_prefix_by_name(name, ctx.envs_dirs)
 
 
 @memoize

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -808,9 +808,9 @@ def _get_user_agent(context_platform):
 
 
 # backward compatibility for conda-build
-def get_prefix(args, search=True):
+def get_prefix(ctx, args, search=True):
     from ..core.envs_manager import determine_target_prefix
-    return determine_target_prefix(context, args)
+    return determine_target_prefix(ctx or context, args)
 
 
 try:

--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -47,9 +47,14 @@ activate' from PATH. """)
         raise CondaSystemExit("No help available for command %s" % ensure_text_type(sys.argv[1]))
 
 
+def locate_prefix_by_name(ctx, name):
+    from ..core.envs_manager import EnvsDirectory
+    return EnvsDirectory.locate_prefix_by_name(name, ctx.envs_dirs)
+
+
 def prefix_from_arg(arg, shell):
     shelldict = shells[shell] if shell else {}
-    from ..base.context import context, locate_prefix_by_name
+    from ..base.context import context
     'Returns a platform-native path'
     # MSYS2 converts Unix paths to Windows paths with unix seps
     # so we must check for the drive identifier too.

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -1,17 +1,19 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from functools import partial
 from os import listdir
 from os.path import basename, isdir, isfile, join
 import re
 import sys
 
 from ..base.constants import PREFIX_MAGIC_FILE, ROOT_ENV_NAME
-from ..base.context import context, get_prefix as context_get_prefix
+from ..base.context import context
 from ..common.compat import itervalues
 from ..models.match_spec import MatchSpec
 
-get_prefix = partial(context_get_prefix, context)
+
+def get_prefix(args, search=True):
+    from ..core.envs_manager import determine_target_prefix
+    return determine_target_prefix(context, args)
 
 
 def ensure_use_local(args):

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -11,11 +11,6 @@ from ..common.compat import itervalues
 from ..models.match_spec import MatchSpec
 
 
-def get_prefix(args, search=True):
-    from ..core.envs_manager import determine_target_prefix
-    return determine_target_prefix(context, args)
-
-
 def ensure_use_local(args):
     if not args.use_local:
         return

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from logging import getLogger
 import os
-from os.path import abspath, basename, exists, isdir, join
+from os.path import abspath, basename, exists, isdir
 
 from . import common
 from .._vendor.auxlib.ish import dals
@@ -17,11 +17,10 @@ from ..base.context import context
 from ..common.compat import text_type
 from ..core.envs_manager import EnvsDirectory
 from ..core.index import get_channel_priority_map, get_index
-from ..core.linked_data import linked as install_linked
 from ..core.solve import Solver
 from ..exceptions import (CondaImportError, CondaOSError, CondaSystemExit, CondaValueError,
                           DirectoryNotFoundError, DryRunExit, EnvironmentLocationNotFound,
-                          PackageNotInstalledError, PackagesNotFoundError, TooManyArgumentsError,
+                          PackagesNotFoundError, TooManyArgumentsError,
                           UnsatisfiableError)
 from ..misc import append_env, clone_env, explicit, touch_nonadmin
 from ..plan import (revert_actions)

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -56,7 +56,8 @@ def clone(src_arg, dst_prefix, json=False, quiet=False, index_args=None):
         if not isdir(src_prefix):
             raise DirectoryNotFoundError(src_arg)
     else:
-        src_prefix = context.clone_src
+        assert context._argparse_args.clone is not None
+        src_prefix = EnvsDirectory.locate_prefix_by_name(context._argparse_args.clone)
 
     if not json:
         print("Source:      %s" % src_prefix)
@@ -108,7 +109,7 @@ def install(args, parser, command='install'):
     isinstall = bool(command == 'install')
     if newenv:
         common.ensure_name_or_prefix(args, command)
-    prefix = context.prefix if newenv or args.mkdir else context.prefix_w_legacy_search
+    prefix = context.target_prefix
     if newenv:
         check_prefix(prefix, json=context.json)
     if context.force_32bit and prefix == context.root_prefix:
@@ -121,17 +122,6 @@ def install(args, parser, command='install'):
 """ % prefix)
 
     args_packages = [s.strip('"\'') for s in args.packages]
-
-    linked_dists = install_linked(prefix)
-    linked_names = tuple(ld.quad[0] for ld in linked_dists)
-    if isupdate and not args.all:
-        for name in args_packages:
-            common.arg2spec(name, json=context.json, update=True)
-            if name not in linked_names:
-                envs_dir = join(context.root_prefix, 'envs')
-                private_env_prefix = EnvsDirectory(envs_dir).get_private_env_prefix(name)
-                if private_env_prefix is None:
-                    raise PackageNotInstalledError(prefix, name)
 
     if newenv and not args.no_default_packages:
         default_packages = list(context.create_default_packages)
@@ -169,11 +159,6 @@ def install(args, parser, command='install'):
         if '@EXPLICIT' in specs:
             explicit(specs, prefix, verbose=not context.quiet, index_args=index_args)
             return
-    elif getattr(args, 'all', False):
-        if not linked_dists:
-            log.info("There are no packages installed in prefix %s", prefix)
-            return
-        specs.extend(d.quad[0] for d in linked_dists)
     specs.extend(common.specs_from_args(args_packages, json=context.json))
 
     if isinstall and args.revision:
@@ -203,7 +188,6 @@ def install(args, parser, command='install'):
         else:
             raise EnvironmentLocationNotFound(prefix)
 
-    index = {}
     try:
         if isinstall and args.revision:
             index = get_index(channel_urls=index_args['channel_urls'],
@@ -214,7 +198,6 @@ def install(args, parser, command='install'):
             progressive_fetch_extract = unlink_link_transaction.get_pfe()
         else:
             solver = Solver(prefix, context.channels, context.subdirs, specs_to_add=specs)
-            index, _ = solver._prepare()
             unlink_link_transaction = solver.solve_for_transaction(
                 force_reinstall=context.force,
             )
@@ -264,7 +247,6 @@ def handle_txn(progressive_fetch_extract, unlink_link_transaction, prefix, args,
     try:
         progressive_fetch_extract.execute()
         unlink_link_transaction.execute()
-        # execute_actions(actions, index, verbose=not context.quiet)
 
     except SystemExit as e:
         raise CondaSystemExit('Exiting', e)

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -207,7 +207,12 @@ def print_explicit(prefix, add_md5=False):
 def execute(args, parser):
     from ..base.context import context
     from .common import stdout_json
-    prefix = context.prefix_w_legacy_search
+    from ..core.envs_manager import EnvsDirectory
+    prefix = context.target_prefix
+    if not EnvsDirectory.is_conda_environment(prefix):
+        from ..exceptions import EnvironmentLocationNotFound
+        raise EnvironmentLocationNotFound(prefix)
+
     regex = args.regex
     if args.full_name:
         regex = r'^%s$' % regex

--- a/conda/cli/main_package.py
+++ b/conda/cli/main_package.py
@@ -18,7 +18,7 @@ import tarfile
 import tempfile
 
 from .conda_argparse import add_parser_prefix
-from ..base.context import context, get_prefix
+from ..base.context import context
 from ..common.compat import PY3, itervalues
 
 descr = "Low-level conda package utility. (EXPERIMENTAL)"
@@ -89,7 +89,7 @@ def remove(prefix, files):
 def execute(args, parser):
     from ..misc import untracked
 
-    prefix = get_prefix(context, args)
+    prefix = context.target_prefix
 
     if args.which:
         for path in args.which:

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -107,6 +107,7 @@ def execute(args, parser):
     from ..exceptions import CondaEnvironmentError, CondaValueError
     from ..gateways.disk.delete import delete_trash
     from ..resolve import MatchSpec
+    from ..core.envs_manager import EnvsDirectory
     from ..core.linked_data import linked_data
     from ..gateways.disk.delete import rm_rf
     from ..instructions import PREFIX
@@ -116,13 +117,17 @@ def execute(args, parser):
         raise CondaValueError('no package names supplied,\n'
                               '       try "conda remove -h" for more details')
 
-    prefix = context.prefix_w_legacy_search
+    prefix = context.target_prefix
     if args.all and prefix == context.default_prefix:
         msg = "cannot remove current environment. deactivate and run conda remove again"
         raise CondaEnvironmentError(msg)
     if args.all and not isdir(prefix):
         # full environment removal was requested, but environment doesn't exist anyway
         return 0
+
+    if not EnvsDirectory.is_conda_environment(prefix):
+        from ..exceptions import EnvironmentLocationNotFound
+        raise EnvironmentLocationNotFound(prefix)
 
     ensure_use_local(args)
     ensure_override_channels_requires_channel(args)

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -168,7 +168,7 @@ def execute_search(args, parser):
                                            "regex error: %(regex_error)s",
                                            regex=regex, regex_error=repr(e))
 
-    prefix = context.prefix_w_legacy_search
+    prefix = context.target_prefix
 
     linked = linked_data(prefix)
     extracted = set(pc_entry.name for pc_entry in PackageCache.get_all_extracted_entries())

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -317,7 +317,8 @@ class EnvsDirectory(object):
             else:
                 drop_these.append(rerec)
         if not drop_these:
-            self._envs_dir_data['registered_envs'] = sorted(keep_these, key=lambda x: x['location'])
+            self._envs_dir_data['registered_envs'] = sorted(keep_these,
+                                                            key=lambda x: x['location'])
             self.write_to_disk()
 
     # # ############################

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -753,7 +753,7 @@ class ExceptionHandler(object):
             message_builder.append(
                 "An unexpected error has occurred. Conda has prepared the above report."
             )
-
+            message_builder.append('')
             self.out_stream.write('\n'.join(message_builder))
 
     def _calculate_ask_do_upload(self):

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import Hashable
-from functools import partial
 from logging import getLogger
 import threading
 from warnings import warn
@@ -79,15 +78,14 @@ from .models.version import VersionOrder  # NOQA
 VersionOrder = VersionOrder
 
 import conda.base.context  # NOQA
-from .base.context import non_x86_linux_machines, sys_rc_path  # NOQA
+from .base.context import get_prefix, non_x86_linux_machines, sys_rc_path  # NOQA
 non_x86_linux_machines, sys_rc_path = non_x86_linux_machines, sys_rc_path
+get_prefix = get_prefix
 
 from ._vendor.auxlib.entity import EntityEncoder # NOQA
 EntityEncoder = EntityEncoder
 from .base.constants import DEFAULT_CHANNELS, DEFAULT_CHANNELS_WIN, DEFAULT_CHANNELS_UNIX  # NOQA
 DEFAULT_CHANNELS, DEFAULT_CHANNELS_WIN, DEFAULT_CHANNELS_UNIX = DEFAULT_CHANNELS, DEFAULT_CHANNELS_WIN, DEFAULT_CHANNELS_UNIX  # NOQA
-from .core.envs_manager import determine_target_prefix as _determine_target_prefix  # NOQA
-get_prefix = partial(_determine_target_prefix, conda.base.context.context)
 get_default_urls = lambda: DEFAULT_CHANNELS
 
 arch_name = conda.base.context.context.arch_name

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -79,14 +79,15 @@ from .models.version import VersionOrder  # NOQA
 VersionOrder = VersionOrder
 
 import conda.base.context  # NOQA
-from .base.context import get_prefix as context_get_prefix, non_x86_linux_machines, sys_rc_path  # NOQA
+from .base.context import non_x86_linux_machines, sys_rc_path  # NOQA
 non_x86_linux_machines, sys_rc_path = non_x86_linux_machines, sys_rc_path
 
 from ._vendor.auxlib.entity import EntityEncoder # NOQA
 EntityEncoder = EntityEncoder
 from .base.constants import DEFAULT_CHANNELS, DEFAULT_CHANNELS_WIN, DEFAULT_CHANNELS_UNIX  # NOQA
 DEFAULT_CHANNELS, DEFAULT_CHANNELS_WIN, DEFAULT_CHANNELS_UNIX = DEFAULT_CHANNELS, DEFAULT_CHANNELS_WIN, DEFAULT_CHANNELS_UNIX  # NOQA
-get_prefix = partial(context_get_prefix, conda.base.context.context)
+from .core.envs_manager import determine_target_prefix as _determine_target_prefix  # NOQA
+get_prefix = partial(_determine_target_prefix, conda.base.context.context)
 get_default_urls = lambda: DEFAULT_CHANNELS
 
 arch_name = conda.base.context.context.arch_name

--- a/conda_env/cli/common.py
+++ b/conda_env/cli/common.py
@@ -3,7 +3,7 @@ from os.path import isdir, join
 import sys
 
 from conda._vendor.auxlib.entity import EntityEncoder
-from conda.base.context import context, get_prefix as context_get_prefix
+from conda.base.context import context
 
 root_env_name = 'root'
 
@@ -16,7 +16,8 @@ def stdout_json(d):
 
 
 def get_prefix(args, search=True):
-    return context_get_prefix(context, args, search)
+    from conda.core.envs_manager import determine_target_prefix
+    return determine_target_prefix(context, args)
 
 
 def find_prefix_name(name):

--- a/conda_env/cli/main_remove.py
+++ b/conda_env/cli/main_remove.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, print_function
 
 from argparse import Namespace, RawDescriptionHelpFormatter
 
+from os.path import isdir
+
 from conda.cli.conda_argparse import (add_parser_json, add_parser_prefix, add_parser_quiet,
                                       add_parser_yes)
 
@@ -45,4 +47,13 @@ def execute(args, parser):
         'all': True, 'channel': None, 'features': None,
         'override_channels': None, 'use_local': None, 'use_cache': None,
         'offline': None, 'force': None, 'pinned': None})
-    conda.cli.main_remove.execute(Namespace(**args), parser)
+    args = Namespace(**args)
+    from conda.base.constants import SEARCH_PATH
+    from conda.base.context import context
+    context.__init__(SEARCH_PATH, 'conda', args)
+
+    if not isdir(context.target_prefix):
+        from conda.exceptions import EnvironmentLocationNotFound
+        raise EnvironmentLocationNotFound(context.target_prefix)
+
+    conda.cli.main_remove.execute(args, parser)

--- a/tests/cli/test_activate.py
+++ b/tests/cli/test_activate.py
@@ -652,7 +652,7 @@ def test_activate_does_not_leak_echo_setting(shell):
         assert_equals(stdout, u'ECHO is on.', stderr)
 
 
-@pytest.mark.skipif(datetime.now() < datetime(2017, 7, 1), reason="save for later")
+@pytest.mark.skipif(datetime.now() < datetime(2017, 8, 1), reason="save for later")
 @pytest.mark.installed
 def test_activate_non_ascii_char_in_path(shell):
     shell_vars = _format_vars(shell)

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -11,7 +11,7 @@ from conda.base.context import context
 from conda.cli.common import list_prefixes
 from conda.cli.main import generate_parser
 from conda.common.io import captured
-from conda.exceptions import EnvironmentNameNotFound
+from conda.exceptions import EnvironmentNameNotFound, EnvironmentLocationNotFound
 from conda.install import rm_rf
 from conda_env.cli.main import create_parser
 from conda_env.exceptions import SpecNotFound
@@ -232,7 +232,7 @@ class NewIntegrationTests(unittest.TestCase):
         run_conda_command(Commands.CREATE, test_env_name_3)
         self.assertTrue(env_is_created(test_env_name_3))
 
-        with pytest.raises(EnvironmentNameNotFound) as execinfo:
+        with pytest.raises(EnvironmentLocationNotFound) as execinfo:
             run_env_command(Commands.ENV_REMOVE, 'does-not-exist')
 
         run_env_command(Commands.ENV_REMOVE, test_env_name_3)

--- a/tests/core/test_envs_manager.py
+++ b/tests/core/test_envs_manager.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from logging import getLogger
+import os
 from os.path import isdir, join, lexists
 from tempfile import gettempdir
 from unittest import TestCase
@@ -10,6 +11,7 @@ from uuid import uuid4
 import pytest
 
 from conda import CondaError
+from conda._vendor.auxlib.collection import AttrDict
 from conda.base.constants import ROOT_ENV_NAME
 from conda.base.context import context, reset_context
 from conda.common.io import env_var
@@ -17,8 +19,14 @@ from conda.common.path import ensure_pad
 from conda.core.envs_manager import EnvsDirectory
 from conda.gateways.disk import mkdir_p
 from conda.gateways.disk.delete import rm_rf
+from conda.gateways.disk.update import touch
 from conda.models.enums import LeasedPathType
 from conda.models.leased_path_entry import LeasedPathEntry
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 log = getLogger(__name__)
 
@@ -177,3 +185,37 @@ class EnvsManagerUnitTests(TestCase):
     #                 'requested_spec': requested_spec,
     #             }
 
+    def test_default_target_is_root_prefix(self):
+        assert context.target_prefix == context.root_prefix
+
+    def test_name_cli_flag(self):
+        envs_dirs = (join(self.prefix, 'first-envs-dir'), join(self.prefix, 'seconds-envs-dir'))
+        with env_var('CONDA_ENVS_DIRS', os.pathsep.join(envs_dirs), reset_context):
+
+            # with both dirs writable, choose first
+            reset_context((), argparse_args=AttrDict(name='blarg'))
+            assert context.target_prefix == join(envs_dirs[0], 'blarg')
+
+            # with first dir read-only, choose second
+            EnvsDirectory(envs_dirs[0])._is_writable = False
+            reset_context((), argparse_args=AttrDict(name='blarg'))
+            assert context.target_prefix == join(envs_dirs[1], 'blarg')
+
+            # if first dir is read-only but environment exists, choose first
+            EnvsDirectory._cache_.pop(envs_dirs[0])
+            mkdir_p(join(envs_dirs[0], 'blarg'))
+            touch(join(envs_dirs[0], 'blarg', 'history'))
+            reset_context((), argparse_args=AttrDict(name='blarg'))
+            assert context.target_prefix == join(envs_dirs[0], 'blarg')
+
+            EnvsDirectory._cache_ = {}
+
+    def test_prefix_cli_flag(self):
+        envs_dirs = (join(self.prefix, 'first-envs-dir'), join(self.prefix, 'seconds-envs-dir'))
+        with env_var('CONDA_ENVS_DIRS', os.pathsep.join(envs_dirs), reset_context):
+
+            # even if prefix doesn't exist, it can be a target prefix
+            reset_context((), argparse_args=AttrDict(prefix='./blarg'))
+            target_prefix = join(os.getcwd(), 'blarg')
+            assert context.target_prefix == target_prefix
+            assert not isdir(target_prefix)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,12 +165,12 @@ class TestJson(unittest.TestCase):
         self.assertIsInstance(res, list)
 
         stdout, stderr, rc = run_inprocess_conda_command('conda list --name nonexistent --json')
-        assert json.loads(stdout.strip())['exception_name'] == 'EnvironmentNameNotFound'
+        assert json.loads(stdout.strip())['exception_name'] == 'EnvironmentLocationNotFound'
         assert stderr == ''
         assert rc > 0
 
         stdout, stderr, rc = run_inprocess_conda_command('conda list --name nonexistent --revisions --json')
-        assert json.loads(stdout.strip())['exception_name'] == 'EnvironmentNameNotFound'
+        assert json.loads(stdout.strip())['exception_name'] == 'EnvironmentLocationNotFound'
         assert stderr == ''
         assert rc > 0
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1185,7 +1185,7 @@ class IntegrationTests(TestCase):
                 mock_method.side_effect = side_effect
                 run_command(Commands.INSTALL, prefix, "flask", "--json", "--use-index-cache")
 
-    @pytest.mark.xfail(datetime.now() < datetime(2017, 7, 1),
+    @pytest.mark.xfail(datetime.now() < datetime(2017, 8, 1),
                        reason="I can't figure out why this if failing yet.", strict=True)
     def test_offline_with_empty_index_cache(self):
         with make_temp_env() as prefix, make_temp_channel(['flask-0.10.1']) as channel:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1350,6 +1350,7 @@ class IntegrationTests(TestCase):
 
         # regression test for #3489
         # don't raise for remove --all if environment doesn't exist
+        rm_rf(prefix)
         run_command(Commands.REMOVE, prefix, "--all")
 
     def test_transactional_rollback_simple(self):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -31,7 +31,7 @@ class ExportIntegrationTests(TestCase):
             output2, error= run_command(Commands.LIST, prefix2, "-e")
             self.assertEqual(output, output2)
 
-    @pytest.mark.xfail(datetime.now() < datetime(2017, 7, 1), reason="Bring back `conda list --export` #3445", strict=True)
+    @pytest.mark.xfail(datetime.now() < datetime(2017, 8, 1), reason="Bring back `conda list --export` #3445", strict=True)
     def test_multi_channel_export(self):
         """
             When try to import from txt


### PR DESCRIPTION
This PR cleans up the `prefix`, `prefix_w_legacy_search`, and `` properties on the `context` object, and adds a `target_prefix` property to the `context` object.  `context.target_prefix` should be used for the prefix that is the target of the command currently being executed.  It's potentially different from the *active* prefix, because target prefix is often specified with `-p` or `-n` command line flags.

