### PR TITLE
Ensure `script_caller` is bound

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -994,6 +994,7 @@ def run_script(prefix, prec, action='post-link', env_prefix=None, activate=False
             environments.  Future versions of conda may deprecate and ignore pre-link scripts.
             """) % prec.dist_str())
 
+    script_caller = None
     if on_win:
         try:
             comspec = os.environ[str('COMSPEC')]
@@ -1024,7 +1025,6 @@ def run_script(prefix, prec, action='post-link', env_prefix=None, activate=False
             command_args = [shell_path, "-x", script_caller]
         else:
             command_args = [shell_path, "-x", path]
-            script_caller = None
 
     env['ROOT_PREFIX'] = context.root_prefix
     env['PREFIX'] = env_prefix or prefix


### PR DESCRIPTION
Leving the variable unbound can trigger `UnboundLocalError("local variable 'script_caller' referenced before assignment")` on windows when executing pre-unlink scripts.

As in:

```00:00:44 ERROR conda.core.link:_execute(544): An error occurred while uninstalling package 'esss::conda-devenv-cleanup-0.1.0-1'.
00:00:44 UnboundLocalError("local variable 'script_caller' referenced before assignment")
00:00:44 Attempting to roll back.
00:00:44 
00:00:44 Rolling back transaction: ...working... done
00:00:44 
00:00:44 UnboundLocalError("local variable 'script_caller' referenced before assignment")
00:00:44```