### PR TITLE
Allow redirecting the installation to another directory.

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import getLogger
 import os
 from os.path import (abspath, basename, expanduser, isdir, isfile, join, normpath,
@@ -53,6 +52,22 @@ _arch_names = {
 user_rc_path = abspath(expanduser('~/.condarc'))
 sys_rc_path = join(sys.prefix, '.condarc')
 
+class TargetPrefix:
+    def __init__(self, prefix, dest):
+        self._prefix = prefix
+        self._dest = dest
+    @property
+    def prefix(self):
+        return self._prefix
+    @property
+    def dest(self):
+        return self._dest if self._dest else self._prefix
+
+    def __repr__(self):
+        if self.dest != self.prefix:
+            return "%s:(into %s)" % (self.prefix, self.dest)
+        else:
+            return "%s" % self.prefix
 
 def channel_alias_validation(value):
     if value and not has_scheme(value):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -505,6 +505,14 @@ def configure_parser_create(sub_parsers):
         action="store_true",
         help='Ignore create_default_packages in the .condarc file.',
     )
+    p.add_argument(
+        "--dest-dir",
+        dest='target_dest',
+        action="store",
+        default=None,
+        help="Path to the install destination, default is to use the prefix.",
+        metavar="PATH",
+    )
     p.set_defaults(func='.main_create.execute')
 
 

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -137,8 +137,8 @@ def install(args, parser, command='install'):
         common.ensure_name_or_prefix(args, command)
     prefix = context.target_prefix
     if newenv:
-        check_prefix(prefix, json=context.json)
-    if context.force_32bit and prefix == context.root_prefix:
+        check_prefix(prefix.dest, json=context.json)
+    if context.force_32bit and prefix.dest == context.root_prefix:
         raise CondaValueError("cannot use CONDA_FORCE_32BIT=1 in root env")
     if isupdate and not (args.file or args.all or args.packages):
         raise CondaValueError("""no package names supplied
@@ -201,10 +201,10 @@ def install(args, parser, command='install'):
         print_activate(args.name if args.name else prefix)
         return
 
-    if not isdir(prefix) and not newenv:
+    if not isdir(prefix.dest) and not newenv:
         if args.mkdir:
             try:
-                os.makedirs(prefix)
+                os.makedirs(prefix.dest)
             except OSError:
                 raise CondaOSError("Error: could not create directory: %s" % prefix)
         else:

--- a/conda/core/linked_data.py
+++ b/conda/core/linked_data.py
@@ -37,8 +37,13 @@ class PrefixDataType(type):
 class PrefixData(object):
     _cache_ = {}
 
-    def __init__(self, prefix_path):
-        self.prefix_path = prefix_path
+    def __init__(self, prefix):
+        from ..base.context import TargetPrefix
+        if isinstance(prefix, TargetPrefix):
+            self.prefix_path = prefix.dest
+        else:
+            self.prefix_path = prefix
+
         self.__prefix_records = None
 
     def load(self):

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -102,7 +102,7 @@ class PrefixPathAction(PathAction):
 
     @property
     def target_full_path(self):
-        trgt, shrt_pth = self.target_prefix, self.target_short_path
+        trgt, shrt_pth = self.target_prefix.dest, self.target_short_path
         if trgt is not None and shrt_pth is not None:
             return join(trgt, win_path_ok(shrt_pth))
         else:
@@ -440,7 +440,7 @@ class PrefixReplaceLinkAction(LinkPathAction):
 
         try:
             log.trace("rewriting prefixes in %s", self.target_full_path)
-            update_prefix(self.intermediate_path, self.target_prefix, self.prefix_placeholder,
+            update_prefix(self.intermediate_path, self.target_prefix.prefix, self.prefix_placeholder,
                           self.file_mode)
         except _PaddingError:
             raise PaddingError(self.target_full_path, self.prefix_placeholder,
@@ -905,7 +905,7 @@ class RegisterEnvironmentLocationAction(EnvsDirectoryPathAction):
         ed = EnvsDirectory(self.envs_dir_path)
 
         self.envs_dir_state = ed._get_state()
-        ed.register_env(self.target_prefix)
+        ed.register_env(self.target_prefix.prefix)
         ed.write_to_disk()
         self._execute_successful = True
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -491,7 +491,7 @@ class Solver(object):
 
 def get_pinned_specs(prefix):
     """Find pinned specs from file and return a tuple of MatchSpec."""
-    pinfile = join(prefix, 'conda-meta', 'pinned')
+    pinfile = join(prefix.dest, 'conda-meta', 'pinned')
     if exists(pinfile):
         with open(pinfile) as f:
             from_file = (i for i in f.read().strip().splitlines()

--- a/conda/history.py
+++ b/conda/history.py
@@ -74,7 +74,7 @@ class History(object):
 
     def __init__(self, prefix):
         self.prefix = prefix
-        self.meta_dir = join(prefix, 'conda-meta')
+        self.meta_dir = join(prefix.dest, 'conda-meta')
         self.path = join(self.meta_dir, 'history')
 
     def __enter__(self):


### PR DESCRIPTION
The key is to differentiate between prefix and dest. I overrode target_prefix to allow this. Most places we want to use dest, except the path that the replacement happens shall be prefix.

This PR serves as a demonstration of idea and needs to be carefully reviewed by an expert.
