### PR TITLE
Preserve status in fish shell

### DIFF
--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -39,10 +39,17 @@ else
     function __fish_prompt_orig
     end
 end
+
+function return_last_status
+  return $argv
+end
+
 function fish_prompt
+  set -l last_status $status
   if set -q CONDA_LEFT_PROMPT
       __conda_add_prompt
   end
+  return_last_status $last_status
   __fish_prompt_orig
 end
 


### PR DESCRIPTION
The fish_prompt function typically does things like changing the color
of the prompt based on the exit status of the last command. This
status is however lost in the function defined by conda, since the
status of the last operation is always zero.

This fixes the issue by defining an identity function that returns the
last status (thereby setting the $status variable) before the original
fish_prompt function is called.