### PR TITLE
Use active code page for encoding activate script on Windows

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -72,9 +72,15 @@ class _Activator(object):
         if ext is None:
             return self.command_join.join(commands)
         elif ext:
+            #with open("C:\\Users\jhelmus\jjh_test.bat", 'w+b') as tf:
             with NamedTemporaryFile('w+b', suffix=ext, delete=False) as tf:
                 # the default mode is 'w+b', and universal new lines don't work in that mode
                 # command_join should account for that
+                #joined_commands = self.command_join.join(commands)
+                #binary = ensure_binary(joined_commands)
+                #tf.write(b'chcp 65001\r\n')
+                #tf.write(binary)
+                #raise ValueError("HI\r\n", joined_commands, "\r\nMORE\r\n", binary)
                 tf.write(ensure_binary(self.command_join.join(commands)))
             return tf.name
         else:
@@ -532,8 +538,18 @@ def expand(path):
 
 
 def ensure_binary(value):
+    encoding = 'utf-8'
+    if on_win:
+        import ctypes
+        acp = ctypes.cdll.kernel32.GetACP()
+        encoding = str(acp)
+        #encoding = '1252'
+        #print(acp, encoding)
+        #assert acp == encoding
     try:
-        return value.encode('utf-8')
+        return value.encode(encoding)
+        #return value.encode('utf-8')
+        #return value.encode('cp1252')
     except AttributeError:  # pragma: no cover
         # AttributeError: '<>' object has no attribute 'encode'
         # In this case assume already binary type and do nothing
@@ -725,6 +741,8 @@ class CmdExeActivator(_Activator):
         self.export_var_tmpl = '@SET "%s=%s"'
         self.set_var_tmpl = '@SET "%s=%s"'  # TODO: determine if different than export_var_tmpl
         self.run_script_tmpl = '@CALL "%s"'
+        #self.run_script_tmpl = 'chcp 65001\r\n@CALL "%s"'
+        #self.run_script_tmpl = 'chcp\r\nchcp 65001\r\n@CALL "%s"'
 
         self.hook_source_path = None
         # TODO: cmd.exe doesn't get a hook function? Or do we need to do something different?

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -72,15 +72,9 @@ class _Activator(object):
         if ext is None:
             return self.command_join.join(commands)
         elif ext:
-            #with open("C:\\Users\jhelmus\jjh_test.bat", 'w+b') as tf:
             with NamedTemporaryFile('w+b', suffix=ext, delete=False) as tf:
                 # the default mode is 'w+b', and universal new lines don't work in that mode
                 # command_join should account for that
-                #joined_commands = self.command_join.join(commands)
-                #binary = ensure_binary(joined_commands)
-                #tf.write(b'chcp 65001\r\n')
-                #tf.write(binary)
-                #raise ValueError("HI\r\n", joined_commands, "\r\nMORE\r\n", binary)
                 tf.write(ensure_binary(self.command_join.join(commands)))
             return tf.name
         else:
@@ -543,13 +537,8 @@ def ensure_binary(value):
         import ctypes
         acp = ctypes.cdll.kernel32.GetACP()
         encoding = str(acp)
-        #encoding = '1252'
-        #print(acp, encoding)
-        #assert acp == encoding
     try:
         return value.encode(encoding)
-        #return value.encode('utf-8')
-        #return value.encode('cp1252')
     except AttributeError:  # pragma: no cover
         # AttributeError: '<>' object has no attribute 'encode'
         # In this case assume already binary type and do nothing
@@ -741,8 +730,6 @@ class CmdExeActivator(_Activator):
         self.export_var_tmpl = '@SET "%s=%s"'
         self.set_var_tmpl = '@SET "%s=%s"'  # TODO: determine if different than export_var_tmpl
         self.run_script_tmpl = '@CALL "%s"'
-        #self.run_script_tmpl = 'chcp 65001\r\n@CALL "%s"'
-        #self.run_script_tmpl = 'chcp\r\nchcp 65001\r\n@CALL "%s"'
 
         self.hook_source_path = None
         # TODO: cmd.exe doesn't get a hook function? Or do we need to do something different?

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -215,7 +215,6 @@ def ensure_text_type(value):
             except ImportError:  # pragma: no cover
                 from pip._vendor.requests.packages.chardet import detect
         encoding = detect(value).get('encoding') or 'utf-8'
-        #return value.decode(encoding)
         return value.decode(encoding, errors='replace')
     except UnicodeEncodeError:  # pragma: no cover
         # it's already text_type, so ignore?

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -215,7 +215,8 @@ def ensure_text_type(value):
             except ImportError:  # pragma: no cover
                 from pip._vendor.requests.packages.chardet import detect
         encoding = detect(value).get('encoding') or 'utf-8'
-        return value.decode(encoding)
+        #return value.decode(encoding)
+        return value.decode(encoding, errors='replace')
     except UnicodeEncodeError:  # pragma: no cover
         # it's already text_type, so ignore?
         # not sure, surfaced with tests/models/test_match_spec.py test_tarball_match_specs

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2156,7 +2156,7 @@ class IntegrationTests(TestCase):
         test_pkg = '_conda_test_env_activated_when_post_link_executed'
         # a non-unicode name must be provided here as activate.d scripts
         # are not execuated on windows, see https://github.com/conda/conda/issues/8241
-        with make_temp_env(test_pkg, '-c conda-test', name='post_link_test') as prefix:
+        with make_temp_env(test_pkg, '-c conda-test') as prefix:
             assert package_is_installed(prefix, test_pkg)
 
     def test_conda_info_python(self):


### PR DESCRIPTION
Allows activate.d scripts to be run on Windows if even if the prefix path contains unicode characters. 
closes #8241