### PR TITLE
conda-init: also install %LIBRARY_BIN%\conda.bat

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -293,6 +293,13 @@ def make_install_plan(conda_prefix):
             },
         })
         plan.append({
+            'function': install_library_bin_conda_bat.__name__,
+            'kwargs': {
+                'target_path': join(conda_prefix, 'Library', 'bin', 'conda.bat'),
+                'conda_prefix': conda_prefix,
+            },
+        })
+        plan.append({
             'function': install_condabin_conda_activate_bat.__name__,
             'kwargs': {
                 'target_path': join(conda_prefix, 'condabin', '_conda_activate.bat'),
@@ -825,6 +832,14 @@ def install_deactivate(target_path, conda_prefix):
 def install_condabin_conda_bat(target_path, conda_prefix):
     # target_path: join(conda_prefix, 'condabin', 'conda.bat')
     conda_bat_src_path = join(CONDA_PACKAGE_ROOT, 'shell', 'condabin', 'conda.bat')
+    with open(conda_bat_src_path) as fsrc:
+        file_content = fsrc.read()
+    return _install_file(target_path, file_content)
+
+
+def install_library_bin_conda_bat(target_path, conda_prefix):
+    # target_path: join(conda_prefix, 'Library', 'bin', 'conda.bat')
+    conda_bat_src_path = join(CONDA_PACKAGE_ROOT, 'shell', 'Library', 'bin', 'conda.bat')
     with open(conda_bat_src_path) as fsrc:
         file_content = fsrc.read()
     return _install_file(target_path, file_content)

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -109,6 +109,13 @@ class InitializeTests(TestCase):
                         }
                     },
                     {
+                        'function': 'install_library_bin_conda_bat',
+                        'kwargs': {
+                            'conda_prefix': '/darwin',
+                            'target_path': '/darwin\\Library\\bin\\conda.bat'
+                        }
+                    },
+                        {
                         "function": "install_condabin_conda_activate_bat",
                         "kwargs": {
                             "conda_prefix": "/darwin",
@@ -502,7 +509,8 @@ class InitializeTests(TestCase):
                 'conda-env.exe',
                 'conda-script.py',
                 'conda-env-script.py',
-                'conda.bat',
+                'conda.bat',  # condabin/conda.bat
+                'conda.bat',  # Library/bin/conda.bat
                 '_conda_activate.bat',
                 'conda_auto_activate.bat',
                 'conda_hook.bat',
@@ -560,7 +568,8 @@ class InitializeTests(TestCase):
                 'conda-env.exe',
                 'conda-script.py',
                 'conda-env-script.py',
-                'conda.bat',
+                'conda.bat',  # condabin/conda.bat
+                'conda.bat',  # Library/bin/conda.bat
                 '_conda_activate.bat',
                 'conda_auto_activate.bat',
                 'conda_hook.bat',
@@ -626,7 +635,8 @@ class InitializeTests(TestCase):
                 'conda-env.exe',
                 'conda-script.py',
                 'conda-env-script.py',
-                'conda.bat',
+                'conda.bat',  # condabin/conda.bat
+                'conda.bat',  # Library/bin/conda.bat
                 '_conda_activate.bat',
                 'conda_auto_activate.bat',
                 'conda_hook.bat',


### PR DESCRIPTION
This patch adds a plan to install shell\Library\bin\conda.bat to
sys.prefix\Library\bin\conda.bat on invoking conda init --install

Fixes https://github.com/conda/conda/issues/7266