### PR TITLE
only add repodata fn into cache key when fn is not repodata.json

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -624,7 +624,11 @@ def cache_fn_url(url, repodata_fn=REPODATA_FN):
     # url must be right-padded with '/' to not invalidate any existing caches
     if not url.endswith('/'):
         url += '/'
-    url += repodata_fn
+    # add the repodata_fn in for uniqueness, but keep it off for standard stuff.
+    #    It would be more sane to add it for everything, but old programs (Navigator)
+    #    are looking for the cache under keys without this.
+    if repodata_fn != REPODATA_FN:
+        url += repodata_fn
     md5 = hashlib.md5(ensure_binary(url)).hexdigest()
     return '%s.json' % (md5[:8],)
 

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -136,11 +136,11 @@ class StaticFunctionTests(TestCase):
     def test_cache_fn_url_repo_continuum_io(self):
         hash1 = cache_fn_url("http://repo.continuum.io/pkgs/free/osx-64/")
         hash2 = cache_fn_url("http://repo.continuum.io/pkgs/free/osx-64")
-        assert "f98ef494.json" == hash1 == hash2
+        assert "aa99d924.json" == hash1 == hash2
 
         hash3 = cache_fn_url("https://repo.continuum.io/pkgs/free/osx-64/")
         hash4 = cache_fn_url("https://repo.continuum.io/pkgs/free/osx-64")
-        assert "1bd6ed8e.json" == hash3 == hash4 != hash1
+        assert "d85a531e.json" == hash3 == hash4 != hash1
 
         hash5 = cache_fn_url("https://repo.continuum.io/pkgs/free/linux-64/")
         assert hash4 != hash5
@@ -151,11 +151,11 @@ class StaticFunctionTests(TestCase):
     def test_cache_fn_url_repo_anaconda_com(self):
         hash1 = cache_fn_url("http://repo.anaconda.com/pkgs/free/osx-64/")
         hash2 = cache_fn_url("http://repo.anaconda.com/pkgs/free/osx-64")
-        assert "e52e9094.json" == hash1 == hash2
+        assert "1e817819.json" == hash1 == hash2
 
         hash3 = cache_fn_url("https://repo.anaconda.com/pkgs/free/osx-64/")
         hash4 = cache_fn_url("https://repo.anaconda.com/pkgs/free/osx-64")
-        assert "f58e011b.json" == hash3 == hash4 != hash1
+        assert "3ce78580.json" == hash3 == hash4 != hash1
 
         hash5 = cache_fn_url("https://repo.anaconda.com/pkgs/free/linux-64/")
         assert hash4 != hash5

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -24,13 +24,13 @@ class TestMisc(unittest.TestCase):
     def test_cache_fn_url(self):
         url = "http://repo.continuum.io/pkgs/pro/osx-64/"
         # implicit repodata.json
-        self.assertEqual(cache_fn_url(url), 'baf7b436.json')
+        self.assertEqual(cache_fn_url(url), '7618c8b6.json')
         # explicit repodata.json
-        self.assertEqual(cache_fn_url(url, 'repodata.json'), 'baf7b436.json')
+        self.assertEqual(cache_fn_url(url, 'repodata.json'), '7618c8b6.json')
         # explicit current_repodata.json
         self.assertEqual(cache_fn_url(url, "current_repodata.json"), '8be5dc16.json')
         url = "http://repo.anaconda.com/pkgs/pro/osx-64/"
-        self.assertEqual(cache_fn_url(url), 'e30ee6ba.json')
+        self.assertEqual(cache_fn_url(url), 'e42afea8.json')
 
     def test_url_pat_1(self):
         m = url_pat.match('http://www.cont.io/pkgs/linux-64/foo.tar.bz2'


### PR DESCRIPTION
This fixes a problem with Navigator where the front tile screen would be mostly empty.  Navigator collects the possible tiles there by looking at repodata caches, and it computes the filenames it expects there without the filename in the url.