### PR TITLE
add http error body to debug information

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -415,7 +415,7 @@ def fetch_repodata_remote_request(url, etag, mod_stamp):
         resp = session.get(join_url(url, filename), headers=headers, proxies=session.proxies,
                            timeout=timeout)
         if log.isEnabledFor(DEBUG):
-            log.debug(stringify(resp))
+            log.debug(stringify(resp, content_max_len=256))
         resp.raise_for_status()
 
     except InvalidSchema as e:

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -424,7 +424,7 @@ class CondaHTTPError(CondaError):
         elapsed_time = elapsed_time or '-'
 
         from ._vendor.auxlib.logz import stringify
-        response_details = (stringify(response) or '') if response else ''
+        response_details = (stringify(response, content_max_len=1024) or '') if response else ''
 
         url = maybe_unquote(url)
         if isinstance(elapsed_time, timedelta):

--- a/conda/gateways/connection/download.py
+++ b/conda/gateways/connection/download.py
@@ -42,7 +42,7 @@ def download(url, target_full_path, md5sum, progress_update_callback=None):
         session = CondaSession()
         resp = session.get(url, stream=True, proxies=session.proxies, timeout=timeout)
         if log.isEnabledFor(DEBUG):
-            log.debug(stringify(resp))
+            log.debug(stringify(resp, content_max_len=256))
         resp.raise_for_status()
 
         content_length = int(resp.headers.get('Content-Length', 0))


### PR DESCRIPTION
A member of the anaconda.org team pointed out in a private issue tracker that, without knowledge of the response body for HTTP 4XX errors such as https://github.com/conda/conda/issues/7140, our hands are kind of tied in understanding what's going on.  This PR should at least give us more information in the debug output.