### PR TITLE
Implement optional strict channel priority

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -174,6 +174,7 @@ class Context(Configuration):
                                         aliases=('channel_alias',),
                                         validation=channel_alias_validation)
     channel_priority = PrimitiveParameter(True)
+    strict_channel_priority = PrimitiveParameter(False)
     _channels = SequenceParameter(string_types, default=(DEFAULTS_CHANNEL_NAME,),
                                   aliases=('channels', 'channel',))  # channel for args.channel
     _custom_channels = MapParameter(string_types, DEFAULT_CUSTOM_CHANNELS,
@@ -716,6 +717,7 @@ class Context(Configuration):
             'aggressive_update_packages',
             'auto_update_conda',
             'channel_priority',
+            'strict_channel_priority',
             'create_default_packages',
             'disallowed_packages',
             'pinned_packages',
@@ -1045,6 +1047,13 @@ class Context(Configuration):
                 """),
             'show_channel_urls': dals("""
                 Show channel URLs when displaying what is going to be downloaded.
+                """),
+            'strict_channel_priority': dals("""
+                When True, packages in lower priority channels are not
+                considered if a package with the same name appears in a higher
+                priority channel. When False, packages from all channels are
+                considered by the solver.  The 'channel_priority' configuration
+                parameter is still applied in either case.
                 """),
             'ssl_verify': dals("""
                 Conda verifies SSL certificates for HTTPS requests, just like a web

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -262,15 +262,11 @@ def _apply_strict_channel_priority(index, channels):
 
     filtered_index = {}
     pkg_names = set()
-    for channel in channels:
-        if isinstance(channel, MultiChannel):
-            c_index = {}
-            for sub_channel in channel._channels:
-                name = Channel(sub_channel).name
-                c_index.update(by_channel[name])
-        else:
-            name = channel.name
-            c_index = by_channel[name]
+
+    channel_names = concat((Channel(cc).name for cc in c._channels)
+        if isinstance(c, MultiChannel) else (c.name, ) for c in channels)
+    for name in channel_names:
+        c_index = by_channel[name]
         # retain packages whose name is not in an higher priority channel
         to_add = {k: v for k, v in c_index.items() if k.name not in pkg_names}
         filtered_index.update(to_add)

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -584,7 +584,8 @@ class Solver(object):
 
             self.channels.update(additional_channels)
             reduced_index = get_reduced_index(self.prefix, self.channels,
-                                              self.subdirs, prepared_specs)
+                                              self.subdirs, prepared_specs,
+                                              context.strict_channel_priority)
             self._prepared_specs = prepared_specs
             self._index = reduced_index
             self._r = Resolve(reduced_index, channels=self.channels)


### PR DESCRIPTION
resolves #7656

Adds a new configuration option, "strict_channel_priority", which determines if packages in lower priority channel are to be considered by the solver if a package with the same name is present in a higher priority channel.  When set to False, the default, these packages are still considered which is consistent with the current behavior.  When True, these packages are not considered for installation.