### PR TITLE
report results of query_all in order

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -87,7 +87,7 @@ class SubdirData(object):
             futures = tuple(executor.submit(
                 SubdirData(Channel(url), repodata_fn=repodata_fn).query, package_ref_or_match_spec
             ) for url in channel_urls)
-            return tuple(concat(future.result() for future in as_completed(futures)))
+            return tuple(concat(future.result() for future in futures))
 
     def query(self, package_ref_or_match_spec):
         if not self._loaded:

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -26,7 +26,7 @@ from ..base.constants import CONDA_HOMEPAGE_URL, CONDA_PACKAGE_EXTENSION_V1, REP
 from ..base.context import context
 from ..common.compat import (ensure_binary, ensure_text_type, ensure_unicode, iteritems, iterkeys,
                              string_types, text_type, with_metaclass)
-from ..common.io import ThreadLimitedThreadPoolExecutor, as_completed
+from ..common.io import ThreadLimitedThreadPoolExecutor
 from ..common.url import join_url, maybe_unquote
 from ..core.package_cache_data import PackageCacheData
 from ..exceptions import (CondaDependencyError, CondaHTTPError, CondaUpgradeError,


### PR DESCRIPTION
Prevents later channels from clobbering early channels