### PR TITLE
Wrap more calls to conda because it may not be on PATH properly

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -395,20 +395,17 @@ class _Activator(object):
     def _get_starting_path_list(self):
         path = self.environ.get('PATH', '')
         if on_win:
-            # On Windows, the Anaconda Python interpreter prepends sys.prefix\Library\bin on
-            # startup. It's a hack that allows users to avoid using the correct activation
-            # procedure; a hack that needs to go away because it doesn't add all the paths.
-            # See: https://github.com/AnacondaRecipes/python-feedstock/blob/master/recipe/0005-Win32-Ensure-Library-bin-is-in-os.environ-PATH.patch  # NOQA
-            # But, we now detect if that has happened because:
-            #   1. In future we would like to remove this hack and require real activation.
-            #   2. We should not assume that the Anaconda Python interpreter is being used.
-            path_split = path.split(os.pathsep)
-            library_bin = r"%s\Library\bin" % (sys.prefix)
-            # ^^^ deliberately the same as: https://github.com/AnacondaRecipes/python-feedstock/blob/8e8aee4e2f4141ecfab082776a00b374c62bb6d6/recipe/0005-Win32-Ensure-Library-bin-is-in-os.environ-PATH.patch#L20  # NOQA
-            if paths_equal(path_split[0], library_bin):
-                return path_split[1:]
-            else:
-                return path_split
+            # We used to prepend sys.prefix\Library\bin to PATH on startup but not anymore.
+            # Instead, in conda 4.6 we add the full suite of entries. This is performed in
+            # condabin\conda.bat and condabin\ _conda_activate.bat
+             path_split = path.split(os.pathsep)
+             prefix_dirs = tuple(self._get_path_dirs2(sys.prefix))
+             start_index = 0
+             while (start_index < len(prefix_dirs) and
+                    start_index < len(path_split) and
+                    path_split[start_index] == prefix_dirs[start_index]):
+                 start_index+=1
+             return path_split[start_index:]
         else:
             return path.split(os.pathsep)
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -398,14 +398,14 @@ class _Activator(object):
             # We used to prepend sys.prefix\Library\bin to PATH on startup but not anymore.
             # Instead, in conda 4.6 we add the full suite of entries. This is performed in
             # condabin\conda.bat and condabin\ _conda_activate.bat
-             path_split = path.split(os.pathsep)
-             prefix_dirs = tuple(self._get_path_dirs2(sys.prefix))
-             start_index = 0
-             while (start_index < len(prefix_dirs) and
-                    start_index < len(path_split) and
-                    path_split[start_index] == prefix_dirs[start_index]):
-                 start_index+=1
-             return path_split[start_index:]
+            path_split = path.split(os.pathsep)
+            prefix_dirs = tuple(self._get_path_dirs2(sys.prefix))
+            start_index = 0
+            while (start_index < len(prefix_dirs) and
+                   start_index < len(path_split) and
+                   path_split[start_index] == prefix_dirs[start_index]):
+                start_index+=1
+            return path_split[start_index:]
         else:
             return path.split(os.pathsep)
 

--- a/conda/shell/condabin/_conda_activate.bat
+++ b/conda/shell/condabin/_conda_activate.bat
@@ -9,12 +9,12 @@
     @SET CONDA_PS1_BACKUP=
 :FIXUP43
 
-@setlocal enabledelayedexpansion
-for %%A in ("%~dp0\.") do set _sysp=%%~dpA
-SET _sysp=%_sysp:~0,-1%
-for %%B in (%~dp0.) do @set PATH=%_sysp%;%_sysp%\Library\mingw-w64\bin;%_sysp%\Library\usr\bin;%_sysp%\Library\bin;%_sysp%\Scripts;%_sysp%\bin;%PATH%
+@SETLOCAL enabledelayedexpansion
+@FOR %%A in ("%~dp0\.") DO @SET _sysp=%%~dpA
+@SET _sysp=%_sysp:~0,-1%
+@FOR %%B in (%~dp0.) DO @SET PATH=%_sysp%;%_sysp%\Library\mingw-w64\bin;%_sysp%\Library\usr\bin;%_sysp%\Library\bin;%_sysp%\Scripts;%_sysp%\bin;%PATH%
 @FOR /F "delims=" %%i IN ('@CALL "%CONDA_EXE%" shell.cmd.exe %*') DO @SET "_TEMP_SCRIPT_PATH=%%i"
