### PR TITLE
Import speedups

### DIFF
--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -44,8 +44,21 @@ try:  # pragma: no cover
     from cytoolz.itertoolz import concat, concatv, unique
 except ImportError:  # pragma: no cover
     from .._vendor.toolz.dicttoolz import merge
-    from .._vendor.toolz.functoolz import excepts
     from .._vendor.toolz.itertoolz import concat, concatv, unique
+
+    # Importing from toolz.functoolz is slow since it imports inspect.
+    # Copy the relevant part of excepts' implementation instead:
+    class excepts(object):
+        def __init__(self, exc, func, handler=lambda exc: None):
+            self.exc = exc
+            self.func = func
+            self.handler = handler
+
+        def __call__(self, *args, **kwargs):
+            try:
+                return self.func(*args, **kwargs)
+            except self.exc as e:
+                return self.handler(e)
 try:  # pragma: no cover
     from ruamel_yaml.comments import CommentedSeq, CommentedMap
     from ruamel_yaml.scanner import ScannerError

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -15,10 +15,9 @@ from .._vendor.auxlib.decorators import memoize
 try:
     # Python 3
     from urllib.parse import unquote, urlsplit
-    from urllib.request import url2pathname
 except ImportError:  # pragma: no cover
     # Python 2
-    from urllib import unquote, url2pathname  # NOQA
+    from urllib import unquote  # NOQA
     from urlparse import urlsplit  # NOQA
 
 try:

--- a/conda/common/serialize.py
+++ b/conda/common/serialize.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 from logging import getLogger
-import re
 
 from .compat import PY2, odict, ensure_text_type
 from .._vendor.auxlib.decorators import memoize
@@ -12,42 +11,9 @@ from .._vendor.auxlib.entity import EntityEncoder
 log = getLogger(__name__)
 
 
-class LazyEval(object):
-    init_count = 0
-    eval_count = 0
-
-    def __init__(self, func, *args, **kwargs):
-        LazyEval.init_count += 1
-
-        def lazy_self():
-            LazyEval.eval_count += 1
-            return_value = func(*args, **kwargs)
-            object.__setattr__(self, "lazy_self", lambda: return_value)
-            return return_value
-        object.__setattr__(self, "lazy_self", lazy_self)
-
-    def __getattribute__(self, name):
-        lazy_self = object.__getattribute__(self, "lazy_self")
-        if name == "lazy_self":
-            return lazy_self
-        return getattr(lazy_self(), name)
-
-    def __setattr__(self, name, value):
-        setattr(self.lazy_self(), name, value)
-
-
-class LazyFunc:
-    def __init__(self, func):
-        self.func = func
-
-    def __call__(self, *args, **kwargs):
-        return LazyEval(self.func, *args, **kwargs)
-
-
 @memoize
 def get_yaml():
     try:
-        re.compile = LazyFunc(re.compile)
         import ruamel_yaml as yaml
     except ImportError:  # pragma: no cover
         try:
@@ -56,8 +22,6 @@ def get_yaml():
             raise ImportError("No yaml library available.\n"
                               "To proceed, conda install "
                               "ruamel_yaml")
-    finally:
-        re.compile = re.compile.func
     return yaml
 
 

--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from getpass import getpass
 from logging import getLogger
+import os
 from os.path import abspath, expanduser
 import re
 import socket
@@ -17,7 +18,13 @@ try:  # pragma: py2 no cover
     # Python 3
     from urllib.parse import (quote, quote_plus, unquote, unquote_plus,  # NOQA
                               urlunparse as stdlib_urlparse, urljoin)  # NOQA
-    from urllib.request import pathname2url  # NOQA
+    # Importing urllib.request is exceptionally slow in Python 3.
+    # Copy pathname2url's implementation directly instead:
+    if os.name == 'nt':
+        from nturl2path import pathname2url  # NOQA
+    else:
+        def pathname2url(pathname):
+            return quote(pathname)
 except ImportError:  # pragma: py3 no cover
     # Python 2
     from urllib import quote, quote_plus, unquote, unquote_plus, pathname2url  # NOQA

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -15,10 +15,8 @@ from ..common.url import (Url, has_scheme, is_url, join_url, path_to_url,
                           urlparse)
 
 try:
-    from cytoolz.functoolz import excepts
     from cytoolz.itertoolz import concat, concatv, drop
 except ImportError:  # pragma: no cover
-    from .._vendor.toolz.functoolz import excepts  # NOQA
     from .._vendor.toolz.itertoolz import concat, concatv, drop  # NOQA
 
 log = getLogger(__name__)


