### PR TITLE
remove dead code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,7 @@ ignore:
   - conda/console.py
   - conda/cli/activate.py
   - conda/cli/main_package.py
+  - conda/exports.py
   - conda/gateways/connection/adapters/ftp.py
   - conda/gateways/connection/adapters/s3.py
   - tests/.*

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -17,9 +17,8 @@ compat, plan = compat, plan
 from .core.solve import Solver  # NOQA
 Solver = Solver
 
-from .plan import display_actions, execute_actions, execute_plan, install_actions  # NOQA
-display_actions, execute_actions = display_actions, execute_actions
-execute_plan, install_actions = execute_plan, install_actions
+from .plan import display_actions  # NOQA
+display_actions = display_actions
 
 from .cli.common import specs_from_args, spec_from_line, specs_from_url  # NOQA
 from .cli.conda_argparse import add_parser_prefix, add_parser_channels  # NOQA
@@ -200,3 +199,231 @@ def hash_file(_):
 
 def verify(_):
     return False  # pragma: no cover
+
+
+def execute_actions(actions, index, verbose=False):
+    plan = _plan_from_actions(actions, index)
+    execute_instructions(plan, index, verbose)
+
+
+def _plan_from_actions(actions, index):
+    from .instructions import ACTION_CODES, PREFIX, PRINT, PROGRESS, PROGRESS_COMMANDS
+
+    if 'op_order' in actions and actions['op_order']:
+        op_order = actions['op_order']
+    else:
+        op_order = ACTION_CODES
+
+    assert PREFIX in actions and actions[PREFIX]
+    prefix = actions[PREFIX]
+    plan = [('PREFIX', '%s' % prefix)]
+
+    unlink_link_transaction = actions.get('UNLINKLINKTRANSACTION')
+    if unlink_link_transaction:
+        raise RuntimeError()
+        # progressive_fetch_extract = actions.get('PROGRESSIVEFETCHEXTRACT')
+        # if progressive_fetch_extract:
+        #     plan.append((PROGRESSIVEFETCHEXTRACT, progressive_fetch_extract))
+        # plan.append((UNLINKLINKTRANSACTION, unlink_link_transaction))
+        # return plan
+
+    axn = actions.get('ACTION') or None
+    specs = actions.get('SPECS', [])
+
+    log.debug("Adding plans for operations: {0}".format(op_order))
+    for op in op_order:
+        if op not in actions:
+            log.trace("action {0} not in actions".format(op))
+            continue
+        if not actions[op]:
+            log.trace("action {0} has None value".format(op))
+            continue
+        if '_' not in op:
+            plan.append((PRINT, '%sing packages ...' % op.capitalize()))
+        elif op.startswith('RM_'):
+            plan.append((PRINT, 'Pruning %s packages from the cache ...' % op[3:].lower()))
+        if op in PROGRESS_COMMANDS:
+            plan.append((PROGRESS, '%d' % len(actions[op])))
+        for arg in actions[op]:
+            log.debug("appending value {0} for action {1}".format(arg, op))
+            plan.append((op, arg))
+
+    plan = _inject_UNLINKLINKTRANSACTION(plan, index, prefix, axn, specs)
+
+    return plan
+
+
+def _inject_UNLINKLINKTRANSACTION(plan, index, prefix, axn, specs):
+    from os.path import isdir
+    from .models.dist import Dist
+    from ._vendor.toolz.itertoolz import groupby
+    from .instructions import LINK, PROGRESSIVEFETCHEXTRACT, UNLINK, UNLINKLINKTRANSACTION
+    from .core.package_cache import ProgressiveFetchExtract
+    from .core.link import PrefixSetup, UnlinkLinkTransaction
+    # this is only used for conda-build at this point
+    first_unlink_link_idx = next((q for q, p in enumerate(plan) if p[0] in (UNLINK, LINK)), -1)
+    if first_unlink_link_idx >= 0:
+        grouped_instructions = groupby(lambda x: x[0], plan)
+        unlink_dists = tuple(Dist(d[1]) for d in grouped_instructions.get(UNLINK, ()))
+        link_dists = tuple(Dist(d[1]) for d in grouped_instructions.get(LINK, ()))
+        unlink_dists, link_dists = _handle_menuinst(unlink_dists, link_dists)
+
+        if isdir(prefix):
+            unlink_precs = tuple(index[d] for d in unlink_dists)
+        else:
+            # there's nothing to unlink in an environment that doesn't exist
+            # this is a hack for what appears to be a logic error in conda-build
+            # caught in tests/test_subpackages.py::test_subpackage_recipes[python_test_dep]
+            unlink_precs = ()
+        link_precs = tuple(index[d] for d in link_dists)
+
+        pfe = ProgressiveFetchExtract(link_precs)
+        pfe.prepare()
+
+        stp = PrefixSetup(prefix, unlink_precs, link_precs, (), specs)
+        plan.insert(first_unlink_link_idx, (UNLINKLINKTRANSACTION, UnlinkLinkTransaction(stp)))
+        plan.insert(first_unlink_link_idx, (PROGRESSIVEFETCHEXTRACT, pfe))
+    elif axn in ('INSTALL', 'CREATE'):
+        plan.insert(0, (UNLINKLINKTRANSACTION, (prefix, (), (), (), specs)))
+
+    return plan
+
+
+def _handle_menuinst(unlink_dists, link_dists):
+    from ._vendor.toolz.itertoolz import concatv
+    from .common.compat import on_win
+    if not on_win:
+        return unlink_dists, link_dists
+
+    # Always link/unlink menuinst first/last on windows in case a subsequent
+    # package tries to import it to create/remove a shortcut
+
+    # unlink
+    menuinst_idx = next((q for q, d in enumerate(unlink_dists) if d.name == 'menuinst'), None)
+    if menuinst_idx is not None:
+        unlink_dists = tuple(concatv(
+            unlink_dists[:menuinst_idx],
+            unlink_dists[menuinst_idx+1:],
+            unlink_dists[menuinst_idx:menuinst_idx+1],
+        ))
+
+    # link
+    menuinst_idx = next((q for q, d in enumerate(link_dists) if d.name == 'menuinst'), None)
+    if menuinst_idx is not None:
+        link_dists = tuple(concatv(
+            link_dists[menuinst_idx:menuinst_idx+1],
+            link_dists[:menuinst_idx],
+            link_dists[menuinst_idx+1:],
+        ))
+
+    return unlink_dists, link_dists
+
+
+def install_actions(prefix, index, specs, force=False, only_names=None, always_copy=False,
+                    pinned=True, update_deps=True, prune=False,
+                    channel_priority_map=None, is_update=False,
+                    minimal_hint=False):  # pragma: no cover
+    # this is for conda-build
+    from os.path import basename
+    from ._vendor.boltons.setutils import IndexedSet
+    from .models.channel import Channel
+    from .models.dist import Dist
+    if channel_priority_map:
+        channel_names = IndexedSet(Channel(url).canonical_name for url in channel_priority_map)
+        channels = IndexedSet(Channel(cn) for cn in channel_names)
+        subdirs = IndexedSet(basename(url) for url in channel_priority_map)
+    else:
+        channels = subdirs = None
+
+    specs = tuple(MatchSpec(spec) for spec in specs)
+
+    from .core.linked_data import PrefixData
+    PrefixData._cache_.clear()
+
+    solver = Solver(prefix, channels, subdirs, specs_to_add=specs)
+    if index:
+        solver._index = index
+    txn = solver.solve_for_transaction(prune=prune, ignore_pinned=not pinned)
+    prefix_setup = txn.prefix_setups[prefix]
+    actions = get_blank_actions(prefix)
+    actions['UNLINK'].extend(Dist(prec) for prec in prefix_setup.unlink_precs)
+    actions['LINK'].extend(Dist(prec) for prec in prefix_setup.link_precs)
+    return actions
+
+
+def get_blank_actions(prefix):
+    from collections import defaultdict
+    from .instructions import (CHECK_EXTRACT, CHECK_FETCH, EXTRACT, FETCH, LINK, PREFIX,
+                               RM_EXTRACTED, RM_FETCHED, SYMLINK_CONDA, UNLINK)
+    actions = defaultdict(list)
+    actions[PREFIX] = prefix
+    actions['op_order'] = (CHECK_FETCH, RM_FETCHED, FETCH, CHECK_EXTRACT,
+                           RM_EXTRACTED, EXTRACT,
+                           UNLINK, LINK, SYMLINK_CONDA)
+    return actions
+
+
+def execute_plan(old_plan, index=None, verbose=False):
+    """
+    Deprecated: This should `conda.instructions.execute_instructions` instead
+    """
+    plan = _update_old_plan(old_plan)
+    execute_instructions(plan, index, verbose)
+
+
+def execute_instructions(plan, index=None, verbose=False, _commands=None):
+    """Execute the instructions in the plan
+
+    :param plan: A list of (instruction, arg) tuples
+    :param index: The meta-data index
+    :param verbose: verbose output
+    :param _commands: (For testing only) dict mapping an instruction to executable if None
+    then the default commands will be used
+    """
+    from .instructions import commands, PROGRESS_COMMANDS
+    from .base.context import context
+    from .models.dist import Dist
+    if _commands is None:
+        _commands = commands
+
+    log.debug("executing plan %s", plan)
+
+    state = {'i': None, 'prefix': context.root_prefix, 'index': index}
+
+    for instruction, arg in plan:
+
+        log.debug(' %s(%r)', instruction, arg)
+
+        if state['i'] is not None and instruction in PROGRESS_COMMANDS:
+            state['i'] += 1
+            getLogger('progress.update').info((Dist(arg).dist_name,
+                                               state['i'] - 1))
+        cmd = _commands[instruction]
+
+        if callable(cmd):
+            cmd(state, arg)
+
+        if (state['i'] is not None and instruction in PROGRESS_COMMANDS and
+                state['maxval'] == state['i']):
+
+            state['i'] = None
+            getLogger('progress.stop').info(None)
+
+
+def _update_old_plan(old_plan):
+    """
+    Update an old plan object to work with
+    `conda.instructions.execute_instructions`
+    """
+    plan = []
+    for line in old_plan:
+        if line.startswith('#'):
+            continue
+        if ' ' not in line:
+            from .exceptions import ArgumentError
+            raise ArgumentError("The instruction '%s' takes at least"
+                                " one argument" % line)
+
+        instruction, arg = line.split(' ', 1)
+        plan.append((instruction, arg))
+    return plan