-@endlocal & @SET "_TEMP_SCRIPT_PATH=%_TEMP_SCRIPT_PATH%"
+@ENDLOCAL & @SET "_TEMP_SCRIPT_PATH=%_TEMP_SCRIPT_PATH%"
 @IF "%_TEMP_SCRIPT_PATH%"=="" @EXIT /B 1
 @IF NOT "%CONDA_PROMPT_MODIFIER%" == "" @CALL SET "PROMPT=%%PROMPT:%CONDA_PROMPT_MODIFIER%=%_empty_not_set_%%%"
 @CALL "%_TEMP_SCRIPT_PATH%"

--- a/conda/shell/condabin/_conda_activate.bat
+++ b/conda/shell/condabin/_conda_activate.bat
@@ -9,7 +9,12 @@
     @SET CONDA_PS1_BACKUP=
 :FIXUP43
 
+@setlocal enabledelayedexpansion
+for %%A in ("%~dp0\.") do set _sysp=%%~dpA
+SET _sysp=%_sysp:~0,-1%
+for %%B in (%~dp0.) do @set PATH=%_sysp%;%_sysp%\Library\mingw-w64\bin;%_sysp%\Library\usr\bin;%_sysp%\Library\bin;%_sysp%\Scripts;%_sysp%\bin;%PATH%
 @FOR /F "delims=" %%i IN ('@CALL "%CONDA_EXE%" shell.cmd.exe %*') DO @SET "_TEMP_SCRIPT_PATH=%%i"
+@endlocal & @SET "_TEMP_SCRIPT_PATH=%_TEMP_SCRIPT_PATH%"
 @IF "%_TEMP_SCRIPT_PATH%"=="" @EXIT /B 1
 @IF NOT "%CONDA_PROMPT_MODIFIER%" == "" @CALL SET "PROMPT=%%PROMPT:%CONDA_PROMPT_MODIFIER%=%_empty_not_set_%%%"
 @CALL "%_TEMP_SCRIPT_PATH%"

--- a/conda/shell/condabin/conda.bat
+++ b/conda/shell/condabin/conda.bat
@@ -5,12 +5,12 @@ IF NOT DEFINED CONDA_EXE @SET "CONDA_EXE=%~dp0..\Scripts\conda.exe"
 IF [%1]==[activate]   "%~dp0_conda_activate" %*
 IF [%1]==[deactivate] "%~dp0_conda_activate" %*
 
-setlocal
-for %%A in ("%~dp0\.") do set _sysp=%%~dpA
-SET _sysp=%_sysp:~0,-1%
-for %%B in (%~dp0.) do @set PATH=%_sysp%;%_sysp%\Library\mingw-w64\bin;%_sysp%\Library\usr\bin;%_sysp%\Library\bin;%_sysp%\Scripts;%_sysp%\bin;%PATH%
+@SETLOCAL
+@FOR %%A IN ("%~dp0\.") DO @SET _sysp=%%~dpA
+@SET _sysp=%_sysp:~0,-1%
+FOR %%B in (%~dp0.) DO @SET PATH=%_sysp%;%_sysp%\Library\mingw-w64\bin;%_sysp%\Library\usr\bin;%_sysp%\Library\bin;%_sysp%\Scripts;%_sysp%\bin;%PATH%
 CALL "%CONDA_EXE%" %*
-endlocal
+@ENDLOCAL
 
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 

