### PR TITLE
Fix ci 4.5.x

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -77,7 +77,7 @@ conda_build_test: &conda_build_test
         name: checkout conda-build
         command: |
           cb_branch="${CONDA_BUILD:-master}"
-          git clone -b $cb_branch --depth 750 https://github.com/conda/conda-build.git ~/conda-build
+          git clone -b $cb_branch https://github.com/conda/conda-build.git ~/conda-build
           cd ~/conda-build
           sudo /opt/conda/bin/pip install --no-deps -U .
           git clone https://github.com/conda/conda_build_test_recipe.git ~/conda_build_test_recipe

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -741,6 +741,7 @@ class IntegrationTests(TestCase):
             assert_package_is_installed(prefix, 'mkl')
 
     @pytest.mark.skipif(on_win and context.bits == 32, reason="no 32-bit windows python on conda-forge")
+    @pytest.mark.skipif(on_win and datetime.now() <= datetime(2018, 9, 1), reason="conda-forge repodata needs vc patching")
     def test_dash_c_usage_replacing_python(self):
         # Regression test for #2606
         with make_temp_env("-c conda-forge python=3.5") as prefix:


### PR DESCRIPTION
The conda-build runs are broken because we released conda-verify 3.0.0 instead of conda-verify 3.0.2.