### PR TITLE
instrument more solve calls

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -546,8 +546,7 @@ class time_recorder(ContextDecorator):  # pragma: no cover
                 fh.write("%s,%f\n" % (entry_name, run_time))
             # total_call_num = self.total_call_num[entry_name]
             # total_run_time = self.total_run_time[entry_name]
-            # log.debug(
-            #     '%s %9.3f %9.3f %d', entry_name, run_time, total_run_time, total_call_num)
+            # log.debug('%s %9.3f %9.3f %d', entry_name, run_time, total_run_time, total_call_num)
 
     @classmethod
     def log_totals(cls):

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -253,6 +253,7 @@ class Solver(object):
 
         return ssc.solution_precs
 
+    @time_recorder(module_name=__name__)
     def _collect_all_metadata(self, ssc):
         if ssc.prune:  # or update_modifier == UpdateModifier.UPDATE_ALL  # pending conda/constructor#138  # NOQA
             # Users are struggling with the prune functionality in --update-all, due to
@@ -335,6 +336,7 @@ class Solver(object):
             ssc.solution_precs = tuple(graph.graph)
         return ssc
 
+    @time_recorder(module_name=__name__)
     def _find_inconsistent_packages(self, ssc):
         # We handle as best as possible environments in inconsistent states. To do this,
         # we remove now from consideration the set of packages causing inconsistencies,
@@ -441,6 +443,7 @@ class Solver(object):
 
         return ssc
 
+    @time_recorder(module_name=__name__)
     def _run_sat(self, ssc):
         final_environment_specs = IndexedSet(concatv(
             itervalues(ssc.specs_map),


### PR DESCRIPTION
The instrumentation added here will be visible with e.g.

```
export CONDA_INSTRUMENTATION_ENABLED=1
conda create -n rtest --dry-run -c r -c anaconda r-base --override-channels -v
```