### PR TITLE
Caught OSError upon missing device.

### DIFF
--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -157,10 +157,11 @@ def read_mod_and_etag(path):
                 match_objects = take(3, re.finditer(REPODATA_HEADER_RE, m))
                 result = dict(map(ensure_unicode, mo.groups()) for mo in match_objects)
                 return result
-        except (BufferError, ValueError):
+        except (BufferError, ValueError, OSError):
             # BufferError: cannot close exported pointers exist
             #   https://github.com/conda/conda/issues/4592
             # ValueError: cannot mmap an empty file
+            # OSError: [Errno 19] No such device
             return {}
 
 


### PR DESCRIPTION
On CentOS line `closing(mmap(f.fileno(), 0, access=ACCESS_READ)) as m:`
caused an OSError.