--- a/conda/instructions.py
+++ b/conda/instructions.py
@@ -3,12 +3,10 @@ from __future__ import absolute_import, division, print_function
 from logging import getLogger
 from os.path import isfile, join
 
-from .base.context import context
 from .core.link import UnlinkLinkTransaction
 from .core.package_cache import ProgressiveFetchExtract
 from .exceptions import CondaFileIOError
 from .gateways.disk.link import islink
-from .models.dist import Dist
 
 log = getLogger(__name__)
 
@@ -105,39 +103,3 @@ OP_ORDER = (RM_FETCHED,
             UNLINK,
             LINK,
             )
-
-
-def execute_instructions(plan, index=None, verbose=False, _commands=None):
-    """Execute the instructions in the plan
-
-    :param plan: A list of (instruction, arg) tuples
-    :param index: The meta-data index
-    :param verbose: verbose output
-    :param _commands: (For testing only) dict mapping an instruction to executable if None
-    then the default commands will be used
-    """
-    if _commands is None:
-        _commands = commands
-
-    log.debug("executing plan %s", plan)
-
-    state = {'i': None, 'prefix': context.root_prefix, 'index': index}
-
-    for instruction, arg in plan:
-
-        log.debug(' %s(%r)', instruction, arg)
-
-        if state['i'] is not None and instruction in PROGRESS_COMMANDS:
-            state['i'] += 1
-            getLogger('progress.update').info((Dist(arg).dist_name,
-                                               state['i'] - 1))
-        cmd = _commands[instruction]
-
-        if callable(cmd):
-            cmd(state, arg)
-
-        if (state['i'] is not None and instruction in PROGRESS_COMMANDS and
-                state['maxval'] == state['i']):
-
-            state['i'] = None
-            getLogger('progress.stop').info(None)

