### PR TITLE
CONDA_EXE and CONDA_BAT quoting changed so that they are quoted on use

### DIFF
--- a/conda/shell/condabin/_conda_activate.bat
+++ b/conda/shell/condabin/_conda_activate.bat
@@ -9,7 +9,7 @@
     @SET CONDA_PS1_BACKUP=
 :FIXUP43
 
-@FOR /F "delims=" %%i IN ('@CALL %CONDA_EXE% shell.cmd.exe %*') DO @SET "_TEMP_SCRIPT_PATH=%%i"
+@FOR /F "delims=" %%i IN ('@CALL "%CONDA_EXE%" shell.cmd.exe %*') DO @SET "_TEMP_SCRIPT_PATH=%%i"
 @IF "%_TEMP_SCRIPT_PATH%"=="" @EXIT /B 1
 @IF NOT "%CONDA_PROMPT_MODIFIER%" == "" @CALL SET "PROMPT=%%PROMPT:%CONDA_PROMPT_MODIFIER%=%_empty_not_set_%%%"
 @CALL "%_TEMP_SCRIPT_PATH%"

--- a/conda/shell/condabin/conda.bat
+++ b/conda/shell/condabin/conda.bat
@@ -1,11 +1,11 @@
 @REM Copyright (C) 2012 Anaconda, Inc
 @REM SPDX-License-Identifier: BSD-3-Clause
-@IF NOT DEFINED CONDA_EXE @SET CONDA_EXE="%~dp0..\Scripts\conda.exe"
+@IF NOT DEFINED CONDA_EXE @SET "CONDA_EXE=%~dp0..\Scripts\conda.exe"
 
 @IF [%1]==[activate]   "%~dp0_conda_activate" %*
 @IF [%1]==[deactivate] "%~dp0_conda_activate" %*
 
-@CALL %CONDA_EXE% %*
+@CALL "%CONDA_EXE%" %*
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 
 @IF [%1]==[install]   "%~dp0_conda_activate" reactivate

--- a/conda/shell/condabin/conda_auto_activate.bat
+++ b/conda/shell/condabin/conda_auto_activate.bat
@@ -3,6 +3,6 @@
 @REM Helper script to conda_hook.bat.  This is a separate script so that the Anaconda Prompt
 @REM can enable this option while only conda_hook.bat can be used in AutoRun.
 
-@FOR /F "delims=" %%i IN ('@CALL %CONDA_EXE% config --show auto_activate_base') DO @SET "__conda_auto_activate_base=%%i"
-@IF NOT "x%__conda_auto_activate_base:True=%"=="x%__conda_auto_activate_base%" @CALL %CONDA_BAT% activate base
+@FOR /F "delims=" %%i IN ('@CALL "%CONDA_EXE%" config --show auto_activate_base') DO @SET "__conda_auto_activate_base=%%i"
+@IF NOT "x%__conda_auto_activate_base:True=%"=="x%__conda_auto_activate_base%" @CALL "%CONDA_BAT%" activate base
 @SET __conda_auto_activate_base=

--- a/conda/shell/condabin/conda_hook.bat
+++ b/conda/shell/condabin/conda_hook.bat
@@ -5,15 +5,15 @@
 
 @IF DEFINED CONDA_SHLVL GOTO :EOF
 
-@FOR %%F in ("%~dp0") do @SET __condabin_dir=%%~dpF
+@FOR %%F in ("%~dp0") do @SET "__condabin_dir=%%~dpF"
 @SET "PATH=%__condabin_dir%;%PATH%"
 @SET "CONDA_BAT=%__condabin_dir%conda.bat"
-@SET __condabin_dir=%__condabin_dir:~0,-1%
-@FOR %%F in ("%__condabin_dir%") do @SET __conda_root=%%~dpF
+@SET "__condabin_dir=%__condabin_dir:~0,-1%"
+@FOR %%F in ("%__condabin_dir%") do @SET "__conda_root=%%~dpF"
 @SET "CONDA_EXE=%__conda_root%Scripts\conda.exe"
 @SET __condabin_dir=
 @SET __conda_root=
 
-@DOSKEY conda=%CONDA_BAT% $*
+@DOSKEY conda="%CONDA_BAT%" $*
 
 @SET CONDA_SHLVL=0

--- a/conda/shell/condabin/conda_hook.bat
+++ b/conda/shell/condabin/conda_hook.bat
@@ -7,10 +7,10 @@
 
 @FOR %%F in ("%~dp0") do @SET __condabin_dir=%%~dpF
 @SET "PATH=%__condabin_dir%;%PATH%"
-@SET CONDA_BAT="%__condabin_dir%conda.bat"
+@SET "CONDA_BAT=%__condabin_dir%conda.bat"
 @SET __condabin_dir=%__condabin_dir:~0,-1%
 @FOR %%F in ("%__condabin_dir%") do @SET __conda_root=%%~dpF
-@SET CONDA_EXE="%__conda_root%Scripts\conda.exe"
+@SET "CONDA_EXE=%__conda_root%Scripts\conda.exe"
 @SET __condabin_dir=
 @SET __conda_root=
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1147,7 +1147,7 @@ class InteractiveShell(object):
             'activator': 'cmd.exe',
             'init_command': 'set "CONDA_SHLVL=" '
                             '&& @CALL conda\\shell\\condabin\\conda_hook.bat '
-                            '&& set "CONDA_EXE=python -m conda"',
+                            '&& set "CONDA_EXE={}"'.format(join(sys.prefix, "Scripts", "conda.exe")),
             'print_env_var': '@echo %%%s%%',
         },
         'csh': {


### PR DESCRIPTION
CONDA_EXE and CONDA_BAT quoting changed so that they are quoted on use rather than on set.

Tested by installing miniconda 4.5 in a directory with spaces on windows, then updating conda to 4.6. At this point the problems show themselves. You can't run conda anything.
Replace the contents of condabin with these modified files and conda works again.

This problem was initially reported by me at https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/jHyb8uvIOnc
