### PR TITLE
Update log.warn (deprecated) to log.warning

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -48,7 +48,7 @@ def check_prefix(prefix, json=False):
         raise CondaValueError(error, json)
 
     if ' ' in prefix:
-        stderrlog.warn("WARNING: A space was detected in your requested environment path\n"
+        stderrlog.warning("WARNING: A space was detected in your requested environment path\n"
                        "'%s'\n"
                        "Spaces in paths can sometimes be problematic." % prefix)
 

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -347,7 +347,7 @@ def execute(args, parser):
                 # try:
                 # $ conda install -n root _license"""))
         except Exception as e:  # pragma: no cover
-            log.warn('%r', e)
+            log.warning('%r', e)
 
     if context.json:
         stdout_json(info_dict)

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -37,7 +37,7 @@ def register_env(location):
             fh.write('\n')
     except EnvironmentError as e:
         if e.errno == EACCES:
-            log.warn("Unable to register environment. Path not writable.\n"
+            log.warning("Unable to register environment. Path not writable.\n"
                      "  environment location: %s\n"
                      "  registry file: %s", location, USER_ENVIRONMENTS_TXT_FILE)
         else:

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -810,7 +810,7 @@ def run_script(prefix, prec, action='post-link', env_prefix=None):
             raise LinkError(message)
         else:
             log.warning("%s script failed for package %s\n"
-                     "consider notifying the package maintainer", action, prec.dist_str())
+                "consider notifying the package maintainer", action, prec.dist_str())
             return False
     else:
         messages(prefix)

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -809,7 +809,7 @@ def run_script(prefix, prec, action='post-link', env_prefix=None):
                 """) % (action, prec.dist_str(), path, m or "<None>")
             raise LinkError(message)
         else:
-            log.warn("%s script failed for package %s\n"
+            log.warning("%s script failed for package %s\n"
                      "consider notifying the package maintainer", action, prec.dist_str())
             return False
     else:

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -441,7 +441,7 @@ def fetch_repodata_remote_request(url, etag, mod_stamp):
                     $ echo '{}' > noarch/repodata.json
                     $ bzip2 -k noarch/repodata.json
                     """) % maybe_unquote(dirname(url))
-                    stderrlog.warn(help_message)
+                    stderrlog.warning(help_message)
                     return None
                 else:
                     help_message = dals("""

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1003,7 +1003,7 @@ class ExceptionHandler(object):
                     message_builder.append(get_env_vars_str(error_report['conda_info']))
                     message_builder.append(get_main_info_str(error_report['conda_info']))
                 except Exception as e:
-                    log.warn("%r", e, exc_info=True)
+                    log.warning("%r", e, exc_info=True)
                     message_builder.append('conda info could not be constructed.')
                     message_builder.append('%r' % e)
             message_builder.append('')
@@ -1032,7 +1032,7 @@ class ExceptionHandler(object):
                     message_builder.append(get_env_vars_str(error_report['conda_info']))
                     message_builder.append(get_main_info_str(error_report['conda_info']))
                 except Exception as e:
-                    log.warn("%r", e, exc_info=True)
+                    log.warning("%r", e, exc_info=True)
                     message_builder.append('conda info could not be constructed.')
                     message_builder.append('%r' % e)
             message_builder.append('')

--- a/conda/gateways/disk/__init__.py
+++ b/conda/gateways/disk/__init__.py
@@ -46,7 +46,7 @@ def exp_backoff_fn(fn, *args, **kwargs):
                 # errno.ENOTEMPTY OSError(41, 'The directory is not empty')
                 raise
             else:
-                log.warn("Uncaught backoff with errno %s %d", errorcode[e.errno], e.errno)
+                log.warning("Uncaught backoff with errno %s %d", errorcode[e.errno], e.errno)
                 raise
         else:
             return result

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -176,7 +176,7 @@ def make_menu(prefix, file_path, remove=False):
     if not on_win:
         return
     elif basename(prefix).startswith('_'):
-        log.warn("Environment name starts with underscore '_'. Skipping menu installation.")
+        log.warning("Environment name starts with underscore '_'. Skipping menu installation.")
         return
 
     try:

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -36,7 +36,7 @@ def make_writable(path):
             log.debug("tried make writable but failed: %s\n%r", path, e)
             return False
         else:
-            log.warn("Error making path writable: %s\n%r", path, e)
+            log.warning("Error making path writable: %s\n%r", path, e)
             raise
 
 

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -155,6 +155,3 @@ def trace(self, message, *args, **kwargs):
 
 logging.addLevelName(TRACE, "TRACE")
 logging.Logger.trace = trace
-
-# suppress DeprecationWarning for warn method
-logging.Logger.warn = logging.Logger.warning

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -48,7 +48,7 @@ def touch(file_name, times=None):
         with open(file_name, 'a'):
             os.utime(file_name, times)
     except (OSError, IOError) as e:
-        log.warn("Failed to create lock, do not run conda in parallel processes [errno %d]",
+        log.warning("Failed to create lock, do not run conda in parallel processes [errno %d]",
                  e.errno)
 
 
@@ -122,7 +122,7 @@ class DirectoryLock(FileLock):  # lgtm [py/missing-call-to-init]
                 os.makedirs(self.directory_path)
                 log.debug("forced to create %s", self.directory_path)
             except (OSError, IOError) as e:
-                log.warn("Failed to create directory %s [errno %d]", self.directory_path, e.errno)
+                log.warning("Failed to create directory %s [errno %d]", self.directory_path, e.errno)
 
 
 Locked = DirectoryLock

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -380,7 +380,7 @@ class IntegrationTests(TestCase):
                 for string in content and content.split('\0') or ():
                     json.loads(string)
             except Exception as e:
-                log.warn(
+                log.warning(
                     "Problem parsing json output.\n"
                     "  content: %s\n"
                     "  string: %s\n"


### PR DESCRIPTION
`log.warn` has been [deprecated](https://docs.python.org/3/library/logging.html#logging.Logger.warning) since the 2.x series. Use `log.warning`
instead.