### PR TITLE
fix #8185 conda package filtering with embedded/vendored python metadata

### DIFF
--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -221,7 +221,9 @@ class PrefixData(object):
         # Get anchor files for corresponding conda (handled) python packages
         prefix_graph = PrefixGraph(self.iter_records())
         python_records = prefix_graph.all_descendants(python_pkg_record)
-        conda_python_packages = get_conda_anchor_files_and_records(site_packages_dir, python_records)
+        conda_python_packages = get_conda_anchor_files_and_records(
+            site_packages_dir, python_records
+        )
 
         # Get all anchor files and compare against conda anchor files to find clobbered conda
         # packages and python packages installed via other means (not handled by conda)

--- a/tests/core/test_prefix_data.py
+++ b/tests/core/test_prefix_data.py
@@ -136,18 +136,19 @@ def test_pip_interop_osx():
 
 def test_get_conda_anchor_files_and_records():
     valid_tests = [
-        os.sep.join(('v', 'site-packages', 'spam', '.egg-info', 'PKG-INFO')),
-        os.sep.join(('v', 'site-packages', 'foo', '.dist-info', 'RECORD')),
-        os.sep.join(('v', 'site-packages', 'bar', '.egg-info')),
+        'v/site-packages/spam.egg-info/PKG-INFO',
+        'v/site-packages/foo.dist-info/RECORD',
+        'v/site-packages/bar.egg-info',
     ]
     invalid_tests = [
-        os.sep.join(('i', 'site-packages', '.egg-link')),
-        os.sep.join(('i', 'spam', '.egg-info', 'PKG-INFO')),
-        os.sep.join(('i', 'foo', '.dist-info', 'RECORD')),
-        os.sep.join(('i', 'bar', '.egg-info')),
-        os.sep.join(('i', 'site-packages', 'spam')),
-        os.sep.join(('i', 'site-packages', 'foo')),
-        os.sep.join(('i', 'site-packages', 'bar')),
+        'v/site-packages/valid-package/_vendor/invalid-now.egg-info/PKG-INFO',
+        'i/site-packages/stuff.egg-link',
+        'i/spam.egg-info/PKG-INFO',
+        'i/foo.dist-info/RECORD',
+        'i/bar.egg-info',
+        'i/site-packages/spam',
+        'i/site-packages/foo',
+        'i/site-packages/bar',
     ]
     tests = valid_tests + invalid_tests
     records = []
@@ -156,10 +157,10 @@ def test_get_conda_anchor_files_and_records():
         record.files = [path]
         records.append(record)
 
-    output = get_conda_anchor_files_and_records(records)
+    output = get_conda_anchor_files_and_records("v/site-packages", records)
     expected_output = odict()
     for i in range(len(valid_tests)):
         expected_output[valid_tests[i]] = records[i]
 
     _print_output(output, expected_output)
-    assert output, expected_output
+    assert output == expected_output


### PR DESCRIPTION
fix #8185