### PR TITLE
add back support for search --reverse-dependency

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -918,9 +918,8 @@ def configure_parser_search(sub_parsers):
     p.add_argument(
         "--reverse-dependency",
         action="store_true",
-        help="Perform a reverse dependency search. When using this flag, the --full-name "
-             "flag is recommended. Use 'conda info package' to see the dependencies of a "
-             "package.",
+        help="Perform a reverse dependency search. Use 'conda info package' to see the "
+             "dependencies of a package.",
     )
     add_parser_offline(p)
     add_parser_channels(p)

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -29,8 +29,12 @@ def execute(args, parser):
         spec_channel = spec.get_exact_value('channel')
         channel_urls = (spec_channel,) if spec_channel else context.channels
 
-        matches = sorted(SubdirData.query_all(channel_urls, subdirs, spec),
-                         key=lambda rec: (rec.name, VersionOrder(rec.version), rec.build))
+        if args.reverse_dependency:
+            matches = sorted(SubdirData.reverse_query_all(channel_urls, subdirs, spec),
+                             key=lambda rec: (rec.name, VersionOrder(rec.version), rec.build))
+        else:
+            matches = sorted(SubdirData.query_all(channel_urls, subdirs, spec),
+                             key=lambda rec: (rec.name, VersionOrder(rec.version), rec.build))
 
     if not matches:
         channels_urls = tuple(calculate_channel_urls(


### PR DESCRIPTION
Add back support for the --reverse-dependency argument in conda search.

closes #6670