### PR TITLE
conda info now raises PackagesNotFoundError

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -331,8 +331,13 @@ def execute(args, parser):
         return
 
     if args.packages:
-        print_package_info(args.packages)
-        return
+        from ..resolve import ResolvePackageNotFound
+        try:
+            print_package_info(args.packages)
+            return
+        except ResolvePackageNotFound as e:
+            from ..exceptions import PackagesNotFoundError
+            raise PackagesNotFoundError(e.bad_deps)
 
     if args.unsafe_channels:
         if not context.json:

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -335,7 +335,7 @@ def execute(args, parser):
         try:
             print_package_info(args.packages)
             return
-        except ResolvePackageNotFound as e:
+        except ResolvePackageNotFound as e:  # pragma: no cover
             from ..exceptions import PackagesNotFoundError
             raise PackagesNotFoundError(e.bad_deps)
 


### PR DESCRIPTION
previously:
```
`$ /Users/tkim/miniconda3/bin/conda info efefef`

    Traceback (most recent call last):
      File "/Users/tkim/Documents/projects/conda/conda/exceptions.py", line 647, in __call__
        return func(*args, **kwargs)
      File "/Users/tkim/Documents/projects/conda/conda/cli/main.py", line 136, in _main
        exit_code = args.func(args, p)
      File "/Users/tkim/Documents/projects/conda/conda/cli/main_info.py", line 334, in execute
        print_package_info(args.packages)
      File "/Users/tkim/Documents/projects/conda/conda/cli/main_info.py", line 153, in print_package_info
        for dist in r.get_dists_for_spec(arg2spec(package)):
      File "/Users/tkim/Documents/projects/conda/conda/resolve.py", line 423, in get_dists_for_spec
        raise ResolvePackageNotFound([(ms,)])
    ResolvePackageNotFound:
      - efefef
```

Now: 
```
PackagesNotFoundError: The following packages are missing from the target environment:
  - efefef
```