### PR TITLE
clean up the formatting of help output

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -484,6 +484,9 @@ class Context(Configuration):
         elif 'update_all' in truthy_params:
             result = DepsModifier.UPDATE_ALL
             truthy_params.remove('update_all')
+        elif 'freeze_installed' in truthy_params:
+            result = DepsModifier.FREEZE_INSTALLED
+            truthy_params.remove('freeze_installed')
         else:
             result = None
 
@@ -665,13 +668,8 @@ class Context(Configuration):
             'disallowed_packages',
             'pinned_packages',
             'track_features',
-
-            'update_deps',
-            'update_all',
-
             'prune',
             'force_reinstall',
-
         )),
         ('Package Linking and Install-time Configuration', (
             'allow_softlinks',
@@ -703,6 +701,8 @@ class Context(Configuration):
             'no_deps',
             'only_deps',
             'freeze_installed',
+            'update_deps',
+            'update_all',
 
             'force',
             'force_remove',
@@ -739,28 +739,6 @@ class Context(Configuration):
     @memoizedproperty
     def description_map(self):
         return frozendict({
-            # 'allow_cycles': 'Undocumented',
-            # 'bld_path': 'Undocumented',
-            # 'conda_build': 'Undocumented',
-            # 'croot': 'Undocumented',
-            # 'debug': 'Undocumented',
-            # 'default_python': 'Undocumented',
-            # 'dry_run': 'Undocumented',
-            # 'enable_private_envs': 'Undocumented',
-            # 'error_upload_url': 'Undocumented',
-            # 'force_32bit': 'Undocumented',
-            # 'ignore_pinned': 'Undocumented',
-            # 'migrated_custom_channels': 'Undocumented',
-            # 'root_prefix': 'Undocumented',
-            # 'subdir': 'Undocumented',
-            # 'subdirs': 'Undocumented',
-            # 'target_prefix_override': 'Undocumented',
-            'update_deps': 'Undocumented',
-            'update_all': 'Undocumented',
-            'prune': 'Undocumented',
-            'force_reinstall': 'Undocumented',
-            # 'use_local': 'Undocumented',
-
             'add_anaconda_token': dals("""
                 In conjunction with the anaconda command-line client (installed with
                 `conda install anaconda-client`), and following logging into an Anaconda
@@ -894,6 +872,10 @@ class Context(Configuration):
                 named environment, the environment will be placed in the first writable
                 location.
                 """),
+            'force_reinstall': dals("""
+                Ensure that any user-requested package for the current operation is uninstalled
+                and reinstalled, even if that package already exists in the environment.
+                """),
             # 'force': dals("""
             #     Override any of conda's objections and safeguards for installing packages and
             #     potentially breaking environments. Also re-installs the package, even if the
@@ -964,6 +946,10 @@ class Context(Configuration):
                 the actual proxy server, and are of the form
                 'scheme://[user:password@]host[:port]'. The optional 'user:password' inclusion
                 enables HTTP Basic Auth with your proxy.
+                """),
+            'prune': dals("""
+                Remove packages that have previously been brought into an environment to satisfy
+                dependencies of user-requested packages, but are no longer needed.
                 """),
             'quiet': dals("""
                 Disable progress bar display and other output.

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -178,7 +178,7 @@ class Context(Configuration):
     _default_channels = SequenceParameter(string_types, DEFAULT_CHANNELS,
                                           aliases=('default_channels',))
     _migrated_channel_aliases = SequenceParameter(string_types,
-                                                  aliases=('migrated_channel_aliases',))  # TODO: also take a list of strings # NOQA
+                                                  aliases=('migrated_channel_aliases',))
     migrated_custom_channels = MapParameter(string_types)  # TODO: also take a list of strings
     override_channels_enabled = PrimitiveParameter(True)
     show_channel_urls = PrimitiveParameter(None, element_type=(bool, NoneType))
@@ -193,16 +193,26 @@ class Context(Configuration):
     error_upload_url = PrimitiveParameter(ERROR_UPLOAD_URL)
     force = PrimitiveParameter(False)
     json = PrimitiveParameter(False)
-    no_dependencies = PrimitiveParameter(False, aliases=('no_deps',))
     offline = PrimitiveParameter(False)
-    only_dependencies = PrimitiveParameter(False, aliases=('only_deps',))
     quiet = PrimitiveParameter(False)
-    prune = PrimitiveParameter(False)
     ignore_pinned = PrimitiveParameter(False)
     report_errors = PrimitiveParameter(None, element_type=(bool, NoneType))
     shortcuts = PrimitiveParameter(True)
-    update_dependencies = PrimitiveParameter(False, aliases=('update_deps',))
     _verbosity = PrimitiveParameter(0, aliases=('verbose', 'verbosity'), element_type=int)
+
+    # ######################################################
+    # ##               Solver Configuration               ##
+    # ######################################################
+    no_deps = PrimitiveParameter(False)  # CLI-only
+    only_deps = PrimitiveParameter(False)   # CLI-only
+    update_deps = PrimitiveParameter(False)
+    update_all = PrimitiveParameter(False)
+    freeze_installed = PrimitiveParameter(False)
+
+    prune = PrimitiveParameter(False)
+    # force_remove = PrimitiveParameter(False)
+    # force_reinstall = PrimitiveParameter(False)
+
 
     target_prefix_override = PrimitiveParameter('')
 
@@ -449,18 +459,41 @@ class Context(Configuration):
     @property
     def deps_modifier(self):
         from ..core.solve import DepsModifier
-        if self.update_dependencies and self.only_dependencies:
-            return DepsModifier.UPDATE_DEPS_ONLY_DEPS
-        elif self.update_dependencies:
-            return DepsModifier.UPDATE_DEPS
-        elif self.only_dependencies:
-            return DepsModifier.ONLY_DEPS
-        elif self.no_dependencies:
-            return DepsModifier.NO_DEPS
-        elif self._argparse_args and 'all' in self._argparse_args and self._argparse_args.all:
-            return DepsModifier.UPDATE_ALL
+
+        param_names = (
+            'no_deps',
+            'only_deps',
+            'update_deps',
+            'update_all',
+            'freeze_installed',
+        )
+        params_map = {name: getattr(self, name) for name in param_names}
+        truthy_params = {name for name, value in iteritems(params_map) if value}
+
+        if {'update_deps', 'only_deps'} <= truthy_params:
+            result = DepsModifier.UPDATE_DEPS_ONLY_DEPS
+            truthy_params -= {'update_deps', 'only_deps'}
+        elif 'update_deps' in truthy_params:
+            result = DepsModifier.UPDATE_DEPS
+            truthy_params.remove('update_deps')
+        elif 'only_deps' in truthy_params:
+            result = DepsModifier.ONLY_DEPS
+            truthy_params.remove('only_deps')
+        elif 'no_deps' in truthy_params:
+            result = DepsModifier.NO_DEPS
+            truthy_params.remove('no_deps')
+        elif 'update_all' in truthy_params:
+            result = DepsModifier.UPDATE_ALL
+            truthy_params.remove('update_all')
         else:
-            return None
+            result = None
+
+        if truthy_params:
+            from .. import CondaError
+            params_map = {k: v for k, v in iteritems(params_map) if v}
+            raise CondaError("Invalid Configuration State: %s" % params_map)
+
+        return result
 
     @property
     def target_prefix(self):
@@ -580,37 +613,6 @@ class Context(Configuration):
                                                 (DEFAULTS_CHANNEL_NAME,))))
         return tuple(IndexedSet(concatv(local_add, self._channels)))
 
