### PR TITLE
break out of minimization when bisection has nowhere to go

### DIFF
--- a/conda/common/logic.py
+++ b/conda/common/logic.py
@@ -838,6 +838,8 @@ class Clauses(object):
                 if newsol is None:
                     lo = mid + 1
                     log.trace("Bisection failure, new range=(%d,%d)" % (lo, hi))
+                    if lo > hi:
+                        break
                     # If this was a failure of the first test after peak minimization,
                     # then it means that the peak minimizer is "tight" and we don't need
                     # any further constraints.


### PR DESCRIPTION
In debugging conda slowness on my computer, I noticed in the debug logs (-vvv) that it seemed like we had an infinite loop:

```
TRACE conda.common.logic:LinearBound_(708): Eliminating 146/146 terms for bound violation
TRACE conda.common.logic:minimize(865): Bisection attempt: (1,0), (807+0) clauses
TRACE conda.common.logic:minimize(869): Bisection failure, new range=(1,0)
TRACE conda.common.logic:LinearBound_(708): Eliminating 146/146 terms for bound violation
TRACE conda.common.logic:minimize(865): Bisection attempt: (1,0), (807+0) clauses
TRACE conda.common.logic:minimize(869): Bisection failure, new range=(1,0)
```

This PR attempts to break out of the bisection loop if the range is empty.  I think this is especially helpful in the presence of inconsistent environments (my root env is pretty awful)