### PR TITLE
don't call find_conflicts on initial ffs

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -103,6 +103,7 @@ def get_revision(arg, json=False):
     except ValueError:
         raise CondaValueError("expected revision number, not: '%s'" % arg, json)
 
+
 def install(args, parser, command='install'):
     """
     conda install, conda update, and conda create
@@ -230,7 +231,8 @@ def install(args, parser, command='install'):
         repodata_fns.append(REPODATA_FN)
 
     args_set_update_modifier = hasattr(args, "update_modifier") and args.update_modifier != NULL
-    # args.update_modifier is different from update_modifier
+    # This helps us differentiate between an update, the --freeze-installed option, and the retry
+    # behavior in our initial fast frozen solve
     _should_retry_solve = not args_set_update_modifier or args.update_modifier not in (
                     UpdateModifier.FREEZE_INSTALLED,
                     UpdateModifier.UPDATE_SPECS)

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -230,11 +230,13 @@ def install(args, parser, command='install'):
         repodata_fns.append(REPODATA_FN)
 
     args_set_update_modifier = hasattr(args, "update_modifier") and args.update_modifier != NULL
-    should_retry_solve = not args_set_update_modifier or args.update_modifier not in (
+    # args.update_modifier is different from update_modifier
+    _should_retry_solve = not args_set_update_modifier or args.update_modifier not in (
                     UpdateModifier.FREEZE_INSTALLED,
                     UpdateModifier.UPDATE_SPECS)
 
     for repodata_fn in repodata_fns:
+        should_retry_solve = _should_retry_solve and repodata_fn != REPODATA_FN
         try:
             update_modifier = context.update_modifier
             if isinstall and args.revision:
@@ -259,6 +261,7 @@ def install(args, parser, command='install'):
                     deps_modifier=deps_modifier,
                     update_modifier=update_modifier,
                     force_reinstall=context.force_reinstall or context.force,
+                    should_retry_solve=should_retry_solve,
                 )
             # we only need one of these to work.  If we haven't raised an exception,
             #   we're good.
@@ -298,6 +301,7 @@ def install(args, parser, command='install'):
                         deps_modifier=deps_modifier,
                         update_modifier=UpdateModifier.UPDATE_SPECS,
                         force_reinstall=context.force_reinstall or context.force,
+                        should_retry_solve=should_retry_solve,
                     )
                 except (UnsatisfiableError, SystemExit, SpecsConfigurationConflictError) as e:
                     # Unsatisfiable package specifications/no such revision/import error

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -230,6 +230,9 @@ def install(args, parser, command='install'):
         repodata_fns.append(REPODATA_FN)
 
     args_set_update_modifier = hasattr(args, "update_modifier") and args.update_modifier != NULL
+    should_retry_solve = not args_set_update_modifier or args.update_modifier not in (
+                    UpdateModifier.FREEZE_INSTALLED,
+                    UpdateModifier.UPDATE_SPECS)
 
     for repodata_fn in repodata_fns:
         try:

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -112,7 +112,8 @@ class Solver(object):
         else:
             unlink_precs, link_precs = self.solve_for_diff(update_modifier, deps_modifier,
                                                            prune, ignore_pinned,
-                                                           force_remove, force_reinstall, should_retry_solve)
+                                                           force_remove, force_reinstall,
+                                                           should_retry_solve)
             stp = PrefixSetup(self.prefix, unlink_precs, link_precs,
                               self.specs_to_remove, self.specs_to_add)
             # TODO: Only explicitly requested remove and update specs are being included in
@@ -122,7 +123,8 @@ class Solver(object):
             return UnlinkLinkTransaction(stp)
 
     def solve_for_diff(self, update_modifier=NULL, deps_modifier=NULL, prune=NULL,
-                       ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL, should_retry_solve=False):
+                       ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL,
+                       should_retry_solve=False):
         """Gives the package references to remove from an environment, followed by
         the package references to add to an environment.
 
