### PR TITLE
strict channel priority via 'channel_priority' config option or --strict-channel-priority CLI flag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,13 @@ environment:
        PYTHON_VERSION: "3.6"
        PYTHON_ARCH: "64"
        PYTHON_ROOT: "C:\\Miniconda36-x64"
+       CONDA_INSTRUMENTATION_ENABLED: "true"
 
      - PYTHON: "C:\\Python27_32"
        PYTHON_VERSION: "2.7"
        PYTHON_ARCH: "32"
        PYTHON_ROOT: "C:\\Miniconda"
+       CONDA_INSTRUMENTATION_ENABLED: "true"
 
 init:
   - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %HOME%

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -189,7 +189,7 @@ class ChannelPriority(six_with_metaclass(ChannelPriorityMeta, Enum)):
     __name__ = "ChannelPriority"
 
     STRICT = 'strict'
-    STRICT_OR_FLEXIBLE = 'strict_or_flexible'
+    # STRICT_OR_FLEXIBLE = 'strict_or_flexible'  # TODO: consider implementing if needed
     FLEXIBLE = 'flexible'
     DISABLED = 'disabled'
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -10,10 +10,11 @@ from os.path import abspath, basename, expanduser, isdir, isfile, join, split as
 import platform
 import sys
 
-from .constants import (APP_NAME, DEFAULTS_CHANNEL_NAME, DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
-                        DEFAULT_CHANNELS, DEFAULT_CHANNEL_ALIAS, DEFAULT_CUSTOM_CHANNELS,
-                        DepsModifier, ERROR_UPLOAD_URL, PLATFORM_DIRECTORIES, PREFIX_MAGIC_FILE,
-                        PathConflict, ROOT_ENV_NAME, SEARCH_PATH, SafetyChecks, UpdateModifier)
+from .constants import (APP_NAME, ChannelPriority, DEFAULTS_CHANNEL_NAME,
+                        DEFAULT_AGGRESSIVE_UPDATE_PACKAGES, DEFAULT_CHANNELS,
+                        DEFAULT_CHANNEL_ALIAS, DEFAULT_CUSTOM_CHANNELS, DepsModifier,
+                        ERROR_UPLOAD_URL, PLATFORM_DIRECTORIES, PREFIX_MAGIC_FILE, PathConflict,
+                        ROOT_ENV_NAME, SEARCH_PATH, SafetyChecks, UpdateModifier)
 from .. import __version__ as CONDA_VERSION
 from .._vendor.appdirs import user_data_dir
 from .._vendor.auxlib.decorators import memoize, memoizedproperty
@@ -169,7 +170,7 @@ class Context(Configuration):
     _channel_alias = PrimitiveParameter(DEFAULT_CHANNEL_ALIAS,
                                         aliases=('channel_alias',),
                                         validation=channel_alias_validation)
