### PR TITLE
activate env when running post-link/unlink scripts

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1002,9 +1002,9 @@ def run_script(prefix, prec, action='post-link', env_prefix=None, activate=False
             return False
         if activate:
             conda_bat = env.get("CONDA_BAT", abspath(join(context.root_prefix, 'bin', 'conda')))
-            with tempfile.NamedTemporaryFile(mode='w', prefix=prefix, delete=False) as fh:
-                fh.write('@CALL {0} activate \"{1}\""\n'.format(conda_bat, prefix))
-                fh.write('@CALL "\{0}\"\n'.format(path))
+            with tempfile.NamedTemporaryFile(mode='w', prefix=prefix, suffix='.bat', delete=False) as fh:
+                fh.write('@CALL \"{0}\" activate \"{1}\"\n'.format(conda_bat, prefix))
+                fh.write('@CALL \"{0}\"\n'.format(path))
                 script_caller = fh.name
             command_args = [comspec, '/d', '/c', script_caller]
         else:

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1002,8 +1002,10 @@ def run_script(prefix, prec, action='post-link', env_prefix=None, activate=False
             return False
         if activate:
             conda_bat = env.get("CONDA_BAT", abspath(join(context.root_prefix, 'bin', 'conda')))
-            with tempfile.NamedTemporaryFile(mode='w', prefix=prefix, suffix='.bat', delete=False) as fh:
+            with tempfile.NamedTemporaryFile(
+                    mode='w', prefix=prefix, suffix='.bat', delete=False) as fh:
                 fh.write('@CALL \"{0}\" activate \"{1}\"\n'.format(conda_bat, prefix))
+                fh.write('echo "PATH: %PATH%\n')
                 fh.write('@CALL \"{0}\"\n'.format(path))
                 script_caller = fh.name
             command_args = [comspec, '/d', '/c', script_caller]

--- a/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/activate_d_test.bat
+++ b/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/activate_d_test.bat
@@ -1,0 +1,2 @@
+echo "setting TEST_VAR"
+set TEST_VAR=1

--- a/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/bld.bat
+++ b/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/bld.bat
@@ -1,0 +1,6 @@
+mkdir %PREFIX%\etc\conda\activate.d
+copy %RECIPE_DIR%\activate_d_test.bat %PREFIX%\etc\conda\activate.d\test.bat
+
+mkdir %PREFIX%\etc\conda\deactivate.d
+echo "echo setting TEST_VAR" > %PREFIX%\etc\conda\deactivate.d\test.bat
+echo set TEST_VAR= > %PREFIX%\etc\conda\deactivate.d\test.bat

--- a/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/build.sh
+++ b/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/build.sh
@@ -1,0 +1,7 @@
+mkdir -p $PREFIX/etc/conda/activate.d
+echo "echo 'setting TEST_VAR' && export TEST_VAR=1" > $PREFIX/etc/conda/activate.d/test.sh
+chmod +x $PREFIX/etc/conda/activate.d/test.sh
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+echo "echo 'unsetting TEST_VAR' && unset TEST_VAR" > $PREFIX/etc/conda/deactivate.d/test.sh
+chmod +x $PREFIX/etc/conda/deactivate.d/test.sh

--- a/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/meta.yaml
+++ b/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: _conda_test_env_activated_when_post_link_executed
+  version: 1.0
+
+about:
+  summary: test package that checks for an activated env in the post link script
+  description: |
+    This is a test packages that checks that conda environment are activated 
+    when running a post link script. This package has an activate.d script which
+    sets the environment variable TEST_VAR. The packages post link script tests
+    that this variable is set, if it is not the script fails. If this post
+    link script is run under a different environment, for example the base env,
+    there is a good chance that it will fail.

--- a/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/post-link.bat
+++ b/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/post-link.bat
@@ -1,0 +1,8 @@
+
+echo "TEST_VAR is set to :%TEST_VAR%:" >> %PREFIX%\.messages.txt
+if "%TEST_VAR%"=="1" (
+    echo "Success: TEST_VAR is set correctly" >> %PREFIX%\.messages.txt
+    exit 0
+)
+echo "ERROR: TEST_VAR is not set or set incorrectly" >> %PREFIX%\.messages.txt
+exit 1

--- a/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/post-link.sh
+++ b/tests/data/_conda_test_env_activated_when_post_link_executed_recipe/post-link.sh
@@ -1,0 +1,8 @@
+# send feedback to .messages to make debugging easier
+echo "TEST_VAR is set to :${TEST_VAR}:" >> "$PREFIX/.messages.txt"
+if [ "${TEST_VAR}" != "1" ]; then
+    echo "Error: TEST_VAR is not set or set incorrectly" >> "$PREFIX/.messages.txt";
+    exit 1;
+fi
+echo "Success: TEST_VAR is set correctly" >> "$PREFIX/.messages.txt"
+exit 0

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2154,7 +2154,9 @@ class IntegrationTests(TestCase):
 
     def test_post_link_run_in_env(self):
         test_pkg = '_conda_test_env_activated_when_post_link_executed'
-        with make_temp_env(test_pkg, '-c conda-test') as prefix:
+        # a non-unicode name must be provided here as activate.d scripts
+        # are not execuated on windows, see https://github.com/conda/conda/issues/8241
+        with make_temp_env(test_pkg, '-c conda-test', name='post_link_test') as prefix:
             assert package_is_installed(prefix, test_pkg)
 
     def test_conda_info_python(self):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -247,7 +247,7 @@ def package_is_installed(prefix, spec):
     spec = MatchSpec(spec)
     prefix_recs = tuple(PrefixData(prefix).query(spec))
     if len(prefix_recs) > 1:
-        raise AssertionError("Multiple packages installed.%s" 
+        raise AssertionError("Multiple packages installed.%s"
                              % (dashlist(prec.dist_str() for prec in prefix_recs)))
     return bool(len(prefix_recs))
 
@@ -2151,6 +2151,11 @@ class IntegrationTests(TestCase):
             with make_temp_env("openssl=1.0.2j --no-deps") as prefix:
                 assert package_is_installed(prefix, 'openssl')
                 assert rs.call_count == 1
+
+    def test_post_link_run_in_env(self):
+        test_pkg = '_conda_test_env_activated_when_post_link_executed'
+        with make_temp_env(test_pkg, '-c conda-test') as prefix:
+            assert package_is_installed(prefix, test_pkg)
 
     def test_conda_info_python(self):
         stdout, stderr = run_command(Commands.INFO, None, "python=3.5")


### PR DESCRIPTION
Run post-link and post-unlink scripts in an activated environment. This is
implemented via an temporary script which activates the environment and then
calls the original script.

closes #7789