### PR TITLE
speed up solver by skipping timestamp minimization when not needed

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -849,6 +849,19 @@ class Resolve(object):
             constraints = r2.generate_spec_constraints(C, specs)
             return C.sat(constraints, add_if)
 
+        # Return a solution of packages
+        def clean(sol):
+            return [q for q in (C.from_index(s) for s in sol)
+                    if q and q[0] != '!' and '@' not in q]
+
+        # Determine if there are multiple "simple" solutions
+        def has_multiple_simple_solutions(solution):
+            psolution = clean(solution)
+            nclause = tuple(C.Not(C.from_name(q)) for q in psolution)
+            if C.sat((nclause,), True) is None:
+                return False
+            return True
+
         r2 = Resolve(reduced_index, True, True, channels=self.channels)
         C = r2.gen_clauses()
         solution = mysat(specs, True)
@@ -933,10 +946,6 @@ class Resolve(object):
         solution, obj6t = C.minimize(eq_t, solution)
         log.debug('Timestamp metric: %d', obj6t)
 
-
-        def clean(sol):
-            return [q for q in (C.from_index(s) for s in sol)
-                    if q and q[0] != '!' and '@' not in q]
         log.debug('Looking for alternate solutions')
         nsol = 1
         psolutions = []

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -941,10 +941,12 @@ class Resolve(object):
         solution, obj7 = C.minimize(eq_c, solution, trymax=True)
         log.debug('Weak dependency count: %d', obj7)
 
-        # Maximize timestamps
-        eq_t.update(eq_req_t)
-        solution, obj6t = C.minimize(eq_t, solution)
-        log.debug('Timestamp metric: %d', obj6t)
+        multiple_solutions = has_multiple_simple_solutions(solution)
+        if multiple_solutions:
+            # Maximize timestamps
+            eq_t.update(eq_req_t)
+            solution, obj6t = C.minimize(eq_t, solution)
+            log.debug('Timestamp metric: %d', obj6t)
 
         log.debug('Looking for alternate solutions')
         nsol = 1

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -923,15 +923,16 @@ class Resolve(object):
         log.debug('Additional package channel/version/build metrics: %d/%d/%d',
                   obj5a, obj5, obj6)
 
+        # Prune unnecessary packages
+        eq_c = r2.generate_package_count(C, specm)
+        solution, obj7 = C.minimize(eq_c, solution, trymax=True)
+        log.debug('Weak dependency count: %d', obj7)
+
         # Maximize timestamps
         eq_t.update(eq_req_t)
         solution, obj6t = C.minimize(eq_t, solution)
         log.debug('Timestamp metric: %d', obj6t)
 
-        # Prune unnecessary packages
-        eq_c = r2.generate_package_count(C, specm)
-        solution, obj7 = C.minimize(eq_c, solution, trymax=True)
-        log.debug('Weak dependency count: %d', obj7)
 
         def clean(sol):
             return [q for q in (C.from_index(s) for s in sol)


### PR DESCRIPTION
Speed up the solver by skipping the timestamp minimization step when there is a single "simple" solution after the package count minimization step.

It may be possible to skip other minimization steps using similar logic but further testing is needed.