### PR TITLE
Fix #6036:  conda.fish doesn't work properly on Mac OS X

### DIFF
--- a/shell/etc/fish/conf.d/conda.fish
+++ b/shell/etc/fish/conf.d/conda.fish
@@ -15,6 +15,8 @@
 #
 #     to the end of your ~/.config/config.fish file.
 #
+#     Use the actual path instead of `conda info --root` to speed up sourcing. See issue #6029.
+#
 # USAGE
 #
 #     To activate an environment (via name or path), you can use one of the following:
@@ -220,11 +222,11 @@ end
 
 # Faster but less tested (?)
 function __fish_conda_commands
-  command echo -e "activate\ndeactivate" ;and ls --color=none (conda info --root)/bin/conda-* | sed -r 's/^.*conda-([a-z]+)/\1/'
+  printf "activate\ndeactivate\n" ;and command ls (conda info --root)/bin/conda-* | sed -E 's/^.*conda-([a-z]+)/\1/'
 end
 
 function __fish_conda_envs
-  command echo root ;and ls -1 --color=none (conda info --root)/envs/
+  command echo root ;and command ls -1 (conda info --root)/envs/
 end
 
 function __fish_conda_packages


### PR DESCRIPTION
1. Update usage documentation.
2. Use `sed -E` for portability as mentioned in [man sed](https://www.gnu.org/software/sed/manual/sed.txt).

    '-E'
    '-r'
    '--regexp-extended'
         Use extended regular expressions rather than basic regular
         expressions.  Extended regexps are those that 'egrep' accepts; they
         can be clearer because they usually have fewer backslashes.
         Historically this was a GNU extension, but the '-E' extension has
         since been added to the POSIX standard
         (http://austingroupbugs.net/view.php?id=528), so use '-E' for
         portability.  GNU sed has accepted '-E' as an undocumented option
         for years, and *BSD seds have accepted '-E' for years as well, but
         scripts that use '-E' might not port to other older systems.  *Note
         Extended regular expressions: ERE syntax.

3. Use `printf` instead of `echo -e` as discussed [here](https://stackoverflow.com/a/46475616/1216965).

4. Use `command ls` instead of `ls --color=none` which is not supported on Mac OS X.