### PR TITLE
fix timestamp field

### DIFF
--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -316,6 +316,8 @@ class IndexJsonRecord(BasePackageRef):
     license = StringField(required=False)
     license_family = StringField(required=False)
 
+    timestamp = TimestampField(required=False)
+
     @property
     def combined_depends(self):
         from .match_spec import MatchSpec

--- a/tests/build-index4-json.py
+++ b/tests/build-index4-json.py
@@ -1,0 +1,229 @@
+import json
+import requests
+
+
+def main():
+    r1 = requests.get('https://repo.continuum.io/pkgs/main/linux-64/repodata.json')
+    r1.raise_for_status()
+
+    r1json = r1.json()
+
+    packages = {}
+    packages.update(r1json['packages'])
+
+    keep_list = (
+        'asn1crypto',
+        'astroid',
+        'backports',
+        'backports_abc',
+        'bkcharts',
+        'bokeh',
+        'boto3',
+        'botocore',
+        'certifi',
+        'cffi',
+        'chest',
+        'click',
+        'cloog',
+        'cloudpickle',
+        'colorama',
+        'conda',
+        'conda-env',
+        'cryptography',
+        'dask',
+        'dateutil',
+        'decorator',
+        'dill',
+        'distribute',
+        'distributed',
+        'docutils',
+        'enum34',
+        'flask',
+        'funcsigs',
+        'futures',
+        'get_terminal_size',
+        'gevent',
+        'gevent-websocket',
+        'gmp',
+        'greenlet',
+        'heapdict',
+        'idna',
+        'ipaddress',
+        'ipython',
+        'ipython_genutils',
+        'isl',
+        'itsdangerous',
+        'jedi',
+        'jinja2',
+        'jmespath',
+        'lazy-object-proxy',
+        'libevent',
+        'libffi',
+        'libgcc',
+        'libgfortran',
+        'libsodium',
+        'llvm',
+        'llvmlite',
+        'llvmmath',
+        'llvmpy',
+        'locket',
+        'logilab-common',
+        'lz4',
+        'markupsafe',
+        'meta',
+        'mkl',
+        'mpc',
+        'mpfr',
+        'msgpack-python',
+        'needs-spiffy-test-app',
+        'nomkl',
+        'nose',
+        'numpy',
+        'openblas',
+        'openssl',
+        'ordereddict',
+        'packaging',
+        'pandas',
+        'partd',
+        'path.py',
+        'pathlib2',
+        'pexpect',
+        'pickleshare',
+        'pip',
+        'prompt_toolkit',
+        'psutil',
+        'ptyprocess',
+        'pyasn1',
+        'pycosat',
+        'pycparser',
+        'pygments',
+        'pyopenssl',
+        'pyparsing',
+        'python',
+        'python-dateutil',
+        'pytz',
+        'pyyaml',
+        'pyzmq',
+        'readline',
+        'redis',
+        'redis-py',
+        'requests',
+        'ruamel_yaml',
+        's3fs',
+        's3transfer',
+        'scandir',
+        'scipy',
+        'setuptools',
+        'simplegeneric',
+        'singledispatch',
+        'six',
+        'sortedcollections',
+        'sortedcontainers',
+        'spiffy-test-app',
+        'sqlite',
+        'ssl_match_hostname',
+        'system',
+        'tblib',
+        'tk',
+        'toolz',
+        'tornado',
+        'traitlets',
+        'ujson',
+        'uses-spiffy-test-app',
+        'util-linux',
+        'wcwidth',
+        'werkzeug',
+        'wheel',
+        'wrapt',
+        'xz',
+        'yaml',
+        'zeromq',
+        'zict',
+        'zlib',
+
+        'intel-openmp',
+        'libgcc-ng',
+        'libedit',
+        'urllib3',
+        'backports.shutil_get_terminal_size',
+        'libgfortran-ng',
+        'ncurses',
+        'matplotlib',
+        'ca-certificates',
+        'chardet',
+        'dask-core',
+        'libstdcxx-ng',
+        'backports.functools_lru_cache',
+        'cycler',
+        'freetype',
+        'icu',
+        'subprocess32',
+        'pysocks',
+        'pyqt',
+        'libpng',
+        'functools32',
+        'qt',
+        'sip',
+        'dbus',
+        'jpeg',
+        'glib',
+        'gst-plugins-base',
+        'libxcb',
+        'fontconfig',
+        'expat',
+        'pcre',
+        'gstreamer',
+        'libxml2',
+    )
+
+    keep = {}
+    missing_in_whitelist = set()
+
+    for fn, info in packages.items():
+        if info['name'] in keep_list:
+            keep[fn] = info
+            for dep in info['depends']:
+                dep = dep.split()[0]
+                if dep not in keep_list:
+                    missing_in_whitelist.add(dep)
+
+    if missing_in_whitelist:
+        print(">>> missing <<<")
+        print(missing_in_whitelist)
+
+
+    additional_records = {
+        "python-3.6.2-hda45abc_19.tar.bz2": {  # later hash, earlier timestamp
+            "build": "hda45abc_19",
+            "build_number": 19,
+            "depends": [
+                "libffi 3.2.*",
+                "libgcc-ng >=7.2.0",
+                "libstdcxx-ng >=7.2.0",
+                "ncurses 6.0.*",
+                "openssl 1.0.*",
+                "readline 7.*",
+                "sqlite >=3.20.1,<4.0a0",
+                "tk 8.6.*",
+                "xz >=5.2.3,<6.0a0",
+                "zlib >=1.2.11,<1.3.0a0"
+            ],
+            "license": "PSF",
+            "md5": "bdc6db1adbe7268e3ecbae13ec02066a",
+            "name": "python",
+            "sha256": "0b77f7c1f88f9b9dff2d25ab2c65b76ea37eb2fbc3eeab59e74a47b7a61ab20a",
+            "size": 28300090,
+            "subdir": "linux-64",
+            "timestamp": 1507190714033,
+            "version": "3.6.2"
+        },
+    }
+
+    keep.update(additional_records)
+
+    with open('index4.json', 'w') as fh:
+        fh.write(json.dumps(keep, indent=2, sort_keys=True, separators=(',', ': ')))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -230,3 +230,29 @@ def get_index_r_3():
     index = {Dist(prec): prec for prec in sd._package_records}
     r = Resolve(index, channels=(channel,))
     return index, r
+
+
+@memoize
+def get_index_r_4():
+    with open(join(dirname(__file__), 'index4.json')) as fi:
+        packages = json.load(fi)
+        repodata = {
+            "info": {
+                "subdir": context.subdir,
+                "arch": context.arch_name,
+                "platform": context.platform,
+            },
+            "packages": packages,
+        }
+
+    channel = Channel('https://conda.anaconda.org/channel-4/%s' % context.subdir)
+    sd = SubdirData(channel)
+    with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", reset_context):
+        sd._process_raw_repodata_str(json.dumps(repodata))
+    sd._loaded = True
+    SubdirData._cache_[channel.url(with_credentials=True)] = sd
+
+    index = {Dist(prec): prec for prec in sd._package_records}
+    r = Resolve(index, channels=(channel,))
+
+    return index, r

