### PR TITLE
[WIP] lower priority for features in Resolve.solve

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -483,6 +483,7 @@ class Context(Configuration):
 # https://conda.io/docs/config.html#disable-updating-of-dependencies-update-dependencies # NOQA
 # I don't think this documentation is correct any longer. # NOQA
             'update_dependencies',
+            'alt_features',  # TODO: Use a more expressive name!
         )
         return tuple(p for p in super(Context, self).list_parameters()
                      if p not in UNLISTED_PARAMETERS)
@@ -532,9 +533,9 @@ def get_help_dict():
             this setting, specifying that certain files should never be soft-linked (see the
             no_link option in the build recipe documentation).
             """),
-        'alt_features': dals("""
-            Prioritize package version and build number maximization over feature optimization.
-            """),  # TODO: Use a more expressive name? Rephrase help text to be more user-friendly.
+        # 'alt_features': dals("""
+        #     Prioritize package version and build number maximization over feature optimization.
+        #     """),  # TODO: Use a more expressive name! Rephrase help to be more user-friendly.
         'always_copy': dals("""
             Register a preference that files be copied into a prefix during install rather
             than hard-linked.

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -136,6 +136,7 @@ class Context(Configuration):
     always_softlink = PrimitiveParameter(False, aliases=('softlink',))
     always_copy = PrimitiveParameter(False, aliases=('copy',))
     always_yes = PrimitiveParameter(False, aliases=('yes',))
+    alt_features = PrimitiveParameter(False)
     channel_priority = PrimitiveParameter(True)
     debug = PrimitiveParameter(False)
     dry_run = PrimitiveParameter(False)
@@ -531,6 +532,9 @@ def get_help_dict():
             this setting, specifying that certain files should never be soft-linked (see the
             no_link option in the build recipe documentation).
             """),
