### PR TITLE
FIx autocompletion in fish

### DIFF
--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -97,7 +97,7 @@ function __fish_conda_env_commands
 end
 
 function __fish_conda_envs
-  conda config --show envs_dirs | awk 'NR > 1 {print $2}' | xargs -IX find X -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort
+  conda config --show envs_dirs | awk 'NR > 1 {print $2}' | xargs -IX find X -maxdepth 1 -mindepth 1 -type d | xargs basename | sort
 end
 
 function __fish_conda_packages


### PR DESCRIPTION
Fixes #7412.

The original code used `find -printf` which does not exist on Mac.
Replaced `printf` (which is is not posix) with `basename` and `xargs` to fix autocompletion in fish.

Thanks!