### PR TITLE
Reorder windows path list

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -66,10 +66,10 @@ def prefix_from_arg(arg, shell):
 def _get_prefix_paths(prefix):
     if on_win:
         yield prefix.rstrip("\\")
-        yield os.path.join(prefix, 'Library', 'mingw-w64', 'bin')
-        yield os.path.join(prefix, 'Library', 'usr', 'bin')
         yield os.path.join(prefix, 'Library', 'bin')
         yield os.path.join(prefix, 'Scripts')
+        yield os.path.join(prefix, 'Library', 'mingw-w64', 'bin')
+        yield os.path.join(prefix, 'Library', 'usr', 'bin')
     else:
         yield os.path.join(prefix, 'bin')
 


### PR DESCRIPTION
Having Library/usr/bin and Library/mingw-w64/bin ahead of Library/bin bit me pretty hard today with curl.  There was a git4win curl version shadowing ours, and that git4win one was busted.