### PR TITLE
path_action.ReplacePrefixLinkAction: if always_copy is set, copy

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -408,8 +408,12 @@ class PrefixReplaceLinkAction(LinkPathAction):
         if not self._verified:
             self.verify()
         source_path = self.intermediate_path or self.source_full_path
-        log.trace("linking %s => %s", source_path, self.target_full_path)
-        create_link(source_path, self.target_full_path, LinkType.hardlink)
+        if context.always_copy:
+            log.trace("copying %s => %s", source_path, self.target_full_path)
+            create_link(source_path, self.target_full_path, LinkType.copy)
+        else:
+            log.trace("linking %s => %s", source_path, self.target_full_path)
+            create_link(source_path, self.target_full_path, LinkType.hardlink)
         self._execute_successful = True
 
 


### PR DESCRIPTION
  instead of creating a hard link

suggested solution for  #7253 
perhaps it is too naive, but at least this allows me to create functional environments. It relies on always_copy instead of making a test similar to determine_link_type for each file. I cannot judge the impact of this change.