### PR TITLE
Properly close over $_CONDA_EXE variable

### DIFF
--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -78,7 +78,7 @@ function fish_right_prompt
 end
 
 
-function conda
+function conda --inherit-variable _CONDA_EXE
     if [ (count $argv) -lt 1 ]
         eval $_CONDA_EXE
     else


### PR DESCRIPTION
This more closely mimics a closure in Python: the value of _CONDA_EXE will be "snapshot" to a local variable (see fish docs https://fishshell.com/docs/current/commands.html#function).

Not doing this can cause problems when sourcing this file from other scripts.