### PR TITLE
Removing --lock from conda clean (not supported)

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -229,11 +229,6 @@ def configure_parser_clean(sub_parsers):
         help="Remove index cache.",
     )
     removal_target_options.add_argument(
-        "-l", "--lock",
-        action="store_true",
-        help="Remove all conda lock files.",
-    )
-    removal_target_options.add_argument(
         '-p', '--packages',
         action='store_true',
         help="Remove unused packages from writable package caches. "


### PR DESCRIPTION
The `--lock` command line option for `conda build` has no behaviour associated to it anymore.

In fact, in the latest stable release of `conda`, invoking `conda clean --lock` gives you an `ArgumentError` error.

So, in this PR, I'm just removing the `--lock` from the `argparse` options.

```
$ conda clean --lock

ArgumentError: At least one removal target must be given. See 'conda clean --help'.
```