### PR TITLE
Add reference to conda config --describe in docs

### DIFF
--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -77,13 +77,14 @@ is available at the terminal or Anaconda Prompt by running
 ``conda config --help``.
 
 .. tip::
+
    Conda supports :doc:`tab completion <enable-tab-completion>`
    with external packages instead of internal configuration.
 
 Conda supports a wide range of configuration options. This page
 gives a non-exhaustive list of the most frequently used options and
-their usage; for a complete list of all available options for your
-version of conda use the ``conda config --describe`` command.
+their usage. For a complete list of all available options for your
+version of conda, use the ``conda config --describe`` command.
 
 
 General configuration

--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -80,6 +80,11 @@ is available at the terminal or Anaconda Prompt by running
    Conda supports :doc:`tab completion <enable-tab-completion>`
    with external packages instead of internal configuration.
 
+Conda supports a wide range of configuration options. This page
+gives a non-exhaustive list of the most frequently used options and
+their usage; for a complete list of all available options for your
+version of conda use the ``conda config --describe`` command.
+
 
 General configuration
 =====================


### PR DESCRIPTION
Indicate that the configuration options on this page are not exhaustive, and refer the user to `conda config --describe` for a complete list of options.