### PR TITLE
Protect against cases where subcommand help fails

### DIFF
--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -42,11 +42,17 @@ function __comp_conda_ensure_root() {
 }
 
 function __comp_conda_commands () {
+    # default core commands
+    echo clean config create help info init install list package
+    echo remove uninstall run search update upgrade
+
+    # check commands from full anaconda install
     for f in $CONDA_SOURCE/cli/main_*.py
     do
         \expr match "$f" '.*_\([a-z]\+\)\.py$'
     done
 
+    # check extra pluggins
     for f in $CONDA_ROOT/bin/conda-*
     do
         if test -x "$f" -a ! -d "$f"
@@ -54,8 +60,9 @@ function __comp_conda_commands () {
             \expr match "$f" '^.*/conda-\(.*\)'
         fi
     done
-    echo activate
-    echo deactivate
+
+    # implied by conda shell function
+    echo activate deactivate
 }
 
 function __comp_conda_env_commands() {

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -31,14 +31,13 @@ function __comp_conda_ensure_root() {
             CONDA_ROOT=$(\dirname "${CONDA_EXE}")
             CONDA_ROOT=$(\dirname "${CONDA_ROOT}")
         fi
-        CONDA_SOURCE=$(
-            cat - <<'            EOF' | sed 's/^ *: //g' | python -
-            : from __future__ import print_function
-            : import os
-            : import conda
-            : print(os.path.dirname(conda.__file__))
-            EOF
-        )
+        \local script="
+        :    from __future__ import print_function
+        :    import os
+        :    import conda
+        :    print(os.path.dirname(conda.__file__))
+        "
+        CONDA_SOURCE=$( python -c "${script//        :    /}" )
     fi
 }
 
@@ -67,17 +66,15 @@ function __comp_conda_env_commands() {
 }
 
 function __comp_conda_envs() {
-    script=$(
-        cat - <<'        EOF' | sed 's/^ *: //g'
-        : from __future__ import print_function;
-        : import json, os, sys;
-        : from os.path import isdir, join;
-        : print('\n'.join(
-        :    d for ed in json.load(sys.stdin)['envs_dirs'] if isdir(ed)
-        :    for d in os.listdir(ed) if isdir(join(ed, d))));
-        EOF
-    )
-    conda config --json --show envs_dirs | python -c "$script"
+    \local script="
+    :    from __future__ import print_function;
+    :    import json, os, sys;
+    :    from os.path import isdir, join;
+    :    print('\n'.join(
+    :       d for ed in json.load(sys.stdin)['envs_dirs'] if isdir(ed)
+    :       for d in os.listdir(ed) if isdir(join(ed, d))));
+    "
+    conda config --json --show envs_dirs | python -c "${script//    :    /}"
 }
 
 function __comp_conda_packages() {

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -37,7 +37,8 @@ function __comp_conda_ensure_root() {
         :    import conda
         :    print(os.path.dirname(conda.__file__))
         "
-        CONDA_SOURCE=$( python -c "${script//        :    /}" )
+        # don't assume an active base environment
+        CONDA_SOURCE=$(conda activate base; python -c "${script//        :    /}")
     fi
 }
 

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -104,6 +104,30 @@ function __comp_conda_cache_dump() {
     done
 }
 
+function __comp_conda_option_lookup() {
+    \local word_list cmd_str cmd_key
+    cmd_str=$1
+
+    # make a key to look up the cached result of the command help
+    # (We should be able to just use $cmd_str, since spaces in an array key are fine,
+    # but this produces an error with an empty cache. I'm not sure why though)
+    cmd_key=${cmd_str// /_}
+
+    if [[ -z "${__comp_conda_cache[$cmd_key]}" ]]; then
+        # parse the output of command help to get completions
+        word_list=$($cmd_str --help 2>&1 | _parse_help -)
+        if [[ ${PIPESTATUS[0]} -eq 0 && -n $word_list ]]; then
+            __comp_conda_cache[$cmd_key]=$word_list
+        else
+            # something went wrong, so abort completion attempt
+            return 1
+        fi
+    else
+        word_list=${__comp_conda_cache[$cmd_key]}
+    fi
+    echo $word_list
+}
+
 # cache conda subcommand help lookups for the duration of the shell
 unset __comp_conda_cache
 declare -A __comp_conda_cache
@@ -120,26 +144,11 @@ _comp_conda()
 
     __comp_conda_ensure_root 2>/dev/null
 
-    \local word_list cmd_str cmd_key
+    \local word_list cmd_str
     if [[ $cur == -* ]]; then
-        # get the current list of commands as a string
+        # get the current list of commands as a string sans options
         cmd_str="$(__comp_conda_cmds_str ${words[@]})"
-        # make a key to look up the cached result of the command help
-        # (We should be able to just use $cmd_str, since spaces in an array key are
-        # fine, but this produces an error with an empty cache. I'm not sure why though)
-        cmd_key=${cmd_str// /_}
-        if [[ -z "${__comp_conda_cache[$cmd_key]}" ]]; then
-            # parse the output of command help to get completions
-            word_list=$($cmd_str --help 2>&1 | _parse_help -)
-            if [[ ${PIPESTATUS[0]} -eq 0 && -n $word_list ]]; then
-                __comp_conda_cache[$cmd_key]=$word_list
-            else
-                # something went wrong, so abort completion attempt
-                return
-            fi
-        else
-            word_list=${__comp_conda_cache[$cmd_key]}
-        fi
+        word_list=$(__comp_conda_option_lookup "$cmd_str")
     else
         case "$prev" in
             conda)

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -111,14 +111,17 @@ function __comp_conda_cache_dump() {
 unset __comp_conda_cache
 declare -A __comp_conda_cache
 
-__comp_conda_ensure_root
+# If conda has not been fully setup/activated yet, some of the above functions may fail
+# and print error messages. This is not helpful during normal usage, so we discard all
+# error output by default.
+__comp_conda_ensure_root 2>/dev/null
 
 _comp_conda()
 {
     \local cur prev words cword
     _init_completion || return
 
-    __comp_conda_ensure_root
+    __comp_conda_ensure_root 2>/dev/null
 
     \local word_list cmds_str
     if [[ $cur == -* ]]; then
@@ -139,24 +142,24 @@ _comp_conda()
     else
         case "$prev" in
             conda)
-                word_list=$(__comp_conda_commands)
+                word_list=$(__comp_conda_commands 2>/dev/null)
                 ;;
             env)
-                word_list=$(__comp_conda_env_commands)
+                word_list=$(__comp_conda_env_commands 2>/dev/null)
                 ;;
             activate)
                 if [[ $cur == ./* || $cur == /* ]]; then
                     # complete for paths
                     COMPREPLY=( $(compgen -d -- "$cur" ) )
                 else
-                    word_list=$(__comp_conda_envs)
+                    word_list=$(__comp_conda_envs 2>/dev/null)
                 fi
                 ;;
             remove|uninstall|upgrade|update)
-                word_list=$(__comp_conda_packages)
+                word_list=$(__comp_conda_packages 2>/dev/null)
                 ;;
             --name|--clone)
-                word_list=$(__comp_conda_envs)
+                word_list=$(__comp_conda_envs 2>/dev/null)
                 ;;
             --*-file|--file|--which|convert)
                 # complete for files

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -19,7 +19,7 @@
 #
 # rather than being managed via the `conda shell.bash hook`, then this file may
 # be sourced before conda is setup.  To support this we allow for a potential
-# late initiallization of the CONDA_ROOT and CONDA_SOURCE environment
+# late initialization of the CONDA_ROOT and CONDA_SOURCE environment
 # variables.
 
 

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -85,16 +85,26 @@ function __comp_conda_packages() {
 }
 
 function __comp_conda_cmds_str() {
-    # get a list of commands
-    \local cmd cmds
+    # get a list of commands, skipping options
+    \local cmd
+    \local -a cmds
     for cmd in $*; do
         case "$cmd" in
             -*) continue ;;
-            *) cmds="$cmds $cmd" ;;
+            *) cmds+=($cmd) ;;
         esac
     done
-    cmds=${cmds# }
-    echo $cmds
+    echo "${cmds[*]}"
+}
+
+# helper for debugging issues with the cache
+function __comp_conda_cache_dump() {
+    for k in "${!__comp_conda_cache[@]}"; do
+        printf "%s:\n" "$k"
+        for w in ${__comp_conda_cache[$k]}; do
+            printf "\t%s\n" "$w"
+        done
+    done
 }
 
 # cache conda subcommand help lookups for the duration of the shell
@@ -113,11 +123,16 @@ _comp_conda()
     \local word_list cmds_str
     if [[ $cur == -* ]]; then
         # get the current list of commands as a string
-        cmds_str="$(__comp_conda_cmds_str ${words[*]})"
+        cmds_str="$(__comp_conda_cmds_str ${words[@]})"
         if [[ -z ${__comp_conda_cache[$cmds_str]} ]]; then
             # parse the output of command help to get completions
             word_list=$($cmds_str --help 2>&1 | _parse_help -)
-            __comp_conda_cache[$cmds_str]=$word_list
+            if [[ ${PIPESTATUS[0]} -eq 0 && -n $word_list ]]; then
+                __comp_conda_cache[$cmds_str]=$word_list
+            else
+                # something went wrong, so abort completion attempt
+                return
+            fi
         else
             word_list=${__comp_conda_cache[$cmds_str]}
         fi

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -6,7 +6,7 @@
 # This was initially based on completion support for `fish`, but later extended
 # complete options for subcommands and files/dirs/paths as appropriate.
 #
-# Dynamic option lookup uses a cache that persists for the duration of the shell. If you
+# Dynamic option lookup uses a cache that persists for the duration of the shell.
 # Updates to the conda command options are relatively rare, but there is a small chance
 # that this cache will hold incorrect/incomplete values. A restart of your shell will
 # fix this.

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -22,7 +22,6 @@
 # late initialization of the CONDA_ROOT and CONDA_SOURCE environment
 # variables.
 
-
 function __comp_conda_ensure_root() {
     if [[ -z "${CONDA_SOURCE-}" && -n "${CONDA_EXE-}" ]] ; then
         if [[ -n "${_CE_CONDA-}" && -n "${WINDIR-}" ]]; then
@@ -47,9 +46,14 @@ function __comp_conda_commands () {
     echo clean config create help info init install list package
     echo remove uninstall run search update upgrade
 
+    # implied by conda shell function
+    echo activate deactivate
+
     # check commands from full anaconda install
     for f in $CONDA_SOURCE/cli/main_*.py
     do
+        # skip pip -- not a sub-command
+        [[ $f == */main_pip.py ]] && continue
         \expr match "$f" '.*_\([a-z]\+\)\.py$'
     done
 
@@ -61,9 +65,6 @@ function __comp_conda_commands () {
             \expr match "$f" '^.*/conda-\(.*\)'
         fi
     done
-
-    # implied by conda shell function
-    echo activate deactivate
 }
 
 function __comp_conda_env_commands() {

--- a/conda/shell/etc/bash_completion.d/conda
+++ b/conda/shell/etc/bash_completion.d/conda
@@ -120,21 +120,25 @@ _comp_conda()
 
     __comp_conda_ensure_root 2>/dev/null
 
-    \local word_list cmds_str
+    \local word_list cmd_str cmd_key
     if [[ $cur == -* ]]; then
         # get the current list of commands as a string
-        cmds_str="$(__comp_conda_cmds_str ${words[@]})"
-        if [[ -z ${__comp_conda_cache[$cmds_str]} ]]; then
+        cmd_str="$(__comp_conda_cmds_str ${words[@]})"
+        # make a key to look up the cached result of the command help
+        # (We should be able to just use $cmd_str, since spaces in an array key are
+        # fine, but this produces an error with an empty cache. I'm not sure why though)
+        cmd_key=${cmd_str// /_}
+        if [[ -z "${__comp_conda_cache[$cmd_key]}" ]]; then
             # parse the output of command help to get completions
-            word_list=$($cmds_str --help 2>&1 | _parse_help -)
+            word_list=$($cmd_str --help 2>&1 | _parse_help -)
             if [[ ${PIPESTATUS[0]} -eq 0 && -n $word_list ]]; then
-                __comp_conda_cache[$cmds_str]=$word_list
+                __comp_conda_cache[$cmd_key]=$word_list
             else
                 # something went wrong, so abort completion attempt
                 return
             fi
         else
-            word_list=${__comp_conda_cache[$cmds_str]}
+            word_list=${__comp_conda_cache[$cmd_key]}
         fi
     else
         case "$prev" in


### PR DESCRIPTION
* fixes some edge cases where attempts to complete --options leaves the cache in a badly broken state.
* handle cases where conda is inactive or only partially setup more gracefully
* workaround obscure bash_completion dynamic loading bug
* ensure completion works even if the base environment is inactive
* always provide completion for core commands