### PR TITLE
removing env the right way

### DIFF
--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -558,7 +558,7 @@ Anaconda Prompt, run:
 
    conda remove --name myenv --all
 
-(You may instead use ``conda env remove --name myenv``.)
+(You may need to use ``conda env remove --name myenv`` after to remove some remnants. But do not run this command first.)
 
 To verify that the environment was removed, in your terminal window or an
 Anaconda Prompt, run:


### PR DESCRIPTION
If I understand right then `conda remove --name myenv --all` would uninstall and unlink all packages. Good. But  `conda env remove --name myenv` would only move env as a whole to permanently occupy .trash folder (I see this behaviour on Windows). If you had pure linked env then it eventually would be freed via conda clean. But if you had mixed link/copy (or even had pip installed packages) then you cannot safely delete trashed env as a whole without breaking other envs. So you cannor really clean completely if you used `conda env remove --name myenv`.

Am I right?