### PR TITLE
prepend root prefix paths to PATH before running conda commands on win

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -114,6 +114,15 @@ def main(*args, **kwargs):
             return ExceptionHandler().handle_exception(exc_val, exc_tb)
 
     from ..exceptions import conda_exception_handler
+    # on Windows, we need to add to PATH so that we find the libraries
+    #   associated with this specific env Without this, we see lots of openssl
+    #   HTTPErrors because either incorrect libraries or no libraries are
+    #   present
+    if sys.platform == "win32":
+        from ..activate import _Activator
+        from ..base.context import context
+        import os
+        os.environ["PATH"] = _Activator._get_path_dirs(context.root_prefix) + os.environ["PATH"]
     return conda_exception_handler(_main, *args, **kwargs)
 
 


### PR DESCRIPTION
supersedes #8287 

This depends on a python patch that is in development.  This should not be merged until we can link it to confirmation that those python builds are available.