### PR TITLE
fix --override-channels and add whitelist_channels config

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -93,8 +93,9 @@ class Context(Configuration):
     changeps1 = PrimitiveParameter(True)
     concurrent = PrimitiveParameter(True)
     create_default_packages = SequenceParameter(string_types)
-    default_python = PrimitiveParameter('%d.%d' % sys.version_info[:2],
-                                        element_type=string_types + (NoneType,))
+    default_python = PrimitiveParameter(default_python_default(),
+                                        element_type=string_types + (NoneType,),
+                                        validation=default_python_validation)
     disallow = SequenceParameter(string_types)
     enable_private_envs = PrimitiveParameter(False)
     force_32bit = PrimitiveParameter(False)
@@ -134,34 +135,36 @@ class Context(Configuration):
     remote_max_retries = PrimitiveParameter(3)
 
     add_anaconda_token = PrimitiveParameter(True, aliases=('add_binstar_token',))
+
+    # #############################
+    # channels
+    # #############################
+    allow_non_channel_urls = PrimitiveParameter(True)
     _channel_alias = PrimitiveParameter(DEFAULT_CHANNEL_ALIAS,
                                         aliases=('channel_alias',),
                                         validation=channel_alias_validation)
-    allow_non_channel_urls = PrimitiveParameter(True)
-
-    # channels
+    channel_priority = PrimitiveParameter(True)
     _channels = SequenceParameter(string_types, default=(DEFAULTS_CHANNEL_NAME,),
                                   aliases=('channels', 'channel',))  # channel for args.channel
-    _migrated_channel_aliases = SequenceParameter(string_types,
-                                                  aliases=('migrated_channel_aliases',))  # TODO: also take a list of strings # NOQA
+    _custom_channels = MapParameter(string_types, aliases=('custom_channels',))
+    _custom_multichannels = MapParameter(list, aliases=('custom_multichannels',))
     _default_channels = SequenceParameter(string_types, DEFAULT_CHANNELS,
                                           aliases=('default_channels',))
-    _custom_channels = MapParameter(string_types, aliases=('custom_channels',))
+    _migrated_channel_aliases = SequenceParameter(string_types,
+                                                  aliases=('migrated_channel_aliases',))  # TODO: also take a list of strings # NOQA
     migrated_custom_channels = MapParameter(string_types)  # TODO: also take a list of strings
-    _custom_multichannels = MapParameter(list, aliases=('custom_multichannels',))
+    override_channels_enabled = PrimitiveParameter(True)
+    show_channel_urls = PrimitiveParameter(None, element_type=(bool, NoneType))
+    whitelist_channels = SequenceParameter(string_types)
 
-    default_python = PrimitiveParameter(default_python_default(),
-                                        validation=default_python_validation)
     always_softlink = PrimitiveParameter(False, aliases=('softlink',))
     always_copy = PrimitiveParameter(False, aliases=('copy',))
     always_yes = PrimitiveParameter(None, aliases=('yes',), element_type=(bool, NoneType))
-    channel_priority = PrimitiveParameter(True)
     debug = PrimitiveParameter(False)
     dry_run = PrimitiveParameter(False)
     error_upload_url = PrimitiveParameter(ERROR_UPLOAD_URL)
     force = PrimitiveParameter(False)
     json = PrimitiveParameter(False)
-    info = PrimitiveParameter(False)
     no_dependencies = PrimitiveParameter(False, aliases=('no_deps',))
     offline = PrimitiveParameter(False)
     only_dependencies = PrimitiveParameter(False, aliases=('only_deps',))
@@ -170,7 +173,6 @@ class Context(Configuration):
     ignore_pinned = PrimitiveParameter(False)
     report_errors = PrimitiveParameter(None, element_type=(bool, NoneType))
     shortcuts = PrimitiveParameter(True)
-    show_channel_urls = PrimitiveParameter(None, element_type=(bool, NoneType))
     update_dependencies = PrimitiveParameter(False, aliases=('update_deps',))
     _verbosity = PrimitiveParameter(0, aliases=('verbose', 'verbosity'), element_type=int)
 
@@ -484,6 +486,22 @@ class Context(Configuration):
 
     @property
     def channels(self):
+        if (self._argparse_args and 'override_channels' in self._argparse_args
+                and self._argparse_args['override_channels']):
+            if not self.override_channels_enabled:
+                from ..exceptions import OperationNotAllowed
+                raise OperationNotAllowed(dals("""
+                Overriding channels has been disabled.
+                """))
+            elif not (self._argparse_args and 'channel' in self._argparse_args
+                      and self._argparse_args['channel']):
+                from ..exceptions import CommandArgumentError
+                raise CommandArgumentError(dals("""
+                At least one -c / --channel flag must be supplied when using --override-channels.
+                """))
+            else:
+                return self._argparse_args['channel']
+
         # add 'defaults' channel when necessary if --channel is given via the command line
         if self._argparse_args and 'channel' in self._argparse_args:
             # TODO: it's args.channel right now, not channels
