### PR TITLE
circleci: switch conda-build 2.1 tests to 2.1.x

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -200,7 +200,7 @@ jobs:
   2.1 conda-build:
     <<: *conda_build_test
     environment:
-      - CONDA_BUILD: 2.1.17
+      - CONDA_BUILD: 2.1.x
       - CONDA_INSTRUMENTATION_ENABLED: true
 
   activate tests: *activate_tests


### PR DESCRIPTION
Switches the `conda-build 2.1` tests from the `2.1.17` tag to the `2.1.x` branch so that `2.1` tests work again.
xref: https://github.com/conda/conda-build/pull/2726