### PR TITLE
fix #6665 KeyError for channel '<unknown>'

### DIFF
--- a/conda/models/dist.py
+++ b/conda/models/dist.py
@@ -147,7 +147,7 @@ class Dist(Entity):
 
         if channel_override != NULL:
             channel = channel_override
-        elif channel is None:
+        if channel is None:
             channel = UNKNOWN_CHANNEL
 
         # enforce dist format


### PR DESCRIPTION
fix #6665

This was brutal.  I wrote several variations of integration tests as regression tests, but everything I wrote seemed to pass fine, thus not reproducing the error.

I was able to reproduce it ultimately though, using the exact steps in #6665, and narrowed the problem down to these two characters.

Ultimately, the best solution will be to kill off the `Dist` object altogether.  Hopefully we can do that in conda 4.5.