### PR TITLE
Improve some exception handling

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -14,7 +14,7 @@ import tarfile
 import tempfile
 
 from . import mkdir_p
-from .delete import rm_rf
+from .delete import rm_rf, path_is_clean
 from .link import islink, lexists, link, readlink, symlink
 from .permissions import make_executable
 from .update import touch
@@ -163,7 +163,13 @@ def extract_tarball(tarball_full_path, destination_directory=None, progress_upda
         destination_directory = tarball_full_path[:-8]
     log.debug("extracting %s\n  to %s", tarball_full_path, destination_directory)
 
-    assert not lexists(destination_directory), destination_directory
+    # the most common reason this happens is due to hard-links, windows thinks
+    #    files in the package cache are in-use. rm_rf should have moved them to
+    #    have a .conda_trash extension though, so it's ok to just write into
+    #    the same existing folder.
+    if not path_is_clean(destination_directory):
+        log.debug("package folder {} was not empty, but we're writing there."
+                  .format(destination_directory))
 
     with open(tarball_full_path, 'rb') as fileobj:
         if progress_update_callback:

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -29,7 +29,7 @@ VALID_KEYS = ('name', 'dependencies', 'prefix', 'channels')
 def validate_keys(data, kwargs):
     """Check for unknown keys, remove them and print a warning."""
     invalid_keys = []
-    new_data = data.copy()
+    new_data = data.copy() if data else {}
     for key in data.keys():
         if key not in VALID_KEYS:
             invalid_keys.append(key)


### PR DESCRIPTION
These were identified from user error logs as very high frequency errors.  There's one more remaining that would be good to fix:

```
Traceback (most recent call last):\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\exceptions.py\"", line 1002, in __call__\n    return func(*args, **kwargs)\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\cli\\main.py\"", line 84, in _main\n    exit_code = do_call(args, p)\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\cli\\conda_argparse.py\"", line 82, in do_call\n    exit_code = getattr(module, func_name)(args, parser)\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\cli\\main_install.py\"", line 20, in execute\n    install(args, parser, 'install')\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\cli\\install.py\"", line 253, in install\n    force_reinstall=context.force_reinstall or context.force,\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\core\\solve.py\"", line 107, in solve_for_transaction\n    force_remove, force_reinstall)\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\core\\solve.py\"", line 145, in solve_for_diff\n    force_remove)\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\core\\solve.py\"", line 244, in solve_final_state\n    ssc = self._check_solution(ssc)\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\conda\\common\\io.py\"", line 402, in __exit__\n    sys.stdout.write(\""done\\n\"")\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\colorama\\ansitowin32.py\"", line 40, in write\n    self.__convertor.write(text)\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\colorama\\ansitowin32.py\"", line 141, in write\n    self.write_and_convert(text)\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\colorama\\ansitowin32.py\"", line 169, in write_and_convert\n    self.write_plain_text(text, cursor, len(text))\n  File \""C:\\Users\\eanb.EDBIT\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\colorama\\ansitowin32.py\"", line 174, in write_plain_text\n    self.wrapped.write(text[start:end])\nOSError: [Errno 22] Invalid argument\n""}
```

Myi best guess is that there's something like writing to stdout while it's captured in a strange way.