### PR TITLE
remove experimental featureless_minimization_disabled_feature_flag

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -233,7 +233,6 @@ class Context(Configuration):
     force_reinstall = PrimitiveParameter(False)
 
     target_prefix_override = PrimitiveParameter('')
-    featureless_minimization_disabled_feature_flag = PrimitiveParameter(False)
 
     # conda_build
     bld_path = PrimitiveParameter('')
@@ -751,7 +750,6 @@ class Context(Configuration):
             'default_python',
             'enable_private_envs',
             'error_upload_url',  # should remain undocumented
-            'featureless_minimization_disabled_feature_flag',
             'force_32bit',
             'pip_interop_enabled',  # temporary feature flag
             'root_prefix',

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1088,11 +1088,9 @@ class Resolve(object):
         # The previous "Track features" minimization pass has chosen 'feat1' for the
         # environment, but not 'feat2'. In this case, the 'feat2' version of foo is
         # considered "featureless."
-        if not context.featureless_minimization_disabled_feature_flag:
-            log.debug("Solve: maximize number of packages that have necessary features")
-            eq_feature_metric = r2.generate_feature_metric(C)
-            solution, obj2 = C.minimize(eq_feature_metric, solution)
-            log.debug('Package misfeature count: %d', obj2)
+        eq_feature_metric = r2.generate_feature_metric(C)
+        solution, obj2 = C.minimize(eq_feature_metric, solution)
+        log.debug('Package misfeature count: %d', obj2)
 
         # Requested packages: maximize builds
         log.debug("Solve: maximize build numbers of requested packages")


### PR DESCRIPTION
The behavior enabled by this experimental feature flag didn't pan out as hoped, and I think it's now safe to remove from the code base.

xref: #7601