### PR TITLE
(WIP) Add zstandard support

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -101,7 +101,8 @@ DEFAULT_AGGRESSIVE_UPDATE_PACKAGES = (
 # Maximum priority, reserved for packages we really want to remove
 MAX_CHANNEL_PRIORITY = 10000
 
-CONDA_TARBALL_EXTENSION = '.tar.bz2'
+CONDA_TARBALL_EXTENSIONS = ('.tar.bz2',)
+# CONDA_TARBALL_EXTENSIONS = ('.tar.zst', '.tar.bz2')
 
 UNKNOWN_CHANNEL = "<unknown>"
 

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -14,7 +14,7 @@ from . import common
 from .common import check_non_admin
 from .. import CondaError
 from .._vendor.auxlib.ish import dals
-from ..base.constants import ROOT_ENV_NAME
+from ..base.constants import CONDA_TARBALL_EXTENSIONS, ROOT_ENV_NAME
 from ..base.context import context, locate_prefix_by_name
 from ..common.compat import on_win, text_type
 from ..core.index import calculate_channel_urls, get_index
@@ -167,7 +167,7 @@ def install(args, parser, command='install'):
         'use_local': args.use_local
     }
 
-    num_cp = sum(s.endswith('.tar.bz2') for s in args_packages)
+    num_cp = sum(s.endswith(CONDA_TARBALL_EXTENSIONS) for s in args_packages)
     if num_cp:
         if num_cp == len(args_packages):
             explicit(args_packages, prefix, verbose=not context.quiet)

--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -12,6 +12,7 @@ from .path import split_filename
 from .._vendor.auxlib.decorators import memoize
 from .._vendor.urllib3.exceptions import LocationParseError
 from .._vendor.urllib3.util.url import Url, parse_url
+from ..base.constants import CONDA_TARBALL_EXTENSIONS
 
 try:  # pragma: py2 no cover
     # Python 3
@@ -189,6 +190,11 @@ def split_anaconda_token(url):
     return cleaned_url.rstrip('/'), token
 
 
