### PR TITLE
Use comma-separated env names in prompt for stacked env

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -580,8 +580,6 @@ class _Activator(object):
 
     def _prompt_modifier(self, prefix, conda_default_env):
         if context.changeps1:
-            base_env_name = self._default_env(context.root_prefix)
-
             # Get current environment and prompt stack
             env_stack = []
             prompt_stack = []
@@ -590,7 +588,8 @@ class _Activator(object):
                 if i == old_shlvl:
                     env_i = self._default_env(self.environ.get('CONDA_PREFIX', ''))
                 else:
-                    env_i = self._default_env(self.environ.get('CONDA_PREFIX_{}'.format(i), '').rstrip())
+                    env_i = self._default_env(
+                            self.environ.get('CONDA_PREFIX_{}'.format(i), '').rstrip())
                 stacked_i = bool(self.environ.get('CONDA_STACKED_{}'.format(i), '').rstrip())
                 env_stack.append(env_i)
                 if not stacked_i:

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -585,8 +585,8 @@ class _Activator(object):
             # Get current environment and prompt stack
             env_stack = []
             prompt_stack = []
-            old_shlvl = int(self.environ.get('CONDA_SHLVL').rstrip())
-            for i in xrange(1, old_shlvl+1):
+            old_shlvl = int(self.environ.get('CONDA_SHLVL', '').rstrip())
+            for i in range(1, old_shlvl+1):
                 if i == old_shlvl:
                     env_i = basename(self.environ.get('CONDA_PREFIX', ''))
                 else:

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -580,7 +580,7 @@ class _Activator(object):
 
     def _prompt_modifier(self, prefix, conda_default_env):
         if context.changeps1:
-            base_env_name = basename(context.root_prefix)
+            base_env_name = self._default_env(context.root_prefix)
 
             # Get current environment and prompt stack
             env_stack = []
@@ -588,15 +588,14 @@ class _Activator(object):
             old_shlvl = int(self.environ.get('CONDA_SHLVL', '0').rstrip())
             for i in range(1, old_shlvl+1):
                 if i == old_shlvl:
-                    env_i = basename(self.environ.get('CONDA_PREFIX', ''))
+                    env_i = self._default_env(self.environ.get('CONDA_PREFIX', ''))
                 else:
-                    env_i = basename(self.environ.get('CONDA_PREFIX_{}'.format(i), '').rstrip())
+                    env_i = self._default_env(self.environ.get('CONDA_PREFIX_{}'.format(i), '').rstrip())
                 stacked_i = bool(self.environ.get('CONDA_STACKED_{}'.format(i), '').rstrip())
                 env_stack.append(env_i)
                 if not stacked_i:
                     prompt_stack = prompt_stack[0:-1]
                 prompt_stack.append(env_i)
-            env_stack = [ROOT_ENV_NAME if env == base_env_name else env for env in env_stack]
 
             # Modify prompt stack according to pending operation
             deactivate = getattr(self, '_deactivate', False)
@@ -614,7 +613,6 @@ class _Activator(object):
                 if not stack:
                     prompt_stack = prompt_stack[0:-1]
                 prompt_stack.append(conda_default_env)
-            prompt_stack = [ROOT_ENV_NAME if pt == base_env_name else pt for pt in prompt_stack]
 
             conda_default_env = ','.join(prompt_stack)
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -613,10 +613,11 @@ class _Activator(object):
                     prompt_stack = prompt_stack[0:-1]
                 prompt_stack.append(conda_default_env)
 
-            conda_default_env = ','.join(prompt_stack)
+            conda_stacked_env = ','.join(prompt_stack[::-1])
 
             return context.env_prompt.format(
                 default_env=conda_default_env,
+                stacked_env=conda_stacked_env,
                 prefix=prefix,
                 name=basename(prefix),
             )

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -585,7 +585,7 @@ class _Activator(object):
             # Get current environment and prompt stack
             env_stack = []
             prompt_stack = []
-            old_shlvl = int(self.environ.get('CONDA_SHLVL', '').rstrip())
+            old_shlvl = int(self.environ.get('CONDA_SHLVL', '0').rstrip())
             for i in range(1, old_shlvl+1):
                 if i == old_shlvl:
                     env_i = basename(self.environ.get('CONDA_PREFIX', ''))


### PR DESCRIPTION
This PR changes the way activated environments are displayed in shell prompt for stacked environments.
Before:
```
(base) $ conda activate envA
(envA) $ conda activate --stack envB
(envB) $ conda activate --stack envC
(envC) $ conda deactivate
(envB) $ conda deactivate
(envA) $ conda deactivate
(base) $
```
After:
```
(base) $ conda activate envA
(envA) $ conda activate --stack envB
(envA,envB) $ conda activate --stack envC
(envA,envB,envC) $ conda deactivate
(envA,envB) $ conda deactivate
(envA) $ conda deactivate
(base) $
```
It also correctly handles reactivation, or deactivation through activating previous environments:
```
(base) $ conda activate envA
(envA) $ conda activate --stack envB
(envA,envB) $ conda activate --stack envC
(envA,envB,envC) $ conda activate envC
(envA,envB,envC) $ conda activate envB
(envA,envB) $ conda activate envC
(envA,envC) $ 
```
In essense, the prompt always reflects the activated environments in the same order as they were activated (i.e the order in $PATH). This keeps users informed of the environments in effect, particularly in cases where the behaviour of environment stacking might be unexpected. For example:
```
(base) $ conda activate envA
(envA) $ conda activate --stack envB
(envA,envB) $ conda activate
(envA,base) $
```
The prompt behaves the same way as it is now when no stacking is involved.