### PR TITLE
resolve #2682 add conda run experimental support

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from argparse import (ArgumentParser as ArgumentParserBase, RawDescriptionHelpFormatter, SUPPRESS,
-                      _CountAction, _HelpAction)
+                      _CountAction, _HelpAction, ZERO_OR_MORE, REMAINDER, ONE_OR_MORE)
 from logging import getLogger
 import os
 from os.path import abspath, expanduser, join
@@ -964,14 +964,20 @@ def configure_parser_run(sub_parsers):
     )
 
     add_parser_prefix(p)
-    add_parser_json(p)
-
     p.add_argument(
-        'executable_name',
-        action="store",
-        help="Executable name.",
+        "-v", "--verbose",
+        action=NullCountAction,
+        help="Use once for info, twice for debug, three times for trace.",
+        dest="verbosity",
+        default=NULL,
     )
 
+    p.add_argument(
+        'executable_call',
+        nargs=ONE_OR_MORE,
+        help="Executable name, with additional arguments to be passed to the executable "
+             "on invocation.",
+    )
     p.set_defaults(func='.main_run.execute')
 
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from argparse import (ArgumentParser as ArgumentParserBase, ONE_OR_MORE,
-                      RawDescriptionHelpFormatter, SUPPRESS, _CountAction, _HelpAction)
+from argparse import (ArgumentParser as ArgumentParserBase, REMAINDER, RawDescriptionHelpFormatter,
+                      SUPPRESS, _CountAction, _HelpAction)
 from logging import getLogger
 import os
 from os.path import abspath, expanduser, join
@@ -986,7 +986,7 @@ def configure_parser_run(sub_parsers):
 
     p.add_argument(
         'executable_call',
-        nargs=ONE_OR_MORE,
+        nargs=REMAINDER,
         help="Executable name, with additional arguments to be passed to the executable "
              "on invocation.",
     )

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -68,17 +68,17 @@ def _main(*args, **kwargs):
     if len(args) == 1:
         args = args + ('-h',)
 
-    try:
-        idx = args.index("--")
-    except ValueError:
-        extra_args = ()
-    else:
-        extra_args = args[idx+1:] if idx < len(args)-1 else ()
-        args = args[:idx]
-
     p = generate_parser()
-    args = p.parse_args(args[1:])
-    args.extra_args = extra_args
+    args, unknown_args = p.parse_known_args(args[1:])
+    if unknown_args:
+        if args.cmd == "run":
+            args.unknown_args = unknown_args
+        else:
+            from ..exceptions import ArgumentError
+            raise ArgumentError("Unknown arguments for command '%(command)s': %(unknown_args)s",
+                                command=args.cmd, unknown_args=unknown_args)
+    else:
+        args.unknown_args = []
 
     from ..base.context import context
     context.__init__(argparse_args=args)

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -69,16 +69,7 @@ def _main(*args, **kwargs):
         args = args + ('-h',)
 
     p = generate_parser()
-    args, unknown_args = p.parse_known_args(args[1:])
-    if unknown_args:
-        if args.cmd == "run":
-            args.unknown_args = unknown_args
-        else:
-            from ..exceptions import ArgumentError
-            raise ArgumentError("Unknown arguments for command '%(command)s': %(unknown_args)s",
-                                command=args.cmd, unknown_args=unknown_args)
-    else:
-        args.unknown_args = []
+    args = p.parse_args(args[1:])
 
     from ..base.context import context
     context.__init__(argparse_args=args)

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -36,8 +36,10 @@ def _get_activated_env_vars_win(env_location):
             tf.write(ensure_binary(
                 "@%CONDA_PYTHON_EXE% -c \"import os, json; print(json.dumps(dict(os.environ)))\""
             ))
