### PR TITLE
Make environments.txt record non-named environments

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -8,7 +8,7 @@ import re
 import sys
 from tempfile import NamedTemporaryFile
 
-from .base.context import ROOT_ENV_NAME, context
+from .base.context import ROOT_ENV_NAME, context, locate_prefix_by_name
 
 try:
     from cytoolz.itertoolz import concatv, drop
@@ -204,8 +204,7 @@ class Activator(object):
         elif env_name_or_prefix in (ROOT_ENV_NAME, 'root'):
             prefix = context.root_prefix
         else:
-            from .core.envs_manager import EnvsDirectory
-            prefix = EnvsDirectory.locate_prefix_by_name(env_name_or_prefix)
+            prefix = locate_prefix_by_name(env_name_or_prefix)
         prefix = normpath(prefix)
 
         # query environment

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -9,6 +9,7 @@ import sys
 from tempfile import NamedTemporaryFile
 
 from .base.context import ROOT_ENV_NAME, context, locate_prefix_by_name
+context.__init__()  # oOn import, context does not include SEARCH_PATH. This line fixes that.
 
 try:
     from cytoolz.itertoolz import concatv, drop

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -120,5 +120,4 @@ class PathConflict(Enum):
 
 # Magic files for permissions determination
 PACKAGE_CACHE_MAGIC_FILE = 'urls.txt'
-ENVS_DIR_MAGIC_FILE = 'environments.txt'
 PREFIX_MAGIC_FILE = join('conda-meta', 'history')

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -120,5 +120,5 @@ class PathConflict(Enum):
 
 # Magic files for permissions determination
 PACKAGE_CACHE_MAGIC_FILE = 'urls.txt'
-ENVS_DIR_MAGIC_FILE = 'catalog.json'
+ENVS_DIR_MAGIC_FILE = 'environments.txt'
 PREFIX_MAGIC_FILE = join('conda-meta', 'history')

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -200,7 +200,7 @@ class Context(Configuration):
                     os.environ['CONDA_PREFIX'] = argparse_args.prefix
                 elif 'name' in argparse_args and argparse_args.name:
                     # Currently, usage of the '-n' flag is inefficient, with all configuration
-                    # files being loaded/re-loaded at least three times.
+                    # files being loaded/re-loaded at least two times.
                     target_prefix = determine_target_prefix(context, argparse_args)
                     if target_prefix != context.root_prefix:
                         os.environ['CONDA_PREFIX'] = determine_target_prefix(context,

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -335,8 +335,8 @@ class Context(Configuration):
     def root_writable(self):
         # rather than using conda.gateways.disk.test.prefix_is_writable
         # let's shortcut and assume the root prefix exists
-        path = self.root_prefix
-        if isfile(join(path, PREFIX_MAGIC_FILE)):
+        path = join(self.root_prefix, PREFIX_MAGIC_FILE)
+        if isfile(path):
             try:
                 fh = open(path, 'a+')
             except (IOError, OSError) as e:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -9,9 +9,9 @@ from platform import machine
 import sys
 
 from .constants import (APP_NAME, DEFAULTS_CHANNEL_NAME, DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS,
-                        ERROR_UPLOAD_URL, PLATFORM_DIRECTORIES, PathConflict, ROOT_ENV_NAME,
-                        SEARCH_PATH, SafetyChecks, PREFIX_MAGIC_FILE)
-from .. import __version__ as CONDA_VERSION, CondaError
+                        ERROR_UPLOAD_URL, PLATFORM_DIRECTORIES, PREFIX_MAGIC_FILE, PathConflict,
+                        ROOT_ENV_NAME, SEARCH_PATH, SafetyChecks)
+from .. import __version__ as CONDA_VERSION
 from .._vendor.appdirs import user_data_dir
 from .._vendor.auxlib.collection import frozendict
 from .._vendor.auxlib.decorators import memoize, memoizedproperty
@@ -194,7 +194,6 @@ class Context(Configuration):
         if argparse_args:
             # This block of code sets CONDA_PREFIX based on '-n' and '-p' flags, so that
             # configuration can be properly loaded from those locations
-
             func_name = ('func' in argparse_args and argparse_args.func or '').rsplit('.', 1)[-1]
             if func_name in ('create', 'install', 'update', 'remove', 'uninstall', 'upgrade'):
                 if 'prefix' in argparse_args and argparse_args.prefix:
@@ -204,7 +203,8 @@ class Context(Configuration):
                     # files being loaded/re-loaded at least three times.
                     target_prefix = determine_target_prefix(context, argparse_args)
                     if target_prefix != context.root_prefix:
-                        os.environ['CONDA_PREFIX'] = determine_target_prefix(context, argparse_args)
+                        os.environ['CONDA_PREFIX'] = determine_target_prefix(context,
+                                                                             argparse_args)
 
         super(Context, self).__init__(search_path=search_path, app_name=APP_NAME,
                                       argparse_args=argparse_args)
@@ -892,7 +892,9 @@ def _get_user_agent(context_platform):
 
 
 def locate_prefix_by_name(name, envs_dirs=None):
-    """Find the location of a prefix given a conda env name."""
+    """Find the location of a prefix given a conda env name.  If the location does not exist, an
+    error is raised.
+    """
     assert name
     if name in (ROOT_ENV_NAME, 'root'):
         return context.root_prefix

--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -48,8 +48,8 @@ activate' from PATH. """)
 
 
 def locate_prefix_by_name(ctx, name):
-    from ..core.envs_manager import EnvsDirectory
-    return EnvsDirectory.locate_prefix_by_name(name, ctx.envs_dirs)
+    from ..base.context import locate_prefix_by_name
+    return locate_prefix_by_name(name, ctx.envs_dirs)
 
 
 def prefix_from_arg(arg, shell):

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from os import listdir
-from os.path import basename, isdir, isfile, join
+from os.path import basename
 import re
 import sys
 
 from .._vendor.auxlib.ish import dals
-from ..base.constants import PREFIX_MAGIC_FILE, ROOT_ENV_NAME
+from ..base.constants import ROOT_ENV_NAME
 from ..base.context import context
 from ..models.match_spec import MatchSpec
 
@@ -170,16 +169,8 @@ def stdout_json_success(success=True, **kwargs):
 
 def list_prefixes():
     # Lists all the prefixes that conda knows about.
-    for envs_dir in context.envs_dirs:
-        if not isdir(envs_dir):
-            continue
-        for dn in sorted(listdir(envs_dir)):
-            prefix = join(envs_dir, dn)
-            if isdir(prefix) and isfile(join(prefix, PREFIX_MAGIC_FILE)):
-                prefix = join(envs_dir, dn)
-                yield prefix
-
-    yield context.root_prefix
+    from conda.core.envs_manager import EnvsDirectory
+    return EnvsDirectory.list_all_envs()
 
 
 def handle_envs_list(acc, output=True):

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -167,13 +167,7 @@ def stdout_json_success(success=True, **kwargs):
     stdout_json(result)
 
 
-def list_prefixes():
-    # Lists all the prefixes that conda knows about.
-    from conda.core.envs_manager import EnvsDirectory
-    return EnvsDirectory.list_all_envs()
-
-
-def handle_envs_list(acc, output=True):
+def handle_envs_list(known_conda_prefixes, output=True):
 
     if output:
         print("# conda environments:")
@@ -187,10 +181,8 @@ def handle_envs_list(acc, output=True):
         if output:
             print(fmt % (name, default, prefix))
 
-    for prefix in list_prefixes():
+    for prefix in known_conda_prefixes:
         disp_env(prefix)
-        if prefix != context.root_prefix:
-            acc.append(prefix)
 
     if output:
         print()

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -14,16 +14,15 @@ from . import common
 from .common import check_non_admin
 from .._vendor.auxlib.ish import dals
 from ..base.constants import ROOT_ENV_NAME
-from ..base.context import context
+from ..base.context import context, locate_prefix_by_name
 from ..common.compat import on_win, text_type
-from ..core.envs_manager import EnvsDirectory
 from ..core.index import calculate_channel_urls, get_index
 from ..core.solve import Solver
 from ..exceptions import (CondaExitZero, CondaImportError, CondaOSError, CondaSystemExit,
                           CondaValueError, DirectoryNotFoundError, DryRunExit,
                           EnvironmentLocationNotFound, PackagesNotFoundError,
                           TooManyArgumentsError, UnsatisfiableError)
-from ..misc import append_env, clone_env, explicit, touch_nonadmin
+from ..misc import clone_env, explicit, touch_nonadmin
 from ..models.match_spec import MatchSpec
 from ..plan import (revert_actions)
 from ..resolve import ResolvePackageNotFound
@@ -58,7 +57,7 @@ def clone(src_arg, dst_prefix, json=False, quiet=False, index_args=None):
             raise DirectoryNotFoundError(src_arg)
     else:
         assert context._argparse_args.clone is not None
-        src_prefix = EnvsDirectory.locate_prefix_by_name(context._argparse_args.clone)
+        src_prefix = locate_prefix_by_name(context._argparse_args.clone)
 
     if not json:
         print("Source:      %s" % src_prefix)
@@ -196,7 +195,6 @@ def install(args, parser, command='install'):
                                         'did not expect any arguments for --clone')
 
         clone(args.clone, prefix, json=context.json, quiet=context.quiet, index_args=index_args)
-        append_env(prefix)
         touch_nonadmin(prefix)
         print_activate(args.name if args.name else prefix)
         return
