### PR TITLE
Uncomplicate logic to avoid ':' at end of PATH

### DIFF
--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -54,15 +54,7 @@ conda() {
 
 if [ -z "${CONDA_SHLVL+x}" ]; then
     \export CONDA_SHLVL=0
-    if [ "${_CE_CONDA+x}" == "condax" ]; then
-        if [ "${PATH+x}" == "x" ]; then
-            PATH="$(dirname "$CONDA_EXE")/condabin"
-        else
-            PATH="$(dirname "$(dirname "$CONDA_EXE")")/condabin:${PATH}"
-        fi
-    else
-        PATH="$(dirname "$(dirname "$CONDA_EXE")")/condabin:${PATH:-}"
-    fi
+    PATH="$(\dirname "$(\dirname "$CONDA_EXE")")/condabin${PATH:+":${PATH}"}"
     \export PATH
 
     # We're not allowing PS1 to be unbound. It must at least be set.


### PR DESCRIPTION
Also:
- Make conda.sh less non-POSIX complaint by removing the use of '=='
 ```
  In conda/shell/etc/profile.d/conda.sh line 57:
    if [ "${_CE_CONDA+x}" == "condax" ]; then
                          ^-- SC2039: In POSIX sh, == in place of = is undefined.


  In conda/shell/etc/profile.d/conda.sh line 58:
        if [ "${PATH+x}" == "x" ]; then
                         ^-- SC2039: In POSIX sh, == in place of = is undefined.
 ```
- Escape dirname, so that aliases/functions don't surprise the end user

Fixes https://github.com/conda/conda/issues/8474