### PR TITLE
Use tcsh/csh initialization script

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -1201,7 +1201,6 @@ def _bashrc_content(conda_prefix, shell):
             else
                 setenv PATH="%(conda_bin)s:$PATH"
             endif
-            unset __conda_setup
             # <<< conda initialize <<<
             """) % {
                 'conda_exe': conda_exe,

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -1192,20 +1192,14 @@ def _bashrc_content(conda_prefix, shell):
         }
     else:
         conda_exe = join(conda_prefix, 'bin', 'conda')
-
         if shell in ("csh", "tcsh"):
             conda_initialize_content = dals("""
             # >>> conda initialize >>>
             # !! Contents within this block are managed by 'conda init' !!
-            set __conda_setup="`%(conda_exe)s shell.%(shell)s hook >& /dev/null`"
-            if ( $? == 0 ) then
-                eval "$__conda_setup"
+            if ( -f "%(conda_prefix)s/etc/profile.d/conda.csh" ) then
+                source "%(conda_prefix)s/etc/profile.d/conda.csh"
             else
-                if ( -f "%(conda_prefix)s/etc/profile.d/conda.sh" ) then
-                    . "%(conda_prefix)s/etc/profile.d/conda.sh"
-                else
-                    export PATH="%(conda_bin)s:$PATH"
-                endif
+                setenv PATH="%(conda_bin)s:$PATH"
             endif
             unset __conda_setup
             # <<< conda initialize <<<

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -787,6 +787,22 @@ class InitializeTests(TestCase):
             print(reversed_content)
             assert reversed_content == expected_reversed_content
 
+    @pytest.mark.skipif(on_win, reason="unix-only test")
+    def test_init_sh_user_tcsh_unix(self):
+        with tempdir() as conda_temp_prefix:
+            target_path = join(conda_temp_prefix, '.tcshrc')
+            init_sh_user(target_path, conda_temp_prefix, 'tcsh')
+
+            with open(target_path) as fh:
+                tcshrc_contet = fh.read()
+
+            conda_csh = "%s/etc/profile.d/conda.csh" % conda_temp_prefix
+            # tcsh/csh doesn't give users the ability to register a function.
+            # Make sure that conda doesn't try to register a function
+            conda_eval_string = "eval \"$__conda_setup\""
+            assert conda_csh in tcshrc_contet
+            assert conda_eval_string not in tcshrc_contet
+
     @pytest.mark.skipif(not on_win, reason="windows-only test")
     def test_init_sh_user_windows(self):
         with tempdir() as conda_temp_prefix:


### PR DESCRIPTION
tcsh/csh do not support shell functions. So to setup conda the conda.csh
script must be sourced.