### PR TITLE
resolve #6192 deprecate 'conda help' in favor of --help CLI flag

### DIFF
--- a/conda/cli/main_help.py
+++ b/conda/cli/main_help.py
@@ -5,7 +5,6 @@
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import subprocess
 import sys
 
 
@@ -13,4 +12,7 @@ def execute(args, parser):
     if not args.command:
         parser.print_help()
         return
-    subprocess.call([sys.executable, sys.argv[0], args.command, '-h'])  # pragma: no cover
+    print("ERROR: The 'conda help' command is deprecated.\n"
+          "Instead use 'conda %s --help'." % args.command,
+          file=sys.stderr)
+    return 1


### PR DESCRIPTION
resolve #6192