### PR TITLE
sharded repodata

### DIFF
--- a/conda/_vendor/auxlib/logz.py
+++ b/conda/_vendor/auxlib/logz.py
@@ -104,7 +104,7 @@ def stringify(obj, content_max_len=0):
         builder.extend("> {0}: {1}".format(key, value)
                        for key, value in sorted(request_object.headers.items(),
                                                 key=request_header_sort_key))
-        builder.append('')
+        builder.append('>')
         if request_object.body:
             builder.append(request_object.body)
 
@@ -117,7 +117,7 @@ def stringify(obj, content_max_len=0):
         elapsed = text_type(response_object.elapsed).split(':', 1)[-1]
         builder.append('< Elapsed: {0}'.format(elapsed))
         if content_max_len:
-            builder.append('')
+            builder.append('<')
             content_type = response_object.headers.get('Content-Type')
             if content_type == 'application/json':
                 content = pformat(response_object.json(), indent=2)

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -144,6 +144,7 @@ def env_vars(var_map=None, callback=None, stack_callback=None):
         if stack_callback:
             stack_callback(False)
 
+
 @contextmanager
 def env_var(name, value, callback=None, stack_callback=None):
     # Maybe, but in env_vars, not here:

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -195,6 +195,7 @@ class ResponseException(Exception):
         super(ResponseException, self).__init__()
         self.url = url
         self.response_code = response_code
+        self.response = response
 
 
 def load_url_object(cache_path_base, url, channel, cache_cls):

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 # Do not use python stdlib imports from this module in other projects. You may be broken
 # without warning.
+import hashlib
+
 try:
     from collections.abc import Hashable as _Hashable
 except ImportError:
@@ -39,7 +41,9 @@ ArgumentParser = ArgumentParser
 
 from .common import compat as _compat  # NOQA
 compat = _compat
-from .common.compat import PY3, StringIO, input, iteritems, on_win, string_types, text_type, itervalues, TemporaryDirectory  # NOQA
+from .common.compat import ensure_binary as _ensure_binary
+from .common.compat import PY3, StringIO, input, iteritems, on_win, string_types, text_type, \
+    itervalues, TemporaryDirectory  # NOQA
 PY3, StringIO,  input, iteritems, string_types, text_type, TemporaryDirectory = PY3, StringIO,  input, iteritems, string_types, text_type, TemporaryDirectory  # NOQA
 from .gateways.connection.session import CondaSession  # NOQA
 CondaSession = CondaSession
@@ -134,9 +138,6 @@ Dist = Dist
 
 from .gateways.subprocess import ACTIVE_SUBPROCESSES, subprocess_call  # NOQA
 ACTIVE_SUBPROCESSES, subprocess_call = ACTIVE_SUBPROCESSES, subprocess_call
-
-from .core.subdir_data import cache_fn_url  # NOQA
-cache_fn_url = cache_fn_url
 
 from .core.package_cache_data import ProgressiveFetchExtract  # NOQA
 ProgressiveFetchExtract = ProgressiveFetchExtract
@@ -392,3 +393,11 @@ def is_linked(prefix, dist):
         return prefix_record
     else:
         return None
+
+
+def cache_fn_url(url):
+    # url must be right-padded with '/' to not invalidate any existing caches
+    if not url.endswith('/'):
+        url += '/'
+    md5 = hashlib.md5(_ensure_binary(url)).hexdigest()
+    return '%s.json' % (md5[:8],)

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -170,7 +170,7 @@ def test_solve_1():
 def test_cuda_1():
     specs = MatchSpec("cudatoolkit"),
 
-    with env_var('CONDA_OVERRIDE_CUDA', '9.2'):
+    with env_var('CONDA_OVERRIDE_CUDA', '9.2', reset_context):
         with get_solver_cuda(specs) as solver:
             final_state = solver.solve_final_state()
             # print(convert_to_dist_str(final_state))
@@ -183,7 +183,7 @@ def test_cuda_1():
 def test_cuda_2():
     specs = MatchSpec("cudatoolkit"),
 
-    with env_var('CONDA_OVERRIDE_CUDA', '10.0'):
+    with env_var('CONDA_OVERRIDE_CUDA', '10.0', reset_context):
         with get_solver_cuda(specs) as solver:
             final_state = solver.solve_final_state()
             # print(convert_to_dist_str(final_state))

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -12,8 +12,8 @@ from conda.common.compat import iteritems
 from conda.common.disk import temporary_content_in_file
 from conda.common.io import env_var
 from conda.core.index import get_index
