### PR TITLE
fix setuptools being removed due to conda run_constrains

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -371,7 +371,10 @@ class Solver(object):
         # add in historically-requested specs
         ssc.specs_map.update(ssc.specs_from_history_map)
 
-        for pkg_name in ('anaconda', 'conda', 'conda-build',
+        # these are things that we want to keep even if they're not explicitly specified.  This
+        #     is to compensate for older installers not recording these appropriately for them
+        #     to be preserved.
+        for pkg_name in ('anaconda', 'conda', 'conda-build', 'python.app',
                          'console_shortcut', 'powershell_shortcut'):
             if pkg_name not in ssc.specs_map and ssc.prefix_data.get(pkg_name, None):
                 ssc.specs_map[pkg_name] = MatchSpec(pkg_name)
@@ -571,7 +574,7 @@ class Solver(object):
                 if target_prec.is_unmanageable:
                     ssc.specs_map[pkg_name] = target_prec.to_match_spec()
                 elif MatchSpec(pkg_name) in context.aggressive_update_packages:
-                    ssc.specs_map[pkg_name] = pkg_name
+                    ssc.specs_map[pkg_name] = MatchSpec(pkg_name)
                 elif self._should_freeze(ssc, target_prec, conflict_specs, explicit_pool,
                                          installed_pool):
                     ssc.specs_map[pkg_name] = target_prec.to_match_spec()
@@ -646,6 +649,7 @@ class Solver(object):
                         or spec.name in ssc.specs_from_history_map):
                     # skip this spec, because it is constrained by pins
                     continue
+                ssc.specs_map[spec.name] = spec
                 # the index is sorted, so the first record here gives us what we want.
                 latest_pkg = ssc.r.find_matches(spec)[0]
                 for ms in list(ssc.specs_map.values()):

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -322,9 +322,9 @@ class PackageRecord(DictSafeMixin, Entity):
     def combined_depends(self):
         from .match_spec import MatchSpec
         result = {ms.name: ms for ms in MatchSpec.merge(self.depends)}
-        result.update({ms.name: ms for ms in MatchSpec.merge(
-            MatchSpec(spec, optional=True) for spec in self.constrains or ()
-        )})
+        for spec in (self.constrains or ()):
+            ms = MatchSpec(spec)
+            result[ms.name] = MatchSpec(ms, optional=(ms.name not in result))
         return tuple(itervalues(result))
 
     # the canonical code abbreviation for PackageRecord is `prec`, not to be confused with


### PR DESCRIPTION
With the `add_pip_as_python_dependency` config parameter set to False, conda was removing setuptools after a `conda update conda` command, leaving things broken.  This was happening because the run_constrains entry came after the depends entry, and the run_constrains entry made the setuptools constraint optional, leading to its removal.