### PR TITLE
fix #7341: constrain tell() return value to [0,filesize]

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -132,6 +132,7 @@ class ProgressFileWrapper(object):
         self.progress_file = fileobj
         self.progress_update_callback = progress_update_callback
         self.progress_file_size = max(1, fstat(fileobj.fileno()).st_size)
+        self.progress_max_pos = 0
 
     def __getattr__(self, name):
         return getattr(self.progress_file, name)
@@ -148,7 +149,10 @@ class ProgressFileWrapper(object):
         return data
 
     def progress_update(self):
-        rel_pos = self.progress_file.tell() / self.progress_file_size
+        pos = max(self.progress_max_pos, self.progress_file.tell())
+        pos = min(pos, self.progress_file_size)
+        self.progress_max_pos = pos
+        rel_pos = pos / self.progress_file_size
         self.progress_update_callback(rel_pos)
 
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1089,7 +1089,7 @@ class ShellWrapperIntegrationTests(TestCase):
         shell.assert_env_var('CONDA_PREFIX', self.prefix, True)
 
         shell.sendline('conda install -yq sqlite openssl')  # TODO: this should be a relatively light package, but also one that has activate.d or deactivate.d scripts
-        shell.expect('Executing transaction: ...working... done.*\n', timeout=25)
+        shell.expect('Executing transaction: ...working... done.*\n', timeout=35)
         shell.assert_env_var('?', '0', True)
         # TODO: assert that reactivate worked correctly
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1187,11 +1187,10 @@ class IntegrationTests(TestCase):
                                          use_exception_handler=True)
             assert "not-a-real-package" in stderr
 
-    @pytest.mark.skipif(on_win, reason="gawk is a windows only package")
-    def test_search_gawk_not_win_1(self):
-        with make_temp_env() as prefix:
-            stdout, stderr = run_command(Commands.SEARCH, prefix, "gawk", "--json", use_exception_handler=True)
-            json_obj = json_loads(stdout.replace("Fetching package metadata ...", "").strip())
+            stdout, stderr = run_command(Commands.SEARCH, prefix, "not-a-real-package", "--json",
+                                         use_exception_handler=True)
+            assert not stderr
+            json_obj = json_loads(stdout.strip())
             assert json_obj['exception_name'] == 'PackagesNotFoundError'
             assert not len(json_obj.keys()) == 0
 


### PR DESCRIPTION
fix #7341

> I think that error being thrown essentially means that a `fileobj.tell()` (with `fileobj` being an `io.BufferedReader` created by `open(..., 'rb')`) can return negative values!? That's a really strange thing...
I'll submit a PR that constrains the values we use to
 ```python
0 <= v <= max(1, fstat(fileobj.fileno()).st_size)
```