### PR TITLE
fix activator path output incorrectly adding to PATH

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -122,7 +122,8 @@ def main(*args, **kwargs):
         from ..activate import _Activator
         from ..base.context import context
         import os
-        os.environ["PATH"] = _Activator._get_path_dirs(context.root_prefix) + os.environ["PATH"]
+        os.environ["PATH"] = (';'.join(_Activator._get_path_dirs(context.root_prefix)) + ';' +
+                              os.environ["PATH"])
     return conda_exception_handler(_main, *args, **kwargs)
 
 

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -56,7 +56,8 @@ def rename(source_path, destination_path, force=False):
         try:
             os.rename(source_path, destination_path)
         except EnvironmentError as e:
-            if on_win and dirname(source_path) == dirname(destination_path):
+            if (on_win and dirname(source_path) == dirname(destination_path)
+                    and os.path.isfile(source_path)):
                 condabin_dir = join(context.conda_prefix, "condabin")
                 rename_script = join(condabin_dir, 'rename_tmp.bat')
                 if exists(rename_script):


### PR DESCRIPTION
os.environ['PATH'] is a string.  You can't add a generator to a string.  Shame on me.