-    channel_priority = PrimitiveParameter(True)
+    channel_priority = PrimitiveParameter(ChannelPriority.FLEXIBLE)
     _channels = SequenceParameter(string_types, default=(DEFAULTS_CHANNEL_NAME,),
                                   aliases=('channels', 'channel',))  # channel for args.channel
     _custom_channels = MapParameter(string_types, DEFAULT_CUSTOM_CHANNELS,

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -847,9 +847,15 @@ class Context(Configuration):
                 The prepended url location to associate with channel names.
                 """),
             'channel_priority': dals("""
-                When True, the solver is instructed to prefer channel order over package
-                version. When False, the solver is instructed to give package version
-                preference over channel priority.
+                Accepts values of 'strict', 'flexible', and 'disabled'. The default value
+                is 'flexible'. With strict channel priority packages in lower priority channels
+                are not considered if a package with the same name appears in a higher
+                priority channel. With flexible channel priority, the solver may reach into
+                lower priority channels to fulfill dependencies, rather than raising an
+                unsatisfiable error. With channel priority disabled, package version takes
+                precedence, and the configured priority of channels is used only to break ties.
+                In previous versions of conda, this parameter was configured as either True or 
+                False. True is now an alias to 'flexible'.
                 """),
             'channels': dals("""
                 The list of conda channels to include for relevant operations.

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -848,13 +848,13 @@ class Context(Configuration):
                 """),
             'channel_priority': dals("""
                 Accepts values of 'strict', 'flexible', and 'disabled'. The default value
-                is 'flexible'. With strict channel priority packages in lower priority channels
+                is 'flexible'. With strict channel priority, packages in lower priority channels
                 are not considered if a package with the same name appears in a higher
                 priority channel. With flexible channel priority, the solver may reach into
                 lower priority channels to fulfill dependencies, rather than raising an
                 unsatisfiable error. With channel priority disabled, package version takes
                 precedence, and the configured priority of channels is used only to break ties.
-                In previous versions of conda, this parameter was configured as either True or 
+                In previous versions of conda, this parameter was configured as either True or
                 False. True is now an alias to 'flexible'.
                 """),
             'channels': dals("""

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1372,6 +1372,15 @@ def add_parser_solver_mode(p):
     solver_mode_options = p.add_argument_group("Solver Mode Modifiers")
     deps_modifiers = solver_mode_options.add_mutually_exclusive_group()
     solver_mode_options.add_argument(
+        "--strict-channel-priority",
+        action="store_const",
+        dest="channel_priority",
+        default=NULL,
+        const="strict",
+        help="Packages in lower priority channels are not considered if a package "
+             "with the same name appears in a higher priority channel.",
+    )
+    solver_mode_options.add_argument(
         "--channel-priority",
         action="store_true",
         dest="channel_priority",
@@ -1380,9 +1389,10 @@ def add_parser_solver_mode(p):
     )
     solver_mode_options.add_argument(
         "--no-channel-priority",
-        action="store_false",
+        action="store_const",
         dest="channel_priority",
         default=NULL,
+        const="disabled",
         help="Package version takes precedence over channel priority. "
              "Overrides the value given by `conda config --show channel_priority`."
     )

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -257,7 +257,7 @@ def install(args, parser, command='install'):
             platform=None,
             use_local=index_args['use_local'],
         ))
-        raise PackagesNotFoundError(e.bad_deps, channels_urls)
+        raise PackagesNotFoundError(e._formatted_chains, channels_urls)
 
     except (UnsatisfiableError, SystemExit) as e:
         # Unsatisfiable package specifications/no such revision/import error

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -13,7 +13,8 @@ from textwrap import wrap
 from .. import CondaError
 from .._vendor.auxlib.entity import EntityEncoder
 from .._vendor.toolz import concat, groupby
-from ..base.constants import DepsModifier, PathConflict, SafetyChecks, UpdateModifier
+from ..base.constants import (ChannelPriority, DepsModifier, PathConflict, SafetyChecks,
+                              UpdateModifier)
 from ..base.context import context, sys_rc_path, user_rc_path
 from ..common.compat import Mapping, Sequence, isiterable, iteritems, itervalues, string_types
 from ..common.configuration import pretty_list, pretty_map
@@ -346,6 +347,7 @@ def execute_config(args, parser):
         yaml.representer.RoundTripRepresenter.add_representer(PathConflict, enum_representer)
         yaml.representer.RoundTripRepresenter.add_representer(DepsModifier, enum_representer)
         yaml.representer.RoundTripRepresenter.add_representer(UpdateModifier, enum_representer)
+        yaml.representer.RoundTripRepresenter.add_representer(ChannelPriority, enum_representer)
 
         try:
             with open(rc_path, 'w') as rc:

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -149,6 +149,21 @@ def with_metaclass(Type, skip_attrs=set(('__dict__', '__weakref__'))):
     return _clone_with_metaclass
 
 
+def six_with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, str('temporary_class'), (), {})
+
 
 NoneType = type(None)
 primitive_types = tuple(chain(string_types, integer_types, (float, complex, bool, NoneType)))

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -915,6 +915,10 @@ class UnlinkLinkTransaction(object):
                 updated_precs[namekey] = (unlink_prec, link_prec)
             elif (link_prec.channel.name == unlink_prec.channel.name
                     and link_prec.subdir == unlink_prec.subdir):
+                if link_prec == unlink_prec:
+                    # noarch: python packages are re-linked on a python version change
+                    # just leave them out of the package report
+                    continue
                 downgraded_precs[namekey] = (unlink_prec, link_prec)
             else:
                 superseded_precs[namekey] = (unlink_prec, link_prec)

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -18,7 +18,7 @@ from .._vendor.auxlib.decorators import memoizedproperty
 from .._vendor.auxlib.ish import dals
 from .._vendor.boltons.setutils import IndexedSet
 from .._vendor.toolz import concat, concatv, groupby
