### PR TITLE
Export PATH prior to deactivate

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -266,6 +266,9 @@ class _Activator(object):
         self.command = command
 
     def _yield_commands(self, cmds_dict):
+        for key, value in sorted(iteritems(cmds_dict.get('export_path', {}))):
+            yield self.export_var_tmpl % (key, value)
+
         for script in cmds_dict.get('deactivate_scripts', ()):
             yield self.run_script_tmpl % script
 
@@ -390,13 +393,13 @@ class _Activator(object):
             # deactivated conda and anything at all in my env still references it (apart from the
             # shell script, we need something I suppose!)
             export_vars, unset_vars = self.get_export_unset_vars(odargs=OrderedDict((
-                ('path', new_path),
                 ('conda_prefix', None),
                 ('conda_shlvl', new_conda_shlvl),
                 ('conda_default_env', None),
                 ('conda_prompt_modifier', None))))
             conda_prompt_modifier = ''
             activate_scripts = ()
+            export_path = {'PATH': new_path, }
         else:
             assert old_conda_shlvl > 1
             new_prefix = self.environ.get('CONDA_PREFIX_%d' % new_conda_shlvl)
@@ -416,13 +419,12 @@ class _Activator(object):
                 )
 
             export_vars, unset_vars2 = self.get_export_unset_vars(odargs=OrderedDict((
-                ('path', new_path),
                 ('conda_prefix', new_prefix),
                 ('conda_shlvl', new_conda_shlvl),
                 ('conda_default_env', conda_default_env),
                 ('conda_prompt_modifier', conda_prompt_modifier))))
             unset_vars += unset_vars2
-
+            export_path = {'PATH': new_path, }
             activate_scripts = self._get_activate_scripts(new_prefix)
 
         if context.changeps1:
@@ -432,6 +434,7 @@ class _Activator(object):
             'unset_vars': unset_vars,
             'set_vars': set_vars,
             'export_vars': export_vars,
+            'export_path': export_path,
             'deactivate_scripts': deactivate_scripts,
             'activate_scripts': activate_scripts,
         }

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -280,8 +280,8 @@ class VersionOrder(object):
                             # str < int
                             return True
                     elif isinstance(c2, string_types):
-                            # not (int < str)
-                            return False
+                        # not (int < str)
+                        return False
                     # c1 and c2 have the same type
                     return c1 < c2
         # self == other

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_ven
 
 [flake8]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504
+ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821
 exclude =  .asv*,build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/tests/test-recipes/activate_deactivate_package/meta.yaml
+++ b/tests/test-recipes/activate_deactivate_package/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: activate_deactivate_package
+  version: 1.0.0
+
+source:
+  path: ./src
+
+build:
+  number: 0
+  noarch: True
+  script:
+    - cp -r etc ${PREFIX}            #[not win]
+    - cp -r etc %LIBRARY_PREFIX%     #[win]
+
+about:
+  summary: Test activate and deactivate scripts effecting environment variables

--- a/tests/test-recipes/activate_deactivate_package/src/etc/conda/activate.d/activate.bat
+++ b/tests/test-recipes/activate_deactivate_package/src/etc/conda/activate.d/activate.bat
@@ -1,0 +1,2 @@
+set TEST=teststringfromactivate
+set PATH=%TEST%/bin/test;%PATH%

--- a/tests/test-recipes/activate_deactivate_package/src/etc/conda/activate.d/activate.sh
+++ b/tests/test-recipes/activate_deactivate_package/src/etc/conda/activate.d/activate.sh
@@ -1,0 +1,2 @@
+export TEST=teststringfromactivate
+export PATH="${TEST}/bin/test:${PATH}"

--- a/tests/test-recipes/activate_deactivate_package/src/etc/conda/deactivate.d/deactivate.bat
+++ b/tests/test-recipes/activate_deactivate_package/src/etc/conda/deactivate.d/deactivate.bat
@@ -1,0 +1,12 @@
+@echo off&cls
+setlocal EnableDelayedExpansion
+
+set TEST=teststringfromactivate
+
+set $line=%PATH%
+set $line=%$line: =#%
+set $line=%$line:;= %
+
+for %%a in (%$line%) do echo %%a | find /i %TEST% || set $newpath=!$newpath!;%%a
+set $newpath=!$newpath:#= !
+set PATH=!$newpath:~1!

