### PR TITLE
fix #5811 change safety_checks default to 'warn' for conda 4.4

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -96,6 +96,15 @@ CONDA_TARBALL_EXTENSION = '.tar.bz2'
 UNKNOWN_CHANNEL = "<unknown>"
 
 
+class SafetyChecks(Enum):
+    disabled = 'disabled'
+    warn = 'warn'
+    enabled = 'enabled'
+
+    def __str__(self):
+        return self.value
+
+
 class PathConflict(Enum):
     clobber = 'clobber'
     warn = 'warn'

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -10,7 +10,7 @@ import sys
 
 from .constants import (APP_NAME, DEFAULTS_CHANNEL_NAME, DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS,
                         ERROR_UPLOAD_URL, PLATFORM_DIRECTORIES, PathConflict, ROOT_ENV_NAME,
-                        SEARCH_PATH)
+                        SEARCH_PATH, SafetyChecks)
 from .. import __version__ as CONDA_VERSION
 from .._vendor.appdirs import user_data_dir
 from .._vendor.auxlib.collection import frozendict
@@ -101,12 +101,15 @@ class Context(Configuration):
     force_32bit = PrimitiveParameter(False)
     max_shlvl = PrimitiveParameter(2)
     non_admin_enabled = PrimitiveParameter(True)
+
+    # Safety & Security
+    safety_checks = PrimitiveParameter(SafetyChecks.warn)
     path_conflict = PrimitiveParameter(PathConflict.clobber)
+
     pinned_packages = SequenceParameter(string_types, string_delimiter='&')  # TODO: consider a different string delimiter  # NOQA
     rollback_enabled = PrimitiveParameter(True)
     track_features = SequenceParameter(string_types)
     use_pip = PrimitiveParameter(True)
-    skip_safety_checks = PrimitiveParameter(False)
     use_index_cache = PrimitiveParameter(False)
 
     _root_prefix = PrimitiveParameter("", aliases=('root_dir', 'root_prefix'))
@@ -532,7 +535,6 @@ class Context(Configuration):
             'only_dependencies',
             'prune',
             'root_prefix',
-            'skip_safety_checks',
             'subdir',
             'subdirs',
 # https://conda.io/docs/config.html#disable-updating-of-dependencies-update-dependencies # NOQA
