### PR TITLE
fix missing powershell function export

### DIFF
--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -294,6 +294,6 @@ Export-ModuleMember `
     -Alias * `
     -Function `
         Invoke-Conda, `
-        Get-CondaEnvironment, `
+        Get-CondaEnvironment, Add-CondaEnvironmentToPrompt, `
         Enter-CondaEnvironment, Exit-CondaEnvironment, `
         TabExpansion, prompt


### PR DESCRIPTION
Reported by QA.  This function shows up in an error report when Anaconda Powershell Prompt is opened.