### PR TITLE
Fix for Anaconda Dir containing spaces

### DIFF
--- a/conda/shell/condabin/conda.bat
+++ b/conda/shell/condabin/conda.bat
@@ -5,7 +5,7 @@
 @IF [%1]==[activate]   "%~dp0_conda_activate" %*
 @IF [%1]==[deactivate] "%~dp0_conda_activate" %*
 
-@CALL %CONDA_EXE% %*
+@CALL "%CONDA_EXE%" %*
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 
 @IF [%1]==[install]   "%~dp0_conda_activate" reactivate


### PR DESCRIPTION
Without quotes around %CONDA_EXE% using the conda command in Anaconda prompt causes an error if the path to conda.exe contains any spaces.