### PR TITLE
fix #6549 'conda activate' has sys.path problem with cwd

### DIFF
--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -5,17 +5,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 
-# before any more imports, leave cwd out of sys.path for internal 'conda shell.*' commands
+# Before any more imports, leave cwd out of sys.path for internal 'conda shell.*' commands.
 # see https://github.com/conda/conda/issues/6549
-if len(sys.argv) > 1 and sys.argv[1].startswith('shell.'):
-    try:
-        # The standard first entry in sys.path is an empty string, and os.path.abspath('')
-        # expands to os.getcwd()
-        idx = sys.path.index('')
-    except ValueError:
-        pass
-    else:
-        del sys.path[idx]
+if len(sys.argv) > 1 and sys.argv[1].startswith('shell.') and sys.path and sys.path[0] == '':
+    # The standard first entry in sys.path is an empty string,
+    # and os.path.abspath('') expands to os.getcwd().
+    del sys.path[0]
 
 import os  # NOQA
 from os.path import dirname  # NOQA

--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -3,12 +3,25 @@
 """OS-agnostic, system-level binary package manager."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
-from os.path import dirname
 import sys
 
-from ._vendor.auxlib.packaging import get_version
-from .common.compat import iteritems, text_type
+# before any more imports, leave cwd out of sys.path for internal 'conda shell.*' commands
+# see https://github.com/conda/conda/issues/6549
+if len(sys.argv) > 1 and sys.argv[1].startswith('shell.'):
+    try:
+        # The standard first entry in sys.path is an empty string, and os.path.abspath('')
+        # expands to os.getcwd()
+        idx = sys.path.index('')
+    except ValueError:
+        pass
+    else:
+        del sys.path[idx]
+
+import os  # NOQA
+from os.path import dirname  # NOQA
+
+from ._vendor.auxlib.packaging import get_version  # NOQA
+from .common.compat import text_type  # NOQA
 
 __all__ = (
     "__name__", "__version__", "__author__", "__email__", "__license__", "__summary__", "__url__",
@@ -59,6 +72,7 @@ class CondaError(Exception):
             raise
 
     def dump_map(self):
+        from .common.compat import iteritems
         result = dict((k, v) for k, v in iteritems(vars(self)) if not k.startswith('_'))
         result.update(exception_type=text_type(type(self)),
                       exception_name=self.__class__.__name__,

--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -17,12 +17,12 @@ from textwrap import dedent
 from time import time
 import warnings
 
-from .. import CondaError, iteritems
+from .. import CondaError
 from .._vendor.auxlib.ish import dals
 from .._vendor.auxlib.logz import stringify
 from ..base.constants import CONDA_HOMEPAGE_URL
 from ..base.context import context
-from ..common.compat import (ensure_binary, ensure_text_type, ensure_unicode, text_type,
+from ..common.compat import (ensure_binary, ensure_text_type, ensure_unicode, iteritems, text_type,
                              with_metaclass)
 from ..common.url import join_url, maybe_unquote
 from ..core.package_cache import PackageCache


### PR DESCRIPTION
fix #6549 

---

The solution proposed here is unconventional.  To be honest, I've never seen another python application do this (although I guess I haven't seen source code for a lot of python *applications*).  I've definitely never seen another python *library* do this.  And since conda is used both as an application and as a library, this PR is conservative in isolating the change only to the internal `shell.*` conda commands used for the shell wrappers.