### PR TITLE
detect prefix paths when -p nor -n not given

### DIFF
--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -94,7 +94,11 @@ def execute(args, parser):
                 * Re-run this command inside an activated conda environment.""").lstrip()
             # TODO Add json support
             raise CondaEnvException(msg)
-        args.name = name
+        if os.sep in name:
+            # assume "names" with a path seperator are actually paths
+            args.prefix = name
+        else:
+            args.name = name
     else:
         name = args.name
     prefix = get_prefix(args)


### PR DESCRIPTION
When neither -p nor -n is given to "conda env export", assume that a
path seperator in CONDA_DEFAULT_ENV should be interpreted as a prefix
path nor an environment name.

closes #9128