### PR TITLE
Improve handling of inconsistent environments

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -354,6 +354,9 @@ class Solver(object):
             log.debug("inconsistent precs: %s",
                       dashlist(inconsistent_precs) if inconsistent_precs else 'None')
         if inconsistent_precs:
+            print(dedent("""
+            The environment is inconsistent, please check the package plan carefully
+            """))
             for prec in inconsistent_precs:
                 # pop and save matching spec in specs_map
                 ssc.add_back_map[prec.name] = (prec, ssc.specs_map.pop(prec.name, None))

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -356,7 +356,8 @@ class Solver(object):
         if inconsistent_precs:
             print(dedent("""
             The environment is inconsistent, please check the package plan carefully
-            """))
+            The following packages are causing the inconsistency:"""))
+            print(dashlist(inconsistent_precs))
             for prec in inconsistent_precs:
                 # pop and save matching spec in specs_map
                 spec = ssc.specs_map.pop(prec.name, None)

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -359,7 +359,13 @@ class Solver(object):
             """))
             for prec in inconsistent_precs:
                 # pop and save matching spec in specs_map
-                ssc.add_back_map[prec.name] = (prec, ssc.specs_map.pop(prec.name, None))
+                spec = ssc.specs_map.pop(prec.name, None)
+                ssc.add_back_map[prec.name] = (prec, spec)
+                # inconsistent environments should maintain the python version
+                # unless explicitly requested by the user. This along with the logic in
+                # _add_specs maintains the major.minor version
+                if prec.name == 'python':
+                    ssc.specs_map['python'] = spec
             ssc.solution_precs = tuple(prec for prec in ssc.solution_precs
                                        if prec not in inconsistent_precs)
         return ssc

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -892,6 +892,13 @@ class Resolve(object):
             sat_name_map[self.to_sat_name(prec)] = prec
             specs.append(MatchSpec('%s %s %s' % (prec.name, prec.version, prec.build)))
         new_index = {prec: prec for prec in itervalues(sat_name_map)}
+        name_map = {p.name: p for p in new_index}
+        if 'python' in name_map and 'pip' not in name_map:
+            python_prec = new_index[name_map['python']]
+            if 'pip' in python_prec.depends:
+                # strip pip dependency from python if not installed in environment
+                new_deps = [d for d in python_prec.depends if d != 'pip']
+                python_prec.depends = new_deps
         r2 = Resolve(new_index, True, channels=self.channels)
         C = r2.gen_clauses()
         constraints = r2.generate_spec_constraints(C, specs)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -598,7 +598,7 @@ class IntegrationTests(TestCase):
             assert stderr == ''
             self.assertIsInstance(stdout, str)
 
-    @pytest.mark.skipif(on_win and context.subdir == "win-32", reason="conda-forge doesn't do win-32")
+    @pytest.mark.skipif(reason="conda-forge doesn't have a full set of packages")
     def test_strict_channel_priority(self):
         stdout, stderr = run_command(
             Commands.CREATE, "/",

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1030,6 +1030,20 @@ def test_broken_install():
     # always insure installed packages _are_ in the index
 
 
+def test_pip_depends_removed_on_inconsistent_env():
+    installed = r.install(['python 2.7*'])
+    pkg_names = [p.name for p in installed]
+    assert 'python' in pkg_names
+    assert 'pip' not in pkg_names
+    # add pip as python dependency
+    for pkg in installed:
+        if pkg.name == 'python':
+            pkg.depends += ('pip', )
+        assert pkg.name != 'pip'
+    bad_pkgs = r.bad_installed(installed, [])[0]
+    assert bad_pkgs is None
+
+
 def test_remove():
     installed = r.install(['pandas', 'python 2.7*'])
     _installed = [rec.dist_str() for rec in installed]


### PR DESCRIPTION
Improve the user experience when an environment is inconsistent.  
* Environments where pip has been removing or upgraded and `add_pip_as_python_dependency` was set when installing python will remove pip and a dependency of pip to try to restore consistency.
* The Python major and minor version will be maintained during modification of a inconsistent environment unless the user explicitly requests a Python version.
* A message is printed out informing users when a inconsistent environment is being modified.

closes #8391 