### PR TITLE
resolve #5158 --override-channels

### DIFF
--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -160,6 +160,8 @@ def get_reduced_index(prefix, channels, subdirs, specs):
     with backdown_thread_pool() as executor:
 
         channel_urls = all_channel_urls(channels, subdirs=subdirs)
+        check_whitelist(channel_urls)
+
         if context.offline:
             grouped_urls = groupby(lambda url: url.startswith('file://'), channel_urls)
             ignored_urls = grouped_urls.get(False, ())


### PR DESCRIPTION
resolves #5158 
resolves #6400

---

Turns out this was already done, including configuration options that allow us to not violate the security model.

```
override_channels_enabled:
    Permit use of the --overide-channels command-line flag.

whitelist_channels:
    The exclusive list of channels allowed to be used on the system. Use of any
    other channels will result in an error. If conda-build channels are to be
    allowed, along with the --use-local command line flag, be sure to include the
    'local' channel in the list. If the list is empty or left undefined, no
    channel exclusions will be enforced.
```

This PR *only* adds whitelist checking at one particularly important point where it was previously missed.