### PR TITLE
minimal cleanup: shell: make variable 'sourced' local

### DIFF
--- a/conda/shell/bin/activate
+++ b/conda/shell/bin/activate
@@ -38,7 +38,7 @@ _conda_set_vars() {
 
 _conda_script_is_sourced() {
     # http://stackoverflow.com/a/28776166/2127762
-    sourced=0
+    local sourced=0
     if [ -n "${ZSH_EVAL_CONTEXT:+x}" ]; then
       case $ZSH_EVAL_CONTEXT in *:file) sourced=1;; esac
     elif [ -n "${KSH_VERSION:+x}" ]; then

--- a/conda/shell/bin/deactivate
+++ b/conda/shell/bin/deactivate
@@ -38,7 +38,7 @@ _conda_set_vars() {
 
 _conda_script_is_sourced() {
     # http://stackoverflow.com/a/28776166/2127762
-    sourced=0
+    local sourced=0
     if [ -n "${ZSH_EVAL_CONTEXT:+x}" ]; then
       case $ZSH_EVAL_CONTEXT in *:file) sourced=1;; esac
     elif [ -n "${KSH_VERSION:+x}" ]; then


### PR DESCRIPTION
With `4.4.x` after an `source activate; source deactivate` some environment variables and functions are left over, namely
* `conda` shell function,
* `CONDA_SHLVL` (`export`ed) variable,
* `sourced` variable,
* `_CONDA_*` variables,
* `_conda_*` functions.

The PR marks `sourced` as `local` but nothing more.
Otherwise, I mainly only wanted to document the leftover changes after a "complete" deactivate:
```bash
$ set >set0
$ export >export0
$ source bin/activate 
(base) $ conda --version
conda 4.4.7
(base) $ source deactivate
$ set >set1
$ export >export1
$ 
$ diff -u0 set{0,1}
--- set0	2018-01-13 15:05:28.033420633 +0100
+++ set1	2018-01-13 15:06:01.499636484 +0100
@@ -13,0 +14 @@
+CONDA_SHLVL=0
@@ -82,0 +84,103 @@
+_CONDA_EXE=/home/maba/code/conda/conda-4.4/bin/conda
+_CONDA_ROOT=/home/maba/code/conda/conda-4.4
+_CONDA_SHELL_FLAVOR=bash
+sourced=0
+_conda_activate () 
+{ 
+    if [ -n "${CONDA_PS1_BACKUP:+x}" ]; then
+        PS1="$CONDA_PS1_BACKUP";
+        unset CONDA_PS1_BACKUP;
+    fi;
+    local ask_conda;
+    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix activate "$@")" || return $?;
+    eval "$ask_conda";
+    _conda_hashr
+}
+_conda_deactivate () 
+{ 
+    local ask_conda;
+    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix deactivate "$@")" || return $?;
+    eval "$ask_conda";
+    _conda_hashr
+}
+_conda_hashr () 
+{ 
+    case "$_CONDA_SHELL_FLAVOR" in 
+        zsh)
+            rehash
+        ;;
+        posh)
+
+        ;;
+        *)
+            hash -r
+        ;;
+    esac
+}
+_conda_reactivate () 
+{ 
+    local ask_conda;
+    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix reactivate)" || return $?;
+    eval "$ask_conda";
+    _conda_hashr
+}
+_conda_script_is_sourced () 
+{ 
+    sourced=0;
+    if [ -n "${ZSH_EVAL_CONTEXT:+x}" ]; then
+        case $ZSH_EVAL_CONTEXT in 
+            *:file)
+                sourced=1
+            ;;
+        esac;
+    else
+        if [ -n "${KSH_VERSION:+x}" ]; then
+            [ "$(cd $(dirname -- $0) && pwd -P)/$(basename -- $0)" != "$(cd $(dirname -- ${.sh.file}) && pwd -P)/$(basename -- ${.sh.file})" ] && sourced=1;
+        else
+            if [ -n "${BASH_VERSION:+x}" ]; then
+                [ "${BASH_SOURCE[0]}" = "$0" ] && sourced=1;
+            else
+                case ${0##*/} in 
+                    sh | dash)
+                        sourced=0
+                    ;;
+                    *)
+                        sourced=1
+                    ;;
+                esac;
+            fi;
+        fi;
+    fi;
+    return $sourced
+}
+_conda_set_vars () 
+{ 
+    if [ -n "${BASH_VERSION:+x}" ]; then
+        _CONDA_SHELL_FLAVOR=bash;
+    else
+        if [ -n "${ZSH_VERSION:+x}" ]; then
+            _CONDA_SHELL_FLAVOR=zsh;
+        else
+            if [ -n "${KSH_VERSION:+x}" ]; then
+                _CONDA_SHELL_FLAVOR=ksh;
+            else
+                if [ -n "${POSH_VERSION:+x}" ]; then
+                    _CONDA_SHELL_FLAVOR=posh;
+                else
+                    _CONDA_SHELL_FLAVOR=dash;
+                fi;
+            fi;
+        fi;
+    fi;
+    if [ -z "${_CONDA_EXE+x}" ]; then
+        if [ -n "${_CONDA_ROOT:+x}" ]; then
+            _CONDA_EXE="$_CONDA_ROOT/conda/shell/bin/conda";
+        fi;
+        if ! [ -f "${_CONDA_EXE-x}" ]; then
+            _CONDA_EXE="$PWD/conda/shell/bin/conda";
+        fi;
+    fi;
+    if [ -z "${PS1+x}" ]; then
+        PS1=;
+    fi
+}
@@ -119,0 +224,24 @@
+}
+conda () 
+{ 
+    if [ "$#" -ge 1 ]; then
+        local cmd="$1";
+        shift;
+    else
+        local cmd="";
+    fi;
+    case "$cmd" in 
+        activate)
+            _conda_activate "$@"
+        ;;
+        deactivate)
+            _conda_deactivate "$@"
+        ;;
+        install | update | uninstall | remove)
+            $_CONDA_EXE "$cmd" "$@";
+            _conda_reactivate
+        ;;
+        *)
+            $_CONDA_EXE "$cmd" "$@"
+        ;;
+    esac
$ diff -u0 export{0,1}
--- export0	2018-01-13 15:05:32.556693035 +0100
+++ export1	2018-01-13 15:06:05.826244868 +0100
@@ -2,0 +3 @@
+declare -x CONDA_SHLVL="0"
```