### PR TITLE
issue template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -45,22 +45,28 @@ If your issue is a bug report or feature request for:
 
 
 ## Environment Information
-##### `conda info`
+<details open><summary><code>`conda info`</code></summary><p>
 <!-- between the ticks below, paste the output of 'conda info' -->
-```
 
 ```
 
+```
+</p></details>
 
-##### `conda config --show-sources`
+
+<details open><summary><code>`conda config --show-sources`</code></summary><p>
 <!-- between the ticks below, paste the output of 'conda config --show-sources' -->
-```
 
 ```
 
+```
+</p></details>
 
-##### `conda list --show-channel-urls`
+
+<details><summary><code>`conda list --show-channel-urls`</code></summary><p>
 <!-- between the ticks below, paste the output of 'conda list --show-channel-urls' -->
+
 ```
 
 ```
+</p></details>

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,12 +27,12 @@ If your issue is a bug report or feature request for:
   - [ ] feature request
 
 
-### Current Behavior
+## Current Behavior
 <!-- What actually happens?
      If you want to include console output, please use "Steps to Reproduce" below. -->
 
 
-#### Steps to Reproduce
+### Steps to Reproduce
 <!-- If the current behavior is a bug, please provide specific, minimal steps to independently reproduce.
      Include the exact conda commands that reproduce the issue and their output between the ticks below. -->
 ```
@@ -40,11 +40,11 @@ If your issue is a bug report or feature request for:
 ```
 
 
-### Expected Behavior
+## Expected Behavior
 <!-- What do you think should happen? -->
 
 
-### Environment Information
+## Environment Information
 ##### `conda info`
 <!-- between the ticks below, paste the output of 'conda info' -->
 ```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -40,6 +40,7 @@ If your issue is a bug report or feature request for:
 <!-- What do you think should happen? -->
 
 
+### Environment Information
 ##### `conda info`
 <!-- between the ticks below, paste the output of 'conda info' -->
 ```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -31,7 +31,7 @@ If your issue is a bug report or feature request for:
 <!-- What actually happens? -->
 
 
-### Steps to Reproduce
+#### Steps to Reproduce
 <!-- If the current behavior is a bug, please provide specific, minimal steps to independently reproduce.
      Include the exact conda commands that reproduce the issue. -->
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -28,12 +28,16 @@ If your issue is a bug report or feature request for:
 
 
 ### Current Behavior
-<!-- What actually happens? -->
+<!-- What actually happens?
+     If you want to include console output, please use "Steps to Reproduce" below. -->
 
 
 #### Steps to Reproduce
 <!-- If the current behavior is a bug, please provide specific, minimal steps to independently reproduce.
-     Include the exact conda commands that reproduce the issue. -->
+     Include the exact conda commands that reproduce the issue and their output between the ticks below. -->
+```
+
+```
 
 
 ### Expected Behavior


### PR DESCRIPTION
Some improvements to `.github/ISSUE_TEMPLATE.md` I like to suggest after seeing the first uses of the issue template.
Changes are in single single commits so can be (mostly) cherry-picked if only a subset is used. Changes are:
* Add `Environment Information` section: so that `conda info` etc. are not part of `Expected Behavior` secion.
* `Steps to Reproduce` can be part of `Current Behavior`: mainly to hint at/"indirectly suggest" to rather put output from commands there.
* Directly suggest to include console output between tick-enclosed lines: to hopefully make the user put tracebacks and such there for better formatting.
* Reducing subsection depth: gives better visual separation, esp. if `Steps to Reproduce` is moved inside `Current Behavior`.
* Put `conda (info|config|list)` output in `<details>` HTML tags: makes them collapsible which is esp. useful for `conda list` output, e.g., with long package lists from `anaconda` users. `conda (info|config)` outputs are uncollapsed on default whereas `conda list` is collapsed.