### PR TITLE
tweak some logic in trash renaming to fix permission errors

### DIFF
--- a/conda/compat.py
+++ b/conda/compat.py
@@ -58,9 +58,6 @@ class TemporaryDirectory(object):
                     raise
                 _rm_rf(self.name)
             self._closed = True
-            if _warn and _warnings.warn:
-                _warnings.warn("Implicitly cleaning up {!r}".format(self),
-                                _warnings.ResourceWarning)
 
     def __exit__(self, exc, value, tb):
         self.cleanup()


### PR DESCRIPTION
The previous code here was incorrect.  It led to only the first file being renamed in-place to .conda_trash - all others were left untouched, which resulted in permissions errors on the next thing to overwrite them.  This was especially a problem with conda-build and subpackages, where a prefix is removed and then created with new deps.