@@ -761,6 +763,10 @@ def get_help_dict():
         'rollback_enabled': dals("""
             Should any error occur during an unlink/link transaction, revert any disk
             mutations made to that point in the transaction.
+            """),
+        'safety_checks': dals("""
+            Enforce available safety guarantees during package installation.
+            The value must be one of 'enabled', 'warn', or 'disabled'.
             """),
         'shortcuts': dals("""
             Allow packages to create OS-specific shortcuts (e.g. in the Windows Start

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -11,6 +11,7 @@ from tempfile import mkdtemp
 from traceback import format_exception_only
 import warnings
 
+from conda.base.constants import SafetyChecks
 from .linked_data import PrefixData, get_python_version_for_prefix, linked_data as get_linked_data
 from .package_cache import PackageCache
 from .path_actions import (CompilePycAction, CreatePrefixRecordAction, CreateNonadminAction,
@@ -193,7 +194,7 @@ class UnlinkLinkTransaction(object):
 
         assert not context.dry_run
 
-        if context.skip_safety_checks:
+        if context.safety_checks == SafetyChecks.disabled:
             self._verified = True
             return
 

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -22,7 +22,7 @@ from ..common.path import (get_bin_directory_short_path, get_leaf_directories,
                            parse_entry_point_def,
                            pyc_path, url_to_path, win_path_ok)
 from ..common.url import has_platform, path_to_url, unquote
-from ..exceptions import CondaUpgradeError, CondaVerificationError, PaddingError
+from ..exceptions import CondaUpgradeError, CondaVerificationError, PaddingError, SafetyError
 from ..gateways.connection.download import download
 from ..gateways.disk.create import (compile_pyc, copy, create_hard_link_or_copy,
                                     create_link, create_python_entry_point, extract_tarball,
@@ -347,7 +347,7 @@ class LinkPathAction(CreateInPrefixPathAction):
                 reported_sha256 = None
             source_sha256 = compute_sha256sum(self.source_full_path)
             if reported_sha256 and reported_sha256 != source_sha256:
-                return CondaVerificationError(dals("""
+                return SafetyError(dals("""
                 The package for %s located at %s
                 appears to be corrupted. The path '%s'
                 has a sha256 mismatch.
@@ -367,7 +367,7 @@ class LinkPathAction(CreateInPrefixPathAction):
             if reported_size_in_bytes:
                 source_size_in_bytes = getsize(self.source_full_path)
                 if reported_size_in_bytes != source_size_in_bytes:
-                    return CondaVerificationError(dals("""
+                    return SafetyError(dals("""
                     The package for %s located at %s
                     appears to be corrupted. The path '%s'
                     has an incorrect size.

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -12,7 +12,7 @@ from . import CondaError, CondaExitZero, CondaMultiError, text_type
 from ._vendor.auxlib.entity import EntityEncoder
 from ._vendor.auxlib.ish import dals
 from ._vendor.auxlib.type_coercion import boolify
-from .base.constants import PathConflict
+from .base.constants import PathConflict, SafetyChecks
 from .common.compat import ensure_text_type, input, iteritems, iterkeys, on_win, string_types
 from .common.io import timeout
 from .common.signals import get_signal_name
@@ -536,6 +536,11 @@ class CondaVerificationError(CondaError):
         super(CondaVerificationError, self).__init__(message)
 
 
+class SafetyError(CondaError):
+    def __init__(self, message):
+        super(SafetyError, self).__init__(message)
+
+
 class NotWritableError(CondaError):
 
     def __init__(self, path):
@@ -602,19 +607,32 @@ def maybe_raise(error, context):
     if isinstance(error, CondaMultiError):
         groups = groupby(lambda e: isinstance(e, ClobberError), error.errors)
         clobber_errors = groups.get(True, ())
-        non_clobber_errors = groups.get(False, ())
-        if clobber_errors:
-            if context.path_conflict == PathConflict.prevent and not context.clobber:
-                raise error
-            elif context.path_conflict == PathConflict.warn and not context.clobber:
-                print_conda_exception(CondaMultiError(clobber_errors))
-        if non_clobber_errors:
-            raise CondaMultiError(non_clobber_errors)
+        groups = groupby(lambda e: isinstance(e, SafetyError), groups.get(False, ()))
+        safety_errors = groups.get(True, ())
+        other_errors = groups.get(False, ())
+
+        if ((safety_errors and context.safety_checks == SafetyChecks.enabled)
+                or (clobber_errors and context.path_conflict == PathConflict.prevent
+                    and not context.clobber)
+                or other_errors):
+            raise error
+        elif ((safety_errors and context.safety_checks == SafetyChecks.warn)
+              or (clobber_errors and context.path_conflict == PathConflict.warn
+                  and not context.clobber)):
+            print_conda_exception(error)
+
     elif isinstance(error, ClobberError):
         if context.path_conflict == PathConflict.prevent and not context.clobber:
             raise error
         elif context.path_conflict == PathConflict.warn and not context.clobber:
             print_conda_exception(error)
+
+    elif isinstance(error, SafetyError):
+        if context.safety_checks == SafetyChecks.enabled:
+            raise error
+        elif context.safety_checks == SafetyChecks.warn:
+            print_conda_exception(error)
+
     else:
         raise error
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -26,7 +26,7 @@ import requests
 
 from conda import CondaError, CondaMultiError
 from conda._vendor.auxlib.entity import EntityEncoder
-from conda.base.constants import CONDA_TARBALL_EXTENSION, PACKAGE_CACHE_MAGIC_FILE
+from conda.base.constants import CONDA_TARBALL_EXTENSION, PACKAGE_CACHE_MAGIC_FILE, SafetyChecks
 from conda.base.context import Context, context, reset_context
 from conda.cli.main import generate_parser, init_loggers
 from conda.common.compat import PY2, iteritems, itervalues, text_type
@@ -312,33 +312,58 @@ class IntegrationTests(TestCase):
             assert not package_is_installed(prefix, 'flask')
             assert_package_is_installed(prefix, 'python-3')
 
-    def test_skip_safety_checks_basic(self):
+    def test_safety_checks(self):
+        # This test uses https://anaconda.org/conda-test/spiffy-test-app/0.5/download/noarch/spiffy-test-app-0.5-pyh6afbcc8_0.tar.bz2
+        # which is a modification of https://anaconda.org/conda-test/spiffy-test-app/1.0/download/noarch/spiffy-test-app-1.0-pyh6afabb7_0.tar.bz2
+        # as documented in info/README within that package.
+        # I also had to fix the post-link script in the package by adding quotation marks to handle
+        # spaces in path names.
+
         with make_temp_env() as prefix:
             with open(join(prefix, 'condarc'), 'a') as fh:
-                fh.write("skip_safety_checks: true\n")
+                fh.write("safety_checks: enabled\n")
             reload_config(prefix)
-            assert context.skip_safety_checks is True
+            assert context.safety_checks is SafetyChecks.enabled
 
-            run_command(Commands.INSTALL, prefix, 'python=3.5')
-            assert exists(join(prefix, PYTHON_BINARY))
-            assert_package_is_installed(prefix, 'python-3')
+            with pytest.raises(CondaMultiError) as exc:
+                run_command(Commands.INSTALL, prefix, '-c conda-test spiffy-test-app=0.5')
 
-            run_command(Commands.INSTALL, prefix, 'flask=0.10')
-            assert_package_is_installed(prefix, 'flask-0.10.1')
-            assert_package_is_installed(prefix, 'python-3')
+            error_message = text_type(exc.value)
+            message1 = dals("""
+            The path 'site-packages/spiffy_test_app-1.0-py2.7.egg-info/top_level.txt'
+            has an incorrect size.
+              reported size: 32 bytes
+              actual size: 16 bytes
+            """)
+            message2 = dals("""
+            The path 'site-packages/spiffy_test_app/__init__.py'
+            has a sha256 mismatch.
+              reported sha256: 1234567890123456789012345678901234567890123456789012345678901234
+              actual sha256: 32d822669b582f82da97225f69e3ef01ab8b63094e447a9acca148a6e79afbed
+            """)
+            assert message1 in error_message
+            assert message2 in error_message
 
-            run_command(Commands.INSTALL, prefix, '--force', 'flask=0.10')
-            assert_package_is_installed(prefix, 'flask-0.10.1')
-            assert_package_is_installed(prefix, 'python-3')
+            with open(join(prefix, 'condarc'), 'a') as fh:
+                fh.write("safety_checks: warn\n")
+            reload_config(prefix)
+            assert context.safety_checks is SafetyChecks.warn
 
-            run_command(Commands.UPDATE, prefix, 'flask')
-            assert not package_is_installed(prefix, 'flask-0.10.1')
-            assert_package_is_installed(prefix, 'flask')
-            assert_package_is_installed(prefix, 'python-3')
+            stdout, stderr = run_command(Commands.INSTALL, prefix, '-c conda-test spiffy-test-app=0.5')
+            assert message1 in stderr
+            assert message2 in stderr
+            assert package_is_installed(prefix, "spiffy-test-app-0.5")
 
-            run_command(Commands.REMOVE, prefix, 'flask')
-            assert not package_is_installed(prefix, 'flask-0.')
-            assert_package_is_installed(prefix, 'python-3')
+        with make_temp_env() as prefix:
+            with open(join(prefix, 'condarc'), 'a') as fh:
+                fh.write("safety_checks: disabled\n")
+            reload_config(prefix)
+            assert context.safety_checks is SafetyChecks.disabled
+
+            stdout, stderr = run_command(Commands.INSTALL, prefix, '-c conda-test spiffy-test-app=0.5')
+            assert message1 not in stderr
+            assert message2 not in stderr
+            assert package_is_installed(prefix, "spiffy-test-app-0.5")
 
     @pytest.mark.xfail(strict=True)
     def test_non_root_conda(self):

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -374,7 +374,7 @@ conda_build_test() {
     . $prefix/etc/profile.d/conda.sh
     conda activate root
     conda info
-    echo "skip_safety_checks: true" >> ~/.condarc
+    echo "safety_checks: disabled" >> ~/.condarc
 
     pushd conda-build
 


### PR DESCRIPTION
fix #5811 

Conda 4.4 added per-path checking of sha256 and byte size as part of of the pre-transaction verification step.  There are packages in the ecosystem that have bad shas recorded though.  #5811 has an example.  This PR changes the `skip_safety_checks` configuration parameter that had a boolean value to just a `safety_checks` configuration parameter that has enum values `enabled`, `warn`, and `disabled`.

The default for Conda 4.4 will now be `warn`, and we'll schedule the default to change to `enabled` in conda 4.5.  We've also added a rule to conda-verify https://github.com/conda/conda-verify/pull/12 to help get the packaging ecosystem cleaned up.