### PR TITLE
Fix detection of cached, but unextracted .conda packages.

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -457,7 +457,7 @@ class UrlsData(object):
         #       That's probably a good assumption going forward, because we should now always
         #       be recording the extension in urls.txt.  The extensionless situation should be
         #       legacy behavior only.
-        if not package_path.endswith(CONDA_PACKAGE_EXTENSION_V1):
+        if not package_path.endswith(CONDA_PACKAGE_EXTENSIONS):
             package_path += CONDA_PACKAGE_EXTENSION_V1
         return first(self, lambda url: basename(url) == package_path)
 

--- a/tests/data/conda_format_repo/linux-64/current_repodata.json
+++ b/tests/data/conda_format_repo/linux-64/current_repodata.json
@@ -27,10 +27,10 @@
       "legacy_bz2_md5": "2e5b81671cc2b53177b94b258b1658b2",
       "license": "zlib",
       "license_family": "Other",
-      "md5": "2e5b81671cc2b53177b94b258b1658b2",
+      "md5": "cb23839f06da92ec92c6d2d2d5e0cb4a",
       "name": "zlib",
-      "sha256": "1f07873d6aa0cd18760a7b215d9956f7fa63c2f2761b03f293c659fe982923fa",
-      "size": 122456,
+      "sha256": "f33afff2144e1d6c4cf2e3e184937db8bf825b4537df74662aea5ee207b6a31b",
+      "size": 105917,
       "subdir": "linux-64",
       "timestamp": 1542814864621,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/linux-64/repodata.json
+++ b/tests/data/conda_format_repo/linux-64/repodata.json
@@ -42,10 +42,10 @@
       ],
       "license": "zlib",
       "license_family": "Other",
-      "md5": "2e5b81671cc2b53177b94b258b1658b2",
+      "md5": "cb23839f06da92ec92c6d2d2d5e0cb4a",
       "name": "zlib",
-      "sha256": "1f07873d6aa0cd18760a7b215d9956f7fa63c2f2761b03f293c659fe982923fa",
-      "size": 122456,
+      "sha256": "f33afff2144e1d6c4cf2e3e184937db8bf825b4537df74662aea5ee207b6a31b",
+      "size": 105917,
       "subdir": "linux-64",
       "timestamp": 1542814864621,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/osx-64/current_repodata.json
+++ b/tests/data/conda_format_repo/osx-64/current_repodata.json
@@ -11,10 +11,10 @@
       "legacy_bz2_md5": "5eab2de4933e1914f86d1586a8a40c39",
       "license": "zlib",
       "license_family": "Other",
-      "md5": "5eab2de4933e1914f86d1586a8a40c39",
+      "md5": "a1b03ba4ff40c83e4eb9c8fae40315a7",
       "name": "zlib",
-      "sha256": "9b73eb4e3197eccb485250709c6f4782a83a8688d5b8251a212251c451d9b9ad",
-      "size": 106948,
+      "sha256": "857293f389b188ba1fb02401a873fca5098db612ce6646c684efee77ad807f77",
+      "size": 91992,
       "subdir": "osx-64",
       "timestamp": 1542815100324,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/osx-64/repodata.json
+++ b/tests/data/conda_format_repo/osx-64/repodata.json
@@ -25,10 +25,10 @@
       "depends": [],
       "license": "zlib",
       "license_family": "Other",
-      "md5": "5eab2de4933e1914f86d1586a8a40c39",
+      "md5": "a1b03ba4ff40c83e4eb9c8fae40315a7",
       "name": "zlib",
-      "sha256": "9b73eb4e3197eccb485250709c6f4782a83a8688d5b8251a212251c451d9b9ad",
-      "size": 106948,
+      "sha256": "857293f389b188ba1fb02401a873fca5098db612ce6646c684efee77ad807f77",
+      "size": 91992,
       "subdir": "osx-64",
       "timestamp": 1542815100324,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/win-32/current_repodata.json
