### PR TITLE
[skip ci] Argparse now keeps double hyphens as is

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,9 @@ extensions = [
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+# Leave double dashes as they are in the docs. Don't replace -- with -
+smartquotes = False
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #


### PR DESCRIPTION
Argparse was "fixing" double hyphens into a longer dash. Added in smartquotes = False to conf.py to stop this behavior.