### PR TITLE
Fix checking for docs changes 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,7 @@ main_test: &main_test
     - run:
         name: unit tests
         command: |
-          diff_or=$(git diff origin/master --name-only)
-          if [[ $(echo $diff_or | wc -l) == $(echo $diff_or | grep docs | wc -l) && $(echo $diff_or | grep docs) ]]; then
+          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
             echo "Only docs changed detected, skipping tests"
           else
             echo "local_repodata_ttl: 1800" >> ~/.condarc
@@ -27,8 +26,7 @@ main_test: &main_test
     - run:
         name: integration tests
         command: |
-          diff_or=$(git diff origin/master --name-only)
-          if [[ $(echo $diff_or | wc -l) == $(echo $diff_or | grep docs | wc -l) && $(echo $diff_or | grep docs) ]]; then
+          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
             echo "Only docs changed detected, skipping tests"
           else
             eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
@@ -38,8 +36,7 @@ main_test: &main_test
     - run:
         name: upload codecov
         command: |
-          diff_or=$(git diff origin/master --name-only)
-          if [[ $(echo $diff_or | wc -l) == $(echo $diff_or | grep docs | wc -l) && $(echo $diff_or | grep docs) ]]; then
+          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
             echo "No codecov report to upload"
           else
             /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
@@ -138,8 +135,7 @@ conda_build_test: &conda_build_test
           # test_overlinking_detection package doesn't have configure
           # test_python_line_up_with_compiled_lib because older CB honors run_exports.yaml and not run_exports.json
         command: |
-          diff_or=$(git diff origin/master --name-only)
-          if [[ $(echo $diff_or | wc -l) == $(echo $diff_or | grep docs | wc -l) && $(echo $diff_or | grep docs) ]]; then
+          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
             echo "Only docs changed detected, skipping tests"
           else
             eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
@@ -167,8 +163,7 @@ conda_build_test: &conda_build_test
           # test_setuptools_test_requirements upstream changes that affect 'conda skeleton'
           # rpm-libX11-devel returns 404 error
         command: |
-          diff_or=$(git diff origin/master --name-only)
-          if [[ $(echo $diff_or | wc -l) == $(echo $diff_or | grep docs | wc -l) && $(echo $diff_or | grep docs) ]]; then
+          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
               echo "Only docs changed detected, skipping tests"
           else
             eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"


### PR DESCRIPTION
The previous method of doing this on circleci broke since the
git diff, when stored in an environment variable did not include
any line breaks