+def rreplace(s, old, new, occurrence):
+    li = s.rsplit(old, occurrence)
+    return new.join(li)
+
+
 def split_platform(url, known_subdirs):
     """
 
@@ -201,7 +207,7 @@ def split_platform(url, known_subdirs):
     _platform_match_regex = r'/(%s)/?' % r'|'.join(r'%s' % d for d in known_subdirs)
     _platform_match = re.search(_platform_match_regex, url, re.IGNORECASE)
     platform = _platform_match.groups()[0] if _platform_match else None
-    cleaned_url = url.replace('/' + platform, '', 1) if platform is not None else url
+    cleaned_url = rreplace(url, '/' + platform, '', 1) if platform is not None else url
     return cleaned_url.rstrip('/'), platform
 
 
@@ -214,7 +220,7 @@ def has_platform(url, known_subdirs):
 
 
 def _split_package_filename(url):
-    cleaned_url, package_filename = (url.rsplit('/', 1) if url.endswith(('.tar.bz2', '.json'))
+    cleaned_url, package_filename = (url.rsplit('/', 1) if url.endswith((CONDA_TARBALL_EXTENSIONS + ('.json',)))
                                      else (url, None))
     return cleaned_url, package_filename
 

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -13,7 +13,7 @@ from conda._vendor.auxlib.decorators import memoizemethod
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler
 from .._vendor.auxlib.collection import first
-from ..base.constants import CONDA_TARBALL_EXTENSION, PACKAGE_CACHE_MAGIC_FILE
+from ..base.constants import CONDA_TARBALL_EXTENSIONS, PACKAGE_CACHE_MAGIC_FILE
 from ..base.context import context
 from ..common.compat import (JSONDecodeError, iteritems, itervalues, odict, string_types,
                              text_type, with_metaclass)
@@ -88,7 +88,7 @@ class PackageCacheData(object):
             if islink(full_path):
                 continue
             elif (isdir(full_path) and isfile(join(full_path, 'info', 'index.json'))
-                  or isfile(full_path) and full_path.endswith(CONDA_TARBALL_EXTENSION)):
+                  or isfile(full_path) and full_path.endswith(CONDA_TARBALL_EXTENSIONS)):
                 package_cache_record = self._make_single_record(base_name)
                 if package_cache_record:
                     _package_cache_records[package_cache_record] = package_cache_record
@@ -269,12 +269,12 @@ class PackageCacheData(object):
         return "%s(%s)" % (self.__class__.__name__, ', '.join(args))
 
     def _make_single_record(self, package_filename):
-        if not package_filename.endswith(CONDA_TARBALL_EXTENSION):
-            package_filename += CONDA_TARBALL_EXTENSION
+        if not package_filename.endswith(CONDA_TARBALL_EXTENSIONS):
+            package_filename += CONDA_TARBALL_EXTENSIONS[0]
 
         package_tarball_full_path = join(self.pkgs_dir, package_filename)
         log.trace("adding to package cache %s", package_tarball_full_path)
-        extracted_package_dir = package_tarball_full_path[:-len(CONDA_TARBALL_EXTENSION)]
+        extracted_package_dir = package_tarball_full_path[:-len(CONDA_TARBALL_EXTENSIONS[0])]
 
         # try reading info/repodata_record.json
         try:
@@ -385,7 +385,7 @@ class PackageCacheData(object):
         contents = []
 
         def _process(x, y):
-            if x + CONDA_TARBALL_EXTENSION != y:
+            if x + CONDA_TARBALL_EXTENSIONS[0] != y:
                 contents.append(x)
             return y
 
@@ -425,8 +425,8 @@ class UrlsData(object):
         # package path can be a full path or just a basename
         #   can be either an extracted directory or tarball
         package_path = basename(package_path)
-        if not package_path.endswith(CONDA_TARBALL_EXTENSION):
-            package_path += CONDA_TARBALL_EXTENSION
+        if not package_path.endswith(CONDA_TARBALL_EXTENSIONS):
+            package_path += CONDA_TARBALL_EXTENSIONS[0]
         return first(self, lambda url: basename(url) == package_path)
 
 
@@ -500,7 +500,7 @@ class ProgressiveFetchExtract(object):
                 md5sum=md5,
                 expected_size_in_bytes=expected_size_in_bytes,
             )
-            trgt_extracted_dirname = pcrec_from_read_only_cache.fn[:-len(CONDA_TARBALL_EXTENSION)]
+            trgt_extracted_dirname = pcrec_from_read_only_cache.fn[:-len(CONDA_TARBALL_EXTENSIONS[0])]
             extract_axn = ExtractPackageAction(
                 source_full_path=cache_axn.target_full_path,
                 target_pkgs_dir=first_writable_cache.pkgs_dir,
@@ -528,7 +528,7 @@ class ProgressiveFetchExtract(object):
         extract_axn = ExtractPackageAction(
             source_full_path=cache_axn.target_full_path,
             target_pkgs_dir=first_writable_cache.pkgs_dir,
-            target_extracted_dirname=pref_or_spec.fn[:-len(CONDA_TARBALL_EXTENSION)],
+            target_extracted_dirname=pref_or_spec.fn[:-len(CONDA_TARBALL_EXTENSIONS[0])],
             record_or_spec=pref_or_spec,
             md5sum=md5,
         )

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -13,7 +13,7 @@ from .portability import _PaddingError, update_prefix
 from .prefix_data import PrefixData
 from .._vendor.auxlib.compat import with_metaclass
 from .._vendor.auxlib.ish import dals
-from ..base.constants import CONDA_TARBALL_EXTENSION
+from ..base.constants import CONDA_TARBALL_EXTENSIONS
 from ..base.context import context
 from ..common.compat import iteritems, on_win, text_type
 from ..common.path import (get_bin_directory_short_path, get_leaf_directories,
@@ -774,7 +774,7 @@ class CreatePrefixRecordAction(CreateInPrefixPathAction):
             type=self.requested_link_type,
         )
         extracted_package_dir = self.package_info.extracted_package_dir
-        package_tarball_full_path = extracted_package_dir + CONDA_TARBALL_EXTENSION
+        package_tarball_full_path = extracted_package_dir + CONDA_TARBALL_EXTENSIONS[0]
         # TODO: don't make above assumption; put package_tarball_full_path in package_info
 
         files = (x.target_short_path for x in self.all_link_path_actions if x)

--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -6,7 +6,7 @@ from os import listdir
 from logging import getLogger
 from os.path import isfile, join, lexists
 
-from ..base.constants import CONDA_TARBALL_EXTENSION, PREFIX_MAGIC_FILE
+from ..base.constants import CONDA_TARBALL_EXTENSIONS, PREFIX_MAGIC_FILE
 from ..base.context import context
 from ..common.compat import JSONDecodeError, itervalues, string_types, with_metaclass
 from ..common.constants import NULL
@@ -59,8 +59,8 @@ class PrefixData(object):
     def insert(self, prefix_record):
         assert prefix_record.name not in self._prefix_records
 
-        assert prefix_record.fn.endswith(CONDA_TARBALL_EXTENSION)
-        filename = prefix_record.fn[:-len(CONDA_TARBALL_EXTENSION)] + '.json'
+        assert prefix_record.fn.endswith(CONDA_TARBALL_EXTENSIONS)
+        filename = prefix_record.fn[:-len(CONDA_TARBALL_EXTENSIONS[0])] + '.json'
 
         prefix_record_json_path = join(self.prefix_path, 'conda-meta', filename)
         if lexists(prefix_record_json_path):
@@ -80,7 +80,7 @@ class PrefixData(object):
 
         prefix_record = self._prefix_records[package_name]
 
-        filename = prefix_record.fn[:-len(CONDA_TARBALL_EXTENSION)] + '.json'
+        filename = prefix_record.fn[:-len(CONDA_TARBALL_EXTENSIONS[0])] + '.json'
         conda_meta_full_path = join(self.prefix_path, 'conda-meta', filename)
         rm_rf(conda_meta_full_path)
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import contextlib
 from errno import EACCES, ELOOP, EPERM
 from io import open
 from logging import getLogger
 import os
-from os import X_OK, access, fstat
+from os import X_OK, access, fstat, makedirs
 from os.path import basename, dirname, isdir, isfile, join, splitext
 from shutil import copyfileobj, copystat
+import libarchive
 import sys
 import tarfile
 
@@ -156,6 +158,27 @@ class ProgressFileWrapper(object):
         self.progress_update_callback(rel_pos)
 
 
+@contextlib.contextmanager
+def tmp_chdir(dest):
+    curdir = os.getcwd()
+    try:
+        os.chdir(dest)
+        yield
+    finally:
+        os.chdir(curdir)
+
+def tar_xf(tarball, dir_path):
+    flags = libarchive.extract.EXTRACT_TIME | \
+            libarchive.extract.EXTRACT_PERM | \
+            libarchive.extract.EXTRACT_SECURE_NODOTDOT | \
+            libarchive.extract.EXTRACT_SECURE_SYMLINKS | \
+            libarchive.extract.EXTRACT_SECURE_NOABSOLUTEPATHS
+    if not os.path.isabs(tarball):
+        tarball = os.path.join(os.getcwd(), tarball)
+    with tmp_chdir(dir_path):
+        libarchive.extract_file(tarball, flags)
+
+
 def extract_tarball(tarball_full_path, destination_directory=None, progress_update_callback=None):
     if destination_directory is None:
         destination_directory = tarball_full_path[:-8]
@@ -163,21 +186,25 @@ def extract_tarball(tarball_full_path, destination_directory=None, progress_upda
 
     assert not lexists(destination_directory), destination_directory
 
+    makedirs(destination_directory)
     with open(tarball_full_path, 'rb') as fileobj:
         if progress_update_callback:
             fileobj = ProgressFileWrapper(fileobj, progress_update_callback)
-        with tarfile.open(fileobj=fileobj) as tar_file:
-            try:
-                tar_file.extractall(path=destination_directory)
-            except EnvironmentError as e:
-                if e.errno == ELOOP:
-                    raise CaseInsensitiveFileSystemError(
-                        package_location=tarball_full_path,
-                        extract_location=destination_directory,
-                        caused_by=e,
-                    )
-                else:
-                    raise
+        if tarball_full_path.endswith('.tar.bz2'):
+            with tarfile.open(fileobj=fileobj) as tar_file:
+                try:
+                    tar_file.extractall(path=destination_directory)
+                except EnvironmentError as e:
+                    if e.errno == ELOOP:
+                        raise CaseInsensitiveFileSystemError(
+                            package_location=tarball_full_path,
+                            extract_location=destination_directory,
+                            caused_by=e,
+                        )
+                    else:
+                        raise
+        else:
+            tar_xf(tarball_full_path, destination_directory)
 
     if sys.platform.startswith('linux') and os.getuid() == 0:
         # When extracting as root, tarfile will by restore ownership

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import sys
 
+from .base.constants import CONDA_TARBALL_EXTENSIONS
 from .base.context import context
 from .common.compat import iteritems, itervalues, on_win, open
 from .common.path import expand
@@ -40,8 +41,9 @@ def conda_installed_files(prefix, exclude_self_build=False):
     return res
 
 
+exts = r'|'.join([re.escape(ext) for ext in CONDA_TARBALL_EXTENSIONS])
 url_pat = re.compile(r'(?:(?P<url_p>.+)(?:[/\\]))?'
-                     r'(?P<fn>[^/\\#]+\.tar\.bz2)'
+                     r'(?P<fn>[^/\\#]+('+exts+r'))'
                      r'(:?#(?P<md5>[0-9a-f]{32}))?$')
 def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, index=None):
     actions = defaultdict(list)

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -6,7 +6,7 @@ from itertools import chain
 from logging import getLogger
 
 from .._vendor.boltons.setutils import IndexedSet
-from ..base.constants import DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL
+from ..base.constants import CONDA_TARBALL_EXTENSIONS, DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL
 from ..base.context import context
 from ..common.compat import ensure_text_type, isiterable, iteritems, odict, with_metaclass
 from ..common.path import is_path, win_path_backout
@@ -108,7 +108,7 @@ class Channel(object):
             return Channel.from_url(value)
         elif is_path(value):
             return Channel.from_url(path_to_url(value))
-        elif value.endswith('.tar.bz2'):
+        elif value.endswith(CONDA_TARBALL_EXTENSIONS):
             if value.startswith('file:'):
                 value = win_path_backout(value)
             return Channel.from_url(value)

--- a/conda/models/dist.py
+++ b/conda/models/dist.py
@@ -10,7 +10,7 @@ from .records import PackageRecord, PackageRef
 from .package_info import PackageInfo
 from .. import CondaError
 from .._vendor.auxlib.entity import Entity, EntityType, IntegerField, StringField
-from ..base.constants import CONDA_TARBALL_EXTENSION, DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
+from ..base.constants import CONDA_TARBALL_EXTENSIONS, DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
 from ..base.context import context
 from ..common.compat import ensure_text_type, text_type, with_metaclass
 from ..common.constants import NULL
@@ -115,11 +115,17 @@ class Dist(Entity):
     def is_channel(self):
         return bool(self.base_url and self.platform)
 
-    def to_filename(self, extension='.tar.bz2'):
+    def to_filename(self, extension=CONDA_TARBALL_EXTENSIONS[0]):
         if self.is_feature_package:
             return self.dist_name
         else:
             return self.dist_name + extension
+
+    def to_filenames(self):
+        if self.is_feature_package:
+            return [self.dist_name]
+        else:
+            return [self.dist_name + extension for extension in CONDA_TARBALL_EXTENSIONS]
 
     def to_matchspec(self):
         return ' '.join(self.quad[:3])
@@ -145,8 +151,8 @@ class Dist(Entity):
                      )
         channel, original_dist, w_f_d = re.search(REGEX_STR, string).groups()
 
-        if original_dist.endswith(CONDA_TARBALL_EXTENSION):
-            original_dist = original_dist[:-len(CONDA_TARBALL_EXTENSION)]
+        if original_dist.endswith(CONDA_TARBALL_EXTENSIONS):
+            original_dist = original_dist[:-len(CONDA_TARBALL_EXTENSIONS[0])]
 
         if channel_override != NULL:
             channel = channel_override
@@ -168,8 +174,8 @@ class Dist(Entity):
         try:
             string = ensure_text_type(string)
 
-            no_tar_bz2_string = (string[:-len(CONDA_TARBALL_EXTENSION)]
-                                 if string.endswith(CONDA_TARBALL_EXTENSION)
+            no_tar_bz2_string = (string[:-len(CONDA_TARBALL_EXTENSIONS[0])]
+                                 if string.endswith(CONDA_TARBALL_EXTENSIONS)
                                  else string)
 
             # remove any directory or channel information
@@ -196,7 +202,7 @@ class Dist(Entity):
     @classmethod
     def from_url(cls, url):
         assert is_url(url), url
-        if not url.endswith(CONDA_TARBALL_EXTENSION) and '::' not in url:
+        if not url.endswith(CONDA_TARBALL_EXTENSIONS) and '::' not in url:
             raise CondaError("url '%s' is not a conda package" % url)
 
         dist_details = cls.parse_dist_name(url)
@@ -223,7 +229,7 @@ class Dist(Entity):
     def to_url(self):
         if not self.base_url:
             return None
-        filename = self.dist_name + CONDA_TARBALL_EXTENSION
+        filename = self.dist_name + CONDA_TARBALL_EXTENSIONS[0]
         return (join_url(self.base_url, self.platform, filename)
                 if self.platform
                 else join_url(self.base_url, filename))
@@ -273,8 +279,8 @@ class Dist(Entity):
 
     def __contains__(self, item):
         item = ensure_text_type(item)
-        if item.endswith(CONDA_TARBALL_EXTENSION):
-            item = item[:-len(CONDA_TARBALL_EXTENSION)]
+        if item.endswith(CONDA_TARBALL_EXTENSIONS):
+            item = item[:-len(CONDA_TARBALL_EXTENSIONS[0])]
         return item in self.__str__()
 
     @property

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -12,7 +12,7 @@ from .dist import Dist
 from .records import PackageRecord, PackageRef
 from .version import BuildNumberMatch, VersionSpec
 from .._vendor.auxlib.collection import frozendict
-from ..base.constants import CONDA_TARBALL_EXTENSION
+from ..base.constants import CONDA_TARBALL_EXTENSIONS
 from ..common.compat import (isiterable, iteritems, itervalues, string_types, text_type,
                              with_metaclass)
 from ..common.path import expand
@@ -233,7 +233,7 @@ class MatchSpec(object):
             return fn_field
         vals = tuple(self.get_exact_value(x) for x in ('name', 'version', 'build'))
         if not any(x is None for x in vals):
-            return '%s-%s-%s.tar.bz2' % vals
+            return '%s-%s-%s2%s' % (vals, CONDA_TARBALL_EXTENSIONS[0])
         else:
             return None
 
@@ -476,8 +476,8 @@ def _parse_legacy_dist(dist_str):
         >>> _parse_legacy_dist("_license-1.1-py27_1")
         ('_license', '1.1', 'py27_1')
     """
