### PR TITLE
Performance enhancement for Dist objects

### DIFF
--- a/conda/models/dist.py
+++ b/conda/models/dist.py
@@ -73,7 +73,6 @@ class Dist(Entity):
                                    platform=platform)
 
         self.__key = (channel, dist_name)
-        self.__key_hash = hash(self.__key)
 
     def to_package_ref(self):
         return PackageRef(
@@ -244,7 +243,7 @@ class Dist(Entity):
         return isinstance(other, self.__class__) and self.__key >= other.__key
 
     def __hash__(self):
-        return self.__key_hash
+        return hash(self.__key)
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.__key == other.__key

--- a/conda/models/dist.py
+++ b/conda/models/dist.py
@@ -72,6 +72,9 @@ class Dist(Entity):
                                    base_url=base_url,
                                    platform=platform)
 
+        self.__key = (channel, dist_name)
+        self.__key_hash = hash(self.__key)
+
     def to_package_ref(self):
         return PackageRef(
             channel=self.channel,
@@ -228,33 +231,26 @@ class Dist(Entity):
                 if self.platform
                 else join_url(self.base_url, filename))
 
-    def __key__(self):
-        return self.channel, self.dist_name
-
     def __lt__(self, other):
-        assert isinstance(other, self.__class__)
-        return self.__key__() < other.__key__()
+        return isinstance(other, self.__class__) and self.__key < other.__key
 
     def __gt__(self, other):
-        assert isinstance(other, self.__class__)
-        return self.__key__() > other.__key__()
+        return isinstance(other, self.__class__) and self.__key > other.__key
 
     def __le__(self, other):
-        assert isinstance(other, self.__class__)
-        return self.__key__() <= other.__key__()
+        return isinstance(other, self.__class__) and self.__key <= other.__key
 
     def __ge__(self, other):
-        assert isinstance(other, self.__class__)
-        return self.__key__() >= other.__key__()
+        return isinstance(other, self.__class__) and self.__key >= other.__key
 
     def __hash__(self):
-        return hash(self.__key__())
+        return self.__key_hash
 
     def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__key__() == other.__key__()
+        return isinstance(other, self.__class__) and self.__key == other.__key
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
     # ############ conda-build compatibility ################
 


### PR DESCRIPTION
Remove key function and replace with key attribute.

Since the key is immutable, we don't need a function call to produce it.
Building the key once at object creation avoids a lot of new tuple
objects and function calls.  I also store the hash of the key since
tuples recursively calculate their hash values each time.

In creating a basic data science environment, these changes shave about 1.7s off the total runtime for conda.
```
time python main.py create -n testdev python numpy scipy pandas jupyter --dry-run
dist-key2: 13.32s user 0.20s system 93% cpu 14.521 total

master: 15.33s user 0.21s system 95% cpu 16.223 total
```
The improvement is more noticeable with more packages.
```
time python main.py create -n testdev python numpy scipy pandas jupyter pytables bokeh cython dask datashader holoviews seaborn --dry-run
dist-key2: 30.51s user 0.29s system 96% cpu 32.031 total

master: 35.55s user 0.44s system 96% cpu 37.267 total
```