### PR TITLE
Change developer warnings to use warnings module, for better filtering

### DIFF
--- a/conda/compat.py
+++ b/conda/compat.py
@@ -65,7 +65,3 @@ class TemporaryDirectory(object):
     def __del__(self):
         # Issue a ResourceWarning if implicit cleanup needed
         self.cleanup(_warn=True)
-
-
-print("WARNING: The conda.compat module is deprecated and will be removed in a future release.",
-      file=sys.stderr)


### PR DESCRIPTION
The `WARNING` is turning up in client code running `conda info` via the shell, creating the illusion that something is broken in the way that conda is being employed. Using the warning module would be an option, but still require all parts of `conda` itself to catch that warning. 