### PR TITLE
fix for issue 7142

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -14,6 +14,7 @@ import sys
 
 from ..base.constants import CONDA_TARBALL_EXTENSION
 from ..base.context import context
+from ..gateways.disk.delete import delete_trash
 
 log = getLogger(__name__)
 
@@ -291,6 +292,8 @@ def execute(args, parser):
         from ..exceptions import ArgumentError
         raise ArgumentError("One of {--lock, --tarballs, --index-cache, --packages, "
                             "--source-cache, --all} required")
+
+    delete_trash()
 
     if context.json:
         stdout_json(json_result)

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -44,7 +44,6 @@ def execute(args, parser):
         from ..exceptions import EnvironmentLocationNotFound
         raise EnvironmentLocationNotFound(prefix)
 
-    delete_trash()
     if args.all:
         if prefix == context.root_prefix:
             raise CondaEnvironmentError('cannot remove root environment,\n'
@@ -66,6 +65,8 @@ def execute(args, parser):
             confirm_yn()
         rm_rf(prefix)
         unregister_env(prefix)
+
+        delete_trash()
 
         if context.json:
             stdout_json({


### PR DESCRIPTION
Fix for  #7142.
After testing i see that the change in `conda/cli/main_remove.py` is well worth when removing `conda` environments.
When removing an env it is moved entirely in `.trash`. If `delete_trash()` is called _after_ the move, at least the subdirectories (conda-meta DLLs, etc) are emptied and space is recovered.

Instead there is NO WAY in windows to delete dll's and python executables hardlinks that point to the same python that is running `conda`, from `conda` itself. They will be in use and `os.unlink()` will get permission denied error.

I think it should be documented that cleaning the `.trash` after removing env's in windows, can require manual intervention.
