### PR TITLE
DO NOT MERGE: small tweaks to make solve environment faster

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -234,7 +234,7 @@ class Solver(object):
                      context.json):
             ssc = self._collect_all_metadata(ssc)
 
-        with Spinner("Solving environment", not context.verbosity and not context.quiet,
+        with Spinner("xxx Solving environment xxx", not context.verbosity and not context.quiet,
                      context.json):
             ssc = self._remove_specs(ssc)
             ssc = self._find_inconsistent_packages(ssc)
@@ -442,6 +442,9 @@ class Solver(object):
         return ssc
 
     def _run_sat(self, ssc):
+        import cProfile, pstats, io as StringIO
+        pr = cProfile.Profile()
+        pr.enable()
         final_environment_specs = IndexedSet(concatv(
             itervalues(ssc.specs_map),
             ssc.track_features_specs,
@@ -505,6 +508,12 @@ class Solver(object):
                         final_environment_specs.add(spec)
 
         ssc.final_environment_specs = final_environment_specs
+        pr.disable()
+        s = StringIO.StringIO()
+        sortby = 'cumulative'
+        ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+        ps.print_stats()
+        print(s.getvalue(), file=open("profile.txt", "w"))
         return ssc
 
     def _post_sat_handling(self, ssc):


### PR DESCRIPTION
For discussion only.

I know there is work on this elsewhere, but in my profiling, it seems much of the time spent solving environment is outside of the pure SAT stuff. I made a few small changes and get a 10-15% improvement. Perhaps someone more familiar with the code can get more with other small changes.

I added the profiling code, then ran `conda create --dry-run -n conda_forge_r -c conda-forge r-essentials
` 3 times without any other changes. The fastest time reported in profile.txt was 82 seconds. Then made the other changes and the fastest of 3 was 71 seconds. Since this is not far from the improvement reported [here](https://www.anaconda.com/blog/developer-blog/conda-4-6-release/) by using a different solver, I thought it might be worth reporting.

I think most of the improvement comes from putting `hash` inside of the `_hash_key` memoized property.