### PR TITLE
fix #6445 scale back directory activation in PWD

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -191,14 +191,8 @@ class Activator(object):
             yield self.run_script_tmpl % script
 
     def build_activate(self, env_name_or_prefix):
-        test_path = expand(env_name_or_prefix)
-        if isdir(test_path):
-            prefix = test_path
-            if not isdir(join(prefix, 'conda-meta')):
-                from .exceptions import EnvironmentLocationNotFound
-                raise EnvironmentLocationNotFound(prefix)
-        elif re.search(r'\\|/', env_name_or_prefix):
-            prefix = env_name_or_prefix
+        if re.search(r'\\|/', env_name_or_prefix):
+            prefix = expand(env_name_or_prefix)
             if not isdir(join(prefix, 'conda-meta')):
                 from .exceptions import EnvironmentLocationNotFound
                 raise EnvironmentLocationNotFound(prefix)


### PR DESCRIPTION
fix #6445 issue 2

With this change, if you have a conda environment in your current working directory with folder name `tests`, you must now use

    conda activate ./tests

The upshot is that if your `tests` directory in your current directory isn't a conda environment, but you have an environments named `tests` in one of your `envs` directories, behavior is as expected.