### PR TITLE
WIP/RFC: eliminate package cache overwrites

### DIFF
--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -27,7 +27,7 @@ from ...models.package_info import PackageInfo, PackageMetadata, PathData, PathD
 log = getLogger(__name__)
 
 listdir = listdir
-lexists, isdir, isfile = lexists, isdir, isfile
+lexists, isdir, isfile, glob = lexists, isdir, isfile, glob
 
 
 def yield_lines(path):


### PR DESCRIPTION
cc: @bkreider @ijstokes 

My brain's background processes have been churning to see if there's a relatively low-impact way to eliminate overwriting packages in the package cache due to cache conflicts. This is what I came up with. In short, if there is a package cache conflict, it creates a _subdirectory_ in the first available, writable package cache, and adds that to the package cache search list. It will create as many such directories as necessary.

One thing I discovered with this approach is that, even now, we're missing easy opportunities to avoid cache collisions. In a standard conda setup, a user has _two_ writable package caches: `~/miniconda3/pkgs` (for instance) and `~/.conda/pkgs`. But the package cache logic always uses the first writable cache for all writes. So this code immediately opens up `~/.conda/pkgs` as a second cache destination, where it wasn't available before. But we may actually prefer not to do this, and aggressively stick to `~/miniconda3/pkgs` at all times. I'll call out how to do this in the logic.