### PR TITLE
Fix `conda.bat` return code

### DIFF
--- a/conda/shell/Library/bin/conda.bat
+++ b/conda/shell/Library/bin/conda.bat
@@ -8,6 +8,7 @@
 @IF "%1"=="deactivate" GOTO :DO_DEACTIVATE
 
 @CALL %_CONDA_EXE% %*
+@IF %ERRORLEVEL% NEQ 0 GOTO :ErrorEnd
 
 @REM This block should really be the equivalent of
 @REM   if "install" in %* GOTO :DO_REACTIVATE


### PR DESCRIPTION
The return (status) code of `conda.bat` is not reliable and might return `0` while the command actually failed. 
This issue is particularly annoying in the context of CI:

```
BUILD START: ['test-0.0.1-0.tar.bz2']
source tree in: C:\miniconda3\conda-bld\test_1541521612815\work
Traceback (most recent call last):
  ...
  File "C:\miniconda3\lib\site-packages\conda_build\utils.py", line 313, in check_call_env
    return _func_defaulting_env_to_os_environ('call', *popenargs, **kwargs)
  File "C:\miniconda3\lib\site-packages\conda_build\utils.py", line 293, in _func_defaulting_env_to_os_environ
    raise subprocess.CalledProcessError(proc.returncode, _args)
subprocess.CalledProcessError: Command '['cmd.exe', '/c', 'bld.bat']' returned non-zero exit status 1.
Job succeeded
```

I believe this is fixed in the upcoming 4.6 version, but it might be worth the trouble to consider a 4.5.12.