### PR TITLE
fixes for fish code completion

### DIFF
--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -87,11 +87,13 @@ end
 
 # Faster but less tested (?)
 function __fish_conda_commands
-  command echo -e "activate\ndeactivate" ;and ls --color=none (conda info --root)/bin/conda-* | sed -r 's/^.*conda-([a-z]+)/\1/'
+  string replace -r '.*_([a-z]+)\.py$' '$1' $_CONDA_ROOT/lib/python*/site-packages/conda/cli/main_*.py
+  echo activate
+  echo deactivate
 end
 
 function __fish_conda_envs
-  command echo root ;and ls -1 --color=none (conda info --root)/envs/
+  basename -a $_CONDA_ROOT/envs/*/
 end
 
 function __fish_conda_packages

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -198,7 +198,9 @@ install_conda_shell_scripts() {
 
     mkdir -p "$prefix/etc/fish/conf.d/"
     rm -f "$prefix/etc/fish/conf.d/conda.fish"
-    cp "$src_dir/conda/shell/etc/fish/conf.d/conda.fish" "$prefix/etc/fish/conf.d/conda.fish"
+    echo "set _CONDA_EXE \"$conda_exe\"" > "$prefix/etc/fish/conf.d/conda.fish"
+    echo "set _CONDA_ROOT \"$prefix\"" >> "$prefix/etc/fish/conf.d/conda.fish"
+    cat "$src_dir/conda/shell/etc/fish/conf.d/conda.fish" >> "$prefix/etc/fish/conf.d/conda.fish"
 
     local sp_dir=$("$PYTHON_EXE" -c "from distutils.sysconfig import get_python_lib as g; print(g())")
     mkdir -p "$sp_dir/xonsh"


### PR DESCRIPTION
supersedes #5912 to target 4.4.x

Also adds templating of `_CONDA_EXE` and `_CONDA_ROOT` for the installed versions of `conda.fish`.