### PR TITLE
30% performance improvement on resolve (4.5.x)

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -142,6 +142,13 @@ class Channel(object):
 
     @property
     def canonical_name(self):
+        try:
+            return self.__canonical_name
+        except AttributeError:
+            self.__canonical_name = self._compute_canonical_name()
+        return self.__canonical_name
+
+    def _compute_canonical_name(self):
         for multiname, channels in iteritems(context.custom_multichannels):
             for channel in channels:
                 if self.name == channel.name:

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -236,7 +236,11 @@ class PackageRef(BasePackageRef):
                 self.build_number, self.build)
 
     def __hash__(self):
-        return hash(self._pkey)
+        try:
+            return self._hash
+        except AttributeError:
+            self._hash = hash(self._pkey)
+        return self._hash
 
     def __eq__(self, other):
         return self._pkey == other._pkey


### PR DESCRIPTION
I took a quick stab at profiling conda with http://www.pyvmmonitor.com to improve on https://github.com/conda/conda/issues/7239 -- working on 4.5.x instead of master as it's the version I'm using and it should've a working release sooner ;)

For what I could see in the profile, it seems that 80% of the time is in the resolve.

The first really low hanging fruit is that `records.PackageRef.__hash__` is called tons of times, so, just memoizing the result gave a 25% improvement (in my use case from 15.09 seconds to 11.39 seconds).

Doing a profile after that has shown another problem in the `entity.box` -- I'm not really sure how to solve it, but the profiler shows almost 25% of the time is spent creating the entities structure in `prefix_data:133:load_single_record`... (given that there's such a big amount of time spent here it should probably use a lighter data structure for the solve, but given that such changes are controversial, I won't provide a pull request for that as this is better suited for someone with deeper understanding of the code as it should be a bigger change -- also, probably better suited to tackle on master and not on the 4.5.x branch).

Another quick grab was in `models.channel.Channel.canonical_name` which was almost 5% of the execution time (so, memoized that too).

I'm short on time to do more on this front right now, but I think a 30% improvement with those 2 changes is already worthwhile 😄 .