-    def get_descriptions(self):
-        return get_help_dict()
-
-    def list_parameters(self):
-        UNLISTED_PARAMETERS = (
-            'allow_cycles',  # allow cyclical dependencies, or raise
-            'bld_path',
-            'conda_build',
-            'croot',
-            'debug',
-            'default_python',
-            'dry_run',
-            'enable_private_envs',
-            'error_upload_url',  # should remain undocumented
-            'force_32bit',
-            'ignore_pinned',
-            'migrated_custom_channels',
-            'only_dependencies',
-            'prune',
-            'root_prefix',
-            'subdir',
-            'subdirs',
-# https://conda.io/docs/config.html#disable-updating-of-dependencies-update-dependencies # NOQA
-# I don't think this documentation is correct any longer. # NOQA
-            'target_prefix_override',  # used to override prefix rewriting, for e.g. building docker containers or RPMs  # NOQA
-            'update_dependencies',
-            'use_local',
-        )
-        return tuple(p for p in super(Context, self).list_parameters()
-                     if p not in UNLISTED_PARAMETERS)
-
     @property
     def binstar_upload(self):
         # backward compatibility for conda-build
@@ -623,6 +625,413 @@ class Context(Configuration):
     @property
     def verbosity(self):
         return 2 if self.debug else self._verbosity
