### PR TITLE
always remove linked prefix entry with rm_rf

### DIFF
--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -30,16 +30,12 @@ def rm_rf(path, max_retries=5, trash=True):
         path = abspath(path)
         log.trace("rm_rf %s", path)
         if isdir(path) and not islink(path):
-            try:
-                # On Windows, always move to trash first.
-                if trash and on_win:
-                    move_result = move_path_to_trash(path, preclean=False)
-                    if move_result:
-                        return True
-                backoff_rmdir(path)
-            finally:
-                from ...core.linked_data import delete_prefix_from_linked_data
-                delete_prefix_from_linked_data(path)
+            # On Windows, always move to trash first.
+            if trash and on_win:
+                move_result = move_path_to_trash(path, preclean=False)
+                if move_result:
+                    return True
+            backoff_rmdir(path)
         elif lexists(path):
             try:
                 backoff_unlink(path)
@@ -51,11 +47,12 @@ def rm_rf(path, max_retries=5, trash=True):
                     if move_result:
                         return True
                 log.info("Failed to remove %s.", path)
-
         else:
             log.trace("rm_rf failed. Not a link, file, or directory: %s", path)
         return True
     finally:
+        from ...core.linked_data import delete_prefix_from_linked_data
+        delete_prefix_from_linked_data(path)
         if lexists(path):
             log.info("rm_rf failed for %s", path)
             return False

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -431,6 +431,12 @@ class IntegrationTests(TestCase):
             assert any(line.endswith("<pip>") for line in stdout_lines
                        if line.lower().startswith("flask"))
 
+            # regression test for #5847
+            #   when using rm_rf on a directory
+            assert prefix in linked_data_
+            rm_rf(join(prefix, get_python_site_packages_short_path("3.5")))
+            assert prefix not in linked_data_
+
     def test_list_with_pip_wheel(self):
         with make_temp_env("python=3.5 pip") as prefix:
             check_call(PYTHON_BINARY + " -m pip install flask==0.10.1",
@@ -443,6 +449,12 @@ class IntegrationTests(TestCase):
             # regression test for #3433
             run_command(Commands.INSTALL, prefix, "python=3.4")
             assert_package_is_installed(prefix, 'python-3.4.')
+
+            # regression test for #5847
+            #   when using rm_rf on a file
+            assert prefix in linked_data_
+            rm_rf(join(prefix, get_python_site_packages_short_path("3.4")), "os.py")
+            assert prefix not in linked_data_
 
     def test_install_tarball_from_local_channel(self):
         # Regression test for #2812


### PR DESCRIPTION
resolves #5847

The cached prefix entry was sticking around on windows.  This was causing bizarre errors removing envs, especially when switching to a different subdir (win-64 --> win-32 for example).  This addresses the intradependencies conda-build test failure, and so should make a completely green conda-build build on appveyor.