### PR TITLE
add target to specs from historic specs

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -493,7 +493,9 @@ class Solver(object):
                                          installed_pool):
                     ssc.specs_map[pkg_name] = target_prec.to_match_spec()
                 elif pkg_name in ssc.specs_from_history_map:
-                    ssc.specs_map[pkg_name] = ssc.specs_from_history_map[pkg_name]
+                    ssc.specs_map[pkg_name] = MatchSpec(
+                        ssc.specs_from_history_map[pkg_name],
+                        target=target_prec.dist_str())
                 else:
                     ssc.specs_map[pkg_name] = MatchSpec(pkg_name, target=target_prec.dist_str())
 


### PR DESCRIPTION
Historic specs should not be considered with the same priority as
explicit specs. By adding a target to historic specs they are still
included as constrains but not optmized at the same level as explicit
specs.