### PR TITLE
Conda env create corrupts existing folders

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -38,8 +38,6 @@ def check_prefix(prefix, json=False):
     if name == ROOT_ENV_NAME:
         error = "'%s' is a reserved environment name" % name
     if exists(prefix):
-        if isdir(prefix) and 'conda-meta' not in os.listdir(prefix):
-            return None
         error = "prefix already exists: %s" % prefix
 
     if error:

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -39,7 +39,6 @@ test_env_name_2 = "snowflakes"
 test_env_name_3 = "env_foo"
 test_env_name_4 = "env_bar"
 test_env_name_5 = "env_baz"
-test_env_name_6 = "env_boo"
 
 def escape_for_winpath(p):
     if p:

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -38,6 +38,8 @@ test_env_name_1 = "env-1"
 test_env_name_2 = "snowflakes"
 test_env_name_3 = "env_foo"
 test_env_name_4 = "env_bar"
+test_env_name_5 = "env_baz"
+test_env_name_6 = "env_boo"
 
 def escape_for_winpath(p):
     if p:
@@ -240,24 +242,33 @@ class NewIntegrationTests(unittest.TestCase):
         run_env_command(Commands.ENV_REMOVE, test_env_name_3)
         self.assertFalse(env_is_created(test_env_name_3))
     
-    def test_remove_env_leaves_working_dir_untouched(self):
+    def test_create_env_leaves_working_dir_untouched(self):
         """
-            Test that conda env create and remove work as intended even if there is a folder in the working directory
-            with - coincidentally or on purpose - the same name as the environment.
+            Test that conda env create will not use an existing folder in the working dir.
         """
         os.makedirs(test_env_name_4, exist_ok=False)
         try:
             run_conda_command(Commands.CREATE, test_env_name_4)
-            self.assertTrue(env_is_created(test_env_name_4), "environment was not created in the prefix dir but "
-                                                             "in the folder in the working directory instead")
-
-            run_env_command(Commands.ENV_REMOVE, test_env_name_4)
-            self.assertFalse(env_is_created(test_env_name_4), "environment was not removed from prefix dir")
-
-            self.assertTrue(os.path.exists(test_env_name_4), "folder in working directory was removed")
+            self.assertTrue(env_is_created(test_env_name_4), "environment was not created in the prefix dir")
         finally:
             shutil.rmtree(test_env_name_4)
+    
+    def test_remove_env_leaves_working_dir_untouched(self):
+        """
+            Test that conda env remove will not use an existing folder in the working dir.
+        """
+        run_conda_command(Commands.CREATE, test_env_name_5)
+        self.assertTrue(env_is_created(test_env_name_5))
 
+        os.makedirs(test_env_name_5, exist_ok=False)
+        try:
+            run_env_command(Commands.ENV_REMOVE, test_env_name_5)
+            self.assertFalse(env_is_created(test_env_name_5), "environment was not removed from prefix dir")
+
+            self.assertTrue(os.path.exists(test_env_name_5), "folder in working directory was removed")
+        finally:
+            if os.path.exists(test_env_name_5):
+                shutil.rmtree(test_env_name_5)
 
     def test_export(self):
         """


### PR DESCRIPTION
This PR adds a failing test `test_create_env_leaves_working_dir_untouched`, so that we can work out the resolution to the test together.

It demonstrates that conda will "take over" an existing folder if it has the same name as the environment that we are creating with the command `conda env create -n {name}`. Developers will fail to notice, and when they call `conda env remove -n {name}` conda will actually remove the existing folder. We use environment.yml files for our project requirements, so the environment name typically matches the package name.

Hopefully you've worked out what will happen here; conda will remove your package, with all the modifications you have not yet committed to git or hg.

Preferably, this PR would change conda to throw the "prefix already exists" error in this scenario, like it does for other scenarios too!

P.S. Note that this is the reproduction of bug #3383, which I've reopened accordingly. I finally noticed what the pattern was that lead to this situation. :)

Update; I have since pushed my proposed fix in commit 5d3eeee

Alternatively we could consider removing `getcwd()` from `env_manager.locate_prefix_by_name`