### PR TITLE
Standardize "conda env list" behavior between platforms

### DIFF
--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -11,6 +11,7 @@ from os.path import dirname, isdir, isfile, join, normpath
 from .prefix_data import PrefixData
 from ..base.context import context
 from ..common.compat import ensure_text_type, on_win, open
+from ..common._os import is_admin
 from ..common.path import expand
 from ..gateways.disk.read import yield_lines
 from ..gateways.disk.test import is_conda_environment
@@ -63,23 +64,21 @@ def unregister_env(location):
 
 def list_all_known_prefixes():
     all_env_paths = set()
-    if on_win:
-        home_dir_dir = dirname(expand('~'))
-        for home_dir in listdir(home_dir_dir):
-            environments_txt_file = get_user_environments_txt_file(join(home_dir_dir, home_dir))
-            if isfile(environments_txt_file):
-                all_env_paths.update(_clean_environments_txt(environments_txt_file))
-    else:
-        from os import geteuid
-        from pwd import getpwall
-        if geteuid() == 0:
-            search_dirs = tuple(pwentry.pw_dir for pwentry in getpwall()) or (expand('~'),)
+    # If the user is an admin, load environments from all user home directories
+    if is_admin():
+        if on_win:
+            home_dir_dir = dirname(expand('~'))
+            search_dirs = tuple(join(home_dir_dir, d) for d in listdir(home_dir_dir))
         else:
-            search_dirs = (expand('~'),)
-        for home_dir in search_dirs:
-            environments_txt_file = get_user_environments_txt_file(home_dir)
-            if isfile(environments_txt_file):
-                all_env_paths.update(_clean_environments_txt(environments_txt_file))
+            from pwd import getpwall
+            search_dirs = tuple(pwentry.pw_dir for pwentry in getpwall()) or (expand('~'),)
+    else:
+        search_dirs = (expand('~'),)
+    for home_dir in search_dirs:
+        environments_txt_file = get_user_environments_txt_file(home_dir)
+        if isfile(environments_txt_file):
+            all_env_paths.update(_clean_environments_txt(environments_txt_file))
+
 
     # in case environments.txt files aren't complete, also add all known conda environments in
     # all envs_dirs

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -460,6 +460,8 @@ A list similar to the following is displayed:
    snowflakes            /home/username/miniconda/envs/snowflakes
    bunnies               /home/username/miniconda/envs/bunnies
 
+If this command is run by an administrator, a list of all environments
+belonging to all users will be displayed.
 
 Viewing a list of the packages in an environment
 ================================================


### PR DESCRIPTION
"conda env list" previously behaved differently on Windows and Unix -
on Unix, administrators got a list of all environments on the system,
and regular users saw only their environments. On Windows, however,
all users saw all environments.

This change standardizes both platforms to use the Unix behavior.
Administrators see all environments, and standard users only see
their own environments.

Closes #9165 