### PR TITLE
Update download link (silent mode)

### DIFF
--- a/docs/source/user-guide/install/macos.rst
+++ b/docs/source/user-guide/install/macos.rst
@@ -54,7 +54,7 @@ EXAMPLE:
 
 .. code-block:: bash
 
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh
     bash ~/miniconda.sh -b -p $HOME/miniconda
     export PATH="$HOME/miniconda/bin:$PATH"
 


### PR DESCRIPTION
We are installing Miniconda for MacOS but the linkt to download the lastest MacOS version was pointing to the Linux version.