### PR TITLE
Fix twofold tarball extraction, improve progress update

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -139,15 +139,16 @@ def extract_tarball(tarball_full_path, destination_directory=None, progress_upda
         with tarfile.open(fileobj=fileobj) as tar_file:
             def members_with_progress():
                 for member in tar_file:
-                    if progress_update_callback:
-                        rel_pos = fileobj.tell() / f_size
-                        progress_update_callback(rel_pos)
+                    rel_pos = fileobj.tell() / f_size
+                    progress_update_callback(rel_pos)
                     yield member
-                if progress_update_callback:
-                    progress_update_callback(1.0)
+                progress_update_callback(1.0)
 
             try:
-                tar_file.extractall(path=destination_directory, members=members_with_progress())
+                if progress_update_callback:
+                    tar_file.extractall(path=destination_directory, members=members_with_progress())
+                else:
+                    tar_file.extractall(path=destination_directory)
             except EnvironmentError as e:
                 if e.errno == ELOOP:
                     raise CaseInsensitiveFileSystemError(


### PR DESCRIPTION
Tarballs are index-less archives, thus a call of `tarfile.TarFile.getmembers()` usually extracts the whole file, such that `tar_file.getmembers() ; tar_file.extractall()` extracts the file twice.
Because of that, users see a "stall" on the progress output at `75 %` for big tarballs when the package extraction starts. That lead them to cancel (CTRL+C) the process. When they re-run that `conda` command the extraction happens silently without any progress indication, i.e., another perceived stall. (This was reported some weeks ago -- need to find that issue again...)

This PR fixes the first part, that is, avoid the twofold extraction and progress bar stall, but not the silent extraction for previously interrupted extractions.
The first commit retained the progress update on a tarball member basis. That fixes the stalled progress output for big packages like with `conda create -yntmp mkl`. But it still lacks progress updates if the files inside the tarball also have large file sizes. A good example for that is `conda create -yntmp bioconda::gatk4`. To fix that case, I just added a wrapper to the file object that updates the progress bar on each `fileobj.read()` call.