### PR TITLE
msys2 path conversion

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ init:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
-  - "%PYTHON_ROOT%\\Scripts\\conda install -y -c defaults -c conda-forge python=%PYTHON_VERSION% pycosat conda requests ruamel_yaml pytest pytest-cov pytest-timeout mock responses pexpect"
+  - "%PYTHON_ROOT%\\Scripts\\conda install -y -c defaults -c conda-forge python=%PYTHON_VERSION% pycosat conda requests ruamel_yaml pytest pytest-cov pytest-timeout mock responses pexpect pywin32"
   # conda install -y -c defaults -c conda-forge pytest pytest-cov pytest-timeout mock responses pexpect xonsh
   # TODO: add xonsh for PY3 builds
   - "%PYTHON_ROOT%\\Scripts\\pip install codecov==2.0.5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,6 @@ build: false
 
 test_script:
   - CALL dev-init.bat
-  - py.test %ADD_COV% -m "not integration and not installed" -v
-  - py.test %ADD_COV% --cov-append -m "integration and not installed" -v
+  - py.test %ADD_COV% --cov-append -m "integration and not installed" -vv -k test_bash_basic_integration
   - codecov --env PYTHON_VERSION --required
   - python -m conda.common.io

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ build: false
 
 test_script:
   - CALL dev-init.bat
-  - py.test %ADD_COV% --cov-append -m "integration and not installed" -vv -k test_bash_basic_integration
+  - py.test %ADD_COV% -m "not integration and not installed" -v
+  - py.test %ADD_COV% --cov-append -m "integration and not installed" -v
   - codecov --env PYTHON_VERSION --required
   - python -m conda.common.io

--- a/circle.yml
+++ b/circle.yml
@@ -102,7 +102,7 @@ conda_build_test: &conda_build_test
           eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
           conda info
           cd ~/conda-build
-          py.test --basetemp /tmp/cb -v --durations=20 -n 3 -m "not serial" tests -k "$CONDABUILD_SKIP"
+          py.test --basetemp /tmp/cb -v --durations=20 -n 2 -m "not serial" tests -k "$CONDABUILD_SKIP"
 
     - run:
         name: conda-build tests [serial]
@@ -145,11 +145,11 @@ jobs:
       - image: condatest/linux-64-python-2.7
     environment:
       - CONDA_INSTRUMENTATION_ENABLED: true
-  3.0 conda-build:
-    <<: *conda_build_test
-    environment:
-      - CONDA_BUILD: 3.0.21
-      - CONDA_INSTRUMENTATION_ENABLED: true
+#  3.0 conda-build:
+#    <<: *conda_build_test
+#    environment:
+#      - CONDA_BUILD: 3.0.21
+#      - CONDA_INSTRUMENTATION_ENABLED: true
   3.10 conda-build:
     <<: *conda_build_test
     environment:
@@ -165,6 +165,6 @@ workflows:
     jobs:
       - py36 main tests
       - py27 main tests
-      - 3.0 conda-build
+#      - 3.0 conda-build
       - 3.10 conda-build
       - flake8

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -605,10 +605,7 @@ class PosixActivator(_Activator):
 
     def _hook_preamble(self):
         if on_win:
-            return ('export CONDA_EXE="$(cygpath \'%s\')"\n'
-                    'export CONDA_BAT="%s"'
-                    % (context.conda_exe, join(context.conda_prefix, 'condacmd', 'conda.bat'))
-                    )
+            return 'export CONDA_EXE="$(cygpath \'%s\')"' % context.conda_exe
         else:
             return 'export CONDA_EXE="%s"' % context.conda_exe
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -605,7 +605,10 @@ class PosixActivator(_Activator):
 
     def _hook_preamble(self):
         if on_win:
-            return 'export CONDA_EXE="$(cygpath \'%s\')"' % context.conda_exe
+            return ('export CONDA_EXE="$(cygpath \'%s\')"\n'
+                    'export CONDA_BAT="%s"'
+                    % (context.conda_exe, join(context.conda_prefix, 'condacmd', 'conda.bat'))
+                    )
         else:
             return 'export CONDA_EXE="%s"' % context.conda_exe
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -211,7 +211,8 @@ class _Activator(object):
 
         if old_conda_shlvl == 0:
             new_path = self.pathsep_join(self._add_prefix_to_path(prefix))
