### PR TITLE
add a verification rule to ensure we never clobber system python

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -4,12 +4,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import defaultdict, namedtuple
 from logging import getLogger
 import os
-from os.path import basename, dirname, isdir, join
+from os.path import basename, dirname, isdir, join, exists
 from subprocess import CalledProcessError
 import sys
 from tempfile import mkdtemp
 from traceback import format_exception_only
 import warnings
+
+import re
 
 from .package_cache_data import PackageCacheData
 from .path_actions import (CompilePycAction, CreateNonadminAction, CreatePrefixRecordAction,
@@ -29,7 +31,8 @@ from ..common.path import (explode_directories, get_all_directories, get_major_m
                            get_python_site_packages_short_path)
 from ..common.signals import signal_handler
 from ..exceptions import (DisallowedPackageError, KnownPackageClobberError, LinkError, RemoveError,
-                          SharedLinkPathClobberError, UnknownPackageClobberError, maybe_raise)
+                          SharedLinkPathClobberError, UnknownPackageClobberError, maybe_raise,
+                          SystemPrefixClobberError)
 from ..gateways.disk import mkdir_p
 from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.read import isfile, lexists, read_package_info
@@ -412,6 +415,7 @@ class UnlinkLinkTransaction(object):
         # 2. make sure we're not removing a conda dependency from conda's env
         # 3. enforce context.disallowed_packages
         # 4. make sure we're not removing pinned packages without no-pin flag
+        # 5. make sure we're not going to touch in any way the system python at /usr/bin/python
         # TODO: Verification 4
 
         conda_prefixes = (join(context.root_prefix, 'envs', '_conda_'), context.root_prefix)
@@ -470,6 +474,22 @@ class UnlinkLinkTransaction(object):
             for prec in prefix_setup.link_precs:
                 if any(d.match(prec) for d in disallowed):
                     yield DisallowedPackageError(prec)
+
+        # 5. make sure we're not going to touch in any way the system python at /usr/bin/python
+        for prefix_setup in itervalues(prefix_setups):
+            if prefix_setup.target_prefix == '/usr' and exists('/usr/bin/python'):
+                python_unlink_prec = next((prec for prec in prefix_setup.unlink_precs
+                                           if prec.name == 'python'), None)
+                python_link_prec = next((prec for prec in prefix_setup.link_precs
+                                         if prec.name == 'python'), None)
+                if python_unlink_prec or python_link_prec:
+                    prefix_data = PrefixData(prefix_setup.target_prefix)
+                    python_record = prefix_data.get('python', None)
+                    if not python_record:
+                        yield SystemPrefixClobberError(
+                            "A python interpreter exists at /usr/bin/python, and it was not\n"
+                            "conda-installed. Refusing to mutate environment with prefix '/usr'."
+                        )
 
     @classmethod
     def _verify(cls, prefix_setups, prefix_action_groups):

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -4,14 +4,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import defaultdict, namedtuple
 from logging import getLogger
 import os
-from os.path import basename, dirname, isdir, join, exists
+from os.path import basename, dirname, exists, isdir, join
 from subprocess import CalledProcessError
 import sys
 from tempfile import mkdtemp
 from traceback import format_exception_only
 import warnings
-
-import re
 
 from .package_cache_data import PackageCacheData
 from .path_actions import (CompilePycAction, CreateNonadminAction, CreatePrefixRecordAction,
@@ -31,8 +29,8 @@ from ..common.path import (explode_directories, get_all_directories, get_major_m
                            get_python_site_packages_short_path)
 from ..common.signals import signal_handler
 from ..exceptions import (DisallowedPackageError, KnownPackageClobberError, LinkError, RemoveError,
-                          SharedLinkPathClobberError, UnknownPackageClobberError, maybe_raise,
-                          SystemPrefixClobberError)
+                          SharedLinkPathClobberError, SystemPrefixClobberError,
+                          UnknownPackageClobberError, maybe_raise)
 from ..gateways.disk import mkdir_p
 from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.read import isfile, lexists, read_package_info

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -8,11 +8,10 @@ from os import listdir
 from os.path import basename, dirname, join
 from tarfile import ReadError
 
-from conda._vendor.auxlib.decorators import memoizemethod
-
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler
 from .._vendor.auxlib.collection import first
+from .._vendor.auxlib.decorators import memoizemethod
 from ..base.constants import CONDA_TARBALL_EXTENSION, PACKAGE_CACHE_MAGIC_FILE
 from ..base.context import context
 from ..common.compat import (JSONDecodeError, iteritems, itervalues, odict, string_types,

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -169,6 +169,14 @@ class SharedLinkPathClobberError(ClobberError):
         )
 
 
+class SystemPrefixClobberError(CondaError):
+    # NOTE: specifically *not* inheriting from ClobberError because this should always raise
+    #       regardless of context.path_conflict
+
+    def __init__(self, message, **kwargs):
+        super(SystemPrefixClobberError, self).__init__(message, **kwargs)
+
+
 class CommandNotFoundError(CondaError):
     def __init__(self, command):
         activate_commands = {

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -43,7 +43,7 @@ from conda.core.package_cache_data import PackageCacheData
 from conda.core.subdir_data import create_cache_dir
 from conda.exceptions import CommandArgumentError, DryRunExit, OperationNotAllowed, \
     PackagesNotFoundError, RemoveError, conda_exception_handler, PackageNotInstalledError, \
-    DisallowedPackageError, UnsatisfiableError
+    DisallowedPackageError, UnsatisfiableError, SystemPrefixClobberError
 from conda.gateways.anaconda_client import read_binstar_tokens
 from conda.gateways.disk.create import mkdir_p
 from conda.gateways.disk.delete import rm_rf
@@ -726,6 +726,16 @@ class IntegrationTests(TestCase):
 
             run_command(Commands.REMOVE, prefix, '--all')
             assert not exists(prefix)
+
+    @pytest.mark.skipif(on_win, reason="unix-only test")
+    def test_dont_clobber_system_python(self):
+        if not exists('/usr/bin/python'):
+            return
+        prefix = '/usr'
+        with pytest.raises(CondaError) as exc:
+            run_command(Commands.INSTALL, prefix, 'itsdangerous')
+        assert isinstance(exc.value, CondaMultiError)
+        assert any(isinstance(err, SystemPrefixClobberError) for err in exc.value.errors)
 
     @pytest.mark.skipif(on_win, reason="windows usually doesn't support symlinks out-of-the box")
     @patch('conda.core.link.hardlink_supported', side_effect=lambda x, y: False)


### PR DESCRIPTION
As we make our way to supporting `pip install conda` via #6518, I want to add this check in to make it extra hard for people to use conda to change their system python.