### PR TITLE
speed up the creation of repository

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -509,8 +509,9 @@ class UnlinkLinkTransaction(object):
         axn_idx, action, is_unlink = 0, None, axngroup.type == 'unlink'
         prec = axngroup.pkg_data
 
-        if not isdir(join(target_prefix, 'conda-meta')):
-            mkdir_p(join(target_prefix, 'conda-meta'))
+        meta = join(target_prefix, 'conda-meta')
+        if not isdir(meta):
+            mkdir_p(meta)
 
         try:
             if axngroup.type == 'unlink':


### PR DESCRIPTION
I'm working to create a clone on the local disk while the origin is on the network file system.

Here is a few optimization. In particular, the first commit remove many operation on the remove file system and speed up the operation by doing bigger read/write. The new size is the same as the cp Linux command line.