### PR TITLE
Fix return condition in package_cache_data

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -634,7 +634,7 @@ class ProgressiveFetchExtract(object):
 
         assert not context.dry_run
 
-        if not self.cache_actions or not self.extract_actions:
+        if not self.cache_actions and not self.extract_actions:
             return
 
         if not context.verbosity and not context.quiet and not context.json:


### PR DESCRIPTION
This is related to https://github.com/conda/conda/issues/9034. It is the reason why there is different behavior for no packages missing from the cache (where cache_actions is false and the code returns early) versus one or more packages missing from the cache.