### PR TITLE
Remove reference to 'system' channel.

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1176,8 +1176,7 @@ def add_parser_channels(p):
         help="""Additional channel to search for packages. These are URLs searched in the order
         they are given (including file:// for local directories).  Then, the defaults
         or channels from .condarc are searched (unless --override-channels is given).  You can use
-        'defaults' to get the default packages for conda, and 'system' to get the system
-        packages, which also takes .condarc into account.  You can also use any name and the
+        'defaults' to get the default packages for conda.  You can also use any name and the
         .condarc channel_alias value will be prepended.  The default channel_alias
         is http://conda.anaconda.org/.""",
     )


### PR DESCRIPTION
This channel no longer exists, and looks like an artifact left over in
the doc from a conda 2.x feature that is no longer supported nor
necessary (.condarc specified channels are search by default). This came
up on the conda mailing list as a point of confusion, and is confusing
since the term 'system' is already overloaded with multiple meanings.