### PR TITLE
fix #6512 reactivate does not accept arguments

### DIFF
--- a/conda/shell/Library/bin/conda.bat
+++ b/conda/shell/Library/bin/conda.bat
@@ -58,7 +58,7 @@
 @GOTO :End
 
 :DO_REACTIVATE
-@FOR /F "delims=" %%i IN ('@CALL %_CONDA_EXE% shell.cmd.exe reactivate %*') DO @SET "_TEMP_SCRIPT_PATH=%%i"
+@FOR /F "delims=" %%i IN ('@CALL %_CONDA_EXE% shell.cmd.exe reactivate') DO @SET "_TEMP_SCRIPT_PATH=%%i"
 @IF "%_TEMP_SCRIPT_PATH%"=="" GOTO :ErrorEnd
 @CALL "%_TEMP_SCRIPT_PATH%"
 @DEL /F /Q "%_TEMP_SCRIPT_PATH%"

--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -68,7 +68,7 @@ _conda_deactivate() {
 
 _conda_reactivate() {
     local ask_conda
-    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix reactivate "$@")" || return $?
+    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix reactivate)" || return $?
     eval "$ask_conda"
 
     _conda_hashr


### PR DESCRIPTION
fix #6512

Note that only `conda.sh` and `conda.bat` have this problem.  The xonsh, csh, and fish wrappers aren't affected.