### PR TITLE
skip scanning folders for contents during reversal of transactions

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -32,7 +32,7 @@ from ..gateways.disk.create import (compile_multiple_pyc, copy,
                                     create_hard_link_or_copy, create_link,
                                     create_python_entry_point, extract_tarball,
                                     make_menu, mkdir_p, write_as_json_to_file)
-from ..gateways.disk.delete import rm_rf, path_is_clean
+from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.permissions import make_writable
 from ..gateways.disk.read import (compute_md5sum, compute_sha256sum, islink, lexists,
                                   read_index_json)
@@ -370,7 +370,7 @@ class LinkPathAction(CreateInPrefixPathAction):
     def reverse(self):
         if self._execute_successful:
             log.trace("reversing link creation %s", self.target_prefix)
-            if not isdir(self.target_full_path) or path_is_clean(self.target_full_path):
+            if not isdir(self.target_full_path):
                 rm_rf(self.target_full_path, clean_empty_parents=True)
 
 
@@ -976,7 +976,7 @@ class UnlinkPathAction(RemoveFromPrefixPathAction):
             backoff_rename(self.holding_full_path, self.target_full_path, force=True)
 
     def cleanup(self):
-        if not isdir(self.holding_full_path) or path_is_clean(self.target_full_path):
+        if not isdir(self.holding_full_path):
             rm_rf(self.holding_full_path, clean_empty_parents=True)
 
 

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -326,9 +326,11 @@ class PathActionsTests(TestCase):
         assert isdir(join(self.prefix, target_short_path))
 
         axn.reverse()
-        assert not lexists(axn.target_full_path)
-        assert not lexists(dirname(axn.target_full_path))
-        assert not lexists(dirname(dirname(axn.target_full_path)))
+        # this is counter-intuitive, but it's faster to tell conda to ignore folders for removal in transactions
+        #    than it is to try to have it scan to see if anything else has populated that folder.
+        assert lexists(axn.target_full_path)
+        assert lexists(dirname(axn.target_full_path))
+        assert lexists(dirname(dirname(axn.target_full_path)))
 
     def test_simple_LinkPathAction_copy(self):
         source_full_path = make_test_file(self.pkgs_dir)


### PR DESCRIPTION
Just ignore folders for these reversals.  It's a bit messy, but it maintains the fix and it'll be faster.