### PR TITLE
fix checkout of urllib code into cleaner location

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1543,9 +1543,9 @@ class IntegrationTests(TestCase):
             assert package_is_installed(prefix, "python")
 
             # install an "editable" urllib3 that cannot be managed
-            output, err = run_command(Commands.RUN, prefix, "python -m pip install -e git://github.com/urllib3/urllib3.git@1.19.1#egg=urllib3")
+            output, err = run_command(Commands.RUN, prefix, "python -m pip install -e git://github.com/urllib3/urllib3.git@1.19.1#egg=urllib3", workdir=prefix)
             print(output)
-            assert isfile(join("src", "urllib3", "urllib3", "__init__.py"))
+            assert isfile(join(prefix, "src", "urllib3", "urllib3", "__init__.py"))
             PrefixData._cache_.clear()
             assert package_is_installed(prefix, "urllib3")
             urllib3_record = next(PrefixData(prefix).query("urllib3"))


### PR DESCRIPTION
This was a bit of a regression in #8307.  This fixes the source code ending up in cwd, which is generally conda root, which then dumps this extra "src" folder where you don't really want it.