### PR TITLE
PrefixData: replace glob with fnmatch 4.5.x

### DIFF
--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from glob import glob
+import fnmatch
+from os import listdir
 from logging import getLogger
 from os.path import isfile, join, lexists
 
@@ -46,8 +47,10 @@ class PrefixData(object):
 
     def load(self):
         self.__prefix_records = {}
-        for meta_file in glob(join(self.prefix_path, 'conda-meta', '*.json')):
-            self._load_single_record(meta_file)
+        _conda_meta_dir = join(self.prefix_path, 'conda-meta')
+        if lexists(_conda_meta_dir):
+            for meta_file in fnmatch.filter(listdir(_conda_meta_dir), '*.json'):
+                self._load_single_record(join(_conda_meta_dir, meta_file))
 
     def reload(self):
         self.load()


### PR DESCRIPTION
Special characters like '[',']' in prefix path need to be escaped for the glob module, which is annoying. Use fnmatch instead, which is used by glob1 internally anyway.