### PR TITLE
Try to use `mmap` when hashing files

### DIFF
--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -76,6 +76,9 @@ def _digest_path(algo, path):
         except OSError:
             for chunk in iter(partial(fh.read, 8192), b''):
                 hasher.update(chunk)
+        except ValueError:
+            # File is empty
+            pass
     return hasher.hexdigest()
 
 


### PR DESCRIPTION
If that doesn't work due to some unusual filesystems or OSes, fallback to the current strategy. ( https://github.com/conda/conda-build/pull/1764 )

Note: Have not benchmarked this and am unsure if I will have time to. However have found this to be a good solution historically. So am putting this up as a suggestion.