### PR TITLE
Edge case for RO FS & environments.txt

### DIFF
--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from errno import EACCES, EROFS
+from errno import EACCES, EROFS, ENOENT
 from logging import getLogger
 from os import listdir
 from os.path import dirname, isdir, isfile, join, normpath
@@ -37,8 +37,8 @@ def register_env(location):
             fh.write(ensure_text_type(location))
             fh.write('\n')
     except EnvironmentError as e:
-        if e.errno in (EACCES, EROFS):
-            log.warn("Unable to register environment. Path not writable.\n"
+        if e.errno in (EACCES, EROFS, ENOENT):
+            log.warn("Unable to register environment. Path not writable or missing.\n"
                      "  environment location: %s\n"
                      "  registry file: %s", location, USER_ENVIRONMENTS_TXT_FILE)
         else:

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -26,7 +26,7 @@ from ..common.path import (get_bin_directory_short_path, get_leaf_directories,
                            parse_entry_point_def,
                            pyc_path, url_to_path, win_path_ok)
 from ..common.url import has_platform, path_to_url, unquote
-from ..exceptions import CondaUpgradeError, CondaVerificationError, PaddingError, SafetyError
+from ..exceptions import CondaUpgradeError, CondaVerificationError, PaddingError, SafetyError, NotWritableError
 from ..gateways.connection.download import download
 from ..gateways.disk.create import (compile_multiple_pyc, copy,
                                     create_hard_link_or_copy, create_link,
@@ -918,8 +918,12 @@ class RegisterEnvironmentLocationAction(PathAction):
         self._execute_successful = False
 
     def verify(self):
-        touch(USER_ENVIRONMENTS_TXT_FILE, mkdir=True, sudo_safe=True)
-        self._verified = True
+        try:
+            touch(USER_ENVIRONMENTS_TXT_FILE, mkdir=True, sudo_safe=True)
+            self._verified = True
+        except NotWritableError as e:
+            log.warn("Unable to create environments file. Path not writable.\n"
+                     "  environment location: %s\n", USER_ENVIRONMENTS_TXT_FILE)
 
     def execute(self):
         log.trace("registering environment in catalog %s", self.target_prefix)


### PR DESCRIPTION
I found an edge case related to #8451 where if the environments.txt file didn't exist package installation would fail when the user home directory was on a read-only file system. This patch prevents failure when trying to create the environments.txt or if the file doesn't exist when trying to register the environment.