### PR TITLE
fix windows test failures when symlink not available

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -102,7 +102,7 @@ conda_build_test: &conda_build_test
           eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
           conda info
           cd ~/conda-build
-          py.test --basetemp /tmp/cb -v --durations=20 -n 3 -m "not serial" tests -k "$CONDABUILD_SKIP"
+          py.test --basetemp /tmp/cb -v --durations=20 -n 2 -m "not serial" tests -k "$CONDABUILD_SKIP"
 
     - run:
         name: conda-build tests [serial]
@@ -145,11 +145,11 @@ jobs:
       - image: condatest/linux-64-python-2.7
     environment:
       - CONDA_INSTRUMENTATION_ENABLED: true
-  3.0 conda-build:
-    <<: *conda_build_test
-    environment:
-      - CONDA_BUILD: 3.0.21
-      - CONDA_INSTRUMENTATION_ENABLED: true
+#  3.0 conda-build:
+#    <<: *conda_build_test
+#    environment:
+#      - CONDA_BUILD: 3.0.21
+#      - CONDA_INSTRUMENTATION_ENABLED: true
   3.10 conda-build:
     <<: *conda_build_test
     environment:
@@ -165,6 +165,6 @@ workflows:
     jobs:
       - py36 main tests
       - py27 main tests
-      - 3.0 conda-build
+#      - 3.0 conda-build
       - 3.10 conda-build
       - flake8

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -28,6 +28,7 @@ from conda.gateways.disk.delete import rm_rf
 from conda.gateways.disk.link import islink, stat_nlink
 from conda.gateways.disk.permissions import is_executable
 from conda.gateways.disk.read import compute_md5sum, compute_sha256sum
+from conda.gateways.disk.test import softlink_supported
 from conda.gateways.disk.update import touch
 from conda.models.enums import LinkType, NoarchType, PathType
 from conda.models.records import PathDataV1
@@ -107,6 +108,9 @@ class PathActionsTests(TestCase):
         assert axns == ()
 
     def test_CompilePycAction_noarch_python(self):
