### PR TITLE
fix #6419 set PS1 in python code

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -51,7 +51,7 @@ class Activator(object):
             self.shift_args = 0
 
             self.unset_var_tmpl = 'unset %s'
-            self.set_var_tmpl = 'export %s="%s"'
+            self.set_var_tmpl = "export %s='%s'"
             self.run_script_tmpl = '. "%s"'
 
         elif shell == 'csh':
@@ -73,7 +73,7 @@ class Activator(object):
             self.shift_args = 0
 
             self.unset_var_tmpl = 'del $%s'
-            self.set_var_tmpl = '$%s = "%s"'
+            self.set_var_tmpl = "$%s = '%s'"
             self.run_script_tmpl = 'source "%s"'
 
         elif shell == 'cmd.exe':
@@ -257,6 +257,8 @@ class Activator(object):
             }
             deactivate_scripts = ()
 
+        self._update_prompt(set_vars, conda_prompt_modifier)
+
         return {
             'unset_vars': (),
             'set_vars': set_vars,
@@ -283,6 +285,7 @@ class Activator(object):
         assert old_conda_shlvl > 0
         if old_conda_shlvl == 1:
             # TODO: warn conda floor
+            conda_prompt_modifier = ''
             unset_vars = (
                 'CONDA_PREFIX',
                 'CONDA_DEFAULT_ENV',
@@ -310,6 +313,8 @@ class Activator(object):
                 'CONDA_PROMPT_MODIFIER': conda_prompt_modifier,
             }
             activate_scripts = self._get_activate_scripts(new_prefix)
+
+        self._update_prompt(set_vars, conda_prompt_modifier)
 
         return {
             'unset_vars': unset_vars,
@@ -398,6 +403,19 @@ class Activator(object):
             if new_prefix is not None:
                 path_list.insert(idx, join(new_prefix, 'bin'))
         return self.path_conversion(path_list)
+
+    def _update_prompt(self, set_vars, conda_prompt_modifier):
+        if not context.changeps1:
+            return
+
+        if self.shell == 'posix':
+            ps1 = os.environ.get('PS1', '')
+            current_prompt_modifier = os.environ.get('CONDA_PROMPT_MODIFIER')
+            if current_prompt_modifier:
+                ps1 = re.sub(re.escape(current_prompt_modifier), r'', ps1)
+            set_vars.update({
+                'PS1': conda_prompt_modifier + ps1,
+            })
 
     def _default_env(self, prefix):
         if prefix == context.root_prefix:

--- a/shell/etc/profile.d/conda.sh
+++ b/shell/etc/profile.d/conda.sh
@@ -24,9 +24,13 @@ _conda_set_vars() {
         fi
     fi
 
-    # PS1 needs to be passed to subprocesses. Exporting it here fixes issues
-    # that could come up later.
-    export PS1
+    # We're not allowing PS1 to be unbound. It must at least be set.
+    # However, we're not exporting it, which can cause problems when starting a second shell
+    # via a first shell (i.e. starting zsh from bash).
+    if [ -z "${PS1+x}" ]; then
+        PS1=
+    fi
+
 }
 
 
@@ -43,12 +47,12 @@ _conda_activate() {
     if [ -n "${CONDA_PS1_BACKUP:+x}" ]; then
         # Handle transition from shell activated with conda <= 4.3 to a subsequent activation
         # after conda updated to >= 4.4. See issue #6173.
-        export PS1="$CONDA_PS1_BACKUP"
+        PS1="$CONDA_PS1_BACKUP"
         unset CONDA_PS1_BACKUP
     fi
 
     local ask_conda
-    ask_conda="$($_CONDA_EXE shell.posix activate "$@")" || return $?
+    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix activate "$@")" || return $?
     eval "$ask_conda"
 
     _conda_hashr
@@ -56,7 +60,7 @@ _conda_activate() {
 
 _conda_deactivate() {
     local ask_conda
-    ask_conda="$($_CONDA_EXE shell.posix deactivate "$@")" || return $?
+    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix deactivate "$@")" || return $?
     eval "$ask_conda"
 
     _conda_hashr
@@ -64,7 +68,7 @@ _conda_deactivate() {
 
 _conda_reactivate() {
     local ask_conda
-    ask_conda="$($_CONDA_EXE shell.posix reactivate "$@")" || return $?
+    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix reactivate "$@")" || return $?
     eval "$ask_conda"
 
     _conda_hashr

--- a/shell/etc/profile.d/conda.sh
+++ b/shell/etc/profile.d/conda.sh
@@ -24,6 +24,9 @@ _conda_set_vars() {
         fi
     fi
 
+    # PS1 needs to be passed to subprocesses. Exporting it here fixes issues
+    # that could come up later.
+    export PS1
 }
 
 
@@ -48,21 +51,6 @@ _conda_activate() {
     ask_conda="$($_CONDA_EXE shell.posix activate "$@")" || return $?
     eval "$ask_conda"
 
-    case "$_CONDA_SHELL_FLAVOR" in
-        dash)
-            if [ "$(echo "${PS1-}" | awk '{ string=substr($0, 1, 22); print string; }')" != '$CONDA_PROMPT_MODIFIER' ]; then
-                PS1='$CONDA_PROMPT_MODIFIER\[\]'"$PS1"
-            fi
-            ;;
-        *)
-            if [ -z "${PS1+x}" ] || [ "${PS1:0:22}" != '$CONDA_PROMPT_MODIFIER' ]; then
-                # the extra \[\] is because the prompt fails for some reason if there's no
-                # character after the end of the environment variable name
-                PS1='$CONDA_PROMPT_MODIFIER\[\]'"${PS1-}"
-            fi
-            ;;
-    esac
-
     _conda_hashr
 }
 
@@ -70,13 +58,6 @@ _conda_deactivate() {
     local ask_conda
     ask_conda="$($_CONDA_EXE shell.posix deactivate "$@")" || return $?
     eval "$ask_conda"
-
-    if [ -z "${CONDA_PREFIX+x}" ]; then
-        case "$_CONDA_SHELL_FLAVOR" in
-            dash) PS1=$(echo "${PS1-}" | awk '{ string=substr($0, 27); print string; }') ;;
-            *) [ -n "${PS1:+x}" ] && [ "${PS1:0:22}" = '$CONDA_PROMPT_MODIFIER' ] && PS1=${PS1:26} ;;
-        esac
-    fi
 
     _conda_hashr
 }

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -152,6 +152,8 @@ class ActivatorUnitTests(TestCase):
                     activator = Activator('posix')
                     builder = activator.build_activate(td)
                     new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