-from ..base.constants import ChannelPriority, DepsModifier, UNKNOWN_CHANNEL, UpdateModifier
+from ..base.constants import DepsModifier, UNKNOWN_CHANNEL, UpdateModifier
 from ..base.context import context
 from ..common.compat import iteritems, itervalues, odict, text_type
 from ..common.constants import NULL

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -440,8 +440,6 @@ class Solver(object):
             ssc.pinned_specs,
         ))
 
-        strict_channel_priority = context.channel_priority == ChannelPriority.STRICT
-
         # We've previously checked `solution` for consistency (which at that point was the
         # pre-solve state of the environment). Now we check our compiled set of
         # `final_environment_specs` for the possibility of a solution.  If there are conflicts,
@@ -453,8 +451,7 @@ class Solver(object):
         # get_conflicting_specs() returns a "minimal unsatisfiable subset" which
         # may not be the only unsatisfiable subset. We may have to call get_conflicting_specs()
         # several times, each time making modifications to loosen constraints.
-        conflicting_specs = ssc.r.get_conflicting_specs(tuple(final_environment_specs),
-                                                        strict_channel_priority)
+        conflicting_specs = ssc.r.get_conflicting_specs(tuple(final_environment_specs))
         while conflicting_specs:
             specs_modified = False
             if log.isEnabledFor(DEBUG):
@@ -489,8 +486,7 @@ class Solver(object):
         if log.isEnabledFor(DEBUG):
             log.debug("final specs to add: %s",
                       dashlist(sorted(text_type(s) for s in final_environment_specs)))
-        ssc.solution_precs = ssc.r.solve(tuple(final_environment_specs),
-                                         strict_channel_priority=strict_channel_priority)
+        ssc.solution_precs = ssc.r.solve(tuple(final_environment_specs))
 
         # add back inconsistent packages to solution
         if ssc.add_back_map:

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -31,8 +31,11 @@ log = getLogger(__name__)
 class ResolvePackageNotFound(CondaError):
     def __init__(self, bad_deps):
         # bad_deps is a list of lists
+        # bad_deps should really be named 'invalid_chains'
         self.bad_deps = tuple(dep for deps in bad_deps for dep in deps if dep)
-        message = '\n' + '\n'.join(('  - %s' % dep) for dep in self.bad_deps)
+        formatted_chains = tuple(" -> ".join(map(str, bad_chain)) for bad_chain in bad_deps)
+        self._formatted_chains = formatted_chains
+        message = '\n' + '\n'.join(('  - %s' % bad_chain) for bad_chain in formatted_chains)
         super(ResolvePackageNotFound, self).__init__(message)
 NoPackagesFound = NoPackagesFoundError = ResolvePackageNotFound  # NOQA
 

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -45,6 +45,9 @@ class NoarchField(EnumField):
 
 class TimestampField(NumberField):
 
+    def __init__(self):
+        super(TimestampField, self).__init__(default=0, required=False, default_in_dump=False)
+
     @staticmethod
     def _make_seconds(val):
         if val:
@@ -77,8 +80,8 @@ class TimestampField(NumberField):
         except AttributeError:
             try:
                 return int(dt_to_timestamp(isoparse(instance.date)))
-            except ValueError:
-                raise AttributeError()
+            except (AttributeError, ValueError):
+                return 0
 
 
 class Link(DictSafeMixin, Entity):
@@ -299,7 +302,7 @@ class PackageRecord(DictSafeMixin, Entity):
     def is_unmanageable(self):
         return self.package_type in PackageType.unmanageable_package_types()
 
-    timestamp = TimestampField(required=False)
+    timestamp = TimestampField()
 
     @property
     def combined_depends(self):

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import defaultdict
 from logging import DEBUG, getLogger
 
-from itertools import chain
-
 from ._vendor.toolz import concat, groupby
 from .base.constants import ChannelPriority, MAX_CHANNEL_PRIORITY
 from .base.context import context
