### PR TITLE
allow skipping feature maximization in resolver

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -209,6 +209,7 @@ class Context(Configuration):
     # ######################################################
     deps_modifier = PrimitiveParameter(DepsModifier.NOT_SET)
     update_modifier = PrimitiveParameter(UpdateModifier.UPDATE_SPECS)
+    featureless_minimization_feature_flag_enabled = PrimitiveParameter(True)
 
     # no_deps = PrimitiveParameter(NULL, element_type=(type(NULL), bool))  # CLI-only
     # only_deps = PrimitiveParameter(NULL, element_type=(type(NULL), bool))   # CLI-only
@@ -695,6 +696,7 @@ class Context(Configuration):
             # I don't think this documentation is correct any longer. # NOQA
             'target_prefix_override',
             # used to override prefix rewriting, for e.g. building docker containers or RPMs  # NOQA
+            'featureless_minimization_feature_flag_enabled',
         )),
     ))
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -855,9 +855,10 @@ class Resolve(object):
         # The previous "Track features" minimization pass has chosen 'feat1' for the
         # environment, but not 'feat2'. In this case, the 'feat2' version of foo is
         # considered "featureless."
-        eq_feature_metric = r2.generate_feature_metric(C)
-        solution, obj2 = C.minimize(eq_feature_metric, solution)
-        log.debug('Package misfeature count: %d', obj2)
+        if context.featureless_minimization_feature_flag_enabled is True:
+            eq_feature_metric = r2.generate_feature_metric(C)
+            solution, obj2 = C.minimize(eq_feature_metric, solution)
+            log.debug('Package misfeature count: %d', obj2)
 
         # Requested packages: maximize builds
         solution, obj4 = C.minimize(eq_req_b, solution)


### PR DESCRIPTION
conda repo (no testing yet) code to try to allow upgrading version > feature for when feature is mutex rather than feature-controlled. all code by @kalefranz 