### PR TITLE
Handle None values for link channel name gracefully

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -896,7 +896,8 @@ class UnlinkLinkTransaction(object):
             if channel_change or subdir_change:
                 if unlink_prec.channel.name is not None:
                     builder_left.append(unlink_prec.channel.name)
-                builder_right.append(link_prec.channel.name)
+                if link_prec.channel.name is not None:
+                    builder_right.append(link_prec.channel.name)
             if subdir_change:
                 builder_left.append("/" + unlink_prec.subdir)
                 builder_right.append("/" + link_prec.subdir)


### PR DESCRIPTION
This was already done for the channel name of the package to unlink
in #8379, but the linking package channel name was missed.

If not handled gracefully, this exits with a TypeError when e.g.
updating a package from a 3rd party channel with a custom URL.