### PR TITLE
fix #6546 update after creating an empty env

### DIFF
--- a/conda/history.py
+++ b/conda/history.py
@@ -163,7 +163,7 @@ class History(object):
                         specs = literal_eval(specs)
                     elif '[' not in specs:
                         specs = specs.split(',')
-                    specs = [spec for spec in specs if not spec.endswith('@')]
+                    specs = [spec for spec in specs if spec and not spec.endswith('@')]
                     if specs and action in ('update', 'install', 'create'):
                         item['update_specs'] = item['specs'] = specs
                     elif specs and action in ('remove', 'uninstall'):


### PR DESCRIPTION
fix #6546

I'm not sure if this is the only fix we should implement for this problem, but at least it's one of them.

It's probably an issue that `MatchSpec('')` is equal to `*`, which matches everything.

This PR at least avoids the issue altogether for the workflow encountered in #6546, which was creating an empty env with no packages, and then installing some packages, and then calling `conda update`.