### PR TITLE
fix #6891 index out of bound when running deactivate on fish shell

### DIFF
--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -82,16 +82,18 @@ function conda
     if [ (count $argv) -lt 1 ]
         eval $_CONDA_EXE
     else
-        switch $argv[1]
+        set -l cmd $argv[1]
+        set -e argv[1]
+        switch $cmd
             case activate
-                eval (eval $_CONDA_EXE shell.fish activate $argv[2..-1])
+                eval (eval $_CONDA_EXE shell.fish activate $argv)
             case deactivate
-                eval (eval $_CONDA_EXE shell.fish deactivate $argv[2..-1])
+                eval (eval $_CONDA_EXE shell.fish deactivate $argv)
             case install update remove uninstall
-                eval $_CONDA_EXE $argv[1..-1]
+                eval $_CONDA_EXE $cmd $argv
                 eval (eval $_CONDA_EXE shell.fish reactivate)
             case '*'
-                eval $_CONDA_EXE $argv[1..-1]
+                eval $_CONDA_EXE $cmd $argv
         end
     end
 end

--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -91,7 +91,7 @@ function conda
                 eval (eval $_CONDA_EXE shell.fish deactivate $argv)
             case install update remove uninstall
                 eval $_CONDA_EXE $cmd $argv
-                eval (eval $_CONDA_EXE shell.fish reactivate)
+                and eval (eval $_CONDA_EXE shell.fish reactivate)
             case '*'
                 eval $_CONDA_EXE $cmd $argv
         end

--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -76,26 +76,26 @@ _conda_reactivate() {
 
 
 conda() {
-    if [ "$#" -ge 1 ]; then
+    if [ "$#" -lt 1 ]; then
+        $_CONDA_EXE
+    else
         \local cmd="$1"
         shift
-    else
-        \local cmd=""
+        case "$cmd" in
+            activate)
+                _conda_activate "$@"
+                ;;
+            deactivate)
+                _conda_deactivate "$@"
+                ;;
+            install|update|uninstall|remove)
+                $_CONDA_EXE "$cmd" "$@" && _conda_reactivate
+                ;;
+            *)
+                $_CONDA_EXE "$cmd" "$@"
+                ;;
+        esac
     fi
-    case "$cmd" in
-        activate)
-            _conda_activate "$@"
-            ;;
-        deactivate)
-            _conda_deactivate "$@"
-            ;;
-        install|update|uninstall|remove)
-            $_CONDA_EXE "$cmd" "$@" && _conda_reactivate
-            ;;
-        *)
-            $_CONDA_EXE "$cmd" "$@"
-            ;;
-    esac
 }
 
 


### PR DESCRIPTION
1. Fix #6891: turns out fish has some unusual list slicing semantics... empty slices
  * raise an error for `fish <2.7b1` (https://github.com/fish-shell/fish-shell/blame/2.7.1/CHANGELOG.md#L22)
  * but also aren't usable in `fish >=2.7b1`:
```fish
~> function f; echo $argv[2..-1]; end
~> f

~> f 1
1
~> f 1 2
2
~> f 1 2 3
2 3
```
But we can mirror the behavior in `conda.sh` by using `set -e argv[1]` as a `shift`.

2. Port return value handling from #6850 over to `conda.fish`.

3. Use the same logic in `conda.sh` when calling `conda` without args: run `$_CONDA_EXE` instead of `$_CONDA_EXE ''`.