### PR TITLE
Avoid clash-prone OLDPATH variable name in activation script

### DIFF
--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -45,20 +45,20 @@ __conda_activate() {
     \local cmd="$1"
     shift
     \local ask_conda
-    OLDPATH="${PATH}"
+    CONDA_INTERNAL_OLDPATH="${PATH}"
     __add_sys_prefix_to_path
     ask_conda="$(PS1="$PS1" "$CONDA_EXE" $_CE_M $_CE_CONDA shell.posix "$cmd" "$@")" || \return $?
-    PATH="${OLDPATH}"
+    PATH="${CONDA_INTERNAL_OLDPATH}"
     \eval "$ask_conda"
     __conda_hashr
 }
 
 __conda_reactivate() {
     \local ask_conda
-    OLDPATH="${PATH}"
+    CONDA_INTERNAL_OLDPATH="${PATH}"
     __add_sys_prefix_to_path
     ask_conda="$(PS1="$PS1" "$CONDA_EXE" $_CE_M $_CE_CONDA shell.posix reactivate)" || \return $?
-    PATH="${OLDPATH}"
+    PATH="${CONDA_INTERNAL_OLDPATH}"
     \eval "$ask_conda"
     __conda_hashr
 }
@@ -74,11 +74,11 @@ conda() {
                 __conda_activate "$cmd" "$@"
                 ;;
             install|update|upgrade|remove|uninstall)
-                OLDPATH="${PATH}"
+                CONDA_INTERNAL_OLDPATH="${PATH}"
                 __add_sys_prefix_to_path
                 "$CONDA_EXE" $_CE_M $_CE_CONDA "$cmd" "$@"
                 \local t1=$?
-                PATH="${OLDPATH}"
+                PATH="${CONDA_INTERNAL_OLDPATH}"
                 if [ $t1 = 0 ]; then
                     __conda_reactivate
                 else
@@ -86,11 +86,11 @@ conda() {
                 fi
                 ;;
             *)
-                OLDPATH="${PATH}"
+                CONDA_INTERNAL_OLDPATH="${PATH}"
                 __add_sys_prefix_to_path
                 "$CONDA_EXE" $_CE_M $_CE_CONDA "$cmd" "$@"
                 \local t1=$?
-                PATH="${OLDPATH}"
+                PATH="${CONDA_INTERNAL_OLDPATH}"
                 return $t1
                 ;;
         esac


### PR DESCRIPTION
Users can now modify the PATH variable in the env_vars.sh script (#8464), which is useful for managing non-conda binaries. It is all too tempting to store your old path as $OLDPATH in the activation script, and set `PATH="$OLDPATH"` in the deactivation script. But this won't have the intended effect because conda.sh already uses that name. This modest PR proposes a less clash-prone name.

Hopefully this will save someone else a day of total confusion.