+        # TODO: refactor into single function along with code in conda.core.link.run_script
         cmd_builder = [
-            "cmd.exe /K \"",
+            "%s" % os.getenv('COMSPEC', 'cmd.exe'),
+            "/C \"",
             "@SET PROMPT= ",
             "&&",
             "@SET CONDA_CHANGEPS1=false"
@@ -83,4 +85,4 @@ def _get_activated_env_vars_unix(env_location):
 def execute(args, parser):
     from .conda_argparse import _exec
     env_vars = get_activated_env_vars()
-    _exec(args.executable_call + args.unknown_args, env_vars)
+    _exec(args.executable_call, env_vars)

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -47,11 +47,16 @@ class LockError(CondaError):
 
 
 class ArgumentError(CondaError):
+    return_code = 2
+
     def __init__(self, message, **kwargs):
         super(ArgumentError, self).__init__(message, **kwargs)
 
 
 class CommandArgumentError(ArgumentError):
+    # TODO: Consolidate with ArgumentError.
+    return_code = 2
+
     def __init__(self, message, **kwargs):
         command = ' '.join(ensure_text_type(s) for s in sys.argv)
         super(CommandArgumentError, self).__init__(message, command=command, **kwargs)

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1362,8 +1362,8 @@ class ShellWrapperIntegrationTests(TestCase):
         assert 'venusaur' in PATH4
         assert PATH4 == PATH2
 
-    # @pytest.mark.xfail(on_win and datetime.now() < datetime(2018, 7, 1), strict=True,
-    #                    reason="Appveyor config changed. Need to debug.")
+    @pytest.mark.xfail(on_win and datetime.now() < datetime(2018, 7, 1), strict=True,
+                       reason="Appveyor config changed. Need to debug.")
     @pytest.mark.skipif(not which('bash'), reason='bash not installed')
     def test_bash_basic_integration(self):
         with InteractiveShell('bash') as shell:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1362,8 +1362,6 @@ class ShellWrapperIntegrationTests(TestCase):
         assert 'venusaur' in PATH4
         assert PATH4 == PATH2
 
-    @pytest.mark.xfail(on_win and datetime.now() < datetime(2018, 7, 1), strict=True,
-                       reason="Appveyor config changed. Need to debug.")
     @pytest.mark.skipif(not which('bash'), reason='bash not installed')
     def test_bash_basic_integration(self):
         with InteractiveShell('bash') as shell:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1304,7 +1304,7 @@ class ShellWrapperIntegrationTests(TestCase):
         shell.expect('3\.21\..*\n')
 
         # conda run integration test
-        shell.sendline('conda run sqlite3 -- -version')
+        shell.sendline('conda run sqlite3 -version')
         shell.expect('3\.21\..*\n')
 
         # regression test for #6840
@@ -1456,7 +1456,7 @@ class ShellWrapperIntegrationTests(TestCase):
             shell.expect('3\.21\..*\n')
 
             # conda run integration test
-            shell.sendline('conda run sqlite3 -- -version')
+            shell.sendline('conda run sqlite3 -version')
             shell.expect('3\.21\..*\n')
 
             shell.sendline('conda deactivate')


### PR DESCRIPTION
resolve #2682

Proof of concept code for `conda run`, implemented at the python level.  So far, only implemented on unix.  To test on unix

1. check out repo
2. `. dev/start`
3. `conda run python -- -V`
   Will show python version.
4. `mkdir -p "$CONDA_PREFIX/etc/conda/activate.d"`
   `echo "export TESTVAR=123456" > "$CONDA_PREFIX/etc/conda/activate.d/test.sh"`
   `conda run python -- -c "import os; print(os.environ['TESTVAR'])"`
   Will print `123456` to stdout.

I used the command `conda run` here instead of `conda exec` because we historically already "own" `conda run`, and I think there's already a `conda-exec` extension project that we would clobber.

This pretty much implements the old `conda run`, except we don't assume that users want to "run a package," but instead users know the name of the executable they want to run.

We may want to think of ways to extend the capabilities here.  For example,

    conda run /path/to/conda/environment/bin/python -- -V

should also maybe "just work" in addition to

    conda run -p /path/to/conda/environment python -- -V

Or maybe not.