### PR TITLE
WIP: strict channel priority by default

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -199,7 +199,7 @@ class Context(Configuration):
     _channel_alias = PrimitiveParameter(DEFAULT_CHANNEL_ALIAS,
                                         aliases=('channel_alias',),
                                         validation=channel_alias_validation)
-    channel_priority = PrimitiveParameter(ChannelPriority.FLEXIBLE)
+    channel_priority = PrimitiveParameter(ChannelPriority.STRICT)
     _channels = SequenceParameter(string_types, default=(DEFAULTS_CHANNEL_NAME,),
                                   aliases=('channels', 'channel',),
                                   expandvars=True)  # channel for args.channel


### PR DESCRIPTION
Strict channel priority solves a number of problems that the user community is experiencing.  It can dramatically reduce the solve times, as well as helping prevent creation of bad environments due to bad dependency metadata on old packages.

This PR is to work out the test changes that are necessary from this change.  This change also requires improvement of the UnsatisfiableError reporting.  @jjhelmus is spearheading that separately.