### PR TITLE
Removing free channel from defaults

### DIFF
--- a/docs/source/user-guide/concepts/channels.rst
+++ b/docs/source/user-guide/concepts/channels.rst
@@ -11,15 +11,15 @@ Conda channels
 What is a "conda channel"?
 ==========================
 
-Conda :doc:`packages <packages>`_ are downloaded from remote channels, which are
-URLs to directories containing conda packages.
-The ``conda``
-command searches a default set of channels, and packages are
-automatically downloaded and updated from
+Conda :doc:`packages <../concepts/packages>` are downloaded
+from remote channels, which are URLs to directories
+containing conda packages.
+The ``conda`` command searches a default set of channels,
+and packages are automatically downloaded and updated from
 https://repo.anaconda.com/pkgs/.
 You can modify what remote channels are automatically searched.
-You might want to do this to maintain a private or internal channel. For details,
-see how to :ref:``modify your channel lists <config-channels>`. 
+You might want to do this to maintain a private or internal channel.
+For details, see how to :ref:`modify your channel lists <config-channels>`.
 
 .. _specifying-channels:
 

--- a/docs/source/user-guide/configuration/enable-tab-completion.rst
+++ b/docs/source/user-guide/configuration/enable-tab-completion.rst
@@ -1,6 +1,6 @@
-========================
+=======================
 Enabling tab completion
-========================
+=======================
 
 Conda versions up to 4.3 supports tab completion in bash shells via the argcomplete
 package. Tab completion is deprecated starting with version 4.4. See `issue #415 <https://github.com/conda/conda-docs/issues/415>`_.

--- a/docs/source/user-guide/configuration/free-channel.rst
+++ b/docs/source/user-guide/configuration/free-channel.rst
@@ -1,0 +1,105 @@
+======================
+Using the free channel
+======================
+
+.. contents::
+   :local:
+   :depth: 2
+
+The free channel contains packages created prior to
+September 26, 2017. Prior to conda 4.7, the free
+channel was part of the ``defaults`` channel.
+Read more about the :ref:`defaults channel <default-channels>`.
+
+Removing the ``free`` channel reduced conda's search space
+and hid old software. That old software could have incompatible
+constraint information.
+
+If you still need the content from the ``free`` channel to reproduce
+old environments, you can re-add the channel following the directions below.
+
+.. _free-channel-default:
+
+Adding the free channel to defaults
+===================================
+
+If you want to add the ``free`` channel back into your default list,
+use the command::
+
+   conda config --set restore_free_channel true
+
+The order of the channels is important. Using the above
+command will restore the ``free`` channel in the correct order.
+
+Changing .condarc
+=================
+
+You can also add the ``free`` channel back into your defaults by
+changing the ``.condarc`` file itself.
+
+Add the following to the conda section of your ``.condarc`` file::
+   
+   restore_free_channel: true
+
+Read more about :doc:`use-condarc`.
+
+Package name changes
+====================
+
+Some packages that are available in the ``free`` channel
+have different names in the ``main`` channel.
+ 
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Package name in ``free``
+     - Package name in ``main``
+   * - dateutil
+     - python-dateutil
+   * - gcc
+     - gcc_linux-64 and similar
+   * - pil
+     - pillow
+   * - ipython-notebook
+     - now installable via notebook, a metapackage could be created
+   * - Ipython-qtconsole
+     - now installable via qtconsole, a metapackage could be created
+   * - beautiful-soup
+     - beautifulsoup4
+   * - pydot-ng
+     - pydot
+
+
+Troubleshooting
+===============
+
+You may encounter some errors, such as UnsatisfiableError
+or a PackagesNotFoundError.
+
+An example of this error is::
+
+   $ conda create -n test -c file:///Users/jsmith/anaconda/conda-bld bad_pkg
+   Collecting package metadata: done
+   Solving environment: failed
+
+   UnsatisfiableError: The following specifications were found to be in conflict:
+     - cryptography=2.6.1 -> openssl[version='>=1.1.1b,<1.1.2a']
+     - python=3.7.0 -> openssl[version='>=1.0.2o,<1.0.3a']
+   Use "conda search <package> --info" to see the dependencies for each package.
+
+This can occur if:
+
+- you’re trying to install a package that is only available in
+  ``free`` and not in ``main``.
+- you have older environments in files you want to recreate.
+  If those spec files reference packages that are in ``free``,
+  they will not show up.
+- a package dependency is only available in the ``free`` channel,
+  the package will fail to work.
+
+If you encounter these errors, consider using a newer package than
+the one in ``free``. If you want those older versions, you can
+:ref:`add the free channel back into your defaults
+<free-channel-default>`.
+

