### PR TITLE
Implement auto_stack config option (issue #9036)

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -244,13 +244,24 @@ class _Activator(object):
                 context.dev = True
 
         if command == 'activate':
+            self.stack = context.auto_stack and context.shlvl <= context.auto_stack
             try:
                 stack_idx = remainder_args.index('--stack')
             except ValueError:
-                self.stack = False
-            else:
-                del remainder_args[stack_idx]
+                stack_idx = -1
+            try:
+                no_stack_idx = remainder_args.index('--no-stack')
+            except ValueError:
+                no_stack_idx = -1
+            if stack_idx >= 0 and no_stack_idx >= 0:
+                from .exceptions import ArgumentError
+                raise ArgumentError('cannot specify both --stack and --no-stack to ' + command)
+            if stack_idx >= 0:
                 self.stack = True
+                del remainder_args[stack_idx]
+            if no_stack_idx >= 0:
+                self.stack = False
+                del remainder_args[no_stack_idx]
             if len(remainder_args) > 1:
                 from .exceptions import ArgumentError
                 raise ArgumentError(command + ' does not accept more than one argument:\n'

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -128,6 +128,7 @@ class Context(Configuration):
     allow_softlinks = PrimitiveParameter(False)
     auto_update_conda = PrimitiveParameter(True, aliases=('self_update',))
     auto_activate_base = PrimitiveParameter(True)
+    auto_stack = PrimitiveParameter(0)
     notify_outdated_conda = PrimitiveParameter(True)
     clobber = PrimitiveParameter(False)
     changeps1 = PrimitiveParameter(True)
@@ -837,6 +838,7 @@ class Context(Configuration):
         ('Output, Prompt, and Flow Control Configuration', (
             'always_yes',
             'auto_activate_base',
+            'auto_stack',
             'changeps1',
             'env_prompt',
             'json',
@@ -938,6 +940,12 @@ class Context(Configuration):
                 """),
             'auto_update_conda': dals("""
                 Automatically update conda when a newer or higher priority version is detected.
+                """),
+            'auto_stack': dals("""
+                Implicitly use --stack when using activate if current level of nesting
+                (as indicated by CONDA_SHLVL environment variable) is less than or equal to
+                specified value. 0 or false disables automatic stacking, 1 or true enables 
+                it for one level.
                 """),
             'bld_path': dals("""
                 The location where conda-build will put built packages. Same as 'croot', but

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -72,7 +72,7 @@ class ActivateHelp(Help):
 
     def __init__(self):
         message = dals("""
-        usage: conda activate [-h] [--stack] [env_name_or_prefix]
+        usage: conda activate [-h] [--[no-]stack] [env_name_or_prefix]
 
         Activate a conda environment.
 
@@ -88,7 +88,11 @@ class ActivateHelp(Help):
           --stack               Stack the environment being activated on top of the
                                 previous active environment, rather replacing the
                                 current active environment with a new one. Currently,
-                                only the PATH environment variable is stacked.
+                                only the PATH environment variable is stacked. This 
+                                may be enabled implicitly by the 'auto_stack' 
+                                configuration variable.
+          --no-stack            Do not stack the environment. Overrides 'auto_stack'
+                                setting.
         """)
         super(ActivateHelp, self).__init__(message)
 

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -386,6 +386,29 @@ sometimes choose this setting to speed up the time their shell takes
 to start up or to keep conda-installed software from automatically
 hiding their other software.
 
+Nested activation
+-----------------
+
+By default, ``conda activate`` will deactivate the current environment
+before activating the new environment and reactivate it when
+deactivating the new environment. Sometimes you may want to leave
+the current environment PATH entries in place so that you can continue
+to easily access command line programs from the first environment. 
+This is most commonly encountered when common command-line utilities
+are installed in the base environment. To retain the current environment
+in the PATH, you can activate the new environment using:
+
+``conda activate --stack myenv``
+
+If you wish to always stack when going from the outermost environment, 
+which is typically the base environment, you can set the ``auto_stack`` 
+configuration option:
+
+``conda config --set auto_stack 1``
+
+You may specify a larger number for a deeper level of automatic stacking,
+but this is not recommended since deeper levels of stacking are more likely
+to lead to confusion.
 
 Deactivating an environment
 ===========================
@@ -400,7 +423,8 @@ your system command.
    activate`` with no environment specified, rather than to try to deactivate. If
    you run ``conda deactivate`` from your base environment, you may lose the
    ability to run conda at all. Don't worry, that's local to this shell - you can
-   start a new one.
+   start a new one. However, if the environment was activated using ``--stack``
+   (or was automatically stacked) then it is better to use ``conda deactivate``.
 
 
 .. _determine-current-env:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1688,12 +1688,10 @@ class ShellWrapperIntegrationTests(TestCase):
         shell.sendline('conda' + deactivate)
         shell.assert_env_var('CONDA_SHLVL', '1')
         PATH5 = shell.get_env_var('PATH')
-        assert 'charizard' not in PATH4
-        assert 'venusaur' not in PATH4
         assert PATH1 == PATH5
 
         # Test auto_stack
-        shell.sendline('conda config --system --set auto_stack true' )
+        shell.sendline('conda config --env --set auto_stack 1' )
 
         shell.sendline('conda' + activate + '"%s"' % self.prefix3)
         shell.assert_env_var('CONDA_SHLVL', '2')

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1685,6 +1685,8 @@ class ShellWrapperIntegrationTests(TestCase):
         assert 'venusaur' in PATH4
         assert PATH4 == PATH2
 
+        # TODO - test --no-stack and auto_stack config setting
+
     @pytest.mark.skipif(bash_unsupported(), reason=bash_unsupported_because())
     def test_bash_basic_integration(self):
         with InteractiveShell('bash') as shell:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1685,7 +1685,29 @@ class ShellWrapperIntegrationTests(TestCase):
         assert 'venusaur' in PATH4
         assert PATH4 == PATH2
 
-        # TODO - test --no-stack and auto_stack config setting
+        shell.sendline('conda' + deactivate)
+        shell.assert_env_var('CONDA_SHLVL', '1')
+        PATH5 = shell.get_env_var('PATH')
+        assert 'charizard' not in PATH4
+        assert 'venusaur' not in PATH4
+        assert PATH1 == PATH5
+
+        # Test auto_stack
+        shell.sendline('conda config --system --set auto_stack true' )
+
+        shell.sendline('conda' + activate + '"%s"' % self.prefix3)
+        shell.assert_env_var('CONDA_SHLVL', '2')
+        PATH2 = shell.get_env_var('PATH')
+        assert 'charizard' in PATH2
+        assert 'venusaur' in PATH2
+        assert len(PATH0.split(':')) + num_paths_added * 2 == len(PATH2.split(':'))
+
+        shell.sendline('conda' + activate + '"%s"' % prefix_p)
+        shell.assert_env_var('CONDA_SHLVL', '3')
+        PATH3 = shell.get_env_var('PATH')
+        assert 'charizard' in PATH3
+        assert 'venusaur' not in PATH3
+        assert len(PATH0.split(':')) + num_paths_added * 2 == len(PATH3.split(':'))
 
     @pytest.mark.skipif(bash_unsupported(), reason=bash_unsupported_because())
     def test_bash_basic_integration(self):


### PR DESCRIPTION
* Added an `auto_stack` config option that can be set to a positive integer specifying
  the lowest stack level at which `--stack` is implicitly called along with `activate`.
  Probably won't make sense to set this higher than 1 in most cases.

* Added `--no-stack` argumument to `conda activate` to disable auto stacking.

* Updated command line help for `conda activate`:

```
usage: conda activate [-h] [--[no-]stack] [env_name_or_prefix]

Activate a conda environment.

Options:

positional arguments:
  env_name_or_prefix    The environment name or prefix to activate. If the
                        prefix is a relative path, it must start with './'
                        (or '.\' on Windows).

optional arguments:
  -h, --help            Show this help message and exit.
  --stack               Stack the environment being activated on top of the
                        previous active environment, rather replacing the
                        current active environment with a new one. Currently,
                        only the PATH environment variable is stacked. This 
                        may be enabled implicitly by the 'auto_stack' 
                        configuration variable.
  --no-stack            Do not stack the environment. Overrides 'auto_stack'
                        setting.
```

* Updated user documentation

* Added integration test case to `tests/test_activate.py::ShellWrapperIntegrationTests::basic_posix`
  method.
