### PR TITLE
PackageRecord: cache __hash__ value

### DIFF
--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -252,7 +252,11 @@ class PackageRecord(DictSafeMixin, Entity):
             return __pkey
 
     def __hash__(self):
-        return hash(self._pkey)
+        try:
+            return self._hash
+        except AttributeError:
+            self._hash = hash(self._pkey)
+        return self._hash
 
     def __eq__(self, other):
         return self._pkey == other._pkey


### PR DESCRIPTION
gh-7689, courtesy of @fabioz, targeted at `master`.
For the test case given in https://github.com/conda/conda/pull/7689#issuecomment-416271341, this takes about `4%` (`8.6 s` vs. `9.0 s`) less overall time when excluding repodata download, i.e., setting `local_repodata_ttl` to some high value.