### PR TITLE
fix #6643 difference between '==' and 'exact_match_'

### DIFF
--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -463,12 +463,17 @@ class VersionSpec(object):
             self.op = VersionOrder.startswith
             self.cmp = VersionOrder(spec.rstrip('*').rstrip('.'))
             self.match = self.veval_match_
+        elif '@' not in spec:
+            self.op = opdict["=="]
+            self.cmp = VersionOrder(spec)
+            self.match = self.veval_match_
         else:
             self.match = self.exact_match_
         return self
 
     def is_exact(self):
-        return self.match == self.exact_match_
+        return (self.match == self.exact_match_
+                or self.match == self.veval_match_ and self.op == op.__eq__)
 
     def __eq__(self, other):
         try:

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -50,6 +50,7 @@ class MatchSpecTests(TestCase):
             ('numpy >1.8,<2|==1.7', False),('numpy >1.8,<2|>=1.7.1', True),
             ('numpy >=1.8|1.7*', True),    ('numpy ==1.7', False),
             ('numpy >=1.5,>1.6', True),    ('numpy ==1.7.1', True),
+            ('numpy ==1.7.1.0', True),     ('numpy==1.7.1.0.0', True),
             ('numpy >=1,*.7.*', True),     ('numpy *.7.*,>=1', True),
             ('numpy >=1,*.8.*', False),    ('numpy >=2,*.7.*', False),
             ('numpy 1.6*|1.7*', True),     ('numpy 1.6*|1.8*', False),
@@ -559,6 +560,14 @@ class SpecStrParsingTests(TestCase):
         assert _parse_spec_str("numpy ==1.7") == {
             "name": "numpy",
             "version": "1.7",
+        }
+        assert _parse_spec_str("numpy=1.7") == {
+            "name": "numpy",
+            "version": "1.7*",
+        }
+        assert _parse_spec_str("numpy =1.7") == {
+            "name": "numpy",
+            "version": "1.7*",
         }
 
     def test_parse_hard(self):


### PR DESCRIPTION
fix #6643

This PR makes the following work as expected

    CONDA_SUBDIR=linux-64 conda search boost==1.60
    CONDA_SUBDIR=linux-64 conda search boost==1.60.0
    CONDA_SUBDIR=linux-64 conda search boost==1.60.0.0

This behavior is identical to 4.3.x.  It changed in 4.4.x because of a parsing change.  The PR brings 4.4.x behavior inline with 4.3.x.

After this PR is merged, there will be a difference that specifically affects conda-build and meta.yaml.  Given the below examples

```
requirements:
  run:
    - boost 1.60.0
```

```
requirements:
  run:
    - boost ==1.60.0
```

Currently in 4.4, the above are treated differently (also in 4.3).  The first uses `exact_match_()` and thus the version string has to be exactly `1.60.0`.  The second uses `veval_match_()` and thus will match `1.60`, or `1.60.0.0`, etc.  With this PR, `MatchSpec('boost 1.60.0')` *will* now match a version string of `1.60.0.0`.

I've spoken with @msarahan, and for various reasons, we believe this PR should be fine and not impact builder personas.

