### PR TITLE
Remove clean source cache option from conda

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1092,21 +1092,6 @@ class IntegrationTests(TestCase):
             shutil.move(pkgs_dir_hold, pkgs_dir)
             PackageCache.clear()
 
-    def test_clean_source_cache(self):
-        cache_dirs = {
-            'source cache': text_type(context.src_cache),
-            'git cache': text_type(context.git_cache),
-            'hg cache': text_type(context.hg_cache),
-            'svn cache': text_type(context.svn_cache),
-        }
-
-        assert all(isdir(d) for d in itervalues(cache_dirs))
-
-        # --json flag is regression test for #5451
-        run_command(Commands.CLEAN, '', "--source-cache --yes  --json")
-
-        assert not all(isdir(d) for d in itervalues(cache_dirs))
-
     def test_install_mkdir(self):
         try:
             prefix = make_temp_prefix()


### PR DESCRIPTION
The clean source cache option has been replaced with a warning about using conda build instead of conda to remove source cache files. I also removed the rm_source_cache function and its related test.