### PR TITLE
update circle and appveyor to test with py37 instead of 36

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ environment:
 
   matrix:
      - PYTHON: "C:\\Python36_64"
-       PYTHON_VERSION: "3.6"
+       PYTHON_VERSION: "3.7"
        PYTHON_ARCH: "64"
-       PYTHON_ROOT: "C:\\Miniconda36-x64"
+       PYTHON_ROOT: "C:\\Miniconda3-x64"
        CONDA_INSTRUMENTATION_ENABLED: "true"
 
      - PYTHON: "C:\\Python27_32"

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,8 @@
 defaults: &defaults
   working_directory: ~/conda
   docker:
-    - image: condatest/linux-64-python-3.6
-      # Dockerfile at https://github.com/conda/conda-docker/blob/master/condatest/linux-64-python3.6/Dockerfile
+    - image: condatest/linux-64-python-3.7
+      # Dockerfile at https://github.com/conda/conda-docker/blob/master/condatest/linux-64-python3.7/Dockerfile
 
 
 main_test: &main_test


### PR DESCRIPTION
This is expected to fail on circle right now.  I need permissions to push the new test docker image for py37 to docker hub.  Putting this up so we can just re-run it when that is available.