### PR TITLE
resolve #6582 swallow_broken_pipe context manager and Spinner refactor

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -7,6 +7,7 @@ import sys
 from .._vendor.auxlib.ish import dals
 from ..base.constants import ROOT_ENV_NAME
 from ..base.context import context
+from ..common.io import swallow_broken_pipe
 from ..common.path import paths_equal
 from ..models.match_spec import MatchSpec
 
@@ -155,6 +156,7 @@ def disp_features(features):
         return ''
 
 
+@swallow_broken_pipe
 def stdout_json(d):
     import json
     from .._vendor.auxlib.entity import EntityEncoder

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -2,12 +2,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import defaultdict
-import sys
 
 from .install import calculate_channel_urls
 from ..base.context import context
 from ..cli.common import stdout_json
-from ..common.io import spinner
+from ..common.io import Spinner
 from ..compat import text_type
 from ..core.repodata import SubdirData
 from ..models.match_spec import MatchSpec
@@ -25,7 +24,7 @@ def execute(args, parser):
     else:
         subdirs = context.subdirs
 
-    with spinner("Loading channels", not context.verbosity and not context.quiet, context.json):
+    with Spinner("Loading channels", not context.verbosity and not context.quiet, context.json):
         spec_channel = spec.get_exact_value('channel')
         channel_urls = (spec_channel,) if spec_channel else context.channels
 
@@ -66,8 +65,7 @@ def execute(args, parser):
                 record.build,
                 record.schannel,
             ))
-        sys.stdout.write('\n'.join(builder))
-        sys.stdout.write('\n')
+        print('\n'.join(builder))
 
 
 def pretty_record(record):
@@ -95,5 +93,4 @@ def pretty_record(record):
     push_line("md5", "md5")
     builder.append("%-12s: %s" % ("dependencies", dashlist(record.depends)))
     builder.append('\n')
-    sys.stdout.write('\n'.join(builder))
-    sys.stdout.write('\n')
+    print('\n'.join(builder))

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -24,7 +24,7 @@ from .._vendor.auxlib.ish import dals
 from ..base.constants import SafetyChecks
 from ..base.context import context
 from ..common.compat import ensure_text_type, iteritems, itervalues, odict, on_win
-from ..common.io import spinner, time_recorder
+from ..common.io import Spinner, time_recorder
 from ..common.path import (explode_directories, get_all_directories, get_major_minor_version,
                            get_python_site_packages_short_path)
 from ..common.signals import signal_handler
@@ -181,7 +181,7 @@ class UnlinkLinkTransaction(object):
 
         self.transaction_context = {}
 
-        with spinner("Preparing transaction", not context.verbosity and not context.quiet,
+        with Spinner("Preparing transaction", not context.verbosity and not context.quiet,
                      context.json):
             for stp in itervalues(self.prefix_setups):
                 grps = self._prepare(self.transaction_context, stp.target_prefix,
@@ -202,7 +202,7 @@ class UnlinkLinkTransaction(object):
             self._verified = True
             return
 
-        with spinner("Verifying transaction", not context.verbosity and not context.quiet,
+        with Spinner("Verifying transaction", not context.verbosity and not context.quiet,
                      context.json):
             exceptions = self._verify(self.prefix_setups, self.prefix_action_groups)
             if exceptions:
@@ -466,7 +466,7 @@ class UnlinkLinkTransaction(object):
         with signal_handler(conda_signal_handler), time_recorder("unlink_link_execute"):
             pkg_idx = 0
             try:
-                with spinner("Executing transaction", not context.verbosity and not context.quiet,
+                with Spinner("Executing transaction", not context.verbosity and not context.quiet,
                              context.json):
                     for pkg_idx, axngroup in enumerate(all_action_groups):
                         cls._execute_actions(pkg_idx, axngroup)
@@ -483,7 +483,7 @@ class UnlinkLinkTransaction(object):
                 # reverse all executed packages except the one that failed
                 rollback_excs = []
                 if context.rollback_enabled:
-                    with spinner("Rolling back transaction",
+                    with Spinner("Rolling back transaction",
                                  not context.verbosity and not context.quiet, context.json):
                         failed_pkg_idx = pkg_idx
                         reverse_actions = reversed(tuple(enumerate(

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -18,7 +18,7 @@ from .._vendor.boltons.setutils import IndexedSet
 from ..base.context import context
 from ..common.compat import iteritems, itervalues, odict, string_types, text_type
 from ..common.constants import NULL
-from ..common.io import spinner
+from ..common.io import Spinner
 from ..common.path import get_major_minor_version, paths_equal
 from ..exceptions import PackagesNotFoundError
 from ..gateways.logging import TRACE
@@ -492,7 +492,7 @@ class Solver(object):
             UnlinkLinkTransaction:
 
         """
-        with spinner("Solving environment", not context.verbosity and not context.quiet,
+        with Spinner("Solving environment", not context.verbosity and not context.quiet,
                      context.json):
             if self.prefix == context.root_prefix and context.enable_private_envs:
                 # This path has the ability to generate a multi-prefix transaction. The basic logic
@@ -516,7 +516,7 @@ class Solver(object):
                 )
                 if conda_newer_records:
                     latest_version = conda_newer_records[-1].version
-                    sys.stderr.write(dedent("""
+                    print(dedent("""
 
                     ==> WARNING: A newer version of conda exists. <==
                       current version: %s
@@ -527,7 +527,7 @@ class Solver(object):
                         $ conda update -n base conda
 
 
-                    """) % (CONDA_VERSION, latest_version))
+                    """) % (CONDA_VERSION, latest_version), file=sys.stderr)
 
         return UnlinkLinkTransaction(stp)
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -526,7 +526,6 @@ class Solver(object):
 
                         $ conda update -n base conda
 
-
                     """) % (CONDA_VERSION, latest_version), file=sys.stderr)
 
         return UnlinkLinkTransaction(stp)


### PR DESCRIPTION
resolve #6582

Besides the Spinner refactor and swallow_broken_pipe context manager, this PR also replaces several `sys.stderr.write()` and `sys.stdout.write()` calls with `print()`.