### PR TITLE
Address issue with aggressive freezing of packages

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1542,6 +1542,14 @@ def add_parser_update_modifiers(solver_mode_options):
         help="Update all installed packages in the environment.",
         default=NULL,
     )
+    update_modifiers.add_argument(
+        "--update-specs",
+        action="store_const",
+        const=UpdateModifier.UPDATE_SPECS,
+        dest="update_modifier",
+        help="Update based on provided specifications.",
+        default=NULL,
+    )
 
 
 def add_parser_prune(p):

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -25,8 +25,7 @@ from ..common.compat import iteritems, itervalues, odict, text_type
 from ..common.constants import NULL
 from ..common.io import Spinner, dashlist, time_recorder
 from ..common.path import get_major_minor_version, paths_equal
-from ..exceptions import (PackagesNotFoundError, SpecsConfigurationConflictError,
-                          ResolvePackageNotFound)
+from ..exceptions import PackagesNotFoundError, SpecsConfigurationConflictError
 from ..history import History
 from ..models.channel import Channel
 from ..models.enums import NoarchType

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -279,15 +279,24 @@ def test_prune_1():
         pprint(convert_to_dist_str(link_precs))
         unlink_order = (
             'channel-1::accelerate-1.1.0-np16py27_p0',
+            'channel-1::mkl-11.0-np16py27_p0',
+            'channel-1::scikit-learn-0.13.1-np16py27_p0',
             'channel-1::numbapro-0.11.0-np16py27_p0',
+            'channel-1::scipy-0.12.0-np16py27_p0',
+            'channel-1::numexpr-2.1-np16py27_p0',
             'channel-1::numba-0.8.1-np16py27_0',
+            'channel-1::numpy-1.6.2-py27_p4',
+            'channel-1::mkl-service-1.0.0-py27_p0',
             'channel-1::meta-0.4.2.dev-py27_0',
             'channel-1::llvmpy-0.11.2-py27_0',
             'channel-1::bitarray-0.8.1-py27_0',
             'channel-1::llvm-3.2-0',
+            'channel-1::mkl-rt-11.0-p0',
             'channel-1::libnvvm-1.0-p0',
         )
-        link_order = tuple()
+        link_order = (
+            'channel-1::numpy-1.6.2-py27_4',
+        )
         assert convert_to_dist_str(unlink_precs) == unlink_order
         assert convert_to_dist_str(link_precs) == link_order
 
@@ -1415,12 +1424,18 @@ def test_fast_update_with_update_modifier_not_set():
         pprint(convert_to_dist_str(unlink_precs))
         pprint(convert_to_dist_str(link_precs))
         unlink_order = (
+            'channel-4::python-2.7.14-h89e7a4a_22',
             'channel-4::sqlite-3.21.0-h1bed415_2',
+            'channel-4::libedit-3.1-heed3624_0',
             'channel-4::openssl-1.0.2l-h077ae2c_5',
+            'channel-4::ncurses-6.0-h9df7e31_2',
         )
         link_order = (
+            'channel-4::ncurses-6.1-hf484d3e_0',
             'channel-4::openssl-1.0.2p-h14c3975_0',
-            'channel-4::sqlite-3.23.1-he433501_0',
+            'channel-4::libedit-3.1.20170329-h6b74fdf_2',
+            'channel-4::sqlite-3.24.0-h84994c4_0',  # sqlite is upgraded
+            'channel-4::python-2.7.15-h1571d57_0',  # python is not upgraded
         )
         assert convert_to_dist_str(unlink_precs) == unlink_order
         assert convert_to_dist_str(link_precs) == link_order

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -259,6 +259,116 @@ def get_index_r_5(subdir=context.subdir):
     return index, r
 
 
+@memoize
+def get_index_must_unfreeze(subdir=context.subdir):
+    repodata = {
+        "info": {
+            "subdir": subdir,
+            "arch": context.arch_name,
+            "platform": context.platform,
+        },
+        "packages": {
+            "foobar-1.0-0.tar.bz2": {
+                "build": "0",
+                "build_number": 0,
+                "depends": [
+                    "libbar 2.0.*",
+                    "libfoo 1.0.*"
+                ],
+                "md5": "11ec1194bcc56b9a53c127142a272772",
+                "name": "foobar",
+                "timestamp": 1562861325613,
+                "version": "1.0"
+            },
+            "foobar-2.0-0.tar.bz2": {
+                "build": "0",
+                "build_number": 0,
+                "depends": [
+                    "libbar 2.0.*",
+                    "libfoo 2.0.*"
+                ],
+                "md5": "f8eb5a7fa1ff6dead4e360631a6cd048",
+                "name": "foobar",
+                "version": "2.0"
+            },
+
+            "libbar-1.0-0.tar.bz2": {
+                "build": "0",
+                "build_number": 0,
+                "depends": [],
+                "md5": "f51f4d48a541b7105b5e343704114f0f",
+                "name": "libbar",
+                "timestamp": 1562858881022,
+                "version": "1.0"
+            },
+            "libbar-2.0-0.tar.bz2": {
+                "build": "0",
+                "build_number": 0,
+                "depends": [],
+                "md5": "27f4e717ed263f909074f64d9cbf935d",
+                "name": "libbar",
+                "timestamp": 1562858881748,
+                "version": "2.0"
+            },
+
+            "libfoo-1.0-0.tar.bz2": {
+                "build": "0",
+                "build_number": 0,
+                "depends": [],
+                "md5": "ad7c088566ffe2389958daedf8ff312c",
+                "name": "libfoo",
+                "timestamp": 1562858763881,
+                "version": "1.0"
+            },
+            "libfoo-2.0-0.tar.bz2": {
+                "build": "0",
+                "build_number": 0,
+                "depends": [],
+                "md5": "daf7af7086d8f22be49ae11bdc41f332",
+                "name": "libfoo",
+                "timestamp": 1562858836924,
+                "version": "2.0"
+            },
+
+            "qux-1.0-0.tar.bz2": {
+                "build": "0",
+                "build_number": 0,
+                "depends": [
+                    "libbar 2.0.*",
+                    "libfoo 1.0.*"
+                ],
+                "md5": "18604cbe4f789fe853232eef4babd4f9",
+                "name": "qux",
+                "timestamp": 1562861393808,
+                "version": "1.0"
+            },
+            "qux-2.0-0.tar.bz2": {
+                "build": "0",
+                "build_number": 0,
+                "depends": [
+                    "libbar 1.0.*",
+                    "libfoo 2.0.*"
+                ],
+                "md5": "892aa4b9ec64b67045a46866ef1ea488",
+                "name": "qux",
+                "timestamp": 1562861394828,
+                "version": "2.0"
+            }
+        }
+    }
+    channel = Channel('https://conda.anaconda.org/channel-freeze/%s' % subdir)
+    sd = SubdirData(channel)
+    with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
+        sd._process_raw_repodata_str(json.dumps(repodata))
+    sd._loaded = True
+    SubdirData._cache_[channel.url(with_credentials=True)] = sd
+
+    index = {prec: prec for prec in sd._package_records}
+    r = Resolve(index, channels=(channel,))
+
+    return index, r
+
+
 # Do not memoize this get_index to allow different CUDA versions to be detected
 def get_index_cuda(subdir=context.subdir):
     with open(join(dirname(__file__), 'data', 'index.json')) as fi:


### PR DESCRIPTION
* do not freeze packages unless in FREEZE_INSTALLED mode
* add a --update-specs argument to conda install/update which opts out of all freezing behavior
* fallback to UPDATE_SPECS mode if no solution is found in FREEZE_INSTALLED mode