### PR TITLE
fix #6796 update PATH/prompt on reactivate

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -361,11 +361,16 @@ class Activator(object):
                 'activate_scripts': (),
             }
         conda_default_env = self.environ.get('CONDA_DEFAULT_ENV', self._default_env(conda_prefix))
+        new_path = self.pathsep_join(self._replace_prefix_in_path(conda_prefix, conda_prefix))
+        set_vars = {}
+        conda_prompt_modifier = self._prompt_modifier(conda_default_env)
+        self._update_prompt(set_vars, conda_prompt_modifier)
         # environment variables are set only to aid transition from conda 4.3 to conda 4.4
         return {
             'unset_vars': (),
-            'set_vars': {},
+            'set_vars': set_vars,
             'export_vars': {
+                'PATH': new_path,
                 'CONDA_SHLVL': conda_shlvl,
                 'CONDA_PROMPT_MODIFIER': self._prompt_modifier(conda_default_env),
             },

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -295,14 +295,23 @@ class ActivatorUnitTests(TestCase):
             with env_var('CONDA_SHLVL', '1'):
                 with env_var('CONDA_PREFIX', old_prefix):
                     activator = Activator('posix')
+
                     builder = activator.build_activate(td)
 
+                    new_path_parts = activator._replace_prefix_in_path(old_prefix, old_prefix)
+                    conda_prompt_modifier = "(%s) " % old_prefix
+                    ps1 = conda_prompt_modifier + os.environ.get('PS1', '')
+
+                    set_vars = {
+                        'PS1': ps1,
+                    }
                     export_vars = {
+                        'PATH': activator.pathsep_join(new_path_parts),
                         'CONDA_PROMPT_MODIFIER': "(%s) " % td,
                         'CONDA_SHLVL': 1,
                     }
                     assert builder['unset_vars'] == ()
-                    assert builder['set_vars'] == {}
+                    assert builder['set_vars'] == set_vars
                     assert builder['export_vars'] == export_vars
                     assert builder['activate_scripts'] == (activator.path_conversion(activate_d_1),)
                     assert builder['deactivate_scripts'] == (activator.path_conversion(deactivate_d_1),)
@@ -478,15 +487,20 @@ class ShellWrapperUnitTests(TestCase):
             assert rc == 0
             reactivate_data = c.stdout
 
+            new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
             assert reactivate_data == dals("""
             . "%(deactivate1)s"
+            PS1='%(ps1)s'
             export CONDA_PROMPT_MODIFIER='(%(native_prefix)s) '
             export CONDA_SHLVL='1'
+            export PATH='%(new_path)s'
             . "%(activate1)s"
             """) % {
                 'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.sh')),
                 'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.sh')),
                 'native_prefix': self.prefix,
+                'new_path': activator.pathsep_join(new_path_parts),
+                'ps1': '(%s) ' % self.prefix + os.environ.get('PS1', ''),
             }
 
             with captured() as c:
@@ -560,15 +574,18 @@ class ShellWrapperUnitTests(TestCase):
                 reactivate_data = fh.read()
             rm_rf(reactivate_result)
 
+            new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
             assert reactivate_data == dals("""
             @CALL "%(deactivate1)s"
             @SET "CONDA_PROMPT_MODIFIER=(%(native_prefix)s) "
             @SET "CONDA_SHLVL=1"
+            @SET "PATH=%(new_path)s"
             @CALL "%(activate1)s"
             """) % {
                 'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.bat')),
                 'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.bat')),
                 'native_prefix': self.prefix,
+                'new_path': activator.pathsep_join(new_path_parts),
             }
 
             with captured() as c:
@@ -635,12 +652,17 @@ class ShellWrapperUnitTests(TestCase):
             assert rc == 0
             reactivate_data = c.stdout
 
+            new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
             assert reactivate_data == dals("""
             source "%(deactivate1)s";
+            set prompt='%(prompt)s';
             setenv CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
             setenv CONDA_SHLVL "1";
+            setenv PATH "%(new_path)s";
             source "%(activate1)s";
             """) % {
+                'prompt': '(%s) ' % self.prefix + os.environ.get('prompt', ''),
+                'new_path': activator.pathsep_join(new_path_parts),
                 'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.csh')),
                 'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.csh')),
                 'native_prefix': self.prefix,
@@ -714,15 +736,18 @@ class ShellWrapperUnitTests(TestCase):
                 reactivate_data = fh.read()
             rm_rf(reactivate_result)
 
+            new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
             assert reactivate_data == dals("""
             source "%(deactivate1)s"
             $CONDA_PROMPT_MODIFIER = '(%(native_prefix)s) '
             $CONDA_SHLVL = '1'
+            $PATH = '%(new_path)s'
             source "%(activate1)s"
             """) % {
                 'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.xsh')),
                 'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.xsh')),
                 'native_prefix': self.prefix,
+                'new_path': activator.pathsep_join(new_path_parts),
             }
 
             with captured() as c:
@@ -787,12 +812,15 @@ class ShellWrapperUnitTests(TestCase):
             assert rc == 0
             reactivate_data = c.stdout
 
+            new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
             assert reactivate_data == dals("""
             source "%(deactivate1)s";
             set -gx CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
             set -gx CONDA_SHLVL "1";
+            set -gx PATH "%(new_path)s";
             source "%(activate1)s";
             """) % {
+                'new_path': activator.pathsep_join(new_path_parts),
                 'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.fish')),
                 'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.fish')),
                 'native_prefix': self.prefix,
@@ -857,15 +885,18 @@ class ShellWrapperUnitTests(TestCase):
             assert rc == 0
             reactivate_data = c.stdout
 
+            new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
             assert reactivate_data == dals("""
             . "%(deactivate1)s"
             $env:CONDA_PROMPT_MODIFIER = "(%(prefix)s) "
             $env:CONDA_SHLVL = "1"
+            $env:PATH = "%(new_path)s"
             . "%(activate1)s"
             """) % {
                 'activate1': join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.ps1'),
                 'deactivate1': join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.ps1'),
                 'prefix': self.prefix,
+                'new_path': activator.pathsep_join(new_path_parts),
             }
 
             with captured() as c:


### PR DESCRIPTION
fix #6796
By launching a new shell (that isn't as subshell), e.g., via `tmux`, `PATH` and `PS1` are reset. A `conda activate base` would then "reactivate" the environment if `base` was previously active. The "reactivate" previously skipped resetting path and prompt since in a normal shell (/subshell) context those weren't reset in the meantime.