### PR TITLE
"source activate" -> "conda activate" in create CLI help

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -513,7 +513,7 @@ def configure_parser_config(sub_parsers):
 
 def configure_parser_create(sub_parsers):
     help = "Create a new conda environment from a list of specified packages. "
-    descr = (help + "To use the created environment, use 'source activate "
+    descr = (help + "To use the created environment, use 'conda activate "
              "envname' look in that directory first.  This command requires either "
              "the -n NAME or -p PREFIX option.")
 


### PR DESCRIPTION
Btw, I don't get it when it says "look in that directory first". Is it right? Or is there a grammar issue/typo?