### PR TITLE
Update conda.sh to support all shells

### DIFF
--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -54,8 +54,8 @@ conda() {
 
 if [ -z "${CONDA_SHLVL+x}" ]; then
     \export CONDA_SHLVL=0
-    if [ "${_CE_CONDA+x}" == "condax" ]; then
-        if [ "${PATH+x}" == "x" ]; then
+    if [ "${_CE_CONDA+x}" = "condax" ]; then
+        if [ "${PATH+x}" = "x" ]; then
             PATH="$(dirname "$CONDA_EXE")/condabin"
         else
             PATH="$(dirname "$(dirname "$CONDA_EXE")")/condabin:${PATH}"


### PR DESCRIPTION
testing with ==  works in bash, but not in zsh (may be other shells too), causing errors like "eval: = not found". Using single = ensures proper posix behaviour.