### PR TITLE
Fix handling of non-ascii characters in custom_multichannels

### DIFF
--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -128,7 +128,8 @@ def execute_config(args, parser):
                 }
             # TODO: custom_multichannels needs better formatting
             if 'custom_multichannels' in d:
-                d['custom_multichannels'] = {k: json.dumps([text_type(c) for c in chnls])
+                d['custom_multichannels'] = {k: json.dumps([text_type(c) for c in chnls],
+                                                           ensure_ascii=False)
                                              for k, chnls in iteritems(d['custom_multichannels'])}
 
             print('\n'.join(format_dict(d)))


### PR DESCRIPTION
I have a private conda repository in the local network. The path to it contains non-ascii characters, because of my german language.

I recently found out that I can assign an alias by setting up a `custom_multichannel` like it is done for the locally built packages with [conda-build](https://github.com/conda/conda-build).

However the non-ascii characters are parsed differently there, which can be shown with the following example:

```python
import os
from conda.cli.python_api import Commands, run_command

config = """
channels:
  - defaults
  - file:///C:/some-drive/cäöüßc
  - file:////some-network-share/cäöüßc
custom_multichannels:
  mychannel1: ["file:///C:/some-drive/cäöüßc"]
  mychannel2: ["file:////some-network-share/cäöüßc"]
"""

with open('.condarc', 'w') as fh:
    fh.writelines(config)

os.environ['CONDARC'] = '.condarc'

stdout, stderr, return_code = run_command(Commands.CONFIG, '--show channels custom_multichannels')

print(stdout)
```

Which returns the following output:

```
channels:
  - defaults
  - file:///C:/some-drive/cäöüßc
  - file:////some-network-share/cäöüßc
custom_multichannels:
  mychannel1: ["file:///C:/some-drive/c\u00e4\u00f6\u00fc\u00dfc"]
  mychannel2: ["file:///some-network-share/c\u00e4\u00f6\u00fc\u00dfc"]
  defaults: ["https://repo.anaconda.com/pkgs/main", "https://repo.anaconda.com/pkgs/free", "https://repo.anaconda.com/pkgs/r", "https://repo.anaconda.com/pkgs/pro"]
```

I did some debugging, the parsing of the `.condarc` in the yaml format is fine, the error happens in the following line:

https://github.com/conda/conda/blob/deb16ee5dbfa68ae3433f1cc2766999613914b20/conda/cli/main_config.py#L131-L132

The command `json.dumps` by default escapes non-ascii characters, which can be a problem for paths.

My proposal is to pass to pass the argument `ensure_ascii=False` to `json.dumps` to disable escaping of non-ascii characters.