### PR TITLE
rework calls on appveyor a bit to help 32-bit win work

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,13 +30,13 @@ init:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
-  - '%PYTHON_ROOT%\\Scripts\\conda install -y -c conda-canary -c defaults -c conda-forge python=%PYTHON_VERSION% pycosat conda requests ruamel_yaml pytest pytest-cov pytest-timeout mock responses pexpect pywin32 anaconda-client conda-package-handling'
-  - "%PYTHON_ROOT%\\Scripts\\conda install -yq conda-build=3.13"
+  - CALL "%PYTHON_ROOT%\\Scripts\\activate.bat"
+  - 'conda install -y -c conda-canary -c defaults -c conda-forge python=%PYTHON_VERSION% pycosat conda requests ruamel_yaml pytest pytest-cov pytest-timeout mock responses pexpect pywin32 anaconda-client conda-package-handling'
+  - "conda install -yq conda-build=3.13"
   # conda install -y -c defaults -c conda-forge pytest pytest-cov pytest-timeout mock responses pexpect xonsh
   # TODO: add xonsh for PY3 builds
-  - "%PYTHON_ROOT%\\Scripts\\pip install codecov==2.0.5"
-  - CALL %PYTHON_ROOT%\\Scripts\\activate
-  - "%PYTHON_ROOT%\\python -m conda init cmd.exe --dev"
+  - "pip install codecov==2.0.5"
+  - "python -m conda init cmd.exe --dev"
 
 build: false
 
@@ -45,6 +45,6 @@ test_script:
   - py.test %ADD_COV% -m "not integration and not installed" -v --basetemp=C:\tmp
   - py.test %ADD_COV% --cov-append -m "integration and not installed" -v --basetemp=C:\tmp
   - DEL /Q /F conda.egg-info
-  - conda.exe build conda.recipe
+  - conda build conda.recipe
   - codecov --env PYTHON_VERSION --required
   - python -m conda.common.io

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2778,6 +2778,7 @@ class IntegrationTests(TestCase):
             assert exists(join(prefix, PYTHON_BINARY))
             assert package_is_installed(prefix, 'moto=1.3.7')
 
+    @pytest.mark.skipif(context.subdir == "win-32", reason="dependencies not available for win-32")
     def test_cross_channel_incompatibility(self):
         # regression test for https://github.com/conda/conda/issues/8772
         # conda-forge puts a run_constrains on libboost, which they don't have on conda-forge.
@@ -3062,4 +3063,3 @@ class PrivateEnvIntegrationTests(TestCase):
         assert package_is_installed(self.prefix, "spiffy-test-app=2")
         assert package_is_installed(self.prefix, "needs-spiffy-test-app")
         assert not isfile(self.exe_file(self.preferred_env_prefix, 'spiffy-test-app'))
-


### PR DESCRIPTION
conda.exe does not do any special PATH insertion stuff, so libarchive and friends can be missing.  This should fix it.