### PR TITLE
Fix #5885 improve conda env error messages and add extra tests

### DIFF
--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -23,6 +23,32 @@ except ImportError:  # pragma: no cover
     from conda._vendor.toolz.itertoolz import concatv, groupby  # NOQA
 
 
+VALID_KEYS = ('name', 'dependencies', 'prefix', 'channels')
+
+
+def validate_keys(data, kwargs):
+    """Check for unknown keys, remove them and print a warning."""
+    invalid_keys = []
+    new_data = data.copy()
+    for key in data.keys():
+        if key not in VALID_KEYS:
+            invalid_keys.append(key)
+            new_data.pop(key)
+
+    if invalid_keys:
+        filename = kwargs.get('filename')
+        verb = 'are' if len(invalid_keys) != 1 else 'is'
+        plural = 's' if len(invalid_keys) != 1 else ''
+        print("\nEnvironmentSectionNotValid: The following section{plural} on "
+              "'{filename}' {verb} invalid and will be ignored:"
+              "".format(filename=filename, plural=plural, verb=verb))
+        for key in invalid_keys:
+            print(' - {}'.format(key))
+        print('')
+
+    return new_data
+
+
 def load_from_directory(directory):
     """Load and return an ``Environment`` from a given ``directory``"""
     files = ['environment.yml', 'environment.yaml']
@@ -86,9 +112,12 @@ def from_environment(name, prefix, no_builds=False, ignore_channels=False):
 def from_yaml(yamlstr, **kwargs):
     """Load and return a ``Environment`` from a given ``yaml string``"""
     data = yaml_load_standard(yamlstr)
+    data = validate_keys(data, kwargs)
+
     if kwargs is not None:
         for key, value in kwargs.items():
             data[key] = value
+
     return Environment(**data)
 
 

--- a/conda_env/exceptions.py
+++ b/conda_env/exceptions.py
@@ -6,13 +6,13 @@ from conda import CondaError
 
 class CondaEnvException(CondaError):
     def __init__(self, message, *args, **kwargs):
-        msg = "Conda Env Exception: %s" % message
+        msg = "%s" % message
         super(CondaEnvException, self).__init__(msg, *args, **kwargs)
 
 
 class EnvironmentFileNotFound(CondaEnvException):
     def __init__(self, filename, *args, **kwargs):
-        msg = '{} file not found'.format(filename)
+        msg = "'{}' file not found".format(filename)
         self.filename = filename
         super(EnvironmentFileNotFound, self).__init__(msg, *args, **kwargs)
 

--- a/conda_env/exceptions.py
+++ b/conda_env/exceptions.py
@@ -17,6 +17,13 @@ class EnvironmentFileNotFound(CondaEnvException):
         super(EnvironmentFileNotFound, self).__init__(msg, *args, **kwargs)
 
 
+class EnvironmentFileExtensionNotValid(CondaEnvException):
+    def __init__(self, filename, *args, **kwargs):
+        msg = "'{}' file extension must be one of '.txt', '.yaml' or '.yml'".format(filename)
+        self.filename = filename
+        super(EnvironmentFileExtensionNotValid, self).__init__(msg, *args, **kwargs)
+
+
 class NoBinstar(CondaError):
     def __init__(self):
         msg = 'The anaconda-client cli must be installed to perform this action'

--- a/conda_env/specs/requirements.py
+++ b/conda_env/specs/requirements.py
@@ -12,6 +12,7 @@ class RequirementsSpec(object):
     and returns an Environment object from it.
     '''
     msg = None
+    extensions = set(['.txt',])
 
     def __init__(self, filename=None, name=None, **kwargs):
         self.filename = filename

--- a/conda_env/specs/requirements.py
+++ b/conda_env/specs/requirements.py
@@ -12,7 +12,7 @@ class RequirementsSpec(object):
     and returns an Environment object from it.
     '''
     msg = None
-    extensions = set(['.txt',])
+    extensions = set(['.txt', ])
 
     def __init__(self, filename=None, name=None, **kwargs):
         self.filename = filename

--- a/conda_env/specs/yaml_file.py
+++ b/conda_env/specs/yaml_file.py
@@ -7,6 +7,7 @@ from ..exceptions import EnvironmentFileNotFound
 
 class YamlFileSpec(object):
     _environment = None
