### PR TITLE
Two phase deactivate

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -593,9 +593,9 @@ class PosixActivator(_Activator):
 
         self.postsep = ':'
         self.post_tmpl = "\n".join((
-            '\local ask_conda',
-            'ask_conda="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix post)" || \\return $?',
-            '\eval "${ask_conda}"'))
+            '\local ask_conda2',
+            'ask_conda2="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix post)" || \\return $?',
+            '\eval "${ask_conda2}"'))
 
         super(PosixActivator, self).__init__(arguments)
 
@@ -630,10 +630,10 @@ class CshActivator(_Activator):
 
         self.postsep = ':'
         self.post_tmpl = "\n".join((
-            ('set ask_conda="`('
+            ('set ask_conda2="`('
                 "setenv prompt '${prompt}' ; ${_CONDA_EXE}' shell.csh post"
              ')`" || exit ${status}'),
-            'eval "${ask_conda}"'))
+            'eval "${ask_conda2}"'))
 
         super(CshActivator, self).__init__(arguments)
 
@@ -691,11 +691,11 @@ class CmdExeActivator(_Activator):
         self.post_tmpl = "\n".join((
             ('@FOR /F "delims=" %%i IN ('
                 "'@CALL %_CONDA_EXE% shell.cmd.exe post %*'"
-             ') DO @SET "_TEMP_SCRIPT_PATH=%%i"'),
-            '@IF "%_TEMP_SCRIPT_PATH%"=="" GOTO :ErrorEnd',
-            '@CALL "%_TEMP_SCRIPT_PATH%"',
-            '@DEL /F /Q "%_TEMP_SCRIPT_PATH%"',
-            '@SET _TEMP_SCRIPT_PATH=',
+             ') DO @SET "_TEMP_SCRIPT_PATH2=%%i"'),
+            '@IF "%_TEMP_SCRIPT_PATH2%"=="" GOTO :ErrorEnd',
+            '@CALL "%_TEMP_SCRIPT_PATH2%"',
+            '@DEL /F /Q "%_TEMP_SCRIPT_PATH2%"',
+            '@SET _TEMP_SCRIPT_PATH2=',
             '@SET _CONDA_POST=',
             '',
             '@GOTO :End',

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -680,7 +680,7 @@ class CmdExeActivator(_Activator):
         self.run_script_tmpl = '@CALL "%s"'
 
         self.post_tmpl = "\n".join((
-            "@CALL %%_CONDA_EXE%% shell.cmd.exe post"))
+            "@CALL %%_CONDA_EXE%% shell.cmd.exe post",))
 
         super(CmdExeActivator, self).__init__(arguments)
 
@@ -708,7 +708,7 @@ class FishActivator(_Activator):
         self.run_script_tmpl = 'source "%s"'
 
         self.post_tmpl = "\n".join((
-            "eval (eval $_CONDA_EXE shell.fish post)"))
+            "eval (eval $_CONDA_EXE shell.fish post)",))
 
         super(FishActivator, self).__init__(arguments)
 
@@ -729,7 +729,7 @@ class PowershellActivator(_Activator):
         self.run_script_tmpl = '. "%s"'
 
         self.post_tmpl = "\n".join((
-                ""))
+                "",))
 
         super(PowershellActivator, self).__init__(arguments)
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -680,7 +680,24 @@ class CmdExeActivator(_Activator):
         self.run_script_tmpl = '@CALL "%s"'
 
         self.post_tmpl = "\n".join((
-            "@CALL %%_CONDA_EXE%% shell.cmd.exe post",))
+            ('@FOR /F "delims=" %%i IN ('
+                "'@CALL %_CONDA_EXE% shell.cmd.exe post %*'"
+             ') DO @SET "_TEMP_SCRIPT_PATH=%%i"'),
+            '@IF "%_TEMP_SCRIPT_PATH%"=="" GOTO :ErrorEnd',
+            '@CALL "%_TEMP_SCRIPT_PATH%"',
+            '@DEL /F /Q "%_TEMP_SCRIPT_PATH%"',
+            '@SET _TEMP_SCRIPT_PATH=',
+            '@SET _CONDA_POST=',
+            '',
+            '@GOTO :End',
+            '',
+            ':End',
+            '@SET _CONDA_EXE=',
+            '@GOTO :EOF',
+            '',
+            ':ErrorEnd',
+            '@SET _CONDA_EXE=',
+            '@EXIT /B 1'))
 
         super(CmdExeActivator, self).__init__(arguments)
 

--- a/conda/shell/etc/profile.d/conda.csh
+++ b/conda/shell/etc/profile.d/conda.csh
@@ -9,9 +9,9 @@
 if (! $?_CONDA_EXE) then
   set _CONDA_EXE="${PWD}/conda/shell/bin/conda"
 else
-  if ("$_CONDA_EXE" == "") then
-      set _CONDA_EXE="${PWD}/conda/shell/bin/conda"
-  endif
+    if ("${_CONDA_EXE}" == "") then
+        set _CONDA_EXE="${PWD}/conda/shell/bin/conda"
+    endif
 endif
 
 if ("`alias conda`" == "") then