-            conda_python_exe, conda_exe = self.path_conversion((sys.executable, context.conda_exe))
+            conda_python_exe = self.path_conversion(sys.executable)
+            conda_exe = self.path_conversion(context.conda_exe)
             export_vars = {
                 'CONDA_PYTHON_EXE': conda_python_exe,
                 'CONDA_EXE': conda_exe,
@@ -428,7 +429,8 @@ class _Activator(object):
         return self._replace_prefix_in_path(prefix, None, starting_path_dirs)
 
     def _replace_prefix_in_path(self, old_prefix, new_prefix, starting_path_dirs=None):
-        old_prefix, new_prefix = self.path_conversion((old_prefix, new_prefix))
+        old_prefix = self.path_conversion(old_prefix)
+        new_prefix = self.path_conversion(new_prefix)
         if starting_path_dirs is None:
             path_list = list(self.path_conversion(self._get_starting_path_list()))
         else:

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -560,7 +560,12 @@ def native_path_to_unix(paths):  # pragma: unix no cover
 
 
 def path_identity(paths):
-    return paths if isinstance(paths, string_types) else tuple(paths)
+    if isinstance(paths, string_types):
+        return paths
+    elif paths is None:
+        return None
+    else:
+        return tuple(paths)
 
 
 def paths_equal(path1, path2):

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -517,7 +517,7 @@ def native_path_to_unix(paths):  # pragma: unix no cover
     # on windows, uses cygpath to convert windows native paths to posix paths
     if not on_win:
         return path_identity(paths)
-    elif paths is None:
+    if paths is None:
         return None
     from subprocess import CalledProcessError, PIPE, Popen
     from shlex import split

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -163,6 +163,7 @@ class UpdateModifier(Enum):
     UPDATE_DEPS = 'update_deps'
     UPDATE_SPECS = 'update_specs'  # default
     UPDATE_ALL = 'update_all'
+    # TODO: add REINSTALL_ALL, see https://github.com/conda/conda/issues/6247 and https://github.com/conda/conda/issues/3149  # NOQA
 
     def __str__(self):
         return self.value

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from errno import ENOENT
 from logging import getLogger
 import os
-from os.path import (abspath, basename, expanduser, isdir, isfile, join, normpath,
-                     split as path_split)
+from os.path import abspath, basename, expanduser, isdir, isfile, join, split as path_split
 from platform import machine
 import sys
 
@@ -474,13 +473,13 @@ class Context(Configuration):
         if self._root_prefix:
             return abspath(expanduser(self._root_prefix))
         elif conda_in_private_env():
-            return normpath(join(self.conda_prefix, '..', '..'))
+            return abspath(join(self.conda_prefix, '..', '..'))
         else:
             return self.conda_prefix
 
     @property
     def conda_prefix(self):
-        return normpath(sys.prefix)
+        return abspath(sys.prefix)
 
     @property
     def conda_exe(self):
@@ -1057,7 +1056,7 @@ def locate_prefix_by_name(name, envs_dirs=None):
             continue
         prefix = join(envs_dir, name)
         if isdir(prefix):
-            return prefix
+            return abspath(prefix)
 
     from ..exceptions import EnvironmentNameNotFound
     raise EnvironmentNameNotFound(name)

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -942,10 +942,18 @@ def configure_parser_remove(sub_parsers, name='remove'):
 
 def configure_parser_run(sub_parsers):
     help = "Run an executable in a conda environment. [Experimental]"
-    descr = help
+    descr = help + dedent("""
+
+    Use '--' (double dash) to separate CLI flags for 'conda run' from CLI flags sent to
+    the process being launched.
+
+    Example usage:
+
+        $ conda create -y -n my-python-2-env python=2
+        $ conda run -n my-python-2-env python -- --version
+    """)
 
     epilog = dedent("""
-
     """)
 
     p = sub_parsers.add_parser(

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -65,30 +65,12 @@ def generate_parser():
     configure_parser_package(sub_parsers)
     configure_parser_remove(sub_parsers)
     configure_parser_remove(sub_parsers, name='uninstall')
+    configure_parser_run(sub_parsers)
     configure_parser_search(sub_parsers)
     configure_parser_update(sub_parsers)
     configure_parser_update(sub_parsers, name='upgrade')
 
     return p
-
-
-def generate_pip_parser():
-    p = ArgumentParser(
-        description='conda is a tool for managing and deploying applications,'
-                    ' environments and packages.',
-    )
-    p.add_argument(
-        '-V', '--version',
-        action='version',
-        version='conda %s' % __version__,
-        help="Show the conda version number and exit."
-    )
-    sub_parsers = p.add_subparsers(
-        metavar='command',
-        dest='cmd',
-    )
-    configure_parser_info(sub_parsers)
-    configure_parser_init(sub_parsers)
 
 
 def do_call(args, parser):
@@ -956,6 +938,33 @@ def configure_parser_remove(sub_parsers, name='remove'):
     )
 
     p.set_defaults(func='.main_remove.execute')
+
+
+def configure_parser_run(sub_parsers):
+    help = "Run an executable in a conda environment. [Experimental]"
+    descr = help
+
+    epilog = dedent("""
+
+    """)
+
+    p = sub_parsers.add_parser(
+        'run',
+        description=descr,
+        help=help,
+        epilog=epilog,
+    )
+
+    add_parser_prefix(p)
+    add_parser_json(p)
+
+    p.add_argument(
+        'executable_name',
+        action="store",
+        help="Executable name.",
+    )
+
+    p.set_defaults(func='.main_run.execute')
 
 
 def configure_parser_search(sub_parsers):

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -68,8 +68,17 @@ def _main(*args, **kwargs):
     if len(args) == 1:
         args = args + ('-h',)
 
+    try:
+        idx = args.index("--")
+    except ValueError:
+        extra_args = ()
+    else:
+        extra_args = args[idx+1:] if idx < len(args)-1 else ()
+        args = args[:idx]
+
     p = generate_parser()
     args = p.parse_args(args[1:])
+    args.extra_args = extra_args
 
     from ..base.context import context
     context.__init__(argparse_args=args)

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+import os
+from os.path import isfile, join
+
+from ..base.context import context
+from ..common.compat import on_win
+from ..gateways.subprocess import subprocess_call
+
+# OLD conda-run help
+"""
+$ python -m conda run --help
+usage: __main__.py run [-h] [-n ENVIRONMENT | -p PATH] [-q] [--json]
+                       [--offline]
+                       [COMMAND] [ARGUMENTS [ARGUMENTS ...]]
+
+Launches an application installed with conda.
+
+To include command line options in a command, separate the command from the
+other options with --, like
+
+    conda run -- ipython --matplotlib
+
+Options:
+
+positional arguments:
+  COMMAND               Package to launch.
+  ARGUMENTS             Additional arguments to application.
+
+optional arguments:
+  -h, --help            Show this help message and exit.
+  -n ENVIRONMENT, --name ENVIRONMENT
+                        Name of environment (in
+                        /Users/kfranz/continuum/conda/devenv/envs).
+  -p PATH, --prefix PATH
+                        Full path to environment prefix (default:
+                        /Users/kfranz/continuum/conda/devenv/envs/base).
+  -q, --quiet           Do not display progress bar.
+  --json                Report all output as json. Suitable for using conda
+                        programmatically.
+  --offline             Offline mode, don't connect to the Internet.
+
+Examples:
+
+    conda run ipython-notebook
+"""
+
+def get_activated_env_vars():
+    env_location = context.target_prefix
+    cmd_builder = []
+    if on_win:
+        conda_bat = os.environ["CONDA_BAT"]
+        # TODO: currently requires shell=True with Popen; fix
+        cmd_builder += [
+            "CALL \"{0}\" activate \"{1}\"".format(conda_bat, env_location),
+            "&&",
+            "%CONDA_PYTHON_EXE% -c \"import os, json; print(json.dumps(dict(os.environ)))\"",
+        ]
+    else:
+        conda_exe = os.environ["CONDA_EXE"]
+        cmd_builder += [
+            "sh -c \'"
+            "eval \"$(\"{0}\" shell.posix hook)\"".format(conda_exe),
+            "&&",
+            "conda activate {0}".format(env_location),
+            "&&",
+            "\"$CONDA_PYTHON_EXE\" -c \"import os, json; print(json.dumps(dict(os.environ)))\"",
+            "\'",
+        ]
+
+    cmd = " ".join(cmd_builder)
+
+    result = subprocess_call(cmd)
+    assert not result.stderr
+    env_var_map = json.loads(result.stdout)
+    return env_var_map
+
+
+def find_executable(executable_name):
+    if on_win:
+        executable_path = _find_executable_win(executable_name)
+    else:
+        executable_path = _find_executable_unix(executable_name)
+    if executable_path is None:
+        raise ExecutableNotFound()
+    return executable_path
+
+
+def _find_executable_win(executable_name):
+    from ..activate import _Activator
+    pathext = os.environ["PATHEXT"].split(';')
+    if executable_name.endswith(pathext):
+        for path_dir in _Activator._get_path_dirs(context.target_prefix):
+            executable_path = join(path_dir, executable_name)
+            if isfile(executable_path):
+                return executable_path
+    else:
+        for path_dir in _Activator._get_path_dirs(context.target_prefix):
+            for ext in pathext:
+                executable_path = join(path_dir, executable_name + ext)
+                if isfile(executable_path):
+                    return executable_path
+    return None
+
+
+def _find_executable_unix(executable_name):
+    executable_path = join(context.target_prefix, 'bin', executable_name)
+    if isfile(executable_path):  # TODO: add add is_executable()
+        return executable_path
+    return None
+
+
+def execute(args, parser):
+    executable_path = find_executable(args.executable_name)
+
+    env_var_map = {str(k): str(v) for k, v in get_activated_env_vars().items()}
+    extra_args = (executable_path,) + args.extra_args
+    os.execve(executable_path, extra_args, env_var_map)
+
+
+

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -6,101 +6,115 @@ import os
 from os.path import isfile, join
 from subprocess import Popen
 import sys
+from tempfile import NamedTemporaryFile
 
+from conda.exceptions import CommandNotFoundError
+from .. import CondaError
 from ..base.context import context
-from ..common.compat import on_win, iteritems
+from ..common.compat import ensure_binary, iteritems, on_win
+from ..gateways.disk.delete import rm_rf
 from ..gateways.subprocess import subprocess_call
 
-# OLD conda-run help
-"""
-$ python -m conda run --help
-usage: __main__.py run [-h] [-n ENVIRONMENT | -p PATH] [-q] [--json]
-                       [--offline]
-                       [COMMAND] [ARGUMENTS [ARGUMENTS ...]]
 
-Launches an application installed with conda.
+class ExecutableNotFound(CondaError):
 
-To include command line options in a command, separate the command from the
-other options with --, like
+    def __init__(self, target_prefix, executable_name):
+        message = ("The executable was not found in the target prefix.\n"
+                   "  target prefix: %(target_prefix)s\n"
+                   "  executable name: %(executable_name)s"
+                   )
+        super(ExecutableNotFound, self).__init__(message, target_prefix=target_prefix,
+                                                 executable_name=executable_name)
 
-    conda run -- ipython --matplotlib
 
-Options:
+def _get_activated_env_vars_win(env_location):
+    try:
+        conda_bat = os.environ["CONDA_BAT"]
+    except KeyError:
+        raise CommandNotFoundError("run")
 
-positional arguments:
-  COMMAND               Package to launch.
-  ARGUMENTS             Additional arguments to application.
+    temp_path = None
+    try:
+        with NamedTemporaryFile('w+b', suffix='.bat', delete=False) as tf:
+            temp_path = tf.name
+            tf.write(ensure_binary(
+                "@%CONDA_PYTHON_EXE% -c \"import os, json; print(json.dumps(dict(os.environ)))\""
+            ))
+        cmd_builder = [
+            "cmd.exe /K \"",
+            "@SET PROMPT= ",
+            "&&",
+            "@SET CONDA_CHANGEPS1=false"
+            "&&",
+            "@CALL {0} activate \"{1}\"".format(conda_bat, env_location),
+            "&&",
+            "\"{0}\"".format(tf.name),
+            "\"",
+        ]
+        cmd = " ".join(cmd_builder)
+        result = subprocess_call(cmd)
+    finally:
+        if temp_path:
+            rm_rf(temp_path)
 
-optional arguments:
-  -h, --help            Show this help message and exit.
-  -n ENVIRONMENT, --name ENVIRONMENT
-                        Name of environment (in
-                        /Users/kfranz/continuum/conda/devenv/envs).
-  -p PATH, --prefix PATH
-                        Full path to environment prefix (default:
-                        /Users/kfranz/continuum/conda/devenv/envs/base).
-  -q, --quiet           Do not display progress bar.
-  --json                Report all output as json. Suitable for using conda
-                        programmatically.
-  --offline             Offline mode, don't connect to the Internet.
+    assert not result.stderr, result.stderr
+    env_var_map = json.loads(result.stdout)
+    return env_var_map
 
-Examples:
 
-    conda run ipython-notebook
-"""
+def _get_activated_env_vars_unix(env_location):
+    try:
+        conda_exe = os.environ["CONDA_EXE"]
+    except KeyError:
+        raise CommandNotFoundError("run")
+
+    cmd_builder = [
+        "sh -c \'"
+        "eval \"$(\"{0}\" shell.posix hook)\"".format(conda_exe),
+        "&&",
+        "conda activate {0}".format(env_location),
+        "&&",
+        "\"$CONDA_PYTHON_EXE\" -c \"import os, json; print(json.dumps(dict(os.environ)))\"",
+        "\'",
+    ]
+    cmd = " ".join(cmd_builder)
+    result = subprocess_call(cmd)
+    assert not result.stderr, result.stderr
+    env_var_map = json.loads(result.stdout)
+    return env_var_map
+
 
 def get_activated_env_vars():
     env_location = context.target_prefix
-    cmd_builder = []
     if on_win:
-        conda_bat = os.environ["CONDA_BAT"]
-        # TODO: currently requires shell=True with Popen; fix
-        cmd_builder += [
-            "CALL \"{0}\" activate \"{1}\"".format(conda_bat, env_location),
-            "&&",
-            "%CONDA_PYTHON_EXE% -c \"import os, json; print(json.dumps(dict(os.environ)))\"",
-        ]
+        env_var_map = _get_activated_env_vars_win(env_location)
     else:
-        conda_exe = os.environ["CONDA_EXE"]
-        cmd_builder += [
-            "sh -c \'"
-            "eval \"$(\"{0}\" shell.posix hook)\"".format(conda_exe),
-            "&&",
-            "conda activate {0}".format(env_location),
-            "&&",
-            "\"$CONDA_PYTHON_EXE\" -c \"import os, json; print(json.dumps(dict(os.environ)))\"",
-            "\'",
-        ]
-
-    cmd = " ".join(cmd_builder)
-
-    result = subprocess_call(cmd)
-    assert not result.stderr
-    env_var_map = json.loads(result.stdout)
+        env_var_map = _get_activated_env_vars_unix(env_location)
     env_var_map = {str(k): str(v) for k, v in iteritems(env_var_map)}
     return env_var_map
 
 
 def find_executable(executable_name):
+    target_prefix = context.target_prefix
     if on_win:
-        executable_path = _find_executable_win(executable_name)
+        executable_path = _find_executable_win(target_prefix, executable_name)
     else:
-        executable_path = _find_executable_unix(executable_name)
+        executable_path = _find_executable_unix(target_prefix, executable_name)
     if executable_path is None:
-        raise ExecutableNotFound()
+        raise ExecutableNotFound(target_prefix, executable_name)
     return executable_path
 
 
-def _find_executable_win(executable_name):
+def _find_executable_win(target_prefix, executable_name):
     from ..activate import _Activator
     pathext = os.environ["PATHEXT"].split(';')
     if executable_name.endswith(pathext):
-        for path_dir in _Activator._get_path_dirs(context.target_prefix):
+        for path_dir in _Activator._get_path_dirs(target_prefix):
             executable_path = join(path_dir, executable_name)
             if isfile(executable_path):
                 return executable_path
     else:
-        for path_dir in _Activator._get_path_dirs(context.target_prefix):
+        for path_dir in _Activator._get_path_dirs(target_prefix):
             for ext in pathext:
                 executable_path = join(path_dir, executable_name + ext)
                 if isfile(executable_path):
@@ -108,8 +122,8 @@ def _find_executable_win(executable_name):
     return None
 
 
-def _find_executable_unix(executable_name):
-    executable_path = join(context.target_prefix, 'bin', executable_name)
+def _find_executable_unix(target_prefix, executable_name):
+    executable_path = join(target_prefix, 'bin', executable_name)
     if isfile(executable_path) and os.access(executable_path, os.X_OK):
         return executable_path
     return None
@@ -144,4 +158,5 @@ def execute(args, parser):
         _exec_unix(executable_path, args.extra_args, env_vars)
 
 
-
+if __name__ == "__main__":
+    print(get_activated_env_vars())

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -87,11 +87,7 @@ def _get_activated_env_vars_unix(env_location):
 def get_activated_env_vars():
     env_location = context.target_prefix
     if on_win:
-        in_posix_like_shell = os.getenv('TEMP', os.getenv('TMP', '')).startswith('/')
-        if in_posix_like_shell:
-            env_var_map = _get_activated_env_vars_unix(env_location)
-        else:
-            env_var_map = _get_activated_env_vars_win(env_location)
+        env_var_map = _get_activated_env_vars_win(env_location)
     else:
         env_var_map = _get_activated_env_vars_unix(env_location)
     env_var_map = {str(k): str(v) for k, v in iteritems(env_var_map)}

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -111,7 +111,7 @@ def find_executable(executable_name):
 
 def _find_executable_win(target_prefix, executable_name):
     from ..activate import _Activator
-    pathext = os.environ["PATHEXT"].split(';')
+    pathext = tuple(os.environ["PATHEXT"].split(';'))
     if executable_name.endswith(pathext):
         for path_dir in _Activator._get_path_dirs(target_prefix):
             executable_path = join(path_dir, executable_name)

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -87,7 +87,11 @@ def _get_activated_env_vars_unix(env_location):
 def get_activated_env_vars():
     env_location = context.target_prefix
     if on_win:
-        env_var_map = _get_activated_env_vars_win(env_location)
+        in_posix_like_shell = os.getenv('TEMP', os.getenv('TMP', '')).startswith('/')
+        if in_posix_like_shell:
+            env_var_map = _get_activated_env_vars_unix(env_location)
+        else:
+            env_var_map = _get_activated_env_vars_win(env_location)
     else:
         env_var_map = _get_activated_env_vars_unix(env_location)
     env_var_map = {str(k): str(v) for k, v in iteritems(env_var_map)}

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -8,10 +8,10 @@ from subprocess import Popen
 import sys
 from tempfile import NamedTemporaryFile
 
-from conda.exceptions import CommandNotFoundError
 from .. import CondaError
 from ..base.context import context
 from ..common.compat import ensure_binary, iteritems, on_win
+from ..exceptions import CommandNotFoundError
 from ..gateways.disk.delete import rm_rf
 from ..gateways.subprocess import subprocess_call
 
@@ -72,7 +72,7 @@ def _get_activated_env_vars_unix(env_location):
         "sh -c \'"
         "eval \"$(\"{0}\" shell.posix hook)\"".format(conda_exe),
         "&&",
-        "conda activate {0}".format(env_location),
+        "conda activate \"{0}\"".format(env_location),
         "&&",
         "\"$CONDA_PYTHON_EXE\" -c \"import os, json; print(json.dumps(dict(os.environ)))\"",
         "\'",

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from functools import reduce
 from logging import getLogger
 import os
-from os.path import abspath, basename, expanduser, expandvars, join, normpath, split, splitext, \
-    normcase
+from os.path import abspath, basename, expanduser, expandvars, join, normcase, split, splitext
 import re
 import subprocess
 

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from functools import reduce
 from logging import getLogger
 import os
-from os.path import abspath, basename, expanduser, expandvars, join, normpath, split, splitext
+from os.path import abspath, basename, expanduser, expandvars, join, normpath, split, splitext, \
+    normcase
 import re
 import subprocess
 
@@ -59,7 +60,10 @@ def paths_equal(path1, path2):
         True
 
     """
-    return normpath(abspath(path1)) == normpath(abspath(path2))
+    if on_win:
+        return normcase(abspath(path1)) == normcase(abspath(path2))
+    else:
+        return abspath(path1) == abspath(path2)
 
 
 @memoize

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -228,6 +228,7 @@ class CommandNotFoundError(CondaError):
         activate_commands = {
             'activate',
             'deactivate',
+            'run',
         }
         conda_commands = {
             'clean',

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -41,7 +41,7 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
     """This utility function should be preferred for all conda subprocessing.
     It handles multiple tricky details.
     """
-    env = {str(k): str(v) for k, v in iteritems(env if env else os.environ)}
+    env = {str(k): str(v) for k, v in iteritems(os.environ if env is None else env)}
     cwd = sys.prefix if path is None else abspath(path)
     command_str = command if isinstance(command, string_types) else ' '.join(command)
     command_arg = _split_on_unix(command) if isinstance(command, string_types) else command

--- a/conda/shell/condacmd/conda_hook.bat
+++ b/conda/shell/condacmd/conda_hook.bat
@@ -3,7 +3,7 @@
 @REM The file name is conda_hook.bat rather than conda-hook.bat because conda will see
 @REM the latter as a 'conda hook' command.
 
-@IF DEFINED CONDA_SHLVL GOTO :EOF
+@IF DEFINED CONDA_BAT GOTO :EOF
 
 @FOR %%F in ("%~dp0") do @SET __condacmd_dir=%%~dpF
 @SET "PATH=%__condacmd_dir%;%PATH%"
@@ -16,4 +16,5 @@
 
 @DOSKEY conda=%CONDA_BAT% $*
 
+@IF DEFINED CONDA_SHLVL GOTO :EOF
 @SET CONDA_SHLVL=0

--- a/conda/shell/condacmd/conda_hook.bat
+++ b/conda/shell/condacmd/conda_hook.bat
@@ -3,7 +3,7 @@
 @REM The file name is conda_hook.bat rather than conda-hook.bat because conda will see
 @REM the latter as a 'conda hook' command.
 
-@IF DEFINED CONDA_BAT GOTO :EOF
+@IF DEFINED CONDA_SHLVL GOTO :EOF
 
 @FOR %%F in ("%~dp0") do @SET __condacmd_dir=%%~dpF
 @SET "PATH=%__condacmd_dir%;%PATH%"
@@ -16,5 +16,4 @@
 
 @DOSKEY conda=%CONDA_BAT% $*
 
-@IF DEFINED CONDA_SHLVL GOTO :EOF
 @SET CONDA_SHLVL=0

--- a/conda/shell/etc/profile.d/conda.csh
+++ b/conda/shell/etc/profile.d/conda.csh
@@ -1,5 +1,5 @@
-# Copyright (C) 2012 Anaconda, Inc
-# SPDX-License-Identifier: BSD-3-Clause
+echo "Copyright (C) 2012 Anaconda, Inc" > /dev/null
+echo "SPDX-License-Identifier: BSD-3-Clause" > /dev/null
 
 if (! $?_CONDA_EXE) then
   set _CONDA_EXE="${PWD}/conda/shell/bin/conda"

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -332,10 +332,12 @@ class InitializeTests(TestCase):
             with open(target_path) as fh:
                 created_file_contents = fh.read()
 
-            first_line, remainder = created_file_contents.split('\n', 1)
             if on_win:
+                first_line, second_line, remainder = created_file_contents.split('\n', 2)
                 assert first_line == "export CONDA_EXE=\"$(cygpath '%s')\"" % context.conda_exe
+                assert second_line == "export CONDA_BAT=\"%s\"" % join(context.conda_prefix, 'condacmd', 'conda.bat')
             else:
+                first_line, remainder = created_file_contents.split('\n', 1)
                 assert first_line == 'export CONDA_EXE="%s"' % context.conda_exe
 
             with open(join(CONDA_PACKAGE_ROOT, 'shell', 'etc', 'profile.d', 'conda.sh')) as fh:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1363,8 +1363,6 @@ class ShellWrapperIntegrationTests(TestCase):
         assert 'venusaur' in PATH4
         assert PATH4 == PATH2
 
-    @pytest.mark.xfail(on_win and datetime.now() < datetime(2018, 7, 1), strict=True,
-                       reason="Appveyor config changed. Need to debug.")
     @pytest.mark.skipif(not which('bash'), reason='bash not installed')
     def test_bash_basic_integration(self):
         with InteractiveShell('bash') as shell:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1296,10 +1296,17 @@ class ShellWrapperIntegrationTests(TestCase):
         assert len(PATH0.split(':')) + num_paths_added == len(PATH2.split(':'))
         assert len(PATH0.split(':')) + num_paths_added == len(PATH3.split(':'))
 
-        shell.sendline('conda install -yq sqlite openssl')  # TODO: this should be a relatively light package, but also one that has activate.d or deactivate.d scripts
+        shell.sendline('conda install -yq sqlite=3.21 openssl')  # TODO: this should be a relatively light package, but also one that has activate.d or deactivate.d scripts
         shell.expect('Executing transaction: ...working... done.*\n', timeout=35)
         shell.assert_env_var('?', '0', True)
         # TODO: assert that reactivate worked correctly
+
+        shell.sendline('sqlite3 -version')
+        shell.expect('3\.21\..*\n')
+
+        # conda run integration test
+        shell.sendline('conda run sqlite3 -- -version')
+        shell.expect('3\.21\..*\n')
 
         # regression test for #6840
         shell.sendline('conda install --blah')
@@ -1441,10 +1448,17 @@ class ShellWrapperIntegrationTests(TestCase):
             shell.assert_env_var('CONDA_SHLVL', '2\r')
             shell.assert_env_var('CONDA_PREFIX', self.prefix, True)
 
-            shell.sendline('conda install -yq sqlite openssl')  # TODO: this should be a relatively light package, but also one that has activate.d or deactivate.d scripts
-            shell.expect('Executing transaction: ...working... done.*\n', timeout=25)
+            shell.sendline('conda install -yq sqlite=3.21 openssl')  # TODO: this should be a relatively light package, but also one that has activate.d or deactivate.d scripts
+            shell.expect('Executing transaction: ...working... done.*\n', timeout=35)
             shell.assert_env_var('errorlevel', '0', True)
             # TODO: assert that reactivate worked correctly
+
+            shell.sendline('sqlite3 -version')
+            shell.expect('3\.21\..*\n')
+
+            # conda run integration test
+            shell.sendline('conda run sqlite3 -- -version')
+            shell.expect('3\.21\..*\n')
 
             shell.sendline('conda deactivate')
             shell.assert_env_var('CONDA_SHLVL', '1\r')

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1362,6 +1362,8 @@ class ShellWrapperIntegrationTests(TestCase):
         assert 'venusaur' in PATH4
         assert PATH4 == PATH2
 
+    @pytest.mark.xfail(on_win and datetime.now() < datetime(2018, 7, 1), strict=True,
+                       reason="Appveyor config changed. Need to debug.")
     @pytest.mark.skipif(not which('bash'), reason='bash not installed')
     def test_bash_basic_integration(self):
         with InteractiveShell('bash') as shell:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1272,12 +1272,14 @@ class ShellWrapperIntegrationTests(TestCase):
         shell.assert_env_var('PS1', '(base).*')
         shell.assert_env_var('CONDA_SHLVL', '1')
         PATH1 = shell.get_env_var('PATH').strip(':')
+        assert len(PATH0.split(':')) + num_paths_added == len(PATH1.split(':'))
 
         shell.sendline('conda activate "%s"' % self.prefix)
         # shell.sendline('env | sort')
         shell.assert_env_var('CONDA_SHLVL', '2')
         shell.assert_env_var('CONDA_PREFIX', self.prefix, True)
         PATH2 = shell.get_env_var('PATH').strip(':')
+        assert len(PATH0.split(':')) + num_paths_added == len(PATH2.split(':'))
 
         shell.sendline('env | sort | grep CONDA')
         shell.expect('CONDA_')
@@ -1291,9 +1293,6 @@ class ShellWrapperIntegrationTests(TestCase):
         shell.assert_env_var('PS1', '(charizard).*')
         shell.assert_env_var('CONDA_SHLVL', '3')
         PATH3 = shell.get_env_var('PATH').strip(':')
-
-        assert len(PATH0.split(':')) + num_paths_added == len(PATH1.split(':'))
-        assert len(PATH0.split(':')) + num_paths_added == len(PATH2.split(':'))
         assert len(PATH0.split(':')) + num_paths_added == len(PATH3.split(':'))
 
         shell.sendline('conda install -yq sqlite=3.21 openssl')  # TODO: this should be a relatively light package, but also one that has activate.d or deactivate.d scripts

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1157,14 +1157,9 @@ class InteractiveShell(object):
 
         # remove all CONDA_ env vars
         env = os.environ.copy()
-        env = {str(k): str(v) for k, v in iteritems(env)}
         remove_these = {var_name for var_name in env if var_name.startswith('CONDA_')}
         for var_name in remove_these:
             del env[var_name]
-
-        p = PopenSpawn(self.shell_name, timeout=12, maxread=2000, searchwindowsize=None,
-                       logfile=sys.stdout, cwd=os.getcwd(), env=env, encoding=None,
-                       codec_errors='strict')
 
         # set state for context
         joiner = os.pathsep.join if self.shell_name == 'fish' else self.activator.pathsep_join
@@ -1173,13 +1168,18 @@ class InteractiveShell(object):
             self.activator._get_starting_path_list(),
         )))
         self.original_path = PATH
-        env = {
+        env.update({
             'CONDA_AUTO_ACTIVATE_BASE': 'false',
             'PYTHONPATH': CONDA_PACKAGE_ROOT,
             'PATH': PATH,
-        }
-        for name, val in env.items():
-            p.sendline(self.activator.export_var_tmpl % (name, val))
+        })
+        env = {str(k): str(v) for k, v in iteritems(env)}
+        # for name, val in env.items():
+        #     p.sendline(self.activator.export_var_tmpl % (name, val))
+
+        p = PopenSpawn(self.shell_name, timeout=12, maxread=2000, searchwindowsize=None,
+                       logfile=sys.stdout, cwd=os.getcwd(), env=env, encoding=None,
+                       codec_errors='strict')
 
         if self.init_command:
             p.sendline(self.init_command)

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1166,6 +1166,7 @@ class InteractiveShell(object):
         PATH = joiner(self.activator.path_conversion(concatv(
             (dirname(sys.executable),),
             self.activator._get_starting_path_list(),
+            (which(self.shell_name),),
         )))
         self.original_path = PATH
         env.update({
@@ -1174,8 +1175,6 @@ class InteractiveShell(object):
             'PATH': PATH,
         })
         env = {str(k): str(v) for k, v in iteritems(env)}
-        # for name, val in env.items():
-        #     p.sendline(self.activator.export_var_tmpl % (name, val))
 
         p = PopenSpawn(self.shell_name, timeout=12, maxread=2000, searchwindowsize=None,
                        logfile=sys.stdout, cwd=os.getcwd(), env=env, encoding=None,

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1123,9 +1123,9 @@ class InteractiveShell(object):
         },
         'cmd.exe': {
             'activator': 'cmd.exe',
-            'init_command': 'set CONDA_SHLVL= '
-                            '&& conda\\shell\\condacmd\\conda_hook.bat '
-                            '&& set CONDA_EXE="python -m conda"',
+            'init_command': 'set "CONDA_SHLVL=" '
+                            '&& @CALL conda\\shell\\condacmd\\conda_hook.bat '
+                            '&& set "CONDA_EXE=python -m conda"',
             'print_env_var': '@echo %%%s%%',
         },
         'csh': {


### PR DESCRIPTION
Per conversation with @mingwandroid, `cygpath "$(cygpath -w "$PATH")"` is not invariant.  See https://github.com/conda/conda/pull/7316 for additional context. This PR is only a partial fix. A full fix would require substantial hacks and additional logic in `conda.sh`.  It's my opinion at this time that suboptimal decisions made by upstream msys2 have lead to this situation (msys2 should have no `/bin`--just `/usr/bin`--and there'd be no bind mount for us to worry about here), and a full solution is ultimately incumbent on upstream.

NOTE: This PR needs to be rebased against master following merge of https://github.com/conda/conda/pull/7320. The functionality in this PR will most likely be back ported to conda 4.5.x.

The first commit of this PR is https://github.com/conda/conda/pull/7389/commits/4b9e0799012bfa1443ef12806d259c3ea1c72bf6.  If reviewing, start by looking only at that commit.