### PR TITLE
fix #6508 environments.txt permissions error stack trace

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -982,7 +982,7 @@ def _first_writable_envs_dir():
             return envs_dir
 
     from ..exceptions import NotWritableError
-    raise NotWritableError(context.envs_dirs[0])
+    raise NotWritableError(context.envs_dirs[0], None)
 
 
 # backward compatibility for conda-build

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -591,12 +591,13 @@ class SafetyError(CondaError):
         super(SafetyError, self).__init__(message)
 
 
-class NotWritableError(CondaError):
+class NotWritableError(CondaError, OSError):
 
-    def __init__(self, path):
-        kwargs = {
+    def __init__(self, path, errno, **kwargs):
+        kwargs.update({
             'path': path,
-        }
+            'errno': errno,
+        })
         if on_win:
             message = dals("""
             The current user does not have write permissions to a required path.

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -12,6 +12,7 @@ from .delete import rm_rf
 from .link import lexists
 from ...common.compat import on_win
 from ...common.path import expand
+from ...exceptions import NotWritableError
 
 log = getLogger(__name__)
 
@@ -62,29 +63,32 @@ def touch(path, mkdir=False, sudo_safe=False):
     #   True if the file did not exist but was created
     #   False if the file already existed
     # raises: permissions errors such as EPERM and EACCES
-    path = expand(path)
-    log.trace("touching path %s", path)
-    if lexists(path):
-        utime(path, None)
-        return True
-    else:
-        dirpath = dirname(path)
-        if not isdir(dirpath) and mkdir:
-            if sudo_safe:
-                mkdir_p_sudo_safe(dirpath)
+    try:
+        path = expand(path)
+        log.trace("touching path %s", path)
+        if lexists(path):
+            utime(path, None)
+            return True
+        else:
+            dirpath = dirname(path)
+            if not isdir(dirpath) and mkdir:
+                if sudo_safe:
+                    mkdir_p_sudo_safe(dirpath)
+                else:
+                    mkdir_p(dirpath)
             else:
-                mkdir_p(dirpath)
-        else:
-            assert isdir(dirname(path))
-        try:
-            fh = open(path, 'a')
-        except:
-            raise
-        else:
-            fh.close()
-            if sudo_safe and not on_win and os.environ.get('SUDO_UID') is not None:
-                uid = int(os.environ['SUDO_UID'])
-                gid = int(os.environ.get('SUDO_GID', -1))
-                log.trace("chowning %s:%s %s", uid, gid, path)
-                os.chown(path, uid, gid)
-            return False
+                assert isdir(dirname(path))
+            try:
+                fh = open(path, 'a')
+            except:
+                raise
+            else:
+                fh.close()
+                if sudo_safe and not on_win and os.environ.get('SUDO_UID') is not None:
+                    uid = int(os.environ['SUDO_UID'])
+                    gid = int(os.environ.get('SUDO_GID', -1))
+                    log.trace("chowning %s:%s %s", uid, gid, path)
+                    os.chown(path, uid, gid)
+                return False
+    except (IOError, OSError) as e:
+        raise NotWritableError(path, e.errno, caused_by=e)


### PR DESCRIPTION
fix #6508 

The particular stack trace in #6508 happens when people have used `sudo` in front of `conda` incorrectly.  This will at least give them a helpful error report now on what the problem file is.