### PR TITLE
Fix https://github.com/conda/conda/issues/9034

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -504,7 +504,7 @@ class ProgressiveFetchExtract(object):
         extracted_pcrec = next((
             pcrec for pcrec in concat(PackageCacheData(pkgs_dir).query(pref_or_spec)
                                       for pkgs_dir in context.pkgs_dirs)
-            if pcrec.is_extracteda
+            if pcrec.is_extracted
         ), None)
         if extracted_pcrec and pcrec_matches(extracted_pcrec) and extracted_pcrec.get('url'):
             return None, None

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -501,14 +501,13 @@ class ProgressiveFetchExtract(object):
                 matches = pcrec.md5 in (md5, legacy_bz2_md5)
             return matches
 
-        if md5:
-            extracted_pcrec = next((
-                pcrec for pcrec in concat(PackageCacheData(pkgs_dir).query(pref_or_spec)
-                                          for pkgs_dir in context.pkgs_dirs)
-                if pcrec.is_extracted
-            ), None)
-            if extracted_pcrec and pcrec_matches(extracted_pcrec) and extracted_pcrec.get('url'):
-                return None, None
+        extracted_pcrec = next((
+            pcrec for pcrec in concat(PackageCacheData(pkgs_dir).query(pref_or_spec)
+                                      for pkgs_dir in context.pkgs_dirs)
+            if pcrec.is_extracteda
+        ), None)
+        if extracted_pcrec and pcrec_matches(extracted_pcrec) and extracted_pcrec.get('url'):
+            return None, None
 
         # there is no extracted dist that can work, so now we look for tarballs that
         #   aren't extracted


### PR DESCRIPTION
This fixes https://github.com/conda/conda/issues/9034. The issue is that for @EXPLICIT packages, the md5 is initially None, so conda would end up not using existing packages in the cache.