@@ -276,7 +274,6 @@ def handle_txn(progressive_fetch_extract, unlink_link_transaction, prefix, args,
         raise CondaSystemExit('Exiting', e)
 
     if newenv:
-        append_env(prefix)
         touch_nonadmin(prefix)
         print_activate(args.name if args.name else prefix)
 

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -33,7 +33,6 @@ Additional help for each command can be accessed by using:
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 import sys
 
 PARSER = None

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -71,20 +71,6 @@ def _main(*args):
     p = generate_parser()
     args = p.parse_args(args[1:])
 
-    func_name = args.func.rsplit('.', 1)[-1]
-    if func_name in ('create', 'install', 'update', 'remove', 'uninstall', 'upgrade'):
-        if args.prefix:
-            os.environ['CONDA_PREFIX'] = args.prefix
-        elif args.name:
-            # Currently, usage of the '-n' flag is inefficient, with all configuration files
-            # being loaded/re-loaded at least three times.
-            from ..base.context import locate_prefix_by_name
-            from ..exceptions import EnvironmentNameNotFound
-            try:
-                os.environ['CONDA_PREFIX'] = locate_prefix_by_name(args.name)
-            except EnvironmentNameNotFound:
-                pass  # It's ok here for the prefix to not yet exist. No logger yet configured.
-
     from ..base.context import context
     context.__init__(argparse_args=args)
     init_loggers(context)

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -21,7 +21,7 @@ from .. import CONDA_PACKAGE_ROOT, __version__ as conda_version
 from ..base.context import conda_in_private_env, context, sys_rc_path, user_rc_path
 from ..common.compat import iteritems, itervalues, on_win, text_type
 from ..common.url import mask_anaconda_token
-from ..core.envs_manager import EnvsDirectory
+from ..core.envs_manager import env_name
 from ..core.repodata import query_all
 from ..models.channel import all_channel_urls, offline_keep
 from ..models.match_spec import MatchSpec
@@ -157,7 +157,7 @@ def get_info_dict(system=False):
         if isfile(user_netrc):
             netrc_file = user_netrc
 
-    active_prefix_name = EnvsDirectory.env_name(context.active_prefix)
+    active_prefix_name = env_name(context.active_prefix)
 
     info_dict = dict(
         platform=context.subdir,
@@ -308,6 +308,8 @@ def execute(args, parser):
         print(get_main_info_str(info_dict))
 
     if args.envs:
+        from ..core.envs_manager import list_all_known_prefixes
+        info_dict['envs'] = list_all_known_prefixes()
         handle_envs_list(info_dict['envs'], not context.json)
 
     if args.system:

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -11,9 +11,9 @@ from .common import disp_features, stdout_json
 from ..base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
 from ..base.context import context
 from ..common.compat import text_type
-from ..core.envs_manager import EnvsDirectory
 from ..core.linked_data import is_linked, linked, linked_data
 from ..egg_info import get_egg_info
+from ..gateways.disk.test import is_conda_environment
 from ..history import History
 
 log = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ def print_explicit(prefix, add_md5=False):
 
 def execute(args, parser):
     prefix = context.target_prefix
-    if not EnvsDirectory.is_conda_environment(prefix):
+    if not is_conda_environment(prefix):
         from ..exceptions import EnvironmentLocationNotFound
         raise EnvironmentLocationNotFound(prefix)
 

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -12,11 +12,11 @@ from .common import check_non_admin, confirm_yn, specs_from_args, stdout_json
 from .install import handle_txn
 from ..base.context import context
 from ..common.compat import iteritems, iterkeys
-from ..core.envs_manager import EnvsDirectory
 from ..core.linked_data import linked_data
 from ..core.solve import Solver
 from ..exceptions import CondaEnvironmentError, CondaValueError
 from ..gateways.disk.delete import delete_trash, rm_rf
+from ..gateways.disk.test import is_conda_environment
 from ..instructions import PREFIX
 from ..plan import (add_unlink)
 from ..resolve import MatchSpec
@@ -40,7 +40,7 @@ def execute(args, parser):
         # full environment removal was requested, but environment doesn't exist anyway
         return 0
 
-    if not EnvsDirectory.is_conda_environment(prefix):
+    if not is_conda_environment(prefix):
         from ..exceptions import EnvironmentLocationNotFound
         raise EnvironmentLocationNotFound(prefix)
 

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -82,7 +82,6 @@ def run_command(command, *arguments, **kwargs):
     args.yes = True  # always skip user confirmation, force setting context.always_yes
     context.__init__(
         search_path=configuration_search_path,
-        app_name=APP_NAME,
         argparse_args=args,
     )
     log.debug("executing command >>>  conda %s", command_line)

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -6,7 +6,7 @@ from shlex import split
 
 from .conda_argparse import do_call
 from .main import generate_parser
-from ..base.constants import APP_NAME, SEARCH_PATH
+from ..base.constants import SEARCH_PATH
 from ..base.context import context
 from ..common.io import CaptureTarget, argv, captured
 from ..common.path import win_path_double_escape

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from logging import getLogger
-from os import listdir
+from os import listdir, os
 from os.path import dirname, isdir, isfile, join, normpath, split as path_split
 
 from ..base.constants import ROOT_ENV_NAME
@@ -81,7 +81,11 @@ def list_all_known_prefixes():
                 all_env_paths.update(_clean_environments_txt(environments_txt_file))
     else:
         from pwd import getpwall
-        for home_dir in tuple(pwentry.pw_dir for pwentry in getpwall()) or expand('~'):
+        if os.geteuid() == 0:
+            search_dirs = tuple(pwentry.pw_dir for pwentry in getpwall()) or (expand('~'),)
+        else:
+            search_dirs = (expand('~'),)
+        for home_dir in search_dirs:
             environments_txt_file = join(home_dir, '.conda', 'environments.txt')
             if isfile(environments_txt_file):
                 all_env_paths.update(_clean_environments_txt(environments_txt_file))

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -157,7 +157,6 @@ class EnvsDirectory(object):
         self._clean_environments_txt(location)
 
     def _clean_environments_txt(self, remove_location=None):
-        assert self.is_writable
         environments_txt_lines = list(yield_lines(self.catalog_file))
 
         try:
@@ -169,15 +168,16 @@ class EnvsDirectory(object):
             pass
 
         real_prefixes = tuple(p for p in environments_txt_lines if self.is_conda_environment(p))
-        with open(self.catalog_file, 'w') as fh:
-            fh.write('\n'.join(real_prefixes))
+        if self.is_writable:
+            with open(self.catalog_file, 'w') as fh:
+                fh.write('\n'.join(real_prefixes))
+        return real_prefixes
 
     def list_envs(self):
-        self._clean_environments_txt()
         for path in listdir(self.envs_dir):
             if self.is_conda_environment(join(self.envs_dir, path)):
                 yield path
-        for path in yield_lines(self.catalog_file):
+        for path in self._clean_environments_txt():
             yield path
         if self.is_conda_environment(self.root_dir):
             yield self.root_dir

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -84,7 +84,18 @@ class EnvsDirectory(object):
         self.root_dir = dirname(envs_dir)
         self.catalog_file = join(envs_dir, ENVS_DIR_MAGIC_FILE)
 
-        self._init_dir()
+        # self._init_dir()
+
+
+
+
+
+
+
+
+
+
+
 
     def _init_dir(self):
         self._envs_dir_data = self._read_raw_data()

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -157,8 +157,10 @@ class EnvsDirectory(object):
         self._clean_environments_txt(location)
 
     def _clean_environments_txt(self, remove_location=None):
-        environments_txt_lines = list(yield_lines(self.catalog_file))
+        if not isfile(self.catalog_file):
+            return ()
 
+        environments_txt_lines = list(yield_lines(self.catalog_file))
         try:
             location = normpath(remove_location or '')
             idx = environments_txt_lines.index(location)
@@ -174,9 +176,10 @@ class EnvsDirectory(object):
         return real_prefixes
 
     def list_envs(self):
-        for path in listdir(self.envs_dir):
-            if self.is_conda_environment(join(self.envs_dir, path)):
-                yield path
+        if isdir(self.envs_dir):
+            for path in listdir(self.envs_dir):
+                if self.is_conda_environment(join(self.envs_dir, path)):
+                    yield path
         for path in self._clean_environments_txt():
             yield path
         if self.is_conda_environment(self.root_dir):

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -5,191 +5,97 @@ from logging import getLogger
 from os import listdir
 from os.path import dirname, isdir, isfile, join, normpath, split as path_split
 
-from .. import CondaError
-from ..base.constants import ENVS_DIR_MAGIC_FILE, PREFIX_MAGIC_FILE, ROOT_ENV_NAME
+from ..base.constants import ROOT_ENV_NAME
 from ..base.context import context
-from ..common.compat import with_metaclass
-from ..common.path import paths_equal, right_pad_os_sep
-from ..gateways.disk.create import create_envs_directory
+from ..common.compat import on_win
+from ..common.path import expand, paths_equal
 from ..gateways.disk.read import yield_lines
-from ..gateways.disk.test import file_path_is_writable
+from ..gateways.disk.test import is_conda_environment
 
 log = getLogger(__name__)
 
 
-class EnvsDirectoryType(type):
-    """
-    This metaclass does basic caching of EnvsDirectory instance objects.
-    """
-
-    def __call__(cls, envs_dir):
-        if isinstance(envs_dir, EnvsDirectory):
-            return envs_dir
-        elif envs_dir in EnvsDirectory._cache_:
-            return EnvsDirectory._cache_[envs_dir]
-        else:
-            envs_directory_instance = super(EnvsDirectoryType, cls).__call__(envs_dir)
-            EnvsDirectory._cache_[envs_dir] = envs_directory_instance
-            return envs_directory_instance
+USER_ENVIRONMENTS_TXT_FILE = expand(join('~', '.conda', 'environments.txt'))
 
 
-@with_metaclass(EnvsDirectoryType)
-class EnvsDirectory(object):
-    _cache_ = {}
-    _is_writable = None
+def register_env(location):
+    location = normpath(location)
 
-    def __init__(self, envs_dir):
-        self.envs_dir = normpath(envs_dir)
-        self.root_dir = dirname(envs_dir)
-        self.catalog_file = join(envs_dir, ENVS_DIR_MAGIC_FILE)
+    if "placehold_pl" in location:
+        # Don't record envs created by conda-build.
+        return
 
-    @property
-    def is_writable(self):
-        # lazy and cached
-        # This method takes the action of creating an empty package cache if it does not exist.
-        #   Logic elsewhere, both in conda and in code that depends on conda, seems to make that
-        #   assumption.
-        if self._is_writable is None:
-            if isfile(join(self.envs_dir, ENVS_DIR_MAGIC_FILE)):
-                self._is_writable = file_path_is_writable(self.catalog_file)
-            else:
-                log.debug("env directory '%s' does not exist", self.envs_dir)
-                self._is_writable = create_envs_directory(self.envs_dir)
-        return self._is_writable
+    if location in yield_lines(USER_ENVIRONMENTS_TXT_FILE):
+        # Nothing to do. Location is already recorded in a known environments.txt file.
+        return
 
-    def raise_if_not_writable(self):
-        if not self.is_writable:
-            from ..exceptions import NotWritableError
-            raise NotWritableError(self.catalog_file)
-        return True
+    with open(USER_ENVIRONMENTS_TXT_FILE, 'a') as fh:
+        fh.write(location)
+        fh.write('\n')
 
-    @classmethod
-    def env_name(cls, prefix):
-        if not prefix:
-            return None
-        if paths_equal(prefix, context.root_prefix):
-            return 'base'
-        maybe_envs_dir, maybe_name = path_split(prefix)
-        for envs_dir in context.envs_dirs:
-            if paths_equal(envs_dir, maybe_envs_dir):
-                return maybe_name
-        return prefix
 
-    @classmethod
-    def first_writable(cls, envs_dirs=None):
-        return cls.all_writable(envs_dirs)[0]
+def _clean_environments_txt(environments_txt_file, remove_location=None):
+    if not isfile(environments_txt_file):
+        return ()
 
-    @classmethod
-    def all_writable(cls, envs_dirs=None):
-        _all = cls.all(envs_dirs)
-        writable_caches = tuple(ed for ed in _all if ed.is_writable)
-        if not writable_caches:
-            _all_envs_dirs = tuple(ed.envs_dir for ed in _all)
-            raise CondaError("No writable envs directories found in\n"
-                             "%s" % _all_envs_dirs)
-        return writable_caches
+    environments_txt_lines = list(yield_lines(environments_txt_file))
+    try:
+        location = normpath(remove_location or '')
+        idx = environments_txt_lines.index(location)
+        del environments_txt_lines[idx]
+    except ValueError:
+        # remove_location was not in list.  No problem, just move on.
+        pass
 
-    @classmethod
-    def all(cls, envs_dirs=None):
-        if envs_dirs is None:
-            envs_dirs = context.envs_dirs
-        else:
-            envs_dirs = tuple(normpath(d) for d in envs_dirs)
-        return tuple(cls(ed) for ed in envs_dirs)
-
-    @classmethod
-    def get_envs_directory_for_prefix(cls, prefix_path):
-        prefix_path = right_pad_os_sep(normpath(prefix_path))
-
-        for ed in context.envs_dirs:
-            edo = cls(ed)
-            if prefix_path.startswith(right_pad_os_sep(edo.root_dir)):
-                return edo
-
-        return cls.first_writable()
-
-    @staticmethod
-    def is_conda_environment(prefix):
-        return isdir(prefix) and isfile(join(prefix, PREFIX_MAGIC_FILE))
-
-    def to_prefix(self, env_name):
-        if env_name in (None, ROOT_ENV_NAME, 'root'):
-            return self.root_dir
-        else:
-            return join(self.envs_dir, env_name)
-
-    def register_env(self, location):
-        location = normpath(location)
-
-        if "placehold_pl" in location:
-            # Don't record envs created by conda-build.
-            return
-
-        envs_dir, env_name = path_split(location)
-
-        if paths_equal(envs_dir, self.envs_dir):
-            # Nothing to do.  We're not recording named envs in environments.txt
-            return
-
-        if paths_equal(location, self.root_dir):
-            # Nothing to do.  We don't record the root location in environments.txt
-            return
-
-        if location in yield_lines(self.catalog_file):
-            # Nothing to do. Location is already recorded in a known environments.txt file.
-            return
-
-        assert self.is_writable
-        with open(self.catalog_file, 'a') as fh:
-            fh.write(location)
+    real_prefixes = tuple(p for p in environments_txt_lines if is_conda_environment(p))
+    try:
+        with open(environments_txt_file, 'w') as fh:
+            fh.write('\n'.join(real_prefixes))
             fh.write('\n')
+    except (IOError, OSError) as e:
+        log.info("File not cleaned: %s", environments_txt_file)
+        log.debug('%r', e, exc_info=True)
+    return real_prefixes
 
-    def unregister_env(self, location):
-        if isdir(location):
-            meta_dir = join(location, 'conda-meta')
-            if isdir(meta_dir):
-                meta_dir_contents = listdir(meta_dir)
-                if len(meta_dir_contents) > 1:
-                    # if there are any files left other than 'conda-meta/history'
-                    #   then don't unregister
-                    return
 
-        self._clean_environments_txt(location)
+def unregister_env(location):
+    if isdir(location):
+        meta_dir = join(location, 'conda-meta')
+        if isdir(meta_dir):
+            meta_dir_contents = listdir(meta_dir)
+            if len(meta_dir_contents) > 1:
+                # if there are any files left other than 'conda-meta/history'
+                #   then don't unregister
+                return
 
-    def _clean_environments_txt(self, remove_location=None):
-        if not isfile(self.catalog_file):
-            return ()
+    _clean_environments_txt(USER_ENVIRONMENTS_TXT_FILE, location)
 
-        environments_txt_lines = list(yield_lines(self.catalog_file))
-        try:
-            location = normpath(remove_location or '')
-            idx = environments_txt_lines.index(location)
-            del environments_txt_lines[idx]
-        except ValueError:
-            # remove_location was not in list.  No problem, just move on.
-            pass
 
-        real_prefixes = tuple(p for p in environments_txt_lines if self.is_conda_environment(p))
-        if self.is_writable:
-            with open(self.catalog_file, 'w') as fh:
-                fh.write('\n'.join(real_prefixes))
-        return real_prefixes
+def list_all_known_prefixes():
+    all_env_paths = set()
+    if on_win:
+        home_dir_dir = dirname(expand('~'))
+        for home_dir in listdir(home_dir_dir):
+            environments_txt_file = join(home_dir_dir, home_dir, '.conda', 'environments.txt')
+            if isfile(environments_txt_file):
+                all_env_paths.update(_clean_environments_txt(environments_txt_file))
+    else:
+        from pwd import getpwall
+        for home_dir in tuple(pwentry.pw_dir for pwentry in getpwall()) or expand('~'):
+            environments_txt_file = join(home_dir, '.conda', 'environments.txt')
+            if isfile(environments_txt_file):
+                all_env_paths.update(_clean_environments_txt(environments_txt_file))
+    all_env_paths.add(context.root_prefix)
+    return sorted(all_env_paths)
 
-    def list_envs(self):
-        if isdir(self.envs_dir):
-            for path in listdir(self.envs_dir):
-                if self.is_conda_environment(join(self.envs_dir, path)):
-                    yield path
-        for path in self._clean_environments_txt():
-            yield path
-        if self.is_conda_environment(self.root_dir):
-            yield self.root_dir
 
-    @classmethod
-    def list_all_envs(cls, envs_dirs=None):
-        if envs_dirs is None:
-            envs_dirs = context.envs_dirs
-        all_envs = set()
-        for envs_dir in envs_dirs:
-            all_envs.update(cls(envs_dir).list_envs())
-        return sorted(all_envs)
+def env_name(prefix):
+    if not prefix:
+        return None
+    if paths_equal(prefix, context.root_prefix):
+        return ROOT_ENV_NAME
+    maybe_envs_dir, maybe_name = path_split(prefix)
+    for envs_dir in context.envs_dirs:
+        if paths_equal(envs_dir, maybe_envs_dir):
+            return maybe_name
+    return prefix

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from logging import getLogger
-from os import listdir, os
+from os import listdir
 from os.path import dirname, isdir, isfile, join, normpath, split as path_split
 
 from ..base.constants import ROOT_ENV_NAME
@@ -80,8 +80,9 @@ def list_all_known_prefixes():
             if isfile(environments_txt_file):
                 all_env_paths.update(_clean_environments_txt(environments_txt_file))
     else:
+        from os import geteuid
         from pwd import getpwall
-        if os.geteuid() == 0:
+        if geteuid() == 0:
             search_dirs = tuple(pwentry.pw_dir for pwentry in getpwall()) or (expand('~'),)
         else:
             search_dirs = (expand('~'),)

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -1,19 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from copy import deepcopy
 from logging import getLogger
-from os import getcwd, listdir
-from os.path import basename, dirname, isdir, isfile, join, normpath, split as path_split
+from os import listdir
+from os.path import dirname, isdir, isfile, join, normpath, split as path_split
 
 from .. import CondaError
 from ..base.constants import ENVS_DIR_MAGIC_FILE, PREFIX_MAGIC_FILE, ROOT_ENV_NAME
 from ..base.context import context
 from ..common.compat import with_metaclass
-from ..common.path import ensure_pad, expand, paths_equal, right_pad_os_sep
-from ..common.serialize import json_dump, json_load
-from ..exceptions import CondaValueError, EnvironmentNameNotFound, NotWritableError
+from ..common.path import paths_equal, right_pad_os_sep
 from ..gateways.disk.create import create_envs_directory
+from ..gateways.disk.read import yield_lines
 from ..gateways.disk.test import file_path_is_writable
 
 try:
@@ -42,40 +40,6 @@ class EnvsDirectoryType(type):
 
 @with_metaclass(EnvsDirectoryType)
 class EnvsDirectory(object):
-    """
-    This class manages the `envs/catalog.json` file.
-
-    The 'registered_envs' key is a list of known environment locations.  These locations need
-    not be within the `envs` directory.  Each entry in the 'registered_envs/ list is a map
-    containing two fields:
-
-        name: the designated name of the environment, usually basename(location)
-        location: the full path to the environment location
-
-    The 'leased_paths' key is used for private environments, and specifically for executable paths
-    to be mapped from the root environment one level above the `envs` directory into a private
-    environment contained within the envs directory.  The 'leased_paths' key is a list, with each
-    leased path entry being a map containing the following keys:
-
-        _path: short path for the leased path, using forward slashes
-        target_path: the full path to the executable in the private env
-        target_prefix: the full path to the private environment
-        leased_path: the full path for the lease in the root prefix
-        package_name: the package holding the lease
-        leased_path_type: application_entry_point
-
-    The 'preferred_env_packages' key is a list of packages associated with a private env, and
-    therefore potentially having application entry points in the root env.  Each
-    'preferred_env_packages' entry has the following keys:
-
-        package_name: package name
-        conda_meta_path: path to the package's conda-meta/*.json file within the target_prefix
-        preferred_env_name: private environment name
-        requested_spec: spec used at install time
-
-    A preferred env package cannot also be installed in the root env.
-
-    """
     _cache_ = {}
     _is_writable = None
 
@@ -84,76 +48,6 @@ class EnvsDirectory(object):
         self.root_dir = dirname(envs_dir)
         self.catalog_file = join(envs_dir, ENVS_DIR_MAGIC_FILE)
 
-        # self._init_dir()
-
-
-
-
-
-
-
-
-
-
-
-
-    def _init_dir(self):
-        self._envs_dir_data = self._read_raw_data()
-        self._prune_registered_envs()
-
-    def _read_raw_data(self):
-        # TODO: move this to conda.gateways.disk
-        if isfile(self.catalog_file):
-            with open(self.catalog_file) as fh:
-                catalog_file_content = fh.read().strip()
-                if not catalog_file_content:
-                    return {}
-                else:
-                    _envs_dir_data = json_load(catalog_file_content)
-                    # _envs_dir_data['leased_paths'] = [
-                    #     LeasedPathEntry(**lpe) for lpe in _envs_dir_data.get('leased_paths', ())
-                    # ]
-                    return _envs_dir_data
-        else:
-            return {}
-
-    def write_to_disk(self):
-        # TODO: move this to conda.gateways.disk
-        _data = {}
-        if self._registered_envs:
-            _data['registered_envs'] = self._registered_envs
-        # if self._leased_paths:
-        #     _data['leased_paths'] = self._leased_paths
-        # if self._preferred_env_packages:
-        #     _data['preferred_env_packages'] = self._preferred_env_packages
-
-        if _data:
-            if not self.is_writable:
-                raise RuntimeError()
-            with open(self.catalog_file, 'w') as fh:
-                fh.write(json_dump(_data))
-
-    def _set_state(self, envs_dir_state):
-        self._envs_dir_data = envs_dir_state  # TODO: find a better way
-
-    def _get_state(self):
-        return deepcopy(self._envs_dir_data)  # TODO: find a better way
-
-    @property
-    def _registered_envs(self):
-        # mutable structure for use within this class
-        return self._envs_dir_data.setdefault('registered_envs', [])
-
-    # @property
-    # def _leased_paths(self):
-    #     # mutable structure for use within this class
-    #     return self._envs_dir_data.setdefault('leased_paths', [])
-    #
-    # @property
-    # def _preferred_env_packages(self):
-    #     # mutable structure for use within this class
-    #     return self._envs_dir_data.setdefault('preferred_env_packages', [])
-
     @property
     def is_writable(self):
         # lazy and cached
@@ -161,7 +55,7 @@ class EnvsDirectory(object):
         #   Logic elsewhere, both in conda and in code that depends on conda, seems to make that
         #   assumption.
         if self._is_writable is None:
-            if isdir(self.envs_dir):
+            if isfile(join(self.envs_dir, ENVS_DIR_MAGIC_FILE)):
                 self._is_writable = file_path_is_writable(self.catalog_file)
             else:
                 log.debug("env directory '%s' does not exist", self.envs_dir)
@@ -170,6 +64,7 @@ class EnvsDirectory(object):
 
     def raise_if_not_writable(self):
         if not self.is_writable:
+            from ..exceptions import NotWritableError
             raise NotWritableError(self.catalog_file)
         return True
 
@@ -208,19 +103,6 @@ class EnvsDirectory(object):
         return tuple(cls(ed) for ed in envs_dirs)
 
     @classmethod
-    def locate_prefix_by_name(cls, name, envs_dirs=None):
-        """Find the location of a prefix given a conda env name."""
-        if name in (ROOT_ENV_NAME, 'root'):
-            return context.root_prefix
-
-        for envs_dir in concatv(envs_dirs or context.envs_dirs, (getcwd(),)):
-            prefix = join(envs_dir, name)
-            if isdir(prefix):
-                return prefix
-
-        raise EnvironmentNameNotFound(name)
-
-    @classmethod
     def get_envs_directory_for_prefix(cls, prefix_path):
         prefix_path = right_pad_os_sep(normpath(prefix_path))
 
@@ -232,24 +114,8 @@ class EnvsDirectory(object):
         return cls.first_writable()
 
     @staticmethod
-    def preferred_env_to_prefix(preferred_env):
-        if preferred_env is None:
-            return context.root_prefix
-        else:
-            return join(context.root_prefix, 'envs', ensure_pad(preferred_env, '_'))
-
-    @classmethod
-    def prune_all_registered_envs(cls, envs_dirs=None):
-        for x in cls.all(envs_dirs):
-            x._prune_registered_envs()
-
-    @staticmethod
     def is_conda_environment(prefix):
         return isdir(prefix) and isfile(join(prefix, PREFIX_MAGIC_FILE))
-
-    # ############################
-    # registered envs
-    # ############################
 
     def to_prefix(self, env_name):
         if env_name in (None, ROOT_ENV_NAME, 'root'):
@@ -257,48 +123,31 @@ class EnvsDirectory(object):
         else:
             return join(self.envs_dir, env_name)
 
-    def get_registered_env_by_name(self, env_name, default=None):
-        if env_name is None:
-            return default
-        if env_name == 'root':
-            env_name = ROOT_ENV_NAME
-        env_entry = next((renv for renv in self._registered_envs if renv.get('name') == env_name),
-                         default)
-        return env_entry
-
-    def get_registered_env_by_location(self, location, default=None):
-        location = normpath(location)
-        env_entry = next((renv for renv in self._registered_envs if renv['location'] == location),
-                         default)
-        return env_entry
-
     def register_env(self, location):
         location = normpath(location)
 
-        # figure out what the env name of the location is
-        if location == self.root_dir:
-            env_name = ROOT_ENV_NAME
-        elif dirname(location) == self.envs_dir:
-            env_name = basename(location)
-        else:
-            env_name = None
-
-        # env name might already exist
-        current_entry = self.get_registered_env_by_name(env_name)
-        if env_name and current_entry:
-            assert current_entry['location'] == location
+        if "placehold_pl" in location:
+            # Don't record envs created by conda-build.
             return
 
-        # env location might already exist
-        current_entry = self.get_registered_env_by_location(location)
-        if current_entry:
+        envs_dir, env_name = path_split(location)
+
+        if paths_equal(envs_dir, self.envs_dir):
+            # Nothing to do.  We're not recording named envs in environments.txt
             return
 
-        # finally, add a new entry
-        self._registered_envs.append({
-            'name': env_name,
-            'location': location,
-        })
+        if paths_equal(location, self.root_dir):
+            # Nothing to do.  We don't record the root location in environments.txt
+            return
+
+        if location in yield_lines(self.catalog_file):
+            # Nothing to do. Location is already recorded in a known environments.txt file.
+            return
+
+        assert self.is_writable
+        with open(self.catalog_file, 'a') as fh:
+            fh.write(location)
+            fh.write('\n')
 
     def unregister_env(self, location):
         if isdir(location):
@@ -310,155 +159,20 @@ class EnvsDirectory(object):
                     #   then don't unregister
                     return
 
-        idx = next((q for q, env_record in enumerate(self._registered_envs)
-                    if env_record['location'] == location),
-                   None)
-        if idx is not None:
-            self._registered_envs.pop(idx)
+        location = normpath(location)
+        environments_txt_lines = list(yield_lines(self.catalog_file))
 
-    def _prune_registered_envs(self):
-        if not self.is_writable:
+        try:
+            idx = environments_txt_lines.index(location)
+        except ValueError:
+            # location wasn't recorded; so there's nothing to do
             return
-        registered_env_recs = tuple(self._registered_envs)
-        keep_these = []
-        drop_these = []
-        for rerec in registered_env_recs:
-            if self.is_conda_environment(rerec['location']):
-                keep_these.append(rerec)
-            else:
-                drop_these.append(rerec)
-        if not drop_these:
-            self._envs_dir_data['registered_envs'] = sorted(keep_these,
-                                                            key=lambda x: x['location'])
-            self.write_to_disk()
 
-    # # ############################
-    # # leased paths
-    # # ############################
-    #
-    # def get_leased_path_entry(self, target_short_path, default=None):
-    #     current_lp = next((lp for lp in self._leased_paths
-    #                        if lp._path == target_short_path),
-    #                       default)
-    #     return current_lp
-    #
-    # def assert_path_not_leased(self, target_short_path):
-    #     current_lp = self.get_leased_path_entry(target_short_path)
-    #     if current_lp:
-    #         message = dals("""
-    #         A path in '%(root_prefix)s'
-    #         is already in use by another environment.
-    #           path: %(target_short_path)s
-    #           current prefix: %(current_prefix)s
-    #         """)
-    #         current_prefix = current_lp.target_prefix
-    #         raise CondaError(message,
-    #                          root_prefix=self.root_dir,
-    #                          target_short_path=target_short_path,
-    #                          current_prefix=current_prefix)
-    #
-    # def add_leased_path(self, leased_path_entry):
-    #     self.assert_path_not_leased(leased_path_entry._path)
-    #     self._leased_paths.append(leased_path_entry)
-    #
-    # def remove_leased_paths_for_package(self, package_name):
-    #     q = 0
-    #     while q < len(self._leased_paths):
-    #         leased_path_entry = self._leased_paths[q]
-    #         if leased_path_entry.package_name == package_name:
-    #             self._leased_paths.pop(q)
-    #         else:
-    #             q += 1
-    #
-    # # def remove_leased_path(self, target_short_path):
-    # #     lp_idx = next((q for q, lp in enumerate(self._leased_paths)
-    # #                    if lp._path == target_short_path),
-    # #                   None)
-    # #     if lp_idx is not None:
-    # #         self._leased_paths.pop(lp_idx)
-    #
-    # def get_leased_path_entries_for_package(self, package_name):
-    #     return tuple(lpe for lpe in self._leased_paths if lpe.package_name == package_name)
-    #
-    # # ############################
-    # # preferred env packages
-    # # ############################
-    #
-    # def add_preferred_env_package(self, preferred_env_name, package_name, conda_meta_path,
-    #                               requested_spec):
-    #     # assert package of same name not already installed in root env
-    #     # assert there's not already a similar entry
-    #     preferred_env_packages_entry = {
-    #         'package_name': package_name,
-    #         'conda_meta_path': conda_meta_path,
-    #         'preferred_env_name': ensure_pad(preferred_env_name),
-    #         'requested_spec': text_type(requested_spec),
-    #     }
-    #     self._preferred_env_packages.append(preferred_env_packages_entry)
-    #
-    # def remove_preferred_env_package(self, package_name):
-    #     lp_idx = next((q for q, lp in enumerate(self._preferred_env_packages)
-    #                    if lp['package_name'] == package_name),
-    #                   None)
-    #     self._preferred_env_packages.pop(lp_idx) if lp_idx is not None else None
-    #     self.remove_leased_paths_for_package(package_name)
-    #
-    # def get_registered_preferred_env(self, package_name):
-    #     pep = first(self._preferred_env_packages, lambda p: p['package_name'] == package_name)
-    #     return pep and pep['preferred_env_name']
-    #
-    # def get_registered_packages(self):
-    #     # returns Map[package_name, env_name]
-    #     return {pep['package_name']: pep for pep in self._preferred_env_packages}
-    #
-    # def get_registered_packages_keyed_on_env_name(self):
-    #     get_env_name = lambda x: x['preferred_env_name']
-    #     return groupby(get_env_name, self._preferred_env_packages)
-    #
-    # def get_private_env_prefix(self, spec_str):
-    #     package_name = spec_str.split()[0]
-    #     pep = first(self._preferred_env_packages, lambda p: p['package_name'] == package_name)
-    #     return join(self.envs_dir, pep['preferred_env_name']) if pep else None
-    #
-    # def get_preferred_env_package_entry(self, spec_str):
-    #     package_name = spec_str.split()[0]
-    #     pep = first(self._preferred_env_packages, lambda p: p['package_name'] == package_name)
-    #     return pep or None
+        assert self.is_writable
+        del environments_txt_lines[idx]
 
-
-def determine_target_prefix(ctx, args=None):
-    """Get the prefix to operate in
-
-    Args:
-        ctx: the context of conda
-        args: the argparse args from the command line
-
-    Returns: the prefix
-    Raises: CondaEnvironmentNotFoundError if the prefix is invalid
-    """
-
-    argparse_args = args or ctx._argparse_args
-    try:
-        prefix_name = argparse_args.name
-    except AttributeError:
-        prefix_name = None
-    try:
-        prefix_path = argparse_args.prefix
-    except AttributeError:
-        prefix_path = None
-
-    if prefix_name is None and prefix_path is None:
-        return ctx.default_prefix
-    elif prefix_path is not None:
-        return expand(prefix_path)
-    else:
-        if '/' in prefix_name:
-            raise CondaValueError("'/' not allowed in environment name: %s" %
-                                  prefix_name)
-        if prefix_name in (ROOT_ENV_NAME, 'root'):
-            return ctx.root_prefix
-        else:
-            try:
-                return EnvsDirectory.locate_prefix_by_name(prefix_name)
-            except EnvironmentNameNotFound:
-                return join(EnvsDirectory.first_writable().envs_dir, prefix_name)
+        # while we're writing the file back to disk, we'll also take the opportunity to ensure
+        # the paths we're writing are actually conda environments
+        real_prefixes = tuple(p for p in environments_txt_lines if self.is_conda_environment(p))
+        with open(self.catalog_file, 'w') as fh:
+            fh.write('\n'.join(real_prefixes))

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -163,7 +163,8 @@ class UnlinkLinkTransaction(object):
     def nothing_to_do(self):
         return (
             not any((stp.unlink_precs or stp.link_precs) for stp in itervalues(self.prefix_setups))
-            and all(is_conda_environment(stp.target_prefix) for stp in itervalues(self.prefix_setups))
+            and all(is_conda_environment(stp.target_prefix)
+                    for stp in itervalues(self.prefix_setups))
         )
 
     def get_pfe(self):

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -14,7 +14,7 @@ import warnings
 from conda.base.constants import SafetyChecks
 from .linked_data import PrefixData, get_python_version_for_prefix, linked_data as get_linked_data
 from .package_cache import PackageCache
-from .path_actions import (CompilePycAction, CreatePrefixRecordAction, CreateNonadminAction,
+from .path_actions import (CompilePycAction, CreateNonadminAction, CreatePrefixRecordAction,
                            CreatePythonEntryPointAction, LinkPathAction, MakeMenuAction,
                            RegisterEnvironmentLocationAction, RemoveLinkedPackageRecordAction,
                            RemoveMenuAction, UnlinkPathAction, UnregisterEnvironmentLocationAction,
@@ -33,7 +33,7 @@ from ..exceptions import (KnownPackageClobberError, LinkError, RemoveError,
 from ..gateways.disk import mkdir_p
 from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.read import isfile, lexists, read_package_info
-from ..gateways.disk.test import hardlink_supported, softlink_supported
+from ..gateways.disk.test import hardlink_supported, is_conda_environment, softlink_supported
 from ..gateways.subprocess import subprocess_call
 from ..models.enums import LinkType
 from ..resolve import MatchSpec
@@ -161,8 +161,10 @@ class UnlinkLinkTransaction(object):
 
     @property
     def nothing_to_do(self):
-        return not any((stp.unlink_precs or stp.link_precs)
-                       for stp in itervalues(self.prefix_setups))
+        return (
+            not any((stp.unlink_precs or stp.link_precs) for stp in itervalues(self.prefix_setups))
+            and all(is_conda_environment(stp.target_prefix) for stp in itervalues(self.prefix_setups))
+        )
 
     def get_pfe(self):
         from .package_cache import ProgressiveFetchExtract
@@ -287,7 +289,7 @@ class UnlinkLinkTransaction(object):
         history_actions = UpdateHistoryAction.create_actions(
             transaction_context, target_prefix, remove_specs, update_specs,
         )
-        if link_action_groups:
+        if link_action_groups or not (unlink_action_groups and link_action_groups):
             register_actions = RegisterEnvironmentLocationAction(transaction_context,
                                                                  target_prefix),
         else:

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1062,12 +1062,6 @@ class UnregisterEnvironmentLocationAction(EnvsDirectoryPathAction):
 
     def reverse(self):
         pass
-        # if self._execute_successful:
-        #     log.trace("reversing environment unregistration in catalog for %s", self.target_prefix)
-        #     from .envs_manager import EnvsDirectory
-        #     ed = EnvsDirectory(self.envs_dir_path)
-        #     ed._set_state(self.envs_dir_state)
-        #     ed.write_to_disk()
 
 
 # class UnregisterPrivateEnvAction(EnvsDirectoryPathAction):

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -900,22 +900,12 @@ class RegisterEnvironmentLocationAction(EnvsDirectoryPathAction):
     def execute(self):
         log.trace("registering environment in catalog %s", self.target_prefix)
 
-        # touches env prefix entry in catalog.json
         from .envs_manager import EnvsDirectory
-        ed = EnvsDirectory(self.envs_dir_path)
-
-        self.envs_dir_state = ed._get_state()
-        ed.register_env(self.target_prefix)
-        ed.write_to_disk()
+        EnvsDirectory(self.envs_dir_path).register_env(self.target_prefix)
         self._execute_successful = True
 
     def reverse(self):
-        if self._execute_successful:
-            log.trace("reversing environment registration in catalog for %s", self.target_prefix)
-            from .envs_manager import EnvsDirectory
-            ed = EnvsDirectory(self.envs_dir_path)
-            ed._set_state(self.envs_dir_state)
-            ed.write_to_disk()
+        pass
 
 
 # class RegisterPrivateEnvAction(EnvsDirectoryPathAction):
@@ -1065,22 +1055,19 @@ class UnregisterEnvironmentLocationAction(EnvsDirectoryPathAction):
     def execute(self):
         log.trace("unregistering environment in catalog %s", self.target_prefix)
 
-        # touches env prefix entry in catalog.json
         from .envs_manager import EnvsDirectory
         ed = EnvsDirectory(self.envs_dir_path)
-
-        self.envs_dir_state = ed._get_state()
         ed.unregister_env(self.target_prefix)
-        ed.write_to_disk()
         self._execute_successful = True
 
     def reverse(self):
-        if self._execute_successful:
-            log.trace("reversing environment unregistration in catalog for %s", self.target_prefix)
-            from .envs_manager import EnvsDirectory
-            ed = EnvsDirectory(self.envs_dir_path)
-            ed._set_state(self.envs_dir_state)
-            ed.write_to_disk()
+        pass
+        # if self._execute_successful:
+        #     log.trace("reversing environment unregistration in catalog for %s", self.target_prefix)
+        #     from .envs_manager import EnvsDirectory
+        #     ed = EnvsDirectory(self.envs_dir_path)
+        #     ed._set_state(self.envs_dir_state)
+        #     ed.write_to_disk()
 
 
 # class UnregisterPrivateEnvAction(EnvsDirectoryPathAction):

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -40,6 +40,19 @@ def make_writable(path):
             raise
 
 
+def make_read_only(path):
+    mode = lstat(path).st_mode
+    if S_ISDIR(mode):
+        chmod(path, S_IMODE(mode) & ~S_IWRITE)
+    elif islink(path):
+        lchmod(path, S_IMODE(mode) & ~S_IWRITE)
+    elif S_ISREG(mode):
+        chmod(path, S_IMODE(mode) & ~S_IWRITE)
+    else:
+        log.debug("path cannot be made read only: %s", path)
+    return True
+
+
 def recursive_make_writable(path, max_tries=MAX_TRIES):
     # The need for this function was pointed out at
     #   https://github.com/conda/conda/issues/3266#issuecomment-239241915

--- a/conda/gateways/disk/test.py
+++ b/conda/gateways/disk/test.py
@@ -40,6 +40,7 @@ def file_path_is_writable(path):
         return access(path, W_OK)
 
 
+@memoize
 def prefix_is_writable(prefix):
     """
     Strategy:

--- a/conda/gateways/disk/test.py
+++ b/conda/gateways/disk/test.py
@@ -131,3 +131,7 @@ def softlink_supported(source_file, dest_dir):
         return False
     finally:
         rm_rf(test_path)
+
+
+def is_conda_environment(prefix):
+    return isdir(prefix) and isfile(join(prefix, PREFIX_MAGIC_FILE))

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import defaultdict
 import os
-from os.path import abspath, dirname, exists, expanduser, isdir, isfile, join, relpath
+from os.path import abspath, dirname, exists, isdir, isfile, join, relpath
 import re
 import shutil
 import sys
@@ -152,17 +152,6 @@ def touch_nonadmin(prefix):
             os.makedirs(prefix)
         with open(join(prefix, '.nonadmin'), 'w') as fo:
             fo.write('')
-
-
-def append_env(prefix):
-    dir_path = abspath(expanduser('~/.conda'))
-    try:
-        if not isdir(dir_path):
-            os.mkdir(dir_path)
-        with open(join(dir_path, 'environments.txt'), 'a') as f:
-            f.write('%s\n' % prefix)
-    except (IOError, OSError):
-        pass
 
 
 def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):

--- a/conda_env/cli/common.py
+++ b/conda_env/cli/common.py
@@ -16,7 +16,7 @@ def stdout_json(d):
 
 
 def get_prefix(args, search=True):
-    from conda.core.envs_manager import determine_target_prefix
+    from conda.base.context import determine_target_prefix
     return determine_target_prefix(context, args)
 
 

--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
-from conda.base.constants import SEARCH_PATH
 from conda.base.context import context
 from conda.cli.conda_argparse import ArgumentParser
 from conda.cli.main import init_loggers
@@ -67,13 +66,22 @@ def create_parser():
     return p
 
 
+def do_call(args, parser):
+    relative_mod, func_name = args.func.rsplit('.', 1)
+    # func_name should always be 'execute'
+    from importlib import import_module
+    module = import_module(relative_mod, __name__.rsplit('.', 1)[0])
+    exit_code = getattr(module, func_name)(args, parser)
+    return exit_code
+
+
 def main():
     initialize_logging()
     parser = create_parser()
     args = parser.parse_args()
-    context.__init__(SEARCH_PATH, 'conda', args)
+    context.__init__(argparse_args=args)
     init_loggers(context)
-    return conda_exception_handler(args.func, args, parser)
+    return conda_exception_handler(do_call, args, parser)
 
 
 if __name__ == '__main__':

--- a/conda_env/cli/main_attach.py
+++ b/conda_env/cli/main_attach.py
@@ -68,7 +68,7 @@ def configure_parser(sub_parsers):
         default=None
     )
     add_parser_json(p)
-    p.set_defaults(func=execute)
+    p.set_defaults(func='.main_attach.execute')
 
 
 def execute(args, parser):

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -67,7 +67,7 @@ def configure_parser(sub_parsers):
         default=False,
     )
     add_parser_json(p)
-    p.set_defaults(func=execute)
+    p.set_defaults(func='.main_create.execute')
 
 
 def execute(args, parser):

--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -65,7 +65,7 @@ def configure_parser(sub_parsers):
         required=False,
         help='Do not include channel names with package names.')
     add_parser_json(p)
-    p.set_defaults(func=execute)
+    p.set_defaults(func='.main_export.execute')
 
 
 # TODO Make this aware of channels that were used to install packages

--- a/conda_env/cli/main_list.py
+++ b/conda_env/cli/main_list.py
@@ -2,6 +2,7 @@ from argparse import RawDescriptionHelpFormatter
 
 from conda.cli import common
 from conda.cli.conda_argparse import add_parser_json
+from conda.core.envs_manager import list_all_known_prefixes
 
 description = """
 List the Conda environments
@@ -29,7 +30,7 @@ def configure_parser(sub_parsers):
 
 
 def execute(args, parser):
-    info_dict = {'envs': []}
+    info_dict = {'envs': list_all_known_prefixes()}
     common.handle_envs_list(info_dict['envs'], not args.json)
 
     if args.json:

--- a/conda_env/cli/main_list.py
+++ b/conda_env/cli/main_list.py
@@ -25,7 +25,7 @@ def configure_parser(sub_parsers):
 
     add_parser_json(list_parser)
 
-    list_parser.set_defaults(func=execute)
+    list_parser.set_defaults(func='.main_list.execute')
 
 
 def execute(args, parser):

--- a/conda_env/cli/main_remove.py
+++ b/conda_env/cli/main_remove.py
@@ -37,7 +37,7 @@ def configure_parser(sub_parsers):
     add_parser_quiet(p)
     add_parser_yes(p)
 
-    p.set_defaults(func=execute)
+    p.set_defaults(func='.main_remove.execute')
 
 
 def execute(args, parser):
@@ -48,9 +48,8 @@ def execute(args, parser):
         'override_channels': None, 'use_local': None, 'use_cache': None,
         'offline': None, 'force': None, 'pinned': None})
     args = Namespace(**args)
-    from conda.base.constants import SEARCH_PATH
     from conda.base.context import context
-    context.__init__(SEARCH_PATH, 'conda', args)
+    context.__init__(argparse_args=args)
 
     if not isdir(context.target_prefix):
         from conda.exceptions import EnvironmentLocationNotFound

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -60,7 +60,7 @@ def configure_parser(sub_parsers):
         nargs='?'
     )
     add_parser_json(p)
-    p.set_defaults(func=execute)
+    p.set_defaults(func='.main_update.execute')
 
 
 def execute(args, parser):

--- a/conda_env/cli/main_upload.py
+++ b/conda_env/cli/main_upload.py
@@ -60,7 +60,7 @@ def configure_parser(sub_parsers):
         nargs='?'
     )
     add_parser_json(p)
-    p.set_defaults(func=execute)
+    p.set_defaults(func='.main_upload.execute')
 
 
 def execute(args, parser):

--- a/shell/etc/profile.d/conda.sh
+++ b/shell/etc/profile.d/conda.sh
@@ -90,7 +90,12 @@ _conda_reactivate() {
 
 
 conda() {
-    local cmd="$1" && shift
+    if [ "$#" -ge 1 ]; then
+        local cmd="$1"
+        shift
+    else
+        local cmd=""
+    fi
     case "$cmd" in
         activate)
             _conda_activate "$@"

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -14,7 +14,7 @@ from conda.cli.main import generate_parser
 from conda.common.io import captured
 from conda.exceptions import EnvironmentLocationNotFound
 from conda.install import rm_rf
-from conda_env.cli.main import create_parser
+from conda_env.cli.main import create_parser, do_call as do_call_conda_env
 from conda_env.exceptions import SpecNotFound
 from conda_env.yaml import load as yaml_load
 
@@ -85,7 +85,7 @@ def run_env_command(command, prefix, *arguments):
     context._set_argparse_args(args)
 
     with captured() as c:
-        args.func(args, p)
+        do_call_conda_env(args, p)
 
     return c.stdout, c.stderr
 

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -135,13 +135,11 @@ class IntegrationTests(unittest.TestCase):
         rm_rf("environment.yml")
         if env_is_created(test_env_name_1):
             run_env_command(Commands.ENV_REMOVE, test_env_name_1)
-        rm_rf(join(context.root_prefix, 'envs', test_env_name_1))
 
     def tearDown(self):
         rm_rf("environment.yml")
         if env_is_created(test_env_name_1):
             run_env_command(Commands.ENV_REMOVE, test_env_name_1)
-        rm_rf(join(context.root_prefix, 'envs', test_env_name_1))
 
     def test_conda_env_create_no_file(self):
         '''
@@ -219,12 +217,16 @@ class NewIntegrationTests(unittest.TestCase):
     """
 
     def setUp(self):
-        rm_rf(join(context.root_prefix, 'envs', test_env_name_2))
-        rm_rf(join(context.root_prefix, 'envs', test_env_name_3))
+        if env_is_created(test_env_name_2):
+            run_env_command(Commands.ENV_REMOVE, test_env_name_2)
+        if env_is_created(test_env_name_3):
+            run_env_command(Commands.ENV_REMOVE, test_env_name_3)
 
     def tearDown(self):
-        rm_rf(join(context.root_prefix, 'envs', test_env_name_2))
-        rm_rf(join(context.root_prefix, 'envs', test_env_name_3))
+        if env_is_created(test_env_name_2):
+            run_env_command(Commands.ENV_REMOVE, test_env_name_2)
+        if env_is_created(test_env_name_3):
+            run_env_command(Commands.ENV_REMOVE, test_env_name_3)
 
     def test_create_remove_env(self):
         """

--- a/tests/conda_env/test_create.py
+++ b/tests/conda_env/test_create.py
@@ -22,6 +22,7 @@ import pytest
 from conda.install import on_win
 from conda_env.cli.main_create import configure_parser as create_configure_parser
 from conda_env.cli.main_update import configure_parser as update_configure_parser
+from conda_env.cli.main import do_call as do_call_conda_env
 from conda.core.linked_data import linked
 
 from . import utils
@@ -70,7 +71,7 @@ def run_command(command, env_name, *arguments):
     command_line = "{0} -n {1} -f {2}".format(command, env_name, " ".join(arguments))
 
     args = p.parse_args(split(command_line))
-    args.func(args, p)
+    do_call_conda_env(args, p)
 
 
 @contextmanager

--- a/tests/core/test_envs_manager.py
+++ b/tests/core/test_envs_manager.py
@@ -8,20 +8,14 @@ from tempfile import gettempdir
 from unittest import TestCase
 from uuid import uuid4
 
-import pytest
-
-from conda import CondaError
 from conda._vendor.auxlib.collection import AttrDict
-from conda.base.constants import ROOT_ENV_NAME
 from conda.base.context import context, reset_context
 from conda.common.io import env_var
-from conda.common.path import ensure_pad
 from conda.core.envs_manager import EnvsDirectory
 from conda.gateways.disk import mkdir_p
 from conda.gateways.disk.delete import rm_rf
+from conda.gateways.disk.read import yield_lines
 from conda.gateways.disk.update import touch
-from conda.models.enums import LeasedPathType
-from conda.models.leased_path_entry import LeasedPathEntry
 
 try:
     from unittest.mock import patch
@@ -53,22 +47,7 @@ class EnvsManagerUnitTests(TestCase):
         ed.register_env(chopo_location)
         ed.register_env(chopo_location)  # should be completely idempotent
 
-        assert ed.get_registered_env_by_location(chopo_location) == {
-            'name': 'chopo',
-            'location': chopo_location,
-        } == ed.get_registered_env_by_name('chopo')
-
-        assert ed.to_prefix('chopo') == chopo_location
-
-        ed.unregister_env(chopo_location)
-        ed.unregister_env(chopo_location)  # should be idempotent
-
-        assert ed.get_registered_env_by_location(chopo_location) is None
-        assert ed.get_registered_env_by_name('chopo') is None
-
-        # test EnvsDirectory cache
-        assert EnvsDirectory(ed) is ed
-        assert EnvsDirectory(envs_dir) is ed
+        assert len(tuple(yield_lines(ed.catalog_file))) == 0
 
     def test_register_unregister_location_env(self):
         envs_dir = join(self.prefix, 'envs')
@@ -79,17 +58,14 @@ class EnvsManagerUnitTests(TestCase):
         ed.register_env(gascon_location)
         ed.register_env(gascon_location)  # should be completely idempotent
 
-        assert ed.get_registered_env_by_location(gascon_location) == {
-            'name': None,
-            'location': gascon_location,
-        }
-        assert ed.get_registered_env_by_name('gascon') is None
+        environments_txt_lines = tuple(yield_lines(ed.catalog_file))
+        assert len(environments_txt_lines) == 1
+        assert environments_txt_lines[0] == gascon_location
 
         ed.unregister_env(gascon_location)
+        assert len(tuple(yield_lines(ed.catalog_file))) == 0
         ed.unregister_env(gascon_location)  # should be idempotent
-
-        assert ed.get_registered_env_by_location(gascon_location) is None
-        assert ed.get_registered_env_by_name('gascon') is None
+        assert len(tuple(yield_lines(ed.catalog_file))) == 0
 
     def test_register_unregister_root_env(self):
         envs_dir = join(self.prefix, 'envs')
@@ -100,90 +76,14 @@ class EnvsManagerUnitTests(TestCase):
         ed.register_env(root_location)
         ed.register_env(root_location)  # should be completely idempotent
 
-        assert ed.get_registered_env_by_location(root_location) == {
-            'name': ROOT_ENV_NAME,
-            'location': root_location,
-        } == ed.get_registered_env_by_name('root')
+        assert len(tuple(yield_lines(ed.catalog_file))) == 0
 
         assert ed.to_prefix('root') == root_location
 
         ed.unregister_env(root_location)
         ed.unregister_env(root_location)  # should be idempotent
 
-        assert ed.get_registered_env_by_location(root_location) is None
-        assert ed.get_registered_env_by_name('root') is None
-
-    # def test_leased_paths(self):
-    #     with env_var('CONDA_ROOT_PREFIX', self.prefix, reset_context):
-    #         alamos_env = EnvsDirectory.preferred_env_to_prefix('alamos')
-    #         lpe_1 = LeasedPathEntry(
-    #             _path='bin/alamos',
-    #             target_path=join(alamos_env, 'bin', 'alamos'),
-    #             target_prefix=alamos_env,
-    #             leased_path=join(context.root_prefix, 'bin', 'alamos'),
-    #             package_name='alamos',
-    #             leased_path_type=LeasedPathType.application_entry_point,
-    #         )
-    #
-    #         ed = EnvsDirectory(join(context.root_prefix, 'envs'))
-    #         ed.add_leased_path(lpe_1)
-    #
-    #         with pytest.raises(CondaError):
-    #             ed.add_leased_path(lpe_1)
-    #
-    #         lpe_2 = LeasedPathEntry(
-    #             _path='bin/itsamalbec',
-    #             target_path=join(alamos_env, 'bin', 'itsamalbec'),
-    #             target_prefix=alamos_env,
-    #             leased_path=join(context.root_prefix, 'bin', 'itsamalbec'),
-    #             package_name='alamos',
-    #             leased_path_type=LeasedPathType.application_entry_point,
-    #         )
-    #         ed.add_leased_path(lpe_2)
-    #
-    #         assert len(ed.get_leased_path_entries_for_package('alamos')) == 2
-    #
-    #         assert ed.get_leased_path_entry('bin/itsamalbec') == lpe_2
-    #
-    #         ed.remove_leased_paths_for_package('alamos')
-    #
-    #         assert len(ed.get_leased_path_entries_for_package('alamos')) == 0
-    #         assert ed.get_leased_path_entry('bin/itsamalbec') is None
-
-    # def test_preferred_env_packages_too_simple(self):
-    #     with env_var('CONDA_ROOT_PREFIX', self.prefix, reset_context):
-    #         envs_dir = join(self.prefix, 'envs')
-    #         ed = EnvsDirectory(envs_dir)
-    #         assert ed.is_writable
-    #
-    #         preferred_env_name = "monster"
-    #         package_name = "monster-zero-ultra"
-    #         env_root = join(self.prefix, 'envs', ensure_pad(preferred_env_name))
-    #         conda_meta_path = join(env_root, 'conda-meta', "%s-1.2.3-4.json" % package_name)
-    #         requested_spec = "monster-zero-ultra 1.2.*"
-    #         ed.add_preferred_env_package(preferred_env_name, package_name, conda_meta_path,
-    #                                      requested_spec)
-    #
-    #         assert ed.get_registered_preferred_env(package_name) == ensure_pad(preferred_env_name)
-    #         assert len(ed.get_registered_packages()) == 1
-    #
-    #         assert ed.get_registered_packages_keyed_on_env_name() == {
-    #             ensure_pad(preferred_env_name): [{
-    #                 'package_name': package_name,
-    #                 'conda_meta_path': conda_meta_path,
-    #                 'preferred_env_name': ensure_pad(preferred_env_name),
-    #                 'requested_spec': requested_spec,
-    #             }],
-    #         }
-    #
-    #         assert ed.get_private_env_prefix(package_name) == env_root
-    #
-    #         assert ed.get_preferred_env_package_entry(package_name) == {
-    #                 'package_name': package_name,
-    #                 'conda_meta_path': conda_meta_path,
-    #                 'preferred_env_name': ensure_pad(preferred_env_name),
-    #                 'requested_spec': requested_spec,
-    #             }
+        assert len(tuple(yield_lines(ed.catalog_file))) == 0
 
     def test_default_target_is_root_prefix(self):
         assert context.target_prefix == context.root_prefix
@@ -193,19 +93,19 @@ class EnvsManagerUnitTests(TestCase):
         with env_var('CONDA_ENVS_DIRS', os.pathsep.join(envs_dirs), reset_context):
 
             # with both dirs writable, choose first
-            reset_context((), argparse_args=AttrDict(name='blarg'))
+            reset_context((), argparse_args=AttrDict(name='blarg', func='create'))
             assert context.target_prefix == join(envs_dirs[0], 'blarg')
 
             # with first dir read-only, choose second
             EnvsDirectory(envs_dirs[0])._is_writable = False
-            reset_context((), argparse_args=AttrDict(name='blarg'))
+            reset_context((), argparse_args=AttrDict(name='blarg', func='create'))
             assert context.target_prefix == join(envs_dirs[1], 'blarg')
 
             # if first dir is read-only but environment exists, choose first
             EnvsDirectory._cache_.pop(envs_dirs[0])
             mkdir_p(join(envs_dirs[0], 'blarg'))
             touch(join(envs_dirs[0], 'blarg', 'history'))
-            reset_context((), argparse_args=AttrDict(name='blarg'))
+            reset_context((), argparse_args=AttrDict(name='blarg', func='create'))
             assert context.target_prefix == join(envs_dirs[0], 'blarg')
 
             EnvsDirectory._cache_ = {}
@@ -215,7 +115,7 @@ class EnvsManagerUnitTests(TestCase):
         with env_var('CONDA_ENVS_DIRS', os.pathsep.join(envs_dirs), reset_context):
 
             # even if prefix doesn't exist, it can be a target prefix
-            reset_context((), argparse_args=AttrDict(prefix='./blarg'))
+            reset_context((), argparse_args=AttrDict(prefix='./blarg', func='create'))
             target_prefix = join(os.getcwd(), 'blarg')
             assert context.target_prefix == target_prefix
             assert not isdir(target_prefix)

--- a/tests/core/test_envs_manager.py
+++ b/tests/core/test_envs_manager.py
@@ -46,6 +46,7 @@ class EnvsManagerUnitTests(TestCase):
         touch(join(gascon_location, PREFIX_MAGIC_FILE), mkdir=True)
         assert gascon_location not in list_all_known_prefixes()
 
+        touch(USER_ENVIRONMENTS_TXT_FILE, mkdir=True, sudo_safe=True)
         register_env(gascon_location)
         assert gascon_location in yield_lines(USER_ENVIRONMENTS_TXT_FILE)
         assert len(tuple(x for x in yield_lines(USER_ENVIRONMENTS_TXT_FILE) if paths_equal(gascon_location, x))) == 1

--- a/tests/core/test_envs_manager.py
+++ b/tests/core/test_envs_manager.py
@@ -9,9 +9,12 @@ from unittest import TestCase
 from uuid import uuid4
 
 from conda._vendor.auxlib.collection import AttrDict
+from conda.base.constants import PREFIX_MAGIC_FILE
 from conda.base.context import context, reset_context
 from conda.common.io import env_var
-from conda.core.envs_manager import EnvsDirectory
+from conda.common.path import paths_equal
+from conda.core.envs_manager import list_all_known_prefixes, register_env, USER_ENVIRONMENTS_TXT_FILE, \
+    unregister_env
 from conda.gateways.disk import mkdir_p
 from conda.gateways.disk.delete import rm_rf
 from conda.gateways.disk.read import yield_lines
@@ -38,77 +41,22 @@ class EnvsManagerUnitTests(TestCase):
         rm_rf(self.prefix)
         assert not lexists(self.prefix)
 
-    def test_register_unregister_named_env(self):
-        envs_dir = join(self.prefix, 'envs')
-        ed = EnvsDirectory(envs_dir)
-        assert ed.is_writable
-
-        chopo_location = join(envs_dir, 'chopo')
-        ed.register_env(chopo_location)
-        ed.register_env(chopo_location)  # should be completely idempotent
-
-        assert len(tuple(yield_lines(ed.catalog_file))) == 0
-
     def test_register_unregister_location_env(self):
-        envs_dir = join(self.prefix, 'envs')
-        ed = EnvsDirectory(envs_dir)
-        assert ed.is_writable
-
         gascon_location = join(self.prefix, 'gascon')
-        ed.register_env(gascon_location)
-        ed.register_env(gascon_location)  # should be completely idempotent
+        touch(join(gascon_location, PREFIX_MAGIC_FILE), mkdir=True)
+        assert gascon_location not in list_all_known_prefixes()
 
-        environments_txt_lines = tuple(yield_lines(ed.catalog_file))
-        assert len(environments_txt_lines) == 1
-        assert environments_txt_lines[0] == gascon_location
+        register_env(gascon_location)
+        assert gascon_location in yield_lines(USER_ENVIRONMENTS_TXT_FILE)
+        assert len(tuple(x for x in yield_lines(USER_ENVIRONMENTS_TXT_FILE) if paths_equal(gascon_location, x))) == 1
 
-        ed.unregister_env(gascon_location)
-        assert len(tuple(yield_lines(ed.catalog_file))) == 0
-        ed.unregister_env(gascon_location)  # should be idempotent
-        assert len(tuple(yield_lines(ed.catalog_file))) == 0
+        register_env(gascon_location)  # should be completely idempotent
+        assert len(tuple(x for x in yield_lines(USER_ENVIRONMENTS_TXT_FILE) if x == gascon_location)) == 1
 
-    def test_register_unregister_root_env(self):
-        envs_dir = join(self.prefix, 'envs')
-        ed = EnvsDirectory(envs_dir)
-        assert ed.is_writable
-
-        root_location = self.prefix
-        ed.register_env(root_location)
-        ed.register_env(root_location)  # should be completely idempotent
-
-        assert len(tuple(yield_lines(ed.catalog_file))) == 0
-
-        assert ed.to_prefix('root') == root_location
-
-        ed.unregister_env(root_location)
-        ed.unregister_env(root_location)  # should be idempotent
-
-        assert len(tuple(yield_lines(ed.catalog_file))) == 0
-
-    def test_default_target_is_root_prefix(self):
-        assert context.target_prefix == context.root_prefix
-
-    def test_name_cli_flag(self):
-        envs_dirs = (join(self.prefix, 'first-envs-dir'), join(self.prefix, 'seconds-envs-dir'))
-        with env_var('CONDA_ENVS_DIRS', os.pathsep.join(envs_dirs), reset_context):
-
-            # with both dirs writable, choose first
-            reset_context((), argparse_args=AttrDict(name='blarg', func='create'))
-            assert context.target_prefix == join(envs_dirs[0], 'blarg')
-
-            # with first dir read-only, choose second
-            EnvsDirectory(envs_dirs[0])._is_writable = False
-            reset_context((), argparse_args=AttrDict(name='blarg', func='create'))
-            assert context.target_prefix == join(envs_dirs[1], 'blarg')
-
-            # if first dir is read-only but environment exists, choose first
-            EnvsDirectory._cache_.pop(envs_dirs[0])
-            mkdir_p(join(envs_dirs[0], 'blarg'))
-            touch(join(envs_dirs[0], 'blarg', 'history'))
-            reset_context((), argparse_args=AttrDict(name='blarg', func='create'))
-            assert context.target_prefix == join(envs_dirs[0], 'blarg')
-
-            EnvsDirectory._cache_ = {}
+        unregister_env(gascon_location)
+        assert gascon_location not in list_all_known_prefixes()
+        unregister_env(gascon_location)  # should be idempotent
+        assert gascon_location not in list_all_known_prefixes()
 
     def test_prefix_cli_flag(self):
         envs_dirs = (join(self.prefix, 'first-envs-dir'), join(self.prefix, 'seconds-envs-dir'))

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -824,7 +824,7 @@ class UrlChannelTests(TestCase):
                     "https://some.url/ch_name",
                     "file:///some/place/on/my/machine",)
         with env_var("CONDA_CHANNELS", ','.join(channels)):
-            new_context = Context((), APP_NAME)
+            new_context = Context(())
             assert new_context.channels == (
                 "file://\\\\network_share\\shared_folder\\path\\conda",
                 "https://some.url/ch_name",


### PR DESCRIPTION
fix #6088
resolve #6303
resolve #5537

This PR fixes an issue were using `-p` or `-n` in `create`, `install`, `update`, and `remove` commands fails to pick up configuration for the target prefix.  It also makes sure we're maintaining the `envs/environments.txt` file.  Only environments that are not 'named' environments are recorded in environments.txt.