### PR TITLE
fix #6880 build_number comparison not functional in match_spec

### DIFF
--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -545,10 +545,13 @@ class BuildNumberMatch(object):
         return self
 
     def exact_match_(self, vspec):
-        return self.spec == vspec
+        try:
+            return int(self.spec) == int(vspec)
+        except ValueError:
+            return False
 
     def veval_match_(self, vspec):
-        return self.op(VersionOrder(vspec), self.cmp)
+        return self.op(VersionOrder(text_type(vspec)), self.cmp)
 
     def triv_match_(self, vspec):
         return True

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -395,6 +395,24 @@ class MatchSpecTests(TestCase):
         assert c.match(DPkg(dst, track_features='nomkl'))
         assert c.match(DPkg(dst, track_features='blas=nomkl debug'))
 
+    def test_bracket_matches(self):
+        record = {
+            'name': 'numpy',
+            'version': '1.11.0',
+            'build': 'py34_7',
+            'build_number': 7,
+        }
+
+        assert MatchSpec("numpy<2").match(record)
+        assert MatchSpec("numpy[version<2]").match(record)
+        assert not MatchSpec("numpy>2").match(record)
+        # assert not MatchSpec("numpy[version='>2']").match(record)  # TODO: make work
+
+        assert MatchSpec("numpy[build_number='7']").match(record)
+        assert MatchSpec("numpy[build_number='<8']").match(record)
+        assert not MatchSpec("numpy[build_number='>7']").match(record)
+        assert MatchSpec("numpy[build_number='>=7']").match(record)
+
 
 class TestArg2Spec(TestCase):
 
@@ -642,3 +660,47 @@ class SpecStrParsingTests(TestCase):
             # "target": "blarg",  # suppressing these for now
             # "optional": True,
         }
+
+    def test_parse_build_number_brackets(self):
+        assert _parse_spec_str("python[build_number=3]") == {
+            "name": "python",
+            "build_number": '3',
+        }
+        assert _parse_spec_str("python[build_number='>3']") == {
+            "name": "python",
+            "build_number": '>3',
+        }
+        assert _parse_spec_str("python[build_number='>=3']") == {
+            "name": "python",
+            "build_number": '>=3',
+        }
+
+        assert _parse_spec_str("python[build_number='<3']") == {
+            "name": "python",
+            "build_number": '<3',
+        }
+        assert _parse_spec_str("python[build_number='<=3']") == {
+            "name": "python",
+            "build_number": '<=3',
+        }
+
+        # # these don't work right now, should they?
+        # assert _parse_spec_str("python[build_number<3]") == {
+        #     "name": "python",
+        #     "build_number": '<3',
+        # }
+        # assert _parse_spec_str("python[build_number<=3]") == {
+        #     "name": "python",
+        #     "build_number": '<=3',
+        # }
+
+        # # these don't work right now, should they?
+        # assert _parse_spec_str("python[build_number>3]") == {
+        #     "name": "python",
+        #     "build_number": '>3',
+        # }
+        # assert _parse_spec_str("python[build_number>=3]") == {
+        #     "name": "python",
+        #     "build_number": '>=3',
+        # }
+

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -406,7 +406,7 @@ class MatchSpecTests(TestCase):
         assert MatchSpec("numpy<2").match(record)
         assert MatchSpec("numpy[version<2]").match(record)
         assert not MatchSpec("numpy>2").match(record)
-        # assert not MatchSpec("numpy[version='>2']").match(record)  # TODO: make work
+        assert not MatchSpec("numpy[version='>2']").match(record)
 
         assert MatchSpec("numpy[build_number='7']").match(record)
         assert MatchSpec("numpy[build_number='<8']").match(record)


### PR DESCRIPTION
fix #6880

There's a lot of surface area to cover here for testing the 4.4 MatchSpec implementation.  We haven't gotten it all yet.  