### PR TITLE
Catch OSError for missing device

### DIFF
--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -82,10 +82,11 @@ def read_mod_and_etag(path):
                 match_objects = take(3, re.finditer(REPODATA_HEADER_RE, m))
                 result = dict(map(ensure_unicode, mo.groups()) for mo in match_objects)
                 return result
-        except (BufferError, ValueError):
+        except (BufferError, ValueError, OSError):
             # BufferError: cannot close exported pointers exist
             #   https://github.com/conda/conda/issues/4592
             # ValueError: cannot mmap an empty file
+            # OSError: [Errno 19] No such device
             return {}
 
 

--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import bz2
 from contextlib import closing
+from errno import ENODEV
 from functools import wraps
 from genericpath import getmtime, isfile
 import hashlib
@@ -82,12 +83,16 @@ def read_mod_and_etag(path):
                 match_objects = take(3, re.finditer(REPODATA_HEADER_RE, m))
                 result = dict(map(ensure_unicode, mo.groups()) for mo in match_objects)
                 return result
-        except (BufferError, ValueError, OSError):
+        except (BufferError, ValueError, OSError):  # pragma: no cover
             # BufferError: cannot close exported pointers exist
             #   https://github.com/conda/conda/issues/4592
             # ValueError: cannot mmap an empty file
-            # OSError: [Errno 19] No such device
             return {}
+        except (IOError, OSError) as e:  # pragma: no cover
+            # OSError: [Errno 19] No such device
+            if e.errno == ENODEV:
+                return {}
+            raise
 
 
 def get_cache_control_max_age(cache_control_value):


### PR DESCRIPTION
supersedes #5719
target is 4.3.x

---

On CentOS line `closing(mmap(f.fileno(), 0, access=ACCESS_READ)) as m:`
caused an OSError.