### PR TITLE
Retry download

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -201,6 +201,7 @@ class Context(Configuration):
     remote_connect_timeout_secs = PrimitiveParameter(9.15)
     remote_read_timeout_secs = PrimitiveParameter(60.)
     remote_max_retries = PrimitiveParameter(3)
+    remote_backoff_factor = PrimitiveParameter(0)
 
     add_anaconda_token = PrimitiveParameter(True, aliases=('add_binstar_token',))
 
@@ -803,6 +804,7 @@ class Context(Configuration):
             'proxy_servers',
             'remote_connect_timeout_secs',
             'remote_max_retries',
+            'remote_backoff_factor',
             'remote_read_timeout_secs',
             'ssl_verify',
         )),
@@ -1147,6 +1149,9 @@ class Context(Configuration):
                 """),
             'remote_max_retries': dals("""
                 The maximum number of retries each HTTP connection should attempt.
+                """),
+            'remote_backoff_factor': dals("""
+                The factor determines the time HTTP connection should wait for attempt.
                 """),
             'remote_read_timeout_secs': dals("""
                 Once conda has connected to a remote resource and sent an HTTP request, the

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -201,7 +201,7 @@ class Context(Configuration):
     remote_connect_timeout_secs = PrimitiveParameter(9.15)
     remote_read_timeout_secs = PrimitiveParameter(60.)
     remote_max_retries = PrimitiveParameter(3)
-    remote_backoff_factor = PrimitiveParameter(0)
+    remote_backoff_factor = PrimitiveParameter(1)
 
     add_anaconda_token = PrimitiveParameter(True, aliases=('add_binstar_token',))
 

--- a/conda/gateways/connection/__init__.py
+++ b/conda/gateways/connection/__init__.py
@@ -28,6 +28,7 @@ try:
     from requests.packages.urllib3.exceptions import InsecureRequestWarning
     from requests.structures import CaseInsensitiveDict
     from requests.utils import get_auth_from_url, get_netrc_auth
+    from requests.packages.urllib3.util.retry import Retry
 
     # monkeypatch requests
     from requests.utils import should_bypass_proxies
@@ -46,6 +47,7 @@ except ImportError:  # pragma: no cover
     from pip._vendor.requests.packages.urllib3.exceptions import InsecureRequestWarning
     from pip._vendor.requests.structures import CaseInsensitiveDict
     from pip._vendor.requests.utils import get_auth_from_url, get_netrc_auth
+    from pip._vendor.requests.packages.urllib3.util.retry import Retry
 
     # monkeypatch requests
     from pip._vendor.requests.utils import should_bypass_proxies
@@ -71,3 +73,4 @@ InvalidSchema = InvalidSchema
 SSLError = SSLError
 InsecureRequestWarning = InsecureRequestWarning
 RequestsProxyError = RequestsProxyError
+Retry = Retry

--- a/conda/gateways/connection/session.py
+++ b/conda/gateways/connection/session.py
@@ -7,7 +7,7 @@ from logging import getLogger
 from threading import local
 
 from . import (AuthBase, BaseAdapter, HTTPAdapter, Session, _basic_auth_str,
-               extract_cookies_to_jar, get_auth_from_url, get_netrc_auth)
+               extract_cookies_to_jar, get_auth_from_url, get_netrc_auth, Retry)
 from .adapters.ftp import FTPAdapter
 from .adapters.localfs import LocalFSAdapter
 from .adapters.s3 import S3Adapter
@@ -74,7 +74,9 @@ class CondaSession(Session):
 
         else:
             # Configure retries
-            http_adapter = HTTPAdapter(max_retries=context.remote_max_retries)
+            retry = Retry(total=context.remote_max_retries,
+                backoff_factor=context.remote_backoff_factor)
+            http_adapter = HTTPAdapter(max_retries=retry)
             self.mount("http://", http_adapter)
             self.mount("https://", http_adapter)
             self.mount("ftp://", FTPAdapter())

--- a/conda/gateways/connection/session.py
+++ b/conda/gateways/connection/session.py
@@ -75,7 +75,7 @@ class CondaSession(Session):
         else:
             # Configure retries
             retry = Retry(total=context.remote_max_retries,
-                backoff_factor=context.remote_backoff_factor)
+                          backoff_factor=context.remote_backoff_factor)
             http_adapter = HTTPAdapter(max_retries=retry)
             self.mount("http://", http_adapter)
             self.mount("https://", http_adapter)


### PR DESCRIPTION
#9312  

``Retry`` class can pass to ``HTTPAdapter`` instead of passing parameter ``max_retries``.
There is an option ``backoff_factor`` in ``Retry`` which can determine the time between two attempts.

### Fix
I add an option ``remote_backoff_factor`` in context and use ``Retry`` class for ``HTTPAdapter`` instead in order to pass the option ``backoff_factor`` in ``Retry`` class.

### Test
Because I cannot reproduce the error "403", I test in the following situation:
1. Run ``conda config --set remote_max_retries 3`` and ``conda config --set remote_backoff_factor 1`` before downloading
2. Execute ``conda install <package>``
3. Before asking ``proceed([y]/N)`` , use ``iptables`` to disable network
4. Enter ``y`` to proceed
5. It waits for about 5 seconds and raised an uncaught exception
    *   Originally, ``conda`` raised an uncaught exception almost immediately
    *   If I use  ``iptables`` to enable network in 5 seconds, it starts downloading