### PR TITLE
Fix MSYS2 path conversion in the face of bind mounts and /etc/fstab

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -89,7 +89,8 @@ def binpath_from_arg(arg, shell, going_to_shell=True):
     prefix = prefix_from_arg(arg, shell)
     # convert paths to shell-native paths
     if going_to_shell:
-        return [shelldict['path_to'](path) for path in _get_prefix_paths(prefix)]
+        return [shelldict['path_to'](path, root_prefix=prefix)
+                for path in _get_prefix_paths(prefix)]
     else:
         return [path for path in _get_prefix_paths(prefix)]
 

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -283,7 +283,17 @@ def win_path_to_unix(path, root_prefix=""):
         return ''
     cygpath = os.environ.get('CYGPATH', 'cygpath.exe')
     try:
-        path = subprocess.check_output([cygpath, '-up', path]).decode('ascii').split('\n')[0]
+        if root_prefix != "":
+            root_prefix = subprocess.check_output([cygpath,
+                                                   '-up',
+                                                   root_prefix]).decode('ascii').split('\n')[0]
+            if root_prefix.ends_wth('/'):
+                return root_prefix + path
+            else:
+                return root_prefix + '/' + path
+        else:
+            path = subprocess.check_output([cygpath, '-up', path]).decode('ascii').split('\n')[0]
+        print(path)
     except Exception as e:
         log.debug('%r' % e, exc_info=True)
         # Convert a path or ;-separated string of paths into a unix representation


### PR DESCRIPTION
There is a subtle issue that is caused by Cygwin/MSYS2's fstab where it
contains a bind mount /bin => /usr/bin. With cygpath in /Library/usr/bin
(translated to /usr/bin) this bind mount is translated to /bin and thus
/Library/usr/bin is shadowed by /usr/bin. To address this we translate
the prefix root and then just append the individual paths to the result
of that thus preventing any and all fstab-related short-circuiting