### PR TITLE
Check if original fish prompt functions exist before copying onto them

### DIFF
--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -43,7 +43,9 @@ function __conda_add_prompt
 end
 
 if functions -q fish_prompt
-    functions -c fish_prompt __fish_prompt_orig
+    if not functions -q __fish_prompt_orig
+        functions -c fish_prompt __fish_prompt_orig
+    end
     functions -e fish_prompt
 else
     function __fish_prompt_orig
@@ -64,7 +66,9 @@ function fish_prompt
 end
 
 if functions -q fish_right_prompt
-    functions -c fish_right_prompt __fish_right_prompt_orig
+    if not functions -q  __fish_right_prompt_orig
+        functions -c fish_right_prompt __fish_right_prompt_orig
+    end
     functions -e fish_right_prompt
 else
     function __fish_right_prompt_orig


### PR DESCRIPTION
Copying fish functions to existing targets yields an error.
So sourcing `conda.fish` twice was not possible.

Besides, if it wouldn't have yielded an error, you'd attach extra copies
of the conda prompt modifier each time you'd source the file.