### PR TITLE
ensure unsat hints are generated when creating environments

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -233,9 +233,9 @@ def install(args, parser, command='install'):
     args_set_update_modifier = hasattr(args, "update_modifier") and args.update_modifier != NULL
     # This helps us differentiate between an update, the --freeze-installed option, and the retry
     # behavior in our initial fast frozen solve
-    _should_retry_unfrozen = not args_set_update_modifier or args.update_modifier not in (
+    _should_retry_unfrozen = (not args_set_update_modifier or args.update_modifier not in (
         UpdateModifier.FREEZE_INSTALLED,
-        UpdateModifier.UPDATE_SPECS)
+        UpdateModifier.UPDATE_SPECS)) and not newenv
 
     for repodata_fn in repodata_fns:
         try:

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -14,10 +14,12 @@ except ImportError:
 class TestCliInstall(TestCase):
     def setUp(self):
         self.prefix = tempfile.mkdtemp()
+        self.testenv = tempfile.mkdtemp()
         run_command(Commands.CREATE, self.prefix, 'python=3.7')
 
     def tearDown(self):
         rm_rf(self.prefix)
+        rm_rf(self.testenv)
 
     def test_find_conflicts_called_once(self):
         bad_deps = {'python': {((MatchSpec("statistics"), MatchSpec("python[version='>=2.7,<2.8.0a0']")), 'python=3')}}
@@ -31,4 +33,8 @@ class TestCliInstall(TestCase):
             monkey.reset_mock()
             with self.assertRaises(UnsatisfiableError):
                 stdout, stderr, _ = run_command(Commands.INSTALL, self.prefix, 'statistics', '--freeze-installed')
+            self.assertEqual(monkey.call_count, 1)
+            monkey.reset_mock()
+            with self.assertRaises(UnsatisfiableError):
+                stdout, stderr, _ = run_command(Commands.CREATE, self.testenv, 'statistics', 'python=3.7')
             self.assertEqual(monkey.call_count, 1)


### PR DESCRIPTION
Didn't account for conda create in this..