### PR TITLE
🐛 fix installing py27 pip requirements files

### DIFF
--- a/conda/_vendor/auxlib/compat.py
+++ b/conda/_vendor/auxlib/compat.py
@@ -66,7 +66,7 @@ if sys.version_info[0] < 3:
         if 'CONDA_TEST_SAVE_TEMPS' in os.environ:
             delete = False
         return codecs.getwriter('utf-8')(NamedTemporaryFile(mode=mode, bufsize=bufsize, suffix=suffix,
-                                 prefix=template, dir=None, delete=delete))
+                                 prefix=template, dir=dir, delete=delete))
 else:
     def Utf8NamedTemporaryFile(mode='w+b', buffering=-1, newline=None,
                                suffix=None, prefix=None, dir=None, delete=True):

--- a/conda_env/pip_util.py
+++ b/conda_env/pip_util.py
@@ -35,6 +35,8 @@ def pip_subprocess(args, prefix, cwd):
     if rc != 0:
         print("Pip subprocess error:")
         print(stderr)
+        raise CondaEnvException("Pip failed")
+
     # This will modify (break) Context. We have a context stack but need to verify it works
     # stdout, stderr, rc = run_command(Commands.RUN, *run_args, stdout=None, stderr=None)
 


### PR DESCRIPTION
Recursive requirements.txt files (that contain
`-r another/requirements.txt`) fail when installing in python2.7.

Regression occurred in the 4.8.9 release, in this patch:
https://github.com/conda/conda/commit/1dc77abacd06eb9bce806ca420068d05309b0cd2#diff-4669597423f213078070c1ee8b92a606R66

Also raise an exception if the pip subprocess fails, so errors like this
don't get missed (in eg CI).

Fixes #8561 .