+        if not softlink_supported(__file__, self.prefix) and on_win:
+            pytest.skip("softlink not supported")
+
         target_python_version = '%d.%d' % sys.version_info[:2]
         sp_dir = get_python_site_packages_short_path(target_python_version)
         transaction_context = {
@@ -261,6 +265,9 @@ class PathActionsTests(TestCase):
         assert not lexists(axn.target_full_path)
 
     def test_simple_LinkPathAction_softlink(self):
+        if not softlink_supported(__file__, self.prefix) and on_win:
+            pytest.skip("softlink not supported")
+
         source_full_path = make_test_file(self.pkgs_dir)
         target_short_path = source_short_path = basename(source_full_path)
 

--- a/tests/gateways/disk/test_delete.py
+++ b/tests/gateways/disk/test_delete.py
@@ -9,7 +9,7 @@ import pytest
 
 from conda.compat import TemporaryDirectory
 from conda.common.compat import on_win
-from conda.gateways.disk.create import create_link
+from conda.gateways.disk.create import create_link, mkdir_p
 from conda.gateways.disk.delete import move_to_trash, rm_rf
 from conda.gateways.disk.link import islink, symlink
 from conda.gateways.disk.test import softlink_supported
@@ -87,17 +87,20 @@ def test_remove_link_to_dir():
     with tempdir() as td:
         dst_link = join(td, "test_link")
         src_dir = join(td, "test_dir")
-        _write_file(src_dir, "welcome to the ministry of silly walks")
-        symlink(src_dir, dst_link)
+        mkdir_p(src_dir)
+        assert isdir(src_dir)
         assert not islink(src_dir)
+        assert not islink(dst_link)
+        symlink(src_dir, dst_link)
         assert islink(dst_link)
         assert rm_rf(dst_link)
         assert not isdir(dst_link)
         assert not islink(dst_link)
+        assert not lexists(dst_link)
+        assert isdir(src_dir)
         assert rm_rf(src_dir)
         assert not isdir(src_dir)
         assert not islink(src_dir)
-        assert not lexists(dst_link)
 
 
 def test_rm_rf_does_not_follow_symlinks():

--- a/tests/gateways/disk/test_delete.py
+++ b/tests/gateways/disk/test_delete.py
@@ -87,10 +87,15 @@ def test_remove_link_to_dir():
     with tempdir() as td:
         dst_link = join(td, "test_link")
         src_dir = join(td, "test_dir")
+        test_file = join(td, "test_file")
         mkdir_p(src_dir)
+        touch(test_file)
         assert isdir(src_dir)
         assert not islink(src_dir)
         assert not islink(dst_link)
+        if not softlink_supported(test_file, td) and on_win:
+            pytest.skip("softlink not supported")
+
         symlink(src_dir, dst_link)
         assert islink(dst_link)
         assert rm_rf(dst_link)

--- a/tests/gateways/disk/test_delete.py
+++ b/tests/gateways/disk/test_delete.py
@@ -8,9 +8,11 @@ from os.path import isdir, isfile, islink, join, lexists
 import pytest
 
 from conda.compat import TemporaryDirectory
+from conda.common.compat import on_win
 from conda.gateways.disk.create import create_link
 from conda.gateways.disk.delete import move_to_trash, rm_rf
 from conda.gateways.disk.link import islink, symlink
+from conda.gateways.disk.test import softlink_supported
 from conda.gateways.disk.update import touch
 from conda.models.enums import LinkType
 from .test_permissions import _make_read_only, _try_open, tempdir
@@ -66,6 +68,9 @@ def test_remove_link_to_file():
         dst_link = join(td, "test_link")
         src_file = join(td, "test_file")
         _write_file(src_file, "welcome to the ministry of silly walks")
+        if not softlink_supported(src_file, td) and on_win:
+            pytest.skip("softlink not supported")
+
         symlink(src_file, dst_link)
         assert isfile(src_file)
         assert not islink(src_file)
@@ -106,6 +111,9 @@ def test_rm_rf_does_not_follow_symlinks():
         os.makedirs(subdir)
         # link to the file in the subfolder
         link_path = join(subdir, 'file_link')
+        if not softlink_supported(real_file, tmp) and on_win:
+            pytest.skip("softlink not supported")
+
         create_link(real_file, link_path, link_type=LinkType.softlink)
         assert islink(link_path)
         # rm_rf the subfolder

--- a/tests/gateways/disk/test_link.py
+++ b/tests/gateways/disk/test_link.py
@@ -7,11 +7,13 @@ from tempfile import gettempdir
 from unittest import TestCase
 import uuid
 
-from conda.common.compat import on_win, PY2
+import pytest
 
+from conda.common.compat import on_win, PY2
 from conda.gateways.disk.create import mkdir_p
 from conda.gateways.disk.delete import rm_rf
 from conda.gateways.disk.link import link, islink, readlink, stat_nlink, symlink
+from conda.gateways.disk.test import softlink_supported
 from conda.gateways.disk.update import touch
 
 log = getLogger(__name__)
@@ -59,6 +61,10 @@ class LinkSymlinkUnlinkIslinkReadlinkTests(TestCase):
         touch(path1_real_file)
         assert isfile(path1_real_file)
         assert not islink(path1_real_file)
+
+        if not softlink_supported(path1_real_file, self.test_dir) and on_win:
+            pytest.skip("softlink not supported")
+
 
         symlink(path1_real_file, path2_symlink)
         assert exists(path2_symlink)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from conda.common.compat import on_win
+
 
 def test_exports():
     import conda.exports
@@ -12,7 +14,8 @@ def test_conda_subprocess():
     from subprocess import Popen, PIPE
     import conda
 
-    p = Popen(['echo', '"%s"' % conda.__version__], env=os.environ, stdout=PIPE, stderr=PIPE)
+    p = Popen(['echo', '"%s"' % conda.__version__], env=os.environ, stdout=PIPE, stderr=PIPE, 
+              shell=on_win)
     stdout, stderr = p.communicate()
     rc = p.returncode
     if rc != 0:


### PR DESCRIPTION
These failures went undiscovered for so long because apparently appveyor is configured with symlinks enabled by default.  The failures showed up in the Anaconda build system, where symlinks aren't enabled by default on Windows workers.