### PR TITLE
handle meta.yaml file in environment commands

### DIFF
--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -64,6 +64,12 @@ def configure_parser(sub_parsers):
         action='store_true',
         default=False,
     )
+    p.add_argument(
+        '--test',
+        action='store_true',
+        default=False,
+        help='install test requirements from meta.yaml file',
+    )
     add_parser_json(p)
     p.set_defaults(func='.main_create.execute')
 
@@ -74,7 +80,7 @@ def execute(args, parser):
 
     try:
         spec = specs.detect(name=name, filename=expand(args.file),
-                            directory=os.getcwd())
+                            directory=os.getcwd(), install_test=args.test)
         env = spec.environment
 
         # FIXME conda code currently requires args to have a name or prefix

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -57,6 +57,12 @@ def configure_parser(sub_parsers):
         default=None,
         nargs='?'
     )
+    p.add_argument(
+        '--test',
+        action='store_true',
+        default=False,
+        help='install test requirements from meta.yaml file',
+    )
     add_parser_json(p)
     p.set_defaults(func='.main_update.execute')
 
@@ -66,7 +72,7 @@ def execute(args, parser):
 
     try:
         spec = install_specs.detect(name=name, filename=expand(args.file),
-                                    directory=os.getcwd())
+                                    directory=os.getcwd(), install_test=args.test)
         env = spec.environment
     except exceptions.SpecNotFound:
         raise

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -124,6 +124,21 @@ def from_environment(name, prefix, no_builds=False, ignore_channels=False):
     return Environment(name=name, dependencies=dependencies, channels=channels, prefix=prefix)
 
 
+def from_meta(metadata, install_test=False, **kwargs):
+    dependencies = []
+    for typ in ('run', 'host', ):
+        dependencies.extend(metadata.get_value('requirements/{}'.format(typ)))
+
+    if install_test:
+        dependencies.extend(metadata.get_value('test/requires'))
+
+    return Environment(
+        name=metadata.name(),
+        filename=metadata.meta_path,
+        dependencies=dependencies
+    )
+
+
 def from_yaml(yamlstr, **kwargs):
     """Load and return a ``Environment`` from a given ``yaml string``"""
     data = yaml_load_standard(yamlstr)

--- a/conda_env/specs/__init__.py
+++ b/conda_env/specs/__init__.py
@@ -5,6 +5,7 @@
 import os
 
 from .binstar import BinstarSpec
+from .meta_file import MetaFileSpec
 from .notebook import NotebookSpec
 from .requirements import RequirementsSpec
 from .yaml_file import YamlFileSpec
@@ -25,6 +26,8 @@ def detect(**kwargs):
     if file_exists:
         if ext == '' or ext not in all_valid_exts:
             raise EnvironmentFileExtensionNotValid(filename)
+        elif ext in YamlFileSpec.extensions and ext in MetaFileSpec.extensions:
+            specs = [MetaFileSpec, YamlFileSpec]
         elif ext in YamlFileSpec.extensions:
             specs = [YamlFileSpec]
         elif ext in RequirementsSpec.extensions:

--- a/conda_env/specs/meta_file.py
+++ b/conda_env/specs/meta_file.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from .. import env
+
+
+class MetaFileSpec(object):
+    _environment = None
+    extensions = set(('.yaml', ))
+
+    def __init__(self, filename=None, install_test=False, **kwargs):
+        self.filename = filename
+        self.install_test = install_test
+        self.msg = None
+
+    def can_handle(self):
+        if os.path.basename(self.filename) != "meta.yaml":
+            return False
+
+        try:
+            from conda_build.metadata import MetaData
+        except ImportError:
+            self.msg = "conda_build package not installed"
+            return False
+
+        try:
+            metadata = MetaData(self.filename)
+        except Exception:
+            self.msg = "{} is not a valid meta.yaml file".format(self.filename)
+            return False
+        self._environment = env.from_meta(metadata, install_test=self.install_test)
+        return True
+
+    @property
+    def environment(self):
+        if not self._environment:
+            self.can_handle()
+        return self._environment


### PR DESCRIPTION
This PR allow `conda env {create/update}` command to handle meta.yaml file. It use `conda_build` to correctly parse Metadata.

Il also add a new argument `--test` to also install test requirements from meta.yaml file.

Feature request: #6788 