### PR TITLE
fix #6930 add missing return statement to S3Adapter

### DIFF
--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -116,3 +116,5 @@ class S3Adapter(BaseAdapter):
             resp.close = resp.raw.close
         else:
             resp.status_code = 404
+
+        return resp


### PR DESCRIPTION
* conda/gateways/connection/adapters/s3.py

  Lack of return statement causes None to be returned, leading to an
  AttributeError when an attribute access is attempted on the return
  value.

Fixes #6930 