--- a/docs/source/user-guide/configuration/free-channel.rst
+++ b/docs/source/user-guide/configuration/free-channel.rst
@@ -95,8 +95,9 @@ This can occur if:
 - you have older environments in files you want to recreate.
   If those spec files reference packages that are in ``free``,
   they will not show up.
-- a package dependency is only available in the ``free`` channel,
-  the package will fail to work.
+- a package is dependent upon files found only in the free
+  channel. Conda will not let you install the package if it cannot
+  install the dependency, which the package requires to work.
 
 If you encounter these errors, consider using a newer package than
 the one in ``free``. If you want those older versions, you can

--- a/docs/source/user-guide/configuration/index.rst
+++ b/docs/source/user-guide/configuration/index.rst
@@ -7,6 +7,7 @@ Configuration
 
    use-condarc
    sample-condarc
+   free-channel
    admin-multi-user-install
    enable-tab-completion
    use-winxp-with-proxy

--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -1,16 +1,18 @@
-============================================
+===========================================
 Using the .condarc conda configuration file
-============================================
+===========================================
+
+.. toctree::
 
 .. contents::
    :local:
-   :depth: 2
-
+   :depth: 1
 
 .. _config-overview:
 
 Overview
 ========
+
 
 The conda configuration file, ``.condarc``, is an optional
 runtime configuration file that allows advanced users to
@@ -26,6 +28,7 @@ A ``.condarc`` file may also be located in the root environment,
 in which case it overrides any in the home directory.
 
 .. note::
+
    A ``.condarc`` file can also be used in an
    administrator-controlled installation to override the users’
    configuration. See :doc:`admin-multi-user-install`.
@@ -77,12 +80,26 @@ is available at the terminal or Anaconda Prompt by running
 ``conda config --help``.
 
 .. tip::
+
    Conda supports :doc:`tab completion <enable-tab-completion>`
    with external packages instead of internal configuration.
 
 
 General configuration
 =====================
+
+* :ref:`config-channels`
+* :ref:`allow-other-channels`
+* :ref:`default-channels`
+* :ref:`auto-update-conda`
+* :ref:`always-yes`
+* :ref:`show-channel-urls`
+* :ref:`change-command-prompt`
+* :ref:`add-pip-python-dependency`
+* :ref:`use-pip`
+* :ref:`config-proxy`
+* :ref:`SSL_verification`
+* :ref:`offline-mode-only`
 
 .. _config-channels:
 
@@ -118,6 +135,7 @@ path may be::
 
   ~/miniconda3/envs/flowers/.condarc
 
+.. _allow-other-channels:
 
 Allow other channels (allow_other_channels)
 -------------------------------------------
@@ -146,6 +164,9 @@ If the system ``.condarc`` file specifies a channel_alias,
 it overrides any channel aliases set in a user's ``.condarc``
 file. See :ref:`channel-alias`.
 
+
+.. _default-channels:
+
 Default channels (default_channels)
 -----------------------------------
 
@@ -161,6 +182,12 @@ This is especially useful for air gap and enterprise installations:
     - http://some.custom/channel
     - file:///some/local/directory
 
+As of conda 3.7, the ``free`` channel is no longer part of the
+``defaults`` channel. If you want to add ``free`` back into your
+defaults, see :doc:`free-channel`.
+
+.. _auto-update-conda:
+
 Update conda automatically (auto_update_conda)
 ----------------------------------------------
 