@@ -225,7 +227,8 @@ class Solver(object):
 
         if not retrying:
             ssc = SolverStateContainer(
-                self.prefix, update_modifier, deps_modifier, prune, ignore_pinned, force_remove, should_retry_solve,
+                self.prefix, update_modifier, deps_modifier, prune, ignore_pinned, force_remove,
+                should_retry_solve,
             )
             self.ssc = ssc
         else:
@@ -1008,7 +1011,8 @@ class SolverStateContainer(object):
     # A mutable container with defined attributes to help keep method signatures clean
     # and also keep track of important state variables.
 
-    def __init__(self, prefix, update_modifier, deps_modifier, prune, ignore_pinned, force_remove, should_retry_solve):
+    def __init__(self, prefix, update_modifier, deps_modifier, prune, ignore_pinned, force_remove,
+                 should_retry_solve):
         # prefix, channels, subdirs, specs_to_add, specs_to_remove
         # self.prefix = prefix
         # self.channels = channels

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -81,7 +81,8 @@ class Solver(object):
         self._pool_cache = {}
 
     def solve_for_transaction(self, update_modifier=NULL, deps_modifier=NULL, prune=NULL,
-                              ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL, should_retry_solve=False):
+                              ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL,
+                              should_retry_solve=False):
         """Gives an UnlinkLinkTransaction instance that can be used to execute the solution
         on an environment.
 
@@ -96,6 +97,8 @@ class Solver(object):
                 See :meth:`solve_final_state`.
             force_reinstall (bool):
                 See :meth:`solve_for_diff`.
+            should_retry_solve (bool):
+                See :meth:`solve_final_state`.
 
         Returns:
             UnlinkLinkTransaction:
@@ -137,6 +140,8 @@ class Solver(object):
                     instructs the solver to remove the package and spec from the environment,
                     and then add it back--possibly with the exact package instance modified,
                     depending on the spec exactness.
+            should_retry_solve (bool):
+                See :meth:`solve_final_state`.
 
         Returns:
             Tuple[PackageRef], Tuple[PackageRef]:
@@ -188,6 +193,9 @@ class Solver(object):
                 for the prefix.
             force_remove (bool):
                 Forces removal of a package without removing packages that depend on it.
+            should_retry_solve (bool):
+                Indicates whether this solve will be retried. This allows us to control
+                find_conflicts in ssc.r.solve
 
         Returns:
             Tuple[PackageRef]:

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -81,7 +81,7 @@ class Solver(object):
         self._pool_cache = {}
 
     def solve_for_transaction(self, update_modifier=NULL, deps_modifier=NULL, prune=NULL,
-                              ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL):
+                              ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL, should_retry_solve=False):
         """Gives an UnlinkLinkTransaction instance that can be used to execute the solution
         on an environment.
 
@@ -109,7 +109,7 @@ class Solver(object):
         else:
             unlink_precs, link_precs = self.solve_for_diff(update_modifier, deps_modifier,
                                                            prune, ignore_pinned,
-                                                           force_remove, force_reinstall)
+                                                           force_remove, force_reinstall, should_retry_solve)
             stp = PrefixSetup(self.prefix, unlink_precs, link_precs,
                               self.specs_to_remove, self.specs_to_add)
             # TODO: Only explicitly requested remove and update specs are being included in
@@ -119,7 +119,7 @@ class Solver(object):
             return UnlinkLinkTransaction(stp)
 
     def solve_for_diff(self, update_modifier=NULL, deps_modifier=NULL, prune=NULL,
-                       ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL):
+                       ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL, should_retry_solve=False):
         """Gives the package references to remove from an environment, followed by
         the package references to add to an environment.
 
@@ -147,7 +147,7 @@ class Solver(object):
 
         """
         final_precs = self.solve_final_state(update_modifier, deps_modifier, prune, ignore_pinned,
-                                             force_remove)
+                                             force_remove, should_retry_solve)
         unlink_precs, link_precs = diff_for_unlink_link_precs(
             self.prefix, final_precs, self.specs_to_add, force_reinstall
         )
