### PR TITLE
fix external command execution issue

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -122,7 +122,7 @@ class ArgumentParser(ArgumentParserBase):
             else:
                 argument = None
             if argument and argument.dest == "cmd":
-                m = re.match(r"invalid choice: u?'(\w*?)'", exc.message)
+                m = re.match(r"invalid choice: u?'([\w\-]*?)'", exc.message)
                 if m:
                     cmd = m.group(1)
                     if not cmd:


### PR DESCRIPTION
When an external command contains a hypne, the command is listed as
available commands but cannot be executed.

At least conda 4.3.30, this https://github.com/lambdalisue/conda-offline-channel external conda command works correctly.

However with conda 4.4.7, the command execution fail even the command is listed in the available commands list.