### PR TITLE
serialize menu creation

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -377,7 +377,7 @@ class Context(Configuration):
 
     @property
     def default_threads(self):
-        return self._default_threads if self._default_threads else  None
+        return self._default_threads if self._default_threads else None
 
     @property
     def repodata_threads(self):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -143,6 +143,17 @@ class Context(Configuration):
 
     pip_interop_enabled = PrimitiveParameter(False)
 
+    # multithreading in various places
+    _default_threads = PrimitiveParameter(0, element_type=int,
+                                          aliases=('default_threads',))
+    _repodata_threads = PrimitiveParameter(0, element_type=int,
+                                           aliases=('repodata_threads',))
+    _verify_threads = PrimitiveParameter(0, element_type=int,
+                                         aliases=('verify_threads',))
+    # this one actually defaults to 1 - that is handled in the property below
+    _execute_threads = PrimitiveParameter(0, element_type=int,
+                                          aliases=('execute_threads',))
+
     # Safety & Security
     _aggressive_update_packages = SequenceParameter(string_types,
                                                     DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
@@ -363,6 +374,34 @@ class Context(Configuration):
     @property
     def platform(self):
         return _platform_map.get(sys.platform, 'unknown')
+
+    @property
+    def default_threads(self):
+        return self._default_threads if self._default_threads else  None
+
+    @property
+    def repodata_threads(self):
+        return self._repodata_threads if self._repodata_threads else self.default_threads
+
+    @property
+    def verify_threads(self):
+        if self._verify_threads:
+            threads = self._verify_threads
+        elif self.default_threads:
+            threads = self.default_threads
+        else:
+            threads = 1
+        return threads
+
+    @property
+    def execute_threads(self):
+        if self._execute_threads:
+            threads = self._execute_threads
+        elif self.default_threads:
+            threads = self.default_threads
+        else:
+            threads = 1
+        return threads
 
     @property
     def subdir(self):
@@ -746,10 +785,12 @@ class Context(Configuration):
             'restore_free_channel',
             'repodata_fns',
             'use_only_tar_bz2',
+            'repodata_threads',
         )),
         ('Basic Conda Configuration', (  # TODO: Is there a better category name here?
             'envs_dirs',
             'pkgs_dirs',
+            'default_threads',
         )),
         ('Network Configuration', (
             'client_ssl_cert',
@@ -783,7 +824,9 @@ class Context(Configuration):
             'extra_safety_checks',
             'shortcuts',
             'non_admin_enabled',
-            'separate_format_cache'
+            'separate_format_cache',
+            'verify_threads',
+            'execute_threads',
         )),
         ('Conda-build Configuration', (
             'bld_path',
@@ -974,6 +1017,14 @@ class Context(Configuration):
             #     version of Python (2/3) to be used in new environments. Defaults to
             #     the version used by conda itself.
             #     """),
+            'default_threads': dals("""
+                Threads to use by default for parallel operations.  Default is None,
+                which allows operations to choose themselves.  For more specific
+                control, see the other *_threads parameters:
+                    * repodata_threads - for fetching/loading repodata
+                    * verify_threads - for verifying package contents in transactions
+                    * execute_threads - for carrying out the unlinking and linking steps
+            """),
             'disallowed_packages': dals("""
                 Package specifications to disallow installing. The default is to allow
                 all packages.
@@ -996,6 +1047,11 @@ class Context(Configuration):
                 flag), or otherwise holds the value of '{prefix}'. Templating uses python's
                 str.format() method.
                 """),
+            'execute_threads': dals("""
+                Threads to use when performing the unlink/link transaction.  When not set,
+                defaults to 1.  This step is pretty strongly I/O limited, and you may not
+                see much benefit here.
+            """),
             'force_reinstall': dals("""
                 Ensure that any user-requested package for the current operation is uninstalled
                 and reinstalled, even if that package already exists in the environment.
@@ -1086,6 +1142,10 @@ class Context(Configuration):
                 read timeout is the number of seconds conda will wait for the server to send
                 a response.
                 """),
+            'repodata_threads': dals("""
+                Threads to use when downloading and reading repodata.  When not set,
+                defaults to None, which uses the default ThreadPoolExecutor behavior.
+            """),
             'report_errors': dals("""
                 Opt in, or opt out, of automatic error reporting to core maintainers. Error
                 reports are anonymous, with only the error stack trace and information given
@@ -1144,9 +1204,18 @@ class Context(Configuration):
             'use_index_cache': dals("""
                 Use cache of channel index files, even if it has expired.
                 """),
+            'use_only_tar_bz2': dals("""
+                A boolean indicating that only .tar.bz2 conda packages should be downloaded.
+                This is forced to True if conda-build is installed and older than 3.18.3,
+                because older versions of conda break when conda feeds it the new file format.
+                """),
             'verbosity': dals("""
                 Sets output log level. 0 is warn. 1 is info. 2 is debug. 3 is trace.
                 """),
+            'verify_threads': dals("""
+                Threads to use when performing the transaction verification step.  When not set,
+                defaults to 1.
+            """),
             'whitelist_channels': dals("""
                 The exclusive list of channels allowed to be used on the system. Use of any
                 other channels will result in an error. If conda-build channels are to be
@@ -1154,11 +1223,7 @@ class Context(Configuration):
                 'local' channel in the list. If the list is empty or left undefined, no
                 channel exclusions will be enforced.
                 """),
-            'use_only_tar_bz2': dals("""
-                A boolean indicating that only .tar.bz2 conda packages should be downloaded.
-                This is forced to True if conda-build is installed and older than 3.18.3,
-                because older versions of conda break when conda feeds it the new file format.
-                """)
+
         })
 
 

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -519,6 +519,11 @@ class DummyExecutor(Executor):
 
             return f
 
+    def map(self, func, *iterables):
+        for iterable in iterables:
+            for thing in iterable:
+                yield func(thing)
+
     def shutdown(self, wait=True):
         with self._shutdownLock:
             self._shutdown = True

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -544,8 +544,9 @@ class UnlinkLinkTransaction(object):
         if conda_final_prefix in prefix_setups:
             for conda_dependency in conda_linked_depends:
                 dep_name = MatchSpec(conda_dependency).name
-                if dep_name not in pkg_names_being_lnkd and (dep_name not in pkg_names_already_lnkd
-                                                             or dep_name in pkg_names_being_unlnkd):
+                if dep_name not in pkg_names_being_lnkd and (
+                        dep_name not in pkg_names_already_lnkd or
+                        dep_name in pkg_names_being_unlnkd):
                     yield RemoveError("'%s' is a dependency of conda and cannot be removed from\n"
                                       "conda's operating environment." % dep_name)
 

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -345,9 +345,6 @@ class PackageCacheData(object):
                                 # see https://github.com/conda/conda/issues/6707
                                 rm_rf(package_tarball_full_path)
                                 rm_rf(extracted_package_dir)
-                                log.warn("Encountered corrupt package tarball at %s. Conda has "
-                                         "removed it, but you need to re-run conda to download "
-                                         "it again." % package_tarball_full_path)
                                 return None
                         try:
                             raw_json_record = read_index_json(extracted_package_dir)
@@ -356,9 +353,6 @@ class PackageCacheData(object):
                             # Remove everything and move on.
                             rm_rf(package_tarball_full_path)
                             rm_rf(extracted_package_dir)
-                            log.warn("Encountered corrupt package tarball at %s. Conda has "
-                                     "removed it, but you need to re-run conda to download "
-                                     "it again." % package_tarball_full_path)
                             return None
                     else:
                         raw_json_record = read_index_json_from_tarball(package_tarball_full_path)

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -12,8 +12,6 @@ from os.path import basename, dirname, getsize, join
 from sys import platform
 from tarfile import ReadError
 
-from conda_package_handling.api import InvalidArchiveError
-
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler
 from .._vendor.auxlib.collection import first
@@ -291,6 +289,9 @@ class PackageCacheData(object):
         return "%s(%s)" % (self.__class__.__name__, ', '.join(args))
 
     def _make_single_record(self, package_filename):
+        # delay-load this to help make sure libarchive can be found
+        from conda_package_handling.api import InvalidArchiveError
+
         package_tarball_full_path = join(self.pkgs_dir, package_filename)
         log.trace("adding to package cache %s", package_tarball_full_path)
         extracted_package_dir, pkg_ext = strip_pkg_extension(package_tarball_full_path)

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -553,8 +553,9 @@ class Solver(object):
         #    specs being added.
         explicit_pool = ssc.r._get_package_pool(self.specs_to_add)
 
-        conflict_specs = ssc.r.get_conflicting_specs(list(concatv(
-            (_.to_match_spec() for _ in ssc.prefix_data.iter_records()))), self.specs_to_add) or []
+        conflict_specs = ssc.r.get_conflicting_specs(tuple(concatv(
+            (_.to_match_spec() for _ in ssc.prefix_data.iter_records()))), self.specs_to_add
+        ) or tuple()
         conflict_specs = set(_.name for _ in conflict_specs)
 
         for pkg_name, spec in iteritems(ssc.specs_map):
@@ -651,10 +652,11 @@ class Solver(object):
                                not ssc.ignore_pinned) or
                               x.name in ssc.specs_from_history_map)
 
-            specs_to_add = [self._package_has_updates(ssc, _, installed_pool)
-                            for _ in self.specs_to_add if not skip(_)]
+            specs_to_add = tuple(self._package_has_updates(ssc, _, installed_pool)
+                                 for _ in self.specs_to_add if not skip(_))
             # the index is sorted, so the first record here gives us what we want.
-            conflicts = ssc.r.get_conflicting_specs([MatchSpec(_) for _ in ssc.specs_map.values()],
+            conflicts = ssc.r.get_conflicting_specs(tuple(MatchSpec(_)
+                                                          for _ in ssc.specs_map.values()),
                                                     specs_to_add)
             for conflict in conflicts:
                 # neuter the spec due to a conflict
@@ -745,7 +747,7 @@ class Solver(object):
         # may not be the only unsatisfiable subset. We may have to call get_conflicting_specs()
         # several times, each time making modifications to loosen constraints.
 
-        conflicting_specs = set(ssc.r.get_conflicting_specs(final_environment_specs,
+        conflicting_specs = set(ssc.r.get_conflicting_specs(tuple(final_environment_specs),
                                                             self.specs_to_add) or [])
         while conflicting_specs:
             specs_modified = False

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -14,8 +14,6 @@ import sys
 import tempfile
 import warnings as _warnings
 
-import conda_package_handling.api
-
 from . import mkdir_p
 from .delete import path_is_clean, rm_rf
 from .link import islink, lexists, link, readlink, symlink
@@ -201,6 +199,8 @@ class ProgressFileWrapper(object):
 
 
 def extract_tarball(tarball_full_path, destination_directory=None, progress_update_callback=None):
+    import conda_package_handling.api
+
     if destination_directory is None:
         if tarball_full_path[-8:] == CONDA_PACKAGE_EXTENSION_V1:
             destination_directory = tarball_full_path[:-8]

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -14,7 +14,6 @@ import json
 from logging import getLogger
 from os import listdir
 from os.path import isdir, isfile, join
-import conda_package_handling.api
 
 from .link import islink, lexists
 from .create import TemporaryDirectory
@@ -119,6 +118,7 @@ def read_index_json(extracted_package_directory):
 
 
 def read_index_json_from_tarball(package_tarball_full_path):
+    import conda_package_handling.api
     with TemporaryDirectory() as tmpdir:
         conda_package_handling.api.extract(package_tarball_full_path, tmpdir, 'info')
         with open(join(tmpdir, 'info', 'index.json')) as f:

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -21,6 +21,7 @@ from .match_spec import MatchSpec
 from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin, Entity,
                                      EnumField, IntegerField, ListField, NumberField,
                                      StringField)
+from .._vendor.auxlib.decorators import memoizedproperty
 from .._vendor.boltons.timeutils import dt_to_timestamp, isoparse
 from ..base.context import context
 from ..common.compat import isiterable, itervalues, string_types, text_type
@@ -318,7 +319,7 @@ class PackageRecord(DictSafeMixin, Entity):
 
     timestamp = TimestampField()
 
-    @property
+    @memoizedproperty
     def combined_depends(self):
         from .match_spec import MatchSpec
         result = {ms.name: ms for ms in MatchSpec.merge(self.depends)}

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -280,7 +280,7 @@ class ContextCustomRcTests(TestCase):
             assert version is None
 
     def test_threads(self):
-        default_value = 1 if on_win else None
+        default_value = None
         assert context.default_threads == default_value
         assert context.repodata_threads == default_value
         assert context.verify_threads == 1

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -1,6 +1,9 @@
 import tempfile
 from unittest import TestCase
 from tests.test_create import run_command, Commands
+
+import pytest
+
 from conda.models.match_spec import MatchSpec
 from conda.exceptions import UnsatisfiableError
 from conda.gateways.disk.delete import rm_rf
@@ -21,6 +24,7 @@ class TestCliInstall(TestCase):
         rm_rf(self.prefix)
         rm_rf(self.testenv)
 
+    @pytest.mark.integration
     def test_find_conflicts_called_once(self):
         bad_deps = {'python': {((MatchSpec("statistics"), MatchSpec("python[version='>=2.7,<2.8.0a0']")), 'python=3')}}
 

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -1502,6 +1502,7 @@ def test_fast_update_with_update_modifier_not_set():
         assert convert_to_dist_str(final_state_2) == order1
 
 
+@pytest.mark.integration
 def test_pinned_1():
     specs = MatchSpec("numpy"),
     with get_solver(specs) as solver:
@@ -2475,6 +2476,7 @@ def test_determine_constricting_specs_no_conflicts_no_upperbound():
     assert constricting is None
 
 
+@pytest.mark.integration
 def test_indirect_dep_optimized_by_version_over_package_count():
     """We need to adjust the Anaconda metapackage - custom version - so that it keeps
     dependencies on all of its components.  That custom package is intended to free up constraints.  However,

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1297,6 +1297,7 @@ def test_channel_priority_1():
     assert installed2 == installed3
 
 
+@pytest.mark.integration
 def test_channel_priority_2():
     this_index = index.copy()
     index4, r4 = get_index_r_4()


### PR DESCRIPTION
menu creation and removal was happening in parallel with unlinking/linking.  This meant that
menuinst might not have the python executable it needed to do its thing.

This also refactors the loops stuff here to do fewer runs through the same loop.