### PR TITLE
Add 'conda env list --size'

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from os.path import basename, dirname
+from os.path import basename, dirname, getsize, islink, join
+from os import walk
 import re
 import sys
+import math
 
 from .._vendor.auxlib.ish import dals
 from ..base.constants import ROOT_ENV_NAME
@@ -177,29 +179,57 @@ def stdout_json_success(success=True, **kwargs):
     stdout_json(result)
 
 
-def print_envs_list(known_conda_prefixes, output=True):
+def print_envs_list(known_conda_prefixes, with_size=False):
+    print("# conda environments:")
+    print("#")
 
-    if output:
-        print("# conda environments:")
-        print("#")
+    def compute_size(prefix):
+        total_size = 0
+        for dirpath, dirnames, filenames in walk(prefix):
+            for filename in filenames:
+                path = join(dirpath, filename)
+                if not islink(path):
+                    total_size += getsize(path)
+        return total_size
 
-    def disp_env(prefix):
-        fmt = '%-20s  %s  %s'
-        default = '*' if prefix == context.default_prefix else ' '
+    def convert_size(size_bytes):
+        """https://stackoverflow.com/a/14822210/1293700"""
+        if size_bytes == 0:
+            return "0B"
+        size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+        i = int(math.floor(math.log(size_bytes, 1024)))
+        p = math.pow(1024, i)
+        s = round(size_bytes / p, 2)
+        return "%s %s" % (s, size_name[i])
+
+    def disp_env(prefix, fmt='{name:20s} {default:1s} {prefix} {size}'):
+        # 'name' column:
         if prefix == context.root_prefix:
             name = ROOT_ENV_NAME
-        elif any(paths_equal(envs_dir, dirname(prefix)) for envs_dir in context.envs_dirs):
+        elif any(paths_equal(envs_dir, dirname(prefix))
+                 for envs_dir in context.envs_dirs):
             name = basename(prefix)
         else:
             name = ''
-        if output:
-            print(fmt % (name, default, prefix))
 
+        # 'default' column:
+        default = '*' if prefix == context.default_prefix else ' '
+
+        # 'size' column:
+        size = convert_size(compute_size(prefix)) if with_size else ''
+
+        print(fmt.format(name=name, default=default, prefix=prefix, size=size))
+
+    # Create optimal string format:
+    prefix_width = max([len(str(prefix)) for prefix in known_conda_prefixes])
+    optimal_fmt = '{name:20s} {default:1s} {prefix:' \
+                  + str(prefix_width) + 's} {size}'
+
+    # Print each prefix:
     for prefix in known_conda_prefixes:
-        disp_env(prefix)
+        disp_env(prefix, optimal_fmt)
 
-    if output:
-        print()
+    print()
 
 
 def check_non_admin():

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -7,7 +7,6 @@ from os.path import basename, dirname, getsize, islink, join
 from os import walk
 import re
 import sys
-import math
 
 from .._vendor.auxlib.ish import dals
 from ..base.constants import ROOT_ENV_NAME
@@ -17,6 +16,7 @@ from ..common.io import swallow_broken_pipe
 from ..common.path import paths_equal
 from ..common.serialize import json_dump
 from ..models.match_spec import MatchSpec
+from ..utils import human_bytes
 
 
 def confirm(message="Proceed", choices=('yes', 'no'), default='yes'):
@@ -192,16 +192,6 @@ def print_envs_list(known_conda_prefixes, with_size=False):
                     total_size += getsize(path)
         return total_size
 
-    def convert_size(size_bytes):
-        """https://stackoverflow.com/a/14822210/1293700"""
-        if size_bytes == 0:
-            return "0B"
-        size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
-        i = int(math.floor(math.log(size_bytes, 1024)))
-        p = math.pow(1024, i)
-        s = round(size_bytes / p, 2)
-        return "%s %s" % (s, size_name[i])
-
     def disp_env(prefix, fmt='{name:20s} {default:1s} {prefix} {size}'):
         # 'name' column:
         if prefix == context.root_prefix:
@@ -216,7 +206,7 @@ def print_envs_list(known_conda_prefixes, with_size=False):
         default = '*' if prefix == context.default_prefix else ' '
 
         # 'size' column:
-        size = convert_size(compute_size(prefix)) if with_size else ''
+        size = human_bytes(compute_size(prefix)) if with_size else ''
 
         print(fmt.format(name=name, default=default, prefix=prefix, size=size))
 

--- a/conda_env/cli/main_list.py
+++ b/conda_env/cli/main_list.py
@@ -14,6 +14,7 @@ List the Conda environments
 example = """
 examples:
     conda env list
+    conda env list --size
     conda env list --json
 """
 
@@ -27,6 +28,13 @@ def configure_parser(sub_parsers):
         epilog=example,
     )
 
+    list_parser.add_argument(
+        "-s", "--size",
+        action="store_true",
+        default=False,
+        help="Show the used disk usage for each environment."
+    )
+
     add_parser_json(list_parser)
 
     list_parser.set_defaults(func='.main_list.execute')
@@ -34,7 +42,7 @@ def configure_parser(sub_parsers):
 
 def execute(args, parser):
     info_dict = {'envs': list_all_known_prefixes()}
-    common.print_envs_list(info_dict['envs'], not args.json)
-
-    if args.json:
+    if not args.json:
+        common.print_envs_list(info_dict['envs'], with_size=bool(args.size))
+    else:
         common.stdout_json(info_dict)


### PR DESCRIPTION
Add argument `--size` to command `conda env list` to compute the disk usage of each environment. It's useful when the user has many environments and want to clean up old and large environments.

And here you can see the result:

```bash
conda env list --size
```

```bash
# conda environments:
#
base                 * /Users/darius/repos/conda/devenv 470.09 MB
env_a                  /opt/miniconda/envs/env_a        117.17 MB
env_b                  /opt/miniconda/envs/env_b        739.96 MB
```

It's similar to the command `find ./envs/prefix -type f -exec ls -l {} \; | awk '{sum += $5} END {print sum}'` which is more accurate than `du -sh ./envs/`.

By the way the computation can be slow, because of that it's an optional argument.

Thanks, Darius