### PR TITLE
Don't truncate channel priority map in conda installer

### DIFF
--- a/conda_env/installers/conda.py
+++ b/conda_env/installers/conda.py
@@ -28,8 +28,7 @@ def install(prefix, specs, args, env, *_, **kwargs):
         channel_urls.extend(context.channels)
     _channel_priority_map = prioritize_channels(channel_urls)
 
-    channel_names = IndexedSet(Channel(url).canonical_name for url in _channel_priority_map)
-    channels = IndexedSet(Channel(cn) for cn in channel_names)
+    channels = IndexedSet(Channel(url) for url in _channel_priority_map)
     subdirs = IndexedSet(basename(url) for url in _channel_priority_map)
 
     solver = Solver(prefix, channels, subdirs, specs_to_add=specs)


### PR DESCRIPTION
Fixes #6745.

As written, the `conda_env` installer (invoked during the `conda env create` command) will:
1) Truncate authentication components of available channels (e.g. token authenticated channels) before passing those channels to the `Solver`.
2) Truncate channels with the same channel name but different properties (e.g. authenticated vs unautheticated) channels before passing those channels to the `Solver`.

This change removes this truncation from the conda installer. Which should bring it in line with other invocations of the `Solver` that are not in `conda env`. 

See #6745 for full details.