### PR TITLE
Add support for local version specs in PYPI installed packages.

### DIFF
--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -48,7 +48,7 @@ PARTIAL_PYPI_SPEC_PATTERN = re.compile(r'''
     \s?
     (\[(?P<extras>.*)\])?
     \s?
-    (?P<constraints>\(? \s? ([\w\d<>=!~,\s\.\*-]*) \s? \)? )?
+    (?P<constraints>\(? \s? ([\w\d<>=!~,\s\.\*+-]*) \s? \)? )?
     \s?
 ''', re.VERBOSE | re.IGNORECASE)
 PY_FILE_RE = re.compile(r'^[^\t\n\r\f\v]+/site-packages/[^\t\n\r\f\v]+\.py$')

--- a/tests/common/pkg_formats/test_python.py
+++ b/tests/common/pkg_formats/test_python.py
@@ -202,6 +202,8 @@ def test_parse_specification():
             PySpec('', [], '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*', '', ''),
         'name>=1.0.0-beta.1,<2.0.0':
             PySpec('name', [], '>=1.0.0.beta.1,<2.0.0', '', ''),
+        'name==1.0.0+localhash':
+            PySpec('name', [], '==1.0.0+localhash', '', ''),
     }
     for req, expected_req in test_reqs.items():
         parsed_req = parse_specification(req)


### PR DESCRIPTION
Currently the PYPI version regex matcher in conda does not support local version identifiers as defined here: https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions . The local version spec allows you to add something like: `'1.2.1+<githash>'`. In some internal environments (such as ours) local versions are occasionally used, and so this breaks our sharing of conda environments using `conda env export`.

This patch adds '+' to the `PARTIAL_PYPI_SPEC_PATTERN` along with an additional unit test.

I just signed the CLA, but I'm not sure how long it take to propagate :).