### PR TITLE
fast frozen solve

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -250,7 +250,7 @@ def install(args, parser, command='install'):
             unlink_link_transaction = revert_actions(prefix, get_revision(args.revision), index)
         else:
             solver = Solver(prefix, context.channels, context.subdirs, specs_to_add=specs)
-            if isinstall and context.update_modifier == NULL:
+            if isinstall and args.update_modifier == NULL:
                 # try to do a quick solve with then existing env frozen by default
                 update_modifier = UpdateModifier.FREEZE_INSTALLED
             if isupdate:
@@ -278,7 +278,7 @@ def install(args, parser, command='install'):
             try:
                 unlink_link_transaction = solver.solve_for_transaction(
                     deps_modifier=deps_modifier,
-                    update_modifier=NULL,
+                    update_modifier=args.update_modifier,
                     force_reinstall=context.force_reinstall or context.force,
                 )
             except (UnsatisfiableError, SystemExit) as e:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -274,7 +274,7 @@ def install(args, parser, command='install'):
 
     except (UnsatisfiableError, SystemExit) as e:
         # Quick solve with frozen env failed.  Try again without that.
-        if isinstall and context.update_modifier == NULL:
+        if isinstall and args.update_modifier == NULL:
             try:
                 unlink_link_transaction = solver.solve_for_transaction(
                     deps_modifier=deps_modifier,

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from itertools import chain
 from operator import methodcaller
 import sys
+from tempfile import mkdtemp
+import warnings as _warnings
 
 on_win = bool(sys.platform == "win32")
 on_mac = bool(sys.platform == "darwin")
@@ -294,3 +296,46 @@ def ensure_utf8_encoding(value):
     except UnicodeEncodeError:
         return value
 
+
+class TemporaryDirectory(object):
+    """Create and return a temporary directory.  This has the same
+    behavior as mkdtemp but can be used as a context manager.  For
+    example:
+
+        with TemporaryDirectory() as tmpdir:
+            ...
+
+    Upon exiting the context, the directory and everything contained
+    in it are removed.
+    """
+
+    # Handle mkdtemp raising an exception
+    name = None
+    _closed = False
+
+    def __init__(self, suffix="", prefix='tmp', dir=None):
+        self.name = mkdtemp(suffix, prefix, dir)
+
+    def __repr__(self):
+        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+    def __enter__(self):
+        return self.name
+
+    def cleanup(self, _warn=False, _warnings=_warnings):
+        from ..gateways.disk.delete import rm_rf as _rm_rf
+        if self.name and not self._closed:
+            try:
+                _rm_rf(self.name)
+            except (TypeError, AttributeError) as ex:
+                if "None" not in '%s' % (ex,):
+                    raise
+                _rm_rf(self.name)
+            self._closed = True
+
+    def __exit__(self, exc, value, tb):
+        self.cleanup()
+
+    def __del__(self):
+        # Issue a ResourceWarning if implicit cleanup needed
+        self.cleanup(_warn=True)

--- a/conda/compat.py
+++ b/conda/compat.py
@@ -4,7 +4,6 @@
 # This module is only being maintained for conda-build compatibility
 from __future__ import absolute_import, division, print_function, unicode_literals
 import warnings as _warnings
-from tempfile import mkdtemp
 
 
 # shim for conda-build
@@ -21,50 +20,6 @@ configparser = configparser
 
 from .gateways.disk.link import lchmod  # NOQA
 lchmod = lchmod
-
-
-class TemporaryDirectory(object):
-    """Create and return a temporary directory.  This has the same
-    behavior as mkdtemp but can be used as a context manager.  For
-    example:
-
-        with TemporaryDirectory() as tmpdir:
-            ...
-
-    Upon exiting the context, the directory and everything contained
-    in it are removed.
-    """
-
-    # Handle mkdtemp raising an exception
-    name = None
-    _closed = False
-
-    def __init__(self, suffix="", prefix='tmp', dir=None):
-        self.name = mkdtemp(suffix, prefix, dir)
-
-    def __repr__(self):
-        return "<{} {!r}>".format(self.__class__.__name__, self.name)
-
-    def __enter__(self):
-        return self.name
-
-    def cleanup(self, _warn=False, _warnings=_warnings):
-        from .gateways.disk.delete import rm_rf as _rm_rf
-        if self.name and not self._closed:
-            try:
-                _rm_rf(self.name)
-            except (TypeError, AttributeError) as ex:
-                if "None" not in '%s' % (ex,):
-                    raise
-                _rm_rf(self.name)
-            self._closed = True
-
-    def __exit__(self, exc, value, tb):
-        self.cleanup()
-
-    def __del__(self):
-        # Issue a ResourceWarning if implicit cleanup needed
-        self.cleanup(_warn=True)
 
 
 print("WARNING: The conda.compat module is deprecated and will be removed in a future release.",

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -25,7 +25,6 @@ from ..common.constants import NULL
 from ..common.io import Spinner, dashlist, time_recorder
 from ..common.path import get_major_minor_version, paths_equal
 from ..exceptions import PackagesNotFoundError, SpecsConfigurationConflictError
-from ..gateways.logging import TRACE
 from ..history import History
 from ..models.channel import Channel
 from ..models.enums import NoarchType
@@ -401,8 +400,7 @@ class Solver(object):
                 else:
                     new_spec = MatchSpec(spec, target=target_prec.dist_str())
                 ssc.specs_map[pkg_name] = new_spec
-        if log.isEnabledFor(TRACE):
-            log.trace("specs_map with targets: %s", ssc.specs_map)
+        log.debug("specs_map with targets: %s", ssc.specs_map)
 
         # If we're in UPDATE_ALL mode, we need to drop all the constraints attached to specs,
         # so they can all float and the solver can find the most up-to-date solution. In the case

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -17,7 +17,7 @@ from os.path import isdir, isfile, join
 import conda_package_handling.api
 
 from .link import islink, lexists
-from ...compat import TemporaryDirectory
+from ...common.compat import TemporaryDirectory
 from ..._vendor.auxlib.collection import first
 from ..._vendor.auxlib.compat import shlex_split_unicode
 from ..._vendor.auxlib.ish import dals

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -73,8 +73,9 @@ def exactness_and_number_of_deps(resolve_obj, ms):
     if ms.strictness == 3:
         prec = resolve_obj.find_matches(ms)
         value = 3
-        for dep in prec[0].depends:
-            value += MatchSpec(dep).strictness
+        if prec:
+            for dep in prec[0].depends:
+                value += MatchSpec(dep).strictness
     else:
         value = ms.strictness
     return value

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -536,12 +536,9 @@ class Resolve(object):
                 this_pkg_constraints = {}
                 for dep in dep_specs:
                     specs = specs_by_name.get(dep.name, list())
-                    if dep not in specs:
-                        specs.append(dep)
-                    specs_by_name[dep.name] = sorted(
-                        specs,
-                        key=lambda x: (exactness_and_number_of_deps(self, x), x.name),
-                        reverse=True)
+                    if dep not in specs and (not specs or dep.strictness >= specs[0].strictness):
+                        specs.insert(0, dep)
+                    specs_by_name[dep.name] = specs
                 this_pkg_constraints = frozendict({k: tuple(v) for k, v in specs_by_name.items()})
 
                 while(dep_specs):

--- a/dev/start
+++ b/dev/start
@@ -19,21 +19,21 @@ if ! [ -f "$devenv/conda-meta/history" ]; then
             curl https://repo.anaconda.com/miniconda/Miniconda${pyver}-latest-Linux-x86_64.sh -o miniconda${pyver}.sh
         fi
         bash miniconda${pyver}.sh -bfp "$devenv"
-        "$devenv/bin/conda" install -yq python=$pyver --file dev/test-requirements.txt -c defaults -c conda-forge
-        "$devenv/bin/conda" install -yq patchelf  # for conda-build
+        "${_CONDA}" install -yq -p $devenv python=$pyver --file dev/test-requirements.txt -c defaults -c conda-forge
+        "${_CONDA}" install -yq -p $devenv patchelf  # for conda-build
     else
         if [ ! -f miniconda${pyver}.exe ]; then
             powershell.exe -Command "(new-object System.Net.WebClient).DownloadFile('https://repo.anaconda.com/miniconda/Miniconda$pyver-latest-Windows-x86_64.exe','miniconda${pyver}.exe')"
         fi
         cmd.exe /c "start /wait \"\" miniconda${pyver}.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=%CD%\$(cygpath -w $devenv)"
         _CONDA="$devenv/Scripts/conda"
-        "$devenv/Scripts/conda" install -yq python=$pyver --file dev/test-requirements.txt -c defaults -c conda-forge
+        "$devenv/Scripts/conda" install -yq -p $devenv python=$pyver --file dev/test-requirements.txt -c defaults -c conda-forge
     fi
 fi
 
 
 if ! [ -f "$devenv/.dev-start-ed" ]; then
-  "${_CONDA}" install -yq python=$pyver --file dev/test-requirements.txt -c defaults -c conda-forge
+  "${_CONDA}" install -yq -p $devenv python=$pyver --file dev/test-requirements.txt -c defaults -c conda-forge
   touch "$devenv/.dev-start-ed"
 fi
 

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -15,7 +15,7 @@ import pytest
 from conda.base.context import context, Context, reset_context, conda_tests_ctxt_mgmt_def_pol
 from conda.common.io import env_var, env_vars, stderr_log_level, captured
 from conda.core.prefix_data import PrefixData
-from conda.core.solve import DepsModifier, Solver, UpdateModifier
+from conda.core.solve import DepsModifier, Solver, UpdateModifier, Resolve
 from conda.exceptions import UnsatisfiableError, SpecsConfigurationConflictError, ResolvePackageNotFound
 from conda.history import History
 from conda.models.channel import Channel


### PR DESCRIPTION
when running conda install, we should try to keep all other deps (those not explicitly specified) frozen.  This should be very fast, relative to having them considered in the solve.

This behavior already existed with the ``--freeze-installed`` or ``--no-update-deps`` CLI arguments, but this puts that behavior as the initial default, with a fallback to the old, full solve if that returns an unsatisfiable result.