### PR TITLE
add activate/deactivate scripts for powershell

### DIFF
--- a/shell/Scripts/activate.ps1
+++ b/shell/Scripts/activate.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+param (
+    [parameter(Mandatory = $true)]
+    [string]$CONDA_ENV_NAME
+)
+
+$PYTHON_EXE = Resolve-Path "$PSScriptRoot\..\python.exe"
+Write-Debug "PYTHON_EXE : $PYTHON_EXE"
+
+$env:PYTHONIOENCODING = (. "$PYTHON_EXE" -c "import ctypes; print(ctypes.cdll.kernel32.GetACP())")
+Write-Debug "env:PYTHONIOENCODING : $env:PYTHONIOENCODING"
+
+chcp $env:PYTHONIOENCODING
+
+$env:CONDA_NEW_ENV = $CONDA_ENV_NAME
+Write-Debug "env:CONDA_NEW_ENV : $env:CONDA_NEW_ENV"
+
+$env:CONDA_EXE = Resolve-Path "$PSScriptRoot\..\Scripts\conda.exe"
+Write-Debug "env:CONDA_EXE : $env:CONDA_EXE"
+
+$env:NEW_PATH = (. $env:CONDA_EXE ..activate cmd.exe $CONDA_ENV_NAME)
+
+if ($env:NEW_PATH -eq $null) 
+{
+    Write-Error "$CONDA_ENV_NAME not found !!!"
+}
+else 
+{
+    $env:PATH_OLD = $env:PATH
+    $env:PATH = "$env:NEW_PATH;$env:PATH"
+    
+    Function global:prompt 
+    {
+        return "PS ($env:CONDA_NEW_ENV) $($pwd.Path)>"
+    }
+}

--- a/shell/Scripts/deactivate.ps1
+++ b/shell/Scripts/deactivate.ps1
@@ -1,0 +1,16 @@
+$PYTHON_EXE = Resolve-Path "$PSScriptRoot\..\python.exe"
+Write-Debug "PYTHON_EXE : $PYTHON_EXE"
+
+$env:CONDA_EXE = Resolve-Path "$PSScriptRoot\..\Scripts\conda.exe"
+Write-Debug "env:CONDA_EXE : $env:CONDA_EXE"
+
+. $env:CONDA_EXE ..activate cmd.exe root
+
+if ($env:PATH_OLD -ne $null) {
+    $env:PATH = $env:PATH_OLD    
+}
+
+Function global:prompt 
+{
+    return "PS $($pwd.Path)>"
+}


### PR DESCRIPTION
I wrote this PR to clean up issue #1519. 
In this case, one bat script can not be used together with window terminal and powershell terminal.  Because there is no general way to move the environment variables set in bat script to the powershell terminal. Therefore, I solved the problem by creating and using a new ps script for the powershell terminal.
![](https://s1.postimg.org/52tmr9q50f/screenshot_92.png)