### PR TITLE
fix #6577, #6580 single quote in PS1

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -426,6 +426,10 @@ class Activator(object):
             current_prompt_modifier = os.environ.get('CONDA_PROMPT_MODIFIER')
             if current_prompt_modifier:
                 ps1 = re.sub(re.escape(current_prompt_modifier), r'', ps1)
+            # Because we're using single-quotes to set shell variables, we need to handle the
+            # proper escaping of single quotes that are already part of the string.
+            # Best solution appears to be https://stackoverflow.com/a/1250279
+            ps1 = ps1.replace("'", "'\"'\"'")
             set_vars.update({
                 'PS1': conda_prompt_modifier + ps1,
             })


### PR DESCRIPTION
fix #6577
fix #6580

Both issues are caused by having single-quotes in the PS1 string, and also trying to re-set that string using single-qutoes, as `PS1='<CONTENTS>'`, where `<CONTENTS>` itself then contains single-quotes.

It appears the best solution is https://stackoverflow.com/a/1250279.  It seems to work, based on my testing.