### PR TITLE
set encoding for PY2 stdout/stderr

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -129,10 +129,7 @@ class Activator(object):
     def _finalize(self, commands, ext):
         commands = concatv(commands, ('',))  # add terminating newline
         if ext is None:
-            output = self.command_join.join(commands)
-            if PY2:
-                return ensure_binary(output)
-            return output
+            return self.command_join.join(commands)
         elif ext:
             with NamedTemporaryFile('w+b', suffix=ext, delete=False) as tf:
                 # the default mode is 'w+b', and universal new lines don't work in that mode

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -568,6 +568,9 @@ else:  # pragma: py2 no cover
 
 
 def main(argv=None):
+    from .common.compat import init_std_stream_encoding
+
+    # init_std_stream_encoding()
     argv = argv or sys.argv
     assert len(argv) >= 3
     assert argv[1].startswith('shell.')

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -570,7 +570,7 @@ else:  # pragma: py2 no cover
 def main(argv=None):
     from .common.compat import init_std_stream_encoding
 
-    # init_std_stream_encoding()
+    init_std_stream_encoding()
     argv = argv or sys.argv
     assert len(argv) >= 3
     assert argv[1].startswith('shell.')

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -82,9 +82,9 @@ def _main(*args):
 
 def main(*args):
     # conda.common.compat contains only stdlib imports
-    from ..common.compat import ensure_text_type  # , init_std_stream_encoding
+    from ..common.compat import ensure_text_type, init_std_stream_encoding
 
-    # init_std_stream_encoding()
+    init_std_stream_encoding()
     if not args:
         args = sys.argv
 

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -151,18 +151,16 @@ def _init_stream_encoding(stream):
     # PY2 compat: Initialize encoding for an IO stream.
     # Python 2 sets the encoding of stdout/stderr to None if not run in a
     # terminal context and thus falls back to ASCII.
-    if getattr(stream, "encoding", True):
-        # avoid the imports below if they are not necessary
+    if not PY2 or not isinstance(stream, file) or stream.encoding:
         return stream
     from codecs import getwriter
     from locale import getpreferredencoding
     encoding = getpreferredencoding()
     try:
-        encoder = getwriter(encoding)
+        writer_class = getwriter(encoding)
     except LookupError:
-        encoder = getwriter("UTF-8")
-    base_stream = getattr(stream, "buffer", stream)
-    return encoder(base_stream)
+        writer_class = getwriter("UTF-8")
+    return writer_class(stream)
 
 
 def init_std_stream_encoding():

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -929,8 +929,7 @@ class ShellWrapperUnitTests(TestCase):
             with tempdir() as td:
                 with open(join(td, "stdout"), "wt") as stdout:
                     with captured(stdout=stdout) as c:
-                        with pytest.raises(UnicodeEncodeError):
-                            rc = activate_main(('', shell, 'activate', self.prefix))
+                        rc = activate_main(('', shell, 'activate', self.prefix))
 
 
 class InteractiveShell(object):

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -920,6 +920,18 @@ class ShellWrapperUnitTests(TestCase):
 
             }
 
+    def test_unicode(self):
+        shell = 'shell.posix'
+        prompt = 'PS1'
+        prompt_value = u'%{\xc2\xbb'.encode(sys.getfilesystemencoding())
+        with env_vars({prompt: prompt_value}):
+            # use a file as output stream to simulate PY2 default stdout
+            with tempdir() as td:
+                with open(join(td, "stdout"), "wt") as stdout:
+                    with captured(stdout=stdout) as c:
+                        with pytest.raises(UnicodeEncodeError):
+                            rc = activate_main(('', shell, 'activate', self.prefix))
+
 
 class InteractiveShell(object):
     activator = None


### PR DESCRIPTION
Followup to #6909. I completely misread
```python
  File "/opt/conda/lib/python3.6/codecs.py", line 377, in write
    self.stream.write(data)
TypeError: string argument expected, got 'bytes'
```
before and though `self.encode` failed instead of `self.stream.write`.
So, easy fix is to apply the IO encoding only for the case that is needed, i.e., `PY2 and isinstance(stream, file)`.
(To make sure everything is in order, I added an "inverted" test that fails for Python 3 and passed for Python 2. Once CI shows exactly that result, I'll update the test accordingly.)