### PR TITLE
The pep8 project has been renamed to pycodestyle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ markers =
     installed: tests that assume conda is pre-installed on PATH
 
 
-[pep8]
+[pycodestyle]
 max-line-length = 99
 ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503
 exclude = build/*,.tox/*,env/*,tests/*,ve/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py


### PR DESCRIPTION
Per [this request from GvR](https://github.com/PyCQA/pycodestyle/issues/466), the project has been renamed, and will emit deprecation warnings when linting conda if the [pep8] section remains.

https://github.com/conda/conda/issues/7220