--- a/tests/test-recipes/activate_deactivate_package/src/etc/conda/deactivate.d/deactivate.sh
+++ b/tests/test-recipes/activate_deactivate_package/src/etc/conda/deactivate.d/deactivate.sh
@@ -1,0 +1,2 @@
+export TEST=teststringfromactivate
+export PATH=`echo $PATH | sed "s|${TEST}/bin/test:||"`

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -366,15 +366,16 @@ class ActivatorUnitTests(TestCase):
                         'PS1': '(/old/prefix)',
                     }
                     export_vars = OrderedDict((
-                        ('PATH', old_path),
                         ('CONDA_PREFIX', old_prefix),
                         ('CONDA_SHLVL', 1),
                         ('CONDA_DEFAULT_ENV', old_prefix),
                         ('CONDA_PROMPT_MODIFIER', '(%s)' % old_prefix),
                     ))
+                    export_path = {'PATH': old_path,}
                     export_vars, unset_vars = activator.add_export_unset_vars(export_vars, unset_vars)
                     assert builder['unset_vars'] == unset_vars
                     assert builder['export_vars'] == export_vars
+                    assert builder['export_path'] == export_path
                     assert builder['activate_scripts'] == ()
                     assert builder['deactivate_scripts'] == ()
 
@@ -447,12 +448,12 @@ class ActivatorUnitTests(TestCase):
                         'PS1': '(/old/prefix)',
                     }
                     export_vars = OrderedDict((
-                        ('PATH', old_path),
                         ('CONDA_PREFIX', old_prefix),
                         ('CONDA_SHLVL', 1),
                         ('CONDA_DEFAULT_ENV', old_prefix),
                         ('CONDA_PROMPT_MODIFIER', '(%s)' % old_prefix)
                     ))
+                    export_path = {'PATH': old_path,}
                     export_vars, unset_vars = activator.add_export_unset_vars(export_vars, unset_vars)
                     assert builder['unset_vars'] == unset_vars
                     assert builder['export_vars'] == export_vars
@@ -544,16 +545,17 @@ class ActivatorUnitTests(TestCase):
                         'PS1': ps1,
                     }
                     export_vars = OrderedDict((
-                        ('PATH', original_path),
                         ('CONDA_PREFIX', old_prefix),
                         ('CONDA_SHLVL', 1),
                         ('CONDA_DEFAULT_ENV', old_prefix),
                         ('CONDA_PROMPT_MODIFIER', conda_prompt_modifier),
                     ))
+                    export_path = {'PATH': original_path,}
                     export_vars, unset_vars = activator.add_export_unset_vars(export_vars, unset_vars)
                     assert builder['unset_vars'] == unset_vars
                     assert builder['set_vars'] == set_vars
                     assert builder['export_vars'] == export_vars
+                    assert builder['export_path'] == export_path
                     assert builder['activate_scripts'] == (activator.path_conversion(activate_d_1),)
                     assert builder['deactivate_scripts'] == (activator.path_conversion(deactivate_d_1),)
 
@@ -595,16 +597,17 @@ class ActivatorUnitTests(TestCase):
                     'PS1': ps1,
                 }
                 export_vars = OrderedDict((
-                    ('PATH', original_path),
                     ('CONDA_PREFIX', old_prefix),
                     ('CONDA_SHLVL', 1),
                     ('CONDA_DEFAULT_ENV', old_prefix),
                     ('CONDA_PROMPT_MODIFIER', conda_prompt_modifier),
                 ))
+                export_path = {'PATH': original_path,}
                 export_vars, unset_vars = activator.add_export_unset_vars(export_vars, unset_vars)
                 assert builder['unset_vars'] == unset_vars
                 assert builder['set_vars'] == set_vars
                 assert builder['export_vars'] == export_vars
+                assert builder['export_path'] == export_path
                 assert builder['activate_scripts'] == (activator.path_conversion(activate_d_1),)
                 assert builder['deactivate_scripts'] == (activator.path_conversion(deactivate_d_1),)
 
