### PR TITLE
Add upgrade flag to pip installer

### DIFF
--- a/conda_env/installers/pip.py
+++ b/conda_env/installers/pip.py
@@ -42,7 +42,7 @@ def _pip_install_via_requirements(prefix, specs, args, *_, **kwargs):
         requirements.write('\n'.join(specs))
         requirements.close()
         # pip command line...
-        pip_cmd = ['install', '-r', requirements.name]
+        pip_cmd = ['install', '-U', '-r', requirements.name]
         pip_subprocess(pip_cmd, prefix, cwd=pip_workdir)
     finally:
         # Win/Appveyor does not like it if we use context manager + delete=True.


### PR DESCRIPTION
This is intended as a fix for #8541.

The `-U` flag ensures that pip-managed packages are always upgraded (within the requirements) when `conda env update` is used.

Adding the flag here causes it to always be used, even for `conda env create`, but in that case the `-U` has no effect because the package is not already installed.

This strikes me as the simplest solution. If using `pip install -U` with `conda env create`, or any other time `_pip_install_via_requirements` is called, were a problem, a more complicated solution could be built in which the `-U` is added only when the call is coming from `conda env update`. However, I don't think that's necessary. 