### PR TITLE
fix #5708 package priority sort order

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -531,8 +531,8 @@ class Resolve(object):
         bld = rec.get('build_number', 0)
         bs = rec.get('build')
         ts = rec.get('timestamp', 0)
-        return ((valid, -cpri, ver, bld, bs, ts) if context.channel_priority else
-                (valid, ver, -cpri, bld, bs, ts))
+        return ((valid, -cpri, ver, bld, ts, bs) if context.channel_priority else
+                (valid, ver, -cpri, bld, ts, bs))
 
     def features(self, dist):
         return set(self.index[dist].get('features', '').split())
@@ -669,7 +669,7 @@ class Resolve(object):
                 elif pkey[3] != version_key[3]:
                     ib += 1
                 # last field is timestamp. Use it as differentiator when build numbers are similar
-                elif pkey[5] != version_key[5]:
+                elif pkey[4] != version_key[4]:
                     ib += 1
 
                 if iv or include0:


### PR DESCRIPTION
Resolves #5708.  Root cause was created in the initial timestamp sort order implementation in https://github.com/conda/conda/pull/5015.  Build string should be prioritized after timestamp, and not before.