### PR TITLE
[powershell] make sure \path\to\conda.exe is always quoted

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -1246,7 +1246,7 @@ def _powershell_profile_content(conda_prefix):
     conda_powershell_module = dals("""
     #region conda initialize
     # !! Contents within this block are managed by 'conda init' !!
-    (& {conda_exe} "shell.powershell" "hook") | Out-String | Invoke-Expression
+    (& "{conda_exe}" "shell.powershell" "hook") | Out-String | Invoke-Expression
     #endregion
     """.format(conda_exe=conda_exe))
 


### PR DESCRIPTION
Fixes #8221