+
+    @property
+    def category_map(self):
+        return odict((
+        ('Channel Configuration', (
+            'channels',
+            'channel_alias',
+            'default_channels',
+            'override_channels_enabled',
+            'whitelist_channels',
+            'custom_channels',
+            'custom_multichannels',
+            'migrated_channel_aliases',
+            'migrated_custom_channels',
+            'add_anaconda_token',
+            'allow_non_channel_urls',
+        )),
+        ('Basic Conda Configuration', (  # TODO: Is there a better category name here?
+            'envs_dirs',
+            'pkgs_dirs',
+            'max_shlvl',
+        )),
+        ('Network Configuration', (
+            'client_ssl_cert',
+            'client_ssl_cert_key',
+            'local_repodata_ttl',
+            'offline',
+            'proxy_servers',
+            'remote_connect_timeout_secs',
+            'remote_max_retries',
+            'remote_read_timeout_secs',
+            'ssl_verify',
+        )),
+        ('Solver Configuration', (
+            'aggressive_update_packages',
+            'auto_update_conda',
+            'channel_priority',
+            'create_default_packages',
+            'disallowed_packages',
+            'pinned_packages',
+            'track_features',
+
+            'update_deps',
+            'update_all',
+            'freeze_installed',
+
+            'prune',
+            # 'force_remove',
+            # 'force_reinstall',
+
+        )),
+        ('Package Linking and Install-time Configuration', (
+            'allow_softlinks',
+            'always_copy',
+            'always_softlink',
+            'path_conflict',
+            'rollback_enabled',
+            'safety_checks',
+            'shortcuts',
+            'non_admin_enabled',
+        )),
+        ('Conda-build Configuration', (
+            'bld_path',
+            'croot',
+            'anaconda_upload',
+            'conda_build',
+        )),
+        ('Output, Prompt, and Control Flow Configuration', (
+            'always_yes',
+            'changeps1',
+            'json',
+            'notify_outdated_conda',
+            'quiet',
+            'report_errors',
+            'show_channel_urls',
+            'verbosity',
+        )),
+        ('CLI-only', (
+            'no_deps',
+            'only_deps',
+
+            'clobber',
+            'dry_run',
+            'download_only',
+            'force',
+            'ignore_pinned',
+            'use_index_cache',
+            'use_local',
+            'use_pip',
+
+        )),
+        ('Hidden and Undocumented', (
+            'allow_cycles',  # allow cyclical dependencies, or raise
+            'add_pip_as_python_dependency',
+            'debug',
+            'default_python',
+            'enable_private_envs',
+            'error_upload_url',  # should remain undocumented
+            'force_32bit',
+            'root_prefix',
+            'subdir',
+            'subdirs',
+            # https://conda.io/docs/config.html#disable-updating-of-dependencies-update-dependencies # NOQA
+            # I don't think this documentation is correct any longer. # NOQA
+            'target_prefix_override',
+            # used to override prefix rewriting, for e.g. building docker containers or RPMs  # NOQA
+        )),
+    ))
+
+    def get_descriptions(self):
+        return self.description_map
+
+    @memoizedproperty
+    def description_map(self):
+        return frozendict({
+            # 'allow_cycles': 'Undocumented',
+            # 'bld_path': 'Undocumented',
+            # 'conda_build': 'Undocumented',
+            # 'croot': 'Undocumented',
+            # 'debug': 'Undocumented',
+            # 'default_python': 'Undocumented',
+            # 'dry_run': 'Undocumented',
+            # 'enable_private_envs': 'Undocumented',
+            # 'error_upload_url': 'Undocumented',
+            # 'force_32bit': 'Undocumented',
+            # 'ignore_pinned': 'Undocumented',
+            # 'migrated_custom_channels': 'Undocumented',
+            # 'root_prefix': 'Undocumented',
+            # 'subdir': 'Undocumented',
+            # 'subdirs': 'Undocumented',
+            # 'target_prefix_override': 'Undocumented',
+            'update_deps': 'Undocumented',
+            'update_all': 'Undocumented',
+            'freeze_installed': 'Undocumented',
+            'prune': 'Undocumented',
+            # 'use_local': 'Undocumented',
+
+            'add_anaconda_token': dals("""
+                In conjunction with the anaconda command-line client (installed with
+                `conda install anaconda-client`), and following logging into an Anaconda
+                Server API site using `anaconda login`, automatically apply a matching
+                private token to enable access to private packages and channels.
+                """),
+            # 'add_pip_as_python_dependency': dals("""
+            #     Add pip, wheel and setuptools as dependencies of python. This ensures pip,
+            #     wheel and setuptools will always be installed any time python is installed.
+            #     """),
+            'aggressive_update_packages': dals("""
+                A list of packages that, if installed, are always updated to the latest possible
+                version.
+                """),
+            'allow_non_channel_urls': dals("""
+                Warn, but do not fail, when conda detects a channel url is not a valid channel.
+                """),
+            'allow_softlinks': dals("""
+                When allow_softlinks is True, conda uses hard-links when possible, and soft-links
+                (symlinks) when hard-links are not possible, such as when installing on a
+                different filesystem than the one that the package cache is on. When
+                allow_softlinks is False, conda still uses hard-links when possible, but when it
+                is not possible, conda copies files. Individual packages can override
+                this setting, specifying that certain files should never be soft-linked (see the
+                no_link option in the build recipe documentation).
+                """),
+            'always_copy': dals("""
+                Register a preference that files be copied into a prefix during install rather
+                than hard-linked.
+                """),
+            'always_softlink': dals("""
+                Register a preference that files be soft-linked (symlinked) into a prefix during
+                install rather than hard-linked. The link source is the 'pkgs_dir' package cache
+                from where the package is being linked. WARNING: Using this option can result in
+                corruption of long-lived conda environments. Package caches are *caches*, which
+                means there is some churn and invalidation. With this option, the contents of
+                environments can be switched out (or erased) via operations on other environments.
+                """),
+            'always_yes': dals("""
+                Automatically choose the 'yes' option whenever asked to proceed with a conda
+                operation, such as when running `conda install`.
+                """),
+            'anaconda_upload': dals("""
+                Automatically upload packages built with conda build to anaconda.org.
+                """),
+            'auto_update_conda': dals("""
+                Automatically update conda when a newer or higher priority version is detected.
+                """),
+            'bld_path': dals("""
+                The location where conda-build will put built packages. Same as 'croot', but
+                'croot' takes precedence when both are defined. Also used in construction of the
+                'local' multichannel.
+                """),
+            'changeps1': dals("""
+                When using activate, change the command prompt ($PS1) to include the
+                activated environment.
+                """),
+            'channel_alias': dals("""
+                The prepended url location to associate with channel names.
+                """),
+            'channel_priority': dals("""
+                When True, the solver is instructed to prefer channel order over package
+                version. When False, the solver is instructed to give package version
+                preference over channel priority.
+                """),
+            'channels': dals("""
+                The list of conda channels to include for relevant operations.
+                """),
+            'client_ssl_cert': dals("""
+                A path to a single file containing a private key and certificate (e.g. .pem
+                file). Alternately, use client_ssl_cert_key in conjuction with client_ssl_cert
+                for individual files.
+                """),
+            'client_ssl_cert_key': dals("""
+                Used in conjunction with client_ssl_cert for a matching key file.
+                """),
+            # 'clobber': dals("""
+            #     Allow clobbering of overlapping file paths within packages, and suppress
+            #     related warnings. Overrides the path_conflict configuration value when
+            #     set to 'warn' or 'prevent'.
+            #     """),
+            'conda_build': dals("""
+                General configuration parameters for conda-build.
+                """),
+            # TODO: add shortened link to docs for conda_build at See https://conda.io/docs/user-guide/configuration/use-condarc.html#conda-build-configuration  # NOQA
+            'create_default_packages': dals("""
+                Packages that are by default added to a newly created environments.
+                """),  # TODO: This is a bad parameter name. Consider an alternate.
+            'croot': dals("""
+                The location where conda-build will put built packages. Same as 'bld_path', but
+                'croot' takes precedence when both are defined. Also used in construction of the
+                'local' multichannel.
+                """),
+            'custom_channels': dals("""
+                A map of key-value pairs where the key is a channel name and the value is
+                a channel location. Channels defined here override the default
+                'channel_alias' value. The channel name (key) is not included in the channel
+                location (value).  For example, to override the location of the 'conda-forge'
+                channel where the url to repodata is
+                https://anaconda-repo.dev/packages/conda-forge/linux-64/repodata.json, add an
+                entry 'conda-forge: https://anaconda-repo.dev/packages'.
+                """),
+            'custom_multichannels': dals("""
+                A multichannel is a metachannel composed of multiple channels. The two reserved
+                multichannels are 'defaults' and 'local'. The 'defaults' multichannel is
+                customized using the 'default_channels' parameter. The 'local'
+                multichannel is a list of file:// channel locations where conda-build stashes
+                successfully-built packages.  Other multichannels can be defined with
+                custom_multichannels, where the key is the multichannel name and the value is
+                a list of channel names and/or channel urls.
+                """),
+            'default_channels': dals("""
+                The list of channel names and/or urls used for the 'defaults' multichannel.
+                """),
+            # 'default_python': dals("""
+            #     specifies the default major & minor version of Python to be used when
+            #     building packages with conda-build. Also used to determine the major
+            #     version of Python (2/3) to be used in new environments. Defaults to
+            #     the version used by conda itself.
+            #     """),
+            'disallowed_packages': dals("""
+                Package specifications to disallow installing. The default is to allow
+                all packages.
+                """),
+            'download_only': dals("""
+                Solve an environment and ensure package caches are populated, but exit
+                prior to unlinking and linking packages into the prefix
+                """),
+            'envs_dirs': dals("""
+                The list of directories to search for named environments. When creating a new
+                named environment, the environment will be placed in the first writable
+                location.
+                """),
+            # 'force': dals("""
+            #     Override any of conda's objections and safeguards for installing packages and
+            #     potentially breaking environments. Also re-installs the package, even if the
+            #     package is already installed. Implies --no-deps.
+            #     """),
+            # 'force_32bit': dals("""
+            #     CONDA_FORCE_32BIT should only be used when running conda-build (in order
+            #     to build 32-bit packages on a 64-bit system).  We don't want to mention it
+            #     in the documentation, because it can mess up a lot of things.
+            #     """),
+            'json': dals("""
+                Ensure all output written to stdout is structured json.
+                """),
+            'local_repodata_ttl': dals("""
+                For a value of False or 0, always fetch remote repodata (HTTP 304 responses
+                respected). For a value of True or 1, respect the HTTP Cache-Control max-age
+                header. Any other positive integer values is the number of seconds to locally
+                cache repodata before checking the remote server for an update.
+                """),
+            'max_shlvl': dals("""
+                The maximum number of stacked active conda environments.
+                """),
+            'migrated_channel_aliases': dals("""
+                A list of previously-used channel_alias values. Useful when switching between 
+                different Anaconda Repository instances.
+                """),
+            'migrated_custom_channels': dals("""
+                A map of key-value pairs where the key is a channel name and the value is
+                the previous location of the channel.
+                """),
+            # 'no_deps': dals("""
+            #     Do not install, update, remove, or change dependencies. This WILL lead to broken
+            #     environments and inconsistent behavior. Use at your own risk.
+            #     """),
+            'non_admin_enabled': dals("""
+                Allows completion of conda's create, install, update, and remove operations, for
+                non-privileged (non-root or non-administrator) users.
+                """),
+            'notify_outdated_conda': dals("""
+                Notify if a newer version of conda is detected during a create, install, update,
+                or remove operation.
+                """),
+            'offline': dals("""
+                Restrict conda to cached download content and file:// based urls.
+                """),
+            'override_channels_enabled': dals("""
+                Permit use of the --overide-channels command-line flag.
+                """),
+            'path_conflict': dals("""
+                The method by which conda handle's conflicting/overlapping paths during a
+                create, install, or update operation. The value must be one of 'clobber',
+                'warn', or 'prevent'. The '--clobber' command-line flag or clobber
+                configuration parameter overrides path_conflict set to 'prevent'.
+                """),
+            'pinned_packages': dals("""
+                A list of package specs to pin for every environment resolution.
+                This parameter is in BETA, and its behavior may change in a future release.
+                """),
+            'pkgs_dirs': dals("""
+                The list of directories where locally-available packages are linked from at
+                install time. Packages not locally available are downloaded and extracted
+                into the first writable directory.
+                """),
+            'proxy_servers': dals("""
+                A mapping to enable proxy settings. Keys can be either (1) a scheme://hostname
+                form, which will match any request to the given scheme and exact hostname, or
+                (2) just a scheme, which will match requests to that scheme. Values are are
+                the actual proxy server, and are of the form
+                'scheme://[user:password@]host[:port]'. The optional 'user:password' inclusion
+                enables HTTP Basic Auth with your proxy.
+                """),
+            'quiet': dals("""
+                Disable progress bar display and other output.
+                """),
+            'remote_connect_timeout_secs': dals("""
+                The number seconds conda will wait for your client to establish a connection
+                to a remote url resource.
+                """),
+            'remote_max_retries': dals("""
+                The maximum number of retries each HTTP connection should attempt.
+                """),
+            'remote_read_timeout_secs': dals("""
+                Once conda has connected to a remote resource and sent an HTTP request, the
+                read timeout is the number of seconds conda will wait for the server to send
+                a response.
+                """),
+            'report_errors': dals("""
+                Opt in, or opt out, of automatic error reporting to core maintainers. Error
+                reports are anonymous, with only the error stack trace and information given
+                by `conda info` being sent.
+                """),
+            'rollback_enabled': dals("""
+                Should any error occur during an unlink/link transaction, revert any disk
+                mutations made to that point in the transaction.
+                """),
+            'safety_checks': dals("""
+                Enforce available safety guarantees during package installation.
+                The value must be one of 'enabled', 'warn', or 'disabled'.
+                """),
+            'shortcuts': dals("""
+                Allow packages to create OS-specific shortcuts (e.g. in the Windows Start
+                Menu) at install time.
+                """),
+            'show_channel_urls': dals("""
+                Show channel URLs when displaying what is going to be downloaded.
+                """),
+            'ssl_verify': dals("""
+                Conda verifies SSL certificates for HTTPS requests, just like a web
+                browser. By default, SSL verification is enabled, and conda operations will
+                fail if a required url's certificate cannot be verified. Setting ssl_verify to
+                False disables certification verification. The value for ssl_verify can also
+                be (1) a path to a CA bundle file, or (2) a path to a directory containing
+                certificates of trusted CA.
+                """),
+            'track_features': dals("""
+                A list of features that are tracked by default. An entry here is similar to
+                adding an entry to the create_default_packages list.
+                """),
+            'use_index_cache': dals("""
+                Use cache of channel index files, even if it has expired.
+                """),
+            'use_pip': dals("""
+                Include non-conda-installed python packages with conda list. This does not
+                affect any conda command or functionality other than the output of the
+                command conda list.
+                """),
+            'verbosity': dals("""
+                Sets output log level. 0 is warn. 1 is info. 2 is debug. 3 is trace.
+                """),
+            'whitelist_channels': dals("""
+                The exclusive list of channels allowed to be used on the system. Use of any
+                other channels will result in an error. If conda-build channels are to be
+                allowed, along with the --use-local command line flag, be sure to include the
+                'local' channel in the list. If the list is empty or left undefined, no
+                channel exclusions will be enforced.
+                """)
+        })
 
 
 def conda_in_private_env():
