### PR TITLE
fix #6837 require at least futures 3.0.0

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - python
     - conda-env >=2.6
     - enum34               [py<34]
-    - futures              [py<34]
+    - futures >=3.0.0      [py<34]
     - menuinst             [win]
     - pycosat >=0.6.3
     - pyopenssl >=16.2.0

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -182,7 +182,7 @@ def get_reduced_index(prefix, channels, subdirs, specs):
         pending_track_features = set()
 
         def query_all(spec):
-            futures = (executor.submit(sd.query, spec) for sd in subdir_datas)
+            futures = tuple(executor.submit(sd.query, spec) for sd in subdir_datas)
             return tuple(concat(future.result() for future in as_completed(futures)))
 
         def push_spec(spec):

--- a/conda/core/repodata.py
+++ b/conda/core/repodata.py
@@ -80,7 +80,7 @@ class SubdirData(object):
         channel_urls = all_channel_urls(channels, subdirs=subdirs)
         check_whitelist(channel_urls)
         with ThreadLimitedThreadPoolExecutor() as executor:
-            futures = (executor.submit(
+            futures = tuple(executor.submit(
                 SubdirData(Channel(url)).query, package_ref_or_match_spec
             ) for url in channel_urls)
             return tuple(concat(future.result() for future in as_completed(futures)))


### PR DESCRIPTION
fix for #6837 : conda apparently requires at least version 3.0.0 of `futures` package