### PR TITLE
Set the necessary PATH entries in conda.bat

### DIFF
--- a/conda/shell/condabin/conda.bat
+++ b/conda/shell/condabin/conda.bat
@@ -5,7 +5,11 @@
 @IF [%1]==[activate]   "%~dp0_conda_activate" %*
 @IF [%1]==[deactivate] "%~dp0_conda_activate" %*
 
+@setlocal
+@for %%B in (%~dp0.) do @set PATH=%%~dpB;%%~dpBLibrary\mingw-w64\bin;%%~dpBLibrary\usr\bin;%%~dpBLibrary\bin;%%~dpBScripts;%%~dpBbin;%PATH%
 @CALL "%CONDA_EXE%" %*
+@endlocal
+
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 
 @IF [%1]==[install]   "%~dp0_conda_activate" reactivate


### PR DESCRIPTION
We cannot run python.exe (and expect it to work in general) without having all of the environment's path entries on PATH.