### PR TITLE
Updated import from collections for python>=3.3

### DIFF
--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -131,7 +131,7 @@ if PY3:  # pragma: py2 no cover
     viewvalues = methodcaller("values")
     viewitems = methodcaller("items")
 
-    from collections import Iterable
+    from collections.abc import Iterable
     def isiterable(obj):
         return not isinstance(obj, string_types) and isinstance(obj, Iterable)
 


### PR DESCRIPTION
This PR updates an import from `collections` to remove a `DeprecationWarning` when running on python3.7.