--- a/tests/index4.json
+++ b/tests/index4.json
@@ -1,0 +1,7276 @@
+{
+  "asn1crypto-0.22.0-py27h94ebe91_1.tar.bz2": {
+    "build": "py27h94ebe91_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "baa8b7230f9d4d6f3446c4fd13cd1ebf",
+    "name": "asn1crypto",
+    "sha256": "9cd074d719e92e022d2a3cb9d42a496874bdd168d3eb76fb391ee3d3d4e57e40",
+    "sig": null,
+    "size": 149118,
+    "subdir": "linux-64",
+    "timestamp": 1505691748075,
+    "version": "0.22.0"
+  },
+  "asn1crypto-0.22.0-py35h0d675fe_1.tar.bz2": {
+    "build": "py35h0d675fe_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "20f8dc3894fb495d4024a61c92e95ce1",
+    "name": "asn1crypto",
+    "sha256": "89228de3505ecadb4196f23153201e8ed37a49218584d9a54870e545d1870a44",
+    "sig": null,
+    "size": 153172,
+    "subdir": "linux-64",
+    "timestamp": 1505691760988,
+    "version": "0.22.0"
+  },
+  "asn1crypto-0.22.0-py36h265ca7c_1.tar.bz2": {
+    "build": "py36h265ca7c_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "d248e43bc478fb3b9bf01f3c67d44a66",
+    "name": "asn1crypto",
+    "sha256": "c732f0334a5dcb50194e0ef54a3f9ae02cfde2c95e4a2c1488823ef1eed0f64b",
+    "sig": null,
+    "size": 152073,
+    "subdir": "linux-64",
+    "timestamp": 1505691774144,
+    "version": "0.22.0"
+  },
+  "astroid-1.5.3-py27h8f8f47c_0.tar.bz2": {
+    "build": "py27h8f8f47c_0",
+    "build_number": 0,
+    "depends": [
+      "backports.functools_lru_cache",
+      "enum34",
+      "lazy-object-proxy",
+      "python >=2.7,<2.8.0a0",
+      "setuptools",
+      "singledispatch",
+      "six",
+      "wrapt"
+    ],
+    "license": "LGPL 2.1",
+    "license_family": "LGPL",
+    "md5": "da8a4ef8e0939c41c133813ae5ef75ed",
+    "name": "astroid",
+    "sha256": "34444c4578ef5855c4c63ce705ebad21a3ce432d0c1ec59c4c056a2a657d36ac",
+    "sig": null,
+    "size": 371988,
+    "subdir": "linux-64",
+    "timestamp": 1505693943294,
+    "version": "1.5.3"
+  },
+  "astroid-1.5.3-py35h1d0c565_0.tar.bz2": {
+    "build": "py35h1d0c565_0",
+    "build_number": 0,
+    "depends": [
+      "lazy-object-proxy",
+      "python >=3.5,<3.6.0a0",
+      "setuptools",
+      "six",
+      "wrapt"
+    ],
+    "license": "LGPL 2.1",
+    "license_family": "LGPL",
+    "md5": "3fb77f2cf362fe6f219e939148c41523",
+    "name": "astroid",
+    "sha256": "df6763e7f6129d6c309a531a4a23555a9b605ef50a1abe170cc0b42c69475e39",
+    "sig": null,
+    "size": 382085,
+    "subdir": "linux-64",
+    "timestamp": 1505693966826,
+    "version": "1.5.3"
+  },
+  "astroid-1.5.3-py36hbdb9df2_0.tar.bz2": {
+    "build": "py36hbdb9df2_0",
+    "build_number": 0,
+    "depends": [
+      "lazy-object-proxy",
+      "python >=3.6,<3.7.0a0",
+      "setuptools",
+      "six",
+      "wrapt"
+    ],
+    "license": "LGPL 2.1",
+    "license_family": "LGPL",
+    "md5": "f0eded893d51e036f022cb0a91303674",
+    "name": "astroid",
+    "sha256": "3df097cf7bb55d96b575b6b145b6a265870238b79170bdcbaad7173e155e2efc",
+    "sig": null,
+    "size": 382001,
+    "subdir": "linux-64",
+    "timestamp": 1505693990671,
+    "version": "1.5.3"
+  },
+  "backports-1.0-py27h63c9359_1.tar.bz2": {
+    "build": "py27h63c9359_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD",
+    "md5": "f31c243bbcc0961ce4982d11673cc9be",
+    "name": "backports",
+    "sha256": "b0429172aba9aedb4662a405cb20553cc8df757dd27676a3781671e84eb22987",
+    "sig": null,
+    "size": 3359,
+    "subdir": "linux-64",
+    "timestamp": 1505956835859,
+    "version": "1.0"
+  },
+  "backports-1.0-py35hd471ac7_1.tar.bz2": {
+    "build": "py35hd471ac7_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD",
+    "md5": "b51366efc44379112446a2a645946ae3",
+    "name": "backports",
+    "sha256": "79c93943b15075423057b9506be922737391cd28bae51243e40a3a9c93a5b375",
+    "sig": null,
+    "size": 3412,
+    "subdir": "linux-64",
+    "timestamp": 1505956848475,
+    "version": "1.0"
+  },
+  "backports-1.0-py36hfa02d7e_1.tar.bz2": {
+    "build": "py36hfa02d7e_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD",
+    "md5": "905fd8cd358b2741316ccc208aa5c3bc",
+    "name": "backports",
+    "sha256": "1db8133f08edf72350324dad4a81d2ea98833df032046812612ba0b5ce4fbd52",
+    "sig": null,
+    "size": 3412,
+    "subdir": "linux-64",
+    "timestamp": 1505956861253,
+    "version": "1.0"
+  },
+  "backports.functools_lru_cache-1.4-py27he8db605_1.tar.bz2": {
+    "build": "py27he8db605_1",
+    "build_number": 1,
+    "depends": [
+      "backports",
+      "python >=2.7,<2.8.0a0",
+      "setuptools"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "31fd3037467df2a4b036ef33d63c55d7",
+    "name": "backports.functools_lru_cache",
+    "sha256": "c2c09a469f5917a9fa27291c61f15553ae76c2b9c2e34dcac2d9a015c23f5194",
+    "sig": null,
+    "size": 8962,
+    "subdir": "linux-64",
+    "timestamp": 1505693903100,
+    "version": "1.4"
+  },
+  "backports.shutil_get_terminal_size-1.0.0-py27h5bc021e_2.tar.bz2": {
+    "build": "py27h5bc021e_2",
+    "build_number": 2,
+    "depends": [
+      "backports",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "be1b5ece34656af0926fc825e9b00425",
+    "name": "backports.shutil_get_terminal_size",
+    "sha256": "6c5f71a8dba08cfbb0248e177a217638f14d07f7a1f3dbe8df0d9572376b6ad8",
+    "sig": null,
+    "size": 7686,
+    "subdir": "linux-64",
+    "timestamp": 1505956875861,
+    "version": "1.0.0"
+  },
+  "backports.shutil_get_terminal_size-1.0.0-py35h40844db_2.tar.bz2": {
+    "build": "py35h40844db_2",
+    "build_number": 2,
+    "depends": [
+      "backports",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "5ec4cd6c85ca5e4aa7d36221df2c0c92",
+    "name": "backports.shutil_get_terminal_size",
+    "sha256": "e76f827fcb2c564de106830b927f50e9215e33ce238709af4018edc9dc6cadf0",
+    "sig": null,
+    "size": 7796,
+    "subdir": "linux-64",
+    "timestamp": 1505956890176,
+    "version": "1.0.0"
+  },
+  "backports.shutil_get_terminal_size-1.0.0-py36hfea85ff_2.tar.bz2": {
+    "build": "py36hfea85ff_2",
+    "build_number": 2,
+    "depends": [
+      "backports",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "4a7f4c0063132ded8bffe3195fc2184a",
+    "name": "backports.shutil_get_terminal_size",
+    "sha256": "f7d0d79bfed724730a3b37e551d78ff62f9c18204f65c154e9e7234133f04135",
+    "sig": null,
+    "size": 7736,
+    "subdir": "linux-64",
+    "timestamp": 1505956904525,
+    "version": "1.0.0"
+  },
+  "backports_abc-0.5-py27h7b3c97b_0.tar.bz2": {
+    "build": "py27h7b3c97b_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "PSF 2",
+    "md5": "cc58276fdcdba4c15b8a8f8493691e9d",
+    "name": "backports_abc",
+    "sha256": "fff61cfe579da8748517fba968dc2c91de01ce2e8da05039b5302e0f54fc4852",
+    "sig": null,
+    "size": 12231,
+    "subdir": "linux-64",
+    "timestamp": 1505690433274,
+    "version": "0.5"
+  },
+  "bkcharts-0.2-py27h241ae91_0.tar.bz2": {
+    "build": "py27h241ae91_0",
+    "build_number": 0,
+    "depends": [
+      "numpy >=1.7.1",
+      "pandas",
+      "python >=2.7,<2.8.0a0",
+      "six >=1.5.2"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "48958668161a71b18ad1c5fdef90de0b",
+    "name": "bkcharts",
+    "sha256": "121afa1f4c73576435b927bd190664a12fa4b19a6e6f935ed688c79159098bbf",
+    "sig": null,
+    "size": 126864,
+    "subdir": "linux-64",
+    "timestamp": 1505728747105,
+    "version": "0.2"
+  },
+  "bkcharts-0.2-py35he4f7e30_0.tar.bz2": {
+    "build": "py35he4f7e30_0",
+    "build_number": 0,
+    "depends": [
+      "numpy >=1.7.1",
+      "pandas",
+      "python >=3.5,<3.6.0a0",
+      "six >=1.5.2"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "c9095dcedb053233a60125f7143e000b",
+    "name": "bkcharts",
+    "sha256": "e365a081b2e0fe401d0c6431a2989d38770e71681d0173103c393a7ce58d9cba",
+    "sig": null,
+    "size": 130864,
+    "subdir": "linux-64",
+    "timestamp": 1505728757269,
+    "version": "0.2"
+  },
+  "bkcharts-0.2-py36h735825a_0.tar.bz2": {
+    "build": "py36h735825a_0",
+    "build_number": 0,
+    "depends": [
+      "numpy >=1.7.1",
+      "pandas",
+      "python >=3.6,<3.7.0a0",
+      "six >=1.5.2"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "c885f7e74c6caf3d719349ef611e4d92",
+    "name": "bkcharts",
+    "sha256": "587d964699268e1d83ec3a8cdb7efe0570778a609a1b771f607ed14cd63b421d",
+    "sig": null,
+    "size": 129957,
+    "subdir": "linux-64",
+    "timestamp": 1505728767491,
+    "version": "0.2"
+  },
+  "bokeh-0.12.10-py27he46cc6b_0.tar.bz2": {
+    "build": "py27he46cc6b_0",
+    "build_number": 0,
+    "depends": [
+      "futures >=3.0.3",
+      "jinja2 >=2.7",
+      "numpy >=1.7.1",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "d6146516cc7b9c2ca436f4962eeb3a27",
+    "name": "bokeh",
+    "sha256": "c1228ea78606842371b3c3a6868f5b29f925642f1de55216cda36f738b445c24",
+    "sig": null,
+    "size": 4533304,
+    "subdir": "linux-64",
+    "timestamp": 1508263083255,
+    "version": "0.12.10"
+  },
+  "bokeh-0.12.10-py35hfdb0b1d_0.tar.bz2": {
+    "build": "py35hfdb0b1d_0",
+    "build_number": 0,
+    "depends": [
+      "jinja2 >=2.7",
+      "numpy >=1.7.1",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "e4d3ce3afd75642a9c2efc4522f61c5b",
+    "name": "bokeh",
+    "sha256": "aa7025dbcf51592c425660a6dfc577991d9b720c946c7b3c24964f47dae93591",
+    "sig": null,
+    "size": 4448429,
+    "subdir": "linux-64",
+    "timestamp": 1508263108730,
+    "version": "0.12.10"
+  },
+  "bokeh-0.12.10-py36hbb0e44a_0.tar.bz2": {
+    "build": "py36hbb0e44a_0",
+    "build_number": 0,
+    "depends": [
+      "jinja2 >=2.7",
+      "numpy >=1.7.1",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "7417c88d16fa4710f08992c77927b8e4",
+    "name": "bokeh",
+    "sha256": "d96584380ad826379c90c52f7e7aa1687ac9e9a1caee93be5d65351ece2f9a5b",
+    "sig": null,
+    "size": 4448232,
+    "subdir": "linux-64",
+    "timestamp": 1508263109298,
+    "version": "0.12.10"
+  },
+  "bokeh-0.12.7-py27he0197c9_1.tar.bz2": {
+    "build": "py27he0197c9_1",
+    "build_number": 1,
+    "depends": [
+      "bkcharts >=0.2",
+      "futures >=3.0.3",
+      "jinja2 >=2.7",
+      "matplotlib",
+      "numpy >=1.7.1",
+      "pandas",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "requests >=1.2.3",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "e6082e98c342333033ec82724d2b9df4",
+    "name": "bokeh",
+    "sha256": "3750590a96bac552d548637a52dbe3f97b7ee9c0d9955892538b76b767f80949",
+    "sig": null,
+    "size": 4383727,
+    "subdir": "linux-64",
+    "timestamp": 1505739753633,
+    "version": "0.12.7"
+  },
+  "bokeh-0.12.7-py35h4751c18_1.tar.bz2": {
+    "build": "py35h4751c18_1",
+    "build_number": 1,
+    "depends": [
+      "bkcharts >=0.2",
+      "jinja2 >=2.7",
+      "matplotlib",
+      "numpy >=1.7.1",
+      "pandas",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "requests >=1.2.3",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "c6d1cd3c7e9013500a114c6ce19a5ead",
+    "name": "bokeh",
+    "sha256": "f4a3602195fd8fbb2838eae061d48746b5f89b8483c1882bef4439f80b932f23",
+    "sig": null,
+    "size": 4444049,
+    "subdir": "linux-64",
+    "timestamp": 1505739800717,
+    "version": "0.12.7"
+  },
+  "bokeh-0.12.7-py36h169c5fd_1.tar.bz2": {
+    "build": "py36h169c5fd_1",
+    "build_number": 1,
+    "depends": [
+      "bkcharts >=0.2",
+      "jinja2 >=2.7",
+      "matplotlib",
+      "numpy >=1.7.1",
+      "pandas",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "requests >=1.2.3",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "6c00d9f65fa73531217f8ad2663cc756",
+    "name": "bokeh",
+    "sha256": "b41887ad998250e79e79673cac2c7be1ce2fb761f3f1294a5758f01324d0c109",
+    "sig": null,
+    "size": 4469133,
+    "subdir": "linux-64",
+    "timestamp": 1505739848870,
+    "version": "0.12.7"
+  },
+  "bokeh-0.12.9-py27h403a6de_0.tar.bz2": {
+    "build": "py27h403a6de_0",
+    "build_number": 0,
+    "depends": [
+      "futures >=3.0.3",
+      "jinja2 >=2.7",
+      "numpy >=1.7.1",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "e8e1a7d8ddd42499ce8ef263042a09b0",
+    "name": "bokeh",
+    "sha256": "96e6478a20c99aeded01fe9346c263af8e95358df91e8b8a7217d2dd4ce7e860",
+    "sig": null,
+    "size": 4379879,
+    "subdir": "linux-64",
+    "timestamp": 1506621189022,
+    "version": "0.12.9"
+  },
+  "bokeh-0.12.9-py35hebc9bbc_0.tar.bz2": {
+    "build": "py35hebc9bbc_0",
+    "build_number": 0,
+    "depends": [
+      "jinja2 >=2.7",
+      "numpy >=1.7.1",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "b2ab7f956b6c53a3dc70a6487d132ea8",
+    "name": "bokeh",
+    "sha256": "6c97548b5af867f6ddcc12037fe28bac86e8a26fa069d0e5c6aa7ef86b493416",
+    "sig": null,
+    "size": 4467824,
+    "subdir": "linux-64",
+    "timestamp": 1506621211683,
+    "version": "0.12.9"
+  },
+  "bokeh-0.12.9-py36hca3971f_0.tar.bz2": {
+    "build": "py36hca3971f_0",
+    "build_number": 0,
+    "depends": [
+      "jinja2 >=2.7",
+      "numpy >=1.7.1",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil >=2.1",
+      "pyyaml >=3.10",
+      "six >=1.5.2",
+      "tornado >=4.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "e65f68c7608782cd61c117d874afe065",
+    "name": "bokeh",
+    "sha256": "a3ac82214034372a3f39b1e05018c4cc1c9e0f5f986c5ed0150692cae5a7878d",
+    "sig": null,
+    "size": 4482060,
+    "subdir": "linux-64",
+    "timestamp": 1506621219178,
+    "version": "0.12.9"
+  },
+  "boto3-1.4.7-py27h11b3982_0.tar.bz2": {
+    "build": "py27h11b3982_0",
+    "build_number": 0,
+    "depends": [
+      "botocore >=1.7.0,<1.8.0",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=2.7,<2.8.0a0",
+      "s3transfer >=0.1.10,<0.2.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "98513a1dbd2f90b7bcf95c06f03deada",
+    "name": "boto3",
+    "sha256": "74f5f656a36b543e6a5d61b6a84bd704a73d95e4a718e876fa84ebd6ae2ae908",
+    "sig": null,
+    "size": 106354,
+    "subdir": "linux-64",
+    "timestamp": 1505957017930,
+    "version": "1.4.7"
+  },
+  "boto3-1.4.7-py35h2161c00_0.tar.bz2": {
+    "build": "py35h2161c00_0",
+    "build_number": 0,
+    "depends": [
+      "botocore >=1.7.0,<1.8.0",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.5,<3.6.0a0",
+      "s3transfer >=0.1.10,<0.2.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "9b765ef77f30ee3e78d60b4bf86024da",
+    "name": "boto3",
+    "sha256": "f532efa9a2594ea1f4f601ff991ff5cd536b6b5ca5531c6926caaf7f385af4fb",
+    "sig": null,
+    "size": 109349,
+    "subdir": "linux-64",
+    "timestamp": 1505957034722,
+    "version": "1.4.7"
+  },
+  "boto3-1.4.7-py36h4cc92d5_0.tar.bz2": {
+    "build": "py36h4cc92d5_0",
+    "build_number": 0,
+    "depends": [
+      "botocore >=1.7.0,<1.8.0",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.6,<3.7.0a0",
+      "s3transfer >=0.1.10,<0.2.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "6bd1aa261430b7da0129f283808cef4f",
+    "name": "boto3",
+    "sha256": "9de50d4f4610a87a9184072e55eee72e8687a8f17fca245d5b9025080c0c0ccb",
+    "sig": null,
+    "size": 108875,
+    "subdir": "linux-64",
+    "timestamp": 1505957051488,
+    "version": "1.4.7"
+  },
+  "botocore-1.5.78-py27hd4e8fcf_0.tar.bz2": {
+    "build": "py27hd4e8fcf_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "14399d61bd1215664591c2cb637b35eb",
+    "name": "botocore",
+    "sha256": "f088ff2cae51ae15686e3c1ef8e9c883b839577bbd160ee5851d88bc041d6fc6",
+    "sig": null,
+    "size": 2627032,
+    "subdir": "linux-64",
+    "timestamp": 1507368009467,
+    "version": "1.5.78"
+  },
+  "botocore-1.5.78-py35h796d66b_0.tar.bz2": {
+    "build": "py35h796d66b_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "724e5b84c16f618d556cfc20b2a38118",
+    "name": "botocore",
+    "sha256": "65be536ee1ef6c7bab7a665a6ef5c71361755371b9c5940c1be7c3c8861348f2",
+    "sig": null,
+    "size": 2655072,
+    "subdir": "linux-64",
+    "timestamp": 1507368021215,
+    "version": "1.5.78"
+  },
+  "botocore-1.5.78-py36h2caa6e9_0.tar.bz2": {
+    "build": "py36h2caa6e9_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "7fbde1bee6a581d2499bdcfb0ffc81b1",
+    "name": "botocore",
+    "sha256": "9c1e862fabeb549499527c3eebcac409ba89ab5e986fb998119923726898f03b",
+    "sig": null,
+    "size": 2653897,
+    "subdir": "linux-64",
+    "timestamp": 1507368015422,
+    "version": "1.5.78"
+  },
+  "botocore-1.7.14-py27h48f721b_0.tar.bz2": {
+    "build": "py27h48f721b_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "4b28df9067aedbc828f5892f645bad25",
+    "name": "botocore",
+    "sha256": "3e6d1631a26a790deb0a6edc214b3f67c017d797e00e2dac62db5a86f8b2d9a7",
+    "sig": null,
+    "size": 2692996,
+    "subdir": "linux-64",
+    "timestamp": 1505956926449,
+    "version": "1.7.14"
+  },
+  "botocore-1.7.14-py35h1ea1bdf_0.tar.bz2": {
+    "build": "py35h1ea1bdf_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "0eadb13595cb691e47f7603a52c0ab70",
+    "name": "botocore",
+    "sha256": "68818344911a2003cf0eef8d6df7e056f74e6ff465885229f9e8a338fe3dac30",
+    "sig": null,
+    "size": 2750545,
+    "subdir": "linux-64",
+    "timestamp": 1505956959560,
+    "version": "1.7.14"
+  },
+  "botocore-1.7.14-py36h38b1d61_0.tar.bz2": {
+    "build": "py36h38b1d61_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "13ff1f1ae3063b338a241a666bdcb65d",
+    "name": "botocore",
+    "sha256": "401c22e56c90f59a1b7e2a7638d423c4b05ccb578f845fdbfc8b4adb428a1b70",
+    "sig": null,
+    "size": 2737140,
+    "subdir": "linux-64",
+    "timestamp": 1505956993084,
+    "version": "1.7.14"
+  },
+  "botocore-1.7.20-py27h89f32a6_0.tar.bz2": {
+    "build": "py27h89f32a6_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "7bbdf1c5b3c18038ba3705a0f9dd683c",
+    "name": "botocore",
+    "sha256": "fa28b1dd3b55666608c27d3d4fb3671183a30115f6692d55e78913fb4ae127b8",
+    "sig": null,
+    "size": 2710541,
+    "subdir": "linux-64",
+    "timestamp": 1507364922448,
+    "version": "1.7.20"
+  },
+  "botocore-1.7.20-py35h627d9b9_0.tar.bz2": {
+    "build": "py35h627d9b9_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "70c9774e27dab0a96493d8adead435a8",
+    "name": "botocore",
+    "sha256": "0f4d806c5ae6ad34129692ace517f845516eba0016f24755972e7e2d1e509175",
+    "sig": null,
+    "size": 2754708,
+    "subdir": "linux-64",
+    "timestamp": 1507364941552,
+    "version": "1.7.20"
+  },
+  "botocore-1.7.20-py36h085fff1_0.tar.bz2": {
+    "build": "py36h085fff1_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "93e72f7537be3182b153f07143fa277a",
+    "name": "botocore",
+    "sha256": "7d9d247e8d1ed51fc1d5f7dd6aee638aaddb16b8d700bfc4fd84e0fec1ea0a32",
+    "sig": null,
+    "size": 2742938,
+    "subdir": "linux-64",
+    "timestamp": 1507364959402,
+    "version": "1.7.20"
+  },
+  "botocore-1.7.5-py27h902c29d_0.tar.bz2": {
+    "build": "py27h902c29d_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "d5cabfa5b56682c8b78c2d6590d78641",
+    "name": "botocore",
+    "sha256": "556e767a3dc5e54c1aed524e4eebf5877a9f10dfb562ab3922de5013b8e0328e",
+    "sig": null,
+    "size": 2682869,
+    "subdir": "linux-64",
+    "timestamp": 1507371777862,
+    "version": "1.7.5"
+  },
+  "botocore-1.7.5-py35h5941762_0.tar.bz2": {
+    "build": "py35h5941762_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "0404f64b0c7ecc8c9309b84b9538566c",
+    "name": "botocore",
+    "sha256": "15be4334c0e761f911bd4bdfa8345981031c7de8d4deae3517a91e828ca0f1ab",
+    "sig": null,
+    "size": 2729634,
+    "subdir": "linux-64",
+    "timestamp": 1507371771755,
+    "version": "1.7.5"
+  },
+  "botocore-1.7.5-py36ha445209_0.tar.bz2": {
+    "build": "py36ha445209_0",
+    "build_number": 0,
+    "depends": [
+      "docutils >=0.10",
+      "jmespath >=0.7.1,<1.0.0",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil >=2.1,<3.0.0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "cb03f62080cbb04a873247ba1b3bb49c",
+    "name": "botocore",
+    "sha256": "055047e05e14dc97ac550e5b6d50d211e759f4ed5c21132d78719a3cbf7729fc",
+    "sig": null,
+    "size": 2718431,
+    "subdir": "linux-64",
+    "timestamp": 1507371803010,
+    "version": "1.7.5"
+  },
+  "ca-certificates-2017.08.26-h1d4fec5_0.tar.bz2": {
+    "build": "h1d4fec5_0",
+    "build_number": 0,
+    "depends": [],
+    "license": "ISC",
+    "md5": "6b74b83b6b78ef64838cb8d6b001fa56",
+    "name": "ca-certificates",
+    "sha256": "994ab7778364d79b7a031d1f1030c82b6046522702fe8b5383c2531cc737b2d7",
+    "sig": null,
+    "size": 269673,
+    "subdir": "linux-64",
+    "timestamp": 1505666760156,
+    "version": "2017.08.26"
+  },
+  "certifi-2017.7.27.1-py27h9ceb091_0.tar.bz2": {
+    "build": "py27h9ceb091_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "ISC",
+    "md5": "0914a222e40dd52b3341a77cb0392ebf",
+    "name": "certifi",
+    "sha256": "a571d97fed7b517518d804a6e4202018fc857cbdcd4a1498f9f878e2676dcd3a",
+    "sig": null,
+    "size": 209549,
+    "subdir": "linux-64",
+    "timestamp": 1505671803420,
+    "version": "2017.7.27.1"
+  },
+  "certifi-2017.7.27.1-py35h19f42a1_0.tar.bz2": {
+    "build": "py35h19f42a1_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "ISC",
+    "md5": "5256d896206897b45d3f401c3f12017d",
+    "name": "certifi",
+    "sha256": "251d7ffc0b13361e87c1c2b3ee13651167a8a205204e3379d40df9869ca5b1f6",
+    "sig": null,
+    "size": 209827,
+    "subdir": "linux-64",
+    "timestamp": 1505671814237,
+    "version": "2017.7.27.1"
+  },
+  "certifi-2017.7.27.1-py36h8b7b77e_0.tar.bz2": {
+    "build": "py36h8b7b77e_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "ISC",
+    "md5": "91fac0c7809ab43597bbaf18831375a3",
+    "name": "certifi",
+    "sha256": "4224660995cbf67752383ee80c04270c4f26b20b1043a6ca819c1ad3753b4c91",
+    "sig": null,
+    "size": 209729,
+    "subdir": "linux-64",
+    "timestamp": 1505671825111,
+    "version": "2017.7.27.1"
+  },
+  "cffi-1.10.0-py27hf1aaaf4_1.tar.bz2": {
+    "build": "py27hf1aaaf4_1",
+    "build_number": 1,
+    "depends": [
+      "libffi",
+      "libgcc-ng >=7.2.0",
+      "pycparser",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "2ee87fdf72a600b132dc79946731e54c",
+    "name": "cffi",
+    "sha256": "6f3fc7ea97db769942aaeeb42ac1a944e8e3c8871aaf8ffa3a264ed225ec191b",
+    "sig": null,
+    "size": 206821,
+    "subdir": "linux-64",
+    "timestamp": 1505691660494,
+    "version": "1.10.0"
+  },
+  "cffi-1.10.0-py35h796c292_1.tar.bz2": {
+    "build": "py35h796c292_1",
+    "build_number": 1,
+    "depends": [
+      "libffi",
+      "libgcc-ng >=7.2.0",
+      "pycparser",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "71078cb61a846e94ce78670957fd02a9",
+    "name": "cffi",
+    "sha256": "f072c451e4db22ae81c835c3ab48188da19132dfa5463dc54d97852eae5d3d82",
+    "sig": null,
+    "size": 211837,
+    "subdir": "linux-64",
+    "timestamp": 1505691679697,
+    "version": "1.10.0"
+  },
+  "cffi-1.10.0-py36had8d393_1.tar.bz2": {
+    "build": "py36had8d393_1",
+    "build_number": 1,
+    "depends": [
+      "libffi",
+      "libgcc-ng >=7.2.0",
+      "pycparser",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "76dd0965706dd3cbb3dcd3bb164bdc26",
+    "name": "cffi",
+    "sha256": "e0d22b596f62ba16aee44393b7c46768ffd757b2bbc1a6f8e76aab181ffb92f5",
+    "sig": null,
+    "size": 210690,
+    "subdir": "linux-64",
+    "timestamp": 1505691698902,
+    "version": "1.10.0"
+  },
+  "chardet-3.0.4-py27hfa10054_1.tar.bz2": {
+    "build": "py27hfa10054_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "LGPL2",
+    "license_family": "GPL",
+    "md5": "cf1e643f7e88f4d5bc3734ff9ecc9582",
+    "name": "chardet",
+    "sha256": "00adb1738dd3e6c9c627f936bafba8500c26bcd47536161fdd8ff2f093ac5b5b",
+    "sig": null,
+    "size": 184052,
+    "subdir": "linux-64",
+    "timestamp": 1505691573037,
+    "version": "3.0.4"
+  },
+  "chardet-3.0.4-py35hb6e9ddf_1.tar.bz2": {
+    "build": "py35hb6e9ddf_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "LGPL2",
+    "license_family": "GPL",
+    "md5": "18ff93df029490aaadeca8e69dc055a4",
+    "name": "chardet",
+    "sha256": "4bb4b83f0441907f3b8950a619c1ef2a76f7d8ed65518df3814d791af0ea9c83",
+    "sig": null,
+    "size": 194947,
+    "subdir": "linux-64",
+    "timestamp": 1505691587564,
+    "version": "3.0.4"
+  },
+  "chardet-3.0.4-py36h0f667ec_1.tar.bz2": {
+    "build": "py36h0f667ec_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "LGPL2",
+    "license_family": "GPL",
+    "md5": "d46061b631f1c77986cc321e0cab3bb4",
+    "name": "chardet",
+    "sha256": "df1d2955676b03a8388027ae6639aed5a6a5382897d4f81034f8ca2f15f7d386",
+    "sig": null,
+    "size": 194419,
+    "subdir": "linux-64",
+    "timestamp": 1505691602341,
+    "version": "3.0.4"
+  },
+  "click-6.7-py27h4225b90_0.tar.bz2": {
+    "build": "py27h4225b90_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "0bd26df9e3d536b6bafb0633d93b8b5e",
+    "name": "click",
+    "sha256": "cefef80840a3fdb77667ecdae16029c853b5b97932712932d8b45e83d591c16b",
+    "sig": null,
+    "size": 104975,
+    "subdir": "linux-64",
+    "timestamp": 1505733208892,
+    "version": "6.7"
+  },
+  "click-6.7-py35h353a69f_0.tar.bz2": {
+    "build": "py35h353a69f_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "3cb898b458fe28afb3f955d54e1cb1ef",
+    "name": "click",
+    "sha256": "148f54d7b32e206935ac6a80e67d1d92a157538b6c217db8757c022930af136c",
+    "sig": null,
+    "size": 107406,
+    "subdir": "linux-64",
+    "timestamp": 1505733221436,
+    "version": "6.7"
+  },
+  "click-6.7-py36h5253387_0.tar.bz2": {
+    "build": "py36h5253387_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "4929a930f8e97eaaf716e00b9c74fef3",
+    "name": "click",
+    "sha256": "90af402bc1cd9cb08c9c1bdbd05910671a1779df20534e3c35157865d8f67d60",
+    "sig": null,
+    "size": 106893,
+    "subdir": "linux-64",
+    "timestamp": 1505733234112,
+    "version": "6.7"
+  },
+  "cloog-0.18.0-0.tar.bz2": {
+    "build": "0",
+    "build_number": 0,
+    "depends": [
+      "gmp",
+      "isl"
+    ],
+    "license": null,
+    "md5": "32e63e74723d6686d0ceb7384e47c2b4",
+    "name": "cloog",
+    "sha256": "252735853bd15e9800e087b019cbce2d282fd9a9915e80e41c939aea24c6a33b",
+    "sig": null,
+    "size": 631488,
+    "timestamp": 1506534614,
+    "version": "0.18.0"
+  },
+  "cloudpickle-0.4.0-py27ha64365b_0.tar.bz2": {
+    "build": "py27ha64365b_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "35695ecf84a6025b68f6f66b76cd5090",
+    "name": "cloudpickle",
+    "sha256": "37aafd7f47af3f244db1505cfa2cee70f65e20d480117a296f235dc8e89ec901",
+    "sig": null,
+    "size": 24689,
+    "subdir": "linux-64",
+    "timestamp": 1505732853036,
+    "version": "0.4.0"
+  },
+  "cloudpickle-0.4.0-py35h10376d1_0.tar.bz2": {
+    "build": "py35h10376d1_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "50862ced9738405cacc83456ad539af2",
+    "name": "cloudpickle",
+    "sha256": "f416d50f9c8d43dda696f22eb0ed0f26fa905af4782244c9ad76cd1819854124",
+    "sig": null,
+    "size": 25059,
+    "subdir": "linux-64",
+    "timestamp": 1505732864342,
+    "version": "0.4.0"
+  },
+  "cloudpickle-0.4.0-py36h30f8c20_0.tar.bz2": {
+    "build": "py36h30f8c20_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "ffd9a6ac4a4b20abc6e7ff03361ad71d",
+    "name": "cloudpickle",
+    "sha256": "9fee5b20d84cd3715ecb5702cf57ac897c2900248216b6d95585f51efc6beb5a",
+    "sig": null,
+    "size": 24983,
+    "subdir": "linux-64",
+    "timestamp": 1505732875767,
+    "version": "0.4.0"
+  },
+  "colorama-0.3.9-py27h5cde069_0.tar.bz2": {
+    "build": "py27h5cde069_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "002c4a08e8804c3651c2b22535c73607",
+    "name": "colorama",
+    "sha256": "0d8bef54d1b9ee1fa8f010b493777af1e494dd1384de40d3b88a45a449dd3261",
+    "sig": null,
+    "size": 23193,
+    "subdir": "linux-64",
+    "timestamp": 1505741945172,
+    "version": "0.3.9"
+  },
+  "colorama-0.3.9-py35h81e2b6c_0.tar.bz2": {
+    "build": "py35h81e2b6c_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "d7ce082b858d6e4d020e3efd6efe7ff0",
+    "name": "colorama",
+    "sha256": "721dbbf706ba88d06d436e6136c5b7236968258014291f4db1eebf8ae2d83ec4",
+    "sig": null,
+    "size": 23604,
+    "subdir": "linux-64",
+    "timestamp": 1505741957440,
+    "version": "0.3.9"
+  },
+  "colorama-0.3.9-py36h489cec4_0.tar.bz2": {
+    "build": "py36h489cec4_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "8a3372480117f3f7b18413ecc3dba6ac",
+    "name": "colorama",
+    "sha256": "174c44ef3f8039aa81aa6876e5df2fee10c6793e8ca5bc6e49b64e3726aa3b2c",
+    "sig": null,
+    "size": 23584,
+    "subdir": "linux-64",
+    "timestamp": 1505741969960,
+    "version": "0.3.9"
+  },
+  "conda-4.3.27-py27hff99c7a_0.tar.bz2": {
+    "build": "py27hff99c7a_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "enum34",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=2.7,<2.8.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "fcf31f31ff9c639b176d0cae4d119071",
+    "name": "conda",
+    "sha256": "bc03745efb749aee6494d71e9b957d986cb5464de063eca0ce00b899d65e95e9",
+    "sig": null,
+    "size": 519692,
+    "subdir": "linux-64",
+    "timestamp": 1506080072319,
+    "version": "4.3.27"
+  },
+  "conda-4.3.27-py35h1706b01_0.tar.bz2": {
+    "build": "py35h1706b01_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=3.5,<3.6.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "c6339a57edde101313f44ad80732925a",
+    "name": "conda",
+    "sha256": "682851fe95adf417830d135233cd869ae9ae4a500d5309456d29ca9fcf7b3c76",
+    "sig": null,
+    "size": 527710,
+    "subdir": "linux-64",
+    "timestamp": 1506080093174,
+    "version": "4.3.27"
+  },
+  "conda-4.3.27-py36h2866c0b_0.tar.bz2": {
+    "build": "py36h2866c0b_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=3.6,<3.7.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "5a51e317f9507e86511bdb472a2ebfad",
+    "name": "conda",
+    "sha256": "c012c226812021ccb546881bea6c770ef32654924e7d5274db753678d8ca2c3a",
+    "sig": null,
+    "size": 523175,
+    "subdir": "linux-64",
+    "timestamp": 1506080114791,
+    "version": "4.3.27"
+  },
+  "conda-4.3.29-py27h13e2077_0.tar.bz2": {
+    "build": "py27h13e2077_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "enum34",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=2.7,<2.8.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "08af2e50780fe834bf07053be6c3ea0d",
+    "name": "conda",
+    "sha256": "44d23568a241a906d7b6aa7a303a0cd76174a24be151265a7c587ec36725b86b",
+    "sig": null,
+    "size": 519579,
+    "subdir": "linux-64",
+    "timestamp": 1507581131695,
+    "version": "4.3.29"
+  },
+  "conda-4.3.29-py34h14158f2_0.tar.bz2": {
+    "build": "py34h14158f2_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=3.4,<3.5.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "ad42f979d6f83b892fcac14c6d09e32a",
+    "name": "conda",
+    "sha256": "53b9435c72cc6d53932254d421510e6a01195adad69945af76aa15ad26fc400f",
+    "sig": null,
+    "size": 531649,
+    "subdir": "linux-64",
+    "timestamp": 1507581148853,
+    "version": "4.3.29"
+  },
+  "conda-4.3.29-py35h8b93296_0.tar.bz2": {
+    "build": "py35h8b93296_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=3.5,<3.6.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "ecb8c264108b6e29f6e2e9baf4971fa4",
+    "name": "conda",
+    "sha256": "dd5bf255573c0fe1ad4dd51e1c7bc6bee8cdb4d6965f726abf2ce5530469b2f5",
+    "sig": null,
+    "size": 528061,
+    "subdir": "linux-64",
+    "timestamp": 1507581159664,
+    "version": "4.3.29"
+  },
+  "conda-4.3.29-py36ha26b0c0_0.tar.bz2": {
+    "build": "py36ha26b0c0_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=3.6,<3.7.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "62d4160fd4eb969b990c42bf50b520bc",
+    "name": "conda",
+    "sha256": "c94ea25eb44c830cd8ef6c91eac253d6b76062faee05021321684d4e8566aabb",
+    "sig": null,
+    "size": 523520,
+    "subdir": "linux-64",
+    "timestamp": 1507581177439,
+    "version": "4.3.29"
+  },
+  "conda-4.3.30-py27h6ae6dc7_0.tar.bz2": {
+    "build": "py27h6ae6dc7_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "enum34",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=2.7,<2.8.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "cb78a85049bfa4f0cbae25f61b660485",
+    "name": "conda",
+    "sha256": "37614392f15289be3a8cc712f7bf70b19b17be99c0b912237f2ee0a00fb1a56b",
+    "sig": null,
+    "size": 519462,
+    "subdir": "linux-64",
+    "timestamp": 1508271588500,
+    "version": "4.3.30"
+  },
+  "conda-4.3.30-py34h69bfab2_0.tar.bz2": {
+    "build": "py34h69bfab2_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=3.4,<3.5.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "1ecfc669916182c451ab2fbe1a77de02",
+    "name": "conda",
+    "sha256": "80fa2538fca1263e4b4d8b7ab11a7e9b17ab5b0e461ae0e7530bf0ff1253a767",
+    "sig": null,
+    "size": 531126,
+    "subdir": "linux-64",
+    "timestamp": 1508271577660,
+    "version": "4.3.30"
+  },
+  "conda-4.3.30-py35hf9359ed_0.tar.bz2": {
+    "build": "py35hf9359ed_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=3.5,<3.6.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "081dcf18d1291f82483b7c108e1361f3",
+    "name": "conda",
+    "sha256": "1211bfd8770324efb6228a5bcc7a9d00ae048add6efca8462c0c8376365e72d9",
+    "sig": null,
+    "size": 528857,
+    "subdir": "linux-64",
+    "timestamp": 1508271605880,
+    "version": "4.3.30"
+  },
+  "conda-4.3.30-py36h5d9f9f4_0.tar.bz2": {
+    "build": "py36h5d9f9f4_0",
+    "build_number": 0,
+    "depends": [
+      "conda-env >=2.6",
+      "pycosat >=0.6.1",
+      "pyopenssl >=16.2.0",
+      "python >=3.6,<3.7.0a0",
+      "requests >=2.12.4",
+      "ruamel_yaml >=0.11.14"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "4074a41829c87c39bcf39c6233de8b42",
+    "name": "conda",
+    "sha256": "5d30b1b1f0522eb7f6973a568dd9fd43e2ae92352dd066706280f27eb8d5f596",
+    "sig": null,
+    "size": 523765,
+    "subdir": "linux-64",
+    "timestamp": 1508271608124,
+    "version": "4.3.30"
+  },
+  "conda-env-2.6.0-h36134e3_1.tar.bz2": {
+    "build": "h36134e3_1",
+    "build_number": 1,
+    "depends": [],
+    "license": "BSD 3-Clause",
+    "md5": "c1a55e6bb160dd26801df411e7dc1dc4",
+    "name": "conda-env",
+    "sha256": "8a6c1e05f974afcaad3c9fe4abcafec6f5ae16202f3845523a1dd1e993f5930f",
+    "sig": null,
+    "size": 2247,
+    "subdir": "linux-64",
+    "timestamp": 1505742067960,
+    "version": "2.6.0"
+  },
+  "cryptography-2.0.3-py27hea39389_1.tar.bz2": {
+    "build": "py27hea39389_1",
+    "build_number": 1,
+    "depends": [
+      "asn1crypto >=0.21.0",
+      "cffi >=1.7",
+      "enum34",
+      "idna >=2.1",
+      "ipaddress",
+      "libgcc-ng >=7.2.0",
+      "openssl 1.0.*",
+      "python >=2.7,<2.8.0a0",
+      "six >=1.4.1"
+    ],
+    "license": "Apache 2.0 or BSD 3-Clause, PSF 2",
+    "license_family": "BSD",
+    "md5": "f148e7ba6e445cc796392a7be0cdf022",
+    "name": "cryptography",
+    "sha256": "8ff5652ca7b6359f2129b0e04d14bffd485a6c5867a398103f521b174266dc20",
+    "sig": null,
+    "size": 599075,
+    "subdir": "linux-64",
+    "timestamp": 1505692156287,
+    "version": "2.0.3"
+  },
+  "cryptography-2.0.3-py35hef72dfd_1.tar.bz2": {
+    "build": "py35hef72dfd_1",
+    "build_number": 1,
+    "depends": [
+      "asn1crypto >=0.21.0",
+      "cffi >=1.7",
+      "idna >=2.1",
+      "libgcc-ng >=7.2.0",
+      "openssl 1.0.*",
+      "python >=3.5,<3.6.0a0",
+      "six >=1.4.1"
+    ],
+    "license": "Apache 2.0 or BSD 3-Clause, PSF 2",
+    "license_family": "BSD",
+    "md5": "f06d1a1812d48ec9203a7c1d85397bdc",
+    "name": "cryptography",
+    "sha256": "bf102e8f53d6b58546b2dcf99e43f76d01a829b055cd214be082baacd12652c5",
+    "sig": null,
+    "size": 606987,
+    "subdir": "linux-64",
+    "timestamp": 1505692423670,
+    "version": "2.0.3"
+  },
+  "cryptography-2.0.3-py36ha225213_1.tar.bz2": {
+    "build": "py36ha225213_1",
+    "build_number": 1,
+    "depends": [
+      "asn1crypto >=0.21.0",
+      "cffi >=1.7",
+      "idna >=2.1",
+      "libgcc-ng >=7.2.0",
+      "openssl 1.0.*",
+      "python >=3.6,<3.7.0a0",
+      "six >=1.4.1"
+    ],
+    "license": "Apache 2.0 or BSD 3-Clause, PSF 2",
+    "license_family": "BSD",
+    "md5": "22cb377a16ef5af133c9920f7e48069d",
+    "name": "cryptography",
+    "sha256": "18c7fe48ed19c9fa6f6de4cee0b28853e3b26c0ee5b629b09ffc7e28a7b08b5d",
+    "sig": null,
+    "size": 605603,
+    "subdir": "linux-64",
+    "timestamp": 1505692706043,
+    "version": "2.0.3"
+  },
+  "cycler-0.10.0-py27hc7354d3_0.tar.bz2": {
+    "build": "py27hc7354d3_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "six"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "ec8bb17195fcee3e9172934dffce97a1",
+    "name": "cycler",
+    "sha256": "75ed7e0e52ab345568e9b1a6538b1b0979924028529ea60a39079f046875a72e",
+    "sig": null,
+    "size": 13255,
+    "subdir": "linux-64",
+    "timestamp": 1505733625213,
+    "version": "0.10.0"
+  },
+  "cycler-0.10.0-py35hc4d5149_0.tar.bz2": {
+    "build": "py35hc4d5149_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "six"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "c46c36026b97638c3a53fb530519080b",
+    "name": "cycler",
+    "sha256": "8acd267b0a595bcafecec2e34435a75d0b296aa797326e4a5d3a5a3fc1b20d64",
+    "sig": null,
+    "size": 13582,
+    "subdir": "linux-64",
+    "timestamp": 1505733636578,
+    "version": "0.10.0"
+  },
+  "cycler-0.10.0-py36h93f1223_0.tar.bz2": {
+    "build": "py36h93f1223_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "six"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "0a9791db782eec74b4018ac12b825048",
+    "name": "cycler",
+    "sha256": "eeb801784593fbb769b10cef543302394c0ffeccab055d1ef45beed72d4ea01b",
+    "sig": null,
+    "size": 13531,
+    "subdir": "linux-64",
+    "timestamp": 1505733648132,
+    "version": "0.10.0"
+  },
+  "dask-0.15.2-py27h7693082_0.tar.bz2": {
+    "build": "py27h7693082_0",
+    "build_number": 0,
+    "depends": [
+      "bokeh",
+      "cloudpickle >=0.2.1",
+      "dask-core 0.15.2.*",
+      "distributed >=1.16.0",
+      "numpy >=1.10",
+      "pandas >=0.19.0",
+      "partd >=0.3.8",
+      "python >=2.7,<2.8.0a0",
+      "toolz >=0.7.3"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "982f29b30742460290ce0ffa6a82773c",
+    "name": "dask",
+    "sha256": "d7612f962d812e93b39e2eade64c19fe256337250d50b14ce443b6a8e88c5480",
+    "sig": null,
+    "size": 3126,
+    "subdir": "linux-64",
+    "timestamp": 1505739872390,
+    "version": "0.15.2"
+  },
+  "dask-0.15.2-py35h08b2748_0.tar.bz2": {
+    "build": "py35h08b2748_0",
+    "build_number": 0,
+    "depends": [
+      "bokeh",
+      "cloudpickle >=0.2.1",
+      "dask-core 0.15.2.*",
+      "distributed >=1.16.0",
+      "numpy >=1.10",
+      "pandas >=0.19.0",
+      "partd >=0.3.8",
+      "python >=3.5,<3.6.0a0",
+      "toolz >=0.7.3"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "329380664f4f70823789a32832904280",
+    "name": "dask",
+    "sha256": "84dd84615f5147a3e35a369a80d841aedf276715663ab87af9b4ec57b09a1a34",
+    "sig": null,
+    "size": 3149,
+    "subdir": "linux-64",
+    "timestamp": 1505739883742,
+    "version": "0.15.2"
+  },
+  "dask-0.15.2-py36h9b48dc4_0.tar.bz2": {
+    "build": "py36h9b48dc4_0",
+    "build_number": 0,
+    "depends": [
+      "bokeh",
+      "cloudpickle >=0.2.1",
+      "dask-core 0.15.2.*",
+      "distributed >=1.16.0",
+      "numpy >=1.10",
+      "pandas >=0.19.0",
+      "partd >=0.3.8",
+      "python >=3.6,<3.7.0a0",
+      "toolz >=0.7.3"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "5c3ea67092579f516fb5c19fd3e855d9",
+    "name": "dask",
+    "sha256": "eababaed6b69e14d9f08e7f6f2e218e564453a757f19f4e4aff4bdb18cebac4c",
+    "sig": null,
+    "size": 3147,
+    "subdir": "linux-64",
+    "timestamp": 1505739895239,
+    "version": "0.15.2"
+  },
+  "dask-0.15.3-py27hb94b45f_0.tar.bz2": {
+    "build": "py27hb94b45f_0",
+    "build_number": 0,
+    "depends": [
+      "bokeh",
+      "cloudpickle >=0.2.1",
+      "dask-core 0.15.3.*",
+      "distributed >=1.19.0",
+      "numpy >=1.10",
+      "pandas >=0.19.0",
+      "partd >=0.3.8",
+      "python >=2.7,<2.8.0a0",
+      "toolz >=0.7.3"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "c6a317c1e6396991e701ed7f9173556c",
+    "name": "dask",
+    "sha256": "865e6962b3db8ab38e8fcf5e1339f2b01bd747e30710847978addc64269ed48b",
+    "sig": null,
+    "size": 3573,
+    "subdir": "linux-64",
+    "timestamp": 1506624173873,
+    "version": "0.15.3"
+  },
+  "dask-0.15.3-py35h52d6c43_0.tar.bz2": {
+    "build": "py35h52d6c43_0",
+    "build_number": 0,
+    "depends": [
+      "bokeh",
+      "cloudpickle >=0.2.1",
+      "dask-core 0.15.3.*",
+      "distributed >=1.19.0",
+      "numpy >=1.10",
+      "pandas >=0.19.0",
+      "partd >=0.3.8",
+      "python >=3.5,<3.6.0a0",
+      "toolz >=0.7.3"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "5c1256b080280febf8b58d7c6bb69847",
+    "name": "dask",
+    "sha256": "63839936df4ee9227556ddf85ed9da603b35dcbd8c5b42d20cefde44ba9f9e2a",
+    "sig": null,
+    "size": 3594,
+    "subdir": "linux-64",
+    "timestamp": 1506624241516,
+    "version": "0.15.3"
+  },
+  "dask-0.15.3-py36hdc2c8aa_0.tar.bz2": {
+    "build": "py36hdc2c8aa_0",
+    "build_number": 0,
+    "depends": [
+      "bokeh",
+      "cloudpickle >=0.2.1",
+      "dask-core 0.15.3.*",
+      "distributed >=1.19.0",
+      "numpy >=1.10",
+      "pandas >=0.19.0",
+      "partd >=0.3.8",
+      "python >=3.6,<3.7.0a0",
+      "toolz >=0.7.3"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "467f00be7f62206fbed370218745c93f",
+    "name": "dask",
+    "sha256": "250d7a399eb78e27f39b208589503562a20da419077f7bd00e98e1bd62b3635d",
+    "sig": null,
+    "size": 3571,
+    "subdir": "linux-64",
+    "timestamp": 1506624227053,
+    "version": "0.15.3"
+  },
+  "dask-core-0.15.2-py27heedc4a4_0.tar.bz2": {
+    "build": "py27heedc4a4_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "ccb070fe2a85a87a6f82cd8860341826",
+    "name": "dask-core",
+    "sha256": "b695ce88531972f60b4db9a176f8e8a2d0772830e9567a0eba3d2a595f809da3",
+    "sig": null,
+    "size": 905181,
+    "subdir": "linux-64",
+    "timestamp": 1505733002745,
+    "version": "0.15.2"
+  },
+  "dask-core-0.15.2-py35h79caba8_0.tar.bz2": {
+    "build": "py35h79caba8_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "d0ea85245993c797394a946e0570700e",
+    "name": "dask-core",
+    "sha256": "4c13f7cac0a64c38a0dbaa576a6e4bec88c697fb9e1814d4f21d72d398385517",
+    "sig": null,
+    "size": 920303,
+    "subdir": "linux-64",
+    "timestamp": 1505733025395,
+    "version": "0.15.2"
+  },
+  "dask-core-0.15.2-py36h0f988a8_0.tar.bz2": {
+    "build": "py36h0f988a8_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "c25bcb7846e1def7722df6eaea0db63e",
+    "name": "dask-core",
+    "sha256": "2a1d1f6009f3a0916d4d3ec9a0b63795e54d04ccc78d5acc4afb1ff3db8ce847",
+    "sig": null,
+    "size": 914157,
+    "subdir": "linux-64",
+    "timestamp": 1505733048226,
+    "version": "0.15.2"
+  },
+  "dask-core-0.15.3-py27h53a7ee6_0.tar.bz2": {
+    "build": "py27h53a7ee6_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "4dd41471c72105eb1a18a7a15bbd65b4",
+    "name": "dask-core",
+    "sha256": "97b736e762f8f7cc1eb54219db3ee9fc61dfa43fcc693fd90da728f54cb0320e",
+    "sig": null,
+    "size": 933132,
+    "subdir": "linux-64",
+    "timestamp": 1506623913203,
+    "version": "0.15.3"
+  },
+  "dask-core-0.15.3-py35hdf4792c_0.tar.bz2": {
+    "build": "py35hdf4792c_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "fc4366d6677ce5581808a47e5be36173",
+    "name": "dask-core",
+    "sha256": "ebc7fbbf536fef914fed69551d9da19645b97a30800a1381f908af10321acfd0",
+    "sig": null,
+    "size": 945545,
+    "subdir": "linux-64",
+    "timestamp": 1506623946353,
+    "version": "0.15.3"
+  },
+  "dask-core-0.15.3-py36h10e6167_0.tar.bz2": {
+    "build": "py36h10e6167_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "05544b56fc55827a8b5249e3626f141d",
+    "name": "dask-core",
+    "sha256": "d04e69ca11de1aafa2224d6be20616fdc236393c1b0c458708158537a3226408",
+    "sig": null,
+    "size": 941847,
+    "subdir": "linux-64",
+    "timestamp": 1506623961580,
+    "version": "0.15.3"
+  },
+  "dbus-1.10.22-h3b5a359_0.tar.bz2": {
+    "build": "h3b5a359_0",
+    "build_number": 0,
+    "depends": [
+      "expat",
+      "glib >=2.53.6,<2.54.0a0",
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "GPL2",
+    "md5": "dcccf9e4873f2e99c6c866d71d1c08f4",
+    "name": "dbus",
+    "sha256": "f4b90f94b5c97b41e359313acfc69fe4bdd3fcb3cf3addb5dc3ab2acf6e24506",
+    "sig": null,
+    "size": 557416,
+    "subdir": "linux-64",
+    "timestamp": 1505735510995,
+    "version": "1.10.22"
+  },
+  "decorator-4.1.2-py27h1544723_0.tar.bz2": {
+    "build": "py27h1544723_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "3bd387cdcfa780916c3bd2bdc02942c5",
+    "name": "decorator",
+    "sha256": "24168d8beb83ee03c6ca5dd521bc8a6aaff3dc28bbedde43ce8bb24d0aeaac84",
+    "sig": null,
+    "size": 15060,
+    "subdir": "linux-64",
+    "timestamp": 1505671998830,
+    "version": "4.1.2"
+  },
+  "decorator-4.1.2-py35h3a268aa_0.tar.bz2": {
+    "build": "py35h3a268aa_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "f0460b9c573d5f598bf4322c643a9759",
+    "name": "decorator",
+    "sha256": "2fe12dcb7a57a18e21bf6ec89616e0f2981af81d0b4f078e0a8ea5814d6f80c6",
+    "sig": null,
+    "size": 15351,
+    "subdir": "linux-64",
+    "timestamp": 1505672010649,
+    "version": "4.1.2"
+  },
+  "decorator-4.1.2-py36hd076ac8_0.tar.bz2": {
+    "build": "py36hd076ac8_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "1c88f6447de6cbbdeb706c7b6e5ebf8d",
+    "name": "decorator",
+    "sha256": "595aecb3077becc424f4e5402cb4d394234659f5f1ca3b5174155487c56dfe86",
+    "sig": null,
+    "size": 15267,
+    "subdir": "linux-64",
+    "timestamp": 1505672022605,
+    "version": "4.1.2"
+  },
+  "dill-0.2.7.1-py27h28bf823_0.tar.bz2": {
+    "build": "py27h28bf823_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "7c13a2ea82caa8cee7f5320dc3878ebf",
+    "name": "dill",
+    "sha256": "058a5a31509d556f54902d857b5ec0e2c3673b9c37431f93024dfb85c71533cf",
+    "sig": null,
+    "size": 83436,
+    "subdir": "linux-64",
+    "timestamp": 1507667955478,
+    "version": "0.2.7.1"
+  },
+  "dill-0.2.7.1-py35h51ed871_0.tar.bz2": {
+    "build": "py35h51ed871_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "069207c83a9948a7d4d236288a23b338",
+    "name": "dill",
+    "sha256": "a6153d18f18276c32f95b694fbad24e9b9edf13367ed30a4c7cea9cf50706d0f",
+    "sig": null,
+    "size": 84545,
+    "subdir": "linux-64",
+    "timestamp": 1507667984668,
+    "version": "0.2.7.1"
+  },
+  "dill-0.2.7.1-py36h644ae93_0.tar.bz2": {
+    "build": "py36h644ae93_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "99fd217c7bb406cf444ccf64dc801fdc",
+    "name": "dill",
+    "sha256": "580b05e42d43ee957433fe6609395f59930f44960906e776cc48ecb3dc7b0adb",
+    "sig": null,
+    "size": 84293,
+    "subdir": "linux-64",
+    "timestamp": 1507667987192,
+    "version": "0.2.7.1"
+  },
+  "distributed-1.18.3-py27h5e7c565_0.tar.bz2": {
+    "build": "py27h5e7c565_0",
+    "build_number": 0,
+    "depends": [
+      "click >=6.6",
+      "cloudpickle >=0.2.2",
+      "dask-core >=0.15.2",
+      "futures",
+      "msgpack-python",
+      "psutil",
+      "python >=2.7,<2.8.0a0",
+      "six",
+      "sortedcontainers",
+      "tblib",
+      "toolz >=0.7.4",
+      "tornado >=4.5.1",
+      "zict >=0.1.2"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "91a2b1cc68074d39651af6ca0b2747c5",
+    "name": "distributed",
+    "sha256": "56554e674e2798013bc431bb21468157537785e6f06b3e37a445d85852f747a3",
+    "sig": null,
+    "size": 654932,
+    "subdir": "linux-64",
+    "timestamp": 1505733266067,
+    "version": "1.18.3"
+  },
+  "distributed-1.18.3-py35h076cbad_0.tar.bz2": {
+    "build": "py35h076cbad_0",
+    "build_number": 0,
+    "depends": [
+      "click >=6.6",
+      "cloudpickle >=0.2.2",
+      "dask-core >=0.15.2",
+      "msgpack-python",
+      "psutil",
+      "python >=3.5,<3.6.0a0",
+      "six",
+      "sortedcontainers",
+      "tblib",
+      "toolz >=0.7.4",
+      "tornado >=4.5.1",
+      "zict >=0.1.2"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "871e11c2fd04c8b05335c5bbe6250c0f",
+    "name": "distributed",
+    "sha256": "2bc8531eb2a93eb5c6837712ffb30c78e7db1ae3c06c74bce6d4abe5c07a7a9e",
+    "sig": null,
+    "size": 674851,
+    "subdir": "linux-64",
+    "timestamp": 1505733290512,
+    "version": "1.18.3"
+  },
+  "distributed-1.18.3-py36h73cd4ae_0.tar.bz2": {
+    "build": "py36h73cd4ae_0",
+    "build_number": 0,
+    "depends": [
+      "click >=6.6",
+      "cloudpickle >=0.2.2",
+      "dask-core >=0.15.2",
+      "msgpack-python",
+      "psutil",
+      "python >=3.6,<3.7.0a0",
+      "six",
+      "sortedcontainers",
+      "tblib",
+      "toolz >=0.7.4",
+      "tornado >=4.5.1",
+      "zict >=0.1.2"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "fb0e5b4b63f11b253e1fc5ab40fcae44",
+    "name": "distributed",
+    "sha256": "bd126cf3835f7ae6427c8ada881c21ca01fee971cbd64f499d9b34c1f8cc618e",
+    "sig": null,
+    "size": 661776,
+    "subdir": "linux-64",
+    "timestamp": 1505733315334,
+    "version": "1.18.3"
+  },
+  "distributed-1.19.1-py27h38c4a05_0.tar.bz2": {
+    "build": "py27h38c4a05_0",
+    "build_number": 0,
+    "depends": [
+      "click >=6.6",
+      "cloudpickle >=0.2.2",
+      "dask-core >=0.15.2",
+      "futures",
+      "msgpack-python",
+      "psutil",
+      "python >=2.7,<2.8.0a0",
+      "six",
+      "sortedcontainers",
+      "tblib",
+      "toolz >=0.7.4",
+      "tornado >=4.5.1",
+      "zict >=0.1.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "c502516ad58ca4462f5fb953651bbbae",
+    "name": "distributed",
+    "sha256": "2faed20307238676c57f3a1a34f6208d968905b2f7ec546ade630f4518c3179b",
+    "sig": null,
+    "size": 679122,
+    "subdir": "linux-64",
+    "timestamp": 1506624063608,
+    "version": "1.19.1"
+  },
+  "distributed-1.19.1-py35h399b246_0.tar.bz2": {
+    "build": "py35h399b246_0",
+    "build_number": 0,
+    "depends": [
+      "click >=6.6",
+      "cloudpickle >=0.2.2",
+      "dask-core >=0.15.2",
+      "msgpack-python",
+      "psutil",
+      "python >=3.5,<3.6.0a0",
+      "six",
+      "sortedcontainers",
+      "tblib",
+      "toolz >=0.7.4",
+      "tornado >=4.5.1",
+      "zict >=0.1.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "2927f95a07d1417ff34ce6952e719394",
+    "name": "distributed",
+    "sha256": "7a4fadcd0debc232ce6c72a5a5dc473ebe8825fadb62b033878e3d9690a5e78c",
+    "sig": null,
+    "size": 695759,
+    "subdir": "linux-64",
+    "timestamp": 1506624102722,
+    "version": "1.19.1"
+  },
+  "distributed-1.19.1-py36h25f3894_0.tar.bz2": {
+    "build": "py36h25f3894_0",
+    "build_number": 0,
+    "depends": [
+      "click >=6.6",
+      "cloudpickle >=0.2.2",
+      "dask-core >=0.15.2",
+      "msgpack-python",
+      "psutil",
+      "python >=3.6,<3.7.0a0",
+      "six",
+      "sortedcontainers",
+      "tblib",
+      "toolz >=0.7.4",
+      "tornado >=4.5.1",
+      "zict >=0.1.3"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "b2208614455fca5b938ee7bb3fdc4dad",
+    "name": "distributed",
+    "sha256": "a8ab0b5f80c5f5d409fbbe8c15cd775c956aa7481f8b7df10636dc4f9aba79d0",
+    "sig": null,
+    "size": 688272,
+    "subdir": "linux-64",
+    "timestamp": 1506624079800,
+    "version": "1.19.1"
+  },
+  "docutils-0.14-py27hae222c1_0.tar.bz2": {
+    "build": "py27hae222c1_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "Public Domain Dedictation and BSD 2-Clause and PSF 2.1.1 and GPL 3.0",
+    "md5": "c4f57a590e4dbc832ad62ab8dd5ec3ac",
+    "name": "docutils",
+    "sha256": "974f62d49a3f4bc00087ef2f6ebdebeab2a5bb9e4b1e74a7745c95bfaec60749",
+    "sig": null,
+    "size": 713493,
+    "subdir": "linux-64",
+    "timestamp": 1505741024841,
+    "version": "0.14"
+  },
+  "docutils-0.14-py35hd11081d_0.tar.bz2": {
+    "build": "py35hd11081d_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "Public Domain Dedictation and BSD 2-Clause and PSF 2.1.1 and GPL 3.0",
+    "md5": "a0b43d4aac0b0d9e433cf28a424b3d5e",
+    "name": "docutils",
+    "sha256": "a10f507e799cd5f33460a65a9866e0db57513285f4365a9232e811bd62a1de75",
+    "sig": null,
+    "size": 718775,
+    "subdir": "linux-64",
+    "timestamp": 1505741103169,
+    "version": "0.14"
+  },
+  "docutils-0.14-py36hb0f60f5_0.tar.bz2": {
+    "build": "py36hb0f60f5_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "Public Domain Dedictation and BSD 2-Clause and PSF 2.1.1 and GPL 3.0",
+    "md5": "68d59617d31e9cde0e16b3c1862e3388",
+    "name": "docutils",
+    "sha256": "1cc004bc06230ff063cb0d7805730b58b514897d1664c183974be5d86f3963ca",
+    "sig": null,
+    "size": 705022,
+    "subdir": "linux-64",
+    "timestamp": 1505741175245,
+    "version": "0.14"
+  },
+  "enum34-1.1.6-py27h99a27e9_1.tar.bz2": {
+    "build": "py27h99a27e9_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "9bd29980d37987cd9ad95270e0d22bcf",
+    "name": "enum34",
+    "sha256": "1673767d01a4a66c63c623dc658b9fcaa792397a1556053c040ac849183d0fc4",
+    "sig": null,
+    "size": 57674,
+    "subdir": "linux-64",
+    "timestamp": 1505672101856,
+    "version": "1.1.6"
+  },
+  "expat-2.2.4-hc00ebd1_1.tar.bz2": {
+    "build": "hc00ebd1_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0"
+    ],
+    "license": "MIT",
+    "md5": "8ff4de06d63f470b238d764870792c79",
+    "name": "expat",
+    "sha256": "cab53cc9f993fe1e015324932ac69eb1e9ec3222875a21c2aba878bf0d732e2d",
+    "sig": null,
+    "size": 189076,
+    "subdir": "linux-64",
+    "timestamp": 1505687765027,
+    "version": "2.2.4"
+  },
+  "flask-0.12.2-py27h6d5c1cd_0.tar.bz2": {
+    "build": "py27h6d5c1cd_0",
+    "build_number": 0,
+    "depends": [
+      "click >=2.0",
+      "itsdangerous >=0.21",
+      "jinja2 >=2.4",
+      "python >=2.7,<2.8.0a0",
+      "werkzeug >=0.7"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "dd813390dc66dce7235b83c80467eebe",
+    "name": "flask",
+    "sha256": "fe78c215934da23afcedd807eb6c3bc0245f58707d9999234e4e150420f0d438",
+    "sig": null,
+    "size": 104986,
+    "subdir": "linux-64",
+    "timestamp": 1505740403221,
+    "version": "0.12.2"
+  },
+  "flask-0.12.2-py35h679e90e_0.tar.bz2": {
+    "build": "py35h679e90e_0",
+    "build_number": 0,
+    "depends": [
+      "click >=2.0",
+      "itsdangerous >=0.21",
+      "jinja2 >=2.4",
+      "python >=3.5,<3.6.0a0",
+      "werkzeug >=0.7"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "9709821ad9a3ce560000bb1d9491fc19",
+    "name": "flask",
+    "sha256": "cf314c72887cb43d9608d79ea0dc980db60c2df965a4342603fe6d2a21d5eda7",
+    "sig": null,
+    "size": 107450,
+    "subdir": "linux-64",
+    "timestamp": 1505740417217,
+    "version": "0.12.2"
+  },
+  "flask-0.12.2-py36hb24657c_0.tar.bz2": {
+    "build": "py36hb24657c_0",
+    "build_number": 0,
+    "depends": [
+      "click >=2.0",
+      "itsdangerous >=0.21",
+      "jinja2 >=2.4",
+      "python >=3.6,<3.7.0a0",
+      "werkzeug >=0.7"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "ed3b287044a6f8fbe61c3bb6caf07ec2",
+    "name": "flask",
+    "sha256": "a4158c495cda3ee7a2a68c00aec39ef55c55dbffff37564dad7330c5dc64b12a",
+    "sig": null,
+    "size": 106873,
+    "subdir": "linux-64",
+    "timestamp": 1505740431814,
+    "version": "0.12.2"
+  },
+  "fontconfig-2.12.4-h88586e7_1.tar.bz2": {
+    "build": "h88586e7_1",
+    "build_number": 1,
+    "depends": [
+      "freetype >=2.8,<2.9.0a0",
+      "icu >=58.2,<59.0a0",
+      "libgcc-ng >=7.2.0",
+      "libpng >=1.6.32,<1.7.0a0",
+      "libxml2 >=2.9.4,<2.10.0a0"
+    ],
+    "license": "MIT",
+    "md5": "970739ad4489311f138fb6deaf73c400",
+    "name": "fontconfig",
+    "sha256": "9945e51bc9a23f123c7409896a7fa1317dc15d078cc10538933d62383f83b5ba",
+    "sig": null,
+    "size": 288852,
+    "subdir": "linux-64",
+    "timestamp": 1505734186823,
+    "version": "2.12.4"
+  },
+  "freetype-2.8-h52ed37b_0.tar.bz2": {
+    "build": "h52ed37b_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libpng >=1.6.32,<1.7.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "GPL-2.0 and FreeType",
+    "md5": "2578a154d4939e827e189937657ebfd5",
+    "name": "freetype",
+    "sha256": "c4ffa5caed57493342ab837514a323c6231ce09ff6e129114da4f2b9d172794a",
+    "sig": null,
+    "size": 822754,
+    "subdir": "linux-64",
+    "timestamp": 1505733467465,
+    "version": "2.8"
+  },
+  "funcsigs-1.0.2-py27h83f16ab_0.tar.bz2": {
+    "build": "py27h83f16ab_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "Apache 2.0",
+    "md5": "596ea0f2d9964075a647f66a914d2b1f",
+    "name": "funcsigs",
+    "sha256": "1842a9e7c382c82a8ce2735eb3cadf7745d005bdf41d695c9a48194368a110c5",
+    "sig": null,
+    "size": 20764,
+    "subdir": "linux-64",
+    "timestamp": 1505691231315,
+    "version": "1.0.2"
+  },
+  "functools32-3.2.3.2-py27h4ead58f_1.tar.bz2": {
+    "build": "py27h4ead58f_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "PSF license",
+    "md5": "7f9b6fccfd6d9ff023707301b285042c",
+    "name": "functools32",
+    "sha256": "2fa6e304d996655b21f74c0c5aee727dfd5958b1eef02d5cd2525231beb1f70f",
+    "sig": null,
+    "size": 22930,
+    "subdir": "linux-64",
+    "timestamp": 1505957251004,
+    "version": "3.2.3.2"
+  },
+  "functools32-3.2.3.2-py36hc1f28f5_1.tar.bz2": {
+    "build": "py36hc1f28f5_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "PSF license",
+    "md5": "52d4e4a42d59b2c6d3969cbccad2e037",
+    "name": "functools32",
+    "sha256": "5144c72fc5da26ed9d4a48d7758faf87f23899464633772e32286d1ffeab0aef",
+    "sig": null,
+    "size": 22816,
+    "subdir": "linux-64",
+    "timestamp": 1505722662729,
+    "version": "3.2.3.2"
+  },
+  "futures-3.1.1-py27hdbc8cbb_0.tar.bz2": {
+    "build": "py27hdbc8cbb_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "PSF",
+    "md5": "fb5b82ad45279ec62e479df558605aa5",
+    "name": "futures",
+    "sha256": "6933525589508842d3ae1a993086aeb20a2f3616d37c34d062c7a87564fc109d",
+    "sig": null,
+    "size": 23586,
+    "subdir": "linux-64",
+    "timestamp": 1505733247585,
+    "version": "3.1.1"
+  },
+  "get_terminal_size-1.0.0-haa9412d_0.tar.bz2": {
+    "build": "haa9412d_0",
+    "build_number": 0,
+    "depends": [
+      "backports.shutil_get_terminal_size"
+    ],
+    "license": "MIT",
+    "md5": "6f23685ff397cc83815632a4bd389516",
+    "name": "get_terminal_size",
+    "sha256": "47efe5289ae82838ebd18eb20aabb991a947140ddb7ff97f53de45fdf76d8945",
+    "sig": null,
+    "size": 2736,
+    "subdir": "linux-64",
+    "timestamp": 1505743304546,
+    "version": "1.0.0"
+  },
+  "gevent-1.2.2-py27h475ea6a_0.tar.bz2": {
+    "build": "py27h475ea6a_0",
+    "build_number": 0,
+    "depends": [
+      "cffi >=1.3.0",
+      "greenlet >=0.4.10",
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "a5a8f0904da12b7079e60e7b368ed66e",
+    "name": "gevent",
+    "sha256": "ca551fae07ca7caa705ebae851185fc24a4f34e0141f7950577a945198c9b224",
+    "sig": null,
+    "size": 772264,
+    "subdir": "linux-64",
+    "timestamp": 1505743619086,
+    "version": "1.2.2"
+  },
+  "gevent-1.2.2-py35he064abf_0.tar.bz2": {
+    "build": "py35he064abf_0",
+    "build_number": 0,
+    "depends": [
+      "cffi >=1.3.0",
+      "greenlet >=0.4.10",
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "dbe9ae8b03951e7b7a6c970cc4ffa92c",
+    "name": "gevent",
+    "sha256": "b8475d63946bfc0b7fcd80bbad0fc671fd0223c586093619d9a145fe47d530af",
+    "sig": null,
+    "size": 790162,
+    "subdir": "linux-64",
+    "timestamp": 1505743706509,
+    "version": "1.2.2"
+  },
+  "gevent-1.2.2-py36h2fe25dc_0.tar.bz2": {
+    "build": "py36h2fe25dc_0",
+    "build_number": 0,
+    "depends": [
+      "cffi >=1.3.0",
+      "greenlet >=0.4.10",
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "bc5fe19ebf2103056286a772f18efb86",
+    "name": "gevent",
+    "sha256": "8799e675be92e0eea63d7e810faaba2bec8638f718abbdde37b30ec39f2bcd4a",
+    "sig": null,
+    "size": 791246,
+    "subdir": "linux-64",
+    "timestamp": 1505743794067,
+    "version": "1.2.2"
+  },
+  "glib-2.53.6-hc861d11_1.tar.bz2": {
+    "build": "hc861d11_1",
+    "build_number": 1,
+    "depends": [
+      "libffi >=3.0.0",
+      "libgcc-ng >=7.2.0",
+      "pcre",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "LGPL-2.1",
+    "md5": "f0c1d8c0fdf91d63c782146c33efa286",
+    "name": "glib",
+    "sha256": "2a5367f5d1dbbf672823dc9194ddd1730262a03b2baf3b503f54f9add21d5920",
+    "sig": null,
+    "size": 8805327,
+    "subdir": "linux-64",
+    "timestamp": 1505735456263,
+    "version": "2.53.6"
+  },
+  "gmp-6.1.2-hb3b607b_0.tar.bz2": {
+    "build": "hb3b607b_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0"
+    ],
+    "license": "GPL 2 and LGPL 3",
+    "md5": "f822d00963fe46a540039993bda1c141",
+    "name": "gmp",
+    "sha256": "3776b447a2e8d094d0d87e5680a8f82694a763ddd7ab4559b5c9b732c60f1ce5",
+    "sig": null,
+    "size": 761774,
+    "subdir": "linux-64",
+    "timestamp": 1505690005789,
+    "version": "6.1.2"
+  },
+  "greenlet-0.4.12-py27hac09c53_0.tar.bz2": {
+    "build": "py27hac09c53_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "af426069b7914bcac5291725ebb2c278",
+    "name": "greenlet",
+    "sha256": "e46ef4abf1767800a23485ba52e0ef54929dbfd9617f9fe9e42d3a002e79f8b7",
+    "sig": null,
+    "size": 19057,
+    "subdir": "linux-64",
+    "timestamp": 1505743502584,
+    "version": "0.4.12"
+  },
+  "greenlet-0.4.12-py35h2547b41_0.tar.bz2": {
+    "build": "py35h2547b41_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "1d8352d2b1af6d8dda4c4cfeb99772d6",
+    "name": "greenlet",
+    "sha256": "3d1d5715d9cbed22e0a330d5f8a11a6fade1d4e216dd49c4d77e1039f4cf37d3",
+    "sig": null,
+    "size": 19046,
+    "subdir": "linux-64",
+    "timestamp": 1505743518057,
+    "version": "0.4.12"
+  },
+  "greenlet-0.4.12-py36h2d503a6_0.tar.bz2": {
+    "build": "py36h2d503a6_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "c2781c885e6b81fa0fa1ec0fb2957a07",
+    "name": "greenlet",
+    "sha256": "1c86e8a8ddcacf6471ea2690da6656aecc6e3cbd26a9fec922e256cf5540dba2",
+    "sig": null,
+    "size": 19055,
+    "subdir": "linux-64",
+    "timestamp": 1505743533853,
+    "version": "0.4.12"
+  },
+  "gst-plugins-base-1.12.2-he3457e5_0.tar.bz2": {
+    "build": "he3457e5_0",
+    "build_number": 0,
+    "depends": [
+      "gstreamer >=1.12.2,<1.13.0a0",
+      "libgcc-ng >=7.2.0",
+      "xz >=5.2.3,<6.0a0"
+    ],
+    "license": "GPL2",
+    "md5": "e22a59540e7dc1cb35c0edc432683d2b",
+    "name": "gst-plugins-base",
+    "sha256": "83307555c6160a891d0ab799431c83e38bc7d248e891ea257b504b255d993ef3",
+    "sig": null,
+    "size": 5145424,
+    "subdir": "linux-64",
+    "timestamp": 1505735977489,
+    "version": "1.12.2"
+  },
+  "gstreamer-1.12.2-h4f93127_0.tar.bz2": {
+    "build": "h4f93127_0",
+    "build_number": 0,
+    "depends": [
+      "glib >=2.53.6,<2.54.0a0",
+      "libgcc-ng >=7.2.0",
+      "xz >=5.2.3,<6.0a0"
+    ],
+    "license": "LGPL 2",
+    "md5": "fab6c29a9f81ff87a0998e9cae9f89d7",
+    "name": "gstreamer",
+    "sha256": "9bfce566aeb911fa82c6e3c7036000cd912a14f615e2018e93cfecb59b516dfb",
+    "sig": null,
+    "size": 3814934,
+    "subdir": "linux-64",
+    "timestamp": 1505735891617,
+    "version": "1.12.2"
+  },
+  "heapdict-1.0.0-py27h33770af_0.tar.bz2": {
+    "build": "py27h33770af_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "8772d50220994a01a25c0c7c5954f266",
+    "name": "heapdict",
+    "sha256": "398cbbb760ef91960143efee6ab9c9336d934e5c8b1dc21b491ab4dc35296ec7",
+    "sig": null,
+    "size": 7605,
+    "subdir": "linux-64",
+    "timestamp": 1505732926826,
+    "version": "1.0.0"
+  },
+  "heapdict-1.0.0-py35h51e6c10_0.tar.bz2": {
+    "build": "py35h51e6c10_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "24f9f659ed95e25da4f3e6c311007c76",
+    "name": "heapdict",
+    "sha256": "d3a56d1a7f1018f53832420b4f2b886c848748380919b19d9b5d17e1999eac1e",
+    "sig": null,
+    "size": 7330,
+    "subdir": "linux-64",
+    "timestamp": 1505732937783,
+    "version": "1.0.0"
+  },
+  "heapdict-1.0.0-py36h79797d7_0.tar.bz2": {
+    "build": "py36h79797d7_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "b2ca4e711414459eadf40e09396347eb",
+    "name": "heapdict",
+    "sha256": "177e40d496e375a66d38a7ee206ddd15f5b256702396c48c8eafbba74f5c2e75",
+    "sig": null,
+    "size": 7322,
+    "subdir": "linux-64",
+    "timestamp": 1505732948871,
+    "version": "1.0.0"
+  },
+  "icu-58.2-h211956c_0.tar.bz2": {
+    "build": "h211956c_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0"
+    ],
+    "license": "MIT",
+    "md5": "f2bcef3d781b1a70d5887a73324b5864",
+    "name": "icu",
+    "sha256": "3075c14d635a50d3097392d14ce457bb1b2bfc3db9460d398662b0358c8fc7da",
+    "sig": null,
+    "size": 23618389,
+    "subdir": "linux-64",
+    "timestamp": 1505733580747,
+    "version": "58.2"
+  },
+  "idna-2.6-py27h5722d68_1.tar.bz2": {
+    "build": "py27h5722d68_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD Like",
+    "md5": "d90055a7b08ca188d2d8841ec7cf2d23",
+    "name": "idna",
+    "sha256": "f661fa246140bbd9f66cc9b35049722c92b0185cf44c214b2b3594105b7971d1",
+    "sig": null,
+    "size": 124748,
+    "subdir": "linux-64",
+    "timestamp": 1505691711574,
+    "version": "2.6"
+  },
+  "idna-2.6-py35h8605a33_1.tar.bz2": {
+    "build": "py35h8605a33_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD Like",
+    "md5": "928f97e845bc28a0aae3ca55df5aad14",
+    "name": "idna",
+    "sha256": "64cf5c56ae666b79cc57a7845310d8c5919382c12bbdc6361a5a406e92436a28",
+    "sig": null,
+    "size": 125898,
+    "subdir": "linux-64",
+    "timestamp": 1505691723368,
+    "version": "2.6"
+  },
+  "idna-2.6-py36h82fb2a8_1.tar.bz2": {
+    "build": "py36h82fb2a8_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD Like",
+    "md5": "79f798ec15f0df45d85fcf83339f6895",
+    "name": "idna",
+    "sha256": "cf1af50445e7efbcee5caec9a34ad1dab17b5b4b19ad7802b02d761b6a07ac43",
+    "sig": null,
+    "size": 125025,
+    "subdir": "linux-64",
+    "timestamp": 1505691735281,
+    "version": "2.6"
+  },
+  "intel-openmp-2018.0.0-h15fc484_7.tar.bz2": {
+    "build": "h15fc484_7",
+    "build_number": 7,
+    "depends": [],
+    "license": "proprietary - Intel",
+    "license_family": "Proprietary",
+    "md5": "43a02edcf628c9ab783f40428cd37eba",
+    "name": "intel-openmp",
+    "sha256": "e6153508be82b599b52f99fee2f842b48df31d24f9a8932650a62be5bd75a268",
+    "sig": null,
+    "size": 631626,
+    "subdir": "linux-64",
+    "timestamp": 1505745611021,
+    "version": "2018.0.0"
+  },
+  "ipaddress-1.0.18-py27h337fd85_0.tar.bz2": {
+    "build": "py27h337fd85_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "PSF 2",
+    "license_family": "PSF",
+    "md5": "75c426b37914c52ea937e6bb6604d9a8",
+    "name": "ipaddress",
+    "sha256": "b9562b893a924c91190ea6d54637f845e8e3463f493cd8443ee24995669ecabc",
+    "sig": null,
+    "size": 32581,
+    "subdir": "linux-64",
+    "timestamp": 1505691786314,
+    "version": "1.0.18"
+  },
+  "ipython-5.4.1-py27h36c99b6_1.tar.bz2": {
+    "build": "py27h36c99b6_1",
+    "build_number": 1,
+    "depends": [
+      "backports.shutil_get_terminal_size",
+      "decorator",
+      "pathlib2",
+      "pexpect",
+      "pickleshare",
+      "prompt_toolkit >=1.0.4,<2.0.0",
+      "pygments",
+      "python >=2.7,<2.8.0a0",
+      "simplegeneric >0.8",
+      "traitlets"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "242274e61d2e7022aeb285cee0ae17bc",
+    "name": "ipython",
+    "sha256": "0f9ad38f99805ced781661e390af2059ecfc86ac099497b79713184f3a5d0785",
+    "sig": null,
+    "size": 1040639,
+    "subdir": "linux-64",
+    "timestamp": 1505690417052,
+    "version": "5.4.1"
+  },
+  "ipython-6.1.0-py35h1b71439_1.tar.bz2": {
+    "build": "py35h1b71439_1",
+    "build_number": 1,
+    "depends": [
+      "decorator",
+      "jedi >=0.10",
+      "pexpect",
+      "pickleshare",
+      "prompt_toolkit >=1.0.4,<2.0.0",
+      "pygments",
+      "python >=3.5,<3.6.0a0",
+      "simplegeneric >0.8",
+      "traitlets"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "9f4835904a439643e734e886815a24bc",
+    "name": "ipython",
+    "sha256": "8c3ddafe06ae7363306f6d24ec5df3db9dececd6db6bba61e48a52ba8ec00d14",
+    "sig": null,
+    "size": 1044142,
+    "subdir": "linux-64",
+    "timestamp": 1505690651442,
+    "version": "6.1.0"
+  },
+  "ipython-6.1.0-py36hc72a948_1.tar.bz2": {
+    "build": "py36hc72a948_1",
+    "build_number": 1,
+    "depends": [
+      "decorator",
+      "jedi >=0.10",
+      "pexpect",
+      "pickleshare",
+      "prompt_toolkit >=1.0.4,<2.0.0",
+      "pygments",
+      "python >=3.6,<3.7.0a0",
+      "simplegeneric >0.8",
+      "traitlets"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "01072ea6bc7887bd4b0583ce3b111bd5",
+    "name": "ipython",
+    "sha256": "f628d5b1978afed99b0f855cdde74967b2b8a68d4d17464a293383975b5f9810",
+    "sig": null,
+    "size": 1047792,
+    "subdir": "linux-64",
+    "timestamp": 1505690685499,
+    "version": "6.1.0"
+  },
+  "ipython_genutils-0.2.0-py27h89fb69b_0.tar.bz2": {
+    "build": "py27h89fb69b_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "2378e2812abf7437313d672d1fda33ec",
+    "name": "ipython_genutils",
+    "sha256": "55723d578cb7879d9648d5321d44041a64396f39e59c30d40275254e5523941f",
+    "sig": null,
+    "size": 38442,
+    "subdir": "linux-64",
+    "timestamp": 1505672034041,
+    "version": "0.2.0"
+  },
+  "ipython_genutils-0.2.0-py35hc9e07d0_0.tar.bz2": {
+    "build": "py35hc9e07d0_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "513e2d4f32efbc7db1e1057ff3928bd5",
+    "name": "ipython_genutils",
+    "sha256": "93bdf44da03d4f66431ae37288fd065c798eb0453dc51a36825dc3e2cdb5ab1a",
+    "sig": null,
+    "size": 39497,
+    "subdir": "linux-64",
+    "timestamp": 1505672045196,
+    "version": "0.2.0"
+  },
+  "ipython_genutils-0.2.0-py36hb52b0d5_0.tar.bz2": {
+    "build": "py36hb52b0d5_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "5e35f443e197f34a95d6222a1806a948",
+    "name": "ipython_genutils",
+    "sha256": "e56714fd8510995fcd5a188fe7d3540f92162d306ad988cf0e33c72c38357275",
+    "sig": null,
+    "size": 39443,
+    "subdir": "linux-64",
+    "timestamp": 1505672056487,
+    "version": "0.2.0"
+  },
+  "isl-0.12.2-0.tar.bz2": {
+    "build": "0",
+    "build_number": 0,
+    "depends": [
+      "gmp"
+    ],
+    "license": "MIT",
+    "md5": "97aaa02735b4c5e71a08cec175287b0e",
+    "name": "isl",
+    "sha256": "814d07ee8b25222dd08ffa01ef20b34d0407927f383d44ef580cefbd6e162f68",
+    "sig": null,
+    "size": 1151169,
+    "timestamp": 1506534636,
+    "version": "0.12.2"
+  },
+  "itsdangerous-0.24-py27hb8295c1_1.tar.bz2": {
+    "build": "py27hb8295c1_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "b2df61b0f2dec6439d065a5fb4bd4892",
+    "name": "itsdangerous",
+    "sha256": "6a6d1c92e297a403aca24731f60d37d1ee2362fc90c2fd957f697196498a12d3",
+    "sig": null,
+    "size": 20243,
+    "subdir": "linux-64",
+    "timestamp": 1505740319564,
+    "version": "0.24"
+  },
+  "itsdangerous-0.24-py35h7c46880_1.tar.bz2": {
+    "build": "py35h7c46880_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "3d42368486991bb72c6e6e1059c43b9c",
+    "name": "itsdangerous",
+    "sha256": "fff001543b1f484e4cb306745ad27e60dc9a8f210f89965e3209b76a223cc3c3",
+    "sig": null,
+    "size": 20833,
+    "subdir": "linux-64",
+    "timestamp": 1505740331441,
+    "version": "0.24"
+  },
+  "itsdangerous-0.24-py36h93cc618_1.tar.bz2": {
+    "build": "py36h93cc618_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "8411601fdb2def4fcd996b15890cc617",
+    "name": "itsdangerous",
+    "sha256": "6f0d7dbe8c200cc66b914b7ee5e76d59e3cf8d91d3bc29277cd17e35d4f5a12a",
+    "sig": null,
+    "size": 20838,
+    "subdir": "linux-64",
+    "timestamp": 1505740343513,
+    "version": "0.24"
+  },
+  "jedi-0.10.2-py27h8af4e35_0.tar.bz2": {
+    "build": "py27h8af4e35_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "96f6e9cc65b973a7c0a2b187e9a71430",
+    "name": "jedi",
+    "sha256": "f2307f4f68d5127646a0523dc5b457c9387a8498ab93d7eb386521b1222dbbc8",
+    "sig": null,
+    "size": 250400,
+    "subdir": "linux-64",
+    "timestamp": 1505690588395,
+    "version": "0.10.2"
+  },
+  "jedi-0.10.2-py35hc33c70f_0.tar.bz2": {
+    "build": "py35hc33c70f_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "0db510aa9c4f16b14714b2ada1a8b1d4",
+    "name": "jedi",
+    "sha256": "f6cf84fc4071c48063a2260edb3d125ecc08352f55ded5f9c5c6792e88fb8624",
+    "sig": null,
+    "size": 256563,
+    "subdir": "linux-64",
+    "timestamp": 1505690603584,
+    "version": "0.10.2"
+  },
+  "jedi-0.10.2-py36h552def0_0.tar.bz2": {
+    "build": "py36h552def0_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "c4cd14cce2dadbbacf0bb11a1c853f77",
+    "name": "jedi",
+    "sha256": "d7a46a2c6689f48065b0b281419555c78450e37c8e3c7098de5b65331a818ff8",
+    "sig": null,
+    "size": 254088,
+    "subdir": "linux-64",
+    "timestamp": 1505690618923,
+    "version": "0.10.2"
+  },
+  "jinja2-2.9.6-py27h82327ae_1.tar.bz2": {
+    "build": "py27h82327ae_1",
+    "build_number": 1,
+    "depends": [
+      "markupsafe >=0.23",
+      "python >=2.7,<2.8.0a0",
+      "setuptools"
+    ],
+    "license": "3-Clause BSD",
+    "md5": "3155dc5e6127587eb16092356ee535dd",
+    "name": "jinja2",
+    "sha256": "4640d8cea047fb6a7e473620b22d593efb1364a65f195d0fd8e19faebb282812",
+    "sig": null,
+    "size": 331783,
+    "subdir": "linux-64",
+    "timestamp": 1505672379234,
+    "version": "2.9.6"
+  },
+  "jinja2-2.9.6-py35h90b8645_1.tar.bz2": {
+    "build": "py35h90b8645_1",
+    "build_number": 1,
+    "depends": [
+      "markupsafe >=0.23",
+      "python >=3.5,<3.6.0a0",
+      "setuptools"
+    ],
+    "license": "3-Clause BSD",
+    "md5": "0da19d39a9da68dbb8cc5058ca9f242b",
+    "name": "jinja2",
+    "sha256": "3576820ffdd1a2372dccb7472579112a8854271812bec1d5c6afe7b37a428518",
+    "sig": null,
+    "size": 365266,
+    "subdir": "linux-64",
+    "timestamp": 1505672392862,
+    "version": "2.9.6"
+  },
+  "jinja2-2.9.6-py36h489bce4_1.tar.bz2": {
+    "build": "py36h489bce4_1",
+    "build_number": 1,
+    "depends": [
+      "markupsafe >=0.23",
+      "python >=3.6,<3.7.0a0",
+      "setuptools"
+    ],
+    "license": "3-Clause BSD",
+    "md5": "e5380d74f4a4a1afb6114b95f2f7dea7",
+    "name": "jinja2",
+    "sha256": "40b33af07ecafa232e72e32b5a5e9a22036a5a041f680ed6d9fb99ab2696e35b",
+    "sig": null,
+    "size": 370938,
+    "subdir": "linux-64",
+    "timestamp": 1505672406680,
+    "version": "2.9.6"
+  },
+  "jmespath-0.9.3-py27h7df6b23_0.tar.bz2": {
+    "build": "py27h7df6b23_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "2de0cbb4ba961400b49c295dcfaf85d4",
+    "name": "jmespath",
+    "sha256": "19ca6219788c9e49003f2e597f9d4586acbe4d374e309bb96412b6cf655a5eff",
+    "sig": null,
+    "size": 34457,
+    "subdir": "linux-64",
+    "timestamp": 1505740978273,
+    "version": "0.9.3"
+  },
+  "jmespath-0.9.3-py35h8a35363_0.tar.bz2": {
+    "build": "py35h8a35363_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "cbbf4fbc3b0d2a3c472be70087691934",
+    "name": "jmespath",
+    "sha256": "a8e6af624b27c868c71a51a4e66d391976180e4a508f2ff70271b38c1e5d0d98",
+    "sig": null,
+    "size": 35562,
+    "subdir": "linux-64",
+    "timestamp": 1505740990926,
+    "version": "0.9.3"
+  },
+  "jmespath-0.9.3-py36hd3948f9_0.tar.bz2": {
+    "build": "py36hd3948f9_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "dfd4be76c119184a5ea4ae87c73ccff4",
+    "name": "jmespath",
+    "sha256": "dbd407f3a04d2c700d7d81dd83e65597b4cf8bc53ebe4c3ce765db415d0cffe4",
+    "sig": null,
+    "size": 35164,
+    "subdir": "linux-64",
+    "timestamp": 1505741003574,
+    "version": "0.9.3"
+  },
+  "jpeg-9b-habf39ab_1.tar.bz2": {
+    "build": "habf39ab_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "Custom free software license",
+    "md5": "16bca0084212b9e8ce7f89516cad0227",
+    "name": "jpeg",
+    "sha256": "03c81fb19b27c2741d529f15d9bcdc0ca1e085a952bbbc66f52e10ef8dff5c25",
+    "sig": null,
+    "size": 253195,
+    "subdir": "linux-64",
+    "timestamp": 1505735527625,
+    "version": "9b"
+  },
+  "lazy-object-proxy-1.3.1-py27h682c727_0.tar.bz2": {
+    "build": "py27h682c727_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "83581e1db3d0ce60d00db1f8703b41d1",
+    "name": "lazy-object-proxy",
+    "sha256": "cb0a33faccf39a2388f1fcee6a7533acd0f5b0bb029670ea22e105b9d160ae56",
+    "sig": null,
+    "size": 29630,
+    "subdir": "linux-64",
+    "timestamp": 1505693814804,
+    "version": "1.3.1"
+  },
+  "lazy-object-proxy-1.3.1-py35h4c720c6_0.tar.bz2": {
+    "build": "py35h4c720c6_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "34e75e5c5d297b2aa11e424f99db1cce",
+    "name": "lazy-object-proxy",
+    "sha256": "be620b9068992ab407bb5a2af605ba0a0136ee26e334775c281312b8a8fee645",
+    "sig": null,
+    "size": 30118,
+    "subdir": "linux-64",
+    "timestamp": 1505693829994,
+    "version": "1.3.1"
+  },
+  "lazy-object-proxy-1.3.1-py36h10fcdad_0.tar.bz2": {
+    "build": "py36h10fcdad_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "69595ff655f6c4adf9f4b61c73ec7e5e",
+    "name": "lazy-object-proxy",
+    "sha256": "d8a684be9d17b9bc838f26e76e04974dc72e7beb309f3b7302a843b99cc2a43f",
+    "sig": null,
+    "size": 30077,
+    "subdir": "linux-64",
+    "timestamp": 1505693845469,
+    "version": "1.3.1"
+  },
+  "libedit-3.1-heed3624_0.tar.bz2": {
+    "build": "heed3624_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "ncurses 6.0.*"
+    ],
+    "license": "3-Clause BSD",
+    "license_family": "BSD",
+    "md5": "91ce7622c3bc0a51cb3b897749f1aeaf",
+    "name": "libedit",
+    "sha256": "2bb9db22098bce99a2511d8d223dca07827f7bde76b14be7a3500c3c166bf211",
+    "sig": null,
+    "size": 175030,
+    "subdir": "linux-64",
+    "timestamp": 1505666480132,
+    "version": "3.1"
+  },
+  "libffi-3.2.1-h4deb6c0_3.tar.bz2": {
+    "build": "h4deb6c0_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0"
+    ],
+    "license": "Custom",
+    "md5": "910c1cfa6413d81007a989fac054d67b",
+    "name": "libffi",
+    "sha256": "68d33d24d3a8321654b85d0fa46270c238c0b77839a7a681476a88f11c6e4b4e",
+    "sig": null,
+    "size": 43748,
+    "subdir": "linux-64",
+    "timestamp": 1505666561994,
+    "version": "3.2.1"
+  },
+  "libgcc-7.2.0-h69d50b8_2.tar.bz2": {
+    "build": "h69d50b8_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0"
+    ],
+    "license": "GNU GPL 3+ with GCC Runtime Library",
+    "license_family": "GPL",
+    "md5": "9962126180acc1a4fec0c6aabe7c2459",
+    "name": "libgcc",
+    "sha256": "fe7f1ac1ce89f37d7314760bf17fad8198435443358d570f620fb1dec33ca051",
+    "sig": null,
+    "size": 311733,
+    "subdir": "linux-64",
+    "timestamp": 1505745053518,
+    "version": "7.2.0"
+  },
+  "libgcc-ng-7.2.0-h7cc24e2_2.tar.bz2": {
+    "build": "h7cc24e2_2",
+    "build_number": 2,
+    "depends": [],
+    "license": "GPL",
+    "md5": "2317e046bcd4aca2bb213b445c61fee0",
+    "name": "libgcc-ng",
+    "sha256": "b85f6408eee136c575a574bbf7ae4ebd0f7b8ad286900da46b915af01ae4e215",
+    "sig": null,
+    "size": 6388124,
+    "subdir": "linux-64",
+    "timestamp": 1507262720504,
+    "version": "7.2.0"
+  },
+  "libgcc-ng-7.2.0-hcbc56d2_1.tar.bz2": {
+    "build": "hcbc56d2_1",
+    "build_number": 1,
+    "depends": [],
+    "license": "GPL",
+    "md5": "dac76163800f4547c1cb27f4460cedb8",
+    "name": "libgcc-ng",
+    "sha256": "4e543bf64ab0ed73ac010e6be6200182e7b3de2647b5e13291e74f843eddac1f",
+    "sig": null,
+    "size": 6386759,
+    "subdir": "linux-64",
+    "timestamp": 1505665562970,
+    "version": "7.2.0"
+  },
+  "libgfortran-ng-7.2.0-h6fcbd8e_1.tar.bz2": {
+    "build": "h6fcbd8e_1",
+    "build_number": 1,
+    "depends": [],
+    "license": "GPL",
+    "md5": "359e284d84fa9cc5eef1085901e722b2",
+    "name": "libgfortran-ng",
+    "sha256": "9092a8f8ee277ce75778eefbf0decb946f2f50f13df5be20abf655f749431838",
+    "sig": null,
+    "size": 357639,
+    "subdir": "linux-64",
+    "timestamp": 1505665568036,
+    "version": "7.2.0"
+  },
+  "libgfortran-ng-7.2.0-h9f7466a_2.tar.bz2": {
+    "build": "h9f7466a_2",
+    "build_number": 2,
+    "depends": [],
+    "license": "GPL",
+    "md5": "f5ae707dd1843643224d5946e901a960",
+    "name": "libgfortran-ng",
+    "sha256": "e5549ff42f3c3c315b756552c51e32d555296a24f2a79e0ee71500116d6b108b",
+    "sig": null,
+    "size": 357812,
+    "subdir": "linux-64",
+    "timestamp": 1507262726991,
+    "version": "7.2.0"
+  },
+  "libpng-1.6.32-hda9c8bc_2.tar.bz2": {
+    "build": "hda9c8bc_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "zlib/libpng",
+    "md5": "884d20e4f66d9ba2ca809cd2575cf2a6",
+    "name": "libpng",
+    "sha256": "1a146ecd1d0ace7bbf409505fa6cdf02af8cddf554d2ea66d67626028a4c0bb5",
+    "sig": null,
+    "size": 342997,
+    "subdir": "linux-64",
+    "timestamp": 1505733443215,
+    "version": "1.6.32"
+  },
+  "libsodium-1.0.13-h31c71d8_2.tar.bz2": {
+    "build": "h31c71d8_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "ISC",
+    "md5": "9f13bef505d380da1e525a720a21edef",
+    "name": "libsodium",
+    "sha256": "7e87ab3d1b87585d1c137a52a4695f2de2e8cbd3a9f1f554533c31d7a52903b8",
+    "sig": null,
+    "size": 377991,
+    "subdir": "linux-64",
+    "timestamp": 1505687591176,
+    "version": "1.0.13"
+  },
+  "libstdcxx-ng-7.2.0-h24385c6_1.tar.bz2": {
+    "build": "h24385c6_1",
+    "build_number": 1,
+    "depends": [],
+    "license": "GPL3 with runtime exception",
+    "md5": "533b28ecc27cd5ab4eb1739f71a24d0a",
+    "name": "libstdcxx-ng",
+    "sha256": "a44bea6c49d4b3facd597b9fc7de0f6b7bf6e944d76faeabfc68a362829a0b55",
+    "sig": null,
+    "size": 2626737,
+    "subdir": "linux-64",
+    "timestamp": 1505665569122,
+    "version": "7.2.0"
+  },
+  "libstdcxx-ng-7.2.0-h7a57d05_2.tar.bz2": {
+    "build": "h7a57d05_2",
+    "build_number": 2,
+    "depends": [],
+    "license": "GPL3 with runtime exception",
+    "md5": "adc03ef4ba1dc78dc5eba80c23be4bb5",
+    "name": "libstdcxx-ng",
+    "sha256": "140ab7d3cf222c385938705a935e8aab1edd8258667e24f9ff739b3a745930e7",
+    "sig": null,
+    "size": 2627769,
+    "subdir": "linux-64",
+    "timestamp": 1507262729393,
+    "version": "7.2.0"
+  },
+  "libxcb-1.12-h84ff03f_3.tar.bz2": {
+    "build": "h84ff03f_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng 7.2.0.*"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "d7d64586921d91ffe4b91404895c15b7",
+    "name": "libxcb",
+    "sha256": "d1429f67beaf3cbc2a7dfb40672ccb1e97dbe8b81c6e5d6ddc1925a0507a15d2",
+    "sig": null,
+    "size": 456031,
+    "subdir": "linux-64",
+    "timestamp": 1507908036832,
+    "version": "1.12"
+  },
+  "libxcb-1.12-he6ee5dd_2.tar.bz2": {
+    "build": "he6ee5dd_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "66af1930d5ddc5cd373858ed884e255b",
+    "name": "libxcb",
+    "sha256": "3c76570cbecc87d83818a217462226fe01b38b3c4cc1ab74fbf53745e1f99cf2",
+    "sig": null,
+    "size": 455918,
+    "subdir": "linux-64",
+    "timestamp": 1505734062961,
+    "version": "1.12"
+  },
+  "libxml2-2.9.4-h6b072ca_5.tar.bz2": {
+    "build": "h6b072ca_5",
+    "build_number": 5,
+    "depends": [
+      "icu >=58.2,<59.0a0",
+      "libgcc-ng >=7.2.0",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "fa4805ca2f09b56d251ba942c58dcb70",
+    "name": "libxml2",
+    "sha256": "1a4f920f16812dd5bcc76d1ff311fe3d6b27eca9b07b8f7a45b8a87cd2cc17a5",
+    "sig": null,
+    "size": 2054309,
+    "subdir": "linux-64",
+    "timestamp": 1505734150613,
+    "version": "2.9.4"
+  },
+  "locket-0.2.0-py27h73929a2_1.tar.bz2": {
+    "build": "py27h73929a2_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "75f8dc45e9814c69647f948c14537b15",
+    "name": "locket",
+    "sha256": "9b15e8fb74dcc7172234049e557c6cb864176179b706e632c596fdf38f02112d",
+    "sig": null,
+    "size": 8022,
+    "subdir": "linux-64",
+    "timestamp": 1505732742217,
+    "version": "0.2.0"
+  },
+  "locket-0.2.0-py35h170bc82_1.tar.bz2": {
+    "build": "py35h170bc82_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "262c0777d757eea48e43a9c6811402f0",
+    "name": "locket",
+    "sha256": "fa3b5d73e16044464bb0bf83c773cab3c8b489551975dcc8c1445252533b8974",
+    "sig": null,
+    "size": 8210,
+    "subdir": "linux-64",
+    "timestamp": 1505732753137,
+    "version": "0.2.0"
+  },
+  "locket-0.2.0-py36h787c0ad_1.tar.bz2": {
+    "build": "py36h787c0ad_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "48dca5102149579a05f2c24a72f7a98c",
+    "name": "locket",
+    "sha256": "f99ec73196a98f7d9e8f2657885112a905af63dd4bb8b2477d89f5fa1b75fd68",
+    "sig": null,
+    "size": 8148,
+    "subdir": "linux-64",
+    "timestamp": 1505732764177,
+    "version": "0.2.0"
+  },
+  "markupsafe-1.0-py27h97b2822_1.tar.bz2": {
+    "build": "py27h97b2822_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "4a55b545c9c57034af28be2e62454178",
+    "name": "markupsafe",
+    "sha256": "1158ee48c15590af26d533c702b1b71e8775216cd73e7a721596e1f8c98ad7cf",
+    "sig": null,
+    "size": 24774,
+    "subdir": "linux-64",
+    "timestamp": 1505672337096,
+    "version": "1.0"
+  },
+  "markupsafe-1.0-py35h4f4fcf6_1.tar.bz2": {
+    "build": "py35h4f4fcf6_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "3f7ca7f2ec71199a7fdf79593891b721",
+    "name": "markupsafe",
+    "sha256": "1ae0b6d767a29ecfd57b9fc35e7d40867ff2b85ff08fc1ac66b2657a632fb57c",
+    "sig": null,
+    "size": 25352,
+    "subdir": "linux-64",
+    "timestamp": 1505672351754,
+    "version": "1.0"
+  },
+  "markupsafe-1.0-py36hd9260cd_1.tar.bz2": {
+    "build": "py36hd9260cd_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "1b720811b3d7ac005156bda76947ef95",
+    "name": "markupsafe",
+    "sha256": "682768465a7285ec8d4a0259caa2c41f7139d7f0630bbb18d4cc83af5f06ab3a",
+    "sig": null,
+    "size": 24944,
+    "subdir": "linux-64",
+    "timestamp": 1505672366435,
+    "version": "1.0"
+  },
+  "matplotlib-2.0.2-py27h334a7c2_1.tar.bz2": {
+    "build": "py27h334a7c2_1",
+    "build_number": 1,
+    "depends": [
+      "cycler >=0.10",
+      "freetype >=2.8,<2.9.0a0",
+      "functools32",
+      "icu >=58.2,<59.0a0",
+      "libgcc-ng >=7.2.0",
+      "libpng >=1.6.32,<1.7.0a0",
+      "libstdcxx-ng >=7.2.0",
+      "numpy",
+      "pyparsing",
+      "pyqt 5.6.*",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil",
+      "pytz",
+      "setuptools",
+      "subprocess32",
+      "tk 8.6.*",
+      "tornado",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF-based",
+    "license_family": "PSF",
+    "md5": "095d532742c7fa829ab42cbc50dcdbad",
+    "name": "matplotlib",
+    "sha256": "8ab42722e10ba037319d0a57507cb9c1a1bbba8682b287bdb6139fa4fae946fa",
+    "sig": null,
+    "size": 6842770,
+    "subdir": "linux-64",
+    "timestamp": 1505739391048,
+    "version": "2.0.2"
+  },
+  "matplotlib-2.0.2-py35hdbc49ba_1.tar.bz2": {
+    "build": "py35hdbc49ba_1",
+    "build_number": 1,
+    "depends": [
+      "cycler >=0.10",
+      "freetype >=2.8,<2.9.0a0",
+      "icu >=58.2,<59.0a0",
+      "libgcc-ng >=7.2.0",
+      "libpng >=1.6.32,<1.7.0a0",
+      "libstdcxx-ng >=7.2.0",
+      "numpy",
+      "pyparsing",
+      "pyqt 5.6.*",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil",
+      "pytz",
+      "setuptools",
+      "tk 8.6.*",
+      "tornado",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF-based",
+    "license_family": "PSF",
+    "md5": "45c888d8af54e3419166c2d9dec617c4",
+    "name": "matplotlib",
+    "sha256": "79327d67667196ba2442ddba548214e674ccbd8ea2756a7491ded6348fe183c7",
+    "sig": null,
+    "size": 6977977,
+    "subdir": "linux-64",
+    "timestamp": 1505739505786,
+    "version": "2.0.2"
+  },
+  "matplotlib-2.0.2-py36h2acb4ad_1.tar.bz2": {
+    "build": "py36h2acb4ad_1",
+    "build_number": 1,
+    "depends": [
+      "cycler >=0.10",
+      "freetype >=2.8,<2.9.0a0",
+      "icu >=58.2,<59.0a0",
+      "libgcc-ng >=7.2.0",
+      "libpng >=1.6.32,<1.7.0a0",
+      "libstdcxx-ng >=7.2.0",
+      "numpy",
+      "pyparsing",
+      "pyqt 5.6.*",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil",
+      "pytz",
+      "setuptools",
+      "tk 8.6.*",
+      "tornado",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF-based",
+    "license_family": "PSF",
+    "md5": "48442e31e93e11fd0cc1fd5c5e5e0a93",
+    "name": "matplotlib",
+    "sha256": "149be7ff0d2f7f05a9751f1d8052757148934e3fda010b08e3fec0bd024937d3",
+    "sig": null,
+    "size": 6919309,
+    "subdir": "linux-64",
+    "timestamp": 1505739618706,
+    "version": "2.0.2"
+  },
+  "matplotlib-2.1.0-py27h09aba24_0.tar.bz2": {
+    "build": "py27h09aba24_0",
+    "build_number": 0,
+    "depends": [
+      "backports.functools_lru_cache",
+      "cycler >=0.10",
+      "freetype >=2.8,<2.9.0a0",
+      "functools32",
+      "icu >=58.2,<59.0a0",
+      "libpng >=1.6.32,<1.7.0a0",
+      "numpy",
+      "pyparsing",
+      "pyqt 5.6.*",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil",
+      "pytz",
+      "setuptools",
+      "subprocess32",
+      "tk 8.6.*",
+      "tornado",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF-based",
+    "license_family": "PSF",
+    "md5": "e1b81b3ba7ad0d4d4a1b0f32dd0353f9",
+    "name": "matplotlib",
+    "sha256": "205f057c1b81a15a0e1febd669dbee553ba247332fe4e2e6d43164f9ef812d38",
+    "sig": null,
+    "size": 6871680,
+    "subdir": "linux-64",
+    "timestamp": 1507569223273,
+    "version": "2.1.0"
+  },
+  "matplotlib-2.1.0-py35h2cbf27e_0.tar.bz2": {
+    "build": "py35h2cbf27e_0",
+    "build_number": 0,
+    "depends": [
+      "cycler >=0.10",
+      "freetype >=2.8,<2.9.0a0",
+      "icu >=58.2,<59.0a0",
+      "libpng >=1.6.32,<1.7.0a0",
+      "numpy",
+      "pyparsing",
+      "pyqt 5.6.*",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil",
+      "pytz",
+      "setuptools",
+      "tk 8.6.*",
+      "tornado",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF-based",
+    "license_family": "PSF",
+    "md5": "850db58dc7be0a094a471def70484d83",
+    "name": "matplotlib",
+    "sha256": "51585f4995a6732f49968028554850019f13041aa1f72ae8f047f222b6aadb36",
+    "sig": null,
+    "size": 7026831,
+    "subdir": "linux-64",
+    "timestamp": 1507569240309,
+    "version": "2.1.0"
+  },
+  "matplotlib-2.1.0-py36hba5de38_0.tar.bz2": {
+    "build": "py36hba5de38_0",
+    "build_number": 0,
+    "depends": [
+      "cycler >=0.10",
+      "freetype >=2.8,<2.9.0a0",
+      "icu >=58.2,<59.0a0",
+      "libpng >=1.6.32,<1.7.0a0",
+      "numpy",
+      "pyparsing",
+      "pyqt 5.6.*",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil",
+      "pytz",
+      "setuptools",
+      "tk 8.6.*",
+      "tornado",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF-based",
+    "license_family": "PSF",
+    "md5": "29f4b54f43a69c0c9bc9bb82078c39b4",
+    "name": "matplotlib",
+    "sha256": "a1d3320bdcb37273a383584625de6f91a6717241f10b8324c5d4e99ceeb482c8",
+    "sig": null,
+    "size": 6964112,
+    "subdir": "linux-64",
+    "timestamp": 1507569254086,
+    "version": "2.1.0"
+  },
+  "mkl-2018.0.0-hb491cac_4.tar.bz2": {
+    "build": "hb491cac_4",
+    "build_number": 4,
+    "depends": [
+      "intel-openmp"
+    ],
+    "license": "proprietary - Intel",
+    "license_family": "Proprietary",
+    "md5": "f6d79cdf2ecf31974344265683386a8e",
+    "name": "mkl",
+    "sha256": "33bc3e20acd0b9368d5fa87f879ad5742454083c5dcb7ac72c61e8ef117b6622",
+    "sig": null,
+    "size": 182821744,
+    "subdir": "linux-64",
+    "timestamp": 1505745615596,
+    "version": "2018.0.0"
+  },
+  "mpc-1.0.3-hf803216_4.tar.bz2": {
+    "build": "hf803216_4",
+    "build_number": 4,
+    "depends": [
+      "gmp >=5.0.1,<7",
+      "libgcc-ng >=7.2.0",
+      "mpfr 3.*"
+    ],
+    "license": "LGPL 3",
+    "md5": "535b567f19c29b3284fb625d4a116f55",
+    "name": "mpc",
+    "sha256": "a0145bcc8a24a87f2799aec0a3d8c1f47a131707e0d52958561d51510263a89b",
+    "sig": null,
+    "size": 96345,
+    "subdir": "linux-64",
+    "timestamp": 1505743972498,
+    "version": "1.0.3"
+  },
+  "mpfr-3.1.5-h12ff648_1.tar.bz2": {
+    "build": "h12ff648_1",
+    "build_number": 1,
+    "depends": [
+      "gmp",
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "LGPL 3",
+    "md5": "cadc73e114bc58a24f6363ef2d27cb7a",
+    "name": "mpfr",
+    "sha256": "efaeceadd912a4b8d5df3a89a4194e1a74288851a52da7789d83c9364ce24e7a",
+    "sig": null,
+    "size": 453945,
+    "subdir": "linux-64",
+    "timestamp": 1505743909510,
+    "version": "3.1.5"
+  },
+  "msgpack-python-0.4.8-py27hc2fa789_0.tar.bz2": {
+    "build": "py27hc2fa789_0",
+    "build_number": 0,
+    "depends": [
+      "libstdcxx-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "973da979b7614b0b0246c9c05dff1df8",
+    "name": "msgpack-python",
+    "sha256": "9fb3381bd122e9b7d6f8fbe54db73cbebac386ac34dc8c7815bc5baf5d2c504a",
+    "sig": null,
+    "size": 90888,
+    "subdir": "linux-64",
+    "timestamp": 1505733156824,
+    "version": "0.4.8"
+  },
+  "msgpack-python-0.4.8-py35h783f4c8_0.tar.bz2": {
+    "build": "py35h783f4c8_0",
+    "build_number": 0,
+    "depends": [
+      "libstdcxx-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "202e05790472a1a7ba258ca8007ffc7a",
+    "name": "msgpack-python",
+    "sha256": "deda164b9d7d62b3d2662cb74a7668e999ab5975fe472f93029c63d49a24e79a",
+    "sig": null,
+    "size": 91797,
+    "subdir": "linux-64",
+    "timestamp": 1505733176278,
+    "version": "0.4.8"
+  },
+  "msgpack-python-0.4.8-py36hec4c5d1_0.tar.bz2": {
+    "build": "py36hec4c5d1_0",
+    "build_number": 0,
+    "depends": [
+      "libstdcxx-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "51439aa809136989b27fa95383bf581c",
+    "name": "msgpack-python",
+    "sha256": "bb9e587af6bef1f1b7ef9b8b972820e5cdc8a7292a175040a89456caafff47ef",
+    "sig": null,
+    "size": 91845,
+    "subdir": "linux-64",
+    "timestamp": 1505733195838,
+    "version": "0.4.8"
+  },
+  "ncurses-6.0-h06874d7_1.tar.bz2": {
+    "build": "h06874d7_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0"
+    ],
+    "license": "Free software (MIT-like)",
+    "md5": "4abb7e108c149953711010eb6a6127b5",
+    "name": "ncurses",
+    "sha256": "5b22e50dee0a8cd645b2c562993e1a3d7d6cf6f4208b092856420475fceba380",
+    "sig": null,
+    "size": 928299,
+    "subdir": "linux-64",
+    "timestamp": 1505666443588,
+    "version": "6.0"
+  },
+  "nose-1.3.7-py27heec2199_2.tar.bz2": {
+    "build": "py27heec2199_2",
+    "build_number": 2,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "setuptools"
+    ],
+    "license": "LGPL-2.1",
+    "md5": "0e30466d222d8686cc054432d39225bd",
+    "name": "nose",
+    "sha256": "ef84af385554a903c6d9ca63394b5f0380dd8721b692b349087fe250d91c3e46",
+    "sig": null,
+    "size": 217422,
+    "subdir": "linux-64",
+    "timestamp": 1505688871443,
+    "version": "1.3.7"
+  },
+  "nose-1.3.7-py35hdc64897_2.tar.bz2": {
+    "build": "py35hdc64897_2",
+    "build_number": 2,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "setuptools"
+    ],
+    "license": "LGPL-2.1",
+    "md5": "0418964c94be00b31de9eba3fe0bade6",
+    "name": "nose",
+    "sha256": "97cee89a1d8f9106689c0f7fa307b739d13c8a05cce54f2b660087c5a5afc764",
+    "sig": null,
+    "size": 221060,
+    "subdir": "linux-64",
+    "timestamp": 1505688890606,
+    "version": "1.3.7"
+  },
+  "nose-1.3.7-py36hcdf7029_2.tar.bz2": {
+    "build": "py36hcdf7029_2",
+    "build_number": 2,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "setuptools"
+    ],
+    "license": "LGPL-2.1",
+    "md5": "1840253466fa90e6571d033c44a869a3",
+    "name": "nose",
+    "sha256": "8db9261f2ebc73d789a0bd57d56380786335f30692c9fdb9a2e794f44546f85d",
+    "sig": null,
+    "size": 218822,
+    "subdir": "linux-64",
+    "timestamp": 1505688910137,
+    "version": "1.3.7"
+  },
+  "numpy-1.13.1-py27hd1b6e02_2.tar.bz2": {
+    "build": "py27hd1b6e02_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "50e6867cce2c0697affc0fb32f15a1c5",
+    "name": "numpy",
+    "sha256": "681975acea61bcd489837424e4068eeed4b92a4002cc817f40368b604bd6ca27",
+    "sig": null,
+    "size": 3988799,
+    "subdir": "linux-64",
+    "timestamp": 1506013346735,
+    "version": "1.13.1"
+  },
+  "numpy-1.13.1-py35h8926d81_2.tar.bz2": {
+    "build": "py35h8926d81_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "689e6a314d3293b7fc59af2fe4670555",
+    "name": "numpy",
+    "sha256": "f8e532becf3c54aa60e5cba130353bb48bda985da8fb478a23a538ec2968f2a2",
+    "sig": null,
+    "size": 3995221,
+    "subdir": "linux-64",
+    "timestamp": 1506013892685,
+    "version": "1.13.1"
+  },
+  "numpy-1.13.1-py36h5bc529a_2.tar.bz2": {
+    "build": "py36h5bc529a_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "6c82b410a46bd64f394e1a3eca1dfa84",
+    "name": "numpy",
+    "sha256": "c19eab030d86ce72708075b9bbc935e5af3f93ee68955d8457cead769e9c4128",
+    "sig": null,
+    "size": 4037374,
+    "subdir": "linux-64",
+    "timestamp": 1506013887446,
+    "version": "1.13.1"
+  },
+  "numpy-1.13.3-py27hbcc08e0_0.tar.bz2": {
+    "build": "py27hbcc08e0_0",
+    "build_number": 0,
+    "depends": [
+      "mkl >=2018.0.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "503945e640b4db4bed7c9d771a21899a",
+    "name": "numpy",
+    "sha256": "622ec90a17c78f8184670617d9d8051b3c70100a68d8c195357a84d97bf51c94",
+    "sig": null,
+    "size": 3988160,
+    "subdir": "linux-64",
+    "timestamp": 1507324248605,
+    "version": "1.13.3"
+  },
+  "numpy-1.13.3-py35hd829ed6_0.tar.bz2": {
+    "build": "py35hd829ed6_0",
+    "build_number": 0,
+    "depends": [
+      "mkl >=2018.0.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "735bc1733584b73a5f9b993b837113d2",
+    "name": "numpy",
+    "sha256": "bb419de6c08decaea12b22c02aa089ecc01c4e853634851c4d6d8f66d4aac3c6",
+    "sig": null,
+    "size": 4006300,
+    "subdir": "linux-64",
+    "timestamp": 1507324287123,
+    "version": "1.13.3"
+  },
+  "numpy-1.13.3-py36ha12f23b_0.tar.bz2": {
+    "build": "py36ha12f23b_0",
+    "build_number": 0,
+    "depends": [
+      "mkl >=2018.0.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "4ebdc7a87b9b954d0cc59d31b1c5c4b6",
+    "name": "numpy",
+    "sha256": "87ade20954b967111f02c22fea33bf7f44bef8159263f45557af66fd2be52d43",
+    "sig": null,
+    "size": 4043525,
+    "subdir": "linux-64",
+    "timestamp": 1507324009304,
+    "version": "1.13.3"
+  },
+  "numpy-1.9.3-py27h7e35acb_3.tar.bz2": {
+    "build": "py27h7e35acb_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "7dfec27d601589f3cf41f8fc2e369058",
+    "name": "numpy",
+    "sha256": "04aafd4eafbbc6a31067eec7f5e87ef66d58a92139519673fbc8deaa18975298",
+    "sig": null,
+    "size": 3370089,
+    "subdir": "linux-64",
+    "timestamp": 1506015990456,
+    "version": "1.9.3"
+  },
+  "numpy-1.9.3-py35hff6eb55_3.tar.bz2": {
+    "build": "py35hff6eb55_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "7225aa5333f40e095a90127ec811146e",
+    "name": "numpy",
+    "sha256": "b3b2d18a401fc59da493645de40d3d04ada7db1ed51056b54168b4dc9cff2395",
+    "sig": null,
+    "size": 3405223,
+    "subdir": "linux-64",
+    "timestamp": 1506015816757,
+    "version": "1.9.3"
+  },
+  "numpy-1.9.3-py36h35fcb08_3.tar.bz2": {
+    "build": "py36h35fcb08_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "67c2ac340672c27b6a327a2042ac040d",
+    "name": "numpy",
+    "sha256": "16a451f517e301ebcd472555da3a9bdabd2259e4fde861f0f2d85f847b128a26",
+    "sig": null,
+    "size": 3415454,
+    "subdir": "linux-64",
+    "timestamp": 1506016053195,
+    "version": "1.9.3"
+  },
+  "openssl-1.0.2l-h077ae2c_5.tar.bz2": {
+    "build": "h077ae2c_5",
+    "build_number": 5,
+    "depends": [
+      "ca-certificates",
+      "libgcc-ng 7.2.0.*"
+    ],
+    "license": "OpenSSL",
+    "license_family": "Apache",
+    "md5": "b0b90d5c91399533c84a40c14bc44759",
+    "name": "openssl",
+    "sha256": "d81c895bc78c20930a85e25efc073d176adf69175ee91b31b7852b79275b8adf",
+    "sig": null,
+    "size": 3592798,
+    "subdir": "linux-64",
+    "timestamp": 1508174907958,
+    "version": "1.0.2l"
+  },
+  "openssl-1.0.2l-h9d1a558_3.tar.bz2": {
+    "build": "h9d1a558_3",
+    "build_number": 3,
+    "depends": [
+      "ca-certificates",
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "OpenSSL",
+    "license_family": "Apache",
+    "md5": "6a50e77df5f26802b5fbcd0b216e4702",
+    "name": "openssl",
+    "sha256": "6db2e5812e3d9873f45d2492ad0a9651e5c4890650e1540e3eaf9aedfb9d581b",
+    "sig": null,
+    "size": 3592154,
+    "subdir": "linux-64",
+    "timestamp": 1505862551189,
+    "version": "1.0.2l"
+  },
+  "openssl-1.0.2l-hd940f6d_1.tar.bz2": {
+    "build": "hd940f6d_1",
+    "build_number": 1,
+    "depends": [
+      "ca-certificates",
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "OpenSSL",
+    "license_family": "Apache",
+    "md5": "e608fd3f0add65ba0c9ef83c10b1727a",
+    "name": "openssl",
+    "sha256": "6202a1a78d45f8455c7f5b3c26c256283a9934bded0493e4f69dbb2c0240ceff",
+    "sig": null,
+    "size": 3593553,
+    "subdir": "linux-64",
+    "timestamp": 1505666977729,
+    "version": "1.0.2l"
+  },
+  "packaging-16.8-py27h5e07c7c_1.tar.bz2": {
+    "build": "py27h5e07c7c_1",
+    "build_number": 1,
+    "depends": [
+      "pyparsing",
+      "python >=2.7,<2.8.0a0",
+      "six"
+    ],
+    "license": "Apache 2.0 or BSD 2-Clause",
+    "md5": "26f1db62d4d081cda64f1f086a7e991e",
+    "name": "packaging",
+    "sha256": "3d9b9bb7c42ccadd71c4024dffbb4b65ce4fb18006b83367bdb5e26b73efc7bc",
+    "sig": null,
+    "size": 31377,
+    "subdir": "linux-64",
+    "timestamp": 1505747167646,
+    "version": "16.8"
+  },
+  "packaging-16.8-py35h2260b46_1.tar.bz2": {
+    "build": "py35h2260b46_1",
+    "build_number": 1,
+    "depends": [
+      "pyparsing",
+      "python >=3.5,<3.6.0a0",
+      "six"
+    ],
+    "license": "Apache 2.0 or BSD 2-Clause",
+    "md5": "66cba2e2e0dc74f2cc5505d4d2f544a2",
+    "name": "packaging",
+    "sha256": "1464e7830449815b6b2e0b74f1c9b21b691b29e8fbe3bb7e36bc4ad524ce3e3e",
+    "sig": null,
+    "size": 32298,
+    "subdir": "linux-64",
+    "timestamp": 1505747180870,
+    "version": "16.8"
+  },
+  "packaging-16.8-py36ha668100_1.tar.bz2": {
+    "build": "py36ha668100_1",
+    "build_number": 1,
+    "depends": [
+      "pyparsing",
+      "python >=3.6,<3.7.0a0",
+      "six"
+    ],
+    "license": "Apache 2.0 or BSD 2-Clause",
+    "md5": "c3b77ede6ee2a065699a350bed1b22bd",
+    "name": "packaging",
+    "sha256": "af58bd91c06b6172827133805484a2c62d81cbac609ce1d998a45dc425d19479",
+    "sig": null,
+    "size": 32169,
+    "subdir": "linux-64",
+    "timestamp": 1505747194122,
+    "version": "16.8"
+  },
+  "pandas-0.20.3-py27h820b67f_2.tar.bz2": {
+    "build": "py27h820b67f_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "numpy >=1.9",
+      "python >=2.7,<2.8.0a0",
+      "python-dateutil",
+      "pytz"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "d846c5f62fc49e97f22dfe51a9b17628",
+    "name": "pandas",
+    "sha256": "1c43975536b0fd3b04ab468a32e7f2823acb4235e6026c00d723975c39a30f5a",
+    "sig": null,
+    "size": 10327696,
+    "subdir": "linux-64",
+    "timestamp": 1505726159262,
+    "version": "0.20.3"
+  },
+  "pandas-0.20.3-py35h85c2c75_2.tar.bz2": {
+    "build": "py35h85c2c75_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "numpy >=1.9",
+      "python >=3.5,<3.6.0a0",
+      "python-dateutil",
+      "pytz"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "c89314b67e05fdfe859419e0335c61d3",
+    "name": "pandas",
+    "sha256": "de4ae420a46f771cc6487cd66ef3ddddcb244a4345a7d674c6044c84a16e8298",
+    "sig": null,
+    "size": 10287928,
+    "subdir": "linux-64",
+    "timestamp": 1505726630344,
+    "version": "0.20.3"
+  },
+  "pandas-0.20.3-py36h842e28d_2.tar.bz2": {
+    "build": "py36h842e28d_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "numpy >=1.9",
+      "python >=3.6,<3.7.0a0",
+      "python-dateutil",
+      "pytz"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "1dec0c38ac0ee39d009e5e2b14de056f",
+    "name": "pandas",
+    "sha256": "a4eaa238eb5d14f9a584c3084594c1ada364ca790b59eb3eca239ab59b0a007c",
+    "sig": null,
+    "size": 10345877,
+    "subdir": "linux-64",
+    "timestamp": 1505727113870,
+    "version": "0.20.3"
+  },
+  "partd-0.3.8-py27h4e55004_0.tar.bz2": {
+    "build": "py27h4e55004_0",
+    "build_number": 0,
+    "depends": [
+      "locket",
+      "python >=2.7,<2.8.0a0",
+      "toolz"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "493f68e9f00b55a9e719092b44dd8102",
+    "name": "partd",
+    "sha256": "70a29d7ec7a12d97b16297ceec2c4d2a29f9b81c1a4f4a13e68c7bc11bdef89f",
+    "sig": null,
+    "size": 30469,
+    "subdir": "linux-64",
+    "timestamp": 1505732816039,
+    "version": "0.3.8"
+  },
+  "partd-0.3.8-py35h68187f2_0.tar.bz2": {
+    "build": "py35h68187f2_0",
+    "build_number": 0,
+    "depends": [
+      "locket",
+      "python >=3.5,<3.6.0a0",
+      "toolz"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "7c9960f0c0a369a9acfadedd38a39e97",
+    "name": "partd",
+    "sha256": "28d597b985318ba606b64044a5d81722ea998f12c51e7e07fcdada1c6037408f",
+    "sig": null,
+    "size": 31361,
+    "subdir": "linux-64",
+    "timestamp": 1505732828325,
+    "version": "0.3.8"
+  },
+  "partd-0.3.8-py36h36fd896_0.tar.bz2": {
+    "build": "py36h36fd896_0",
+    "build_number": 0,
+    "depends": [
+      "locket",
+      "python >=3.6,<3.7.0a0",
+      "toolz"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "d08986bc3f492969815a31cf3ae64f17",
+    "name": "partd",
+    "sha256": "c431054468662cb509285a0ba789c83cd9f6bd0c7103daaa240626ad164ed663",
+    "sig": null,
+    "size": 31342,
+    "subdir": "linux-64",
+    "timestamp": 1505732840860,
+    "version": "0.3.8"
+  },
+  "path.py-10.3.1-py27hc258cac_0.tar.bz2": {
+    "build": "py27hc258cac_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "f2701f843981473e9d72d36921a867e2",
+    "name": "path.py",
+    "sha256": "e05944aa406200bddda550c1ee463fc802bdfba8fb2edabce54458da4b6c588b",
+    "sig": null,
+    "size": 51274,
+    "subdir": "linux-64",
+    "timestamp": 1505747289147,
+    "version": "10.3.1"
+  },
+  "path.py-10.3.1-py35hb82cfee_0.tar.bz2": {
+    "build": "py35hb82cfee_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "189bfedba0219f6b7a2d3fe726f7b13d",
+    "name": "path.py",
+    "sha256": "5b11cb45cf39c603604c537f0cd76c80660fe307bb94cdb5d73f3ac8c9b5e4a6",
+    "sig": null,
+    "size": 52871,
+    "subdir": "linux-64",
+    "timestamp": 1505747301722,
+    "version": "10.3.1"
+  },
+  "path.py-10.3.1-py36he0c6f6d_0.tar.bz2": {
+    "build": "py36he0c6f6d_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "0590768167021c213ca5feef94874e56",
+    "name": "path.py",
+    "sha256": "f19c25c62d8b7d74298fcad39b72d48468c3d49e6aa41a76b62451d416eca48f",
+    "sig": null,
+    "size": 52707,
+    "subdir": "linux-64",
+    "timestamp": 1505747314417,
+    "version": "10.3.1"
+  },
+  "pathlib2-2.3.0-py27h6e9d198_0.tar.bz2": {
+    "build": "py27h6e9d198_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "scandir",
+      "six"
+    ],
+    "license": "MIT",
+    "md5": "2289c7b2df9b353f00fd1989300c20b7",
+    "name": "pathlib2",
+    "sha256": "f51dd95d1673575a650da542ca0516233056163dd59053b9b3de968bdec79dcb",
+    "sig": null,
+    "size": 31430,
+    "subdir": "linux-64",
+    "timestamp": 1505688567061,
+    "version": "2.3.0"
+  },
+  "pathlib2-2.3.0-py35hd637de4_0.tar.bz2": {
+    "build": "py35hd637de4_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "six"
+    ],
+    "license": "MIT",
+    "md5": "9ef98304e0da945b9f9b792794ea72ff",
+    "name": "pathlib2",
+    "sha256": "7abde4842af819dc4e2627b264975c3d71aafee20aa8a690d74b9f507c4a76d8",
+    "sig": null,
+    "size": 32615,
+    "subdir": "linux-64",
+    "timestamp": 1505688577838,
+    "version": "2.3.0"
+  },
+  "pathlib2-2.3.0-py36h49efa8e_0.tar.bz2": {
+    "build": "py36h49efa8e_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "six"
+    ],
+    "license": "MIT",
+    "md5": "48c497335ce45c3aa0d04ecd692ec176",
+    "name": "pathlib2",
+    "sha256": "9390947fc87a6a293fba7fd3ccc84a68ae1071c407242a0ea59de1f8fcce3e1d",
+    "sig": null,
+    "size": 32578,
+    "subdir": "linux-64",
+    "timestamp": 1505688588892,
+    "version": "2.3.0"
+  },
+  "pcre-8.41-hc71a17e_0.tar.bz2": {
+    "build": "hc71a17e_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "c979c852dd26d2e3de370a51d9fc0856",
+    "name": "pcre",
+    "sha256": "7d3e1db4ea2e5749c333b6d4362ab5ce166455109e6567d32d0679fb4a0bdfc8",
+    "sig": null,
+    "size": 256056,
+    "subdir": "linux-64",
+    "timestamp": 1505734397623,
+    "version": "8.41"
+  },
+  "pexpect-4.2.1-py27hcf82287_0.tar.bz2": {
+    "build": "py27hcf82287_0",
+    "build_number": 0,
+    "depends": [
+      "ptyprocess >=0.5",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "ISC",
+    "md5": "d80a3af58ce5665807c2f286bb39ccff",
+    "name": "pexpect",
+    "sha256": "89a65c27dd4d8e85a4f3fb5cf0a5dfbf4d4ac9a506957b432143ca1022908652",
+    "sig": null,
+    "size": 70647,
+    "subdir": "linux-64",
+    "timestamp": 1505690249749,
+    "version": "4.2.1"
+  },
+  "pexpect-4.2.1-py35h8b56cb4_0.tar.bz2": {
+    "build": "py35h8b56cb4_0",
+    "build_number": 0,
+    "depends": [
+      "ptyprocess >=0.5",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "ISC",
+    "md5": "3f527b09fde1eed5059ce13451c822ef",
+    "name": "pexpect",
+    "sha256": "f16dbd42c5d2d37617380265f54057f30cbfdad5b2c86a9c06cbd2995c62359f",
+    "sig": null,
+    "size": 73280,
+    "subdir": "linux-64",
+    "timestamp": 1505690261284,
+    "version": "4.2.1"
+  },
+  "pexpect-4.2.1-py36h3b9d41b_0.tar.bz2": {
+    "build": "py36h3b9d41b_0",
+    "build_number": 0,
+    "depends": [
+      "ptyprocess >=0.5",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "ISC",
+    "md5": "7fc7892974f8a102140e696c13991e34",
+    "name": "pexpect",
+    "sha256": "24afb18b7834532343a8ef3965d95f2b9ead8c684301d3e6022f61ed28ba0d51",
+    "sig": null,
+    "size": 73176,
+    "subdir": "linux-64",
+    "timestamp": 1505690272959,
+    "version": "4.2.1"
+  },
+  "pickleshare-0.7.4-py27h09770e1_0.tar.bz2": {
+    "build": "py27h09770e1_0",
+    "build_number": 0,
+    "depends": [
+      "pathlib2",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "63dd946d096ca17a17e9a4243e1f0751",
+    "name": "pickleshare",
+    "sha256": "3bfb2488c982544f326bfef397e1b87dbb399ea7374adc41e21d8398cca58385",
+    "sig": null,
+    "size": 11419,
+    "subdir": "linux-64",
+    "timestamp": 1505690117722,
+    "version": "0.7.4"
+  },
+  "pickleshare-0.7.4-py35hd57304d_0.tar.bz2": {
+    "build": "py35hd57304d_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "d044a0b9f019284d70210383ba23f065",
+    "name": "pickleshare",
+    "sha256": "be7a8551c80718e5d6504f7a36d954aea4a0848528f666e3b35e133002a6ebc4",
+    "sig": null,
+    "size": 11731,
+    "subdir": "linux-64",
+    "timestamp": 1505690128538,
+    "version": "0.7.4"
+  },
+  "pickleshare-0.7.4-py36h63277f8_0.tar.bz2": {
+    "build": "py36h63277f8_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "f1963de9dee08aa7151260cf947a1268",
+    "name": "pickleshare",
+    "sha256": "84c1ee7f09d6f194ca445ea7526fe464bd083cf04fcc4b664c0be0ffcaccc81b",
+    "sig": null,
+    "size": 11675,
+    "subdir": "linux-64",
+    "timestamp": 1505690139442,
+    "version": "0.7.4"
+  },
+  "pip-9.0.1-py27h4c18a59_2.tar.bz2": {
+    "build": "py27h4c18a59_2",
+    "build_number": 2,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "setuptools",
+      "wheel"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "d71cde7747894237dfc60c7b35bc616f",
+    "name": "pip",
+    "sha256": "627e34e445254ba829c96b72b99abe4b9e7cc9ffa16115125463f195be494b9b",
+    "sig": null,
+    "size": 1743005,
+    "subdir": "linux-64",
+    "timestamp": 1505671923748,
+    "version": "9.0.1"
+  },
+  "pip-9.0.1-py27hbf658b2_3.tar.bz2": {
+    "build": "py27hbf658b2_3",
+    "build_number": 3,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "setuptools",
+      "wheel"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "7701febf3d0b89305ee3b8215bceea36",
+    "name": "pip",
+    "sha256": "8ce6702f416edd83c3ccc319c9d7747e6133890c0ac10c03d94f2577bf76f4bb",
+    "sig": null,
+    "size": 1745487,
+    "subdir": "linux-64",
+    "timestamp": 1506357742693,
+    "version": "9.0.1"
+  },
+  "pip-9.0.1-py35haa8ec2a_3.tar.bz2": {
+    "build": "py35haa8ec2a_3",
+    "build_number": 3,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "setuptools",
+      "wheel"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "bb3b2c3b2ab45d955a4587b10cc0accc",
+    "name": "pip",
+    "sha256": "549454e10121a4743efff5fe020d31551afe95ef370c8f4c2ab8e21a0426465e",
+    "sig": null,
+    "size": 1776324,
+    "subdir": "linux-64",
+    "timestamp": 1506357769885,
+    "version": "9.0.1"
+  },
+  "pip-9.0.1-py35he1b8d41_2.tar.bz2": {
+    "build": "py35he1b8d41_2",
+    "build_number": 2,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "setuptools",
+      "wheel"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "d5e58e8f8ff52b6b27a232a28aa9073b",
+    "name": "pip",
+    "sha256": "4039b0158c8f2194025943134dfc8cd1dca0d8c151c06e2f05a51e263f8ee254",
+    "sig": null,
+    "size": 1775911,
+    "subdir": "linux-64",
+    "timestamp": 1505671952867,
+    "version": "9.0.1"
+  },
+  "pip-9.0.1-py36h30f8307_2.tar.bz2": {
+    "build": "py36h30f8307_2",
+    "build_number": 2,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "setuptools",
+      "wheel"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "89f4c9f104dc57b6b1802803c6deb226",
+    "name": "pip",
+    "sha256": "d3a58544719bd21d859bb7a1aa382036e5545cc71c2baea0c17e136ba1072f9e",
+    "sig": null,
+    "size": 1751838,
+    "subdir": "linux-64",
+    "timestamp": 1505671982188,
+    "version": "9.0.1"
+  },
+  "pip-9.0.1-py36h8ec8b28_3.tar.bz2": {
+    "build": "py36h8ec8b28_3",
+    "build_number": 3,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "setuptools",
+      "wheel"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "54e8e805953b255bce3d44cad92924af",
+    "name": "pip",
+    "sha256": "8e5c2f1fc8abafe7c04331499f4d4336ee49025339eabca020509bbc1137bbb0",
+    "sig": null,
+    "size": 1754976,
+    "subdir": "linux-64",
+    "timestamp": 1506357774387,
+    "version": "9.0.1"
+  },
+  "prompt_toolkit-1.0.15-py27h1b593e1_0.tar.bz2": {
+    "build": "py27h1b593e1_0",
+    "build_number": 0,
+    "depends": [
+      "pygments",
+      "python >=2.7,<2.8.0a0",
+      "six >=1.9.0",
+      "wcwidth"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "657aff474dd320785bae8e75693add53",
+    "name": "prompt_toolkit",
+    "sha256": "2ea504f5ceff5de715c423914f9e0738d545395d24c6c48dfa168b4d5123cd0a",
+    "sig": null,
+    "size": 341007,
+    "subdir": "linux-64",
+    "timestamp": 1505690322202,
+    "version": "1.0.15"
+  },
+  "prompt_toolkit-1.0.15-py35hc09de7a_0.tar.bz2": {
+    "build": "py35hc09de7a_0",
+    "build_number": 0,
+    "depends": [
+      "pygments",
+      "python >=3.5,<3.6.0a0",
+      "six >=1.9.0",
+      "wcwidth"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "070fee45a0542abd99178326e92b6af1",
+    "name": "prompt_toolkit",
+    "sha256": "d41a2d845310f677dd7e44f8be3cde8a6692f1b4b60f0dfc6dbd27433245ca31",
+    "sig": null,
+    "size": 351229,
+    "subdir": "linux-64",
+    "timestamp": 1505690339946,
+    "version": "1.0.15"
+  },
+  "prompt_toolkit-1.0.15-py36h17d85b1_0.tar.bz2": {
+    "build": "py36h17d85b1_0",
+    "build_number": 0,
+    "depends": [
+      "pygments",
+      "python >=3.6,<3.7.0a0",
+      "six >=1.9.0",
+      "wcwidth"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "24c94cefef6f82bac07de84890209f86",
+    "name": "prompt_toolkit",
+    "sha256": "23d86d126a176d9aa231ead36118fabf19c5eb389f00c7f37842c2dbfe8d9e24",
+    "sig": null,
+    "size": 347055,
+    "subdir": "linux-64",
+    "timestamp": 1505690357987,
+    "version": "1.0.15"
+  },
+  "psutil-5.2.2-py27h9b5ba61_0.tar.bz2": {
+    "build": "py27h9b5ba61_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "c5010a4ab9cd9c2b5ed386ec2fb3ac31",
+    "name": "psutil",
+    "sha256": "1570ce4335999994c06541424b5d7abfc050f72fc5563fccede6b4b5288bfd5e",
+    "sig": null,
+    "size": 252123,
+    "subdir": "linux-64",
+    "timestamp": 1505733101999,
+    "version": "5.2.2"
+  },
+  "psutil-5.2.2-py35h75e6a48_0.tar.bz2": {
+    "build": "py35h75e6a48_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "4d183039c997f4d0795a5d5c472fbf5d",
+    "name": "psutil",
+    "sha256": "6536f8d88801d958a74afdfd23f7fc0f2b49c6ae3f27cd173cc51fa0875a3a2f",
+    "sig": null,
+    "size": 259215,
+    "subdir": "linux-64",
+    "timestamp": 1505733119236,
+    "version": "5.2.2"
+  },
+  "psutil-5.2.2-py36h74c8701_0.tar.bz2": {
+    "build": "py36h74c8701_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "aa86eb8f8ae6da569e0bbc7f07b0beee",
+    "name": "psutil",
+    "sha256": "db13e6871a7122f601e7091fcf352fbb518862f18e792fc1262dfece6bb0bbf6",
+    "sig": null,
+    "size": 255016,
+    "subdir": "linux-64",
+    "timestamp": 1505733136390,
+    "version": "5.2.2"
+  },
+  "psutil-5.3.1-py27h4c169b4_0.tar.bz2": {
+    "build": "py27h4c169b4_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "2c723d324170c9c7b66cbb6ea9a1a7b4",
+    "name": "psutil",
+    "sha256": "099204942a20796be12fc067c7fa4ded124081bd77c3b7840a4c21d8887e1fbb",
+    "sig": null,
+    "size": 288725,
+    "subdir": "linux-64",
+    "timestamp": 1507234353221,
+    "version": "5.3.1"
+  },
+  "psutil-5.3.1-py35h6e9e629_0.tar.bz2": {
+    "build": "py35h6e9e629_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "6564701f2fd90be0c8c22f60add905ef",
+    "name": "psutil",
+    "sha256": "620bd75db5acf88323ecce94eb03b0d03ccf04d07c78eb38329644e73ea6a93e",
+    "sig": null,
+    "size": 297259,
+    "subdir": "linux-64",
+    "timestamp": 1507231337345,
+    "version": "5.3.1"
+  },
+  "psutil-5.3.1-py36h0e357b8_0.tar.bz2": {
+    "build": "py36h0e357b8_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "909221503100b73e778fa9132feb74e1",
+    "name": "psutil",
+    "sha256": "1d0a8bf8a714c87eaec26924700f52d22e9ce55d9bf52c2f75ad79eca4496f6f",
+    "sig": null,
+    "size": 294716,
+    "subdir": "linux-64",
+    "timestamp": 1507229148439,
+    "version": "5.3.1"
+  },
+  "ptyprocess-0.5.2-py27h4ccb14c_0.tar.bz2": {
+    "build": "py27h4ccb14c_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "ISC",
+    "md5": "0c917568637fd5ab2e0d071650c312a0",
+    "name": "ptyprocess",
+    "sha256": "25b8ece5d072f9108580707a4670e96eac6e547a41fd5b646542cb3c1cbe62ff",
+    "sig": null,
+    "size": 22091,
+    "subdir": "linux-64",
+    "timestamp": 1505690216282,
+    "version": "0.5.2"
+  },
+  "ptyprocess-0.5.2-py35h38ce0a3_0.tar.bz2": {
+    "build": "py35h38ce0a3_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "ISC",
+    "md5": "ab11f16a560fe4d289b90175c9b4981f",
+    "name": "ptyprocess",
+    "sha256": "9686ff9b2bb81cfbf9a3baf9520bfd57bf2a0cc831ef24e68657a018f6325ff3",
+    "sig": null,
+    "size": 22615,
+    "subdir": "linux-64",
+    "timestamp": 1505690227056,
+    "version": "0.5.2"
+  },
+  "ptyprocess-0.5.2-py36h69acd42_0.tar.bz2": {
+    "build": "py36h69acd42_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "ISC",
+    "md5": "01dd6297fdd8f5d56c978b9d9ef50ae1",
+    "name": "ptyprocess",
+    "sha256": "7aebd3a596408c2ae79b2ef23f6bb3515cff53585b663e811455169409659864",
+    "sig": null,
+    "size": 22558,
+    "subdir": "linux-64",
+    "timestamp": 1505690237910,
+    "version": "0.5.2"
+  },
+  "pyasn1-0.3.7-py27haf6b024_0.tar.bz2": {
+    "build": "py27haf6b024_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "license_family": "BSD",
+    "md5": "a6fe261734e216335ec27cac024da252",
+    "name": "pyasn1",
+    "sha256": "4a3de1ee3cdcd7ce6386838be623a509737ba45ae4d62c19e73d321c166d249e",
+    "sig": null,
+    "size": 91952,
+    "subdir": "linux-64",
+    "timestamp": 1507699147990,
+    "version": "0.3.7"
+  },
+  "pyasn1-0.3.7-py35h2fee745_0.tar.bz2": {
+    "build": "py35h2fee745_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "license_family": "BSD",
+    "md5": "d25b472d0f27403009dde61b408c01e5",
+    "name": "pyasn1",
+    "sha256": "c31408eee6033d13b48b35be1391959be8977df34e8b46526efc5b870a466fe4",
+    "sig": null,
+    "size": 96005,
+    "subdir": "linux-64",
+    "timestamp": 1507699158410,
+    "version": "0.3.7"
+  },
+  "pyasn1-0.3.7-py36h0f28794_0.tar.bz2": {
+    "build": "py36h0f28794_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "license_family": "BSD",
+    "md5": "349e6a7e58e1ea9cbf94f680cf72354f",
+    "name": "pyasn1",
+    "sha256": "b8afcd311d087e38969fe225f4b52d9509f3aa29edcde01b223c7eda12e357e1",
+    "sig": null,
+    "size": 95266,
+    "subdir": "linux-64",
+    "timestamp": 1507699160557,
+    "version": "0.3.7"
+  },
+  "pycosat-0.6.2-py27h1cf261c_1.tar.bz2": {
+    "build": "py27h1cf261c_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "305686a4b7f2fae3ca6786a7cd9083c6",
+    "name": "pycosat",
+    "sha256": "244851531c02b6f7145385475c7e5c478ad1a72d87bf6652fdddf7e62e927c04",
+    "sig": null,
+    "size": 105815,
+    "subdir": "linux-64",
+    "timestamp": 1505742082091,
+    "version": "0.6.2"
+  },
+  "pycosat-0.6.2-py35h9693557_1.tar.bz2": {
+    "build": "py35h9693557_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "12d7766424cdf2670cf3494c61306938",
+    "name": "pycosat",
+    "sha256": "031cd6e2819dc49fa824d624715d0d19efb839fc455167794cde703f6ae73d9c",
+    "sig": null,
+    "size": 106335,
+    "subdir": "linux-64",
+    "timestamp": 1505742100736,
+    "version": "0.6.2"
+  },
+  "pycosat-0.6.2-py36h1a0ea17_1.tar.bz2": {
+    "build": "py36h1a0ea17_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "3129e14e67fea728c64c2dd882d5a0af",
+    "name": "pycosat",
+    "sha256": "1420c4869fa2a5dcb1b8fdb27d9f79a1429a35357502081824d006964ac12f06",
+    "sig": null,
+    "size": 106560,
+    "subdir": "linux-64",
+    "timestamp": 1505742119471,
+    "version": "0.6.2"
+  },
+  "pycparser-2.18-py27hefa08c5_1.tar.bz2": {
+    "build": "py27hefa08c5_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-clause",
+    "license_family": "BSD",
+    "md5": "bdcdd42dfc0ffe1c524e384170d6c71b",
+    "name": "pycparser",
+    "sha256": "8ac4468dc70960f23b5955c06baa7c6869b99e9b6aea6d41aef04abe43d7ad7e",
+    "sig": null,
+    "size": 170870,
+    "subdir": "linux-64",
+    "timestamp": 1505691615710,
+    "version": "2.18"
+  },
+  "pycparser-2.18-py35h61b3040_1.tar.bz2": {
+    "build": "py35h61b3040_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-clause",
+    "license_family": "BSD",
+    "md5": "4fecf6510d34e313dcdfe6c6efa68c40",
+    "name": "pycparser",
+    "sha256": "3d85cfbecbfd4453bfdfb8206f6159db5c06ecf3e2820483cd5de329336dce8f",
+    "sig": null,
+    "size": 173785,
+    "subdir": "linux-64",
+    "timestamp": 1505691628432,
+    "version": "2.18"
+  },
+  "pycparser-2.18-py36hf9f622e_1.tar.bz2": {
+    "build": "py36hf9f622e_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-clause",
+    "license_family": "BSD",
+    "md5": "e001dd2f049ea6d6c77cfe37b73ff3be",
+    "name": "pycparser",
+    "sha256": "5be7482ef3012ad6025e56e7e604b825999b6ae8f5f45888b692971fc5de347b",
+    "sig": null,
+    "size": 172731,
+    "subdir": "linux-64",
+    "timestamp": 1505691641245,
+    "version": "2.18"
+  },
+  "pygments-2.2.0-py27h4a8b6f5_0.tar.bz2": {
+    "build": "py27h4a8b6f5_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "setuptools"
+    ],
+    "license": "BSD 2-clause",
+    "md5": "6f80dc7adc1ad4d70dc97ff4d5374320",
+    "name": "pygments",
+    "sha256": "bc43958e258a3535c22ffc09aaf02341124234007135c1924819490197bd5314",
+    "sig": null,
+    "size": 1403082,
+    "subdir": "linux-64",
+    "timestamp": 1505688802373,
+    "version": "2.2.0"
+  },
+  "pygments-2.2.0-py35h0f41973_0.tar.bz2": {
+    "build": "py35h0f41973_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "setuptools"
+    ],
+    "license": "BSD 2-clause",
+    "md5": "bb61e1ddd98f48cee743cc3bf066c2c6",
+    "name": "pygments",
+    "sha256": "793d9ae48106e9c5b8b101b8a53691220e94b789f7a57e42a3e4be2793d5d0e2",
+    "sig": null,
+    "size": 1397571,
+    "subdir": "linux-64",
+    "timestamp": 1505688828032,
+    "version": "2.2.0"
+  },
+  "pygments-2.2.0-py36h0d3125c_0.tar.bz2": {
+    "build": "py36h0d3125c_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "setuptools"
+    ],
+    "license": "BSD 2-clause",
+    "md5": "ce25508dbdfa0c7f1c12fb8ac021e564",
+    "name": "pygments",
+    "sha256": "b1be4a9d6a26f1f2b49379777cd54a5cfc242af66f090ae56960be84e8fc5d89",
+    "sig": null,
+    "size": 1398174,
+    "subdir": "linux-64",
+    "timestamp": 1505688854125,
+    "version": "2.2.0"
+  },
+  "pyopenssl-17.2.0-py27h189ff3b_0.tar.bz2": {
+    "build": "py27h189ff3b_0",
+    "build_number": 0,
+    "depends": [
+      "cryptography >=1.9",
+      "python >=2.7,<2.8.0a0",
+      "six >=1.5.2"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "7520979aecc8eaf5ffe4c833eb0892ff",
+    "name": "pyopenssl",
+    "sha256": "dbcdb478b7d48f44138899ec882bac4675ebe7e3af5ed041a63f72bfc86beefc",
+    "sig": null,
+    "size": 77457,
+    "subdir": "linux-64",
+    "timestamp": 1505692953929,
+    "version": "17.2.0"
+  },
+  "pyopenssl-17.2.0-py35h1d2a76c_0.tar.bz2": {
+    "build": "py35h1d2a76c_0",
+    "build_number": 0,
+    "depends": [
+      "cryptography >=1.9",
+      "python >=3.5,<3.6.0a0",
+      "six >=1.5.2"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "95783e719ab13ccfbebe6ac786695afd",
+    "name": "pyopenssl",
+    "sha256": "2ff7e5e291bbd8c8d4add836281375ca7561ff4f2a0b4897def5b87efbbd8d06",
+    "sig": null,
+    "size": 79803,
+    "subdir": "linux-64",
+    "timestamp": 1505692966094,
+    "version": "17.2.0"
+  },
+  "pyopenssl-17.2.0-py36h5cc804b_0.tar.bz2": {
+    "build": "py36h5cc804b_0",
+    "build_number": 0,
+    "depends": [
+      "cryptography >=1.9",
+      "python >=3.6,<3.7.0a0",
+      "six >=1.5.2"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "d920a5cb1cdad2f9aa829d077f699c96",
+    "name": "pyopenssl",
+    "sha256": "3aa64ac266b16813154fb07c6cebebe68a8bebeb63f45bbd5f1e4beb058712dc",
+    "sig": null,
+    "size": 79750,
+    "subdir": "linux-64",
+    "timestamp": 1505692978201,
+    "version": "17.2.0"
+  },
+  "pyparsing-2.2.0-py27hf1513f8_1.tar.bz2": {
+    "build": "py27hf1513f8_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "30370cc591a29eb1422b8ad50edfe220",
+    "name": "pyparsing",
+    "sha256": "4fa60d62c3779f911d3e99e876f15712a71e6135e2dd74aa914b86f352405c1c",
+    "sig": null,
+    "size": 95658,
+    "subdir": "linux-64",
+    "timestamp": 1505733480948,
+    "version": "2.2.0"
+  },
+  "pyparsing-2.2.0-py35h041ed72_1.tar.bz2": {
+    "build": "py35h041ed72_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "a9695e3291b6e7cd439e8de6611e5b68",
+    "name": "pyparsing",
+    "sha256": "4b4bdd268252f74cd05020fec28fe0b88c777dc4d45329ff819551fd7e21ca66",
+    "sig": null,
+    "size": 98280,
+    "subdir": "linux-64",
+    "timestamp": 1505733492733,
+    "version": "2.2.0"
+  },
+  "pyparsing-2.2.0-py36hee85983_1.tar.bz2": {
+    "build": "py36hee85983_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "4ae513648760e5c23a1f57c79a39bff5",
+    "name": "pyparsing",
+    "sha256": "657a8106cdd112a7516e3f907ea14e06e4b9086faeb918a32932a5d0662faa05",
+    "sig": null,
+    "size": 98120,
+    "subdir": "linux-64",
+    "timestamp": 1505733504669,
+    "version": "2.2.0"
+  },
+  "pyqt-5.6.0-py27h4b1e83c_5.tar.bz2": {
+    "build": "py27h4b1e83c_5",
+    "build_number": 5,
+    "depends": [
+      "dbus >=1.10.22,<2.0a0",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0",
+      "qt 5.6.*",
+      "sip 4.18.*"
+    ],
+    "license": "Commercial, GPL-2.0, GPL-3.0",
+    "license_family": "GPL",
+    "md5": "8a9eca99ce0b78cfefbb9faca4db793a",
+    "name": "pyqt",
+    "sha256": "b063d9cb90409b4f800e7941140ca273d42078c14b25c8fe53f63016a20ac0cc",
+    "sig": null,
+    "size": 5524409,
+    "subdir": "linux-64",
+    "timestamp": 1505738242615,
+    "version": "5.6.0"
+  },
+  "pyqt-5.6.0-py35h0e41ada_5.tar.bz2": {
+    "build": "py35h0e41ada_5",
+    "build_number": 5,
+    "depends": [
+      "dbus >=1.10.22,<2.0a0",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0",
+      "qt 5.6.*",
+      "sip 4.18.*"
+    ],
+    "license": "Commercial, GPL-2.0, GPL-3.0",
+    "license_family": "GPL",
+    "md5": "b951dab563683ed93fa0503a93270f19",
+    "name": "pyqt",
+    "sha256": "43fae35b2ccb1ff3e80fa89b79b8320f121e6a2de9165d006a3092b0fe9e3333",
+    "sig": null,
+    "size": 5705773,
+    "subdir": "linux-64",
+    "timestamp": 1505738707849,
+    "version": "5.6.0"
+  },
+  "pyqt-5.6.0-py36h0386399_5.tar.bz2": {
+    "build": "py36h0386399_5",
+    "build_number": 5,
+    "depends": [
+      "dbus >=1.10.22,<2.0a0",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0",
+      "qt 5.6.*",
+      "sip 4.18.*"
+    ],
+    "license": "Commercial, GPL-2.0, GPL-3.0",
+    "license_family": "GPL",
+    "md5": "b1624f76a6bba705869f849f7456bd39",
+    "name": "pyqt",
+    "sha256": "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+    "sig": null,
+    "size": 5715107,
+    "subdir": "linux-64",
+    "timestamp": 1505739175210,
+    "version": "5.6.0"
+  },
+  "pysocks-1.6.7-py27he2db6d2_1.tar.bz2": {
+    "build": "py27he2db6d2_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "c595aece629c642a62c2280b5cf7ef50",
+    "name": "pysocks",
+    "sha256": "a019269288944cffc09297085106d3a524fa87891fc5873f314e3e4837fea458",
+    "sig": null,
+    "size": 22159,
+    "subdir": "linux-64",
+    "timestamp": 1505692990681,
+    "version": "1.6.7"
+  },
+  "pysocks-1.6.7-py35h6aefbb0_1.tar.bz2": {
+    "build": "py35h6aefbb0_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "df1062f00a91bd148b247cd19ab6cd36",
+    "name": "pysocks",
+    "sha256": "97dd563b89eabe2467e56a1bd57921e25ada49c1d51a745f70b68b72a2f98086",
+    "sig": null,
+    "size": 22702,
+    "subdir": "linux-64",
+    "timestamp": 1505693001886,
+    "version": "1.6.7"
+  },
+  "pysocks-1.6.7-py36hd97a5b1_1.tar.bz2": {
+    "build": "py36hd97a5b1_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "041efc6b0326de560070094b4f1bc06b",
+    "name": "pysocks",
+    "sha256": "173c5c9a5e7a00a979ae72249db83a8cbb7a2b97e791f13f053f9f9eea7c5fec",
+    "sig": null,
+    "size": 22597,
+    "subdir": "linux-64",
+    "timestamp": 1505693013263,
+    "version": "1.6.7"
+  },
+  "python-2.7.13-hac47a24_15.tar.bz2": {
+    "build": "hac47a24_15",
+    "build_number": 15,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "2fa1d0c654d517d7532d1ea77b1801df",
+    "name": "python",
+    "sha256": "af2ab360a9d08d87da6c4ed6dd5b4582a3bf1e48bdfa3ed21ff2b9bcda2945c9",
+    "sig": null,
+    "size": 10610392,
+    "subdir": "linux-64",
+    "timestamp": 1506704236597,
+    "version": "2.7.13"
+  },
+  "python-2.7.13-heccc3f1_16.tar.bz2": {
+    "build": "heccc3f1_16",
+    "build_number": 16,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "f04d5ad55faa63687352027612cef3c9",
+    "name": "python",
+    "sha256": "92db30a9d0130549bd0c971a936d046e0804478f2bdcbb74302f1913686d373b",
+    "sig": null,
+    "size": 10613762,
+    "subdir": "linux-64",
+    "timestamp": 1506795306306,
+    "version": "2.7.13"
+  },
+  "python-2.7.13-hfff3488_13.tar.bz2": {
+    "build": "hfff3488_13",
+    "build_number": 13,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "2f1dc0c30e0ad8af774a6c8eaaff5601",
+    "name": "python",
+    "sha256": "6335e131661c506c571996443a52cb75971bc743a160e5ed3d7b9b400711b4bf",
+    "sig": null,
+    "size": 10003184,
+    "subdir": "linux-64",
+    "timestamp": 1506041363459,
+    "version": "2.7.13"
+  },
+  "python-2.7.14-h1aa7481_19.tar.bz2": {
+    "build": "h1aa7481_19",
+    "build_number": 19,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "3283b97c9bd14e13e6c9527cb4ee75c9",
+    "name": "python",
+    "sha256": "75e8dd2e17a2c60a04ee054eabb3339f784b4d19dd0772b904846eda945cc6df",
+    "sig": null,
+    "size": 10628482,
+    "subdir": "linux-64",
+    "timestamp": 1507188548940,
+    "version": "2.7.14"
+  },
+  "python-2.7.14-h435b27a_18.tar.bz2": {
+    "build": "h435b27a_18",
+    "build_number": 18,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "011dffda6cc1478143ffc4b77d4868f1",
+    "name": "python",
+    "sha256": "a21d3eb8576a947b26ef5ef8bf06a36dbb2a3426d40c73d328ab3a425035d693",
+    "sig": null,
+    "size": 10627736,
+    "subdir": "linux-64",
+    "timestamp": 1507137677248,
+    "version": "2.7.14"
+  },
+  "python-2.7.14-h931c8b0_15.tar.bz2": {
+    "build": "h931c8b0_15",
+    "build_number": 15,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "6d557821483db1c89afb8a820590d3c1",
+    "name": "python",
+    "sha256": "de8200cbb06a12abd3d150a878496af850fd0be5a8d6023abc182e9f1a3fc180",
+    "sig": null,
+    "size": 10624976,
+    "subdir": "linux-64",
+    "timestamp": 1506702652145,
+    "version": "2.7.14"
+  },
+  "python-2.7.14-h9b67528_20.tar.bz2": {
+    "build": "h9b67528_20",
+    "build_number": 20,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng 7.2.0.*",
+      "libstdcxx-ng 7.2.0.*",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "3347eada8954bfd197a7a03e82af992d",
+    "name": "python",
+    "sha256": "e48ed3a2ad4a3a0075efad42a5ca969cc71690b00e4b7c978a7ca619a9f7a7e8",
+    "sig": null,
+    "size": 10634161,
+    "subdir": "linux-64",
+    "timestamp": 1507891744641,
+    "version": "2.7.14"
+  },
+  "python-2.7.14-hc2b0042_21.tar.bz2": {
+    "build": "hc2b0042_21",
+    "build_number": 21,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng 7.2.0.*",
+      "libstdcxx-ng 7.2.0.*",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "openssl >=1.0.2l,<1.0.3a",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "18482d250db258093e840b43fedfd4a8",
+    "name": "python",
+    "sha256": "e0563adc2d5d40459fddeec67a1241c3936b8f02b0e3dd4bcf8bf69beb0f79f7",
+    "sig": null,
+    "size": 10634233,
+    "subdir": "linux-64",
+    "timestamp": 1508175073462,
+    "version": "2.7.14"
+  },
+  "python-2.7.14-hf918d8d_16.tar.bz2": {
+    "build": "hf918d8d_16",
+    "build_number": 16,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "e79cc967d4063c9ec4f46d96f743318f",
+    "name": "python",
+    "sha256": "17d9f1c6d48d50070685124c5480ed44be6fe55133403be5cd0979bd5dc8c4fe",
+    "sig": null,
+    "size": 10627123,
+    "subdir": "linux-64",
+    "timestamp": 1506795597446,
+    "version": "2.7.14"
+  },
+  "python-3.5.4-h00c01ad_19.tar.bz2": {
+    "build": "h00c01ad_19",
+    "build_number": 19,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "53a4884fd90439fa14266a81b6645835",
+    "name": "python",
+    "sha256": "7d45705df80434961b795372553e9fef188a2f165fe1e3ac2701bfcdedd3708b",
+    "sig": null,
+    "size": 27542089,
+    "subdir": "linux-64",
+    "timestamp": 1507190766612,
+    "version": "3.5.4"
+  },
+  "python-3.5.4-h2170f06_12.tar.bz2": {
+    "build": "h2170f06_12",
+    "build_number": 12,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "07e1ba5942069197577566364a435753",
+    "name": "python",
+    "sha256": "7682d21ccaccb63b65b35b05ee35b30a3f24b6e5ee3bbfb9b869e9eabad89a12",
+    "sig": null,
+    "size": 26915319,
+    "subdir": "linux-64",
+    "timestamp": 1506043755839,
+    "version": "3.5.4"
+  },
+  "python-3.5.4-h3075507_18.tar.bz2": {
+    "build": "h3075507_18",
+    "build_number": 18,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "062343576084dfc16e697d0a139fb06a",
+    "name": "python",
+    "sha256": "a9552a7ddd67b2559a5cd3379e7489420ba615e214c7e47d47abe88882acfab8",
+    "sig": null,
+    "size": 27553509,
+    "subdir": "linux-64",
+    "timestamp": 1507151058414,
+    "version": "3.5.4"
+  },
+  "python-3.5.4-h72f0b78_15.tar.bz2": {
+    "build": "h72f0b78_15",
+    "build_number": 15,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "789359be3d2b615e62929137a741e060",
+    "name": "python",
+    "sha256": "20d48de209f6a47f5080ee4eea0acf5db5e8a0ccdbabb67012b5d072f61fb62c",
+    "sig": null,
+    "size": 27535098,
+    "subdir": "linux-64",
+    "timestamp": 1506797197209,
+    "version": "3.5.4"
+  },
+  "python-3.5.4-hc053d89_14.tar.bz2": {
+    "build": "hc053d89_14",
+    "build_number": 14,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "021cc5388c1fe7a4617e969d340530f3",
+    "name": "python",
+    "sha256": "85437808f9a7bee60b1f8b27abbf3e5a6fcf85b8c5f0f44ab8f8da07c93db87e",
+    "sig": null,
+    "size": 27536491,
+    "subdir": "linux-64",
+    "timestamp": 1506726125431,
+    "version": "3.5.4"
+  },
+  "python-3.5.4-he2c66cf_20.tar.bz2": {
+    "build": "he2c66cf_20",
+    "build_number": 20,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng 7.2.0.*",
+      "libstdcxx-ng 7.2.0.*",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "adb3583d64fc48abebc994bb39322a53",
+    "name": "python",
+    "sha256": "a324aa15f199f5a1eb86a4c426c47785a23e2eab3085afe347f38aa687f0abb1",
+    "sig": null,
+    "size": 27557362,
+    "subdir": "linux-64",
+    "timestamp": 1507894095668,
+    "version": "3.5.4"
+  },
+  "python-3.6.2-h02fb82a_12.tar.bz2": {
+    "build": "h02fb82a_12",
+    "build_number": 12,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "97669d1bb19358a35f18c9b134e572ff",
+    "name": "python",
+    "sha256": "5c8d5217088b833bd2e736f6a7b1823b6e388c208f88f5a40ae45a67bcdb2721",
+    "sig": null,
+    "size": 27680668,
+    "subdir": "linux-64",
+    "timestamp": 1506046126344,
+    "version": "3.6.2"
+  },
+  "python-3.6.2-h0b30769_14.tar.bz2": {
+    "build": "h0b30769_14",
+    "build_number": 14,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "e089cec7dab2bc33f6ceaddab10f5bfa",
+    "name": "python",
+    "sha256": "d0e5c2fb30cf7a13ea662fd69eb731e6ae26c9ccfa50ac08c6809d76baf8dfd8",
+    "sig": null,
+    "size": 28287085,
+    "subdir": "linux-64",
+    "timestamp": 1506708228841,
+    "version": "3.6.2"
+  },
+  "python-3.6.2-h33255ae_18.tar.bz2": {
+    "build": "h33255ae_18",
+    "build_number": 18,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "e31a6732fa4b226f145ebb68f25f0f9e",
+    "name": "python",
+    "sha256": "4fafe721641fc6427aa68b6925978aa59e66e27dbd9d3efbe862ac1c78b41e38",
+    "sig": null,
+    "size": 28292992,
+    "subdir": "linux-64",
+    "timestamp": 1507146137504,
+    "version": "3.6.2"
+  },
+  "python-3.6.2-hca45abc_19.tar.bz2": {
+    "build": "hca45abc_19",
+    "build_number": 19,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "bdc6db1adbe7268e3ecbae13ec02066f",
+    "name": "python",
+    "sha256": "0b77f7c1f88f9b9dff2d25ab2c65b76ea37eb2fbc3eeab59e74a47b7a61ab20c",
+    "sig": null,
+    "size": 28300090,
+    "subdir": "linux-64",
+    "timestamp": 1507190714034,
+    "version": "3.6.2"
+  },
+  "python-3.6.2-hda45abc_19.tar.bz2": {
+    "build": "hda45abc_19",
+    "build_number": 19,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "bdc6db1adbe7268e3ecbae13ec02066f",
+    "name": "python",
+    "sha256": "0b77f7c1f88f9b9dff2d25ab2c65b76ea37eb2fbc3eeab59e74a47b7a61ab20c",
+    "size": 28300090,
+    "subdir": "linux-64",
+    "timestamp": 1507190714033,
+    "version": "3.6.2"
+  },
+  "python-3.6.2-hdfe5801_15.tar.bz2": {
+    "build": "hdfe5801_15",
+    "build_number": 15,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "d2e3a115fa9d29f468cd6b0373e5a4a0",
+    "name": "python",
+    "sha256": "00c32bd99be0fa1bc66cfe8ba0df5a50390d085bf35001df647b439b8ec905c5",
+    "sig": null,
+    "size": 28300423,
+    "subdir": "linux-64",
+    "timestamp": 1506797324550,
+    "version": "3.6.2"
+  },
+  "python-3.6.3-hc9025b9_1.tar.bz2": {
+    "build": "hc9025b9_1",
+    "build_number": 1,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng 7.2.0.*",
+      "libstdcxx-ng 7.2.0.*",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "d51ec205d22100fe47c27354d4d0f7ed",
+    "name": "python",
+    "sha256": "6d1b80008eab9c57f3b1845dd3eb8690a4bca046d8fda92e0bef3694e0f44cfd",
+    "sig": null,
+    "size": 28330815,
+    "subdir": "linux-64",
+    "timestamp": 1507896496429,
+    "version": "3.6.3"
+  },
+  "python-3.6.3-hcad60d5_0.tar.bz2": {
+    "build": "hcad60d5_0",
+    "build_number": 0,
+    "depends": [
+      "libffi 3.2.*",
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "ncurses 6.0.*",
+      "openssl 1.0.*",
+      "readline 7.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "tk 8.6.*",
+      "xz >=5.2.3,<6.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "PSF",
+    "md5": "15871f24d85a686f139f8126d4933856",
+    "name": "python",
+    "sha256": "32e1141372bd7e8641ee7f46373b7c9e47e78881b4b345ce5a71c5270e0e006e",
+    "sig": null,
+    "size": 28333874,
+    "subdir": "linux-64",
+    "timestamp": 1507310424228,
+    "version": "3.6.3"
+  },
+  "python-dateutil-2.6.1-py27h4ca5741_1.tar.bz2": {
+    "build": "py27h4ca5741_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "six"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "dffa336c38a7f4fdb155a034af0cc35b",
+    "name": "python-dateutil",
+    "sha256": "fd33393f8f4bbd663d8a35911e9213aee5d4786c41b1934a9df5923c01e0840d",
+    "sig": null,
+    "size": 242225,
+    "subdir": "linux-64",
+    "timestamp": 1505688441572,
+    "version": "2.6.1"
+  },
+  "python-dateutil-2.6.1-py35h90d5b31_1.tar.bz2": {
+    "build": "py35h90d5b31_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "six"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "81bdd7c0d970ed09e9042e1caaade945",
+    "name": "python-dateutil",
+    "sha256": "82c0c77047b21728b8c2c2e768d198c4cd4b43d746eadc1df034721ee96cf50c",
+    "sig": null,
+    "size": 243871,
+    "subdir": "linux-64",
+    "timestamp": 1505688453376,
+    "version": "2.6.1"
+  },
+  "python-dateutil-2.6.1-py36h88d3b88_1.tar.bz2": {
+    "build": "py36h88d3b88_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "six"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "05517cfd206264a914e81ba0b6217dcc",
+    "name": "python-dateutil",
+    "sha256": "08a38372cfe0c6058d463383e26294d3704828054b9a279d6f7a2a6207580027",
+    "sig": null,
+    "size": 243124,
+    "subdir": "linux-64",
+    "timestamp": 1505688465343,
+    "version": "2.6.1"
+  },
+  "pytz-2017.2-py27hcac29fa_1.tar.bz2": {
+    "build": "py27hcac29fa_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "ee07558943a10d9954aa155db6872d90",
+    "name": "pytz",
+    "sha256": "a6c3b66a6a3f514976fa6865c4f1cba61f6f22738c8dca11c1cd13e80545ddd9",
+    "sig": null,
+    "size": 193078,
+    "subdir": "linux-64",
+    "timestamp": 1505691848966,
+    "version": "2017.2"
+  },
+  "pytz-2017.2-py35h9225bff_1.tar.bz2": {
+    "build": "py35h9225bff_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "0279282336bc6f0621d1f57253337a43",
+    "name": "pytz",
+    "sha256": "126dabb41548bb6539c28cf0f609b4514f176737d0435bfd61b355a0833ed001",
+    "sig": null,
+    "size": 193663,
+    "subdir": "linux-64",
+    "timestamp": 1505691865400,
+    "version": "2017.2"
+  },
+  "pytz-2017.2-py36hc2ccc2a_1.tar.bz2": {
+    "build": "py36hc2ccc2a_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "e4ead5c368a13c8d30f28d788e80931b",
+    "name": "pytz",
+    "sha256": "ff0e925ac25ace2a8db5ae394f49aaa89166f529bf16a6ccf42efbff8a576102",
+    "sig": null,
+    "size": 193789,
+    "subdir": "linux-64",
+    "timestamp": 1505691881888,
+    "version": "2017.2"
+  },
+  "pyyaml-3.12-py27h2d70dd7_1.tar.bz2": {
+    "build": "py27h2d70dd7_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0",
+      "yaml"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "66ec5fbf516d968c5e0f76faec4f0eb8",
+    "name": "pyyaml",
+    "sha256": "0508840eaf9d04500e8cd2f3ff22ca2e093f794ab300fa2a94c346c7903f1d9d",
+    "sig": null,
+    "size": 162823,
+    "subdir": "linux-64",
+    "timestamp": 1505739670245,
+    "version": "3.12"
+  },
+  "pyyaml-3.12-py35h46ef4ae_1.tar.bz2": {
+    "build": "py35h46ef4ae_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0",
+      "yaml"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "e5f83839b9a5737b44cd8cb6942b6946",
+    "name": "pyyaml",
+    "sha256": "e741b73cfd363cdebfa651cbd78ca695e74378cf959025312242632668606a42",
+    "sig": null,
+    "size": 163486,
+    "subdir": "linux-64",
+    "timestamp": 1505739698606,
+    "version": "3.12"
+  },
+  "pyyaml-3.12-py36hafb9ca4_1.tar.bz2": {
+    "build": "py36hafb9ca4_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0",
+      "yaml"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "6f69dc5210195644edb2c4a14a76fbd4",
+    "name": "pyyaml",
+    "sha256": "96d595bf39ba4b8f09fb598340b72ce8013e1a892818d47560138ab41142377d",
+    "sig": null,
+    "size": 162850,
+    "subdir": "linux-64",
+    "timestamp": 1505739726977,
+    "version": "3.12"
+  },
+  "pyzmq-16.0.2-py27h297844f_2.tar.bz2": {
+    "build": "py27h297844f_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libsodium",
+      "python >=2.7,<2.8.0a0",
+      "zeromq 4.2*"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "d6fbaad12dc80b18c643b6a1e901a84e",
+    "name": "pyzmq",
+    "sha256": "5f442698331af17b82edd5b7f1d4c0b23bc7b50a2d1a00f9506c4c26a30d2a79",
+    "sig": null,
+    "size": 411991,
+    "subdir": "linux-64",
+    "timestamp": 1505688320277,
+    "version": "16.0.2"
+  },
+  "pyzmq-16.0.2-py35h4be1f71_2.tar.bz2": {
+    "build": "py35h4be1f71_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libsodium",
+      "python >=3.5,<3.6.0a0",
+      "zeromq 4.2*"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "b6613ac502b47eab75f4c154a120d0de",
+    "name": "pyzmq",
+    "sha256": "d1d01bff98de35f31821adcc5425d156e4ab008c9edf18b314df2e2aa081bcc9",
+    "sig": null,
+    "size": 429086,
+    "subdir": "linux-64",
+    "timestamp": 1505688373594,
+    "version": "16.0.2"
+  },
+  "pyzmq-16.0.2-py36h3b0cf96_2.tar.bz2": {
+    "build": "py36h3b0cf96_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libsodium",
+      "python >=3.6,<3.7.0a0",
+      "zeromq 4.2*"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "b789d078314a001a0426ca9c0fb31dd8",
+    "name": "pyzmq",
+    "sha256": "31c10651c54a2ad3f6240ce7516787003a836243312306d9076b6d0cf7f74f64",
+    "sig": null,
+    "size": 428901,
+    "subdir": "linux-64",
+    "timestamp": 1505688421122,
+    "version": "16.0.2"
+  },
+  "qt-5.6.2-h974d657_12.tar.bz2": {
+    "build": "h974d657_12",
+    "build_number": 12,
+    "depends": [
+      "dbus >=1.10.22,<2.0a0",
+      "fontconfig >=2.12.4,<3.0a0",
+      "freetype >=2.8,<2.9.0a0",
+      "gst-plugins-base >=1.12.2,<1.13.0a0",
+      "icu >=58.2,<59.0a0",
+      "jpeg >=9b,<10a",
+      "libpng >=1.6.32,<1.7.0a0",
+      "libstdcxx-ng >=7.2.0",
+      "libxcb",
+      "openssl 1.0.*",
+      "sqlite >=3.20.1,<4.0a0",
+      "zlib >=1.2.11,<1.3.0a0"
+    ],
+    "license": "LGPL-3.0",
+    "md5": "9e6b736886eedcdd0afab64ee143df7f",
+    "name": "qt",
+    "sha256": "806abf0be8e60b79203c43b39533dfedfcc98dc24e13c8407da7d6a9387b6f92",
+    "sig": null,
+    "size": 46627735,
+    "subdir": "linux-64",
+    "timestamp": 1505737498619,
+    "version": "5.6.2"
+  },
+  "readline-7.0-hac23ff0_3.tar.bz2": {
+    "build": "hac23ff0_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "ncurses 6.0*"
+    ],
+    "license": "GPL3",
+    "md5": "88d1133eeb5d34b66cb16af373db0c46",
+    "name": "readline",
+    "sha256": "bd6716701b6ef1f642851a19fee59494bcf831a3074d3b1d44f987f82a1e866e",
+    "sig": null,
+    "size": 396360,
+    "subdir": "linux-64",
+    "timestamp": 1505667005716,
+    "version": "7.0"
+  },
+  "requests-2.18.4-py27hc5b0589_1.tar.bz2": {
+    "build": "py27hc5b0589_1",
+    "build_number": 1,
+    "depends": [
+      "certifi >=2017.4.17",
+      "chardet >=3.0.2,<3.1.0",
+      "idna >=2.5,<2.7",
+      "python >=2.7,<2.8.0a0",
+      "urllib3 >=1.21.1,<1.23"
+    ],
+    "license": "Apache 2.0",
+    "md5": "b2279ec7ac6e94f815eaf3bb60b8b379",
+    "name": "requests",
+    "sha256": "c8cb9d49200691b5ef34c7bad57f19c34e8af0ee145a2ad4aa65b001db8c122d",
+    "sig": null,
+    "size": 92618,
+    "subdir": "linux-64",
+    "timestamp": 1505693067766,
+    "version": "2.18.4"
+  },
+  "requests-2.18.4-py35hb9e6ad1_1.tar.bz2": {
+    "build": "py35hb9e6ad1_1",
+    "build_number": 1,
+    "depends": [
+      "certifi >=2017.4.17",
+      "chardet >=3.0.2,<3.1.0",
+      "idna >=2.5,<2.7",
+      "python >=3.5,<3.6.0a0",
+      "urllib3 >=1.21.1,<1.23"
+    ],
+    "license": "Apache 2.0",
+    "md5": "7ff98859eaaacae3eeced892fe4e1231",
+    "name": "requests",
+    "sha256": "9d4c7c0b87bf37893576b9ab21501bed38cd5123c9d0b2d0453cc128ea201edf",
+    "sig": null,
+    "size": 94283,
+    "subdir": "linux-64",
+    "timestamp": 1505693080499,
+    "version": "2.18.4"
+  },
+  "requests-2.18.4-py36he2e5f8d_1.tar.bz2": {
+    "build": "py36he2e5f8d_1",
+    "build_number": 1,
+    "depends": [
+      "certifi >=2017.4.17",
+      "chardet >=3.0.2,<3.1.0",
+      "idna >=2.5,<2.7",
+      "python >=3.6,<3.7.0a0",
+      "urllib3 >=1.21.1,<1.23"
+    ],
+    "license": "Apache 2.0",
+    "md5": "d62b0993421d3d9c54d6c1a737714662",
+    "name": "requests",
+    "sha256": "516770cdf8406255bcfe20b0cc5f934c6bafad950159c0b576f158b0e09cee70",
+    "sig": null,
+    "size": 93909,
+    "subdir": "linux-64",
+    "timestamp": 1505693093401,
+    "version": "2.18.4"
+  },
+  "ruamel_yaml-0.11.14-py27h672d447_2.tar.bz2": {
+    "build": "py27h672d447_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0",
+      "yaml"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "a9f09b1c2dc85bd87477b260c985813a",
+    "name": "ruamel_yaml",
+    "sha256": "65d223305731a6952727000b5d62f739c5cf972fa1fa18a7f50c2fb3ae778db5",
+    "sig": null,
+    "size": 209704,
+    "subdir": "linux-64",
+    "timestamp": 1505693600028,
+    "version": "0.11.14"
+  },
+  "ruamel_yaml-0.11.14-py35h8e2c16b_2.tar.bz2": {
+    "build": "py35h8e2c16b_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0",
+      "yaml"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "8d2826b8d293ad6a30525d34ef3bcfd0",
+    "name": "ruamel_yaml",
+    "sha256": "f7dc1d39d3c87e8fb40bf90bbc892149aea78d7c40999d0bdd35bcdba0552c7c",
+    "sig": null,
+    "size": 212023,
+    "subdir": "linux-64",
+    "timestamp": 1505693623828,
+    "version": "0.11.14"
+  },
+  "ruamel_yaml-0.11.14-py36ha2fb22d_2.tar.bz2": {
+    "build": "py36ha2fb22d_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0",
+      "yaml"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "2d156ceeeb4ecad376782357ff8e5795",
+    "name": "ruamel_yaml",
+    "sha256": "ef0f5f1465fc529200d1ff82da756fffb526c2ead3aee83b11d5d3d7a0f918ef",
+    "sig": null,
+    "size": 214897,
+    "subdir": "linux-64",
+    "timestamp": 1505693648310,
+    "version": "0.11.14"
+  },
+  "s3transfer-0.1.10-py27h9fb3302_1.tar.bz2": {
+    "build": "py27h9fb3302_1",
+    "build_number": 1,
+    "depends": [
+      "botocore >=1.3.0,<2.0.0",
+      "futures >=2.2.0,<4.0.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "a13e6b9f6f20e4f3e192cc39c5b1de45",
+    "name": "s3transfer",
+    "sha256": "ebafdf085afa0bcce73c1e50199c011a9a73640aa32350c7a5bceacabe0b3e13",
+    "sig": null,
+    "size": 70050,
+    "subdir": "linux-64",
+    "timestamp": 1505741285250,
+    "version": "0.1.10"
+  },
+  "s3transfer-0.1.10-py35h0bc0b65_1.tar.bz2": {
+    "build": "py35h0bc0b65_1",
+    "build_number": 1,
+    "depends": [
+      "botocore >=1.3.0,<2.0.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "b88f9479cd5c686038110689f54d8104",
+    "name": "s3transfer",
+    "sha256": "cad0510020bf0014d129dba8f50b97ccd3b8e00fb896e987c30ca98650af80e6",
+    "sig": null,
+    "size": 72310,
+    "subdir": "linux-64",
+    "timestamp": 1505741298472,
+    "version": "0.1.10"
+  },
+  "s3transfer-0.1.10-py36h0257dcc_1.tar.bz2": {
+    "build": "py36h0257dcc_1",
+    "build_number": 1,
+    "depends": [
+      "botocore >=1.3.0,<2.0.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "d9179587ba9d0bd549c1542ffa53c1dd",
+    "name": "s3transfer",
+    "sha256": "16f56e0e2f5020688823164b21f3b62a0a8ce7a9f41d674fd715a25854fd21a7",
+    "sig": null,
+    "size": 72197,
+    "subdir": "linux-64",
+    "timestamp": 1505741311941,
+    "version": "0.1.10"
+  },
+  "scandir-1.5-py27h1c9e1f8_1.tar.bz2": {
+    "build": "py27h1c9e1f8_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "4b976667dd52c1bc62815960187a0d49",
+    "name": "scandir",
+    "sha256": "2a617ea2a5a187a7b15c47247bdb8b10ac340e77c49dfafe4615faaf2ea14ae0",
+    "sig": null,
+    "size": 26756,
+    "subdir": "linux-64",
+    "timestamp": 1505863926960,
+    "version": "1.5"
+  },
+  "scandir-1.6-py27hf7388dc_0.tar.bz2": {
+    "build": "py27hf7388dc_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "684db0f18843b16dfd6ec7de58b43955",
+    "name": "scandir",
+    "sha256": "2d939edde6c7ae665cfd594fb09a4923119b381013114f54f37c50fb5819d266",
+    "sig": null,
+    "size": 27689,
+    "subdir": "linux-64",
+    "timestamp": 1507669492470,
+    "version": "1.6"
+  },
+  "scipy-0.19.1-py27h1edc525_3.tar.bz2": {
+    "build": "py27h1edc525_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "numpy >=1.9.3,<2.0a0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "d3f31e79b1321185ba1bb5d83557e37c",
+    "name": "scipy",
+    "sha256": "e579faffb446b1ab3a5805f6b737f88b531e01f5b390073760d4195c7c9d3f63",
+    "sig": null,
+    "size": 18329324,
+    "subdir": "linux-64",
+    "timestamp": 1506017697639,
+    "version": "0.19.1"
+  },
+  "scipy-0.19.1-py35ha8f041b_3.tar.bz2": {
+    "build": "py35ha8f041b_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "numpy >=1.9.3,<2.0a0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "10d0efcc88413dff9c34265333c2c75d",
+    "name": "scipy",
+    "sha256": "2f128f4d591842cd7a67fb5f0540420d55facf4dac5ae7f988bd5867678e1e35",
+    "sig": null,
+    "size": 18232423,
+    "subdir": "linux-64",
+    "timestamp": 1506017721703,
+    "version": "0.19.1"
+  },
+  "scipy-0.19.1-py36h9976243_3.tar.bz2": {
+    "build": "py36h9976243_3",
+    "build_number": 3,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libgfortran-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "mkl >=2018.0.0",
+      "numpy >=1.9.3,<2.0a0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "3e45e6875aa59fd005c97718bb8a7df4",
+    "name": "scipy",
+    "sha256": "7148feab1239d8157dda2be87ec0b97cea77fe8ae029c4bccb2d4c4e3bcc0d8c",
+    "sig": null,
+    "size": 18263885,
+    "subdir": "linux-64",
+    "timestamp": 1506017647024,
+    "version": "0.19.1"
+  },
+  "setuptools-36.5.0-py27h68b189e_0.tar.bz2": {
+    "build": "py27h68b189e_0",
+    "build_number": 0,
+    "depends": [
+      "certifi",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "b8e6e0cb961d12ecb2fe73056566d350",
+    "name": "setuptools",
+    "sha256": "d7c40b897ad7d35b915c306501ebbcaa9468910717959cb8d37487e31cbd0b93",
+    "sig": null,
+    "size": 514809,
+    "subdir": "linux-64",
+    "timestamp": 1505957364946,
+    "version": "36.5.0"
+  },
+  "setuptools-36.5.0-py35ha8c1747_0.tar.bz2": {
+    "build": "py35ha8c1747_0",
+    "build_number": 0,
+    "depends": [
+      "certifi",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "94967e9ab358d5a09691d0af1cded648",
+    "name": "setuptools",
+    "sha256": "b3d97b25fbaec03fd5d711df8e8f3f8e98b9ab2c1238f81510eacd85f6adcce9",
+    "sig": null,
+    "size": 524150,
+    "subdir": "linux-64",
+    "timestamp": 1505957384298,
+    "version": "36.5.0"
+  },
+  "setuptools-36.5.0-py36he42e2e1_0.tar.bz2": {
+    "build": "py36he42e2e1_0",
+    "build_number": 0,
+    "depends": [
+      "certifi",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "cb1383539629db998105faf7e91e2bc7",
+    "name": "setuptools",
+    "sha256": "e7778f99150e41fc7cdc8154965202dc8777c79da7ae974f98a39591c27245e5",
+    "sig": null,
+    "size": 523981,
+    "subdir": "linux-64",
+    "timestamp": 1505957403818,
+    "version": "36.5.0"
+  },
+  "simplegeneric-0.8.1-py27h19e43cd_0.tar.bz2": {
+    "build": "py27h19e43cd_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "Zope Public",
+    "md5": "4f505870aeb3518dd671642a4525feb6",
+    "name": "simplegeneric",
+    "sha256": "87f69f14652e21b736b8f38c2bcb61fae9628d0ccf1f942c697eff64a3a8e435",
+    "sig": null,
+    "size": 9010,
+    "subdir": "linux-64",
+    "timestamp": 1505690370417,
+    "version": "0.8.1"
+  },
+  "simplegeneric-0.8.1-py35h2ec4104_0.tar.bz2": {
+    "build": "py35h2ec4104_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "Zope Public",
+    "md5": "6d283aca6f374bbca96fdf484b76450f",
+    "name": "simplegeneric",
+    "sha256": "bafc9164f0d927060b112d15bfa766c00b7ace7860dc0e49e0d1caa821b7ffe6",
+    "sig": null,
+    "size": 9121,
+    "subdir": "linux-64",
+    "timestamp": 1505690381203,
+    "version": "0.8.1"
+  },
+  "simplegeneric-0.8.1-py36h2cb9092_0.tar.bz2": {
+    "build": "py36h2cb9092_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "Zope Public",
+    "md5": "01147009181acc53bec05e8318ad3d80",
+    "name": "simplegeneric",
+    "sha256": "932eb6384cbed56018f7909b08ddf1be4c036d76c16c438fd48aadb2e9050b59",
+    "sig": null,
+    "size": 9113,
+    "subdir": "linux-64",
+    "timestamp": 1505690392176,
+    "version": "0.8.1"
+  },
+  "singledispatch-3.4.0.3-py27h9bcb476_0.tar.bz2": {
+    "build": "py27h9bcb476_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "six"
+    ],
+    "license": "MIT",
+    "md5": "5901a4ded6ec5dd06e12d75dc1e0f29a",
+    "name": "singledispatch",
+    "sha256": "8498c3a15303efd17a25a48e6936d588467d567ec699d4fa47badec56bda226d",
+    "sig": null,
+    "size": 15198,
+    "subdir": "linux-64",
+    "timestamp": 1505690466797,
+    "version": "3.4.0.3"
+  },
+  "singledispatch-3.4.0.3-py35h0cd4ec3_0.tar.bz2": {
+    "build": "py35h0cd4ec3_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "six"
+    ],
+    "license": "MIT",
+    "md5": "b761d6638d6c9469c620924560292b84",
+    "name": "singledispatch",
+    "sha256": "9e3d00174249e5eee547cc3c4eb44adc13e28e70f824fe402a2f07ac4d99b82d",
+    "sig": null,
+    "size": 15565,
+    "subdir": "linux-64",
+    "timestamp": 1505690477844,
+    "version": "3.4.0.3"
+  },
+  "singledispatch-3.4.0.3-py36h7a266c3_0.tar.bz2": {
+    "build": "py36h7a266c3_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "six"
+    ],
+    "license": "MIT",
+    "md5": "956a431e5c0ed6d15073da672c0a12a6",
+    "name": "singledispatch",
+    "sha256": "551c7bddd69170e97dbd9db86afc97b35b085449f08e591128ec8bf3cae98121",
+    "sig": null,
+    "size": 15540,
+    "subdir": "linux-64",
+    "timestamp": 1505690488981,
+    "version": "3.4.0.3"
+  },
+  "sip-4.18.1-py27he9ba0ab_2.tar.bz2": {
+    "build": "py27he9ba0ab_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "GPL-3.0",
+    "md5": "3bcf12c6ff40ba7f4b52ca759598a1f0",
+    "name": "sip",
+    "sha256": "6e16a06d35384882125e14a2a65b0cbe15bbbb9fcafbe028255d3a4fe5ccbfc7",
+    "sig": null,
+    "size": 285168,
+    "subdir": "linux-64",
+    "timestamp": 1505733898462,
+    "version": "4.18.1"
+  },
+  "sip-4.18.1-py35h9eaea60_2.tar.bz2": {
+    "build": "py35h9eaea60_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "GPL-3.0",
+    "md5": "c9ada20f87ab79f0c8f8134048f345aa",
+    "name": "sip",
+    "sha256": "d3f9cb0203c9db9a3734116b6e2bc64f9057efc2b323560a424325966e87d796",
+    "sig": null,
+    "size": 284431,
+    "subdir": "linux-64",
+    "timestamp": 1505733924941,
+    "version": "4.18.1"
+  },
+  "sip-4.18.1-py36h51ed4ed_2.tar.bz2": {
+    "build": "py36h51ed4ed_2",
+    "build_number": 2,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libstdcxx-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "GPL-3.0",
+    "md5": "1905b17664e34a057132c9a0d8e1a1bb",
+    "name": "sip",
+    "sha256": "ae03cefc5468982f270fe2edc2fdb371589d296f788bda0352eaa5e38fd40898",
+    "sig": null,
+    "size": 283858,
+    "subdir": "linux-64",
+    "timestamp": 1505733951555,
+    "version": "4.18.1"
+  },
+  "six-1.10.0-py27hdcd7534_1.tar.bz2": {
+    "build": "py27hdcd7534_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "09599a7e8d2f6642e220926853479037",
+    "name": "six",
+    "sha256": "86d53c5d34d5088520bf3188873ee8cd94c05dbb384ffa2395ed6a571a68d336",
+    "sig": null,
+    "size": 20568,
+    "subdir": "linux-64",
+    "timestamp": 1505672067944,
+    "version": "1.10.0"
+  },
+  "six-1.10.0-py35h5312c1b_1.tar.bz2": {
+    "build": "py35h5312c1b_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "6092132bf652e4ed46e81d68b9ef8581",
+    "name": "six",
+    "sha256": "e54a871939cf9f54a495340c55223551b8a440e679449939b2252c98d9954480",
+    "sig": null,
+    "size": 20981,
+    "subdir": "linux-64",
+    "timestamp": 1505672078657,
+    "version": "1.10.0"
+  },
+  "six-1.10.0-py36hcac75e4_1.tar.bz2": {
+    "build": "py36hcac75e4_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "816dd34bf45fe338b86fd3c79add7a86",
+    "name": "six",
+    "sha256": "ffb70e93db8c69a63c6cc53abcbeb9af41fa811da4aeced91b7d5f7e043cd6c1",
+    "sig": null,
+    "size": 20918,
+    "subdir": "linux-64",
+    "timestamp": 1505672089464,
+    "version": "1.10.0"
+  },
+  "sortedcollections-0.5.3-py27h135218e_0.tar.bz2": {
+    "build": "py27h135218e_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "sortedcontainers"
+    ],
+    "license": "Apache-2.0",
+    "license_family": "Apache",
+    "md5": "2005a29d78eb57962fb19e7065b2218c",
+    "name": "sortedcollections",
+    "sha256": "acc5d1c1d0db0c9f2234f98e1be9e8bdafea24b93f43d4f6320e74cedbb8c1d5",
+    "sig": null,
+    "size": 14021,
+    "subdir": "linux-64",
+    "timestamp": 1505755963383,
+    "version": "0.5.3"
+  },
+  "sortedcollections-0.5.3-py35hb2f60ff_0.tar.bz2": {
+    "build": "py35hb2f60ff_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "sortedcontainers"
+    ],
+    "license": "Apache-2.0",
+    "license_family": "Apache",
+    "md5": "df886c18a5ff2c3e97e68c64b122099c",
+    "name": "sortedcollections",
+    "sha256": "5fba4615a2b425484d94aee2613fcec394bf49e8cd4cf6fdad470ee88356f26e",
+    "sig": null,
+    "size": 14601,
+    "subdir": "linux-64",
+    "timestamp": 1505755976982,
+    "version": "0.5.3"
+  },
+  "sortedcollections-0.5.3-py36h3c761f9_0.tar.bz2": {
+    "build": "py36h3c761f9_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "sortedcontainers"
+    ],
+    "license": "Apache-2.0",
+    "license_family": "Apache",
+    "md5": "d40c6d63f06f90fa8844945602c7e67d",
+    "name": "sortedcollections",
+    "sha256": "15ea616eff61cb13c0f5eb1a5f84bf9e2b7597e48dbd01ba26380116361ad6d9",
+    "sig": null,
+    "size": 14632,
+    "subdir": "linux-64",
+    "timestamp": 1505755990462,
+    "version": "0.5.3"
+  },
+  "sortedcontainers-1.5.7-py27he59936f_0.tar.bz2": {
+    "build": "py27he59936f_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "Apache 2.0",
+    "md5": "34a48933e7d6b7e6e9b6192d270f5fbe",
+    "name": "sortedcontainers",
+    "sha256": "e0a378a186d0e977147e8d1c9e790229d78a3e14e84e8a957cd67889b718f68d",
+    "sig": null,
+    "size": 45665,
+    "subdir": "linux-64",
+    "timestamp": 1505863970372,
+    "version": "1.5.7"
+  },
+  "sortedcontainers-1.5.7-py35h683703c_0.tar.bz2": {
+    "build": "py35h683703c_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "Apache 2.0",
+    "md5": "b171531b0a75cd619c6ea01d99c1e3d5",
+    "name": "sortedcontainers",
+    "sha256": "05f30315420ac3e7eba572a5e331db919130579207af6f5a2f895ef7e4399ef1",
+    "sig": null,
+    "size": 46792,
+    "subdir": "linux-64",
+    "timestamp": 1505863982813,
+    "version": "1.5.7"
+  },
+  "sortedcontainers-1.5.7-py36hdf89491_0.tar.bz2": {
+    "build": "py36hdf89491_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "Apache 2.0",
+    "md5": "0c84dc5927bcd5cdd31a18365af050aa",
+    "name": "sortedcontainers",
+    "sha256": "9cf8e8c82b8ee19f22955a0bff3e4bd7c3558731c1293344834094d14dd60ec0",
+    "sig": null,
+    "size": 46573,
+    "subdir": "linux-64",
+    "timestamp": 1505863995502,
+    "version": "1.5.7"
+  },
+  "sqlite-3.20.1-h6d8b0f3_1.tar.bz2": {
+    "build": "h6d8b0f3_1",
+    "build_number": 1,
+    "depends": [
+      "libedit",
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "Public-Domain (http://www.sqlite.org/copyright.html)",
+    "md5": "58093fcadd677bc3ed98ddd4a2f7d286",
+    "name": "sqlite",
+    "sha256": "24a3c773abd915d2f13da177a29e264e59a0ae3c6fd2a31267dcc6a8ef9c0a1c",
+    "sig": null,
+    "size": 1540584,
+    "subdir": "linux-64",
+    "timestamp": 1505666546842,
+    "version": "3.20.1"
+  },
+  "ssl_match_hostname-3.5.0.1-py27h4ec10b9_2.tar.bz2": {
+    "build": "py27h4ec10b9_2",
+    "build_number": 2,
+    "depends": [
+      "backports",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "PSF 2",
+    "md5": "aeadae260a04acfbf00eadecd14bf92d",
+    "name": "ssl_match_hostname",
+    "sha256": "2f3d0d9d715c4f3977fcf25900bf470bd39600c6945b3ddf16e0c45c8785c418",
+    "sig": null,
+    "size": 9482,
+    "subdir": "linux-64",
+    "timestamp": 1505690500163,
+    "version": "3.5.0.1"
+  },
+  "subprocess32-3.2.7-py27h373dbce_0.tar.bz2": {
+    "build": "py27h373dbce_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "PSF 2",
+    "md5": "432f053d228c4c18a2bdc5d9e69cad89",
+    "name": "subprocess32",
+    "sha256": "86f60810840ea2fc1c1174a3545b9e33d9cce8a65c745bea2ca9bcc04a8f7feb",
+    "sig": null,
+    "size": 40525,
+    "subdir": "linux-64",
+    "timestamp": 1505739293719,
+    "version": "3.2.7"
+  },
+  "tblib-1.3.2-py27h51fe5ba_0.tar.bz2": {
+    "build": "py27h51fe5ba_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "license_family": "BSD",
+    "md5": "b46c4864741594cf5c8090c467d1ef22",
+    "name": "tblib",
+    "sha256": "ec052f894962cb7a018ced352b3ed9cd6a98e1c682b770f0e06a0ed5a00d6dd3",
+    "sig": null,
+    "size": 15800,
+    "subdir": "linux-64",
+    "timestamp": 1505733062312,
+    "version": "1.3.2"
+  },
+  "tblib-1.3.2-py35hf1eb0b4_0.tar.bz2": {
+    "build": "py35hf1eb0b4_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "license_family": "BSD",
+    "md5": "7425fb2c1c5957ca77a5647a6ad3d024",
+    "name": "tblib",
+    "sha256": "fc7fb9192f663091c790002a9b2f0d178d0bd10d0b6af69eec09c7e9ce1b857e",
+    "sig": null,
+    "size": 16149,
+    "subdir": "linux-64",
+    "timestamp": 1505733073838,
+    "version": "1.3.2"
+  },
+  "tblib-1.3.2-py36h34cf8b6_0.tar.bz2": {
+    "build": "py36h34cf8b6_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "license_family": "BSD",
+    "md5": "4a34b983e438ddd89452dafddbfe1b1f",
+    "name": "tblib",
+    "sha256": "6bd82c9a0fdb7fb71fd8abbddb5401cb277841439049591b136b546428b145f3",
+    "sig": null,
+    "size": 16088,
+    "subdir": "linux-64",
+    "timestamp": 1505733085518,
+    "version": "1.3.2"
+  },
+  "tk-8.6.7-h5979e9b_1.tar.bz2": {
+    "build": "h5979e9b_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "Tcl/Tk",
+    "license_family": "BSD",
+    "md5": "5dae7bc95818ef72988000d4db972a62",
+    "name": "tk",
+    "sha256": "ddc0a581a762816750c3e18da0dbd60c1f36ddd6d6e4501b29721e147322f651",
+    "sig": null,
+    "size": 3310231,
+    "subdir": "linux-64",
+    "timestamp": 1505666716948,
+    "version": "8.6.7"
+  },
+  "toolz-0.8.2-py27hd3b1e7e_0.tar.bz2": {
+    "build": "py27hd3b1e7e_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "e0bb9126b3f0ac12821a7e0dc477c694",
+    "name": "toolz",
+    "sha256": "5fccd36fc4d0e0ed21f9177e8c26118bfc908621ad46c6ef9dc9bd3256b3240d",
+    "sig": null,
+    "size": 91707,
+    "subdir": "linux-64",
+    "timestamp": 1505732776961,
+    "version": "0.8.2"
+  },
+  "toolz-0.8.2-py35h90f1797_0.tar.bz2": {
+    "build": "py35h90f1797_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "a0c6de37e4fe0b3fe3e4c6f90dec818f",
+    "name": "toolz",
+    "sha256": "ec27ba5d45f23e6866cce7dc69e519159c2b781905995dff80e0eafcb3e4d0ce",
+    "sig": null,
+    "size": 94142,
+    "subdir": "linux-64",
+    "timestamp": 1505732789990,
+    "version": "0.8.2"
+  },
+  "toolz-0.8.2-py36h81f2dff_0.tar.bz2": {
+    "build": "py36h81f2dff_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "fde5b9e09e09267bca060ebffd0fbf23",
+    "name": "toolz",
+    "sha256": "a4c9b62c0a676ed385153d92f829c88a58c09c4a669b59ca5852b265605d57dc",
+    "sig": null,
+    "size": 93063,
+    "subdir": "linux-64",
+    "timestamp": 1505732803222,
+    "version": "0.8.2"
+  },
+  "tornado-4.5.2-py27h97b179f_0.tar.bz2": {
+    "build": "py27h97b179f_0",
+    "build_number": 0,
+    "depends": [
+      "backports_abc >=0.4",
+      "certifi",
+      "python >=2.7,<2.8.0a0",
+      "singledispatch",
+      "ssl_match_hostname"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "1e0ba3172d35b24adb8983ad6c241e2c",
+    "name": "tornado",
+    "sha256": "da530e5ad1fd6897d2972e6161d94e4deb2bd25e6ff3baae317c740a681f428a",
+    "sig": null,
+    "size": 607772,
+    "subdir": "linux-64",
+    "timestamp": 1505690514746,
+    "version": "4.5.2"
+  },
+  "tornado-4.5.2-py35hf879e1d_0.tar.bz2": {
+    "build": "py35hf879e1d_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "983dc1a7a6677ea495b9aa40a6ee63cf",
+    "name": "tornado",
+    "sha256": "dad06ecc037215f2e4df0ccfd4c32376b55dfbfe13bd79ff647e018cfe608b44",
+    "sig": null,
+    "size": 636184,
+    "subdir": "linux-64",
+    "timestamp": 1505690531884,
+    "version": "4.5.2"
+  },
+  "tornado-4.5.2-py36h1283b2a_0.tar.bz2": {
+    "build": "py36h1283b2a_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "Apache 2.0",
+    "license_family": "Apache",
+    "md5": "6e44c56eee49ff16e15806b9b4391381",
+    "name": "tornado",
+    "sha256": "3f065f02e3d4c8966741b01daf129a6c15e3f65e6c190b51abaa63da9758a234",
+    "sig": null,
+    "size": 631059,
+    "subdir": "linux-64",
+    "timestamp": 1505690549225,
+    "version": "4.5.2"
+  },
+  "traitlets-4.3.2-py27hd6ce930_0.tar.bz2": {
+    "build": "py27hd6ce930_0",
+    "build_number": 0,
+    "depends": [
+      "decorator",
+      "enum34",
+      "ipython_genutils",
+      "python >=2.7,<2.8.0a0",
+      "six"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "608b5d2a4eaf7d6914a968e43559a697",
+    "name": "traitlets",
+    "sha256": "21faba82272207f6f55e39cf226933c63721a01bbdd1473c99fdf31a8ac77cfa",
+    "sig": null,
+    "size": 128824,
+    "subdir": "linux-64",
+    "timestamp": 1505672115044,
+    "version": "4.3.2"
+  },
+  "traitlets-4.3.2-py35ha522a97_0.tar.bz2": {
+    "build": "py35ha522a97_0",
+    "build_number": 0,
+    "depends": [
+      "decorator",
+      "ipython_genutils",
+      "python >=3.5,<3.6.0a0",
+      "six"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "7d40fb1b8ccb9db0766aac3ec466673a",
+    "name": "traitlets",
+    "sha256": "382402e4d7e1c268f616071978e5993f71066bc195063b1b958b75d525debca8",
+    "sig": null,
+    "size": 134648,
+    "subdir": "linux-64",
+    "timestamp": 1505672128737,
+    "version": "4.3.2"
+  },
+  "traitlets-4.3.2-py36h674d592_0.tar.bz2": {
+    "build": "py36h674d592_0",
+    "build_number": 0,
+    "depends": [
+      "decorator",
+      "ipython_genutils",
+      "python >=3.6,<3.7.0a0",
+      "six"
+    ],
+    "license": "BSD 3-clause",
+    "md5": "162155efee546ec07a9b10acaefb8b90",
+    "name": "traitlets",
+    "sha256": "a4c619d68abafa03df3f12d4b050fe72578dd5ead84577bb9f10165b014b2e22",
+    "sig": null,
+    "size": 134101,
+    "subdir": "linux-64",
+    "timestamp": 1505672142545,
+    "version": "4.3.2"
+  },
+  "urllib3-1.22-py27ha55213b_0.tar.bz2": {
+    "build": "py27ha55213b_0",
+    "build_number": 0,
+    "depends": [
+      "certifi",
+      "cryptography >=1.3.4",
+      "idna >=2.0.0",
+      "ipaddress",
+      "pyopenssl >=0.14",
+      "pysocks >=1.5.6,<2.0,!=1.5.7",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "9b27cc242c7cf45110067a2a494da4cb",
+    "name": "urllib3",
+    "sha256": "d5fdbf5c653ee9e5fcf16cb45fc5c588561149a6141109d1216416291a96b309",
+    "sig": null,
+    "size": 156311,
+    "subdir": "linux-64",
+    "timestamp": 1505693026646,
+    "version": "1.22"
+  },
+  "urllib3-1.22-py35h2ab6e29_0.tar.bz2": {
+    "build": "py35h2ab6e29_0",
+    "build_number": 0,
+    "depends": [
+      "certifi",
+      "cryptography >=1.3.4",
+      "idna >=2.0.0",
+      "pyopenssl >=0.14",
+      "pysocks >=1.5.6,<2.0,!=1.5.7",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "2da7d6a3bb4d7840c13625e90a3bf5a4",
+    "name": "urllib3",
+    "sha256": "cffb1e90f6da408c6b9c7cf819ae04a9a955699c5c484dd2ad9331b846f0b53d",
+    "sig": null,
+    "size": 158739,
+    "subdir": "linux-64",
+    "timestamp": 1505693040638,
+    "version": "1.22"
+  },
+  "urllib3-1.22-py36hbe7ace6_0.tar.bz2": {
+    "build": "py36hbe7ace6_0",
+    "build_number": 0,
+    "depends": [
+      "certifi",
+      "cryptography >=1.3.4",
+      "idna >=2.0.0",
+      "pyopenssl >=0.14",
+      "pysocks >=1.5.6,<2.0,!=1.5.7",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "license_family": "MIT",
+    "md5": "eb8e6b582465154dcd1904cb8f524f02",
+    "name": "urllib3",
+    "sha256": "8c44fd45f14486364e15126c53a95f75189b8e274d3e1fb23cf9559bb1c7de83",
+    "sig": null,
+    "size": 158237,
+    "subdir": "linux-64",
+    "timestamp": 1505693054673,
+    "version": "1.22"
+  },
+  "wcwidth-0.1.7-py27h9e3e1ab_0.tar.bz2": {
+    "build": "py27h9e3e1ab_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "MIT",
+    "md5": "a5ae2d8d2a4d7ac88bbde95f4501b01e",
+    "name": "wcwidth",
+    "sha256": "9082ce2419c3a1ae9ee103e33b4d6906b0ff55b75d7eca68cc6c9b934b8697e1",
+    "sig": null,
+    "size": 25283,
+    "subdir": "linux-64",
+    "timestamp": 1505864079686,
+    "version": "0.1.7"
+  },
+  "wcwidth-0.1.7-py35hcd08066_0.tar.bz2": {
+    "build": "py35hcd08066_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "MIT",
+    "md5": "8964832c7b5b53d2e44df2ad6e4900ba",
+    "name": "wcwidth",
+    "sha256": "feb752dd0b6f67bc06d56630dc06c6b85e0a3a51cb92eac01dd7740ca6cfc875",
+    "sig": null,
+    "size": 25326,
+    "subdir": "linux-64",
+    "timestamp": 1505864091824,
+    "version": "0.1.7"
+  },
+  "wcwidth-0.1.7-py36hdf4376a_0.tar.bz2": {
+    "build": "py36hdf4376a_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "MIT",
+    "md5": "c45454e37a4024e4dccf0d855a974515",
+    "name": "wcwidth",
+    "sha256": "a01b3eafd73de3e98cc73c83811a313667f936a7ef53be5e3b828382e46a45da",
+    "sig": null,
+    "size": 25277,
+    "subdir": "linux-64",
+    "timestamp": 1505864104033,
+    "version": "0.1.7"
+  },
+  "werkzeug-0.12.2-py27hbf75dff_0.tar.bz2": {
+    "build": "py27hbf75dff_0",
+    "build_number": 0,
+    "depends": [
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "c4ed50a23fcad257667e367a12460fad",
+    "name": "werkzeug",
+    "sha256": "571dfb9e5f0bbb3d83103709b922cde2ca0c37ffa6cb0d71e0314af00afffce4",
+    "sig": null,
+    "size": 417863,
+    "subdir": "linux-64",
+    "timestamp": 1505740357794,
+    "version": "0.12.2"
+  },
+  "werkzeug-0.12.2-py35hbfc1ea6_0.tar.bz2": {
+    "build": "py35hbfc1ea6_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "1e39d67f9790263ac1e322939e4ef1b4",
+    "name": "werkzeug",
+    "sha256": "7972f4838ffcae8f7a35431bdcc9184cb21d8ae74953d860c87f2e95659b5532",
+    "sig": null,
+    "size": 424828,
+    "subdir": "linux-64",
+    "timestamp": 1505740372988,
+    "version": "0.12.2"
+  },
+  "werkzeug-0.12.2-py36hc703753_0.tar.bz2": {
+    "build": "py36hc703753_0",
+    "build_number": 0,
+    "depends": [
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "license_family": "BSD",
+    "md5": "e323c692c6034daf4eeb1228b9666b31",
+    "name": "werkzeug",
+    "sha256": "bbdf5250caad82fa4694f31dd16dade63017d754c7f7ee64c5d174a580c6a64a",
+    "sig": null,
+    "size": 422973,
+    "subdir": "linux-64",
+    "timestamp": 1505740388434,
+    "version": "0.12.2"
+  },
+  "wheel-0.29.0-py27h411dd7b_1.tar.bz2": {
+    "build": "py27h411dd7b_1",
+    "build_number": 1,
+    "depends": [
+      "python >=2.7,<2.8.0a0",
+      "setuptools"
+    ],
+    "license": "MIT",
+    "md5": "3cddb4a59b117098a9ebc4157f54f3a1",
+    "name": "wheel",
+    "sha256": "5ee4654df95fe87782240c5fe52feb0b701df3e4ab4a3fe0cb3d314d26ec7f2b",
+    "sig": null,
+    "size": 89253,
+    "subdir": "linux-64",
+    "timestamp": 1505671888349,
+    "version": "0.29.0"
+  },
+  "wheel-0.29.0-py35h601ca99_1.tar.bz2": {
+    "build": "py35h601ca99_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.5,<3.6.0a0",
+      "setuptools"
+    ],
+    "license": "MIT",
+    "md5": "4e875ace91954cfca9b678b2c243c990",
+    "name": "wheel",
+    "sha256": "c9ab1df7578cfb7e064427d7c108e6587e124fcc04e049d69eb7c367935c6e77",
+    "sig": null,
+    "size": 90513,
+    "subdir": "linux-64",
+    "timestamp": 1505671897680,
+    "version": "0.29.0"
+  },
+  "wheel-0.29.0-py36he7f4e38_1.tar.bz2": {
+    "build": "py36he7f4e38_1",
+    "build_number": 1,
+    "depends": [
+      "python >=3.6,<3.7.0a0",
+      "setuptools"
+    ],
+    "license": "MIT",
+    "md5": "d5e8a04bf8cd765f5bc805ba04cbb08f",
+    "name": "wheel",
+    "sha256": "7e7cfa50843564822abfd4448c887bc6561a68d29af5800601b3af7d1bdd4d6b",
+    "sig": null,
+    "size": 90320,
+    "subdir": "linux-64",
+    "timestamp": 1505671907011,
+    "version": "0.29.0"
+  },
+  "wrapt-1.10.11-py27h04f6869_0.tar.bz2": {
+    "build": "py27h04f6869_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "b560cb96557a0cd2a20a351150ea2103",
+    "name": "wrapt",
+    "sha256": "04dcfed0d4ccf3dc761ef251ab5c78e6ce49f38f6ee8d5a29fc73d01b00965bc",
+    "sig": null,
+    "size": 44938,
+    "subdir": "linux-64",
+    "timestamp": 1505693861107,
+    "version": "1.10.11"
+  },
+  "wrapt-1.10.11-py35hfdafd39_0.tar.bz2": {
+    "build": "py35hfdafd39_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "5fa1630db3c0f006b121cc63400d1ceb",
+    "name": "wrapt",
+    "sha256": "f3ad84513e306ed131a2665659df62023e5c936130d9069b543e4efe2ebc9c59",
+    "sig": null,
+    "size": 45785,
+    "subdir": "linux-64",
+    "timestamp": 1505693876080,
+    "version": "1.10.11"
+  },
+  "wrapt-1.10.11-py36h28b7045_0.tar.bz2": {
+    "build": "py36h28b7045_0",
+    "build_number": 0,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 2-Clause",
+    "md5": "a9ff34652b7d82011f8b9d2cd5ccb998",
+    "name": "wrapt",
+    "sha256": "5eaac194041c237e6685f5ac0f7f1a1f85fc5fc45fbc0f031d5aefee8bf89938",
+    "sig": null,
+    "size": 45731,
+    "subdir": "linux-64",
+    "timestamp": 1505693891235,
+    "version": "1.10.11"
+  },
+  "xz-5.2.3-h2bcbf08_1.tar.bz2": {
+    "build": "h2bcbf08_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "LGPL-2.1 and GPL-2.0",
+    "md5": "83ab851989997fe62dad9eeac1a54bfa",
+    "name": "xz",
+    "sha256": "592153affd97114f52dc9d923980e2991cc043ebc60e467532e2d49a453d6555",
+    "sig": null,
+    "size": 364971,
+    "subdir": "linux-64",
+    "timestamp": 1505665902645,
+    "version": "5.2.3"
+  },
+  "yaml-0.1.7-h96e3832_1.tar.bz2": {
+    "build": "h96e3832_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "MIT",
+    "md5": "92f59bc8dfead80b573089868ee71cd2",
+    "name": "yaml",
+    "sha256": "7f253072c76601507b2e235de2eb2a3614e3e29e7d19ba018585c857344947b7",
+    "sig": null,
+    "size": 86260,
+    "subdir": "linux-64",
+    "timestamp": 1505957511206,
+    "version": "0.1.7"
+  },
+  "zeromq-4.2.2-hb0b69da_1.tar.bz2": {
+    "build": "hb0b69da_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0",
+      "libsodium",
+      "libstdcxx-ng >=7.2.0"
+    ],
+    "license": "LGPL 3",
+    "md5": "b557230be953bdc899bc76a53f7c9967",
+    "name": "zeromq",
+    "sha256": "3cc90a1766ebf3142c886478720bd405c72c561636a85ac1c16a4a590b2f4513",
+    "sig": null,
+    "size": 677864,
+    "subdir": "linux-64",
+    "timestamp": 1505688169910,
+    "version": "4.2.2"
+  },
+  "zict-0.1.2-py27hd58a209_0.tar.bz2": {
+    "build": "py27hd58a209_0",
+    "build_number": 0,
+    "depends": [
+      "heapdict",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "817c14270b0fcbf1d1a250d8df16f7a5",
+    "name": "zict",
+    "sha256": "156c7bbd264729c702f8530ee7a5ac45e8d243202e97353664f43e489debaffa",
+    "sig": null,
+    "size": 17379,
+    "subdir": "linux-64",
+    "timestamp": 1505864116669,
+    "version": "0.1.2"
+  },
+  "zict-0.1.2-py35h00a3a39_0.tar.bz2": {
+    "build": "py35h00a3a39_0",
+    "build_number": 0,
+    "depends": [
+      "heapdict",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "7f3a78e0961f907a90d233c36f94d213",
+    "name": "zict",
+    "sha256": "a3d60ec7b68a7128732ff74d26ccdeec5783c64c99b91102c4c8efb7134ef8bf",
+    "sig": null,
+    "size": 18061,
+    "subdir": "linux-64",
+    "timestamp": 1505864129358,
+    "version": "0.1.2"
+  },
+  "zict-0.1.2-py36ha0d441b_0.tar.bz2": {
+    "build": "py36ha0d441b_0",
+    "build_number": 0,
+    "depends": [
+      "heapdict",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "a6ce06a0c82fcff768ae00f42751b469",
+    "name": "zict",
+    "sha256": "22b9c911694b47598315260d029728893c1c05b3588709d8943865c417b66623",
+    "sig": null,
+    "size": 17947,
+    "subdir": "linux-64",
+    "timestamp": 1505864141657,
+    "version": "0.1.2"
+  },
+  "zict-0.1.3-py27h12c336c_0.tar.bz2": {
+    "build": "py27h12c336c_0",
+    "build_number": 0,
+    "depends": [
+      "heapdict",
+      "python >=2.7,<2.8.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "5fe9bff7b54a7e16c6b6799c36348c33",
+    "name": "zict",
+    "sha256": "1832cf03a27046a589462d7d1c7d444439925a153f17b32d5b738a07e8324745",
+    "sig": null,
+    "size": 18169,
+    "subdir": "linux-64",
+    "timestamp": 1506623950570,
+    "version": "0.1.3"
+  },
+  "zict-0.1.3-py35h29275ca_0.tar.bz2": {
+    "build": "py35h29275ca_0",
+    "build_number": 0,
+    "depends": [
+      "heapdict",
+      "python >=3.5,<3.6.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "0653c1c6f85168d743c50ec51741889d",
+    "name": "zict",
+    "sha256": "0678e2edb75f7d31a4e972376d445c69a982bf110bc3718af4dfdaba20da109e",
+    "sig": null,
+    "size": 18784,
+    "subdir": "linux-64",
+    "timestamp": 1506623963574,
+    "version": "0.1.3"
+  },
+  "zict-0.1.3-py36h3a3bf81_0.tar.bz2": {
+    "build": "py36h3a3bf81_0",
+    "build_number": 0,
+    "depends": [
+      "heapdict",
+      "python >=3.6,<3.7.0a0"
+    ],
+    "license": "BSD 3-Clause",
+    "md5": "eec234595d7a7745fe3e482b004863c2",
+    "name": "zict",
+    "sha256": "415b25e1c7f6f2db818e922e37a55759624af03da28c7f3bcd7d9493ac5be5bd",
+    "sig": null,
+    "size": 18637,
+    "subdir": "linux-64",
+    "timestamp": 1506623934600,
+    "version": "0.1.3"
+  },
+  "zlib-1.2.11-hfbfcf68_1.tar.bz2": {
+    "build": "hfbfcf68_1",
+    "build_number": 1,
+    "depends": [
+      "libgcc-ng >=7.2.0"
+    ],
+    "license": "zlib",
+    "license_family": "Other",
+    "md5": "cb3dfd6392fcc03474b8d71cf8f0b264",
+    "name": "zlib",
+    "sha256": "97c9bd774d08dcc6383c297e4378e1486061e7af426f3e62fda449454de7defb",
+    "sig": null,
+    "size": 102991,
+    "subdir": "linux-64",
+    "timestamp": 1505666570797,
+    "version": "1.2.11"
+  }
+}


### PR DESCRIPTION
The timestamp field on package records got lost in a merge-up flub somewhere.  This PR fixes that, along with adds an additional test for `core/solve.py` targeting timestamps.  It adds in a new `index4.json` file into the repository for solver testing that's based on the current `pkgs/main/linux-64`.