### PR TITLE
integration test updates targeted at 4.5.x

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -735,13 +735,17 @@ class IntegrationTests(TestCase):
             assert_package_is_installed(prefix, 'nomkl')
             assert not package_is_installed(prefix, 'mkl')
 
+            # A consequence of discontinuing use of the 'features' key and instead
+            # using direct dependencies is that removing the feature means that
+            # packages associated with the track_features base package are completely removed
+            # and not replaced with equivalent non-variant packages as before.
             run_command(Commands.REMOVE, prefix, '--features', 'nomkl')
-            assert_package_is_installed(prefix, 'numpy')
+            # assert assert_package_is_installed(prefix, 'numpy')  # removed per above comment
             assert not package_is_installed(prefix, 'nomkl')
-            assert_package_is_installed(prefix, 'mkl')
+            # assert_package_is_installed(prefix, 'mkl')  # removed per above comment
 
     @pytest.mark.skipif(on_win and context.bits == 32, reason="no 32-bit windows python on conda-forge")
-    @pytest.mark.skipif(on_win and datetime.now() <= datetime(2018, 9, 1), reason="conda-forge repodata needs vc patching")
+    @pytest.mark.skipif(on_win and datetime.now() <= datetime(2018, 10, 1), reason="conda-forge repodata needs vc patching")
     def test_dash_c_usage_replacing_python(self):
         # Regression test for #2606
         with make_temp_env("-c conda-forge python=3.5") as prefix:


### PR DESCRIPTION
> A consequence of discontinuing use of the 'features' key and instead
> using direct dependencies is that removing the feature means that
> packages associated with the track_features base package are completely removed
> and not replaced with equivalent non-variant packages as before.