### PR TITLE
Adjust the feature score assigned to packages not installed

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -628,7 +628,14 @@ class Resolve(object):
         for name, group in iteritems(self.groups):
             nf = [len(self.features(dist)) for dist in group]
             maxf = max(nf)
-            eq.update({dist.full_name: maxf-fc for dist, fc in zip(group, nf) if fc < maxf})
+            if maxf > 0:
+                eq.update({dist.full_name: maxf-fc for dist, fc in zip(group, nf) if maxf > fc})
+                # This entry causes conda to weight the absence of a package the same
+                # as if a non-featured version were instaslled. If this were not here,
+                # conda will sometimes select an earlier build of a requested package
+                # if doing so can eliminate this package as a dependency.
+                # https://github.com/conda/conda/issues/6765
+                eq['!' + self.push_MatchSpec(C, name)] = maxf
             total += maxf
         return eq, total
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -766,6 +766,28 @@ def test_install_package_with_feature():
     r.install(['mypackage','feature 1.0'])
 
 
+def test_unintentional_feature_downgrade():
+    # See https://github.com/conda/conda/issues/6765
+    # With the bug in place, this bad build of scipy
+    # will be selected for install instead of a later
+    # build of scipy 0.11.0.
+    good_rec = index[Dist('scipy-0.11.0-np17py33_3.tar.bz2')]
+    bad_deps = tuple(d for d in good_rec.depends
+                     if not d.startswith('numpy'))
+    bad_rec = IndexRecord.from_objects(good_rec,
+                  build=good_rec.build.replace('_3','_x0'),
+                  build_number=0, depends=bad_deps,
+                  fn=good_rec.fn.replace('_3','_x0'),
+                  url=good_rec.url.replace('_3','_x0'))
+    bad_dist = Dist(bad_rec)
+    index2 = index.copy()
+    index2[bad_dist] = bad_rec
+    r = Resolve(index2)
+    install = r.install(['scipy 0.11.0'])
+    assert bad_dist not in install
+    assert any(d.name == 'numpy' for d in install)
+
+
 def test_circular_dependencies():
     index2 = index.copy()
     index2['package1-1.0-0.tar.bz2'] = IndexRecord(**{


### PR DESCRIPTION
Fixes #6765 . Built off of 4.3.x, but it should to port to 4.4.x with no changes.

The bug is this: consider the first three optimization passes:

1. Maximize the channel priority and version of the requested packages
2. Minimize the number of features required
3. Maximize the number of installed packages that utilize the features
4. Maximize the build number of the requested packages

We deliberately placed 4 after 2 and 3 in response to previous issues; for instance, if there are fewer builds of a featured package than a non-featured package, we need to be able to reach back and grab the featured build if requested. Now, per #6765, however, consider this scenario:

- The current version of a package `foo` has multiple builds with distinct build numbers.
- Newer builds depend on a second package `bar`, while older builds do not.
- Some of the valid choices for the `bar` dependency have features, and some do not.

The problem arises in the implementation 3. In effect, we were giving the same score to a package that is _not installed_ as we were to packages that are _installed with active features_. Therefore, if `foo` is requested, `conda` actually preferred _downgrading_ to an older build, if doing so allowed it to remove `bar` altogether.

To fix this, we're actually giving the SAT variable corresponding to "don't install `bar`" the same score as a package with no features. This will give `conda` a slight preference for pulling in unnecessary packages. However, `get_reduced_index` ensures that most unnecessary packages will not even be considered, so the likelihood of this occurring is small. And it's also a somewhat benign effect, compared to the downgrading behavior itself.