+    extensions = set(('.yaml', '.yml'))
 
     def __init__(self, filename=None, **kwargs):
         self.filename = filename

--- a/tests/conda_env/support/invalid_keys.yml
+++ b/tests/conda_env/support/invalid_keys.yml
@@ -1,0 +1,6 @@
+names: nlp
+chanels:
+  - anaconda
+dependecies:
+  - nltk
+prefis: /something/miniconda/envs/test

--- a/tests/conda_env/support/valid_keys.yml
+++ b/tests/conda_env/support/valid_keys.yml
@@ -1,0 +1,6 @@
+name: nlp
+channels:
+  - anaconda
+dependencies:
+  - nltk
+prefix: /something/miniconda/envs/test

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -264,7 +264,7 @@ class NewIntegrationTests(unittest.TestCase):
 
         snowflake, e,  = run_env_command(Commands.ENV_EXPORT, test_env_name_2)
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix="yml", delete=False) as env_yaml:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as env_yaml:
             env_yaml.write(snowflake)
             env_yaml.flush()
             env_yaml.close()
@@ -292,7 +292,7 @@ class NewIntegrationTests(unittest.TestCase):
 
         snowflake, e = run_conda_command(Commands.LIST, test_env_name_2, "-e")
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix="txt", delete=False) as env_txt:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as env_txt:
             env_txt.write(snowflake)
             env_txt.flush()
             env_txt.close()
@@ -320,7 +320,7 @@ class NewIntegrationTests(unittest.TestCase):
 
         check1, e = run_conda_command(Commands.LIST, test_env_name_2, "--explicit")
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix="yml", delete=False) as env_yaml:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as env_yaml:
             env_yaml.write(snowflake)
             env_yaml.flush()
             env_yaml.close()

--- a/tests/conda_env/test_env.py
+++ b/tests/conda_env/test_env.py
@@ -25,8 +25,20 @@ class FakeStream(object):
         self.output += chunk.decode('utf-8')
 
 
+def get_environment(filename):
+    return env.from_file(support_file(filename))
+
+
 def get_simple_environment():
-    return env.from_file(support_file('simple.yml'))
+    return get_environment('simple.yml')
+
+
+def get_valid_keys_environment():
+    return get_environment('valid_keys.yml')
+
+
+def get_invalid_keys_environment():
+    return get_environment('invalid_keys.yml')
 
 
 class from_file_TestCase(unittest.TestCase):
@@ -214,6 +226,18 @@ class EnvironmentTestCase(unittest.TestCase):
         assert 'bar' not in e.dependencies['conda']
         e.dependencies.add('bar')
         assert 'bar' in e.dependencies['conda']
+
+    def test_valid_keys(self):
+        e = get_valid_keys_environment()
+        e_dict = e.to_dict()
+        for key in env.VALID_KEYS:
+            assert key in e_dict
+
+    def test_invalid_keys(self):
+        e = get_invalid_keys_environment()
+        e_dict = e.to_dict()
+        assert 'name' in e_dict
+        assert len(e_dict) == 1
 
 
 class DirectoryTestCase(unittest.TestCase):


### PR DESCRIPTION
fix #5885 

## Invalid filename 

```
$ conda env create -f asdadsasdasd

EnvironmentFileNotFound: '/Users/gpena-castellanos/Continuum/conda/asdadsasdasd' file not found
```

## Invalid keys

For a file environment.yml of contents
```yaml
name: ps-env3
dependecies:
  - python = 3.6
foo: bar
```

```

$ conda env create -f environment.yml

EnvironmentSectionNotValid: The following sections on '/Users/gpena-castellanos/Continuum/conda/environment.yml' are invalid and will be ignored:
 - dependecies
 - foo

#
# To activate this environment, use
#
#     $ conda activate ps-env3
#
# To deactivate an active environment, use
#
#     $ conda deactivate
```

## Invalid extensions

For a file environment.ymlaa
```
$ conda env create -f environment.ymlaa 

EnvironmentFileExtensionNotValid: '/Users/gpena-castellanos/Continuum/conda/environment.ymlaa' file extension must be one of '.txt', '.yaml' or '.yml'
```