@@ -100,8 +98,8 @@ class Resolve(object):
             return v_ms_(spec) if isinstance(spec, MatchSpec) else v_fkey_(spec)
 
         def v_ms_(ms):
-            return ((optional and ms.optional) or
-                    any(v_fkey_(fkey) for fkey in self.find_matches(ms)))
+            return (optional and ms.optional
+                    or any(v_fkey_(fkey) for fkey in self.find_matches(ms)))
 
         def v_fkey_(prec):
             val = filter.get(prec)
@@ -324,7 +322,6 @@ class Resolve(object):
         snames = set()
         top_level_spec = None
 
-        cp_map = self._channel_priorities_map
         cp_filter_applied = set()  # values are package names
 
         def filter_group(_specs):
@@ -471,7 +468,7 @@ class Resolve(object):
             candidate_precs = self.groups.get(spec_name, ())
         elif spec.get_exact_value('track_features'):
             feature_names = spec.get_exact_value('track_features')
-            candidate_precs = chain.from_iterable(
+            candidate_precs = concat(
                 self.trackers.get(feature_name, ()) for feature_name in feature_names
             )
         else:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -305,9 +305,11 @@ class Resolve(object):
         return channel_name
 
     @time_recorder(module_name=__name__)
-    def get_reduced_index(self, specs, strict_channel_priority=False):
+    def get_reduced_index(self, specs):
         # TODO: fix this import; this is bad
         from .core.subdir_data import make_feature_record
+
+        strict_channel_priority = context.channel_priority == ChannelPriority.STRICT
 
         cache_key = strict_channel_priority, frozenset(specs)
         if cache_key in self._reduced_index_cache:
@@ -418,7 +420,7 @@ class Resolve(object):
                 # Messaging to users should be more descriptive.
                 # 1. Are there no direct matches?
                 # 2. Are there no matches for first-level dependencies?
-                # 3. Have the first level depedendencies been invalidated?
+                # 3. Have the first level dependencies been invalidated?
                 break
 
         # Determine all valid packages in the dependency graph
@@ -758,10 +760,10 @@ class Resolve(object):
         solution = C.sat(constraints)
         return bool(solution)
 
-    def get_conflicting_specs(self, specs, strict_channel_priority=False):
+    def get_conflicting_specs(self, specs):
         if not specs:
             return ()
-        reduced_index = self.get_reduced_index(specs, strict_channel_priority)
+        reduced_index = self.get_reduced_index(specs)
 
         # Check if satisfiable
         def mysat(specs, add_if=False):
@@ -911,7 +913,7 @@ class Resolve(object):
         return pkgs
 
     @time_recorder(module_name=__name__)
-    def solve(self, specs, returnall=False, _remove=False, strict_channel_priority=False):
+    def solve(self, specs, returnall=False, _remove=False):
         # type: (List[str], bool) -> List[PackageRecord]
         if log.isEnabledFor(DEBUG):
             log.debug('Solving for: %s', dashlist(sorted(text_type(s) for s in specs)))
@@ -919,7 +921,7 @@ class Resolve(object):
         # Find the compliant packages
         len0 = len(specs)
         specs = tuple(map(MatchSpec, specs))
-        reduced_index = self.get_reduced_index(specs, strict_channel_priority)
+        reduced_index = self.get_reduced_index(specs)
         if not reduced_index:
             return False if reduced_index is None else ([[]] if returnall else [])
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -4,11 +4,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import defaultdict
-from itertools import chain
 from logging import DEBUG, getLogger
 
+from itertools import chain
+
 from ._vendor.toolz import concat, groupby
-from .base.constants import MAX_CHANNEL_PRIORITY
+from .base.constants import ChannelPriority, MAX_CHANNEL_PRIORITY
 from .base.context import context
 from .common.compat import iteritems, iterkeys, itervalues, odict, on_win, text_type
 from .common.io import time_recorder
@@ -59,10 +60,11 @@ class Resolve(object):
         self._cached_find_matches = {}  # Dict[MatchSpec, Set[PackageRecord]]
         self.ms_depends_ = {}  # Dict[PackageRecord, List[MatchSpec]]
         self._reduced_index_cache = {}
+        self._strict_channel_cache = {}
 
         if sort:
-            for name, group in iteritems(groups):
-                groups[name] = sorted(group, key=self.version_key, reverse=True)
+            for group in itervalues(groups):
+                group.sort(key=self.version_key, reverse=True)
 
     def default_filter(self, features=None, filter=None):
         # TODO: fix this import; this is bad
@@ -294,12 +296,22 @@ class Resolve(object):
 
         raise UnsatisfiableError(bad_deps)
 
+    def _get_strict_channel(self, package_name):
+        try:
+            channel_name = self._strict_channel_cache[package_name]
+        except KeyError:
+            all_channel_names = set(prec.channel.name for prec in self.groups[package_name])
+            by_cp = {self._channel_priorities_map.get(cn, 1): cn for cn in all_channel_names}
+            highest_priority = sorted(by_cp)[0]  # highest priority is the lowest number
+            channel_name = self._strict_channel_cache[package_name] = by_cp[highest_priority]
+        return channel_name
+
     @time_recorder(module_name=__name__)
-    def get_reduced_index(self, specs):
+    def get_reduced_index(self, specs, strict_channel_priority=False):
         # TODO: fix this import; this is bad
         from .core.subdir_data import make_feature_record
 
-        cache_key = frozenset(specs)
+        cache_key = strict_channel_priority, frozenset(specs)
         if cache_key in self._reduced_index_cache:
             return self._reduced_index_cache[cache_key]
 
@@ -312,10 +324,21 @@ class Resolve(object):
         snames = set()
         top_level_spec = None
 
+        cp_map = self._channel_priorities_map
+        cp_filter_applied = set()  # values are package names
+
         def filter_group(_specs):
             # all _specs should be for the same package name
             name = next(iter(_specs)).name
             group = self.groups.get(name, ())
+
+            # implement strict channel priority
+            if strict_channel_priority and name not in cp_filter_applied:
+                sole_source_channel_name = self._get_strict_channel(name)
+                for prec in group:
+                    if prec.channel.name != sole_source_channel_name:
+                        filter_out[prec] = "removed due to strict channel priority"
+                cp_filter_applied.add(name)
 
             # Prune packages that don't match any of the patterns
             # or which have unsatisfiable dependencies
@@ -412,6 +435,12 @@ class Resolve(object):
                 prec for prec in self.find_matches(this_spec)
                 if prec not in reduced_index2 and self.valid2(prec, filter_out)
             )