@@ -175,6 +202,7 @@ EXAMPLE:
 
   auto_update_conda: False
 
+.. _always-yes:
 
 Always yes (always_yes)
 -----------------------
@@ -189,6 +217,7 @@ EXAMPLE:
 
   always_yes: True
 
+.. _show-channel-urls:
 
 Show channel URLs (show_channel_urls)
 -------------------------------------
@@ -202,6 +231,7 @@ EXAMPLE:
 
   show_channel_urls: True
 
+.. _change-command-prompt:
 
 Change command prompt (changeps1)
 ---------------------------------
@@ -215,6 +245,7 @@ EXAMPLE:
 
   changeps1: False
 
+.. _add-pip-python-dependency:
 
 Add pip as Python dependency (add_pip_as_python_dependency)
 -----------------------------------------------------------
@@ -229,6 +260,7 @@ EXAMPLE:
 
   add_pip_as_python_dependency: False
 
+.. _use-pip:
 
 Use pip (use_pip)
 -----------------
@@ -305,6 +337,7 @@ which can be used to verify SSL connections:
 
   ssl_verify: corp.crt
 
+.. _offline-mode-only:
 
 Offline mode only (offline)
 ---------------------------
@@ -321,7 +354,17 @@ EXAMPLE:
 
 Advanced configuration
 ======================
+* :ref:`disallow-soft-linking`
+* :ref:`set-ch-alias`
+* :ref:`config-add-default-pkgs`
+* :ref:`track-features`
+* :ref:`disable-updating`
+* :ref:`disallow-install`
+* :ref:`add-anaconda-token`
+* :ref:`specify-env-directories`
+* :ref:`specify-pkg-directories`
 
+.. _disallow-soft-linking:
 
 Disallow soft-linking (allow_softlinks)
 ---------------------------------------
@@ -408,6 +451,7 @@ EXAMPLE:
     - ipython
     - scipy=0.15.0
 
+.. _track-features:
 
 Track features (track_features)
 -------------------------------
@@ -422,6 +466,8 @@ EXAMPLE:
 
   track_features:
     - mkl
+
+.. _disable-updating:
 
 Disable updating of dependencies (update_dependencies)
 ------------------------------------------------------
@@ -441,6 +487,7 @@ set update_dependencies to ``True``:
    update_dependencies: False
 
 .. note::
+
    Conda still ensures that dependency specifications are
    satisfied. Thus, some dependencies may still be updated or,
    conversely, this may prevent packages given at the command line
@@ -452,6 +499,7 @@ To avoid updating only specific packages in an environment, a
 better option may be to pin them. For more information, see
 :ref:`pinning-packages`.
 
+.. _disallow-install:
 
 Disallow installation of specific packages (disallow)
 -----------------------------------------------------
@@ -466,6 +514,7 @@ EXAMPLE:
   disallow:
     - anaconda
 
+.. _add-anaconda-token:
 
 Add Anaconda.org token to automatically see private packages (add_anaconda_token)
 ---------------------------------------------------------------------------------
@@ -486,10 +535,12 @@ EXAMPLE:
   add_anaconda_token: False
 
 .. note::
+
    Even when set to ``True``, this setting is enabled only if
    the Anaconda command-line client is installed and you are
    logged in with the ``anaconda login`` command.
 
+.. _specify-env-directories:
 
 Specify environment directories (envs_dirs)
 -------------------------------------------
@@ -519,6 +570,7 @@ The CONDA_ENVS_PATH environment variable overwrites this setting:
 * For Windows:
   ``set CONDA_ENVS_PATH=C:\Users\joe\envs;C:\Anaconda\envs``
 
+.. _specify-pkg-directories:
 
 Specify package directories (pkgs_dirs)
 ---------------------------------------
@@ -545,6 +597,23 @@ The CONDA_PKGS_DIRS environment variable overwrites this setting:
 Conda build configuration
 =========================
 