+++ b/tests/data/conda_format_repo/win-32/current_repodata.json
@@ -13,10 +13,10 @@
       "legacy_bz2_md5": "d56715ca9b345d3c51f2b19dba1dbf04",
       "license": "zlib",
       "license_family": "Other",
-      "md5": "d56715ca9b345d3c51f2b19dba1dbf04",
+      "md5": "1d40234f3fa0006e3a77c15c5aa6f2b7",
       "name": "zlib",
-      "sha256": "ea899e1c10ab22e565a201df1ee9d69b9260aa8ad4527b37d2dcd21a28f3a11d",
-      "size": 115056,
+      "sha256": "1f3fe788d266c16e35d1e737fd9b7c82dd1f1ba4d3973f0907c8a7634c5d484b",
+      "size": 99106,
       "subdir": "win-32",
       "timestamp": 1542815118406,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/win-32/repodata.json
+++ b/tests/data/conda_format_repo/win-32/repodata.json
@@ -29,10 +29,10 @@
       ],
       "license": "zlib",
       "license_family": "Other",
-      "md5": "d56715ca9b345d3c51f2b19dba1dbf04",
+      "md5": "1d40234f3fa0006e3a77c15c5aa6f2b7",
       "name": "zlib",
-      "sha256": "ea899e1c10ab22e565a201df1ee9d69b9260aa8ad4527b37d2dcd21a28f3a11d",
-      "size": 115056,
+      "sha256": "1f3fe788d266c16e35d1e737fd9b7c82dd1f1ba4d3973f0907c8a7634c5d484b",
+      "size": 99106,
       "subdir": "win-32",
       "timestamp": 1542815118406,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/win-64/current_repodata.json
+++ b/tests/data/conda_format_repo/win-64/current_repodata.json
@@ -43,10 +43,10 @@
       "legacy_bz2_md5": "a46cf10ba0eece37dffcec2d45a1f4ec",
       "license": "zlib",
       "license_family": "Other",
-      "md5": "a46cf10ba0eece37dffcec2d45a1f4ec",
+      "md5": "edad165fc3d25636d4f0a61c42873fbc",
       "name": "zlib",
-      "sha256": "10363f6c023d7fb3d11fdb4cc8de59b5ad5c6affdf960210dd95a252a3fced2b",
-      "size": 131285,
+      "sha256": "2fb5900c4a2ca7e0f509ebc344b3508815d7647c86cfb6721a1690365222e55a",
+      "size": 112305,
       "subdir": "win-64",
       "timestamp": 1542815182812,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/win-64/repodata.json
+++ b/tests/data/conda_format_repo/win-64/repodata.json
@@ -70,10 +70,10 @@
       ],
       "license": "zlib",
       "license_family": "Other",
-      "md5": "a46cf10ba0eece37dffcec2d45a1f4ec",
+      "md5": "edad165fc3d25636d4f0a61c42873fbc",
       "name": "zlib",
-      "sha256": "10363f6c023d7fb3d11fdb4cc8de59b5ad5c6affdf960210dd95a252a3fced2b",
-      "size": 131285,
+      "sha256": "2fb5900c4a2ca7e0f509ebc344b3508815d7647c86cfb6721a1690365222e55a",
+      "size": 112305,
       "subdir": "win-64",
       "timestamp": 1542815182812,
       "version": "1.2.11"


### PR DESCRIPTION
Resolves error when reusing a package cache with both `.conda` and
`.tar.bz2` files. `.conda` files are extracted, then re-downloaded from
source during `conda install` pass.

Occurs because re-extracted `.conda` repodata.json, see
package_cache_data.py 383, is written with an "<unknown>" channel entry,
resulting in a cache miss in `ProgressiveFetchExtract.make_actions_for_record`.
This is due to a failure to resolve the `.conda` package url from
`urls.txt`.

Error can be trivially reproduced by removing the extracted package
directory for an existing .conda sourced package, then reinstalling.