--- a/conda/shell/condabin/conda.bat
+++ b/conda/shell/condabin/conda.bat
@@ -1,14 +1,14 @@
-REM Copyright (C) 2012 Anaconda, Inc
-REM SPDX-License-Identifier: BSD-3-Clause
-IF NOT DEFINED CONDA_EXE @SET "CONDA_EXE=%~dp0..\Scripts\conda.exe"
+@REM Copyright (C) 2012 Anaconda, Inc
+@REM SPDX-License-Identifier: BSD-3-Clause
+@IF NOT DEFINED CONDA_EXE @SET "CONDA_EXE=%~dp0..\Scripts\conda.exe"
 
-IF [%1]==[activate]   "%~dp0_conda_activate" %*
-IF [%1]==[deactivate] "%~dp0_conda_activate" %*
+@IF [%1]==[activate]   "%~dp0_conda_activate" %*
+@IF [%1]==[deactivate] "%~dp0_conda_activate" %*
 
 @SETLOCAL
 @FOR %%A IN ("%~dp0\.") DO @SET _sysp=%%~dpA
 @SET _sysp=%_sysp:~0,-1%
-FOR %%B in (%~dp0.) DO @SET PATH=%_sysp%;%_sysp%\Library\mingw-w64\bin;%_sysp%\Library\usr\bin;%_sysp%\Library\bin;%_sysp%\Scripts;%_sysp%\bin;%PATH%
+@FOR %%B in (%~dp0.) DO @SET PATH=%_sysp%;%_sysp%\Library\mingw-w64\bin;%_sysp%\Library\usr\bin;%_sysp%\Library\bin;%_sysp%\Scripts;%_sysp%\bin;%PATH%
 CALL "%CONDA_EXE%" %*
 @ENDLOCAL
 

--- a/conda/shell/condabin/conda.bat
+++ b/conda/shell/condabin/conda.bat
@@ -1,14 +1,16 @@
-@REM Copyright (C) 2012 Anaconda, Inc
-@REM SPDX-License-Identifier: BSD-3-Clause
-@IF NOT DEFINED CONDA_EXE @SET "CONDA_EXE=%~dp0..\Scripts\conda.exe"
+REM Copyright (C) 2012 Anaconda, Inc
+REM SPDX-License-Identifier: BSD-3-Clause
+IF NOT DEFINED CONDA_EXE @SET "CONDA_EXE=%~dp0..\Scripts\conda.exe"
 
-@IF [%1]==[activate]   "%~dp0_conda_activate" %*
-@IF [%1]==[deactivate] "%~dp0_conda_activate" %*
+IF [%1]==[activate]   "%~dp0_conda_activate" %*
+IF [%1]==[deactivate] "%~dp0_conda_activate" %*
 
-@setlocal
-@for %%B in (%~dp0.) do @set PATH=%%~dpB;%%~dpBLibrary\mingw-w64\bin;%%~dpBLibrary\usr\bin;%%~dpBLibrary\bin;%%~dpBScripts;%%~dpBbin;%PATH%
-@CALL "%CONDA_EXE%" %*
-@endlocal
+setlocal
+for %%A in ("%~dp0\.") do set _sysp=%%~dpA
+SET _sysp=%_sysp:~0,-1%
+for %%B in (%~dp0.) do @set PATH=%_sysp%;%_sysp%\Library\mingw-w64\bin;%_sysp%\Library\usr\bin;%_sysp%\Library\bin;%_sysp%\Scripts;%_sysp%\bin;%PATH%
+CALL "%CONDA_EXE%" %*
+endlocal
 
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -3,3 +3,5 @@ pycosat >=0.6.3
 pyopenssl >=16.2.0
 requests >=2.12.4,<3
 ruamel_yaml >=0.11.14
+git
+


### PR DESCRIPTION
And make all MS-DOS commands uppercase BECAUSE THIS WAS THE HEIGHT
OF TECHNOLOGICAL SOPHISTICATION BACK IN THE OLDEN DAYS AND DID NOT
MEAN SHOUTING LIKE IT DOES NOW.