### PR TITLE
allow conda to be downgraded with explicit spec

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -598,7 +598,7 @@ class Solver(object):
                 if not conda_in_specs_to_add_version:
                     conda_spec = MatchSpec(conda_spec, version=">=%s" % conda_prefix_rec.version)
                 if context.auto_update_conda:
-                    conda_spec = MatchSpec('conda', target=None)
+                    conda_spec = MatchSpec(conda_spec, target=None)
                 ssc.specs_map['conda'] = conda_spec
 
         return ssc


### PR DESCRIPTION
Allow conda to be downgraded if by the user with an explicit spec.
For example conda 4.7.6 can be downgraded to 4.6.14 if a user runs:
    conda install conda=4.6.14
Since ea6aae6c21d04b057404cfc8cea6efe50bcc574e in #8741
conda was only downgraded with an explicit spec if conda was configured
not to automatically update.

closes #8824