### PR TITLE
[WIP] Simple conda exec functionality

### DIFF
--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -42,6 +42,11 @@ conda() {
             activate|deactivate)
                 __conda_activate "$cmd" "$@"
                 ;;
+            exec)
+                \local env=$1
+                shift
+                _conda_activate "$env" && exec $@
+                ;;
             install|update|upgrade|remove|uninstall)
                 "$CONDA_EXE" "$cmd" "$@" && __conda_reactivate
                 ;;


### PR DESCRIPTION
This allows a user to do the following in any shell where the `conda` shell command is available:
```
conda exec <env_name> <command> <arg1> ... <argN>
```
[EDITED] It activates the named environment and then executes the command. It's an attempt to address #6820, at least in part.

The biggest problem with this as written is that it only works in a shell that has sourced the conda shell commands; so it doesn't work within a bash script or other non-login shell. To rectify this, we can create a `conda-exec` script as follows:
```
#!/bin/bash
. <prefix>/etc/profile.d/conda.sh
conda exec $@
```
(where `<prefix>` points to the sys.prefix of conda's environment.)