### PR TITLE
Handle read-only FS for environments.txt

### DIFF
--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from errno import EACCES
+from errno import EACCES, EROFS
 from logging import getLogger
 from os import listdir
 from os.path import dirname, isdir, isfile, join, normpath
@@ -37,7 +37,7 @@ def register_env(location):
             fh.write(ensure_text_type(location))
             fh.write('\n')
     except EnvironmentError as e:
-        if e.errno == EACCES:
+        if e.errno in (EACCES, EROFS):
             log.warn("Unable to register environment. Path not writable.\n"
                      "  environment location: %s\n"
                      "  registry file: %s", location, USER_ENVIRONMENTS_TXT_FILE)


### PR DESCRIPTION
In my Disaster Recovery environment we have read-only home directories because they are replicated from our normal environment.