### PR TITLE
call conda.bat more directly in legacy activate.bat

### DIFF
--- a/conda/shell/Scripts/activate.bat
+++ b/conda/shell/Scripts/activate.bat
@@ -15,14 +15,12 @@
 @set _args1_last=%_args1_last:"=+%
 @set _args1=
 
-@CALL "%~dp0..\condabin\conda_hook.bat"
-
 @if "%_args1_first%"=="+" if NOT "%_args1_last%"=="+" (
-    @CALL conda.bat activate
+    @CALL "%~dp0..\condabin\conda.bat" activate
     @GOTO :End
 )
 
-@CALL conda.bat activate %*
+@CALL "%~dp0..\condabin\conda.bat" activate %*
 
 :End
 @set _args1_first=


### PR DESCRIPTION
Conda-forge has been complaining that direct calls to the old activate script, like:

```call c:\blah\Miniconda3\Scripts\activate.bat "env_path"```

are broken with conda 4.6, resulting in errors like 

```
CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
If using 'conda activate' from a batch script, change your
invocation to 'CALL conda.bat activate'.
To initialize your shell, run
    $ conda init <SHELL_NAME>
Currently supported shells are:
  - bash
  - cmd.exe
  - fish
  - tcsh
  - xonsh
  - zsh
  - powershell
See 'conda init --help' for more information and options.
IMPORTANT: You may need to close and restart your shell after running 'conda init'.
```

This PR should fix those errors and provide better continuing support for this script.