### PR TITLE
Delay timestamp maximization until late in the optimization passes

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -637,10 +637,13 @@ class Resolve(object):
         return {self.push_MatchSpec(C, nm): 1 for nm in missing}
 
     def generate_version_metrics(self, C, specs, include0=False):
-        eqc = {}  # a C.minimize() objective: Dict[varname, coeff]
-        eqv = {}  # a C.minimize() objective: Dict[varname, coeff]
-        eqb = {}  # a C.minimize() objective: Dict[varname, coeff]
-        eqt = {}  # a C.minimize() objective: Dict[varname, coeff]
+        # each of these are weights saying how well packages match the specs
+        #    format for each: a C.minimize() objective: Dict[varname, coeff]
+        eqc = {}  # channel
+        eqv = {}  # version
+        eqb = {}  # build number
+        eqt = {}  # timestamp
+
         sdict = {}  # Dict[package_name, Dist]
 
         for s in specs:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -640,6 +640,7 @@ class Resolve(object):
         eqc = {}  # a C.minimize() objective: Dict[varname, coeff]
         eqv = {}  # a C.minimize() objective: Dict[varname, coeff]
         eqb = {}  # a C.minimize() objective: Dict[varname, coeff]
+        eqt = {}  # a C.minimize() objective: Dict[varname, coeff]
         sdict = {}  # Dict[package_name, Dist]
 
         for s in specs:
@@ -661,18 +662,21 @@ class Resolve(object):
                 if targets and any(dist == t for t in targets):
                     continue
                 if pkey is None:
-                    ic = iv = ib = 0
+                    ic = iv = ib = it = 0
                 # valid package, channel priority
                 elif pkey[0] != version_key[0] or pkey[1] != version_key[1]:
                     ic += 1
-                    iv = ib = 0
+                    iv = ib = it = 0
                 # version
                 elif pkey[2] != version_key[2]:
                     iv += 1
-                    ib = 0
-                # build number, timestamp
-                elif pkey[3] != version_key[3] or pkey[4] != version_key[4]:
+                    ib = it = 0
+                # build number
+                elif pkey[3] != version_key[3]:
                     ib += 1
+                    it = 0
+                elif pkey[4] != version_key[4]:
+                    it += 1
 
                 if ic or include0:
                     eqc[dist.full_name] = ic
@@ -680,9 +684,11 @@ class Resolve(object):
                     eqv[dist.full_name] = iv
                 if ib or include0:
                     eqb[dist.full_name] = ib
+                if it or include0:
+                    eqt[dist.full_name] = it
                 pkey = version_key
 
-        return eqc, eqv, eqb
+        return eqc, eqv, eqb, eqt
 
     def dependency_sort(self, must_have):
         # type: (Dict[package_name, Dist]) -> List[Dist]
@@ -888,10 +894,10 @@ class Resolve(object):
             log.debug('Package removal metric: %d', obj7)
 
             # Requested packages: maximize versions
-            eq_req_c, eq_req_v, eq_req_b = r2.generate_version_metrics(C, specr)
+            eq_req_c, eq_req_v, eq_req_b, eq_req_t = r2.generate_version_metrics(C, specr)
             solution, obj3a = C.minimize(eq_req_c, solution)
             solution, obj3 = C.minimize(eq_req_v, solution)
-            log.debug('Initial package version metric: %d/%d', obj3a, obj3)
+            log.debug('Initial package channel/version metric: %d/%d', obj3a, obj3)
 
             # Track features: minimize feature count
             eq_feature_count = r2.generate_feature_count(C)
@@ -914,11 +920,17 @@ class Resolve(object):
             log.debug('Dependency update count: %d', obj50)
 
             # Remaining packages: maximize versions, then builds
-            eq_c, eq_v, eq_b = r2.generate_version_metrics(C, speca)
+            eq_c, eq_v, eq_b, eq_t = r2.generate_version_metrics(C, speca)
             solution, obj5a = C.minimize(eq_c, solution)
             solution, obj5 = C.minimize(eq_v, solution)
             solution, obj6 = C.minimize(eq_b, solution)
-            log.debug('Additional package version/build metrics: %d/%d/%d', obj5a, obj5, obj6)
+            log.debug('Additional package channel/version/build metrics: %d/%d/%d',
+                      obj5a, obj5, obj6)
+
+            # Maximize timestamps
+            eq_t.update(eq_req_t)
+            solution, obj6t = C.minimize(eq_t, solution)
+            log.debug('Timestamp metric: %d', obj6t)
 
             # Prune unnecessary packages
             eq_c = r2.generate_package_count(C, specm)


### PR DESCRIPTION
Aggressive timestamp maximization is causing issues like #6271. This delays timestamp maximization until late in the optimization process.

We need to document somewhere that all versions of a package with the same version & build combination should now be considered "equivalent" for the purposes of optimization.