### PR TITLE
Improve detection of explicit pip specs in environment yml files

### DIFF
--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, print_function
 from collections import OrderedDict
 from itertools import chain
 import os
+import re
 
 from conda.base.context import context
 from conda.cli import common  # TODO: this should never have to import form conda.cli
@@ -47,9 +48,10 @@ def validate_keys(data, kwargs):
         print('')
 
     deps = data.get('dependencies', [])
+    depsplit = re.compile(r"[\s=]")
     for dep in deps:
-        if (isinstance(dep, dict) and 'pip' in dep
-                and not any(_.split()[0] == 'pip' for _ in deps if not hasattr(_, 'keys'))):
+        if (isinstance(dep, dict) and 'pip' in dep and not
+                any(depsplit.split(_)[0] == 'pip' for _ in deps if not hasattr(_, 'keys'))):
             print("Warning: you have pip-installed dependencies in your environment file, "
                   "but you do not list pip itself as one of your conda dependencies.  Conda "
                   "may not use the correct pip to install your packages, and they may end up "

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -48,7 +48,7 @@ def validate_keys(data, kwargs):
         print('')
 
     deps = data.get('dependencies', [])
-    depsplit = re.compile(r"[\s=]")
+    depsplit = re.compile(r"[<>~\s=]")
     for dep in deps:
         if (isinstance(dep, dict) and 'pip' in dep and not
                 any(depsplit.split(_)[0] == 'pip' for _ in deps if not hasattr(_, 'keys'))):


### PR DESCRIPTION
This PR fixes a minor bug in the detection of `pip` as a conda dependency in environment files. Without this patch, `conda env` would warn about `pip` dependencies being used when `pip` itself wasn't listed as a dependency, even if `pip` was listed like this:

```yaml
  - pip=x.y.z
```

The change uses a regular expression (`r"[\s=]"`) to detect the name `pip` in the dependencies list.