-from conda.core.subdir_data import Response304ContentUnchanged, cache_fn_url, read_mod_and_etag, \
-    SubdirData, fetch_repodata_remote_request, UnavailableInvalidChannel
+from conda.core.subdir_data import cache_fn_url, read_mod_and_etag, \
+    SubdirData, UnavailableInvalidChannel, fetch_remote_request
 from conda.models.channel import Channel
 
 try:
@@ -171,7 +171,7 @@ class FetchLocalRepodataTests(TestCase):
         url = 'file:///fake/fake/fake/linux-64'
         etag = None
         mod_stamp = 'Mon, 28 Jan 2019 01:01:01 GMT'
-        result = fetch_repodata_remote_request(url, etag, mod_stamp)
+        result = fetch_remote_request(url, etag, mod_stamp)
         assert result is None
 
     def test_fetch_repodata_remote_request_invalid_noarch(self):
@@ -179,7 +179,7 @@ class FetchLocalRepodataTests(TestCase):
         etag = None
         mod_stamp = 'Mon, 28 Jan 2019 01:01:01 GMT'
         with pytest.raises(UnavailableInvalidChannel):
-            result = fetch_repodata_remote_request(url, etag, mod_stamp)
+            result = fetch_remote_request(url, etag, mod_stamp)
 
 
 def test_subdir_data_prefers_conda_to_tar_bz2():

--- a/tests/data/build-index2-json.py
+++ b/tests/data/build-index2-json.py
@@ -7,7 +7,7 @@ from conda.core.subdir_data import fetch_remote_request
 DATA_DIR = abspath(join(dirname(__file__), "..", "..", "test-data", "repodata"))
 
 def save_data_source(url, name):
-    raw_repodata_str = fetch_remote_request(join_url(url, "repodata.json"), None, None)
+    raw_repodata_str, _ = fetch_remote_request(join_url(url, "repodata.json"), None, None)
     json.loads(raw_repodata_str)
     with open(join(DATA_DIR, name + ".json"), 'w') as fh:
         json.dump(json.loads(raw_repodata_str), fh, indent=2, sort_keys=True, separators=(',', ': '))

--- a/tests/data/build-index2-json.py
+++ b/tests/data/build-index2-json.py
@@ -1,12 +1,13 @@
 import json
 from os.path import abspath, dirname, join
 
-from conda.core.subdir_data import fetch_repodata_remote_request
+from conda.common.url import join_url
+from conda.core.subdir_data import fetch_remote_request
 
 DATA_DIR = abspath(join(dirname(__file__), "..", "..", "test-data", "repodata"))
 
 def save_data_source(url, name):
-    raw_repodata_str = fetch_repodata_remote_request(url, None, None)
+    raw_repodata_str = fetch_remote_request(join_url(url, "repodata.json"), None, None)
     json.loads(raw_repodata_str)
     with open(join(DATA_DIR, name + ".json"), 'w') as fh:
         json.dump(json.loads(raw_repodata_str), fh, indent=2, sort_keys=True, separators=(',', ': '))

--- a/tests/data/build-index4-json.py
+++ b/tests/data/build-index4-json.py
@@ -9,7 +9,7 @@ from conda.core.subdir_data import fetch_remote_request
 DATA_DIR = abspath(join(dirname(__file__), "..", "..", "test-data", "repodata"))
 
 def save_data_source(url, name):
-    raw_repodata_str = fetch_remote_request(join_url(url, "repodata.json"), None, None)
+    raw_repodata_str, _ = fetch_remote_request(join_url(url, "repodata.json"), None, None)
     json.loads(raw_repodata_str)
     with open(join(DATA_DIR, name + ".json"), 'w') as fh:
         json.dump(json.loads(raw_repodata_str), fh, indent=2, sort_keys=True, separators=(',', ': '))

--- a/tests/data/build-index4-json.py
+++ b/tests/data/build-index4-json.py
@@ -3,12 +3,13 @@ from os.path import abspath, dirname, join
 from pprint import pprint
 
 from conda.common.compat import itervalues