+            if strict_channel_priority and add_these_precs2:
+                strict_chanel_name = self._get_strict_channel(add_these_precs2[0].name)
+                add_these_precs2 = tuple(
+                    prec for prec in add_these_precs2 if prec.channel.name == strict_chanel_name
+                )
+
             reduced_index2.update((prec, prec) for prec in add_these_precs2)
             # We do not pull packages into the reduced index due
             # to a track_features dependency. Remember, a feature
@@ -469,7 +498,7 @@ class Resolve(object):
         build_number = prec.get('build_number', 0)
         build_string = prec.get('build')
         ts = prec.get('timestamp', 0)
-        if context.channel_priority:
+        if context.channel_priority != ChannelPriority.DISABLED:
             return valid, -channel_priority, version_comparator, build_number, ts, build_string
         else:
             return valid, version_comparator, -channel_priority, build_number, ts, build_string
@@ -732,10 +761,10 @@ class Resolve(object):
         solution = C.sat(constraints)
         return bool(solution)
 
-    def get_conflicting_specs(self, specs):
+    def get_conflicting_specs(self, specs, strict_channel_priority=False):
         if not specs:
             return ()
-        reduced_index = self.get_reduced_index(specs)
+        reduced_index = self.get_reduced_index(specs, strict_channel_priority)
 
         # Check if satisfiable
         def mysat(specs, add_if=False):
@@ -885,7 +914,7 @@ class Resolve(object):
         return pkgs
 
     @time_recorder(module_name=__name__)
-    def solve(self, specs, returnall=False, _remove=False):
+    def solve(self, specs, returnall=False, _remove=False, strict_channel_priority=False):
         # type: (List[str], bool) -> List[PackageRecord]
         if log.isEnabledFor(DEBUG):
             log.debug('Solving for: %s', dashlist(sorted(text_type(s) for s in specs)))
