### PR TITLE
review gh-8248 sat solver choice

### DIFF
--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -310,7 +310,7 @@ def execute_config(args, parser):
     for key, item in args.set:
         key, subkey = key.split('.', 1) if '.' in key else (key, None)
         if key in primitive_parameters:
-            value = context.typify_parameter(key, item)
+            value = context.typify_parameter(key, item, "--set parameter")
             rc_config[key] = value
         elif key in map_parameters:
             argmap = rc_config.setdefault(key, {})

--- a/conda/common/logic.py
+++ b/conda/common/logic.py
@@ -33,8 +33,7 @@ from array import array
 from itertools import chain, combinations
 from logging import DEBUG, getLogger
 
-from .compat import iteritems, odict
-from ..base.constants import SatSolverChoice
+from .compat import iteritems
 
 log = getLogger(__name__)
 
@@ -263,34 +262,6 @@ class PySatSolver(SatSolver):
         else:
             solution = sat_solution
         return solution
-
-
-def get_sat_solver_cls(sat_solver_choice=SatSolverChoice.PYCOSAT):
-    solvers = odict([
-        (SatSolverChoice.PYCOSAT, PycoSatSolver),
-        (SatSolverChoice.PYCRYPTOSAT, CryptoMiniSatSolver),
-        (SatSolverChoice.PYSAT, PySatSolver),
-    ])
-    cls = solvers[sat_solver_choice]
-    try:
-        cls().run(0)
-    except Exception as e:
-        log.warning("Could not run SAT solver through interface '%s'.", sat_solver_choice)
-        log.debug("SAT interface error due to: %s", e, exc_info=True)
-    else:
-        log.debug("Using SAT solver interface '%s'.", sat_solver_choice)
-        return cls
-    for solver_choice, cls in solvers.items():
-        try:
-            cls().run(0)
-        except Exception as e:
-            log.debug("Attempted SAT interface '%s' but unavailable due to: %s",
-                      sat_solver_choice, e)
-        else:
-            log.debug("Falling back to SAT solver interface '%s'.", sat_solver_choice)
-            return cls
-    from ..exceptions import CondaDependencyError
-    raise CondaDependencyError("Cannot run solver. No functioning SAT implementations available.")
 
 
 # Code that uses special cases (generates no clauses) is in ADTs/FEnv.h in


### PR DESCRIPTION
This is a review for gh-8248.

- moves the SAT solver choice from `conda.common.logic` into `conda.resolve` to avoid importing from `conda.base` into `conda.common.
- adds the choices for enum-based configuration parameters to error messages and replaces `auxlib`'s `TypeCoercionError` with a `CustomValidationError`. With that change we get the following instead of nasty tracebacks:
```
$ conda config --set sat_solver asdf

CustomValidationError: Parameter sat_solver = 'asdf' declared in --set parameter is invalid.
'asdf' is not a valid SatSolverChoice
Valid choices for sat_solver: 'pycosat', 'pycryptosat', 'pysat'

$ CONDA_SAT_SOLVER=asdf conda config --show sat_solver

CustomValidationError: Parameter sat_solver = 'asdf' declared in <<merged>> is invalid.
'asdf' is not a valid SatSolverChoice
Valid choices for sat_solver: 'pycosat', 'pycryptosat', 'pysat'
```