### PR TITLE
resolve #6569 make conda more conservative writing to home directories

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -32,6 +32,10 @@ log = getLogger(__name__)
 _FORMATTER = Formatter("%(levelname)s %(name)s:%(funcName)s(%(lineno)d): %(message)s")
 
 
+def dashlist(iterable, indent=2):
+    return ''.join('\n' + ' ' * indent + '- ' + str(x) for x in iterable)
+
+
 class ContextDecorator(object):
     """Base class for a context manager class (implementing __enter__() and __exit__()) that also
     makes it a decorator.

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -8,22 +8,20 @@ from os import listdir
 from os.path import basename, dirname, join
 from tarfile import ReadError
 
-from .._vendor.auxlib.decorators import memoizemethod
-
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler
-from ..exceptions import NoWritablePkgsDirError, NotWritableError
 from .._vendor.auxlib.collection import first
+from .._vendor.auxlib.decorators import memoizemethod
 from ..base.constants import CONDA_TARBALL_EXTENSION, PACKAGE_CACHE_MAGIC_FILE
 from ..base.context import context
 from ..common.compat import (JSONDecodeError, iteritems, itervalues, odict, string_types,
                              text_type, with_metaclass)
 from ..common.constants import NULL
-from ..common.io import ProgressBar, time_recorder
+from ..common.io import ProgressBar, dashlist, time_recorder
 from ..common.path import expand, url_to_path
 from ..common.signals import signal_handler
 from ..common.url import path_to_url
-from ..exceptions import NotWritableError
+from ..exceptions import NoWritablePkgsDirError, NotWritableError
 from ..gateways.disk.create import (create_package_cache_directory, extract_tarball,
                                     write_as_json_to_file)
 from ..gateways.disk.delete import rm_rf
@@ -65,7 +63,7 @@ class PackageCacheData(object):
     def __init__(self, pkgs_dir):
         self.pkgs_dir = pkgs_dir
         self.__package_cache_records = None
-        self.__is_writable = None
+        self.__is_writable = NULL
 
         self._urls_data = UrlsData(pkgs_dir)
 
@@ -133,10 +131,8 @@ class PackageCacheData(object):
         if pkgs_dirs is None:
             pkgs_dirs = context.pkgs_dirs
 
-        return concat(pcache.query(package_ref_or_match_spec) for pcache in concatv(
-            cls.writable_caches(pkgs_dirs),
-            cls.read_only_caches(pkgs_dirs),
-        ))
+        return concat(pcache.query(package_ref_or_match_spec)
+                      for pcache in cls.all_caches_writable_first(pkgs_dirs))
 
     # ##########################################################################################
     # these class methods reach across all package cache directories (usually context.pkgs_dirs)
@@ -144,7 +140,25 @@ class PackageCacheData(object):
 
     @classmethod
     def first_writable(cls, pkgs_dirs=None):
-        return cls.writable_caches(pkgs_dirs)[0]
+        # Calling this method will *create* a package cache directory if one does not already
+        # exist. Any caller should intend to *use* that directory for *writing*, not just reading.
+        if pkgs_dirs is None:
+            pkgs_dirs = context.pkgs_dirs
+        for pkgs_dir in pkgs_dirs:
+            package_cache = cls(pkgs_dir)
+            i_wri = package_cache.is_writable
+            if i_wri is True:
+                return package_cache
+            elif i_wri is None:
+                # means package cache directory doesn't exist, need to try to create it
+                created = create_package_cache_directory(package_cache.pkgs_dir)
+                if created:
+                    package_cache.__is_writable = True
+                    return package_cache
+
+        # TODO: raise NoWritablePackageCacheError()
+        raise CondaError("No writable package cache directories found in"
+                         "%s" % dashlist(pkgs_dirs))
 
     @classmethod
     def writable_caches(cls, pkgs_dirs=None):
@@ -152,8 +166,6 @@ class PackageCacheData(object):
             pkgs_dirs = context.pkgs_dirs
         writable_caches = tuple(filter(lambda c: c.is_writable,
                                        (cls(pd) for pd in pkgs_dirs)))
-        if not writable_caches:
-            raise NoWritablePkgsDirError(pkgs_dirs)
         return writable_caches
 
     @classmethod
@@ -163,6 +175,16 @@ class PackageCacheData(object):
         read_only_caches = tuple(filter(lambda c: not c.is_writable,
                                         (cls(pd) for pd in pkgs_dirs)))
         return read_only_caches
+
+    @classmethod
+    def all_caches_writable_first(cls, pkgs_dirs=None):
+        if pkgs_dirs is None:
+            pkgs_dirs = context.pkgs_dirs
+        pc_groups = groupby(
+            lambda pc: pc.is_writable,
+            (cls(pd) for pd in pkgs_dirs)
+        )
+        return tuple(concatv(pc_groups.get(True, ()), pc_groups.get(False, ())))
 
     @classmethod
     def get_all_extracted_entries(cls):
@@ -183,10 +205,9 @@ class PackageCacheData(object):
         # if ProgressiveFetchExtract did its job correctly, what we're looking for
         #   should be the matching dist_name in the first writable package cache
         # we'll search all caches for a match, but search writable caches first
-        caches = concatv(cls.writable_caches(), cls.read_only_caches())
         dist_str = package_ref.dist_str().rsplit(':', 1)[-1]
         pc_entry = next((cache._scan_for_dist_no_channel(dist_str)
-                         for cache in caches if cache), None)
+                         for cache in cls.all_caches_writable_first() if cache), None)
         if pc_entry is not None:
             return pc_entry
         raise CondaError("No package '%s' found in cache directories." % Dist(package_ref))
@@ -222,18 +243,20 @@ class PackageCacheData(object):
 
     @property
     def is_writable(self):
-        if self.__is_writable is None:
+        # returns None if package cache directory does not exist / has not been created
+        if self.__is_writable is NULL:
             return self._check_writable()
         return self.__is_writable
 
     def _check_writable(self):
-        if isdir(self.pkgs_dir):
+        magic_file = join(self.pkgs_dir, PACKAGE_CACHE_MAGIC_FILE)
+        if isfile(magic_file):
             i_wri = file_path_is_writable(join(self.pkgs_dir, PACKAGE_CACHE_MAGIC_FILE))
+            self.__is_writable = i_wri
+            log.debug("package cache directory '%s' writable: %s", self.pkgs_dir, i_wri)
         else:
             log.trace("package cache directory '%s' does not exist", self.pkgs_dir)
-            i_wri = create_package_cache_directory(self.pkgs_dir)
-        log.debug("package cache directory '%s' writable: %s", self.pkgs_dir, i_wri)
-        self.__is_writable = i_wri
+            self.__is_writable = i_wri = None
         return i_wri
 
     @staticmethod

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -156,9 +156,7 @@ class PackageCacheData(object):
                     package_cache.__is_writable = True
                     return package_cache
 
-        # TODO: raise NoWritablePackageCacheError()
-        raise CondaError("No writable package cache directories found in"
-                         "%s" % dashlist(pkgs_dirs))
+        raise NoWritablePkgsDirError(pkgs_dirs)
 
     @classmethod
     def writable_caches(cls, pkgs_dirs=None):

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -14,8 +14,8 @@ from ._vendor.auxlib.entity import EntityEncoder
 from ._vendor.auxlib.ish import dals
 from ._vendor.auxlib.type_coercion import boolify
 from .base.constants import PathConflict, SafetyChecks
-from .common.compat import ensure_text_type, input, iteritems, iterkeys, on_win, string_types, PY2
-from .common.io import timeout
+from .common.compat import PY2, ensure_text_type, input, iteritems, iterkeys, on_win, string_types
+from .common.io import dashlist, timeout
 from .common.signals import get_signal_name
 from .common.url import maybe_unquote
 
@@ -692,6 +692,20 @@ class NotWritableError(CondaError, OSError):
                 'gid': os.getegid(),
             })
         super(NotWritableError, self).__init__(message, **kwargs)
+
+
+class NoWritableEnvsDirError(CondaError):
+
+    def __init__(self, envs_dirs, **kwargs):
+        message = "No writeable envs directories configured.%s" % dashlist(envs_dirs)
+        super(NoWritableEnvsDirError, self).__init__(message, envs_dirs=envs_dirs, **kwargs)
+
+
+class NoWritablePkgsDirError(CondaError):
+
+    def __init__(self, pkgs_dirs, **kwargs):
+        message = "No writeable pkgs directories configured.%s" % dashlist(pkgs_dirs)
+        super(NoWritablePkgsDirError, self).__init__(message, pkgs_dirs=pkgs_dirs, **kwargs)
 
 
 class CondaDependencyError(CondaError):

--- a/conda/gateways/disk/__init__.py
+++ b/conda/gateways/disk/__init__.py
@@ -79,3 +79,7 @@ def mkdir_p_sudo_safe(path):
         gid = int(os.environ.get('SUDO_GID', -1))
         log.trace("chowning %s:%s %s", uid, gid, path)
         os.chown(path, uid, gid)
+    if not on_win:
+        # set newly-created directory permissions to 02775
+        # https://github.com/conda/conda/issues/6610#issuecomment-354478489
+        os.chmod(path, 0o2775)

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -351,3 +351,23 @@ def create_package_cache_directory(pkgs_dir):
         else:
             raise
     return True
+
+
+def create_envs_directory(envs_dir):
+    # returns False if envs directory cannot be created
+
+    # The magic file being used here could change in the future.  Don't write programs
+    # outside this code base that rely on the presence of this file.
+    # This value is duplicated in conda.base.context._first_writable_envs_dir().
+    envs_dir_magic_file = join(envs_dir, '.conda_envs_dir_test')
+    try:
+        log.trace("creating envs directory '%s'", envs_dir)
+        sudo_safe = expand(envs_dir).startswith(expand('~'))
+        touch(join(envs_dir, envs_dir_magic_file), mkdir=True, sudo_safe=sudo_safe)
+    except (IOError, OSError) as e:
+        if e.errno in (EACCES, EPERM):
+            log.trace("cannot create envs directory '%s'", envs_dir)
+            return False
+        else:
+            raise
+    return True

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -76,7 +76,7 @@ def touch(path, mkdir=False, sudo_safe=False):
     # returns:
     #   True if the file did not exist but was created
     #   False if the file already existed
-    # raises: permissions errors such as EPERM and EACCES
+    # raises: NotWritableError, which is also an OSError having attached errno
     try:
         path = expand(path)
         log.trace("touching path %s", path)

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -238,7 +238,7 @@ class ContextCustomRcTests(TestCase):
 
                 # with first dir read-only, choose second
                 PackageCacheData._cache_.clear()
-                make_read_only(join(prefix, 'first', 'pkgs', 'urls.txt'))
+                make_read_only(join(envs_dirs[0], '.conda_envs_dir_test'))
                 reset_context((), argparse_args=AttrDict(name='blarg', func='create'))
                 assert context.target_prefix == join(envs_dirs[1], 'blarg')
 


### PR DESCRIPTION
resolve #6569

The goal of this PR is to only *write* to these magic file locations when we know we're actually going to be writing to that "location" (either `pkgs` dir or `envs` dir).