+:ref:`specify-root-dir`
+:ref:`specify-output-folder`
+:ref:`auto-upload`
+:ref:`anaconda-token`
+:ref:`quiet`
+:ref:`filename-hashing`
+:ref:`no-verify`
+:ref:`set-build-id`
+:ref:`skip-existing`
+:ref:`include-recipe`
+:ref:`disable-activation`
+:ref:`long-test-prefix`
+:ref:`pypi-upload-settings`
+:ref:`pypi-repository`
+
+
+.. _specify-root-dir:
 
 Specify conda build output root directory (root-dir)
 ----------------------------------------------------
@@ -562,6 +631,7 @@ EXAMPLE:
   conda-build:
       root-dir: ~/conda-builds
 
+.. specify-output-folder:
 
 Specify conda build build folder (conda-build 3.16.3+) (output_folder)
 ----------------------------------------------------------------------
@@ -575,6 +645,7 @@ the root build directory (``root-dir``).
    conda-build:
        output_folder: conda-bld
 
+.. _auto-upload:
 
 Automatically upload conda build packages to Anaconda.org (anaconda_upload)
 ---------------------------------------------------------------------------
@@ -588,6 +659,7 @@ EXAMPLE:
 
   anaconda_upload: True
 
+.. _anaconda-token:
 
 Token to be used for Anaconda.org uploads (conda-build 3.0+) (anaconda_token)
 -----------------------------------------------------------------------------
@@ -602,6 +674,7 @@ anaconda_upload.
      conda-build:
          anaconda_token: gobbledygook
 
+.. _quiet:
 
 Limit build output verbosity (conda-build 3.0+) (quiet)
 -------------------------------------------------------
@@ -614,6 +687,7 @@ more verbosity use the CLI flag ``--debug``.
    conda-build:
        quiet: true
 
+.. _filename-hashing:
 
 Disable filename hashing (conda-build 3.0+) (filename_hashing)
 --------------------------------------------------------------
@@ -628,22 +702,26 @@ with the following config entry:
        filename_hashing: false
 
 .. note::
+
    Conda-build does no checking when clobbering packages. If you
    utilize conda-build 3's build matrices with a build configuration that is not
    reflected in the build string, packages will be missing due to clobbering.
 
+.. _no-verify:
 
 Disable recipe and package verification (conda-build 3.0+) (no_verify)
 ----------------------------------------------------------------------
 
-By default, conda-build uses conda-verify to ensure that your recipe and package
-meet some minimum sanity checks. You can disable these:
+By default, conda-build uses conda-verify to ensure that your recipe
+and package meet some minimum sanity checks. You can disable these:
 
 .. code-block:: yaml
 
    conda-build:
        no_verify: true
 
+
+.. _set-build-id:
 
 Disable per-build folder creation (conda-build 3.0+) (set_build_id)
 -------------------------------------------------------------------
@@ -659,6 +737,7 @@ setting described above, but fall back to this as necessary:
    conda-build:
        set_build_id: false
 
+.. _skip-existing:
 
 Skip building packages that already exist (conda-build 3.0+) (skip_existing)
 ----------------------------------------------------------------------------
@@ -672,6 +751,7 @@ its outputs are available on your currently configured channels.
    conda-build:
        skip_existing: true
 
+.. _include-recipe:
 
 Omit recipe from package (conda-build 3.0+) (include_recipe)
 ------------------------------------------------------------
@@ -685,6 +765,7 @@ If this contains sensitive or proprietary information, you can omit the recipe.
        include_recipe: false
 
 .. note::
