### PR TITLE
Handle errors from read only filesystems

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import codecs
-from errno import EACCES, ENOENT, EPERM
+from errno import EACCES, ENOENT, EPERM, EROFS
 from functools import reduce
 from logging import getLogger
 from os import listdir
@@ -402,7 +402,7 @@ class PackageCacheData(object):
                 try:
                     write_as_json_to_file(repodata_record_path, repodata_record)
                 except (IOError, OSError) as e:
-                    if e.errno in (EACCES, EPERM) and isdir(dirname(repodata_record_path)):
+                    if e.errno in (EACCES, EPERM, EROFS) and isdir(dirname(repodata_record_path)):
                         raise NotWritableError(repodata_record_path, e.errno, caused_by=e)
                     else:
                         raise

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import bz2
 from collections import defaultdict
 from contextlib import closing
-from errno import EACCES, ENODEV, EPERM
+from errno import EACCES, ENODEV, EPERM, EROFS
 from genericpath import getmtime, isfile
 import hashlib
 import json
@@ -230,7 +230,7 @@ class SubdirData(object):
                 with io_open(self.cache_path_json, 'w') as fh:
                     fh.write(raw_repodata_str or '{}')
             except (IOError, OSError) as e:
-                if e.errno in (EACCES, EPERM):
+                if e.errno in (EACCES, EPERM, EROFS):
                     raise NotWritableError(self.cache_path_json, e.errno, caused_by=e)
                 else:
                     raise

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import codecs
-from errno import EACCES, EPERM
+from errno import EACCES, EPERM, EROFS
 from io import open
 from logging import getLogger
 import os
@@ -392,7 +392,7 @@ def create_package_cache_directory(pkgs_dir):
         touch(join(pkgs_dir, PACKAGE_CACHE_MAGIC_FILE), mkdir=True, sudo_safe=sudo_safe)
         touch(join(pkgs_dir, 'urls'), sudo_safe=sudo_safe)
     except (IOError, OSError) as e:
-        if e.errno in (EACCES, EPERM):
+        if e.errno in (EACCES, EPERM, EROFS):
             log.trace("cannot create package cache directory '%s'", pkgs_dir)
             return False
         else:
@@ -412,7 +412,7 @@ def create_envs_directory(envs_dir):
         sudo_safe = expand(envs_dir).startswith(expand('~'))
         touch(join(envs_dir, envs_dir_magic_file), mkdir=True, sudo_safe=sudo_safe)
     except (IOError, OSError) as e:
-        if e.errno in (EACCES, EPERM):
+        if e.errno in (EACCES, EPERM, EROFS):
             log.trace("cannot create envs directory '%s'", envs_dir)
             return False
         else:

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from errno import EACCES, ENOENT, EPERM
+from errno import EACCES, ENOENT, EPERM, EROFS
 from itertools import chain
 from logging import getLogger
 from os import X_OK, access, chmod, lstat, walk
@@ -34,7 +34,7 @@ def make_writable(path):
         if eno in (ENOENT,):
             log.debug("tried to make writable, but didn't exist: %s", path)
             raise
-        elif eno in (EACCES, EPERM):
+        elif eno in (EACCES, EPERM, EROFS):
             log.debug("tried make writable but failed: %s\n%r", path, e)
             return False
         else:

--- a/conda/history.py
+++ b/conda/history.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from ast import literal_eval
 import codecs
-from errno import EACCES, EPERM
+from errno import EACCES, EPERM, EROFS
 import logging
 from operator import itemgetter
 import os
@@ -114,7 +114,7 @@ class History(object):
             curr = set(prefix_rec.dist_str() for prefix_rec in pd.iter_records())
             self.write_changes(last, curr)
         except EnvironmentError as e:
-            if e.errno in (EACCES, EPERM):
+            if e.errno in (EACCES, EPERM, EROFS):
                 raise NotWritableError(self.path, e.errno)
             else:
                 raise

--- a/tests/gateways/disk/test_permissions.py
+++ b/tests/gateways/disk/test_permissions.py
@@ -6,7 +6,7 @@ import uuid
 
 import errno
 import pytest
-from errno import ENOENT, EACCES, EROFS
+from errno import ENOENT, EACCES, EROFS, EPERM
 from shutil import rmtree
 from contextlib import contextmanager
 from tempfile import gettempdir
@@ -104,6 +104,15 @@ def test_make_writable_doesnt_exist():
 
 
 def test_make_writable_dir_EPERM():
+    import conda.gateways.disk.permissions
+    from conda.gateways.disk.permissions import make_writable
+    with patch.object(conda.gateways.disk.permissions, 'chmod') as chmod_mock:
+        chmod_mock.side_effect = IOError(EPERM, 'some message', 'foo')
+        with tempdir() as td:
+            assert not make_writable(td)
+
+
+def test_make_writable_dir_EACCES():
     import conda.gateways.disk.permissions
     from conda.gateways.disk.permissions import make_writable
     with patch.object(conda.gateways.disk.permissions, 'chmod') as chmod_mock:

--- a/tests/gateways/disk/test_permissions.py
+++ b/tests/gateways/disk/test_permissions.py
@@ -6,7 +6,7 @@ import uuid
 
 import errno
 import pytest
-from errno import ENOENT, EACCES
+from errno import ENOENT, EACCES, EROFS
 from shutil import rmtree
 from contextlib import contextmanager
 from tempfile import gettempdir
@@ -108,6 +108,15 @@ def test_make_writable_dir_EPERM():
     from conda.gateways.disk.permissions import make_writable
     with patch.object(conda.gateways.disk.permissions, 'chmod') as chmod_mock:
         chmod_mock.side_effect = IOError(EACCES, 'some message', 'foo')
+        with tempdir() as td:
+            assert not make_writable(td)
+
+
+def test_make_writable_dir_EROFS():
+    import conda.gateways.disk.permissions
+    from conda.gateways.disk.permissions import make_writable
+    with patch.object(conda.gateways.disk.permissions, 'chmod') as chmod_mock:
+        chmod_mock.side_effect = IOError(EROFS, 'some message', 'foo')
         with tempdir() as td:
             assert not make_writable(td)
 


### PR DESCRIPTION
I'm currently setting up a multiuser conda installation on a distributed read only filesystem ([CVMFS](https://cernvm.cern.ch/portal/filesystem)). This currently fails to skip the root environment as the error raised is `EROFS` ("Read-only filesystem") instead of `EACCES` or `EPERM`.

My issues were with `create_envs_directory` and `create_package_cache_directory` but I've grep-ed though and added it an a few other places as well.

I've also fixed a minor typo in the tests.