### PR TITLE
Always delete_prefix_from_linked_data in rm_rf

### DIFF
--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -49,6 +49,8 @@ def rm_rf(path, max_retries=5, trash=True):
                 log.info("Failed to remove %s.", path)
         else:
             log.trace("rm_rf failed. Not a link, file, or directory: %s", path)
+            from ...core.linked_data import delete_prefix_from_linked_data
+            delete_prefix_from_linked_data(path)
         return True
     finally:
         from ...core.linked_data import delete_prefix_from_linked_data


### PR DESCRIPTION
conda-build uses rd on Windows to remove the prefix before calling
this, so we need conda to foget about the installed packages.

cc @msarahan, this addresses a case that seems to have been missed in https://github.com/conda/conda/commit/be2dd4e3fd73df5111831cbe20f8ad16e915f2ef
