### PR TITLE
fix anaconda metapkg being removed because history matching was too r…

### DIFF
--- a/conda/history.py
+++ b/conda/history.py
@@ -281,9 +281,8 @@ class History(object):
         # Conda hasn't always been good about recording when specs have been removed from
         # environments.  If the package isn't installed in the current environment, then we
         # shouldn't try to force it here.
-        prefix_recs = tuple(PrefixData(self.prefix).iter_records())
-        return dict((name, spec) for name, spec in iteritems(spec_map)
-                    if any(spec.match(dist) for dist in prefix_recs))
+        prefix_recs = set(_.name for _ in PrefixData(self.prefix).iter_records())
+        return dict((name, spec) for name, spec in iteritems(spec_map) if name in prefix_recs)
 
     def construct_states(self):
         """


### PR DESCRIPTION
…estrictive

fixes #8842 

The reason why this was causing things to be removed is:
1. conda 4.7 depends much more on the history specs to build up its list of specs than earlier versions did.
2. This iteration over prefix records was too tight of a match condition.  The anaconda metapackage was getting filtered out of the history, which then led to its ultimate removal.