### PR TITLE
Remove subdir in PackageRecord pkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ miniconda*.exe
 docs/source/_build
 **/.vscode
 conda.tmp/
+*.iml

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -261,7 +261,7 @@ class PackageRecord(DictSafeMixin, Entity):
             return self.__pkey
         except AttributeError:
             __pkey = self.__pkey = [
-                self.channel.canonical_name, self.subdir, self.name,
+                self.channel.canonical_name, self.name,
                 self.version, self.build_number, self.build
             ]
             # NOTE: fn is included to distinguish between .conda and .tar.bz2 packages

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -945,6 +945,50 @@ def test_circular_dependencies():
     ]
 
 
+def test_identical_dependencies():
+    index2 = index.copy()
+    package1_noarch = PackageRecord(**{
+        "channel": "defaults",
+        "subdir": "noarch",
+        "md5": "0123456789",
+        "fn": "doesnt-matter-here",
+        'build': '0',
+        'build_number': 0,
+        'depends': [],
+        'name': 'package1',
+        'requires': [],
+        'version': '1.0',
+    })
+    index2[package1_noarch] = package1_noarch
+    package1_linux64 = PackageRecord(**{
+        "channel": "defaults",
+        "subdir": "linux-64",
+        "md5": "0123456789",
+        "fn": "doesnt-matter-here",
+        'build': '0',
+        'build_number': 0,
+        'depends': [],
+        'name': 'package1',
+        'requires': [],
+        'version': '1.0',
+    })
+    index2[package1_linux64] = package1_linux64
+    index2 = {key: value for key, value in iteritems(index2)}
+    r = Resolve(index2)
+
+    matches = r.find_matches(MatchSpec('package1'))
+    assert len(matches) == 1
+    assert set(prec.dist_str() for prec in r.find_matches(MatchSpec('package1'))) == {
+        'defaults::package1-1.0-0',
+    }
+
+    result = r.install(['package1'])
+    result = [rec.dist_str() for rec in result]
+    assert result == [
+        'defaults::package1-1.0-0',
+    ]
+
+
 def test_optional_dependencies():
     index2 = index.copy()
     p1 = PackageRecord(**{


### PR DESCRIPTION
Fixes #9116.

Since conda 4.6, the switch to using `PackageRecord` over `Dist` in `resolve.py` means otherwise identical packages in different subdirs are considered distinct, which breaks the solver when given this input as reduced_index.* Previously in the `Dist` object, these would not be considered distinct and one would be arbitrarily chosen over the other for input into the solver, so the bug is considered a regression.

This PR removes the `subdir` parameter in `PackageRecord._pkey` which is utilized to compute equality, allowing the same behavior as before. This is especially important in here: https://github.com/conda/conda/blob/master/conda/resolve.py#L753 when conda prepares the index for the solve.

*Note: I am not sure why the solver is unable to solve this case when it feels like it should. I opted to file this fix first for discussion before investigating further.