### PR TITLE
Invoke cmd.exe with /D for pre/post link/unlink scripts

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -476,7 +476,7 @@ def run_script(prefix, dist, action='post-link', env_prefix=None):
 
     if on_win:
         try:
-            command_args = [os.environ[str('COMSPEC')], '/c', path]
+            command_args = [os.environ[str('COMSPEC')], '/d', '/c', path]
         except KeyError:
             log.info("failed to run %s for %s due to COMSPEC KeyError", action, dist)
             return False

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -438,7 +438,7 @@ class IntegrationTests(TestCase):
             assert prefix not in linked_data_
 
     def test_list_with_pip_wheel(self):
-        with make_temp_env("python=3.5 pip") as prefix:
+        with make_temp_env("python=3.6 pip") as prefix:
             check_call(PYTHON_BINARY + " -m pip install flask==0.10.1",
                        cwd=prefix, shell=True)
             stdout, stderr = run_command(Commands.LIST, prefix)
@@ -447,13 +447,13 @@ class IntegrationTests(TestCase):
                        if line.lower().startswith("flask"))
 
             # regression test for #3433
-            run_command(Commands.INSTALL, prefix, "python=3.4")
-            assert_package_is_installed(prefix, 'python-3.4.')
+            run_command(Commands.INSTALL, prefix, "python=3.5")
+            assert_package_is_installed(prefix, 'python-3.5.')
 
             # regression test for #5847
             #   when using rm_rf on a file
             assert prefix in linked_data_
-            rm_rf(join(prefix, get_python_site_packages_short_path("3.4")), "os.py")
+            rm_rf(join(prefix, get_python_site_packages_short_path("3.5")), "os.py")
             assert prefix not in linked_data_
 
     def test_install_tarball_from_local_channel(self):


### PR DESCRIPTION
supersedes #5727
target is 4.3.x

------------


The /D flag prevents the command prompt to invoke an autorun script that
is otherwise being run at the beginning of every command prompt session if
specified in the registry. From the `cmd.exe /?` output:

```
If /D was NOT specified on the command line, then when CMD.EXE starts, it
looks for the following REG_SZ/REG_EXPAND_SZ registry variables, and if
either or both are present, they are executed first.

    HKEY_LOCAL_MACHINE\Software\Microsoft\Command Processor\AutoRun

        and/or

    HKEY_CURRENT_USER\Software\Microsoft\Command Processor\AutoRun
```

Since such autorun scripts might make one pre/post link/unlink script to
behave different on one machine than on another, this provides a more
reproducible environment to run these scripts in.