### PR TITLE
fix #7094 exit early for --dry-run with explicit and clone

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -18,12 +18,12 @@ from .core.index import get_index
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.package_cache_data import PackageCacheData, ProgressiveFetchExtract
 from .core.prefix_data import PrefixData, linked_data
-from .exceptions import DisallowedPackageError, PackagesNotFoundError, ParseError
+from .exceptions import DisallowedPackageError, DryRunExit, PackagesNotFoundError, ParseError
 from .gateways.disk.delete import rm_rf
 from .gateways.disk.link import islink, readlink, symlink
 from .models.dist import Dist
-from .models.records import PackageRecord
 from .models.match_spec import MatchSpec
+from .models.records import PackageRecord
 from .resolve import Resolve
 
 
@@ -64,6 +64,9 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
         # url_p is everything but the tarball_basename and the md5sum
 
         fetch_specs.append(MatchSpec(url, md5=md5sum) if md5sum else MatchSpec(url))
+
+    if context.dry_run:
+        raise DryRunExit()
 
     pfe = ProgressiveFetchExtract(fetch_specs)
     pfe.execute()
@@ -237,6 +240,9 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
     if verbose:
         print('Packages: %d' % len(dists))
         print('Files: %d' % len(untracked_files))
+
+    if context.dry_run:
+        raise DryRunExit()
 
     for f in untracked_files:
         src = join(prefix1, f)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -656,6 +656,10 @@ class IntegrationTests(TestCase):
 
             assert isfile(tar_old_path)
 
+            with pytest.raises(DryRunExit):
+                run_command(Commands.INSTALL, prefix, tar_old_path, "--dry-run")
+                assert not package_is_installed(prefix, 'flask-0.')
+
             # regression test for #2886 (part 1 of 2)
             # install tarball from package cache, default channel
             run_command(Commands.INSTALL, prefix, tar_old_path)


### PR DESCRIPTION
backport of #7096 to 4.5.x