### PR TITLE
Quote path to temporary requirements file - fixes #8347

### DIFF
--- a/conda_env/installers/pip.py
+++ b/conda_env/installers/pip.py
@@ -38,7 +38,7 @@ def _pip_install_via_requirements(prefix, specs, args, *_, **kwargs):
         requirements.write('\n'.join(specs))
         requirements.close()
         # pip command line...
-        pip_cmd = ['install', '-r', requirements.name]
+        pip_cmd = ['install', '-r', '"{}"'.format(requirements.name)]
         pip_subprocess(pip_cmd, prefix, cwd=pip_workdir)
     finally:
         # Win/Appveyor does not like it if we use context manager + delete=True.


### PR DESCRIPTION
If there is a space in the path to the .yml file for an environment, conda create will fail. This is because the temporary requirements file created here will be created in the same directory as the .yml file, and when the path to it is given to pip, it will fail if there is a space in it and the full path isn't quoted. This commit is ensuring that the path is quoted as part of the pip command. This fixes #8347.

I have not tested this change on Windows or Linux, just Mac OS.