+                    conda_prompt_modifier = "(%s) " % td
+                    ps1 = conda_prompt_modifier + os.environ.get('PS1', '')
 
                     assert builder['unset_vars'] == ()
 
@@ -161,7 +163,8 @@ class ActivatorUnitTests(TestCase):
                         'CONDA_PREFIX': td,
                         'CONDA_SHLVL': 1,
                         'CONDA_DEFAULT_ENV': td,
-                        'CONDA_PROMPT_MODIFIER': "(%s) " % td,
+                        'CONDA_PROMPT_MODIFIER': conda_prompt_modifier,
+                        'PS1': ps1,
                     }
                     assert builder['set_vars'] == set_vars
                     assert builder['activate_scripts'] == (activator.path_conversion(activate_d_1),)
@@ -182,6 +185,8 @@ class ActivatorUnitTests(TestCase):
                     activator = Activator('posix')
                     builder = activator.build_activate(td)
                     new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
+                    conda_prompt_modifier = "(%s) " % td
+                    ps1 = conda_prompt_modifier + os.environ.get('PS1', '')
 
                     assert builder['unset_vars'] == ()
 
@@ -191,7 +196,8 @@ class ActivatorUnitTests(TestCase):
                         'CONDA_PREFIX_1': old_prefix,
                         'CONDA_SHLVL': 2,
                         'CONDA_DEFAULT_ENV': td,
-                        'CONDA_PROMPT_MODIFIER': "(%s) " % td,
+                        'CONDA_PROMPT_MODIFIER': conda_prompt_modifier,
+                        'PS1': ps1,
                     }
                     assert builder['set_vars'] == set_vars
                     assert builder['activate_scripts'] == (activator.path_conversion(activate_d_1),)
@@ -218,6 +224,8 @@ class ActivatorUnitTests(TestCase):
                     activator = Activator('posix')
                     builder = activator.build_activate(td)
                     new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