### PR DESCRIPTION
`conda`'s startup time is heavily influenced by some costly imports of external modules.
This PR alone cuts the overall import time of `conda.base.context` by approx. 25 % (using `conda 4.5.0`+`python 3.6.5`).

One costly import we cannot avoid is `ruamel.yaml`/`ruamel_yaml`. 1/3 of the import time\* of that package is spent compiling regular expression (of which usually only few are actually used). We could monkeypatch `re.compile` to avoid this, but the saner approach is of course to fix this upstream. This is done in https://bitbucket.org/ruamel/yaml/pull-requests/27/improve-package-import-time/diff.
```python
>>> t_base = 0.01278
>>> t_ruamel_unpatched = 0.04364
>>> t_ruamel_patched = 0.03291
>>> (t_ruamel_patched - t_base) / (t_ruamel_unpatched - t_base)
0.6523007128969541
```
If that `ruamel.yaml` PR gets accepted, the overall time savings combined with this PR would be approx. 33 %.

----
```
 runtime in seconds (percentiles of 1000 runs)  | shell command
      0        25        50        75       100 |
------------------------------------------------|-------------------------------------------------
## base
------------------------------------------------|-------------------------------------------------
0.00169   0.00182   0.00185   0.00188   0.00501 | true
0.01236   0.01270   0.01278   0.01289   0.01729 | python -c 'pass'
------------------------------------------------|-------------------------------------------------
## base conda imports
------------------------------------------------|-------------------------------------------------
0.02038   0.02080   0.02095   0.02118   0.03383 | python -c 'import conda'
0.02046   0.02089   0.02103   0.02122   0.02558 | python -c 'import conda.base'
0.02030   0.02082   0.02096   0.02117   0.02652 | python -c 'import conda.common'
------------------------------------------------|-------------------------------------------------
## external imports
------------------------------------------------|-------------------------------------------------
0.02504   0.02579   0.02599   0.02632   0.03171 | python -c 'import inspect'
0.01254   0.01285   0.01292   0.01303   0.01771 | python -c 'import urllib'
0.04746   0.04873   0.05025   0.05266   0.05886 | python -c 'import urllib.request'
0.02052   0.02090   0.02104   0.02126   0.02633 | python -c 'import conda._vendor
0.02057   0.02105   0.02121   0.02140   0.02667 | python -c 'import conda._vendor.toolz'
0.03012   0.03086   0.03110   0.03162   0.03635 | python -c 'import conda._vendor.toolz.functoolz'
0.04172   0.04272   0.04364   0.04503   0.05020 | python -c 'import ruamel_yaml'
------------------------------------------------|-------------------------------------------------
## conda modules with costly imports
------------------------------------------------|-------------------------------------------------
0.05470   0.05590   0.05764   0.06027   0.06399 | python -c 'import conda.common.path'
0.05579   0.05742   0.05905   0.06177   0.07585 | python -c 'import conda.common.url'
0.05349   0.05526   0.05712   0.05940   0.06720 | python -c 'import conda.common.serialize'
0.08788   0.09484   0.09662   0.09722   0.10350 | python -c 'import conda.common.configuration'
0.09521   0.10202   0.10533   0.10595   0.11980 | python -c 'import conda.base.context'
------------------------------------------------|-------------------------------------------------
## after applying this PR
------------------------------------------------|-------------------------------------------------
0.03354   0.03420   0.03459   0.03518   0.04024 | python -c 'import conda.common.path'
0.03711   0.03804   0.03854   0.03938   0.04418 | python -c 'import conda.common.url'
0.06232   0.06420   0.06715   0.06926   0.07643 | python -c 'import conda.common.configuration'
0.07469   0.07793   0.08171   0.08296   0.08962 | python -c 'import conda.base.context'
------------------------------------------------|-------------------------------------------------
## this PR + https://bitbucket.org/ruamel/yaml/pull-requests/27/improve-package-import-time
------------------------------------------------|-------------------------------------------------
0.03147   0.03242   0.03291   0.03406   0.04619 | python -c 'import ruamel_yaml'
0.04366   0.04494   0.04639   0.04814   0.05386 | python -c 'import conda.common.serialize'
0.05225   0.05371   0.05651   0.05808   0.08065 | python -c 'import conda.common.configuration'
0.06442   0.06807   0.07103   0.07165   0.08386 | python -c 'import conda.base.context'
------------------------------------------------|-------------------------------------------------
```