### PR TITLE
WIP: verification transaction speedups

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -127,6 +127,7 @@ class Context(Configuration):
                                                     DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
                                                     aliases=('aggressive_update_packages',))
     safety_checks = PrimitiveParameter(SafetyChecks.warn)
+    extra_safety_checks = PrimitiveParameter(False)
     path_conflict = PrimitiveParameter(PathConflict.clobber)
 
     pinned_packages = SequenceParameter(string_types, string_delimiter='&')  # TODO: consider a different string delimiter  # NOQA
@@ -697,6 +698,7 @@ class Context(Configuration):
             'path_conflict',
             'rollback_enabled',
             'safety_checks',
+            'extra_safety_checks',
             'shortcuts',
             'non_admin_enabled',
         )),
@@ -1014,6 +1016,9 @@ class Context(Configuration):
             'safety_checks': dals("""
                 Enforce available safety guarantees during package installation.
                 The value must be one of 'enabled', 'warn', or 'disabled'.
+                """),
+            'extra_safety_checks': dals("""
+                Run extra verification checks on package contents (per-file sha256).
                 """),
             'shortcuts': dals("""
                 Allow packages to create OS-specific shortcuts (e.g. in the Windows Start

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -255,29 +255,11 @@ class LinkPathAction(CreateInPrefixPathAction):
             )
 
         elif source_path_data.path_type == PathType.hardlink:
-            try:
-                reported_sha256 = source_path_data.sha256
-            except AttributeError:
-                reported_sha256 = None
-            source_sha256 = compute_sha256sum(self.source_full_path)
-            if reported_sha256 and reported_sha256 != source_sha256:
-                return SafetyError(dals("""
-                The package for %s located at %s
-                appears to be corrupted. The path '%s'
-                has a sha256 mismatch.
-                  reported sha256: %s
-                  actual sha256: %s
-                """ % (self.package_info.repodata_record.name,
-                       self.package_info.extracted_package_dir,
-                       self.source_short_path,
-                       reported_sha256,
-                       source_sha256,
-                       )))
-
+            reported_size_in_bytes = source_size_in_bytes = None
             try:
                 reported_size_in_bytes = source_path_data.size_in_bytes
             except AttributeError:
-                reported_size_in_bytes = None
+                pass
             if reported_size_in_bytes:
                 source_size_in_bytes = getsize(self.source_full_path)
                 if reported_size_in_bytes != source_size_in_bytes:
@@ -292,6 +274,27 @@ class LinkPathAction(CreateInPrefixPathAction):
                            self.source_short_path,
                            reported_size_in_bytes,
                            source_size_in_bytes,
+                           )))
+
+            try:
+                reported_sha256 = source_path_data.sha256
+            except AttributeError:
+                reported_sha256 = None
+            # sha256 is expensive.  Only run if file sizes agree, and then only if enabled
+            if reported_size_in_bytes == source_size_in_bytes and context.extra_safety_checks:
+                source_sha256 = compute_sha256sum(self.source_full_path)
+                if reported_sha256 and reported_sha256 != source_sha256:
+                    return SafetyError(dals("""
+                    The package for %s located at %s
+                    appears to be corrupted. The path '%s'
+                    has a sha256 mismatch.
+                    reported sha256: %s
+                    actual sha256: %s
+                    """ % (self.package_info.repodata_record.name,
+                           self.package_info.extracted_package_dir,
+                           self.source_short_path,
+                           reported_sha256,
+                           source_sha256,
                            )))
 
             self.prefix_path_data = PathDataV1.from_objects(


### PR DESCRIPTION
* disable per-file sha256 safety checks by default; add extra_safety_checks config option for it instead

This is meant to address user complaints that the verification step takes too long.

As a worst case scenario, I've been trying with our boost package, because it has so many files.  With that package, this PR cuts a 35 sec total time down to 20 sec.

As @kalefranz has mentioned, pip does do these checks, so by disabling this, we're less "safe" than pip: https://github.com/pypa/pip/blob/873662179aebbf5eacdf681078f47bbfe5ee6149/src/pip/_vendor/distlib/database.py#L735