### PR TITLE
target prefix override

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -382,6 +382,9 @@ class PrefixReplaceLinkAction(LinkPathAction):
                                                       extracted_package_dir, source_short_path,
                                                       target_prefix, target_short_path,
                                                       LinkType.copy, source_path_data)
+        import os
+        self.target_prefix_override = os.getenv('CONDA_TARGET_PREFIX_OVERRIDE', '')
+
         self.prefix_placeholder = prefix_placeholder
         self.file_mode = file_mode
         self.intermediate_path = None
@@ -404,7 +407,7 @@ class PrefixReplaceLinkAction(LinkPathAction):
 
         try:
             log.trace("rewriting prefixes in %s", self.target_full_path)
-            update_prefix(self.intermediate_path, self.target_prefix, self.prefix_placeholder,
+            update_prefix(self.intermediate_path, self.target_prefix_override or self.target_prefix, self.prefix_placeholder,
                           self.file_mode)
         except _PaddingError:
             raise PaddingError(self.target_full_path, self.prefix_placeholder,

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -382,9 +382,6 @@ class PrefixReplaceLinkAction(LinkPathAction):
                                                       extracted_package_dir, source_short_path,
                                                       target_prefix, target_short_path,
                                                       LinkType.copy, source_path_data)
-        import os
-        self.target_prefix_override = os.getenv('CONDA_TARGET_PREFIX_OVERRIDE', '')
-
         self.prefix_placeholder = prefix_placeholder
         self.file_mode = file_mode
         self.intermediate_path = None
@@ -407,7 +404,9 @@ class PrefixReplaceLinkAction(LinkPathAction):
 
         try:
             log.trace("rewriting prefixes in %s", self.target_full_path)
-            update_prefix(self.intermediate_path, self.target_prefix_override or self.target_prefix, self.prefix_placeholder,
+            update_prefix(self.intermediate_path,
+                          context.target_prefix_override or self.target_prefix,
+                          self.prefix_placeholder,
                           self.file_mode)
         except _PaddingError:
             raise PaddingError(self.target_full_path, self.prefix_placeholder,


### PR DESCRIPTION
This PR does what I think is the goal of #6162 (and detailed in #6104) by @rainwoodman.  I ended up needing it myself for building some minimal docker containers.

Usage remains undocumented right now.  Easiest way to use is to set and environment variable, e.g.

    export CONDA_TARGET_PREFIX_OVERRIDE=/usr/local

