### PR TITLE
fix #6910 conda 4.4 sort key prioritizes build string over build number

### DIFF
--- a/conda/models/index_record.py
+++ b/conda/models/index_record.py
@@ -229,7 +229,8 @@ class PackageRef(BasePackageRef):
 
     @property
     def _pkey(self):
-        return self.channel.canonical_name, self.subdir, self.name, self.version, self.build
+        return (self.channel.canonical_name, self.subdir, self.name, self.version,
+                self.build_number, self.build)
 
     def __hash__(self):
         return hash(self._pkey)


### PR DESCRIPTION
fix #6910