### PR TITLE
resolve #6523 don't prune with --update-all

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -144,7 +144,11 @@ class Solver(object):
         prefix_data = PrefixData(self.prefix)
         solution = tuple(Dist(d) for d in prefix_data.iter_records())
         specs_from_history_map = History(self.prefix).get_requested_specs_map()
-        if prune or deps_modifier == DepsModifier.UPDATE_ALL:
+        if prune:  # or deps_modifier == DepsModifier.UPDATE_ALL  # pending conda/constructor#138
+            # Users are struggling with the prune functionality in --update-all, due to
+            # https://github.com/conda/constructor/issues/138.  Until that issue is resolved,
+            # and for the foreseeable future, it's best to be more conservative with --update-all.
+
             # Start with empty specs map for UPDATE_ALL because we're optimizing the update
             # only for specs the user has requested; it's ok to remove dependencies.
             specs_map = odict()

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -1058,28 +1058,29 @@ def test_pinned_1():
             )
             assert tuple(final_state_5) == tuple(solver._index[Dist(d)] for d in order)
 
-    # now update without pinning
-    specs_to_add = MatchSpec("python"),
-    history_specs = MatchSpec("python"), MatchSpec("system=5.8=0"), MatchSpec("numba"),
-    with get_solver(specs_to_add=specs_to_add, prefix_records=final_state_4,
-                    history_specs=history_specs) as solver:
-        final_state_5 = solver.solve_final_state(deps_modifier=DepsModifier.UPDATE_ALL)
-        # PrefixDag(final_state_1, specs).open_url()
-        print([Dist(rec).full_name for rec in final_state_5])
-        order = (
-            'channel-1::openssl-1.0.1c-0',
-            'channel-1::readline-6.2-0',
-            'channel-1::sqlite-3.7.13-0',
-            'channel-1::system-5.8-1',
-            'channel-1::tk-8.5.13-0',
-            'channel-1::zlib-1.2.7-0',
-            'channel-1::llvm-3.2-0',
-            'channel-1::python-3.3.2-0',
-            'channel-1::llvmpy-0.11.2-py33_0',
-            'channel-1::numpy-1.7.1-py33_0',
-            'channel-1::numba-0.8.1-np17py33_0',
-        )
-        assert tuple(final_state_5) == tuple(solver._index[Dist(d)] for d in order)
+    # # TODO: re-enable when UPDATE_ALL gets prune behavior again, following completion of https://github.com/conda/constructor/issues/138
+    # # now update without pinning
+    # specs_to_add = MatchSpec("python"),
+    # history_specs = MatchSpec("python"), MatchSpec("system=5.8=0"), MatchSpec("numba"),
+    # with get_solver(specs_to_add=specs_to_add, prefix_records=final_state_4,
+    #                 history_specs=history_specs) as solver:
+    #     final_state_5 = solver.solve_final_state(deps_modifier=DepsModifier.UPDATE_ALL)
+    #     # PrefixDag(final_state_1, specs).open_url()
+    #     print([Dist(rec).full_name for rec in final_state_5])
+    #     order = (
+    #         'channel-1::openssl-1.0.1c-0',
+    #         'channel-1::readline-6.2-0',
+    #         'channel-1::sqlite-3.7.13-0',
+    #         'channel-1::system-5.8-1',
+    #         'channel-1::tk-8.5.13-0',
+    #         'channel-1::zlib-1.2.7-0',
+    #         'channel-1::llvm-3.2-0',
+    #         'channel-1::python-3.3.2-0',
+    #         'channel-1::llvmpy-0.11.2-py33_0',
+    #         'channel-1::numpy-1.7.1-py33_0',
+    #         'channel-1::numba-0.8.1-np17py33_0',
+    #     )
+    #     assert tuple(final_state_5) == tuple(solver._index[Dist(d)] for d in order)
 
 
 def test_no_update_deps_1():  # i.e. FREEZE_DEPS


### PR DESCRIPTION
resolve #6523

Until we get https://github.com/conda/constructor/issues/138 resolved and also until it has some time to settle in, we're just going to have to be more conservative with what `--update-all` is allowed to do.  If users want prune behavior, there's always the `--prune` flag.