### PR TITLE
Fix python_api.rst page title

### DIFF
--- a/docs/source/api/python_api.rst
+++ b/docs/source/api/python_api.rst
@@ -1,4 +1,4 @@
-``conda.api.python_api``
+``conda.cli.python_api``
 ========================
 
 .. py:module:: conda.cli.python_api


### PR DESCRIPTION
 It was referring to nonexistent "conda.api.python_api" module.