--- a/conda/models/dag.py
+++ b/conda/models/dag.py
@@ -132,7 +132,7 @@ class PrefixDag(object):
                 yield record
         yield self.remove(node)
 
-    def dot_repr(self, title=None):
+    def dot_repr(self, title=None):  # pragma: no cover
         # graphviz DOT graph description language
 
         builder = ['digraph g {']
@@ -164,10 +164,10 @@ class PrefixDag(object):
         builder.append('}')
         return '\n'.join(builder)
 
-    def format_url(self):
+    def format_url(self):  # pragma: no cover
         return "https://condaviz.glitch.me/%s" % url_quote(self.dot_repr())
 
-    def request_svg(self):
+    def request_svg(self):  # pragma: no cover
         from tempfile import NamedTemporaryFile
         import requests
         from ..common.compat import ensure_binary
@@ -179,7 +179,7 @@ class PrefixDag(object):
         print("saved to: %s" % fh.name, file=sys.stderr)
         return fh.name
 
-    def open_url(self):
+    def open_url(self):  # pragma: no cover
         import webbrowser
         from ..common.url import path_to_url
         location = self.request_svg()

--- a/conda/models/package_cache_record.py
+++ b/conda/models/package_cache_record.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from errno import ENOENT
 from logging import getLogger
 from os.path import basename, join
 
 from .index_record import PackageRecord