@@ -893,7 +922,7 @@ class Resolve(object):
         # Find the compliant packages
         len0 = len(specs)
         specs = tuple(map(MatchSpec, specs))
-        reduced_index = self.get_reduced_index(specs)
+        reduced_index = self.get_reduced_index(specs, strict_channel_priority)
         if not reduced_index:
             return False if reduced_index is None else ([[]] if returnall else [])
 

--- a/tests/base/test_constants.py
+++ b/tests/base/test_constants.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from conda.base.constants import ChannelPriority
 from conda.common.constants import NULL
 from logging import getLogger
 
@@ -9,3 +10,10 @@ log = getLogger(__name__)
 
 def test_null_is_falsey():
     assert not NULL
+
+
+def test_ChannelPriority():
+    assert ChannelPriority("strict") == ChannelPriority.STRICT
+    assert ChannelPriority["STRICT"] == ChannelPriority.STRICT
+    assert ChannelPriority(False) == ChannelPriority.DISABLED
+    assert ChannelPriority('false') == ChannelPriority.DISABLED

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -12,7 +12,7 @@ import pytest
 from conda._vendor.auxlib.collection import AttrDict
 from conda._vendor.auxlib.ish import dals
 from conda._vendor.toolz.itertoolz import concat
-from conda.base.constants import PathConflict
+from conda.base.constants import PathConflict, ChannelPriority
 from conda.base.context import context, reset_context
 from conda.common.compat import odict, iteritems
 from conda.common.configuration import ValidationError, YamlRawParameter
@@ -61,6 +61,7 @@ class ContextCustomRcTests(TestCase):
           ftps: false
           rsync: 'false'
         aggressive_update_packages: []
