### PR TITLE
resolve #6733 make empty env vars sequence-safe for sequence parameters

### DIFF
--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -206,6 +206,7 @@ class EnvRawParameter(RawParameter):
 
     def value(self, parameter_obj):
         if hasattr(parameter_obj, 'string_delimiter'):
+            assert isinstance(self._raw_value, string_types)
             string_delimiter = getattr(parameter_obj, 'string_delimiter')
             # TODO: add stripping of !important, !top, and !bottom
             return tuple(v for v in (

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -210,9 +210,9 @@ class EnvRawParameter(RawParameter):
             # TODO: add stripping of !important, !top, and !bottom
             raw_value = self._raw_value
             if string_delimiter in raw_value:
-                value = raw_value.split(string_delimiter)
+                value = [v for v in raw_value.split(string_delimiter) if v]
             else:
-                value = [raw_value]
+                value = [raw_value] if raw_value else []
             return tuple(v.strip() for v in value)
         else:
             return self.__important_split_value[0].strip()

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -208,12 +208,9 @@ class EnvRawParameter(RawParameter):
         if hasattr(parameter_obj, 'string_delimiter'):
             string_delimiter = getattr(parameter_obj, 'string_delimiter')
             # TODO: add stripping of !important, !top, and !bottom
-            raw_value = self._raw_value
-            if string_delimiter in raw_value:
-                value = [v for v in raw_value.split(string_delimiter) if v]
-            else:
-                value = [raw_value] if raw_value else []
-            return tuple(v.strip() for v in value)
+            return tuple(v for v in (
+                vv.strip() for vv in self._raw_value.split(string_delimiter)
+            ) if v)
         else:
             return self.__important_split_value[0].strip()
 

--- a/tests/common/test_configuration.py
+++ b/tests/common/test_configuration.py
@@ -241,6 +241,21 @@ class ConfigurationTests(TestCase):
         finally:
             [environ.pop(key) for key in test_dict]
 
+    def test_env_var_config_empty_sequence(self):
+        def make_key(appname, key):
+            return "{0}_{1}".format(appname.upper(), key.upper())
+        appname = "myapp"
+        test_dict = {}
+        test_dict[make_key(appname, 'channels')] = ''
+
+        try:
+            environ.update(test_dict)
+            assert 'MYAPP_CHANNELS' in environ
+            config = SampleConfiguration()._set_env_vars(appname)
+            assert config.channels == ()
+        finally:
+            [environ.pop(key) for key in test_dict]
+
     def test_load_raw_configs(self):
         try:
             tempdir = mkdtemp()


### PR DESCRIPTION
resolve #6733 

@mbargull Let's see how this works...  I don't even know if there's a situation where we'd actually *want* an empty string, instead of just an empty sequence.