+        'alt_features': dals("""
+            Prioritize package version and build number maximization over feature optimization.
+            """),  # TODO: Use a more expressive name? Rephrase help text to be more user-friendly.
         'always_copy': dals("""
             Register a preference that files be copied into a prefix during install rather
             than hard-linked.

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -298,6 +298,13 @@ def add_parser_install(p):
         help="Don't update dependencies (default: %s)." % (not context.update_dependencies,),
     )
     p.add_argument(
+        "--alt-features",
+        action="store_true",
+        default=NULL,
+        help="Prioritize package version and build number maximization over "
+             "feature optimization (default: %s). " % (context.alt_features,),
+    )  # TODO: Use a more expressive name? Rephrase help text to be more user-friendly.
+    p.add_argument(
         "--channel-priority", "--channel-pri", "--chan-pri",
         action="store_true",
         dest="channel_priority",

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -298,13 +298,6 @@ def add_parser_install(p):
         help="Don't update dependencies (default: %s)." % (not context.update_dependencies,),
     )
     p.add_argument(
-        "--alt-features",
-        action="store_true",
-        default=NULL,
-        help="Prioritize package version and build number maximization over "
-             "feature optimization (default: %s). " % (context.alt_features,),
-    )  # TODO: Use a more expressive name? Rephrase help text to be more user-friendly.
-    p.add_argument(
         "--channel-priority", "--channel-pri", "--chan-pri",
         action="store_true",
         dest="channel_priority",

--- a/conda/config.py
+++ b/conda/config.py
@@ -50,6 +50,7 @@ rc_bool_keys = [
     'show_channel_urls',
     'allow_other_channels',
     'update_dependencies',
+    'alt_features',
     'channel_priority',
     'shortcuts',
 ]

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -944,11 +944,12 @@ class Resolve(object):
                 log.debug('Additional package channel/version/build metrics (feature split): '
                           '%d/%d/%d', obj5a_f, obj5_f, obj6_f)
 
-            # Requested packages: maximize versions
             eq_req_c, eq_req_v, eq_req_b, eq_req_t = r2.generate_version_metrics(C, specr)
-            solution, obj3a = C.minimize(eq_req_c, solution)
-            solution, obj3 = C.minimize(eq_req_v, solution)
-            log.debug('Initial package channel/version metric: %d/%d', obj3a, obj3)
+            if not context.alt_features:
+                # Requested packages: maximize versions
+                solution, obj3a = C.minimize(eq_req_c, solution)
+                solution, obj3 = C.minimize(eq_req_v, solution)
+                log.debug('Initial package channel/version metric: %d/%d', obj3a, obj3)
 
             # Track features: minimize feature count
             eq_feature_count = r2.generate_feature_count(C)
@@ -961,22 +962,24 @@ class Resolve(object):
             obj2 = ftotal - obj2
             log.debug('Package feature count: %d', obj2)
 
-            # Requested packages: maximize builds
-            solution, obj4 = C.minimize(eq_req_b, solution)
-            log.debug('Initial package build metric: %d', obj4)
+            if not context.alt_features:
+                # Requested packages: maximize builds
+                solution, obj4 = C.minimize(eq_req_b, solution)
+                log.debug('Initial package build metric: %d', obj4)
 
             # Dependencies: minimize the number of packages that need upgrading
             eq_u = r2.generate_update_count(C, speca)
             solution, obj50 = C.minimize(eq_u, solution)
             log.debug('Dependency update count: %d', obj50)
 
-            # Remaining packages: maximize versions, then builds
             eq_c, eq_v, eq_b, eq_t = r2.generate_version_metrics(C, speca)
-            solution, obj5a = C.minimize(eq_c, solution)
-            solution, obj5 = C.minimize(eq_v, solution)
-            solution, obj6 = C.minimize(eq_b, solution)
-            log.debug('Additional package channel/version/build metrics: %d/%d/%d',
-                      obj5a, obj5, obj6)
+            if not context.alt_features:
+                # Remaining packages: maximize versions, then builds
+                solution, obj5a = C.minimize(eq_c, solution)
+                solution, obj5 = C.minimize(eq_v, solution)
+                solution, obj6 = C.minimize(eq_b, solution)
+                log.debug('Additional package channel/version/build metrics: %d/%d/%d',
+                          obj5a, obj5, obj6)
 
             # Maximize timestamps
             eq_t.update(eq_req_t)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -902,6 +902,17 @@ class Resolve(object):
             solution, obj3 = C.minimize(eq_req_v, solution)
             log.debug('Initial package channel/version metric: %d/%d', obj3a, obj3)
 
+            # Track features: minimize feature count
+            eq_feature_count = r2.generate_feature_count(C)
+            solution, obj1 = C.minimize(eq_feature_count, solution)
+            log.debug('Track feature count: %d', obj1)
+
+            # Featured packages: maximize featured package count
+            eq_feature_metric, ftotal = r2.generate_feature_metric(C)
+            solution, obj2 = C.minimize(eq_feature_metric, solution)
+            obj2 = ftotal - obj2
+            log.debug('Package feature count: %d', obj2)
+
             # Requested packages: maximize builds
             solution, obj4 = C.minimize(eq_req_b, solution)
             log.debug('Initial package build metric: %d', obj4)
@@ -918,17 +929,6 @@ class Resolve(object):
             solution, obj6 = C.minimize(eq_b, solution)
             log.debug('Additional package channel/version/build metrics: %d/%d/%d',
                       obj5a, obj5, obj6)
-
-            # Track features: minimize feature count
-            eq_feature_count = r2.generate_feature_count(C)
-            solution, obj1 = C.minimize(eq_feature_count, solution)
-            log.debug('Track feature count: %d', obj1)
-
-            # Featured packages: maximize featured package count
-            eq_feature_metric, ftotal = r2.generate_feature_metric(C)
-            solution, obj2 = C.minimize(eq_feature_metric, solution)
-            obj2 = ftotal - obj2
-            log.debug('Package feature count: %d', obj2)
 
             # Maximize timestamps
             eq_t.update(eq_req_t)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -902,17 +902,6 @@ class Resolve(object):
             solution, obj3 = C.minimize(eq_req_v, solution)
             log.debug('Initial package channel/version metric: %d/%d', obj3a, obj3)
 
-            # Track features: minimize feature count
-            eq_feature_count = r2.generate_feature_count(C)
-            solution, obj1 = C.minimize(eq_feature_count, solution)
-            log.debug('Track feature count: %d', obj1)
-
-            # Featured packages: maximize featured package count
-            eq_feature_metric, ftotal = r2.generate_feature_metric(C)
-            solution, obj2 = C.minimize(eq_feature_metric, solution)
-            obj2 = ftotal - obj2
-            log.debug('Package feature count: %d', obj2)
-
             # Requested packages: maximize builds
             solution, obj4 = C.minimize(eq_req_b, solution)
             log.debug('Initial package build metric: %d', obj4)
@@ -929,6 +918,17 @@ class Resolve(object):
             solution, obj6 = C.minimize(eq_b, solution)
             log.debug('Additional package channel/version/build metrics: %d/%d/%d',
                       obj5a, obj5, obj6)
+
+            # Track features: minimize feature count
+            eq_feature_count = r2.generate_feature_count(C)
+            solution, obj1 = C.minimize(eq_feature_count, solution)
+            log.debug('Track feature count: %d', obj1)
+
+            # Featured packages: maximize featured package count
+            eq_feature_metric, ftotal = r2.generate_feature_metric(C)
+            solution, obj2 = C.minimize(eq_feature_metric, solution)
+            obj2 = ftotal - obj2
+            log.debug('Package feature count: %d', obj2)
 
             # Maximize timestamps
             eq_t.update(eq_req_t)


### PR DESCRIPTION
This postpones the minimization of feature count to happen after
1. build number maximization of requested packages,
2. minimization of updates,
3. maximization of (channel, ) version and build of additional packages.

I don't believe features should be prioritized higher than the mentioned steps.

IMHO, avoiding the re-installation of packages due to changes to features should happen either implicitly by 2. (minimization of updates) or explicitly by not removing explicitly installed features. But frankly, I didn't look into those cases but only at new installations. So while reviewing please consider that I might have missed some use cases for this.

I did not dig into `conda`'s test framework so please feel free to convert/incorporate the following self-contained test cases into your tests:

<details><summary>
T1: Installation of package whose newer builds requires a feature.
</summary>

* **Problem**: Feature minimization happened before build number maximization.
* **Expected behavior**: Newer builds always get picked up.
* **Current behavior**: Newer builds only get picked if feature providing package is installed explicitly.
* **Related issues**: https://github.com/conda/conda/issues/6199
<p>

```bash
#!/bin/bash -xe

_TMPDIR=$(mktemp -d)
trap 'rm -rf "$_TMPDIR"' EXIT
cd $_TMPDIR

mkdir -p ./channel/noarch
mkdir -p ./channel/linux-64
touch ./channel/noarch/repodata.json

cat >./channel/linux-64/repodata.json <<EOF
{
  "info": {
    "arch": "x86_64",
    "platform": "linux",
    "subdir": "linux-64"
  },
  "packages": {
    "_bottom_no_feature-1.0-0.tar.bz2": {
      "name": "_bottom_no_feature", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": []
    },
    "_bottom_with_feature-1.0-0.tar.bz2": {
      "name": "_bottom_with_feature", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": [],
      "track_features": "_new_feature"
    },
    "_top-1.0-0.tar.bz2": {
      "name": "_top", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": ["_bottom_no_feature"]
    },
    "_top-1.0-needs_feature_1.tar.bz2": {
      "name": "_top", "version": "1.0", "size": 0,
      "build": "needs_feature_1", "build_number": 1,
      "depends": ["_bottom_with_feature"],
      "features": "_new_feature"
    }
  }
}
EOF

find . -name repodata.json -exec bzip2 -f {} ";"

conda create --dry-run -n test -c file://$PWD/channel _top
conda create --dry-run -n test -c file://$PWD/channel _top _bottom_with_feature
```
</p></details>

<details><summary>
T2: Some old version of a (transitive) dependency required a feature.
</summary>

* **Problem**: Maximization of featured package count before build number maximization and maximization of version/build of dependencies.
* **Expected behavior**: Newer builds and dependencies with higher versions are chosen, feature is not required.
* **Current behavior**: Newer builds only get picked if dependency or feature providing transitive dependency is installed explicitly.
* **Related issues**: https://github.com/conda/conda/issues/6269, https://github.com/bioconda/bioconda-recipes/issues/6637, https://github.com/bioconda/bioconda-recipes/issues/6163
<p>

```bash
#!/bin/bash -xe

_TMPDIR=$(mktemp -d)
trap 'rm -rf "$_TMPDIR"' EXIT
cd $_TMPDIR

mkdir -p ./channel/noarch
mkdir -p ./channel/linux-64
touch ./channel/noarch/repodata.json

cat >./channel/linux-64/repodata.json <<EOF
{
  "info": {
    "arch": "x86_64",
    "platform": "linux",
    "subdir": "linux-64"
  },
  "packages": {
    "_provides_features-1.0-0.tar.bz2": {
      "name": "_provides_features", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": [],
      "track_features": "_old_feature"
    },
    "_bottom-0.1-0.tar.bz2": {
      "name": "_bottom", "version": "0.1", "size": 0,
      "build": "0", "build_number": 0,
      "depends": ["_provides_features"],
      "features": "_old_feature"
    },
    "_bottom-1.0-0.tar.bz2": {
      "name": "_bottom", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": []
    },
    "_middle-1.0-0.tar.bz2": {
      "name": "_middle", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": []
    },
    "_middle-1.1-0.tar.bz2": {
      "name": "_middle", "version": "1.1", "size": 0,
      "build": "0", "build_number": 0,
      "depends": ["_bottom"]
    },
    "_top-1.0-0.tar.bz2": {
      "name": "_top", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": ["_middle"]
    },
    "_top-1.0-1.tar.bz2": {
      "name": "_top", "version": "1.0", "size": 0,
      "build": "1", "build_number": 1,
      "depends": ["_middle >=1.1"]
    }
  }
}
EOF

find . -name repodata.json -exec bzip2 -f {} ";"

conda create --dry-run -n test -c file://$PWD/channel _top
conda create --dry-run -n test -c file://$PWD/channel _top _bottom
conda create --dry-run -n test -c file://$PWD/channel _top _middle
conda create --dry-run -n test -c file://$PWD/channel _middle
conda create --dry-run -n test -c file://$PWD/channel _middle _bottom
```
</p></details>

<details><summary>
T3: Package in higher priority channel requires feature.
</summary>

* **Problem**: Minimization of feature count before maximization of version/build of dependencies.
* **Expected behavior**: Package dependency from higher priority channel gets installed.
* **Current behavior**: Dependency from lower priority channel is chosen instead.
* **Related issues**: https://github.com/conda/conda/issues/6199
<p>

```bash
#!/bin/bash -xe

_TMPDIR=$(mktemp -d)
trap 'rm -rf "$_TMPDIR"' EXIT
cd $_TMPDIR

mkdir -p ./high-priority-channel/noarch
mkdir -p ./high-priority-channel/linux-64

mkdir -p ./low-priority-channel/noarch
mkdir -p ./low-priority-channel/linux-64

touch ./high-priority-channel/noarch/repodata.json
touch ./low-priority-channel/noarch/repodata.json

cat >./high-priority-channel/linux-64/repodata.json <<EOF
{
  "info": {
    "arch": "x86_64",
    "platform": "linux",
    "subdir": "linux-64"
  },
  "packages": {
    "_bottom_with_feature-1.0-0.tar.bz2": {
      "name": "_bottom_with_feature", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": [],
      "track_features": "_feature"
    },
    "_middle-1.0-needs_feature_1.tar.bz2": {
      "name": "_middle", "version": "1.0", "size": 0,
      "build": "needs_feature_1", "build_number": 1,
      "depends": ["_bottom_with_feature"],
      "features": "_feature"
    },
    "_top-1.0-0.tar.bz2": {
      "name": "_top", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": ["_middle"]
    }
  }
}
EOF

cat >./low-priority-channel/linux-64/repodata.json <<EOF
{
  "info": {
    "arch": "x86_64",
    "platform": "linux",
    "subdir": "linux-64"
  },
  "packages": {
    "_bottom_no_feature-1.0-0.tar.bz2": {
      "name": "_bottom_no_feature", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": []
    },
    "_middle-1.0-0.tar.bz2": {
      "name": "_middle", "version": "1.0", "size": 0,
      "build": "0", "build_number": 0,
      "depends": ["_bottom_no_feature"]
    }
  }
}
EOF

find . -name repodata.json -exec bzip2 -f {} ";"

conda create --dry-run -n test -c file://$PWD/high-priority-channel -c file://$PWD/low-priority-channel _top
conda create --dry-run -n test -c file://$PWD/high-priority-channel -c file://$PWD/low-priority-channel _top _bottom_no_feature
conda create --dry-run -n test -c file://$PWD/high-priority-channel -c file://$PWD/low-priority-channel _top _bottom_with_feature
conda create --dry-run -n test -c file://$PWD/high-priority-channel -c file://$PWD/low-priority-channel _top _middle
conda create --dry-run -n test -c file://$PWD/high-priority-channel -c file://$PWD/low-priority-channel _middle _bottom_no_feature
conda create --dry-run -n test -c file://$PWD/high-priority-channel -c file://$PWD/low-priority-channel _middle _bottom_with_feature
conda create --dry-run -n test -c file://$PWD/high-priority-channel -c file://$PWD/low-priority-channel _middle
```
</p></details>
