### PR TITLE
Windows: Ignore all PYTHON* environment variables

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -765,8 +765,8 @@ def make_entry_point(target_path, conda_prefix, module, func):
         original_ep_content = ""
 
     if on_win:
-        # no shebang needed on windows
-        new_ep_content = ""
+        # Ignore all PYTHON* environment variables
+        new_ep_content = "#!python -E"
     else:
         new_ep_content = "#!%s\n" % join(conda_prefix, get_python_short_path())
 


### PR DESCRIPTION
https://github.com/conda/conda/issues/9230

Conda is a package and environment manager. Conda should not depend on PYTHON* variables.

Very often an error occurs if PYTHONHOME has the wrong path.
```
Traceback (most recent call last):
  File "c:\Anaconda\Scripts\conda-script.py", line 16, in <module>
    from conda.cli import main
ModuleNotFoundError: No module named 'conda'
```
This patch fixes this error.