### PR TITLE
Unnecessary verification even when safety checks are disabled

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -409,9 +409,10 @@ class PrefixReplaceLinkAction(LinkPathAction):
         self._verified = True
 
     def execute(self):
-        if not context.safety_checks == SafetyChecks.disabled:
-            if not self._verified:
-                self.verify()
+        if context.safety_checks == SafetyChecks.disabled:
+            self._verified = True
+        if not self._verified:
+            self.verify()
         source_path = self.intermediate_path or self.source_full_path
         log.trace("linking %s => %s", source_path, self.target_full_path)
         create_link(source_path, self.target_full_path, self.link_type)


### PR DESCRIPTION
The packages are verified even when safety checks are disabled , this increases the executing transaction time by a large amount. 