@@ -637,264 +1046,6 @@ def reset_context(search_path=SEARCH_PATH, argparse_args=None):
     Channel._reset_state()
     # need to import here to avoid circular dependency
     return context
-
-
-@memoize
-def get_help_dict():
-    # this is a function so that most of the time it's not evaluated and loaded into memory
-    return frozendict({
-        'add_anaconda_token': dals("""
-            In conjunction with the anaconda command-line client (installed with
-            `conda install anaconda-client`), and following logging into an Anaconda
-            Server API site using `anaconda login`, automatically apply a matching
-            private token to enable access to private packages and channels.
-            """),
-        'add_pip_as_python_dependency': dals("""
-            Add pip, wheel and setuptools as dependencies of python. This ensures pip,
-            wheel and setuptools will always be installed any time python is installed.
-            """),
-        'aggressive_update_packages': dals("""
-            A list of packages that, if installed, are always updated to the latest possible
-            version.
-            """),
-        'allow_non_channel_urls': dals("""
-            Warn, but do not fail, when conda detects a channel url is not a valid channel.
-            """),
-        'allow_softlinks': dals("""
-            When allow_softlinks is True, conda uses hard-links when possible, and soft-links
-            (symlinks) when hard-links are not possible, such as when installing on a
-            different filesystem than the one that the package cache is on. When
-            allow_softlinks is False, conda still uses hard-links when possible, but when it
-            is not possible, conda copies files. Individual packages can override
-            this setting, specifying that certain files should never be soft-linked (see the
-            no_link option in the build recipe documentation).
-            """),
-        'always_copy': dals("""
-            Register a preference that files be copied into a prefix during install rather
-            than hard-linked.
-            """),
-        'always_softlink': dals("""
-            Register a preference that files be soft-linked (symlinked) into a prefix during
-            install rather than hard-linked. The link source is the 'pkgs_dir' package cache
-            from where the package is being linked. WARNING: Using this option can result in
-            corruption of long-lived conda environments. Package caches are *caches*, which
-            means there is some churn and invalidation. With this option, the contents of
-            environments can be switched out (or erased) via operations on other environments.
-            """),
-        'always_yes': dals("""
-            Automatically choose the 'yes' option whenever asked to proceed with a conda
-            operation, such as when running `conda install`.
-            """),
-        'anaconda_upload': dals("""
-            Automatically upload packages built with conda build to anaconda.org.
-            """),
-        'auto_update_conda': dals("""
-            Automatically update conda when a newer or higher priority version is detected.
-            """),
-        'changeps1': dals("""
-            When using activate, change the command prompt ($PS1) to include the
-            activated environment.
-            """),
-        'channel_alias': dals("""
-            The prepended url location to associate with channel names.
-            """),
-        'channel_priority': dals("""
-            When True, the solver is instructed to prefer channel order over package
-            version. When False, the solver is instructed to give package version
-            preference over channel priority.
-            """),
-        'channels': dals("""
-            The list of conda channels to include for relevant operations.
-            """),
-        'client_ssl_cert': dals("""
-            A path to a single file containing a private key and certificate (e.g. .pem
-            file). Alternately, use client_ssl_cert_key in conjuction with client_ssl_cert
-            for individual files.
-            """),
-        'client_ssl_cert_key': dals("""
-            Used in conjunction with client_ssl_cert for a matching key file.
-            """),
-        'clobber': dals("""
-            Allow clobbering of overlapping file paths within packages, and suppress
-            related warnings. Overrides the path_conflict configuration value when
-            set to 'warn' or 'prevent'.
-            """),
-        'create_default_packages': dals("""
-            Packages that are by default added to a newly created environments.
-            """),  # TODO: This is a bad parameter name. Consider an alternate.
-        'custom_channels': dals("""
-            A map of key-value pairs where the key is a channel name and the value is
-            a channel location. Channels defined here override the default
-            'channel_alias' value. The channel name (key) is not included in the channel
-            location (value).  For example, to override the location of the 'conda-forge'
-            channel where the url to repodata is
-            https://anaconda-repo.dev/packages/conda-forge/linux-64/repodata.json, add an
-            entry 'conda-forge: https://anaconda-repo.dev/packages'.
-            """),
-        'custom_multichannels': dals("""
-            A multichannel is a metachannel composed of multiple channels. The two reserved
-            multichannels are 'defaults' and 'local'. The 'defaults' multichannel is
-            customized using the 'default_channels' parameter. The 'local'
-            multichannel is a list of file:// channel locations where conda-build stashes
-            successfully-built packages.  Other multichannels can be defined with
-            custom_multichannels, where the key is the multichannel name and the value is
-            a list of channel names and/or channel urls.
-            """),
-        'default_channels': dals("""
-            The list of channel names and/or urls used for the 'defaults' multichannel.
-            """),
-        # 'default_python': dals("""
-        #     specifies the default major & minor version of Python to be used when
-        #     building packages with conda-build. Also used to determine the major
-        #     version of Python (2/3) to be used in new environments. Defaults to
-        #     the version used by conda itself.
-        #     """),
-        'disallowed_packages': dals("""
-            Package specifications to disallow installing. The default is to allow
-            all packages.
-            """),
-        'download_only': dals("""
-            Solve an environment and ensure package caches are populated, but exit
-            prior to unlinking and linking packages into the prefix
-            """),
-        'envs_dirs': dals("""
-            The list of directories to search for named environments. When creating a new
-            named environment, the environment will be placed in the first writable
-            location.
-            """),
-        'force': dals("""
-            Override any of conda's objections and safeguards for installing packages and
-            potentially breaking environments. Also re-installs the package, even if the
-            package is already installed. Implies --no-deps.
-            """),
-        # 'force_32bit': dals("""
-        #     CONDA_FORCE_32BIT should only be used when running conda-build (in order
-        #     to build 32-bit packages on a 64-bit system).  We don't want to mention it
-        #     in the documentation, because it can mess up a lot of things.
-        #     """),
-        'json': dals("""
-            Ensure all output written to stdout is structured json.
-            """),
-        'local_repodata_ttl': dals("""
-            For a value of False or 0, always fetch remote repodata (HTTP 304 responses
-            respected). For a value of True or 1, respect the HTTP Cache-Control max-age
-            header. Any other positive integer values is the number of seconds to locally
-            cache repodata before checking the remote server for an update.
-            """),
-        'max_shlvl': dals("""
-            The maximum number of stacked active conda environments.
-            """),
-        'migrated_channel_aliases': dals("""
-            A list of previously-used channel_alias values, useful for example when switching
-            between different Anaconda Repository instances.
-            """),
-        'no_dependencies': dals("""
-            Do not install, update, remove, or change dependencies. This WILL lead to broken
-            environments and inconsistent behavior. Use at your own risk.
-            """),
-        'non_admin_enabled': dals("""
-            Allows completion of conda's create, install, update, and remove operations, for
-            non-privileged (non-root or non-administrator) users.
-            """),
-        'notify_outdated_conda': dals("""
-            Notify if a newer version of conda is detected during a create, install, update,
-            or remove operation.
-            """),
-        'offline': dals("""
-            Restrict conda to cached download content and file:// based urls.
-            """),
-        'override_channels_enabled': dals("""
-            Permit use of the --overide-channels command-line flag.
-            """),
-        'path_conflict': dals("""
-            The method by which conda handle's conflicting/overlapping paths during a
-            create, install, or update operation. The value must be one of 'clobber',
-            'warn', or 'prevent'. The '--clobber' command-line flag or clobber
-            configuration parameter overrides path_conflict set to 'prevent'.
-            """),
-        'pinned_packages': dals("""
-            A list of package specs to pin for every environment resolution.
-            This parameter is in BETA, and its behavior may change in a future release.
-            """),
-        'pkgs_dirs': dals("""
-            The list of directories where locally-available packages are linked from at
-            install time. Packages not locally available are downloaded and extracted
-            into the first writable directory.
-            """),
-        'proxy_servers': dals("""
-            A mapping to enable proxy settings. Keys can be either (1) a scheme://hostname
-            form, which will match any request to the given scheme and exact hostname, or
-            (2) just a scheme, which will match requests to that scheme. Values are are
-            the actual proxy server, and are of the form
-            'scheme://[user:password@]host[:port]'. The optional 'user:password' inclusion
-            enables HTTP Basic Auth with your proxy.
-            """),
-        'quiet': dals("""
-            Disable progress bar display and other output.
-            """),
-        'remote_connect_timeout_secs': dals("""
-            The number seconds conda will wait for your client to establish a connection
-            to a remote url resource.
-            """),
-        'remote_max_retries': dals("""
-            The maximum number of retries each HTTP connection should attempt.
-            """),
-        'remote_read_timeout_secs': dals("""
-            Once conda has connected to a remote resource and sent an HTTP request, the
-            read timeout is the number of seconds conda will wait for the server to send
-            a response.
-            """),
-        'report_errors': dals("""
-            Opt in, or opt out, of automatic error reporting to core maintainers. Error
-            reports are anonymous, with only the error stack trace and information given
-            by `conda info` being sent.
-            """),
-        'rollback_enabled': dals("""
-            Should any error occur during an unlink/link transaction, revert any disk
-            mutations made to that point in the transaction.
-            """),
-        'safety_checks': dals("""
-            Enforce available safety guarantees during package installation.
-            The value must be one of 'enabled', 'warn', or 'disabled'.
-            """),
-        'shortcuts': dals("""
-            Allow packages to create OS-specific shortcuts (e.g. in the Windows Start
-            Menu) at install time.
-            """),
-        'show_channel_urls': dals("""
-            Show channel URLs when displaying what is going to be downloaded.
-            """),
-        'ssl_verify': dals("""
-            Conda verifies SSL certificates for HTTPS requests, just like a web
-            browser. By default, SSL verification is enabled, and conda operations will
-            fail if a required url's certificate cannot be verified. Setting ssl_verify to
-            False disables certification verificaiton. The value for ssl_verify can also
-            be (1) a path to a CA bundle file, or (2) a path to a directory containing
-            certificates of trusted CA.
-            """),
-        'track_features': dals("""
-            A list of features that are tracked by default. An entry here is similar to
-            adding an entry to the create_default_packages list.
-            """),
-        'use_index_cache': dals("""
-            Use cache of channel index files, even if it has expired.
-            """),
-        'use_pip': dals("""
-            Include non-conda-installed python packages with conda list. This does not
-            affect any conda command or functionality other than the output of the
-            command conda list.
-            """),
-        'verbosity': dals("""
-            Sets output log level. 0 is warn. 1 is info. 2 is debug. 3 is trace.
-            """),
-        'whitelist_channels': dals("""
-            The exclusive list of channels allowed to be used on the system. Use of any
-            other channels will result in an error. If conda-build channels are to be
-            allowed, along with the --use-local command line flag, be sure to include the
-            'local' channel in the list. If the list is empty or left undefined, no
-            channel exclusions will be enforced.
-            """)
-    })
 
 
 @memoize

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -210,9 +210,8 @@ class Context(Configuration):
     freeze_installed = PrimitiveParameter(False)
 
     prune = PrimitiveParameter(False)
