### PR TITLE
bring back Scripts/deactivate.bat for compatibility

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
     - Scripts/activate.bat         # [win]
     - Scripts/activate             # [win]
     - Scripts/deactivate           # [win]
+    - Scripts/deactivate.bat       # [win]
 
 requirements:
   build:

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -353,6 +353,13 @@ def make_install_plan(conda_prefix):
             },
         })
         plan.append({
+            'function': install_Scripts_deactivate_bat.__name__,
+            'kwargs': {
+                'target_path': join(conda_prefix, 'Scripts', 'deactivate.bat'),
+                'conda_prefix': conda_prefix,
+            },
+        })
+        plan.append({
             'function': install_activate_bat.__name__,
             'kwargs': {
                 'target_path': join(conda_prefix, 'condabin', 'activate.bat'),
@@ -867,6 +874,14 @@ def install_conda_sh(target_path, conda_prefix):
 def install_Scripts_activate_bat(target_path, conda_prefix):
     # target_path: join(conda_prefix, 'Scripts', 'activate.bat')
     src_path = join(CONDA_PACKAGE_ROOT, 'shell', 'Scripts', 'activate.bat')
+    with open(src_path) as fsrc:
+        file_content = fsrc.read()
+    return _install_file(target_path, file_content)
+
+
+def install_Scripts_deactivate_bat(target_path, conda_prefix):
+    # target_path: join(conda_prefix, 'Scripts', 'deactivate.bat')
+    src_path = join(CONDA_PACKAGE_ROOT, 'shell', 'Scripts', 'deactivate.bat')
     with open(src_path) as fsrc:
         file_content = fsrc.read()
     return _install_file(target_path, file_content)

--- a/conda/shell/Scripts/deactivate.bat
+++ b/conda/shell/Scripts/deactivate.bat
@@ -1,0 +1,4 @@
+@REM Copyright (C) 2012 Anaconda, Inc
+@REM SPDX-License-Identifier: BSD-3-Clause
+@ECHO DeprecationWarning: 'deactivate' is deprecated. Use 'conda deactivate'. 1>&2
+conda.bat deactivate %*

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -150,6 +150,13 @@ class InitializeTests(TestCase):
                         }
                     },
                     {
+                        "function": "install_Scripts_deactivate_bat",
+                        "kwargs": {
+                            "conda_prefix": "/darwin",
+                            "target_path": "/darwin\\Scripts\\deactivate.bat"
+                        }
+                    },
+                    {
                         "function": "install_activate_bat",
                         "kwargs": {
                             "conda_prefix": "/darwin",
@@ -531,6 +538,7 @@ class InitializeTests(TestCase):
                 'activate.bat',
                 'activate.bat',
                 'deactivate.bat',
+                'deactivate.bat',
                 'activate',
                 'deactivate',
                 'conda.sh',
@@ -590,6 +598,7 @@ class InitializeTests(TestCase):
                 'conda_hook.bat',
                 'activate.bat',
                 'activate.bat',
+                'deactivate.bat',
                 'deactivate.bat',
                 'activate',
                 'deactivate',
@@ -658,6 +667,7 @@ class InitializeTests(TestCase):
                 'conda_hook.bat',
                 'activate.bat',  # condabin/activate.bat
                 'activate.bat',  # Scripts/activate.bat
+                'deactivate.bat',
                 'deactivate.bat',
                 'activate',
                 'deactivate',


### PR DESCRIPTION
As of conda 4.6.0 deactivate.bat is only included in the condabin directory.  This also includes a copy in the Scripts directory for compatibility.

deactivate.bat was removed in cf5edebb138a89f0e670a7f580a4e50268f729f2
activate.bat was included in Scripts in 15e6bcd40f76e757d33ab6e2a9e15a383638a0ae