-from conda.core.subdir_data import fetch_repodata_remote_request
+from conda.common.url import join_url
+from conda.core.subdir_data import fetch_remote_request
 
 DATA_DIR = abspath(join(dirname(__file__), "..", "..", "test-data", "repodata"))
 
 def save_data_source(url, name):
-    raw_repodata_str = fetch_repodata_remote_request(url, None, None)
+    raw_repodata_str = fetch_remote_request(join_url(url, "repodata.json"), None, None)
     json.loads(raw_repodata_str)
     with open(join(DATA_DIR, name + ".json"), 'w') as fh:
         json.dump(json.loads(raw_repodata_str), fh, indent=2, sort_keys=True, separators=(',', ': '))

--- a/tests/data/build-index5-json.py
+++ b/tests/data/build-index5-json.py
@@ -8,7 +8,7 @@ from conda.core.subdir_data import fetch_remote_request
 DATA_DIR = abspath(join(dirname(__file__), "..", "..", "test-data", "repodata"))
 
 def save_data_source(url, name):
-    raw_repodata_str = fetch_remote_request(join_url(url, "repodata.json"), None, None)
+    raw_repodata_str, _ = fetch_remote_request(join_url(url, "repodata.json"), None, None)
     json.loads(raw_repodata_str)
     with open(join(DATA_DIR, name + ".json"), 'w') as fh:
         json.dump(json.loads(raw_repodata_str), fh, indent=2, sort_keys=True, separators=(',', ': '))

--- a/tests/data/build-index5-json.py
+++ b/tests/data/build-index5-json.py
@@ -2,12 +2,13 @@ import json
 from os.path import abspath, dirname, join
 from pprint import pprint
 
-from conda.core.subdir_data import fetch_repodata_remote_request
+from conda.common.url import join_url
+from conda.core.subdir_data import fetch_remote_request
 
 DATA_DIR = abspath(join(dirname(__file__), "..", "..", "test-data", "repodata"))
 
 def save_data_source(url, name):
-    raw_repodata_str = fetch_repodata_remote_request(url, None, None)
+    raw_repodata_str = fetch_remote_request(join_url(url, "repodata.json"), None, None)
     json.loads(raw_repodata_str)
     with open(join(DATA_DIR, name + ".json"), 'w') as fh:
         json.dump(json.loads(raw_repodata_str), fh, indent=2, sort_keys=True, separators=(',', ': '))

--- a/tests/models/test_prefix_graph.py
+++ b/tests/models/test_prefix_graph.py
@@ -36,8 +36,14 @@ def get_pandas_record_set():
 
 @memoize
 def get_windows_conda_build_record_set():
-    specs = (MatchSpec("conda"), MatchSpec("conda-build"), MatchSpec("affine"),
-             MatchSpec("colour"), MatchSpec("uses-spiffy-test-app"),)
+    specs = (
+        MatchSpec("conda"),
+        MatchSpec("conda-build"),
+        MatchSpec("affine"),
+        MatchSpec("colour"),
+        MatchSpec("uses-spiffy-test-app"),
+        MatchSpec("pip"),
+    )
     with get_solver_5(specs) as solver:
         final_state = solver.solve_final_state()
     return final_state, frozenset(specs)
@@ -637,7 +643,7 @@ def test_windows_sort_orders_2():
 
             python_node = graph.get_node_by_name('python')
             pip_node = graph.get_node_by_name('pip')
-            assert pip_node in graph.graph[python_node]
+            assert pip_node not in graph.graph[python_node]
             assert python_node in graph.graph[pip_node]
 
             nodes = tuple(rec.name for rec in graph.records)
@@ -702,7 +708,7 @@ def test_sort_without_prep():
 
         python_node = graph.get_node_by_name('python')
         pip_node = graph.get_node_by_name('pip')
-        assert pip_node in graph.graph[python_node]
+        assert pip_node not in graph.graph[python_node]
         assert python_node in graph.graph[pip_node]
 
         nodes = tuple(rec.name for rec in graph.records)
@@ -713,6 +719,7 @@ def test_sort_without_prep():
             'vs2015_runtime',
             'vc',
             'openssl',
+            'python',
             'yaml',
             'affine',
             'asn1crypto',
@@ -729,8 +736,6 @@ def test_sort_without_prep():
             'psutil',
             'pycosat',
             'pycparser',
-            'cffi',
-            'python',
             'pywin32',
             'pyyaml',
             'ruamel_yaml',