@@ -634,13 +637,14 @@ class ActivatorUnitTests(TestCase):
                         'PS1': os.environ.get('PS1', ''),
                     }
                     export_vars = OrderedDict((
-                        ('PATH', new_path),
                         ('CONDA_SHLVL', 0),
                     ))
+                    export_path = {'PATH': new_path,}
                     export_vars, unset_vars = activator.add_export_unset_vars(export_vars, unset_vars,
                                                                               conda_exe_vars=True)
                     assert builder['export_vars'] == export_vars
                     assert builder['unset_vars'] == unset_vars
+                    assert builder['export_path'] == export_path
                     assert builder['activate_scripts'] == ()
                     assert builder['deactivate_scripts'] == (activator.path_conversion(deactivate_d_1),)
 
@@ -770,13 +774,13 @@ class ShellWrapperUnitTests(TestCase):
             conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars(conda_exe_vars=True)
 
             e_deactivate_data = dals("""
+            export PATH='%(new_path)s'
             . "%(deactivate1)s"
             %(conda_exe_unset)s
             unset CONDA_PREFIX
             unset CONDA_DEFAULT_ENV
             unset CONDA_PROMPT_MODIFIER
             PS1='%(ps1)s'
-            export PATH='%(new_path)s'
             export CONDA_SHLVL='0'
             %(conda_exe_export)s
             """) % {
@@ -953,12 +957,12 @@ class ShellWrapperUnitTests(TestCase):
             conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars(conda_exe_vars=True)
 
             e_deactivate_data = dals("""
+            setenv PATH "%(new_path)s";
             source "%(deactivate1)s";
             unsetenv CONDA_PREFIX;
             unsetenv CONDA_DEFAULT_ENV;
             unsetenv CONDA_PROMPT_MODIFIER;
             set prompt='%(prompt)s';
-            setenv PATH "%(new_path)s";
             setenv CONDA_SHLVL "0";
             %(conda_exe_export)s;
             """) % {
@@ -1044,11 +1048,11 @@ class ShellWrapperUnitTests(TestCase):
 
             new_path = activator.pathsep_join(activator._remove_prefix_from_path(self.prefix))
             e_deactivate_data = dals("""
+            $PATH = '%(new_path)s'
             source "%(deactivate1)s"
             del $CONDA_PREFIX
             del $CONDA_DEFAULT_ENV
             del $CONDA_PROMPT_MODIFIER
-            $PATH = '%(new_path)s'
             $CONDA_SHLVL = '0'
             %(conda_exe_export)s
             """) % {
@@ -1124,11 +1128,11 @@ class ShellWrapperUnitTests(TestCase):
             new_path = activator.pathsep_join(activator._remove_prefix_from_path(self.prefix))
             conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
             e_deactivate_data = dals("""
+            set -gx PATH "%(new_path)s";
             source "%(deactivate1)s";
             set -e CONDA_PREFIX;
             set -e CONDA_DEFAULT_ENV;
             set -e CONDA_PROMPT_MODIFIER;
-            set -gx PATH "%(new_path)s";
             set -gx CONDA_SHLVL "0";
             %(conda_exe_export)s;
             """) % {
@@ -1201,12 +1205,12 @@ class ShellWrapperUnitTests(TestCase):
 
             new_path = activator.pathsep_join(activator._remove_prefix_from_path(self.prefix))
             assert deactivate_data == dals("""
+            $env:PATH = "%(new_path)s"
             . "%(deactivate1)s"
             Remove-Item Env:/CONDA_PREFIX
             Remove-Item Env:/CONDA_DEFAULT_ENV
             Remove-Item Env:/CONDA_PROMPT_MODIFIER
-            $Env:PATH = "%(new_path)s"
-            $Env:CONDA_SHLVL = "0"
+            $env:CONDA_SHLVL = "0"
             %(conda_exe_export)s
             """) % {
                 'new_path': new_path,


### PR DESCRIPTION
I think PATH can be treated differently on deactivation since deactivation scripts might depend on stuff that exists in it. 
Should resolve https://github.com/conda/conda/issues/8393