### PR TITLE
handle None values for channel name in diff_strs gracefully

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -845,7 +845,8 @@ class UnlinkLinkTransaction(object):
             builder_right = []
 
             if channel_change or subdir_change:
-                builder_left.append(unlink_prec.channel.name)
+                if unlink_prec.channel.name is not None:
+                    builder_left.append(unlink_prec.channel.name)
                 builder_right.append(link_prec.channel.name)
             if subdir_change:
                 builder_left.append("/" + unlink_prec.subdir)


### PR DESCRIPTION
Reported by @oleksandr-pavlyk in conda 4.6.7