### PR TITLE
Fix msys2 activate and deactivate

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -74,12 +74,15 @@ def _get_prefix_paths(prefix):
         yield os.path.join(prefix, 'bin')
 
 
-def binpath_from_arg(arg, shell):
+def binpath_from_arg(arg, shell, going_to_shell=True):
     shelldict = shells[shell] if shell else {}
     # prefix comes back as platform-native path
     prefix = prefix_from_arg(arg, shell)
     # convert paths to shell-native paths
-    return [shelldict['path_to'](path) for path in _get_prefix_paths(prefix)]
+    if going_to_shell:
+        return [shelldict['path_to'](path) for path in _get_prefix_paths(prefix)]
+    else:
+        return [path for path in _get_prefix_paths(prefix)]
 
 
 def pathlist_to_str(paths, escape_backslashes=True):
@@ -96,12 +99,15 @@ def pathlist_to_str(paths, escape_backslashes=True):
     return path
 
 
-def get_activate_path(prefix, shell):
+def get_activate_path(prefix, shell, going_to_shell=True):
     shelldict = shells[shell] if shell else {}
-    binpath = binpath_from_arg(prefix, shell)
+    binpath = binpath_from_arg(prefix, shell, going_to_shell)
 
     # prepend our new entries onto the existing path and make sure that the separator is native
-    path = shelldict['pathsep'].join(binpath)
+    if going_to_shell:
+        path = shelldict['pathsep'].join(binpath)
+    else:
+        path = os.pathsep.join(binpath)
     return path
 
 
@@ -135,11 +141,11 @@ def main():
                                              shell and env name".format(sys_argv[1]))
 
     if sys_argv[1] == '..activate':
-        print(get_activate_path(sys_argv[3], shell))
+        print(get_activate_path(sys_argv[3], shell, True))
         sys.exit(0)
 
     elif sys_argv[1] == '..deactivate.path':
-        activation_path = get_activate_path(sys_argv[3], shell)
+        activation_path = get_activate_path(sys_argv[3], shell, False)
 
         if os.getenv('_CONDA_HOLD'):
             new_path = regex.sub(r'%s(:?)' % regex.escape(activation_path),
@@ -149,6 +155,7 @@ def main():
             new_path = regex.sub(r'%s(:?)' % regex.escape(activation_path), r'',
                                  os.environ[str('PATH')], 1)
 
+        new_path = shells[shell]['path_to'](new_path)
         print(new_path)
         sys.exit(0)
 

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -77,16 +77,17 @@ def path_identity(path):
 
 
 def win_path_to_unix(path, root_prefix=""):
-    """Convert a path or ;-separated string of paths into a unix representation
-
-    Does not add cygdrive.  If you need that, set root_prefix to "/cygdrive"
-    """
-    path_re = '(?<![:/^a-zA-Z])([a-zA-Z]:[\/\\\\]+(?:[^:*?"<>|]+[\/\\\\]+)*[^:*?"<>|;\/\\\\]+?(?![a-zA-Z]:))'  # noqa
-
-    def _translation(found_path):
-        found = found_path.group(1).replace("\\", "/").replace(":", "").replace("//", "/")
-        return root_prefix + "/" + found
-    path = re.sub(path_re, _translation, path).replace(";/", ":/")
+    import subprocess, os
+    # If the user wishes to drive conda from MSYS2 itself while also having
+    # msys2 packages in their environment this allows the path conversion to
+    # happen relative to the actual shell. The onus is on the user to set
+    # CYGPATH to e.g. /usr/bin/cygpath.exe (this will be translated to e.g.
+    # (C:\msys32\usr\bin\cygpath.exe by MSYS2) to ensure this one is used.
+    try:
+        cygpath = os.environ[str('CYGPATH')]
+    except:
+        cygpath = 'cygpath.exe'
+    path = subprocess.check_output([cygpath, '-up', path]).decode('ascii').split('\n')[0]
     return path
 
 


### PR DESCRIPTION
Mostly deactivate was returning a Windows PATH to the
MSYS2 shell, but also, the conversion was hand-rolled
and incorrect; it did not respect /etc/fstab. Instead
use cygpath.exe (or CYGPATH env var).

Also, the conversions were being done incorrectly. We
need to convert to or from the shell depending on the
context.