@@ -680,9 +698,6 @@ def get_help_dict():
         'json': dals("""
             Ensure all output written to stdout is structured json.
             """),
-        'info': dals("""
-            Provide detail information on each build of a package
-            """),
         'local_repodata_ttl': dals("""
             For a value of False or 0, always fetch remote repodata (HTTP 304 responses
             respected). For a value of True or 1, respect the HTTP Cache-Control max-age
@@ -699,6 +714,9 @@ def get_help_dict():
             """),
         'offline': dals("""
             Restrict conda to cached download content and file:// based urls.
+            """),
+        'override_channels_enabled': dals("""
+            Permit use of the --overide-channels command-line flag.
             """),
         'path_conflict': dals("""
             The method by which conda handle's conflicting/overlapping paths during a
@@ -774,6 +792,13 @@ def get_help_dict():
         'verbosity': dals("""
             Sets output log level. 0 is warn. 1 is info. 2 is debug. 3 is trace.
             """),
+        'whitelist_channels': dals("""
+            The exclusive list of channels allowed to be used on the system. Use of any
+            other channels will result in an error. If conda-build channels are to be
+            allowed, along with the --use-local command line flag, be sure to include the
+            'local' channel in the list. If the list is empty or left undefined, no
+            channel exclusions will be enforced.
+            """)
     })
 
 

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -12,22 +12,6 @@ from ..common.compat import itervalues
 from ..models.match_spec import MatchSpec
 
 
-def ensure_use_local(args):
-    if not args.use_local:
-        return
-
-
-def ensure_override_channels_requires_channel(args, dashc=True):
-    if args.override_channels and not (args.channel or args.use_local):
-        from ..exceptions import CondaValueError
-        if dashc:
-            raise CondaValueError('--override-channels requires -c/--channel'
-                                  ' or --use-local')
-        else:
-            raise CondaValueError('--override-channels requires --channel'
-                                  'or --use-local')
-
-
 def confirm(message="Proceed", choices=('yes', 'no'), default='yes'):
     assert default in choices, default
     if context.dry_run:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -134,8 +134,6 @@ def install(args, parser, command='install'):
             if default_pkg_name not in args_packages_names:
                 args_packages.append(default_pkg)
 
-    common.ensure_use_local(args)
-    common.ensure_override_channels_requires_channel(args)
     index_args = {
         'use_cache': args.use_index_cache,
         'channel_urls': context.channels,

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -97,8 +97,7 @@ def configure_parser(sub_parsers, name='remove'):
 
 
 def execute(args, parser):
-    from .common import (check_non_admin, confirm_yn, ensure_override_channels_requires_channel,
-                         ensure_use_local, specs_from_args, stdout_json)
+    from .common import check_non_admin, confirm_yn, specs_from_args, stdout_json
     from ..base.context import context
     from ..common.compat import iteritems, iterkeys
     from ..core.index import get_index
@@ -131,8 +130,6 @@ def execute(args, parser):
         from ..exceptions import EnvironmentLocationNotFound
         raise EnvironmentLocationNotFound(prefix)
 
-    ensure_use_local(args)
-    ensure_override_channels_requires_channel(args)
     if not args.features and args.all:
         index = linked_data(prefix)
         index = {dist: info for dist, info in iteritems(index)}

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -177,7 +177,7 @@ def execute(args, parser):
             json_obj[match.name].append(match)
         stdout_json(json_obj)
 
-    elif context.info:
+    elif args.info:
         for record in matches:
             pretty_record(record)
 

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -123,8 +123,6 @@ package.""",
 
 
 def execute(args, parser):
-    from .common import (ensure_override_channels_requires_channel,
-                         ensure_use_local)
     from ..core.index import get_index
     from ..models.match_spec import MatchSpec
     from ..models.version import VersionOrder
@@ -139,14 +137,6 @@ def execute(args, parser):
         platform = ''
     if platform and platform != context.subdir:
         args.unknown = False
-    ensure_use_local(args)
-    ensure_override_channels_requires_channel(args, dashc=False)
-
-    platform = args.platform or ''
-    if platform and platform != context.subdir:
-        args.unknown = False
-    ensure_use_local(args)
-    ensure_override_channels_requires_channel(args, dashc=False)
 
     with spinner("Loading channels", not context.verbosity and not context.quiet, context.json):
         spec_channel = spec.get_exact_value('channel')

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -437,7 +437,12 @@ class Solver(object):
             known_channels = tuple(c.canonical_name for c in self.channels)
 
             _supplement_index_with_prefix(self._index, self.prefix, known_channels)
-            _supplement_index_with_cache(self._index, known_channels)
+            if context.offline or ('unknown' in context._argparse_args
+                                   and context._argparse_args.unknown):
+                # This is really messed up right now.  Dates all the way back to
+                # https://github.com/conda/conda/commit/f761f65a82b739562a0d997a2570e2b8a0bdc783
+                # TODO: revisit this later
+                _supplement_index_with_cache(self._index, known_channels)
             _supplement_index_with_features(self._index)
 
             self._r = Resolve(self._index)

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -222,6 +222,10 @@ class Channel(object):
             return None
         return "%s://%s" % (self.scheme, join_url(self.location, self.name))
 
+    @property
+    def base_urls(self):
+        return self.base_url,
+
     def __str__(self):
         return self.base_url or ""
 
@@ -315,6 +319,10 @@ class MultiChannel(Channel):
     @property
     def base_url(self):
         return None
+
+    @property
+    def base_urls(self):
+        return tuple(c.base_url for c in self._channels)
 
     def url(self, with_credentials=False):
         return None

--- a/conda_env/installers/conda.py
+++ b/conda_env/installers/conda.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from os.path import basename
 
 from conda._vendor.boltons.setutils import IndexedSet
+from conda.base.context import context
 from conda.core.solve import Solver
 from conda.models.channel import Channel, prioritize_channels
 
@@ -23,6 +24,8 @@ def install(prefix, specs, args, env, prune=False):
     # TODO: support all various ways this happens
     # Including 'nodefaults' in the channels list disables the defaults
     channel_urls = channel_urls + [chan for chan in env.channels if chan != 'nodefaults']
+    if 'nodefaults' not in env.channels:
+        channel_urls.extend(context.channels)
     _channel_priority_map = prioritize_channels(channel_urls)
 
     channel_names = IndexedSet(Channel(url).canonical_name for url in _channel_priority_map)

--- a/tests/cli/test_activate.py
+++ b/tests/cli/test_activate.py
@@ -652,7 +652,7 @@ def test_activate_does_not_leak_echo_setting(shell):
         assert_equals(stdout, u'ECHO is on.', stderr)
 
 
-@pytest.mark.skipif(datetime.now() < datetime(2017, 8, 1), reason="save for later")
+@pytest.mark.skipif(datetime.now() < datetime(2017, 9, 1), reason="save for later")
 @pytest.mark.installed
 def test_activate_non_ascii_char_in_path(shell):
     shell_vars = _format_vars(shell)

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -6,8 +6,12 @@ from unittest import TestCase
 
 import pytest
 
+from conda.base.constants import DEFAULT_CHANNELS
+from conda.base.context import reset_context
 from conda.common.compat import iteritems
-from conda.core.index import get_index
+from conda.common.io import env_var
+from conda.core.index import get_index, check_whitelist
+from conda.exceptions import OperationNotAllowed
 from tests.core.test_repodata import platform_in_record
 
 try:
@@ -16,6 +20,28 @@ except ImportError:
     from mock import patch
 
 log = getLogger(__name__)
+
+
+def test_check_whitelist():
+    # get_index(channel_urls=(), prepend=True, platform=None, use_local=False, use_cache=False, unknown=None, prefix=None)
+    whitelist = (
+        'defaults',
+        'conda-forge',
+        'https://beta.conda.anaconda.org/conda-test'
+    )
+    with env_var('CONDA_WHITELIST_CHANNELS', ','.join(whitelist), reset_context):
+        with pytest.raises(OperationNotAllowed):
+            get_index(("conda-canary",))
+
+        with pytest.raises(OperationNotAllowed):
+            get_index(("https://repo.continuum.io/pkgs/denied",))
+
+        check_whitelist(("defaults",))
+        check_whitelist((DEFAULT_CHANNELS[0], DEFAULT_CHANNELS[1]))
+        check_whitelist(("https://conda.anaconda.org/conda-forge/linux-64",))
+
+    check_whitelist(("conda-canary",))
+
 
 
 @pytest.mark.integration


### PR DESCRIPTION
In addition to re-enabling the `--override-channels` command line functionality, this PR adds two additional configuration parameters, and implements the associated logic.

```
       'override_channels_enabled': dals("""
            Permit use of the --overide-channels command-line flag.
            """),

       'whitelist_channels': dals("""
            The exclusive list of channels allowed to be used on the system. Use of any
            other channels will result in an error. If conda-build channels are to be
            allowed, along with the --use-local command line flag, be sure to include the
            'local' channel in the list. If the list is empty or left undefined, no
            channel exclusions will be enforced.
            """)
```