### PR TITLE
Look for more git executables on Windows, add BuildToolPackageNotInstalledError exception, add GIT_DESCRIBE_TAG_PEP440, use it in embedded `conda.recipe/meta.yaml`

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -149,6 +149,73 @@ def main(*args, **kwargs):
             return ExceptionHandler().handle_exception(exc_val, exc_tb)
 
     from ..exceptions import conda_exception_handler
+
+    # Here we are detecting (badly) the case when conda.bat has been run but not
+    # to the front of PATH (so that this conda executable can find its DLLs), but
+    # we do not prefix PATH with the new prefixes entries; we swap them in-place
+    # (a-la reactivate) or may even do nothing at all when re-activating the
+    # currently active env.
+    #
+    # I do not want to be messing with PATH here at all though (at least not until
+    # conda has loaded every DLL it could possibly want). We need a new proxy for
+    # os.environ['PATH'] which gets used for any PATH qeuries made by conda and
+    # which strips sysp from the result (which would be emitted to all script files
+    # that need to set the PATH env var) and all subprocess envs.
+    #
+    '''
+    from os import environ, getpid, pathsep, sep
+    try:
+        from psutil import Process
+        pp = Process(Process(getpid()).ppid())
+        if pp and pp.name() == 'conda.exe':
+            pp = Process(Process(Process(getpid()).ppid()).ppid())
+        if pp:
+            cmdline = pp.cmdline()[0]
+            if 'conda.bat' in pp.name():
+                print('conda.bat launched me')
+            elif 'charm' in pp.name() or 'code' in pp.name():
+                print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
+            else:
+                print('unknowwn ({}) launched me: {}'.format(pp.name(), cmdline))
+    except:
+        pass
+    '''
+    import os
+    if 'CONDA_PREFIX' in os.environ:
+        oep = os.environ['PATH']
+        paths = oep.split(os.pathsep)
+        if sys.platform != 'win32':
+            bin = '/bin'
+            shell = 'bash'
+        else:
+            bin = ''
+            shell = 'cmd.exe'
+        spb = sys.prefix + bin
+        # We do not catch the case of CONDA_PREFIX == sys.prefix. That just works.
+        if spb in paths and paths.index(spb) < paths.index(os.environ['CONDA_PREFIX'] + bin):
+            from conda.cli.activate import get_activate_path
+            res = get_activate_path(sys.prefix, shell)
+            if res in os.environ['PATH']:
+                old_oep = oep
+                oep = oep.replace(res, '', 1)
+                if oep.startswith(os.sep):
+                    oep.replace(os.sep, '', 1)
+                if oep.startswith(';') and not old_oep.startswith(';'):
+                    oep = oep.strip(';')
+                # We really cannot mess with os.environ['PATH'] like this because this
+                # python has not finished loading its DLLs in yet. By importing ssl now
+                # we ensure that at least that gets loaded before we've removed this
+                # conda env from PATH. Really we want to change only a proxy of
+                # os.environ['PATH'] so as to fool only the things that we launch.
+                import ssl
+                os.environ['PATH'] = oep
+            from logging import getLogger
+            log = getLogger(__name__)
+            log.warning("WARNING: Stripping sys.prefix from PATH as it comes before CONDA_PREFIX.\n"
+                        "         .. it was probably added there by conda.bat (sysp stuff)\n"
+                        "         .. and will cause the wrong software to run in some cases.\n"
+                        "         .. From:\n{}\nTo:\n{}\n".format(old_oep, oep))
+
     return conda_exception_handler(_main, *args, **kwargs)
 
 


### PR DESCRIPTION
Without this the assert fails on Windows. conda 4.4 runs a wrapper version of this function that converts Dicts to PackageRecords before calling this function. I have no idea why this has not manifested until now though and tips on that would be appreciated!

edit: The root cause was that version was miscalculated (and the problems start with the embedded recipe). I am also wishing to add support to `conda-build` so that it complains (error? warning?) when tools needed to render the recipe (e.g. git for `GIT_DESCRIBE_TAG` etc are not present in the build env, hence the addition of `BuildToolPackageNotInstalledError` exception. PR to `conda-build` incoming.

Instead of relying on `git` being on `PATH` alone, we look in some standard places on Windows. I bias that search to MSYS2/git over Git for Windows at present, but I don't think it matters very much, they all work here for me. If people feel there are other paths we should look at (`~/brew/bin/git`, `/usr/local/bin/git`) then I'm happy to add more. It is important that either a usable `git` gets found or else we should fail early and fail hard (let me know if you want that added too actually, and which exception is best to use).

This PR also adds `GIT_DESCRIBE_TAG_PEP440` which does what you'd expect (`GIT_DESCRIBE_TAG` will not generate a useful version, rather it'll generate one that caused the same failure the initial version of this PR incorrectly attempted to work around). The embedded `conda.recipe/meta.yaml` itself is also updated to use this and any python project built from a git repo should use it too probably!

I also sped and cleaned things up by not generating full single-string command lines that then need to be split into separate args via `shlex_split_unicode` by just not doing that and instead presenting an list of args in the first place.

So there's no longer any `Dist` `=>` `PackageRecord` hacking going on, now that version is detected in more situations, the right `display_actions` gets used (in those situations) and we can build conda.recipe from development sources and have a sensible version embedded (which obviates the need for a good `git` .. once you've gotten that far!)