-    # force_remove = PrimitiveParameter(False)
-    # force_reinstall = PrimitiveParameter(False)
-
+    force_remove = PrimitiveParameter(False)
+    force_reinstall = PrimitiveParameter(False)
 
     target_prefix_override = PrimitiveParameter('')
 
@@ -669,11 +668,9 @@ class Context(Configuration):
 
             'update_deps',
             'update_all',
-            'freeze_installed',
 
             'prune',
-            # 'force_remove',
-            # 'force_reinstall',
+            'force_reinstall',
 
         )),
         ('Package Linking and Install-time Configuration', (
@@ -692,7 +689,7 @@ class Context(Configuration):
             'anaconda_upload',
             'conda_build',
         )),
-        ('Output, Prompt, and Control Flow Configuration', (
+        ('Output, Prompt, and Flow Control Configuration', (
             'always_yes',
             'changeps1',
             'json',
@@ -705,16 +702,18 @@ class Context(Configuration):
         ('CLI-only', (
             'no_deps',
             'only_deps',
+            'freeze_installed',
 
+            'force',
+            'force_remove',
             'clobber',
+
             'dry_run',
             'download_only',
-            'force',
             'ignore_pinned',
             'use_index_cache',
             'use_local',
             'use_pip',
-
         )),
         ('Hidden and Undocumented', (
             'allow_cycles',  # allow cyclical dependencies, or raise
@@ -758,8 +757,8 @@ class Context(Configuration):
             # 'target_prefix_override': 'Undocumented',
             'update_deps': 'Undocumented',
             'update_all': 'Undocumented',
-            'freeze_installed': 'Undocumented',
             'prune': 'Undocumented',
+            'force_reinstall': 'Undocumented',
             # 'use_local': 'Undocumented',
 
             'add_anaconda_token': dals("""
@@ -918,7 +917,7 @@ class Context(Configuration):
                 The maximum number of stacked active conda environments.
                 """),
             'migrated_channel_aliases': dals("""
-                A list of previously-used channel_alias values. Useful when switching between 
+                A list of previously-used channel_alias values. Useful when switching between
                 different Anaconda Repository instances.
                 """),
             'migrated_custom_channels': dals("""

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -952,6 +952,8 @@ def configure_parser_update(sub_parsers, name='update'):
         "--all",
         action="store_true",
         help="Update all installed packages in the environment.",
+        dest='update_all',
+        default=NULL,
     )
     p.set_defaults(func='.main_update.execute')
 
@@ -970,36 +972,34 @@ def add_parser_create_install_update(p):
 
     solver_mode_options = p.add_argument_group("Solver Mode Modifiers")
     solver_mode_options.add_argument(
-        "--update-dependencies", "--update-deps",
-        action="store_true",
-        dest="update_deps",
-        default=NULL,
-        help="Update dependencies. Overrides the value given by "
-             "`conda config --show update_deps`.",
-    )
-    solver_mode_options.add_argument(
-        "--no-update-dependencies", "--no-update-deps",
-        action="store_false",
-        dest="update_deps",
-        default=NULL,
-        help="Don't update dependencies. Overrides the value given by "
-             "`conda config --show update_deps`.",
-    )
-    solver_mode_options.add_argument(
-        "--channel-priority", "--channel-pri", "--chan-pri",
+        "--channel-priority",
         action="store_true",
         dest="channel_priority",
         default=NULL,
-        help="Channel priority takes precedence over package version. "
-             "Overrides the value given by `conda config --show channel_priority`."
+        help=SUPPRESS,
     )
     solver_mode_options.add_argument(
-        "--no-channel-priority", "--no-channel-pri", "--no-chan-pri",
+        "--no-channel-priority",
         action="store_false",
         dest="channel_priority",
         default=NULL,
         help="Package version takes precedence over channel priority. "
              "Overrides the value given by `conda config --show channel_priority`."
+    )
+    solver_mode_options.add_argument(
+        "--update-deps",
+        action="store_true",
+        dest="update_deps",
+        default=NULL,
+        help="Update dependencies.",
+    )
+    solver_mode_options.add_argument(
+        "--no-update-deps",
+        action="store_false",
+        dest="update_deps",
+        default=NULL,
+        help="Don't update dependencies. Overrides the value given by "
+             "`conda config --show update_deps`.",
     )
     solver_mode_options.add_argument(
         "--no-deps",
@@ -1013,21 +1013,6 @@ def add_parser_create_install_update(p):
         help="Only install dependencies.",
     )
     add_parser_no_pin(solver_mode_options)
-    if on_win:
-        solver_mode_options.add_argument(
-            "--shortcuts",
-            action="store_true",
-            help=SUPPRESS,
-            dest="shortcuts",
-            default=NULL,
-        )
-        solver_mode_options.add_argument(
-            "--no-shortcuts",
-            action="store_false",
-            help="Don't install start menu shortcuts",
-            dest="shortcuts",
-            default=NULL,
-        )
 
     package_install_options = p.add_argument_group("Install Behavior Modifiers",
                                                    "Options to modify aspects of package "
@@ -1045,6 +1030,21 @@ def add_parser_create_install_update(p):
              "and suppress related warnings.",
     )
     add_parser_copy(package_install_options)
+    if on_win:
+        package_install_options.add_argument(
+            "--shortcuts",
+            action="store_true",
+            help=SUPPRESS,
+            dest="shortcuts",
+            default=NULL,
+        )
+        package_install_options.add_argument(
+            "--no-shortcuts",
+            action="store_false",
+            help="Don't install start menu shortcuts",
+            dest="shortcuts",
+            default=NULL,
+        )
 
     channel_customization_options = add_parser_channels(p)
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -584,13 +584,26 @@ def configure_parser_install(sub_parsers):
         help="Ensure that any user-requested package for the current operation is uninstalled and "
              "reinstalled, even if that package already exists in the environment.",
     )
+    solver_mode_options.add_argument(
+        "--update-all",
+        action="store_true",
+        help="Update all installed packages in the environment.",
+        dest='update_all',
+        default=NULL,
+    )
 
     package_install_options.add_argument(
         '-m', "--mkdir",
         action="store_true",
         help="Create the environment directory if necessary.",
     )
-
+    package_install_options.add_argument(
+        "--clobber",
+        action="store_true",
+        default=NULL,
+        help="Allow clobbering of overlapping file paths within packages, "
+             "and suppress related warnings.",
+    )
     p.set_defaults(func='.main_install.execute')
 
 
@@ -953,6 +966,7 @@ def configure_parser_update(sub_parsers, name='update'):
             epilog=example % name,
         )
     solver_mode_options, package_install_options = add_parser_create_install_update(p)
+
     add_parser_prune(solver_mode_options)
     solver_mode_options.add_argument(
         "--force-reinstall",
@@ -962,11 +976,19 @@ def configure_parser_update(sub_parsers, name='update'):
              "reinstalled, even if that package already exists in the environment.",
     )
     solver_mode_options.add_argument(
-        "--all",
+        "--update-all", "--all",
         action="store_true",
         help="Update all installed packages in the environment.",
         dest='update_all',
         default=NULL,
+    )
+
+    package_install_options.add_argument(
+        "--clobber",
+        action="store_true",
+        default=NULL,
+        help="Allow clobbering of overlapping file paths within packages, "
+             "and suppress related warnings.",
     )
     p.set_defaults(func='.main_update.execute')
 
@@ -1257,17 +1279,10 @@ def add_parser_networking(p):
 def add_parser_package_install_options(p):
     package_install_options = p.add_argument_group("Package Linking and Install-time Options")
     package_install_options.add_argument(
-        "--clobber",
-        action="store_true",
-        default=NULL,
-        help="Allow clobbering of overlapping file paths within packages, "
-             "and suppress related warnings.",
-    )
-    package_install_options.add_argument(
         '-f', "--force",
         action="store_true",
         default=NULL,
-        help="Force install (even when package already installed).",
+        help=SUPPRESS,
     )
     package_install_options.add_argument(
         '--copy',

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -232,7 +232,7 @@ def install(args, parser, command='install'):
         else:
             solver = Solver(prefix, context.channels, context.subdirs, specs_to_add=specs)
             unlink_link_transaction = solver.solve_for_transaction(
-                force_reinstall=context.force_reinstall,
+                force_reinstall=context.force_reinstall or context.force,
             )
 
     except ResolvePackageNotFound as e:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -232,7 +232,7 @@ def install(args, parser, command='install'):
         else:
             solver = Solver(prefix, context.channels, context.subdirs, specs_to_add=specs)
             unlink_link_transaction = solver.solve_for_transaction(
-                force_reinstall=context.force,
+                force_reinstall=context.force_reinstall,
             )
 
     except ResolvePackageNotFound as e:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -142,7 +142,7 @@ def install(args, parser, command='install'):
         check_prefix(prefix, json=context.json)
     if context.force_32bit and prefix == context.root_prefix:
         raise CondaValueError("cannot use CONDA_FORCE_32BIT=1 in base env")
-    if isupdate and not (args.file or args.all or args.packages):
+    if isupdate and not (args.file or args.update_all or args.packages):
         raise CondaValueError("""no package names supplied
 # If you want to update to a newer version of Anaconda, type:
 #
@@ -193,7 +193,7 @@ def install(args, parser, command='install'):
 
     # for 'conda update', make sure the requested specs actually exist in the prefix
     # and that they are name-only specs
-    if isupdate and not args.all:
+    if isupdate and not args.update_all:
         prefix_data = PrefixData(prefix)
         for spec in specs:
             spec = MatchSpec(spec)

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -69,16 +69,16 @@ def parameter_description_builder(name):
     if aliases:
         builder.append("  aliases: %s" % ', '.join(aliases))
     if string_delimiter:
-        builder.append("  string delimiter: '%s'" % string_delimiter)
+        builder.append("  env var string delimiter: '%s'" % string_delimiter)
 
     builder.extend('  ' + line for line in wrap(details['description'], 70))
 
     builder.append('')
+    builder = ['# ' + line for line in builder]
 
     builder.extend(yaml_dump({name: json.loads(default_value_str)}).strip().split('\n'))
 
     builder = ['# ' + line for line in builder]
-    builder.append('')
     builder.append('')
     return builder
 
@@ -95,6 +95,7 @@ def describe_all_parameters():
         builder.append('')
         builder.extend(concat(parameter_description_builder(name)
                               for name in parameter_names))
+        builder.append('')
     return '\n'.join(builder)
 
 

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -13,7 +13,7 @@ from .. import CondaError
 from .._vendor.auxlib.entity import EntityEncoder
 from ..base.constants import PathConflict, SafetyChecks
 from ..base.context import context, sys_rc_path, user_rc_path
-from ..common.compat import isiterable, iteritems, itervalues, string_types, text_type
+from ..common.compat import isiterable, iteritems, itervalues, string_types
 from ..common.configuration import pretty_list, pretty_map
 from ..common.io import timeout
 from ..common.serialize import yaml, yaml_dump, yaml_load
@@ -85,7 +85,7 @@ def parameter_description_builder(name):
 
 def describe_all_parameters():
     builder = []
-    skip_categories = ('CLI-Only', 'Hidden and Undocumented')
+    skip_categories = ('CLI-only', 'Hidden and Undocumented')
     for category, parameter_names in iteritems(context.category_map):
         if category in skip_categories:
             continue

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -3,10 +3,20 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
+
 from .install import install
+from ..base.context import context
 from ..gateways.disk.delete import delete_trash
 
 
 def execute(args, parser):
+    if context.force:
+        print("\n\n"
+              "WARNING: The --force flag will be removed in a future conda release.\n"
+              "         See 'conda install --help' for details about the --force-reinstall\n"
+              "         and --clobber flags.\n"
+              "\n", file=sys.stderr)
+
     install(args, parser, 'install')
     delete_trash()

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -82,7 +82,7 @@ def execute(args, parser):
         channel_urls = ()
         subdirs = ()
         solver = Solver(prefix, channel_urls, subdirs, specs_to_remove=specs)
-        txn = solver.solve_for_transaction(force_remove=args.force)
+        txn = solver.solve_for_transaction()
         handle_txn(txn, prefix, args, False, True)
 
     # Keep this code for dev reference until private envs can be re-enabled in

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -21,8 +21,6 @@ def execute(args, parser):
     spec = MatchSpec(args.match_spec)
     if spec.get_exact_value('subdir'):
         subdirs = spec.get_exact_value('subdir'),
-    elif args.platform:
-        subdirs = args.platform,
     else:
         subdirs = context.subdirs
 

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -6,10 +6,20 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
+
 from .install import install
+from ..base.context import context
 from ..gateways.disk.delete import delete_trash
 
 
 def execute(args, parser):
+    if context.force:
+        print("\n\n"
+              "WARNING: The --force flag will be removed in a future conda release.\n"
+              "         See 'conda update --help' for details about the --force-reinstall\n"
+              "         and --clobber flags.\n"
+              "\n", file=sys.stderr)
+
     install(args, parser, 'update')
     delete_trash()

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -851,7 +851,7 @@ class Configuration(object):
         name = parameter.name.lstrip('_')
         aliases = tuple(alias for alias in parameter.aliases if alias != name)
 
-        description = self.get_descriptions()[name]
+        description = self.get_descriptions().get(name, '')
         et = parameter._element_type
         if type(et) == EnumMeta:
             et = [et]

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -118,11 +118,12 @@ class Solver(object):
                 the solved state of the environment.
 
         """
-        prune = context.prune if prune is NULL else prune
-        ignore_pinned = context.ignore_pinned if ignore_pinned is NULL else ignore_pinned
         deps_modifier = context.deps_modifier if deps_modifier is NULL else deps_modifier
         if isinstance(deps_modifier, string_types):
             deps_modifier = DepsModifier(deps_modifier.lower())
+        prune = context.prune if prune is NULL else prune
+        ignore_pinned = context.ignore_pinned if ignore_pinned is NULL else ignore_pinned
+        force_remove = context.force_remove if force_remove is NULL else force_remove
         specs_to_remove = self.specs_to_remove
         specs_to_add = self.specs_to_add
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -529,13 +529,13 @@ class UnsatisfiableError(CondaError):
                 chains[key] = ' -> '.join(deps)
             bad_deps = [chains[key] for key in sorted(iterkeys(chains))]
             msg = '''The following specifications were found to be in conflict:%s
-Use "conda info <package>" to see the dependencies for each package.'''
+Use "conda search <package> --info" to see the dependencies for each package.'''
         else:
             bad_deps = [sorted(dep) for dep in bad_deps]
             bad_deps = [', '.join(dep) for dep in sorted(bad_deps)]
             msg = '''The following specifications were found to be incompatible with the
 others, or with the existing package set:%s
-Use "conda info <package>" to see the dependencies for each package.'''
+Use "conda search <package> --info" to see the dependencies for each package.'''
         msg = msg % dashlist(bad_deps)
         super(UnsatisfiableError, self).__init__(msg)
 

--- a/conda_env/cli/main_remove.py
+++ b/conda_env/cli/main_remove.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, print_function
 
 from argparse import Namespace, RawDescriptionHelpFormatter
-
 from os.path import isdir
 
-from conda.cli.conda_argparse import (add_parser_json, add_parser_prefix, add_parser_quiet,
-                                      add_parser_yes)
+from conda.cli.conda_argparse import add_output_and_prompt_options, add_parser_prefix
 
 _help = "Remove an environment"
 _description = _help + """
@@ -33,9 +31,7 @@ def configure_parser(sub_parsers):
     )
 
     add_parser_prefix(p)
-    add_parser_json(p)
-    add_parser_quiet(p)
-    add_parser_yes(p)
+    add_output_and_prompt_options(p)
 
     p.set_defaults(func='.main_remove.execute')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ exclude = build/*,.tox/*,env/*,tests/*,ve/*,*/_vendor/*,conda/compat.py,conda/co
 [flake8]
 max-line-length = 99
 ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503
-exclude = build/*,.tox/*,env/*,tests/*,ve/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
+exclude = build/*,.tox/*,env/*,tests/*,ve/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py,devenv/*
 
 
 [coverage:report]

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from itertools import chain
 import os
 from os.path import join
 from tempfile import gettempdir
@@ -13,7 +14,7 @@ from conda._vendor.auxlib.ish import dals
 from conda._vendor.toolz.itertoolz import concat
 from conda.base.constants import PathConflict
 from conda.base.context import context, reset_context
-from conda.common.compat import odict
+from conda.common.compat import odict, iteritems
 from conda.common.configuration import ValidationError, YamlRawParameter
 from conda.common.io import env_var
 from conda.common.path import expand, win_path_backout
@@ -187,10 +188,25 @@ class ContextCustomRcTests(TestCase):
         with env_var("CONDA_PATH_CONFLICT", 'prevent', reset_context):
             assert context.path_conflict == PathConflict.prevent
 
-    def test_describe_all(self):
-        paramter_names = context.list_parameters()
+    def test_context_parameter_map(self):
+        all_parameter_names = context.list_parameters()
+        all_mapped_parameter_names = tuple(chain.from_iterable(context.category_map.values()))
+
+        unmapped_parameter_names = set(all_parameter_names) - set(all_mapped_parameter_names)
+        assert not unmapped_parameter_names, unmapped_parameter_names
+
+        assert len(all_parameter_names) == len(all_mapped_parameter_names)
+
+    def test_context_parameters_have_descriptions(self):
+        skip_categories = ('CLI-only', 'Hidden and Undocumented')
+        documented_parameter_names = chain.from_iterable((
+            parameter_names for category, parameter_names in iteritems(context.category_map)
+            if category not in skip_categories
+        ))
+
         from pprint import pprint
-        for name in paramter_names:
+        for name in documented_parameter_names:
+            description = context.get_descriptions()[name]
             pprint(context.describe_parameter(name))
 
     def test_local_build_root_custom_rc(self):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -823,6 +823,7 @@ class IntegrationTests(TestCase):
     def test_install_update_deps_only_deps_flags(self):
         raise NotImplementedError()
 
+    @pytest.mark.skipif(on_win, reason="tensorflow package used in test not available on Windows")
     def test_install_freeze_installed_flag(self):
         with make_temp_env("bleach") as prefix:
             assert package_is_installed(prefix, "bleach-2")


### PR DESCRIPTION
This PR dramatically cleans up the output of `conda <COMMAND> --help` and `conda config --describe`. 

Easiest way to review this PR will be to just test the outputs.  E.g.

    python -m conda config --describe
    python -m conda install --help

