### PR TITLE
Use cpNNN instead of NNN for PYTHONIOENCODING

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   # conda install -y -c defaults -c conda-forge pytest pytest-cov pytest-timeout mock responses pexpect xonsh
   # TODO: add xonsh for PY3 builds
   - "%PYTHON_ROOT%\\Scripts\\pip install codecov==2.0.5"
-  - "%PYTHON_ROOT%\\python -m conda init --dev"
+  - "%PYTHON_ROOT%\\python -m conda init --dev -v"
 
 build: false
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -723,7 +723,7 @@ class CmdExeActivator(_Activator):
         if on_win:
             import ctypes
             export_vars.update({
-                "PYTHONIOENCODING": "cp" + ctypes.cdll.kernel32.GetACP(),
+                "PYTHONIOENCODING": ("cp%s" % ctypes.cdll.kernel32.GetACP()),
             })
 
     def _hook_preamble(self):

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -723,7 +723,7 @@ class CmdExeActivator(_Activator):
         if on_win:
             import ctypes
             export_vars.update({
-                "PYTHONIOENCODING": ctypes.cdll.kernel32.GetACP(),
+                "PYTHONIOENCODING": "cp" + ctypes.cdll.kernel32.GetACP(),
             })
 
     def _hook_preamble(self):

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -37,7 +37,7 @@ log = getLogger(__name__)
 
 if on_win:
     import ctypes
-    PYTHONIOENCODING = ctypes.cdll.kernel32.GetACP()
+    PYTHONIOENCODING = "cp" + ctypes.cdll.kernel32.GetACP()
 else:
     PYTHONIOENCODING = None
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -37,7 +37,7 @@ log = getLogger(__name__)
 
 if on_win:
     import ctypes
-    PYTHONIOENCODING = "cp" + ctypes.cdll.kernel32.GetACP()
+    PYTHONIOENCODING = ("cp%s" % ctypes.cdll.kernel32.GetACP())
 else:
     PYTHONIOENCODING = None
 


### PR DESCRIPTION
Number only encoding is not same to cpNNN on all code pages.
Some people encounters "Unknown encoding: NNN" error because of this:

* https://bugs.python.org/issue33865
* https://stackoverflow.com/questions/43306103/error-in-anaconda-when-activate-env
* https://medium.com/@jatupornjirundorn/%E0%B9%80%E0%B8%A1%E0%B8%B7%E0%B9%88%E0%B8%AD%E0%B9%80%E0%B8%9B%E0%B8%B4%E0%B8%94-anaconda-prompt-%E0%B9%81%E0%B8%A5%E0%B9%89%E0%B8%A7%E0%B9%80%E0%B8%88%E0%B8%AD-err-%E0%B9%81%E0%B8%9A%E0%B8%9A%E0%B8%99%E0%B8%B5%E0%B9%89-fatal-python-error-py-initialize-cant-initialize-sys-1186db3b0bc9

"cpNNN" is right name for codepage encoding.

---

BTW, I don't know much about why this was needed.
I found [the issue](https://github.com/ContinuumIO/anaconda-issues/issues/1410) but I don't know why this is required to fix it.
Maybe, this was needed for only Python 2?
Python 3 is much better than Python 2 about unicode paths.
Especially, from 3.6, Python uses ConsoleIO which can print all unicode.
I think PYTHONIOENCODING shouldn't be used on Windows now, at least for Python 3.