+                    conda_prompt_modifier = "(%s) " % td
+                    ps1 = conda_prompt_modifier + os.environ.get('PS1', '')
 
                     assert builder['unset_vars'] == ()
 
@@ -225,7 +233,8 @@ class ActivatorUnitTests(TestCase):
                         'PATH': new_path,
                         'CONDA_PREFIX': td,
                         'CONDA_DEFAULT_ENV': td,
-                        'CONDA_PROMPT_MODIFIER': "(%s) " % td,
+                        'CONDA_PROMPT_MODIFIER': conda_prompt_modifier,
+                        'PS1': ps1,
                     }
                     assert builder['set_vars'] == set_vars
                     assert builder['activate_scripts'] == (activator.path_conversion(activate_d_1),)
@@ -289,13 +298,16 @@ class ActivatorUnitTests(TestCase):
                         assert builder['unset_vars'] == ('CONDA_PREFIX_1',)
 
                         new_path = activator.pathsep_join(activator.path_conversion(original_path))
+                        conda_prompt_modifier = "(%s) " % old_prefix
+                        ps1 = conda_prompt_modifier + os.environ.get('PS1', '')
 
                         set_vars = {
                             'PATH': new_path,
                             'CONDA_SHLVL': 1,
                             'CONDA_PREFIX': old_prefix,
                             'CONDA_DEFAULT_ENV': old_prefix,
-                            'CONDA_PROMPT_MODIFIER': "(%s) " % old_prefix,
+                            'CONDA_PROMPT_MODIFIER': conda_prompt_modifier,
+                            'PS1': ps1,
                         }
                         assert builder['set_vars'] == set_vars
                         assert builder['activate_scripts'] == (activator.path_conversion(activate_d_1),)
@@ -327,6 +339,7 @@ class ActivatorUnitTests(TestCase):
                     assert builder['set_vars'] == {
                         'PATH': new_path,
                         'CONDA_SHLVL': 0,
+                        'PS1': os.environ.get('PS1', ''),
                     }
                     assert builder['activate_scripts'] == ()
                     assert builder['deactivate_scripts'] == (activator.path_conversion(deactivate_d_1),)
@@ -389,12 +402,13 @@ class ShellWrapperUnitTests(TestCase):
 
         new_path_parts = activator._add_prefix_to_path(self.prefix)
         assert activate_data == dals("""
-        export CONDA_DEFAULT_ENV="%(native_prefix)s"
-        export CONDA_PREFIX="%(native_prefix)s"
-        export CONDA_PROMPT_MODIFIER="(%(native_prefix)s) "
-        export CONDA_PYTHON_EXE="%(sys_executable)s"
-        export CONDA_SHLVL="1"
-        export PATH="%(new_path)s"
+        export CONDA_DEFAULT_ENV='%(native_prefix)s'
+        export CONDA_PREFIX='%(native_prefix)s'
+        export CONDA_PROMPT_MODIFIER='(%(native_prefix)s) '
+        export CONDA_PYTHON_EXE='%(sys_executable)s'
+        export CONDA_SHLVL='1'
+        export PATH='%(new_path)s'
+        export PS1='%(ps1)s'
         . "%(activate1)s"
         """) % {
             'converted_prefix': activator.path_conversion(self.prefix),
@@ -402,6 +416,7 @@ class ShellWrapperUnitTests(TestCase):
             'new_path': activator.pathsep_join(new_path_parts),
             'sys_executable': activator.path_conversion(sys.executable),
             'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.sh')),