+        channel_priority: false
         """)
         reset_context()
         rd = odict(testdata=YamlRawParameter.make_raw_parameters('testdata', yaml_load(string)))
@@ -254,6 +255,9 @@ class ContextCustomRcTests(TestCase):
         specs = ['certifi', 'openssl>=1.1']
         with env_var('CONDA_AGGRESSIVE_UPDATE_PACKAGES', ','.join(specs), reset_context):
             assert context.aggressive_update_packages == tuple(MatchSpec(s) for s in specs)
+
+    def test_channel_priority(self):
+        assert context.channel_priority == ChannelPriority.DISABLED
 
 
 class ContextDefaultRcTests(TestCase):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -565,13 +565,6 @@ class IntegrationTests(TestCase):
             assert stderr == ''
             self.assertIsInstance(stdout, str)
 
-    def test_anaconda_solve_time(self):
-        stdout, stderr = run_command(Commands.CREATE, "/", "-qd anaconda",
-                                     use_exception_handler=True)
-        assert not stderr
-        assert "The following NEW packages will be INSTALLED:" in stdout
-        assert "Dry run. Exiting." in stdout
-
     @pytest.mark.skipif(on_win and context.subdir == "win-32", reason="conda-forge doesn't do win-32")
     def test_strict_channel_priority(self):
         stdout, stderr = run_command(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -565,6 +565,14 @@ class IntegrationTests(TestCase):
             assert stderr == ''
             self.assertIsInstance(stdout, str)
 
+    def test_anaconda_solve_time(self):
+        stdout, stderr = run_command(Commands.CREATE, "/", "-qd anaconda",
+                                     use_exception_handler=True)
+        assert not stderr
+        assert "The following NEW packages will be INSTALLED:" in stdout
+        assert "Dry run. Exiting." in stdout
+
+    @pytest.mark.skipif(on_win and context.subdir == "win-32", reason="conda-forge doesn't do win-32")
     def test_strict_channel_priority(self):
         stdout, stderr = run_command(
             Commands.CREATE, "/",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -569,13 +569,14 @@ class IntegrationTests(TestCase):
         with env_var("CONDA_CHANNEL_PRIORITY", "strict", reset_context):
             stdout, stderr = run_command(
                 Commands.CREATE, "/",
-                "-c conda-forge -c defaults python=3.6 geopandas --dry-run --json",
+                "-c conda-forge -c defaults python=3.6 fiona --strict-channel-priority --dry-run --json",
                 use_exception_handler=True
             )
             assert not stderr
             json_obj = json_loads(stdout)
-            channels = set(dist["channel"] for dist in json_obj["actions"]["LINK"])
-            assert channels == {"conda-forge"}
+            channel_groups = groupby("channel",json_obj["actions"]["LINK"])
+            # conda-forge should be the only channel in the solution on unix
+            assert list(channel_groups) == ["conda-forge"]
 
     def test_strict_resolve_get_reduced_index(self):
         channels = (Channel("defaults"),)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1355,7 +1355,7 @@ def test_channel_priority_2():
 
     # setting strict actually doesn't do anything here; just ensures it's not 'disabled'
     with env_var("CONDA_CHANNEL_PRIORITY", "strict", reset_context):
-        dists = this_r.get_reduced_index(spec, strict_channel_priority=True)
+        dists = this_r.get_reduced_index(spec)
         r2 = Resolve(dists, True, True, channels=channels)
         C = r2.gen_clauses()
         eqc, eqv, eqb, eqt = r2.generate_version_metrics(C, list(r2.groups.keys()))

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -5,6 +5,8 @@ from os.path import isdir, join
 from pprint import pprint
 import unittest
 
+import pytest
+
 from conda.base.context import context, reset_context
 from conda.common.compat import iteritems, itervalues
 from conda.common.io import env_var
@@ -14,8 +16,6 @@ from conda.models.channel import Channel
 from conda.models.enums import PackageType
 from conda.models.records import PackageRecord
 from conda.resolve import MatchSpec, Resolve, ResolvePackageNotFound
-import pytest
-
 from .helpers import TEST_DATA_DIR, get_index_r_1, get_index_r_4, raises
 
 index, r, = get_index_r_1()
@@ -1338,6 +1338,33 @@ def test_channel_priority_2():
         installed_w_priority = [prec.dist_str() for prec in this_r.install(spec)]
         pprint(installed_w_priority)
         assert installed_w_priority == [
+            'channel-1::dateutil-2.1-py27_1',
+            'channel-1::numpy-1.7.1-py27_0',
+            'channel-1::openssl-1.0.1c-0',
+            'channel-1::pandas-0.11.0-np17py27_1',
+            'channel-1::python-2.7.5-0',
+            'channel-1::pytz-2013b-py27_0',
+            'channel-1::readline-6.2-0',
+            'channel-1::scipy-0.12.0-np17py27_0',
+            'channel-1::six-1.3.0-py27_0',
+            'channel-1::sqlite-3.7.13-0',
+            'channel-1::system-5.8-1',
+            'channel-1::tk-8.5.13-0',
+            'channel-1::zlib-1.2.7-0',
+        ]
+
+    # setting strict actually doesn't do anything here; just ensures it's not 'disabled'
+    with env_var("CONDA_CHANNEL_PRIORITY", "strict", reset_context):
+        dists = this_r.get_reduced_index(spec, strict_channel_priority=True)
+        r2 = Resolve(dists, True, True, channels=channels)
+        C = r2.gen_clauses()
+        eqc, eqv, eqb, eqt = r2.generate_version_metrics(C, list(r2.groups.keys()))
+        eqc = {key: value for key, value in iteritems(eqc)}
+        pprint(eqc)
+        assert eqc == {}
+        installed_w_strict = [prec.dist_str() for prec in this_r.install(spec)]
+        pprint(installed_w_strict)
+        assert installed_w_strict == [
             'channel-1::dateutil-2.1-py27_1',
             'channel-1::numpy-1.7.1-py27_0',
             'channel-1::openssl-1.0.1c-0',


### PR DESCRIPTION
resolves #7656 
supersedes #7660

```
$ conda config --describe channel_priority
# # channel_priority (ChannelPriority)
# #   Accepts values of 'strict', 'flexible', and 'disabled'. The default
# #   value is 'flexible'. With strict channel priority packages in lower
# #   priority channels are not considered if a package with the same name
# #   appears in a higher priority channel. With flexible channel priority,
# #   the solver may reach into lower priority channels to fulfill
# #   dependencies, rather than raising an unsatisfiable error. With channel
# #   priority disabled, package version takes precedence, and the
# #   configured priority of channels is used only to break ties. In
# #   previous versions of conda, this parameter was configured as either
# #   True or  False. True is now an alias to 'flexible'.
# #
# channel_priority: flexible
```