### PR TITLE
add undocumented sat_solver config parameter

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -206,6 +206,7 @@ class Context(Configuration):
     # ######################################################
     deps_modifier = PrimitiveParameter(DepsModifier.NOT_SET)
     update_modifier = PrimitiveParameter(UpdateModifier.UPDATE_SPECS)
+    sat_solver = PrimitiveParameter(None, element_type=string_types + (NoneType,))
 
     # no_deps = PrimitiveParameter(NULL, element_type=(type(NULL), bool))  # CLI-only
     # only_deps = PrimitiveParameter(NULL, element_type=(type(NULL), bool))   # CLI-only
@@ -741,6 +742,7 @@ class Context(Configuration):
             'force_32bit',
             'pip_interop_enabled',  # temporary feature flag
             'root_prefix',
+            'sat_solver',
             'subdir',
             'subdirs',
             # https://conda.io/docs/config.html#disable-updating-of-dependencies-update-dependencies # NOQA


### PR DESCRIPTION
The first two commits are not related to the configuration parameter and are just to move the stored clauses to the `SatSolver` instances (helpful in regards to https://github.com/conda/conda/issues/7697 and https://github.com/conda/conda/issues/7699). With CMS `5.6.5` we can then easily use `conda.common.logic.ClauseArray` without affecting the Pycosat interface that doesn't yet support that.

The main objective for this PR is to get some configuration parameter into the next prerelease versions so that people can easily try out the CryptoMiniSat solver, e.g., via
```sh
conda install -ynbase conda-forge::cryptominisat
export CONDA_TIMED_LOGGING=1
export CONDA_SAT_SOLVER=pycryptosat
conda create -vvdnx anaconda
```
It's obviously not supposed to be a configuration that is meant to stay, thus undocumented. But if it makes it into a prerelease version, we should tell people about it and encourage them to test it out.

(This should work out of the box already, but feel free to apply any changes you deem necessary to this branch. I currently don't have time to look into it any further.)