### PR TITLE
fix #5681 conda env create / update when --file does not exist

### DIFF
--- a/conda_env/specs/__init__.py
+++ b/conda_env/specs/__init__.py
@@ -2,10 +2,8 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Standard library imports
 import os
 
-# Local imports
 from .binstar import BinstarSpec
 from .notebook import NotebookSpec
 from .requirements import RequirementsSpec

--- a/conda_env/specs/__init__.py
+++ b/conda_env/specs/__init__.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+
+# Standard library imports
+import os
+
+# Local imports
 from .binstar import BinstarSpec
-from .yaml_file import YamlFileSpec
 from .notebook import NotebookSpec
 from .requirements import RequirementsSpec
-from ..exceptions import SpecNotFound
+from .yaml_file import YamlFileSpec
+from ..exceptions import EnvironmentFileNotFound, SpecNotFound
+
 
 all_specs = [
     BinstarSpec,
@@ -16,6 +22,12 @@ all_specs = [
 
 
 def detect(**kwargs):
+    # Check file existence if --file was provided
+    filename = kwargs.get('filename')
+    if filename and not os.path.isfile(filename):
+        raise EnvironmentFileNotFound(filename=filename)
+
+    # Check specifications
     specs = []
     for SpecClass in all_specs:
         spec = SpecClass(**kwargs)

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -16,7 +16,7 @@ from conda.core.envs_manager import list_all_known_prefixes
 from conda.exceptions import EnvironmentLocationNotFound
 from conda.install import rm_rf
 from conda_env.cli.main import create_parser, do_call as do_call_conda_env
-from conda_env.exceptions import SpecNotFound
+from conda_env.exceptions import SpecNotFound, EnvironmentFileNotFound
 from conda_env.yaml import load as yaml_load
 
 environment_1 = '''
@@ -149,7 +149,17 @@ class IntegrationTests(unittest.TestCase):
         try:
             run_env_command(Commands.ENV_CREATE, None)
         except Exception as e:
-            self.assertIsInstance(e, SpecNotFound)
+            self.assertIsInstance(e, EnvironmentFileNotFound)
+
+    def test_conda_env_create_no_existent_file(self):
+        '''
+        Test `conda env create --file=not_a_file.txt` with a file that does not
+        exist.
+        '''
+        try:
+            run_env_command(Commands.ENV_CREATE, None, '--file not_a_file.txt')
+        except Exception as e:
+            self.assertIsInstance(e, EnvironmentFileNotFound)
 
     def test_create_valid_env(self):
         '''
@@ -185,7 +195,7 @@ class IntegrationTests(unittest.TestCase):
         try:
             run_env_command(Commands.ENV_CREATE, test_env_name_1, "create")
         except Exception as e:
-            self.assertIsInstance(e, SpecNotFound, str(e))
+            self.assertIsInstance(e, EnvironmentFileNotFound, str(e))
 
 
 def env_is_created(env_name):

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -16,7 +16,7 @@ from conda.core.envs_manager import list_all_known_prefixes
 from conda.exceptions import EnvironmentLocationNotFound
 from conda.install import rm_rf
 from conda_env.cli.main import create_parser, do_call as do_call_conda_env
-from conda_env.exceptions import SpecNotFound, EnvironmentFileNotFound
+from conda_env.exceptions import EnvironmentFileNotFound
 from conda_env.yaml import load as yaml_load
 
 environment_1 = '''
@@ -40,9 +40,11 @@ test_env_name_1 = "env-1"
 test_env_name_2 = "snowflakes"
 test_env_name_3 = "env_foo"
 
+
 def escape_for_winpath(p):
     if p:
         return p.replace('\\', '\\\\')
+
 
 class Commands:
     ENV_CREATE = "create"
@@ -53,6 +55,7 @@ class Commands:
     CREATE = "create"
     INFO = "info"
     INSTALL = "install"
+
 
 def run_env_command(command, prefix, *arguments):
     """
@@ -174,8 +177,7 @@ class IntegrationTests(unittest.TestCase):
         o, e = run_conda_command(Commands.INFO, None, "--json")
         parsed = json.loads(o)
         self.assertNotEqual(
-            len([env for env in parsed['envs'] if env.endswith(test_env_name_1)]),
-            0
+            len([env for env in parsed['envs'] if env.endswith(test_env_name_1)]), 0
         )
 
     def test_update(self):
@@ -330,6 +332,7 @@ class NewIntegrationTests(unittest.TestCase):
         # check explicit that we have same file
         check2, e = run_conda_command(Commands.LIST, test_env_name_2, "--explicit")
         self.assertEqual(check1, check2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #5681 

```
$ conda env create -f does_not_exist.txt

EnvironmentFileNotFound: Conda Env Exception: /Users/gpena-castellanos/Continuum/conda/does_not_exist.txt file not found
```

```
$ conda env update -f does_not_exist.txt

EnvironmentFileNotFound: Conda Env Exception: /Users/gpena-castellanos/Continuum/conda/does_not_exist.txt file not found
```

```
$ conda env create

EnvironmentFileNotFound: Conda Env Exception: /Users/gpena-castellanos/Continuum/conda/environment.yml file not found
```