### PR TITLE
conda.bat: fix #6713 allow parenthesis in prefix path

### DIFF
--- a/conda/shell/Library/bin/conda.bat
+++ b/conda/shell/Library/bin/conda.bat
@@ -1,7 +1,7 @@
 @IF EXIST "%~dp0..\..\Scripts\conda.exe" (
-    @SET "_CONDA_EXE="%~dp0..\..\Scripts\conda.exe""
+    @SET _CONDA_EXE="%~dp0..\..\Scripts\conda.exe"
 ) ELSE (
-    @SET "_CONDA_EXE=python "%~dp0..\..\bin\conda""
+    @SET _CONDA_EXE=python "%~dp0..\..\bin\conda"
 )
 
 @IF "%1"=="activate" GOTO :DO_ACTIVATE


### PR DESCRIPTION
Fixes #6713.
I can't say I know what's exactly going on, but there seems to be a problem with using parenthesis expressions and quoted arguments to `set` that include quotes and `)`, see the following:
```bat
@echo off

set X=")1"

(
  set X=")2"
)

( set X=")3" )

set "X=")4""

(
  set "X=")5""
)

( set "X=")6"" )
```
which fails for case 5 and 6:
```
5"" was unexpected at this time.
```
. I have no idea about the exact semantics for parenthesis expressions...
If we run into trouble with those expressions again, we could also just resort to replacing some
```bat
if condition (
  ...
) else (
  ...
)
```
with
```bat
if not condition goto :condition_else
  ...
goto :condition_end
:condition_else
  ...
:condition_end
```
.