+            'ps1': '(%s) ' % self.prefix + os.environ.get('PS1', '')
         }
 
         with env_vars({
@@ -416,8 +431,8 @@ class ShellWrapperUnitTests(TestCase):
             reactivate_data = c.stdout
 
             assert reactivate_data == dals("""
-            export CONDA_PROMPT_MODIFIER="(%(native_prefix)s) "
-            export CONDA_SHLVL="1"
+            export CONDA_PROMPT_MODIFIER='(%(native_prefix)s) '
+            export CONDA_SHLVL='1'
             . "%(deactivate1)s"
             . "%(activate1)s"
             """) % {
@@ -438,13 +453,14 @@ class ShellWrapperUnitTests(TestCase):
             unset CONDA_PREFIX
             unset CONDA_PROMPT_MODIFIER
             unset CONDA_PYTHON_EXE
-            export CONDA_SHLVL="0"
-            export PATH="%(new_path)s"
+            export CONDA_SHLVL='0'
+            export PATH='%(new_path)s'
+            export PS1='%(ps1)s'
             . "%(deactivate1)s"
             """) % {
                 'new_path': new_path,
                 'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.sh')),
-
+                'ps1': os.environ.get('PS1', ''),
             }
 
     def test_cmd_exe_basic(self):
@@ -612,12 +628,12 @@ class ShellWrapperUnitTests(TestCase):
 
         new_path_parts = activator._add_prefix_to_path(self.prefix)
         assert activate_data == dals("""
-        $CONDA_DEFAULT_ENV = "%(native_prefix)s"
-        $CONDA_PREFIX = "%(native_prefix)s"
-        $CONDA_PROMPT_MODIFIER = "(%(native_prefix)s) "
-        $CONDA_PYTHON_EXE = "%(sys_executable)s"
-        $CONDA_SHLVL = "1"
-        $PATH = "%(new_path)s"
+        $CONDA_DEFAULT_ENV = '%(native_prefix)s'
+        $CONDA_PREFIX = '%(native_prefix)s'
+        $CONDA_PROMPT_MODIFIER = '(%(native_prefix)s) '
+        $CONDA_PYTHON_EXE = '%(sys_executable)s'
+        $CONDA_SHLVL = '1'
+        $PATH = '%(new_path)s'
         source "%(activate1)s"
         """) % {
             'converted_prefix': activator.path_conversion(self.prefix),
@@ -642,8 +658,8 @@ class ShellWrapperUnitTests(TestCase):
             rm_rf(reactivate_result)
 
             assert reactivate_data == dals("""
-            $CONDA_PROMPT_MODIFIER = "(%(native_prefix)s) "
-            $CONDA_SHLVL = "1"
+            $CONDA_PROMPT_MODIFIER = '(%(native_prefix)s) '
+            $CONDA_SHLVL = '1'
             source "%(deactivate1)s"
             source "%(activate1)s"
             """) % {
@@ -667,8 +683,8 @@ class ShellWrapperUnitTests(TestCase):
             del $CONDA_PREFIX
             del $CONDA_PROMPT_MODIFIER
             del $CONDA_PYTHON_EXE
-            $CONDA_SHLVL = "0"
-            $PATH = "%(new_path)s"
+            $CONDA_SHLVL = '0'
+            $PATH = '%(new_path)s'
             source "%(deactivate1)s"
             """) % {
                 'new_path': new_path,
@@ -931,7 +947,7 @@ class ShellWrapperIntegrationTests(TestCase):
     def basic_posix(self, shell):
         shell.assert_env_var('CONDA_SHLVL', '0')
         shell.sendline('conda activate root')
-        shell.assert_env_var('PS1', '\$CONDA_PROMPT_MODIFIER.*')
+        shell.assert_env_var('PS1', '(base).*')
         shell.assert_env_var('CONDA_SHLVL', '1')
         shell.sendline('conda activate "%s"' % self.prefix)
         shell.assert_env_var('CONDA_SHLVL', '2')
@@ -959,10 +975,10 @@ class ShellWrapperIntegrationTests(TestCase):
             shell.sendline('env | sort')
             self.basic_posix(shell)
 
-    # @pytest.mark.skipif(not which('zsh'), reason='zsh not installed')
-    # def test_zsh_basic_integration(self):
-    #     with InteractiveShell('zsh') as shell:
-    #         self.basic_posix(shell)
+    @pytest.mark.skipif(not which('zsh'), reason='zsh not installed')
+    def test_zsh_basic_integration(self):
+        with InteractiveShell('zsh') as shell:
+            self.basic_posix(shell)
 
     @pytest.mark.skipif(not which('cmd.exe'), reason='cmd.exe not installed')
     def test_cmd_exe_basic_integration(self):


### PR DESCRIPTION
fix #6419

This PR slightly reworks how PS1 is set for Bourne shells.  Basically setting PS1 through our python code, and not doing logic at the shell level.