### PR TITLE
Sort activation order of the activation scripts

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -414,9 +414,9 @@ class _Activator(object):
         ))))
 
     def _get_deactivate_scripts(self, prefix):
-        return self.path_conversion(glob(join(
+        return self.path_conversion(sorted(glob(join(
             prefix, 'etc', 'conda', 'deactivate.d', '*' + self.script_extension
-        )))
+        )), reverse=True))
 
 
 def expand(path):

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -409,9 +409,9 @@ class _Activator(object):
         return "(%s) " % conda_default_env if context.changeps1 else ""
 
     def _get_activate_scripts(self, prefix):
-        return self.path_conversion(glob(join(
+        return self.path_conversion(sorted(glob(join(
             prefix, 'etc', 'conda', 'activate.d', '*' + self.script_extension
-        )))
+        ))))
 
     def _get_deactivate_scripts(self, prefix):
         return self.path_conversion(glob(join(

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -170,7 +170,7 @@ class _Activator(object):
             #  i.e. step back down
             return self.build_deactivate()
 
-        activate_scripts = sorted(self._get_activate_scripts(prefix))
+        activate_scripts = self._get_activate_scripts(prefix)
         conda_default_env = self._default_env(prefix)
         conda_prompt_modifier = self._prompt_modifier(conda_default_env)
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -170,7 +170,7 @@ class _Activator(object):
             #  i.e. step back down
             return self.build_deactivate()
 
-        activate_scripts = self._get_activate_scripts(prefix)
+        activate_scripts = sorted(self._get_activate_scripts(prefix))
         conda_default_env = self._default_env(prefix)
         conda_prompt_modifier = self._prompt_modifier(conda_default_env)
 


### PR DESCRIPTION
Currently, the activation script paths are gathered with `glob.glob` which returns its results in arbitrary order. AFAICT the resulting results are not sorted or manipulated anywhere else. This caused us problems when we added an activation script to a metapackage of ours where we wanted to manipulate the environment variables set by the new compilers, https://github.com/ContinuumIO/anaconda-issues/issues/9172. This PR sorts the resulting list of activation scripts. This way packages can ensure when their activation scripts are run by naming them accordingly. As @msarahan [suggested](https://github.com/ContinuumIO/anaconda-issues/issues/9172#issuecomment-381607827), a script named `zz_patch_flags.sh` will run after compiler scripts that are `activate-*.sh`.

Here, sorting is done in two places, but one of them is redundant. I am submitting both of them, but will remove one upon feedback.