### PR TITLE
Invoke cmd.exe with /D for pre/post link/unlink scripts

### DIFF
--- a/conda/install.py
+++ b/conda/install.py
@@ -478,7 +478,7 @@ def run_script(prefix, dist, action='post-link', env_prefix=None):
         return True
     if on_win:
         try:
-            args = [os.environ['COMSPEC'], '/c', path]
+            args = [os.environ['COMSPEC'], '/d', '/c', path]
         except KeyError:
             return False
     else:


### PR DESCRIPTION
The /D flag prevents the command prompt to invoke an autorun script that
is otherwise being run at the beginning of every command prompt session if
specified in the registry. From the `cmd.exe /?` output:

```
If /D was NOT specified on the command line, then when CMD.EXE starts, it
looks for the following REG_SZ/REG_EXPAND_SZ registry variables, and if
either or both are present, they are executed first.

    HKEY_LOCAL_MACHINE\Software\Microsoft\Command Processor\AutoRun

        and/or

    HKEY_CURRENT_USER\Software\Microsoft\Command Processor\AutoRun
```

Since such autorun scripts might make one pre/post link/unlink script to
behave different on one machine than on another, this provides a more
reproducible environment to run these scripts in.

I made this PR against 4.2.x--not sure we not to go back that much, happy to recreate the PR against 4.3.x or 4.4.x if that's preferred.