### PR TITLE
reduce index based on explicit specs further

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2029,10 +2029,9 @@ class IntegrationTests(TestCase):
                                  entry['name'] + '=' + entry['version'] + '=' + entry['build_string'])
 
             specs.append('imagesize')
-            specs = [MatchSpec(s) for s in specs]
+            specs = {MatchSpec(s) for s in specs}
             import conda.core.solve
             r = conda.core.solve.Resolve(get_index())
-            specs = tuple(sorted(specs, key=lambda x: (exactness_and_number_of_deps(r, x), x.name), reverse=True))
             reduced_index = r.get_reduced_index([MatchSpec('imagesize')])
 
             # now add requests to that env.  The call to get_reduced_index should include our exact specs


### PR DESCRIPTION
This shifts the sort introduced in #8117 into get_reduced_index, so that it applies to more tests.  It also implements a new potential optimization: only add specs that have some overlap with the precs found for any explicit specs.  In other words, do not add a package if it conflicts with an explicit spec.

Conversion of sets to tuples is done to preserve order.