### PR TITLE
fix .condarc ignoring conda_build key

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -229,7 +229,7 @@ class Context(Configuration):
     anaconda_upload = PrimitiveParameter(None, aliases=('binstar_upload',),
                                          element_type=(bool, NoneType))
     _croot = PrimitiveParameter('', aliases=('croot',))
-    _conda_build = MapParameter(string_types, aliases=('conda-build',))
+    _conda_build = MapParameter(string_types, aliases=('conda-build', 'conda_build'))
 
     def __init__(self, search_path=None, argparse_args=None):
         if search_path is None:


### PR DESCRIPTION
The docs all show ``conda-build``, not ``conda_build``, but for whatever reason I had ``conda_build`` and I was broken by the refactoring in https://github.com/conda/conda/commit/1418be0fc7368ddbbfdae5994168b98f01b0c190#diff-b48dce471b4b8aed241c3b09306aa176R233, where the variable name determines the key that gets looked for.  The leading underscore addition made conda_build no longer be found.

fixes #7917 