### PR TITLE
Add conda version to conda-meta/history

### DIFF
--- a/conda/history.py
+++ b/conda/history.py
@@ -22,7 +22,7 @@ from .base.context import context
 from .common.compat import ensure_text_type, iteritems, open, text_type
 from .common.path import paths_equal
 from .core.prefix_data import PrefixData
-from .exceptions import CondaFileIOError, CondaHistoryError, CondaUpgradeError, NotWritableError
+from .exceptions import CondaHistoryError, CondaUpgradeError, NotWritableError
 from .gateways.disk.update import touch
 from .models.dist import dist_str_to_quad
 from .models.version import VersionOrder, version_relation_re
@@ -234,11 +234,13 @@ class History(object):
             item['unlink_dists'] = dists.get('-', ())
             item['link_dists'] = dists.get('+', ())
 
-        conda_versions_from_history = tuple(x['conda_version'] for x in res if 'conda_version' in x)
+        conda_versions_from_history = tuple(x['conda_version'] for x in res
+                                            if 'conda_version' in x)
         if conda_versions_from_history:
             minimum_conda_version = sorted(conda_versions_from_history, key=VersionOrder)[-1]
-            minimum_major_minor = '.'.join(minimum_conda_version.split('.')[:2])
-            if VersionOrder(CONDA_VERSION) < VersionOrder(minimum_major_minor):
+            minimum_major_minor = '.'.join(take(2, minimum_conda_version.split('.')))
+            current_major_minor = '.'.join(take(2, CONDA_VERSION.split('.')))
+            if VersionOrder(current_major_minor) < VersionOrder(minimum_major_minor):
                 message = dals("""
                 This environment has previously been operated on by a conda version that's newer
                 than the conda currently being used. A newer version of conda is required.

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,9 +1,14 @@
-from os.path import dirname
+from os.path import dirname, join, isfile
 from pprint import pprint
+from shutil import copy2
 import unittest
 
+import pytest
+
+from conda.exceptions import CondaUpgradeError
+from conda.gateways.disk import mkdir_p
 from .decorators import skip_if_no_mock
-from .helpers import mock
+from .helpers import mock, tempdir
 from .test_create import make_temp_prefix
 
 from conda.history import History
@@ -82,15 +87,10 @@ class UserRequestsTestCase(unittest.TestCase):
                           'link_dists': ['+pyflakes-1.0.0-py27_0'],
                           })
 
-    def test_conda_comment_version_parsin(self):
-        test_cases = [
-            "# conda version: 4.5.1",
-            "# conda version: 4.5.1rc1",
-            "# conda version: 4.5.1dev0",
-        ]
-        for line in test_cases:
-            item = History._parse_comment_line(line)
-            assert not item
+    def test_conda_comment_version_parsing(self):
+        assert History._parse_comment_line("# conda version: 4.5.1") == {"conda_version": "4.5.1"}
+        assert History._parse_comment_line("# conda version: 4.5.1rc1") == {"conda_version": "4.5.1rc1"}
+        assert History._parse_comment_line("# conda version: 4.5.1dev0") == {"conda_version": "4.5.1dev0"}
 
     def test_specs_line_parsing_44(self):
         # New format (>=4.4)
@@ -183,3 +183,25 @@ class UserRequestsTestCase(unittest.TestCase):
                 'pandas', '_license >=1.0.0,<2.0',
             ],
         }
+
+
+def test_minimum_conda_version_error():
+    with tempdir() as prefix:
+        assert not isfile(join(prefix, 'conda-meta', 'history'))
+        mkdir_p(join(prefix, 'conda-meta'))
+        copy2(join(dirname(__file__), 'conda-meta', 'history'),
+              join(prefix, 'conda-meta', 'history'))
+
+        with open(join(prefix, 'conda-meta', 'history'), 'a') as fh:
+            fh.write("==> 2018-07-09 11:18:09 <==\n")
+            fh.write("# cmd: blarg\n")
+            fh.write("# conda version: 42.42.4242\n")
+
+        h = History(prefix)
+
+        with pytest.raises(CondaUpgradeError) as exc:
+            h.get_user_requests()
+        exception_string = repr(exc.value)
+        print(exception_string)
+        assert "minimum conda version: 42.42" in exception_string
+        assert "$ conda install -p" in exception_string


### PR DESCRIPTION
Also raise CondaHistoryError if a newer (minor/major) version of conda is used
to modify an existing environment which was created by an older one