### PR TITLE
fix: configuration: parse map with comments

### DIFF
--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -311,7 +311,7 @@ class YamlRawParameter(RawParameter):
 
     @staticmethod
     def _get_yaml_map_comments(rawvalue):
-        return dict((key, excepts(KeyError,
+        return dict((key, excepts((AttributeError, KeyError),
                                   lambda k: rawvalue.ca.items[k][2].value.strip() or None,
                                   lambda _: None  # default value on exception
                                   )(key))

--- a/tests/common/test_configuration.py
+++ b/tests/common/test_configuration.py
@@ -129,6 +129,12 @@ test_yaml_raw = {
         proxy_servers:
         channels:
     """),
+    'commented_map': dals("""
+        commented_map:
+          key:
+            # comment
+            value
+    """),
 
 }
 
@@ -142,7 +148,7 @@ class SampleConfiguration(Configuration):
 
     always_an_int = PrimitiveParameter(0)
     boolean_map = MapParameter(bool)
-
+    commented_map = MapParameter(string_types)
 
 
 def load_from_string_data(*seq):
@@ -441,6 +447,10 @@ class ConfigurationTests(TestCase):
     def test_empty_map_parameter(self):
         config = SampleConfiguration()._set_raw_data(load_from_string_data('bad_boolean_map'))
         config.check_source('bad_boolean_map')
+
+    def test_commented_map_parameter(self):
+        config = SampleConfiguration()._set_raw_data(load_from_string_data('commented_map'))
+        assert config.commented_map == {'key': 'value'}
 
     def test_invalid_map_parameter(self):
         data = odict(s1=YamlRawParameter.make_raw_parameters('s1', {'proxy_servers': 'blah'}))


### PR DESCRIPTION
Configuration entries like
```yaml
custom_multichannels:
  bioconda-repro:
    # some comment
    - bioconda/label/main
    - conda-forge
    - defaults
    - bioconda/label/deprecated
    - bioconda/label/broken
```
caused
```python
AttributeError: 'NoneType' object has no attribute 'value'
```
to be raised in
```python
common.configuration.YamlRawParameter._get_yaml_map_comments
```