### PR TITLE
resolve #5933 extend package cache with two additional levels of directory structure

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -11,10 +11,9 @@ from tempfile import mkdtemp
 from traceback import format_exception_only
 import warnings
 
-from conda.base.constants import SafetyChecks
 from .linked_data import PrefixData, get_python_version_for_prefix, linked_data as get_linked_data
 from .package_cache import PackageCache
-from .path_actions import (CompilePycAction, CreatePrefixRecordAction, CreateNonadminAction,
+from .path_actions import (CompilePycAction, CreateNonadminAction, CreatePrefixRecordAction,
                            CreatePythonEntryPointAction, LinkPathAction, MakeMenuAction,
                            RegisterEnvironmentLocationAction, RemoveLinkedPackageRecordAction,
                            RemoveMenuAction, UnlinkPathAction, UnregisterEnvironmentLocationAction,
@@ -22,6 +21,7 @@ from .path_actions import (CompilePycAction, CreatePrefixRecordAction, CreateNon
 from .. import CondaError, CondaMultiError, conda_signal_handler
 from .._vendor.auxlib.collection import first
 from .._vendor.auxlib.ish import dals
+from ..base.constants import SafetyChecks
 from ..base.context import context
 from ..common.compat import ensure_text_type, iteritems, itervalues, odict, on_win
 from ..common.io import spinner

--- a/conda/core/linked_data.py
+++ b/conda/core/linked_data.py
@@ -97,6 +97,15 @@ class PrefixData(object):
                 subdir_urls.add(subdir_url)
         return subdir_urls
 
+    def query(self, package_ref_or_match_spec):
+        # returns a generator
+        param = package_ref_or_match_spec
+        if isinstance(param, MatchSpec):
+            return (pcrec for pcrec in itervalues(self._prefix_records) if param.match(pcrec))
+        else:
+            # assume isinstance(param, PackageRef)
+            return (pcrec for pcrec in itervalues(self._prefix_records) if pcrec == param)
+
     @property
     def _prefix_records(self):
         return self.__prefix_records or self.load() or self.__prefix_records

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1145,10 +1145,12 @@ class UnregisterEnvironmentLocationAction(EnvsDirectoryPathAction):
 
 class CacheUrlAction(PathAction):
 
-    def __init__(self, url, target_pkgs_dir, target_package_basename,
-                 md5sum=None, expected_size_in_bytes=None):
+    def __init__(self, url, target_pkgs_dir, target_pkgs_dir_channel_name, target_pkgs_dir_subdir,
+                 target_package_basename, md5sum=None, expected_size_in_bytes=None):
         self.url = url
         self.target_pkgs_dir = target_pkgs_dir
+        self.target_pkgs_dir_channel_name = target_pkgs_dir_channel_name
+        self.target_pkgs_dir_subdir = target_pkgs_dir_subdir
         self.target_package_basename = target_package_basename
         self.md5sum = md5sum
         self.expected_size_in_bytes = expected_size_in_bytes
@@ -1237,7 +1239,10 @@ class CacheUrlAction(PathAction):
 
     @property
     def target_full_path(self):
-        return join(self.target_pkgs_dir, self.target_package_basename)
+        return join(self.target_pkgs_dir,
+                    self.target_pkgs_dir_channel_name or '',
+                    self.target_pkgs_dir_subdir or '',
+                    self.target_package_basename)
 
     def __str__(self):
         return 'CacheUrlAction<url=%r, target_full_path=%r>' % (self.url, self.target_full_path)
@@ -1245,10 +1250,12 @@ class CacheUrlAction(PathAction):
 
 class ExtractPackageAction(PathAction):
 
-    def __init__(self, source_full_path, target_pkgs_dir, target_extracted_dirname,
-                 record_or_spec, md5sum):
+    def __init__(self, source_full_path, target_pkgs_dir, target_pkgs_dir_channel_name,
+                 target_pkgs_dir_subdir, target_extracted_dirname, record_or_spec, md5sum):
         self.source_full_path = source_full_path
         self.target_pkgs_dir = target_pkgs_dir
+        self.target_pkgs_dir_channel_name = target_pkgs_dir_channel_name
+        self.target_pkgs_dir_subdir = target_pkgs_dir_subdir
         self.target_extracted_dirname = target_extracted_dirname
         self.hold_path = self.target_full_path + '.c~'
         self.record_or_spec = record_or_spec
@@ -1322,7 +1329,10 @@ class ExtractPackageAction(PathAction):
 
     @property
     def target_full_path(self):
-        return join(self.target_pkgs_dir, self.target_extracted_dirname)
+        return join(self.target_pkgs_dir,
+                    self.target_pkgs_dir_channel_name or '',
+                    self.target_pkgs_dir_subdir or '',
+                    self.target_extracted_dirname)
 
     def __str__(self):
         return ('ExtractPackageAction<source_full_path=%r, target_full_path=%r>'

--- a/conda/gateways/connection/download.py
+++ b/conda/gateways/connection/download.py
@@ -3,12 +3,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import hashlib
 from logging import DEBUG, getLogger
-from os.path import basename, exists, join
+from os.path import basename, dirname, exists, isdir, join
 import tempfile
 import warnings
 
 from . import ConnectionError, HTTPError, InsecureRequestWarning, InvalidSchema, SSLError
 from .session import CondaSession
+from ..disk import mkdir_p
 from ..disk.delete import rmtree
 from ... import CondaError
 from ..._vendor.auxlib.ish import dals
@@ -31,6 +32,9 @@ def download(url, target_full_path, md5sum, progress_update_callback=None):
     #       header.
     if exists(target_full_path):
         maybe_raise(BasicClobberError(target_full_path, url, context), context)
+
+    if not isdir(dirname(target_full_path)):
+        mkdir_p(dirname(target_full_path))
 
     if not context.ssl_verify:
         disable_ssl_verify_warning()

--- a/conda/gateways/disk/test.py
+++ b/conda/gateways/disk/test.py
@@ -18,6 +18,7 @@ from ...models.enums import LinkType
 log = getLogger(__name__)
 
 
+@memoize
 def file_path_is_writable(path):
     path = expand(path)
     log.trace("checking path is writable %s", path)

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from copy import copy
 from itertools import chain
 from logging import getLogger
+from os.path import split as path_split
 
 from .._vendor.boltons.setutils import IndexedSet
 from ..base.constants import (DEFAULTS_CHANNEL_NAME, DEFAULT_CHANNELS_UNIX, DEFAULT_CHANNELS_WIN,
@@ -11,7 +12,7 @@ from ..base.constants import (DEFAULTS_CHANNEL_NAME, DEFAULT_CHANNELS_UNIX, DEFA
 from ..base.context import context
 from ..common.compat import ensure_text_type, isiterable, iteritems, odict, with_metaclass
 from ..common.path import is_path, win_path_backout
-from ..common.url import (Url, has_scheme, is_url, join_url, path_to_url,
+from ..common.url import (Url, has_scheme, is_url, join_url, path_to_url, quote as url_quote,
                           split_conda_url_easy_parts, split_platform, split_scheme_auth_token,
                           urlparse)
 
@@ -87,6 +88,10 @@ class Channel(object):
         return self.name
 
     @property
+    def safe_name(self):
+        return url_quote(self.name.replace('/', '_').replace('\\', '_'))
+
+    @property
     def subdir(self):
         return self.platform
 
@@ -134,7 +139,10 @@ class Channel(object):
                 location, name = ca.location, test_url.replace(ca.location, '', 1)
             else:
                 url_parts = urlparse(test_url)
-                location, name = Url(host=url_parts.host, port=url_parts.port).url, url_parts.path
+                if url_parts.host:
+                    location, name = Url(host=url_parts.host, port=url_parts.port).url, url_parts.path
+                else:
+                    location, name = path_split(test_url)
             return Channel(scheme=scheme, auth=auth, location=location, token=token,
                            name=name.strip('/'))
         else:
@@ -304,6 +312,10 @@ class MultiChannel(Channel):
         self.token = None
         self.platform = platform
         self.package_filename = None
+
+    @property
+    def safe_name(self):
+        raise RuntimeError("Conda multi-channels do not have safe names.\n%s" % self._channels)
 
     @property
     def channel_location(self):

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -98,7 +98,11 @@ def display_actions(actions, index, show_channel_urls=None, specs_to_remove=(), 
         for dist in actions[FETCH]:
             dist = Dist(dist)
             info = index[dist]
-            extra = '%15s' % human_bytes(info['size'])
+            try:
+                extra = '%15s' % human_bytes(info['size'])
+            except Exception as e:
+                import pdb; pdb.set_trace()
+                assert 0
             schannel = channel_filt(channel_str(info))
             if schannel:
                 extra += '  ' + schannel

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from os.path import join
+from os.path import join, basename, dirname
 from tempfile import gettempdir
 from unittest import TestCase
 
@@ -152,8 +152,8 @@ class ContextCustomRcTests(TestCase):
                     join_url(conda_bld_url, 'noarch'),
                 ]
                 assert channel.url() == join_url(conda_bld_url, context.subdir)
-                assert channel.channel_name.lower() == win_path_backout(conda_bld_path).lstrip('/').lower()
-                assert channel.channel_location == ''  # location really is an empty string; all path information is in channel_name
+                assert channel.channel_name.lower() == basename(conda_bld_path.lstrip('/')).lower()
+                assert channel.channel_location == win_path_backout(dirname(conda_bld_path))
                 assert channel.canonical_name == "local"
         finally:
             rm_rf(conda_bld_path)

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -526,6 +526,10 @@ class CustomConfigChannelTests(TestCase):
                 assert channel.token is None
                 assert channel.scheme == "file"
                 assert channel.canonical_name == "local"
+                assert channel.name == "conda-bld"
+                assert channel.safe_name == "conda-bld"
+                assert channel.location == "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5"
+                assert channel.scheme == 'file'
 
                 assert channel.urls() == Channel(local_channel_first_subchannel).urls()
                 assert channel.urls()[0].startswith('file:///')

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -215,9 +215,6 @@ class MatchSpecTests(TestCase):
 
         assert m('numpy[features="mkl debug" build_number=2]') == "numpy[build_number=2,provides_features='blas=mkl debug=true']"
 
-
-
-
     def test_tarball_match_specs(self):
         def m(string):
             return text_type(MatchSpec(string))
@@ -252,6 +249,9 @@ class MatchSpecTests(TestCase):
         # TODO: we need this working correctly with both channel and subdir
         # especially for usages around PrefixData.all_subdir_urls() and Solver._prepare()
         # assert MatchSpec('defaults/zos::python').get_exact_value('channel').urls() == ()
+
+        url = "file:///usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/conda-bld/osx-64/flask-0.10.1-py35_2.tar.bz2"
+        assert m(url) == "local/osx-64::flask==0.10.1=py35_2"
 
     def test_exact_values(self):
         assert MatchSpec("*").get_exact_value('name') is None

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from os.path import exists, join
 from unittest import TestCase
 
-from .test_create import (Commands, PYTHON_BINARY, assert_package_is_installed, make_temp_env,
+from .test_create import (Commands, PYTHON_BINARY, package_is_installed, make_temp_env,
                           make_temp_prefix, run_command)
 
 
@@ -15,7 +15,7 @@ class ExportIntegrationTests(TestCase):
     def test_basic(self):
         with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
-            assert_package_is_installed(prefix, 'python-3')
+            assert package_is_installed(prefix, 'python=3')
 
             output, error = run_command(Commands.LIST, prefix, "-e")
 
@@ -26,7 +26,7 @@ class ExportIntegrationTests(TestCase):
                 prefix2 = make_temp_prefix()
                 run_command(Commands.CREATE, prefix2 , "--file " + env_txt.name)
 
-                assert_package_is_installed(prefix2, "python")
+                assert package_is_installed(prefix2, "python")
 
             output2, error= run_command(Commands.LIST, prefix2, "-e")
             self.assertEqual(output, output2)
@@ -39,10 +39,10 @@ class ExportIntegrationTests(TestCase):
         """
         with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
-            assert_package_is_installed(prefix, 'python-3')
+            assert package_is_installed(prefix, 'python=3')
 
             run_command(Commands.INSTALL, prefix, "six", "-c", "conda-forge")
-            assert_package_is_installed(prefix, "six")
+            assert package_is_installed(prefix, "six")
 
             output, error = run_command(Commands.LIST, prefix, "-e")
             self.assertIn("conda-forge", output)
@@ -54,7 +54,7 @@ class ExportIntegrationTests(TestCase):
                     prefix2 = make_temp_prefix()
                     run_command(Commands.CREATE, prefix2 , "--file " + env_txt.name)
 
-                    assert_package_is_installed(prefix2, "python")
+                    assert package_is_installed(prefix2, "python")
                 output2, error = run_command(Commands.LIST, prefix2, "-e")
                 self.assertEqual(output, output2)
             finally:
@@ -67,10 +67,10 @@ class ExportIntegrationTests(TestCase):
         """
         with make_temp_env("python=3.5") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
-            assert_package_is_installed(prefix, 'python-3')
+            assert package_is_installed(prefix, 'python=3')
 
             run_command(Commands.INSTALL, prefix, "six", "-c", "conda-forge")
-            assert_package_is_installed(prefix, "six")
+            assert package_is_installed(prefix, "six")
 
             output, error = run_command(Commands.LIST, prefix, "--explicit")
             self.assertIn("conda-forge", output)
@@ -82,8 +82,8 @@ class ExportIntegrationTests(TestCase):
                     prefix2 = make_temp_prefix()
                     run_command(Commands.CREATE, prefix2, "--file " + env_txt.name)
 
-                    assert_package_is_installed(prefix2, "python")
-                    assert_package_is_installed(prefix2, "six")
+                    assert package_is_installed(prefix2, "python")
+                    assert package_is_installed(prefix2, "six")
                 output2, _ = run_command(Commands.LIST, prefix2, "--explicit")
                 self.assertEqual(output, output2)
             finally:

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -4,7 +4,7 @@ import pytest
 
 from conda.base.context import context, reset_context
 from conda.common.io import env_var
-from .test_create import (make_temp_env, assert_package_is_installed,
+from .test_create import (make_temp_env, package_is_installed,
                           run_command, Commands, get_conda_list_tuple)
 
 
@@ -14,8 +14,8 @@ class PriorityIntegrationTests(TestCase):
     def test_channel_order_channel_priority_true(self):
         with env_var("CONDA_PINNED_PACKAGES", "python=3.5", reset_context):
             with make_temp_env("pycosat==0.6.1") as prefix:
-                assert_package_is_installed(prefix, 'python-3.5')
-                assert_package_is_installed(prefix, 'pycosat')
+                assert package_is_installed(prefix, 'python=3.5')
+                assert package_is_installed(prefix, 'pycosat')
 
                 # add conda-forge channel
                 o, e = run_command(Commands.CONFIG, prefix, "--prepend channels conda-forge", '--json')
@@ -26,7 +26,7 @@ class PriorityIntegrationTests(TestCase):
 
                 # this assertion works with the pinned_packages config to make sure
                 # conda update --all still respects the pinned python version
-                assert_package_is_installed(prefix, 'python-3.5')
+                assert package_is_installed(prefix, 'python=3.5')
 
                 # pycosat should be in the SUPERSEDED list
                 # after the 4.4 solver work, looks like it's in the DOWNGRADED list
@@ -52,7 +52,7 @@ class PriorityIntegrationTests(TestCase):
             This case will fail now
         """
         with make_temp_env("python=3.5.3=0") as prefix:
-            assert_package_is_installed(prefix, 'python')
+            assert package_is_installed(prefix, 'python')
 
             # add conda-forge channel
             o, e = run_command(Commands.CONFIG, prefix, "--prepend channels conda-forge", '--json')


### PR DESCRIPTION
resolve #5933 

This change should be both forward and backward compatible with previous versions of conda.  No separate "upgrade" or "downgrade" step should be necessary.