### PR TITLE
Raise UnavailableInvalidChannel only for the noarch subdir

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -448,15 +448,15 @@ def fetch_repodata_remote_request(url, etag, mod_stamp):
         status_code = getattr(e.response, 'status_code', None)
         if status_code in (403, 404):
             if not url.endswith('/noarch'):
+                log.info("Unable to retrieve repodata (%d error) for %s", status_code, url)
+                return None
+            else:
                 if context.allow_non_channel_urls:
                     stderrlog.warning("Unable to retrieve repodata (%d error) for %s",
                                       status_code, url)
                     return None
                 else:
                     raise UnavailableInvalidChannel(Channel(dirname(url)), status_code)
-            else:
-                log.info("Unable to retrieve repodata (%d error) for %s", status_code, url)
-                return None
 
         elif status_code == 401:
             channel = Channel(url)

--- a/tests/core/test_repodata.py
+++ b/tests/core/test_repodata.py
@@ -12,7 +12,7 @@ from conda.common.disk import temporary_content_in_file
 from conda.common.io import env_var
 from conda.core.index import get_index
 from conda.core.subdir_data import Response304ContentUnchanged, cache_fn_url, read_mod_and_etag, \
-    SubdirData
+    SubdirData, fetch_repodata_remote_request, UnavailableInvalidChannel
 from conda.models.channel import Channel
 
 try:
@@ -161,6 +161,24 @@ class StaticFunctionTests(TestCase):
 
         hash6 = cache_fn_url("https://repo.anaconda.com/pkgs/r/osx-64")
         assert hash4 != hash6
+
+
+class FetchLocalRepodataTests(TestCase):
+
+    def test_fetch_repodata_remote_request_invalid_arch(self):
+        # see https://github.com/conda/conda/issues/8150
+        url = 'file:///fake/fake/fake/linux-64'
+        etag = None
+        mod_stamp = 'Mon, 28 Jan 2019 01:01:01 GMT'
+        result = fetch_repodata_remote_request(url, etag, mod_stamp)
+        assert result is None
+
+    def test_fetch_repodata_remote_request_invalid_noarch(self):
+        url = 'file:///fake/fake/fake/noarch'
+        etag = None
+        mod_stamp = 'Mon, 28 Jan 2019 01:01:01 GMT'
+        with pytest.raises(UnavailableInvalidChannel):
+            result = fetch_repodata_remote_request(url, etag, mod_stamp)
 
 
 # @pytest.mark.integration


### PR DESCRIPTION
Raise UnavailableInvalidChannel only when fetching repodata for a noarch subdir channel fails.  Other subdirs are allowed to fail.  This was the behavior in conda 4.5.x.  

closes #8150 