### PR TITLE
Corrected the helper messages shown after 'conda create -n ENV_NAME' 

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -109,10 +109,10 @@ def print_activate(env_name_or_prefix):  # pragma: no cover
             message = dals("""
             #
             # To activate this environment, use:
-            # > source activate %s
+            # > conda activate %s
             #
             # To deactivate an active environment, use:
-            # > source deactivate
+            # > conda deactivate
             #
             """) % env_name_or_prefix
         print(message)  # TODO: use logger


### PR DESCRIPTION
Corrected the helper messages shown after 'conda create -n ENV_NAME'  as noted in [8364](https://github.com/conda/conda/issues/8364). 