### PR TITLE
PR: Allow None or '' values for default_python to avoid pinning python

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -77,14 +77,19 @@ def default_python_default():
 
 
 def default_python_validation(value):
-    if value and len(value) == 3 and value[1] == '.':
-        try:
-            value = float(value)
-            if 2.0 <= value < 4.0:
-                return True
-        except ValueError:  # pragma: no cover
-            pass
-    return "default_python value '%s' not of the form '[23].[0-9]'" % value
+    if value:
+        if len(value) == 3 and value[1] == '.':
+            try:
+                value = float(value)
+                if 2.0 <= value < 4.0:
+                    return True
+            except ValueError:  # pragma: no cover
+                pass
+    else:
+        # Set to None or '' meaning no python pinning
+        return True
+
+    return "default_python value '%s' not of the form '[23].[0-9]' or ''" % value
 
 
 def ssl_verify_validation(value):


### PR DESCRIPTION
Fix https://github.com/ContinuumIO/navigator/issues/1387

@kalefranz it seems the validation was not allowing `None` values. `None` was supposed to mean, no pinning right?
  
Also it seems that default_python is no longer a config option?

If I try to set it on the CLI I get

```
$ conda config --set default_python None --json --force --file /Users/gpena-castellanos/.condarc
{
  "caused_by": "None", 
  "error": "CondaValueError: Key 'default_python' is not a known primitive parameter.", 
  "exception_name": "CondaValueError", 
  "exception_type": "<class 'conda.exceptions.CondaValueError'>", 
  "message": "Key 'default_python' is not a known primitive parameter."
}
```

how is that working then? 