### PR TITLE
fix MatchSpec.match() accepting dict

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -234,7 +234,11 @@ class Channel(object):
         return url
 
     def __str__(self):
-        return self.base_url or ""
+        base = self.base_url or self.name
+        if self.subdir:
+            return join_url(base, self.subdir)
+        else:
+            return base
 
     def __repr__(self):
         return ("Channel(scheme=%r, auth=%r, location=%r, token=%r, name=%r, platform=%r, "

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -10,7 +10,7 @@ from .channel import Channel, MultiChannel
 from .dist import Dist
 from .index_record import IndexRecord, PackageRef
 from .version import BuildNumberMatch, VersionSpec
-from .._vendor.auxlib.collection import AttrDict, frozendict
+from .._vendor.auxlib.collection import frozendict
 from ..base.constants import CONDA_TARBALL_EXTENSION
 from ..common.compat import isiterable, iteritems, string_types, text_type, with_metaclass
 from ..common.path import expand
@@ -204,7 +204,7 @@ class MatchSpec(object):
         in that record.  Returns True for a match, and False for no match.
         """
         if isinstance(rec, dict):
-            rec = AttrDict(rec)
+            rec = IndexRecord.from_objects(rec)
         for field_name, v in iteritems(self._match_components):
             if not self._match_individual(rec, field_name, v):
                 return False

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -10,7 +10,7 @@ from .channel import Channel, MultiChannel
 from .dist import Dist
 from .index_record import IndexRecord, PackageRef
 from .version import BuildNumberMatch, VersionSpec
-from .._vendor.auxlib.collection import frozendict
+from .._vendor.auxlib.collection import AttrDict, frozendict
 from ..base.constants import CONDA_TARBALL_EXTENSION
 from ..common.compat import isiterable, iteritems, string_types, text_type, with_metaclass
 from ..common.path import expand
@@ -203,6 +203,8 @@ class MatchSpec(object):
         Accepts an `IndexRecord` or a dict, and matches can pull from any field
         in that record.  Returns True for a match, and False for no match.
         """
+        if isinstance(rec, dict):
+            rec = AttrDict(rec)
         for field_name, v in iteritems(self._match_components):
             if not self._match_individual(rec, field_name, v):
                 return False

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 from conda._vendor.auxlib.ish import dals
 from conda.base.constants import APP_NAME, DEFAULT_CHANNELS_UNIX, DEFAULT_CHANNELS
 from conda.base.context import Context, context, reset_context
-from conda.common.compat import odict
+from conda.common.compat import odict, text_type
 from conda.common.configuration import YamlRawParameter
 from conda.common.io import env_var
 from conda.common.serialize import yaml_load
@@ -98,6 +98,7 @@ class DefaultConfigChannelTests(TestCase):
         assert dc.canonical_name == 'defaults'
         assert dc.urls() == self.DEFAULT_URLS
         assert dc.subdir is None
+        assert text_type(dc) == 'defaults'
 
         dc = Channel('defaults/win-32')
         assert dc.canonical_name == 'defaults'
@@ -174,6 +175,8 @@ class AnacondaServerChannelTests(TestCase):
             "https://10.2.3.4:8080/conda/bioconda/noarch",
         ]
         assert channel.token == "tk-123-45"
+        assert text_type(channel) == "https://10.2.3.4:8080/conda/bioconda"
+        assert text_type(Channel('bioconda/linux-32')) == "https://10.2.3.4:8080/conda/bioconda/linux-32"
 
     def test_channel_alias_w_subhcnnale(self):
         channel = Channel('bioconda/label/dev')

--- a/tests/models/test_index_record.py
+++ b/tests/models/test_index_record.py
@@ -31,7 +31,7 @@ class PrefixRecordTests(TestCase):
         assert pr.subdir == "win-32"
         assert pr.fn == "austin-1.2.3-py34_2.tar.bz2"
         channel_str = text_type(Channel("https://repo.continuum.io/pkgs/free/win-32/austin-1.2.3-py34_2.tar.bz2"))
-        assert channel_str == "https://repo.continuum.io/pkgs/free"
+        assert channel_str == "https://repo.continuum.io/pkgs/free/win-32"
         assert dict(pr.dump()) == dict(
             name='austin',
             version='1.2.3',

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -246,7 +246,9 @@ class MatchSpecTests(TestCase):
         pref2 = PackageRef.from_objects(pref1, md5="1234")
         assert MatchSpec(url=url).match(pref1)
         assert MatchSpec(m(url)).match(pref1)
+        assert MatchSpec(m(url)).match(pref1.dump())
         assert not MatchSpec(url=url, md5="1234").match(pref1)
+        assert not MatchSpec(url=url, md5="1234").match(pref1.dump())
         assert MatchSpec(url=url, md5="1234").match(pref2)
         assert MatchSpec(url=url, md5="1234").get('md5') == "1234"
 
@@ -285,7 +287,6 @@ class MatchSpecTests(TestCase):
         assert ChannelMatch("conda-forge").match("https://conda.anaconda.org/conda-forge") is True
 
         assert ChannelMatch("https://repo.continuum.io/pkgs/free").match('conda-forge') is False
-
 
     def test_matchspec_errors(self):
         with pytest.raises(ValueError):
@@ -342,12 +343,12 @@ class MatchSpecTests(TestCase):
                                      priority=0,
                                      url='https://repo.continuum.io/pkgs/free/osx-64/python-3.5.1-0.tar.bz2'))
 
-
     def test_index_record(self):
         dst = Dist('defaults::foo-1.2.3-4.tar.bz2')
         rec = DPkg(dst)
         a = MatchSpec(dst)
         b = MatchSpec(rec)
+        assert b.match(rec.dump())
         assert b.match(rec)
         assert a.match(rec)
 


### PR DESCRIPTION
Looks like conda-build-all is incompatible with conda 4.4 without this patch.

See https://github.com/conda-tools/conda-build-all/pull/96