### PR TITLE
Support complete MatchSpec syntax in environment.yml files

### DIFF
--- a/conda_env/installers/conda.py
+++ b/conda_env/installers/conda.py
@@ -11,19 +11,8 @@ from conda.models.channel import Channel, prioritize_channels
 def install(prefix, specs, args, env, *_, **kwargs):
     # TODO: support all various ways this happens
     # Including 'nodefaults' in the channels list disables the defaults
-    new_specs = []
-    channel_urls = set()
-    for elem in specs:
-        if "::" in elem:
-            channel_urls.add(elem.split("::")[0])
-            new_specs.append(elem.split("::")[-1])
-        else:
-            new_specs.append(elem)
-    specs = new_specs
-    channel_urls = list(channel_urls)
-    # TODO: support all various ways this happens
-    # Including 'nodefaults' in the channels list disables the defaults
-    channel_urls = channel_urls + [chan for chan in env.channels if chan != 'nodefaults']
+    channel_urls = [chan for chan in env.channels if chan != 'nodefaults']
+
     if 'nodefaults' not in env.channels:
         channel_urls.extend(context.channels)
     _channel_priority_map = prioritize_channels(channel_urls)


### PR DESCRIPTION
I think this fixes #6385.

I've run the conda_env tests and they seem OK, but I'm not sure if there are other wider impacts of this change. 
