### PR TITLE
Allow setting setgid to fail when making directories

### DIFF
--- a/conda/gateways/disk/__init__.py
+++ b/conda/gateways/disk/__init__.py
@@ -94,4 +94,9 @@ def mkdir_p_sudo_safe(path):
     if not on_win:
         # set newly-created directory permissions to 02775
         # https://github.com/conda/conda/issues/6610#issuecomment-354478489
-        os.chmod(path, 0o2775)
+        try:
+            os.chmod(path, 0o2775)
+        except (OSError, IOError):
+            log.trace("Failed to set permissions to 2775 on %s (%d %d)",
+                      path, e.errno, errorcode[e.errno])
+            pass


### PR DESCRIPTION
I'm currently setting up a multiuser installation where the user's home directories are stored on [AFS](https://en.wikipedia.org/wiki/Andrew_File_System). On this system running `chmod 2775` fails with a permission error. This prevents the package and environment directories from being created.

This PR avoid the issue by silently ignoring the error.