### PR TITLE
common.compat: explicitly add Mapping, Sequence to module namespace

### DIFF
--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -60,6 +60,8 @@ elif PY2:  # pragma: py3 no cover
     from itertools import izip as zip, izip_longest as zip_longest
     JSONDecodeError = ValueError
 
+Mapping = Mapping
+Sequence = Sequence
 StringIO = StringIO
 zip = zip
 zip_longest = zip_longest


### PR DESCRIPTION
Follow up to gh-7675; just fixing a minor oversight.