@@ -738,15 +743,16 @@ def test_sort_without_prep():
             'spiffy-test-app',
             'win_inet_pton',
             'wincertstore',
-            'cryptography',
+            'cffi',
             'menuinst',
             'pysocks',
             'setuptools',
             'uses-spiffy-test-app',
+            'cryptography',
             'jinja2',
-            'pyopenssl',
             'wheel',
             'pip',
+            'pyopenssl',
             'urllib3',
             'requests',
             'conda',
@@ -754,10 +760,11 @@ def test_sort_without_prep():
         )
         assert nodes == order
 
-        with env_var('CONDA_ALLOW_CYCLES', 'false', stack_callback=conda_tests_ctxt_mgmt_def_pol):
-            records, specs = get_windows_conda_build_record_set()
-            with pytest.raises(CyclicalDependencyError):
-                graph = PrefixGraph(records, specs)
+        # # this part of the test no longer applies because no cycle is introduced by add_pip_as_python_dependency
+        # with env_var('CONDA_ALLOW_CYCLES', 'false', stack_callback=conda_tests_ctxt_mgmt_def_pol):
+        #     records, specs = get_windows_conda_build_record_set()
+        #     with pytest.raises(CyclicalDependencyError):
+        #         graph = PrefixGraph(records, specs)
 
 
 def test_deep_cyclical_dependency():

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -11,7 +11,7 @@ from conda.base.context import conda_tests_ctxt_mgmt_def_pol
 from conda.common.io import env_var
 from conda.exceptions import CondaHTTPError
 from conda.gateways.connection.download import TmpDownload
-from conda.core.subdir_data import fetch_repodata_remote_request
+from conda.core.subdir_data import fetch_remote_request
 from conda.core.package_cache_data import download
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,7 +3,6 @@ import codecs
 import sys
 import unittest
 
-from conda.core.subdir_data import cache_fn_url
 from conda.misc import url_pat, walk_prefix
 from conda.utils import Utf8NamedTemporaryFile
 
@@ -20,13 +19,6 @@ class TestMisc(unittest.TestCase):
             assert value == test_string
         except Exception as e:
             raise e
-
-
-    def test_cache_fn_url(self):
-        url = "http://repo.continuum.io/pkgs/pro/osx-64/"
-        self.assertEqual(cache_fn_url(url), '7618c8b6.json')
-        url = "http://repo.anaconda.com/pkgs/pro/osx-64/"
-        self.assertEqual(cache_fn_url(url), 'e42afea8.json')
 
     def test_url_pat_1(self):
         m = url_pat.match('http://www.cont.io/pkgs/linux-64/foo.tar.bz2'


### PR DESCRIPTION
This PR implements a strategy for repodata sharding. It assumes two new file types.

The first is a file type `<name>.json` that sits in each subdir alongside `repodata.json`, where `<name>` is either the package `name` or a `track_features` value.  The package metadata contained within `<name>.json` is that associated with `<name>`, and the format is otherwise similar to `repodata.json`.

The second is a `lastmodified.json` file that sits in each subdir alongside `repodata.json`.  The format of `lastmodifed.json` is

```
{
  "lastmodified_version": 1,
  "packages": {
    "<name>": {
      "etag": "<md5>",
      "mod":  <integer_unix_timestamp>
    },
    ...
  }
}
```

In the above, `mod` is a unix timestamp that is converted to a compliant `If-Modified-Since` header by `datetime.utcfromtimestamp(integer_unix_timestamp).strftime("%a, %d %b %Y %H:%M:%S GMT")`.  It is also optional.  In general `etag` should be preferred over `mod`.  For s3-hosted repositories, the standard etag is the md5 hash of the binary content of the object, in this case the md5 hash of the corresponding `<name>.json` file.  While the md5 has is the standard for s3 buckets, the etag need not be the md5 hash in general.  Another server implementation, for example, may choose to use the first eight characters of the sha256 hash. The etag value in `lastmodified.json` should *not* include escaped quotation marks. Conda will add quotation marks to the `If-None-Match` header as appropriate.

This strategy should be straight-forward to implement with `conda index` for statically-hosted channels.

This PR is currently built on top of #8639.  If/when that PR is merged, the diff for this PR will be substantially smaller.  The bulk of the code change for this PR is isolated to `conda/core/subdir_data.py`.