### PR TITLE
re-enable feature tests in 4.3.x

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -552,7 +552,6 @@ class IntegrationTests(TestCase):
             assert not exists(prefix)
 
     @pytest.mark.skipif(on_win, reason="nomkl not present on windows")
-    @pytest.mark.xfail(conda.__version__.startswith('4.3') and datetime.now() < datetime(2018, 1, 1), reason='currently broken in 4.3')
     def test_remove_features(self):
         with make_temp_env("python=2 numpy nomkl") as prefix:
             assert exists(join(prefix, PYTHON_BINARY))

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -15,8 +15,6 @@ from .test_create import (make_temp_env, assert_package_is_installed,
 class PriorityIntegrationTests(TestCase):
 
     @pytest.mark.skipif(on_win, reason="xz packages are different on windows than unix")
-    @pytest.mark.skipif(conda.__version__.startswith('4.3') and datetime.now() < datetime(2018, 1, 1),
-                        reason='currently broken in 4.3')
     def test_channel_order_channel_priority_true(self):
         with make_temp_env("python=3.5 pycosat==0.6.1") as prefix:
             assert_package_is_installed(prefix, 'python')


### PR DESCRIPTION
These two tests were temporarily ignored in 4.3.x because of some things caused by the `pkgs/main` transition.  They should now be re-enabled.