-from .._vendor.auxlib.decorators import memoizemethod
 from .._vendor.auxlib.entity import StringField
 from ..exceptions import PathNotFoundError
 
@@ -49,27 +47,6 @@ class PackageCacheRecord(PackageRecord):
     @property
     def tarball_basename(self):
         return basename(self.package_tarball_full_path)
-
-    @property
-    def package_cache_writable(self):
-        from ..core.package_cache import PackageCache
-        return PackageCache(self.pkgs_dir).is_writable
-
-    def get_urls_txt_value(self):
-        from ..core.package_cache import PackageCache
-        return PackageCache(self.pkgs_dir)._urls_data.get_url(self.package_tarball_full_path)
-
-    @memoizemethod
-    def _get_repodata_record(self):
-        epd = self.extracted_package_dir
-
-        try:
-            from ..gateways.disk.read import read_repodata_json
-            return read_repodata_json(epd)
-        except (IOError, OSError) as ex:
-            if ex.errno == ENOENT:
-                return None
-            raise  # pragma: no cover
 
     def _calculate_md5sum(self):
         memoized_md5 = getattr(self, '_memoized_md5', None)

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ omit =
     conda/console.py
     conda/cli/activate.py
     conda/cli/main_package.py
+    conda/exports.py
     conda/gateways/connection/adapters/ftp.py
     conda/gateways/connection/adapters/s3.py
     conda_env/*

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -3,7 +3,8 @@ from logging import getLogger, Handler, DEBUG
 import os
 
 from conda import instructions
-from conda.instructions import execute_instructions, commands
+from conda.exports import execute_instructions
+from conda.instructions import commands
 from conda.exceptions import CondaFileIOError
 
 try:


### PR DESCRIPTION
This PR removes large chunks of unused dead code.  It also moves several large chunks to `conda/exports.py`, which should be considered queued for having deprecation warnings added.  There are no functional parts of conda's internal code that use `conda/exports.py`.