### PR TITLE
do not memorize PackageRecord.combined_depends

### DIFF
--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -21,7 +21,6 @@ from .match_spec import MatchSpec
 from .._vendor.auxlib.entity import (BooleanField, ComposableField, DictSafeMixin, Entity,
                                      EnumField, IntegerField, ListField, NumberField,
                                      StringField)
-from .._vendor.auxlib.decorators import memoizedproperty
 from .._vendor.boltons.timeutils import dt_to_timestamp, isoparse
 from ..base.context import context
 from ..common.compat import isiterable, itervalues, string_types, text_type
@@ -319,7 +318,7 @@ class PackageRecord(DictSafeMixin, Entity):
 
     timestamp = TimestampField()
 
-    @memoizedproperty
+    @property
     def combined_depends(self):
         from .match_spec import MatchSpec
         result = {ms.name: ms for ms in MatchSpec.merge(self.depends)}


### PR DESCRIPTION
Change combined_depends from a memoizedproperty to a property.
Memoization was causing problems with conda-build when building against
a matrix using a conda_build_config.yaml file,
c.f. conda/conda-build#3735