@@ -21,6 +21,9 @@ if ("`alias conda`" == "") then
         alias conda source "${PWD}/conda/shell/etc/profile.d/conda.csh"
     endif
     setenv CONDA_SHLVL 0
+
+    # setting to empty such that things don't break weirdly in
+    # non-interactive cases where (T)CSH doesn't set the prompt variable
     if (! $?prompt) then
         set prompt=""
     endif

--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -17,10 +17,10 @@ _conda_set_vars() {
         if [ -n "${_CONDA_ROOT:+x}" ]; then
             # typically this should be for dev only; _CONDA_EXE should be written at top of file
             # for normal installs
-            _CONDA_EXE="$_CONDA_ROOT/conda/shell/bin/conda"
+            _CONDA_EXE="${_CONDA_ROOT}/conda/shell/bin/conda"
         fi
         if ! [ -f "${_CONDA_EXE-x}" ]; then
-            _CONDA_EXE="$PWD/conda/shell/bin/conda"
+            _CONDA_EXE="${PWD}/conda/shell/bin/conda"
         fi
     fi
 
@@ -35,7 +35,7 @@ _conda_set_vars() {
 
 
 _conda_hashr() {
-    case "$_CONDA_SHELL_FLAVOR" in
+    case "${_CONDA_SHELL_FLAVOR}" in
         zsh) \rehash;;
         posh) ;;
         *) \hash -r;;
@@ -47,28 +47,30 @@ _conda_activate() {
     if [ -n "${CONDA_PS1_BACKUP:+x}" ]; then
         # Handle transition from shell activated with conda <= 4.3 to a subsequent activation
         # after conda updated to >= 4.4. See issue #6173.
-        PS1="$CONDA_PS1_BACKUP"
+        PS1="${CONDA_PS1_BACKUP}"
         \unset CONDA_PS1_BACKUP
     fi
 
     \local ask_conda
-    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix activate "$@")" || \return $?
-    \eval "$ask_conda"
+    ask_conda="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix activate "$@")" || \return $?
+    \eval "${ask_conda}"
 
     _conda_hashr
 }
+
 
 _conda_deactivate() {
     \local ask_conda
-    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix deactivate "$@")" || \return $?
+    ask_conda="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix deactivate "$@")" || \return $?
     \eval "$ask_conda"
 
     _conda_hashr
 }
 