+
    If you do not include the recipe, you cannot use conda-build to test
    the package after the build completes. This means that you cannot split your
    build and test steps across two distinct CLI commands (``conda build --notest
@@ -693,6 +774,7 @@ If this contains sensitive or proprietary information, you can omit the recipe.
    tarball artifacts after your test step. Conda-build does not provide tools for
    doing that.
 
+.. _disable-activation:
 
 Disable activation of environments during build/test (conda-build 3.0+) (activate)
 ----------------------------------------------------------------------------------
@@ -708,6 +790,7 @@ recommended, but some people prefer this.
    conda-build:
        activate: false
 
+.. _long-test-prefix:
 
 Disable long prefix during test (conda-build 3.16.3+) (long_test_prefix)
 ------------------------------------------------------------------------
@@ -723,6 +806,7 @@ can disable the long test prefix. This is not recommended.
 
 The default is ``true``.
 
+.. _pypi-upload-settings:
 
 PyPI upload settings (conda-build 3.0+) (pypirc)
 ------------------------------------------------
@@ -736,6 +820,7 @@ setting using credentials from this file path.
    conda-build:
        pypirc: ~/.pypirc
 
+.. _pypi-repository:
 
 PyPI repository to upload to (conda-build 3.0+) (pypi_repository)
 -----------------------------------------------------------------
@@ -779,9 +864,10 @@ environment variable, like so:
 
 
 Obtaining information from the .condarc file
-==============================================
+============================================
 
 .. note::
+
    It may be necessary to add the "force" option ``-f`` to
    the following commands.
 

--- a/docs/source/user-guide/tasks/manage-channels.rst
+++ b/docs/source/user-guide/tasks/manage-channels.rst
@@ -15,32 +15,32 @@ channels in your channel list that host the same package.
 Before conda 4.1.0
 ==================
 
-Before conda 4.1.0 was released on June 14, 2016, when two channels 
-hosted packages with the same name, conda installed the package 
-with the highest version number. If there were two packages 
-with the same version number, conda installed the one with the 
-highest build number. Only if both the version numbers and build 
-numbers were identical did the channel ordering make a 
+Before conda 4.1.0 was released on June 14, 2016, when two channels
+hosted packages with the same name, conda installed the package
+with the highest version number. If there were two packages
+with the same version number, conda installed the one with the
+highest build number. Only if both the version numbers and build
+numbers were identical did the channel ordering make a
 difference. This approach had 3 problems:
 
-* Build numbers from different channels are not comparable. 
-  Channel A could do nightly builds while Channel B does weekly 
-  builds, so build 2 from Channel B could be newer than build 4 
+* Build numbers from different channels are not comparable.
+  Channel A could do nightly builds while Channel B does weekly
+  builds, so build 2 from Channel B could be newer than build 4
   from Channel A.
 
-* Users could not specify a preferred channel. You might consider 
-  Channel B more reliable than Channel A and prefer to get 
-  packages from that channel even if the B version is older than 
-  the package in Channel A. Conda provided no way to choose that 
+* Users could not specify a preferred channel. You might consider
+  Channel B more reliable than Channel A and prefer to get
+  packages from that channel even if the B version is older than
+  the package in Channel A. Conda provided no way to choose that
   behavior. Only version and build numbers mattered.
 
-* Build numbers conflicted. This is an effect of the other 2 
-  problems. Assume you were happily using package Alpha from 
-  Channel A and package Bravo from Channel B. The provider from 
-  Channel B then added a version of Alpha with a very high build 
-  number. Your conda updates would start installing new versions 
-  of Alpha from Channel B whether you wanted that or not. This 
-  could cause unintentional problems and a risk of deliberate 
+* Build numbers conflicted. This is an effect of the other 2
+  problems. Assume you were happily using package Alpha from
+  Channel A and package Bravo from Channel B. The provider from
+  Channel B then added a version of Alpha with a very high build
+  number. Your conda updates would start installing new versions
+  of Alpha from Channel B whether you wanted that or not. This
+  could cause unintentional problems and a risk of deliberate
   attacks.
 
 

--- a/docs/source/user-guide/troubleshooting.rst
+++ b/docs/source/user-guide/troubleshooting.rst
@@ -732,9 +732,9 @@ depends on installing Python 2.7, which conflicts with the
 specification to install python 3.
 
 Solution
-----------
+--------
 
-Use "conda info wxpython" or "conda info wxpython=3" to show
+Use ``conda info wxpython`` or ``conda info wxpython=3`` to show
 information about this package and its dependencies::
 
     wxpython 3.0 py27_0


### PR DESCRIPTION
This PR adds in the free channel page detailing its removal from defaults, minor grammatical/formatting edits, and the reorganized .condarc doc with free channel info.