@@ -161,7 +161,7 @@ class Solver(object):
         return unlink_precs, link_precs
 
     def solve_final_state(self, update_modifier=NULL, deps_modifier=NULL, prune=NULL,
-                          ignore_pinned=NULL, force_remove=NULL):
+                          ignore_pinned=NULL, force_remove=NULL, should_retry_solve=False):
         """Gives the final, solved state of the environment.
 
         Args:
@@ -217,7 +217,7 @@ class Solver(object):
 
         if not retrying:
             ssc = SolverStateContainer(
-                self.prefix, update_modifier, deps_modifier, prune, ignore_pinned, force_remove
+                self.prefix, update_modifier, deps_modifier, prune, ignore_pinned, force_remove, should_retry_solve,
             )
             self.ssc = ssc
         else:
@@ -789,8 +789,9 @@ class Solver(object):
         ssc.solution_precs = ssc.r.solve(tuple(final_environment_specs),
                                          specs_to_add=self.specs_to_add,
                                          history_specs=ssc.specs_from_history_map,
-                                         repodata_fn=self._repodata_fn,
-                                         update_modifier=ssc.update_modifier)
+                                         update_modifier=ssc.update_modifier,
+                                         should_retry_solve=ssc.should_retry_solve
+                                         )
 
         # add back inconsistent packages to solution
         if ssc.add_back_map:
@@ -999,7 +1000,7 @@ class SolverStateContainer(object):
     # A mutable container with defined attributes to help keep method signatures clean
     # and also keep track of important state variables.
 
-    def __init__(self, prefix, update_modifier, deps_modifier, prune, ignore_pinned, force_remove):
+    def __init__(self, prefix, update_modifier, deps_modifier, prune, ignore_pinned, force_remove, should_retry_solve):
         # prefix, channels, subdirs, specs_to_add, specs_to_remove
         # self.prefix = prefix
         # self.channels = channels
@@ -1013,6 +1014,7 @@ class SolverStateContainer(object):
         self.prune = prune
         self.ignore_pinned = ignore_pinned
         self.force_remove = force_remove
+        self.should_retry_solve = should_retry_solve
 
         # Group 2. System state
         self.prefix = prefix

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -789,7 +789,8 @@ class Solver(object):
         ssc.solution_precs = ssc.r.solve(tuple(final_environment_specs),
                                          specs_to_add=self.specs_to_add,
                                          history_specs=ssc.specs_from_history_map,
-                                         repodata_fn=self._repodata_fn)
+                                         repodata_fn=self._repodata_fn,
+                                         update_modifier=ssc.update_modifier)
 
         # add back inconsistent packages to solution
         if ssc.add_back_map:

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1214,9 +1214,6 @@ class Resolve(object):
         solution = mysat(specs, True)
 
         if not solution:
-            if repodata_fn != REPODATA_FN:
-                # bail out until we have the full repodata.
-                raise UnsatisfiableError({})
             if repodata_fn != REPODATA_FN or update_modifier == UpdateModifier.FREEZE_INSTALLED:
                 # we don't want to call find_conflicts until our last try
                 raise UnsatisfiableError({})

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -10,7 +10,7 @@ from logging import DEBUG, getLogger
 from ._vendor.auxlib.collection import frozendict
 from ._vendor.auxlib.decorators import memoize, memoizemethod
 from ._vendor.toolz import concat, groupby
-from .base.constants import ChannelPriority, MAX_CHANNEL_PRIORITY, SatSolverChoice, REPODATA_FN, UpdateModifier
+from .base.constants import ChannelPriority, MAX_CHANNEL_PRIORITY, SatSolverChoice
 from .base.context import context
 from .common.compat import iteritems, iterkeys, itervalues, odict, on_win, text_type
 from .common.io import time_recorder


### PR DESCRIPTION
This cuts the rstudio failure time in half (still takes about 8 minutes almost all of which is spent in find_conflicts) and allows the orange3 install to fail in about 30 seconds..