### PR TITLE
Display package removal plan when deleting an env

### DIFF
--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -19,7 +19,7 @@ from ..gateways.disk.delete import delete_trash, rm_rf
 from ..gateways.disk.test import is_conda_environment
 from ..instructions import PREFIX
 from ..models.match_spec import MatchSpec
-from ..plan import (add_unlink)
+from ..plan import (add_unlink, display_actions)
 
 log = logging.getLogger(__name__)
 
@@ -62,6 +62,7 @@ def execute(args, parser):
         action_groups = (actions, index),
 
         if not context.json:
+            display_actions(actions, index)
             confirm_yn()
         rm_rf(prefix)
         unregister_env(prefix)


### PR DESCRIPTION
Conda 4.3.x displayed the packages that would be removed when a user
chose to remove an environment using `conda env remove`, however Conda
4.4.x did not do so. This patch fixes the problem by making a call to
display_actions() if the context is not json.

Fix #6632