### PR TITLE
Creating env name with space is not supported

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1134,6 +1134,10 @@ def determine_target_prefix(ctx, args=None):
             from ..exceptions import CondaValueError
             raise CondaValueError("'/' not allowed in environment name: %s" %
                                   prefix_name)
+        if ' ' in prefix_name:
+            from ..exceptions import CondaValueError
+            raise CondaValueError("Space not allowed in environment name: '%s'" %
+                                  prefix_name)
         if prefix_name in (ROOT_ENV_NAME, 'root'):
             return ctx.root_prefix
         else:


### PR DESCRIPTION
`CondaValueError` is thrown when `conda create --name "environment name"`.

The exception is raised before the `source activate environment name` is shown in the red box. So the quotes haven't been added.