### PR TITLE
target prefix override for entrypoints

### DIFF
--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -624,7 +624,8 @@ class CreatePythonEntryPointAction(CreateInPrefixPathAction):
         else:
             target_python_version = self.transaction_context['target_python_version']
             python_short_path = get_python_short_path(target_python_version)
-            python_full_path = join(self.target_prefix, win_path_ok(python_short_path))
+            python_full_path = join(
+                context.target_prefix_override or self.target_prefix, win_path_ok(python_short_path))
 
         create_python_entry_point(self.target_full_path, python_full_path,
                                   self.module, self.func)

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -625,7 +625,8 @@ class CreatePythonEntryPointAction(CreateInPrefixPathAction):
             target_python_version = self.transaction_context['target_python_version']
             python_short_path = get_python_short_path(target_python_version)
             python_full_path = join(
-                context.target_prefix_override or self.target_prefix, win_path_ok(python_short_path))
+                context.target_prefix_override or self.target_prefix,
+                win_path_ok(python_short_path))
 
         create_python_entry_point(self.target_full_path, python_full_path,
                                   self.module, self.func)


### PR DESCRIPTION
Target prefix override applies to entry points as well as replacements
of standard files.