### PR TITLE
Fix issue where python version can't be changed in base env with noarch packages

### DIFF
--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -14,6 +14,7 @@ from .compat import on_win, string_types
 from .. import CondaError
 from .._vendor.auxlib.decorators import memoize
 from .._vendor.toolz import accumulate, concat, take
+from distutils.spawn import find_executable
 
 try:
     # Python 3
@@ -308,7 +309,6 @@ def win_path_to_unix(path, root_prefix=""):
 
 
 def which(executable):
-    from distutils.spawn import find_executable
     return find_executable(executable)
 
 

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -12,7 +12,7 @@ from ._vendor.auxlib.decorators import memoize
 from ._vendor.auxlib.compat import shlex_split_unicode, string_types, Utf8NamedTemporaryFile
 from .common.compat import on_win, isiterable
 
-from .common.path import win_path_to_unix
+from .common.path import win_path_to_unix, which
 from .common.url import path_to_url
 from os.path import abspath, join, isfile, basename
 from os import environ
@@ -384,7 +384,6 @@ def wrap_subprocess_call(on_win, root_prefix, prefix, dev_mode, debug_wrapper_sc
             script_caller = fh.name
         command_args = [comspec, '/d', '/c', script_caller]
     else:
-        from shutil import which
         shell_path = which('bash') or which('sh')
         if shell_path is None:
             raise Exception("No compatible shell found!")

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -12,7 +12,7 @@ from ._vendor.auxlib.decorators import memoize
 from ._vendor.auxlib.compat import shlex_split_unicode, string_types, Utf8NamedTemporaryFile
 from .common.compat import on_win, isiterable
 
-from .common.path import win_path_to_unix, which
+from .common.path import win_path_to_unix
 from .common.url import path_to_url
 from os.path import abspath, join, isfile, basename
 from os import environ
@@ -384,6 +384,7 @@ def wrap_subprocess_call(on_win, root_prefix, prefix, dev_mode, debug_wrapper_sc
             script_caller = fh.name
         command_args = [comspec, '/d', '/c', script_caller]
     else:
+        from shutil import which
         shell_path = which('bash') or which('sh')
         if shell_path is None:
             raise Exception("No compatible shell found!")


### PR DESCRIPTION
Fixes #8908 

When changing python version, compile_multiple_pyc() is run for noarch packages which ultimately calls wrap_subprocess_call() after packages (setuptools) have been unlinked/linked and are no longer importable. This change works because shutil is included in python. 