### PR TITLE
Add _file_created attribute

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -472,6 +472,7 @@ class CreateNonadminAction(CreateInPrefixPathAction):
     def __init__(self, transaction_context, package_info, target_prefix):
         super(CreateNonadminAction, self).__init__(transaction_context, package_info, None, None,
                                                    target_prefix, '.nonadmin')
+        self._file_created = None
 
     def execute(self):
         log.trace("touching nonadmin %s", self.target_full_path)

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -472,7 +472,7 @@ class CreateNonadminAction(CreateInPrefixPathAction):
     def __init__(self, transaction_context, package_info, target_prefix):
         super(CreateNonadminAction, self).__init__(transaction_context, package_info, None, None,
                                                    target_prefix, '.nonadmin')
-        self._file_created = None
+        self._file_created = False
 
     def execute(self):
         log.trace("touching nonadmin %s", self.target_full_path)


### PR DESCRIPTION
See error below:

Traceback (most recent call last):
  File "MY_CONDA_DIR\lib\site-packages\conda\core\link.py", line 281, in execute
    pkg_data, actions)
  File "MY_CONDA_DIR\lib\site-packages\conda\core\link.py", line 344, in _execute_actions
    reverse_excs,
conda.CondaMultiError: 
'CreateNonadminAction' object has no attribute '_file_created'


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "MY_CONDA_DIR\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(main())
  File "MY_CONDA_DIR\lib\site-packages\conda_build\cli\main_build.py", line 388, in main
    execute(sys.argv[1:])
  File "MY_CONDA_DIR\lib\site-packages\conda_build\cli\main_build.py", line 379, in execute
    noverify=args.no_verify)
  File "MY_CONDA_DIR\lib\site-packages\conda_build\api.py", line 185, in build
    need_source_download=need_source_download, config=config, variants=variants)
  File "MY_CONDA_DIR\lib\site-packages\conda_build\build.py", line 1772, in build_tree
    notest=notest,
  File "MY_CONDA_DIR\lib\site-packages\conda_build\build.py", line 1000, in build
    is_conda=m.name() == 'conda')
  File "MY_CONDA_DIR\lib\site-packages\conda_build\environ.py", line 785, in create_env
    execute_actions(actions, index, verbose=config.debug)
  File "MY_CONDA_DIR\lib\site-packages\conda\plan.py", line 830, in execute_actions
    execute_instructions(plan, index, verbose)
  File "MY_CONDA_DIR\lib\site-packages\conda\instructions.py", line 247, in execute_instructions
    cmd(state, arg)
  File "MY_CONDA_DIR\lib\site-packages\conda\instructions.py", line 108, in UNLINKLINKTRANSACTION_CMD
    txn.execute()
  File "MY_CONDA_DIR\lib\site-packages\conda\core\link.py", line 297, in execute
    rollback_excs,
conda.CondaMultiError: 
'CreateNonadminAction' object has no attribute '_file_created'