+
 _conda_reactivate() {
     \local ask_conda
-    ask_conda="$(PS1="$PS1" $_CONDA_EXE shell.posix reactivate)" || \return $?
+    ask_conda="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix reactivate)" || \return $?
     \eval "$ask_conda"
 
     _conda_hashr
@@ -100,6 +102,7 @@ conda() {
 
 
 _conda_set_vars
+
 
 if [ -z "${CONDA_SHLVL+x}" ]; then
     \export CONDA_SHLVL=0

--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -1,3 +1,4 @@
+
 _conda_set_vars() {
     # set _CONDA_SHELL_FLAVOR
     if [ -n "${BASH_VERSION:+x}" ]; then

--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -63,7 +63,7 @@ _conda_activate() {
 _conda_deactivate() {
     \local ask_conda
     ask_conda="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix deactivate "$@")" || \return $?
-    \eval "$ask_conda"
+    \eval "${ask_conda}"
 
     _conda_hashr
 }
@@ -72,7 +72,7 @@ _conda_deactivate() {
 _conda_reactivate() {
     \local ask_conda
     ask_conda="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix reactivate)" || \return $?
-    \eval "$ask_conda"
+    \eval "${ask_conda}"
 
     _conda_hashr
 }

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -524,9 +524,9 @@ class ShellWrapperUnitTests(TestCase):
             \\export CONDA_POST='%(native_prefix)s:%(native_prefix)s'
             \\export CONDA_PROMPT_MODIFIER='(%(native_prefix)s) '
             \\export CONDA_SHLVL='1'
-            \\local ask_conda
-            ask_conda="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix post)" || \\return $?
-            \\eval "${ask_conda}"
+            \\local ask_conda2
+            ask_conda2="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix post)" || \\return $?
+            \\eval "${ask_conda2}"
             \\. "%(activate1)s"
             """) % {
                 'activate1': activator.path_conversion(scripts["activate_script"]),
@@ -568,9 +568,9 @@ class ShellWrapperUnitTests(TestCase):
             PS1='%(ps1)s'
             \\export CONDA_POST='%(native_prefix)s:'
             \\export CONDA_SHLVL='0'
-            \\local ask_conda
-            ask_conda="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix post)" || \\return $?
-            \\eval "${ask_conda}"
+            \\local ask_conda2
+            ask_conda2="$(PS1="${PS1}" "${_CONDA_EXE}" shell.posix post)" || \\return $?
+            \\eval "${ask_conda2}"
             """) % {
                 'deactivate1': activator.path_conversion(scripts["deactivate_script"]),
                 'ps1': os.environ.get('PS1', ''),
@@ -650,11 +650,11 @@ class ShellWrapperUnitTests(TestCase):
             @SET "CONDA_POST=%(native_prefix)s;%(native_prefix)s"
             @SET "CONDA_PROMPT_MODIFIER=(%(native_prefix)s) "
             @SET "CONDA_SHLVL=1"
-            @FOR /F "delims=" %%%%i IN ('@CALL %%_CONDA_EXE%% shell.cmd.exe post %%*') DO @SET "_TEMP_SCRIPT_PATH=%%%%i"
-            @IF "%%_TEMP_SCRIPT_PATH%%"=="" GOTO :ErrorEnd
-            @CALL "%%_TEMP_SCRIPT_PATH%%"
-            @DEL /F /Q "%%_TEMP_SCRIPT_PATH%%"
-            @SET _TEMP_SCRIPT_PATH=
+            @FOR /F "delims=" %%%%i IN ('@CALL %%_CONDA_EXE%% shell.cmd.exe post %%*') DO @SET "_TEMP_SCRIPT_PATH2=%%%%i"
+            @IF "%%_TEMP_SCRIPT_PATH2%%"=="" GOTO :ErrorEnd
+            @CALL "%%_TEMP_SCRIPT_PATH2%%"
+            @DEL /F /Q "%%_TEMP_SCRIPT_PATH2%%"
+            @SET _TEMP_SCRIPT_PATH2=
             @SET _CONDA_POST=
 
             @GOTO :End
@@ -712,11 +712,11 @@ class ShellWrapperUnitTests(TestCase):
             @SET CONDA_PYTHON_EXE=
             @SET "CONDA_POST=%(prefix)s;"
             @SET "CONDA_SHLVL=0"
-            @FOR /F "delims=" %%%%i IN ('@CALL %%_CONDA_EXE%% shell.cmd.exe post %%*') DO @SET "_TEMP_SCRIPT_PATH=%%%%i"
-            @IF "%%_TEMP_SCRIPT_PATH%%"=="" GOTO :ErrorEnd
-            @CALL "%%_TEMP_SCRIPT_PATH%%"
-            @DEL /F /Q "%%_TEMP_SCRIPT_PATH%%"
-            @SET _TEMP_SCRIPT_PATH=
+            @FOR /F "delims=" %%%%i IN ('@CALL %%_CONDA_EXE%% shell.cmd.exe post %%*') DO @SET "_TEMP_SCRIPT_PATH2=%%%%i"
+            @IF "%%_TEMP_SCRIPT_PATH2%%"=="" GOTO :ErrorEnd
+            @CALL "%%_TEMP_SCRIPT_PATH2%%"
+            @DEL /F /Q "%%_TEMP_SCRIPT_PATH2%%"
+            @SET _TEMP_SCRIPT_PATH2=
             @SET _CONDA_POST=
 
             @GOTO :End
@@ -801,8 +801,8 @@ class ShellWrapperUnitTests(TestCase):
             setenv CONDA_POST "%(prefix)s:%(prefix)s";
             setenv CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
             setenv CONDA_SHLVL "1";
-            set ask_conda="`(setenv prompt '${prompt}' ; ${_CONDA_EXE}' shell.csh post)`" || exit ${status}
-            eval "${ask_conda}";
+            set ask_conda2="`(setenv prompt '${prompt}' ; ${_CONDA_EXE}' shell.csh post)`" || exit ${status}
+            eval "${ask_conda2}";
             source "%(activate1)s";
             """) % {
                 'prompt': '(%s) ' % self.prefix + os.environ.get('prompt', ''),
@@ -846,8 +846,8 @@ class ShellWrapperUnitTests(TestCase):
             set prompt='%(prompt)s';
             setenv CONDA_POST "%(prefix)s:";
             setenv CONDA_SHLVL "0";
-            set ask_conda="`(setenv prompt '${prompt}' ; ${_CONDA_EXE}' shell.csh post)`" || exit ${status}
-            eval "${ask_conda}";
+            set ask_conda2="`(setenv prompt '${prompt}' ; ${_CONDA_EXE}' shell.csh post)`" || exit ${status}
+            eval "${ask_conda2}";
             """) % {
                 'prefix': self.prefix,
                 'deactivate1': activator.path_conversion(scripts["deactivate_script"]),


### PR DESCRIPTION
This is the PR for #3915.

As discussed there this PR solves the `{de,}activate.d` scripts' issue of being unable to change the `$PATH` by introducing a two phase deactivate.

Two phase because upon the first call, if there are `deactivate.d` scripts then the first phase is to source those scripts and then to do a second conda call - `deactivatepost`. The second phase, the deactivate post, will then perform the final unsetting, prompt modifications, and `$PATH` modification. If however there are no `deactivate.d` scripts then there will only be a single deactivate phase.

This is a relatively dumb fix in my opinion, primarily because I've statically embedded the `deactivatepost` command in the Activator class for each shell. I would love to hear any smarter ideas.

As discussed with @kalefranz, this is not an ideal fix but rather a quick fix until other longterm ideas become reality.