-    if dist_str.endswith(CONDA_TARBALL_EXTENSION):
-        dist_str = dist_str[:-len(CONDA_TARBALL_EXTENSION)]
+    if dist_str.endswith(CONDA_TARBALL_EXTENSIONS):
+        dist_str = dist_str[:-len(CONDA_TARBALL_EXTENSIONS[0])]
     name, version, build = dist_str.rsplit('-', 2)
     return name, version, build
 
@@ -506,7 +506,7 @@ def _parse_spec_str(spec_str):
         spec_str.strip()
 
     # Step 2. done if spec_str is a tarball
-    if spec_str.endswith(CONDA_TARBALL_EXTENSION):
+    if spec_str.endswith(CONDA_TARBALL_EXTENSIONS):
         # treat as a normal url
         if not is_url(spec_str):
             spec_str = unquote(path_to_url(expand(spec_str)))


### PR DESCRIPTION
For discussion only at present, please rip this to shreds @conda/conda-core 

Conda-build PR at: https://github.com/conda/conda-build/pull/3163

Some results:

mkl, pre-sorting by file extension:

```
-rw-r--r--  1 rdonnelly  staff  161938050 21 Sep 02:27 /opt/conda/pkgs/mkl-2019.0-118.tar.bz2
```

mkl post-sorting and using zstandard: (edited)

```
-rw-r--r--  1 rdonnelly  staff  161570441 22 Sep 16:18 /opt/conda/conda-bld/osx-64/mkl-2019.0-118.tar.bz2
-rw-r--r--  1 rdonnelly  staff  106457667 22 Sep 16:23 /opt/conda/conda-bld/osx-64/mkl-2019.0-118.tar.zst
```


```
rm /opt/conda/conda-bld/osx-64//opt/conda/conda-bld/osx-64/mkl-2019.0-118.tar ; time bzip2 -d -k /opt/conda/conda-bld/osx-64/mkl-2019.0-118.tar.bz2

real    0m20.032s
user    0m18.342s
sys    0m0.758s

rm /opt/conda/conda-bld/osx-64/mkl-2019.0-118.tar ; time zstd -d -k /opt/conda/conda-bld/osx-64/mkl-2019.0-118.tar.zst
/opt/conda/conda-bld/osx-64/mkl-2019.0-118.tar.zst: 581647360 bytes

real    0m3.128s
user    0m1.313s
sys    0m0.607s
```