### PR TITLE
Fix for #8687: modified PyPI spec parsing regex to parse hyphenated versions correctly.

### DIFF
--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -48,7 +48,7 @@ PARTIAL_PYPI_SPEC_PATTERN = re.compile(r'''
     \s?
     (\[(?P<extras>.*)\])?
     \s?
-    (?P<constraints>\(? \s? ([\w\d<>=!~,\s\.\*]*) \s? \)? )?
+    (?P<constraints>\(? \s? ([\w\d<>=!~,\s\.\*-]*) \s? \)? )?
     \s?
 ''', re.VERBOSE | re.IGNORECASE)
 PY_FILE_RE = re.compile(r'^[^\t\n\r\f\v]+/site-packages/[^\t\n\r\f\v]+\.py$')

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -853,6 +853,7 @@ def parse_specification(spec):
         if const.startswith('(') and const.endswith(')'):
             # Remove parens
             const = const[1:-1]
+        const = const.replace("-", ".")
 
     return PySpec(name=name, extras=extras, constraints=const, marker=marker, url=url)
 

--- a/tests/common/pkg_formats/test_python.py
+++ b/tests/common/pkg_formats/test_python.py
@@ -201,7 +201,7 @@ def test_parse_specification():
         '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*':
             PySpec('', [], '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*', '', ''),
         'name>=1.0.0-beta.1,<2.0.0':
-            PySpec('name', [], '>=1.0.0-beta.1,<2.0.0', '', ''),
+            PySpec('name', [], '>=1.0.0.beta.1,<2.0.0', '', ''),
     }
     for req, expected_req in test_reqs.items():
         parsed_req = parse_specification(req)

--- a/tests/common/pkg_formats/test_python.py
+++ b/tests/common/pkg_formats/test_python.py
@@ -200,6 +200,8 @@ def test_parse_specification():
             PySpec('', [], '>=3,<2', '', ''),
         '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*':
             PySpec('', [], '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*', '', ''),
+        'name>=1.0.0-beta.1,<2.0.0':
+            PySpec('name', [], '>=1.0.0-beta.1,<2.0.0', '', ''),
     }
     for req, expected_req in test_reqs.items():
         parsed_req = parse_specification(req)


### PR DESCRIPTION
This patch allows the correct parsing of required version strings like ">=1.0.0-beta.1,<2.0.0", which appears in PyPI packages like `eth-keyfile==0.5.1` in the wild.

Unit test case included.