### PR TITLE
add information to displayed error report

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -218,6 +218,21 @@ def get_info_dict(system=False):
     return info_dict
 
 
+def get_env_vars_str(info_dict):
+    from textwrap import wrap
+    builder = []
+    builder.append("%23s:" % "environment variables")
+    env_vars = info_dict.get('env_vars', {})
+    for key in sorted(env_vars):
+        value = wrap(env_vars[key])
+        first_line = value[0]
+        other_lines = value[1:] if len(value) > 1 else ()
+        builder.append("%25s=%s" % (key, first_line))
+        for val in other_lines:
+            builder.append(' ' * 26 + val)
+    return '\n'.join(builder)
+
+
 def get_main_info_str(info_dict):
     for key in 'pkgs_dirs', 'envs_dirs', 'channels', 'config_files':
         info_dict['_' + key] = ('\n' + 26 * ' ').join(info_dict[key])

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -818,8 +818,9 @@ class ExceptionHandler(object):
                                    for line in error_report['traceback'].splitlines())
             message_builder.append('')
             if error_report['conda_info']:
-                from .cli.main_info import get_main_info_str
+                from .cli.main_info import get_env_vars_str, get_main_info_str
                 try:
+                    message_builder.append(get_env_vars_str(error_report['conda_info']))
                     message_builder.append(get_main_info_str(error_report['conda_info']))
                 except Exception as e:
                     message_builder.append('conda info could not be constructed.')
@@ -860,10 +861,11 @@ class ExceptionHandler(object):
         return ask_for_upload, do_upload
 
     def ask_for_upload(self):
-        message_builder = []
-        message_builder.append(
-            "Would you like conda to send this report to the core maintainers?"
-        )
+        message_builder = [
+            "If submitted, this report will be used by core maintainers to improve",
+            "future releases of conda.",
+            "Would you like conda to send this report to the core maintainers?",
+        ]
         message_builder.append(
             "[y/N]: "
         )

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -820,6 +820,7 @@ class ExceptionHandler(object):
             if error_report['conda_info']:
                 from .cli.main_info import get_env_vars_str, get_main_info_str
                 try:
+                    # TODO: Sanitize env vars to remove secrets (e.g credentials for PROXY)
                     message_builder.append(get_env_vars_str(error_report['conda_info']))
                     message_builder.append(get_main_info_str(error_report['conda_info']))
                 except Exception as e:


### PR DESCRIPTION
To be compliant with GDPR (according to Mathew Lodge), for the error upload report, we need to indicate what information is being uploaded, why, and how that information will be used.  This PR should bring us into GDPR compliance.