### PR TITLE
fix aggressive_update_packages availability

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -92,6 +92,12 @@ ROOT_NO_RM = (
     'requests',
 )
 
+DEFAULT_AGGRESSIVE_UPDATE_PACKAGES = (
+    'ca-certificates',
+    'certifi',
+    'openssl',
+)
+
 # Maximum priority, reserved for packages we really want to remove
 MAX_CHANNEL_PRIORITY = 10000
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -9,9 +9,10 @@ from os.path import (abspath, basename, dirname, expanduser, isdir, isfile, join
 from platform import machine
 import sys
 
-from .constants import (APP_NAME, DEFAULTS_CHANNEL_NAME, DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS,
-                        ERROR_UPLOAD_URL, PLATFORM_DIRECTORIES, PREFIX_MAGIC_FILE, PathConflict,
-                        ROOT_ENV_NAME, SEARCH_PATH, SafetyChecks)
+from .constants import (APP_NAME, DEFAULTS_CHANNEL_NAME, DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
+                        DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS, ERROR_UPLOAD_URL,
+                        PLATFORM_DIRECTORIES, PREFIX_MAGIC_FILE, PathConflict, ROOT_ENV_NAME,
+                        SEARCH_PATH, SafetyChecks)
 from .. import __version__ as CONDA_VERSION
 from .._vendor.appdirs import user_data_dir
 from .._vendor.auxlib.collection import frozendict
@@ -121,7 +122,7 @@ class Context(Configuration):
 
     # Safety & Security
     _aggressive_update_packages = SequenceParameter(string_types,
-                                                    ('ca-certificates', 'certifi', 'openssl'),
+                                                    DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
                                                     aliases=('aggressive_update_packages',))
     safety_checks = PrimitiveParameter(SafetyChecks.warn)
     path_conflict = PrimitiveParameter(PathConflict.clobber)

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -120,7 +120,8 @@ class Context(Configuration):
     non_admin_enabled = PrimitiveParameter(True)
 
     # Safety & Security
-    _aggressive_update_packages = SequenceParameter(string_types)
+    _aggressive_update_packages = SequenceParameter(string_types,
+                                                    aliases=('aggressive_update_packages',))
     safety_checks = PrimitiveParameter(SafetyChecks.warn)
     path_conflict = PrimitiveParameter(PathConflict.clobber)
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -121,6 +121,7 @@ class Context(Configuration):
 
     # Safety & Security
     _aggressive_update_packages = SequenceParameter(string_types,
+                                                    ('ca-certificates', 'certifi', 'openssl'),
                                                     aliases=('aggressive_update_packages',))
     safety_checks = PrimitiveParameter(SafetyChecks.warn)
     path_conflict = PrimitiveParameter(PathConflict.clobber)
@@ -439,14 +440,7 @@ class Context(Configuration):
     @property
     def aggressive_update_packages(self):
         from ..models.match_spec import MatchSpec
-        if self._aggressive_update_packages:
-            return tuple(MatchSpec(s, optional=True) for s in self._aggressive_update_packages)
-        else:
-            return (
-                MatchSpec('ca-certificates', optional=True),
-                MatchSpec('certifi', optional=True),
-                MatchSpec('openssl', optional=True),
-            )
+        return tuple(MatchSpec(s, optional=True) for s in self._aggressive_update_packages)
 
     @property
     def deps_modifier(self):

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -25,6 +25,7 @@ from conda.gateways.disk.delete import rm_rf
 from conda.gateways.disk.permissions import make_read_only
 from conda.gateways.disk.update import touch
 from conda.models.channel import Channel
+from conda.models.match_spec import MatchSpec
 from conda.utils import on_win
 
 from ..helpers import tempdir
@@ -58,6 +59,7 @@ class ContextCustomRcTests(TestCase):
           sftp: ''
           ftps: false
           rsync: 'false'
+        aggressive_update_packages: []
         """)
         reset_context()
         rd = odict(testdata=YamlRawParameter.make_raw_parameters('testdata', yaml_load(string)))
@@ -230,6 +232,13 @@ class ContextCustomRcTests(TestCase):
                 touch(join(envs_dirs[0], 'blarg', 'history'))
                 reset_context((), argparse_args=AttrDict(name='blarg', func='create'))
                 assert context.target_prefix == join(envs_dirs[0], 'blarg')
+
+    def test_aggressive_update_packages(self):
+        assert context.aggressive_update_packages == tuple()
+        specs = ['certifi', 'openssl>=1.1']
+        with env_var('CONDA_AGGRESSIVE_UPDATE_PACKAGES', ','.join(specs), reset_context):
+            assert context.aggressive_update_packages == tuple(
+                MatchSpec(s, optional=True) for s in specs)
 
 
 class ContextDefaultRcTests(TestCase):


### PR DESCRIPTION
This is a followup to #6392 and makes `aggressive_update_packages` available under its designated name as it was previously only accessible via
```
_aggressive_update_packages:
  - ...
```
. Additionally, `aggressive_update_packages` wasn't allow to be empty before, which is also fixed.