### PR TITLE
Pass specs as query parameters when fetching repodata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ miniconda*.exe
 docs/source/_build
 **/.vscode
 conda.tmp/
+*.iml
+*.ipr
+*.iws

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - setuptools >=31.0.1
   run:
     - python
+    - backports.functools_lru_cache # [py<33]
     - conda-package-handling
     - enum34                       # [py<34]
     - futures >=3.0.0              # [py<34]

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -84,9 +84,10 @@ def pretty_package(prec):
 def print_package_info(packages):
     from ..core.subdir_data import SubdirData
     results = {}
+    specs = [MatchSpec(package) for package in packages]
     for package in packages:
         spec = MatchSpec(package)
-        results[package] = tuple(SubdirData.query_all(spec))
+        results[package] = tuple(SubdirData.query_all(spec, package_ref_or_match_specs=specs))
 
     if context.json:
         stdout_json({package: results[package] for package in packages})

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -70,8 +70,9 @@ def execute(args, parser):
         spec_channel = spec.get_exact_value('channel')
         channel_urls = (spec_channel,) if spec_channel else context.channels
 
-        matches = sorted(SubdirData.query_all(spec, channel_urls, subdirs, package_ref_or_match_specs=[spec]),
-                         key=lambda rec: (rec.name, VersionOrder(rec.version), rec.build))
+        matches = sorted(
+            SubdirData.query_all(spec, channel_urls, subdirs, package_ref_or_match_specs=[spec]),
+            key=lambda rec: (rec.name, VersionOrder(rec.version), rec.build))
     if not matches and spec.get_exact_value("name"):
         flex_spec = MatchSpec(spec, name="*%s*" % spec.name)
         if not context.json:

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -70,7 +70,7 @@ def execute(args, parser):
         spec_channel = spec.get_exact_value('channel')
         channel_urls = (spec_channel,) if spec_channel else context.channels
 
-        matches = sorted(SubdirData.query_all(spec, channel_urls, subdirs),
+        matches = sorted(SubdirData.query_all(spec, channel_urls, subdirs, package_ref_or_match_specs=[spec]),
                          key=lambda rec: (rec.name, VersionOrder(rec.version), rec.build))
     if not matches and spec.get_exact_value("name"):
         flex_spec = MatchSpec(spec, name="*%s*" % spec.name)

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -210,8 +210,11 @@ def get_reduced_index(prefix, channels, subdirs, specs, repodata_fn):
             name = pending_names.pop()
             collected_names.add(name)
             spec = MatchSpec(name)
-            new_records = SubdirData.query_all(spec, channels=channels, subdirs=subdirs,
-                                               package_ref_or_match_specs=specs, repodata_fn=repodata_fn)
+            new_records = SubdirData.query_all(spec,
+                                               channels=channels,
+                                               subdirs=subdirs,
+                                               package_ref_or_match_specs=specs,
+                                               repodata_fn=repodata_fn)
             for record in new_records:
                 push_record(record)
             records.update(new_records)
@@ -220,8 +223,11 @@ def get_reduced_index(prefix, channels, subdirs, specs, repodata_fn):
             feature_name = pending_track_features.pop()
             collected_track_features.add(feature_name)
             spec = MatchSpec(track_features=feature_name)
-            new_records = SubdirData.query_all(spec, channels=channels, subdirs=subdirs,
-                                               package_ref_or_match_specs=specs, repodata_fn=repodata_fn)
+            new_records = SubdirData.query_all(spec,
+                                               channels=channels,
+                                               subdirs=subdirs,
+                                               package_ref_or_match_specs=specs,
+                                               repodata_fn=repodata_fn)
             for record in new_records:
                 push_record(record)
             records.update(new_records)

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -15,7 +15,6 @@ from .._vendor.toolz import concat, concatv
 from ..base.context import context
 from ..common.compat import itervalues
 from ..common.io import ThreadLimitedThreadPoolExecutor, time_recorder
-from ..common._os.linux import linux_get_libc_version
 from ..exceptions import ChannelNotAllowed, InvalidSpec
 from ..gateways.logging import initialize_logging
 from ..models.channel import Channel, all_channel_urls

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -211,7 +211,7 @@ def get_reduced_index(prefix, channels, subdirs, specs, repodata_fn):
             collected_names.add(name)
             spec = MatchSpec(name)
             new_records = SubdirData.query_all(spec, channels=channels, subdirs=subdirs,
-                                               repodata_fn=repodata_fn)
+                                               package_ref_or_match_specs=specs, repodata_fn=repodata_fn)
             for record in new_records:
                 push_record(record)
             records.update(new_records)
@@ -221,7 +221,7 @@ def get_reduced_index(prefix, channels, subdirs, specs, repodata_fn):
             collected_track_features.add(feature_name)
             spec = MatchSpec(track_features=feature_name)
             new_records = SubdirData.query_all(spec, channels=channels, subdirs=subdirs,
-                                               repodata_fn=repodata_fn)
+                                               package_ref_or_match_specs=specs, repodata_fn=repodata_fn)
             for record in new_records:
                 push_record(record)
             records.update(new_records)

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -63,11 +63,14 @@ class SubdirDataType(type):
         assert type(channel) is Channel
         cache_key = channel.url(with_credentials=True), repodata_fn
         if package_ref_or_match_specs:
-            cache_key = channel.url(with_credentials=True), frozenset(package_ref_or_match_specs), repodata_fn
+            cache_key = (channel.url(with_credentials=True),
+                         frozenset(package_ref_or_match_specs),
+                         repodata_fn)
         if not cache_key[0].startswith('file://') and cache_key in SubdirData._cache_:
             return SubdirData._cache_[cache_key]
 
-        subdir_data_instance = super(SubdirDataType, cls).__call__(channel, package_ref_or_match_specs, repodata_fn)
+        subdir_data_instance = super(SubdirDataType, cls).__call__(
+            channel, package_ref_or_match_specs, repodata_fn)
         SubdirData._cache_[cache_key] = subdir_data_instance
         return subdir_data_instance
 
@@ -463,7 +466,12 @@ class Response304ContentUnchanged(Exception):
     pass
 
 
-def fetch_repodata_remote_request(url, etag, mod_stamp, package_ref_or_match_specs=None, repodata_fn=REPODATA_FN):
+def fetch_repodata_remote_request(
+        url,
+        etag,
+        mod_stamp,
+        package_ref_or_match_specs=None,
+        repodata_fn=REPODATA_FN):
     if not context.ssl_verify:
         warnings.simplefilter('ignore', InsecureRequestWarning)
 
@@ -484,7 +492,10 @@ def fetch_repodata_remote_request(url, etag, mod_stamp, package_ref_or_match_spe
 
     try:
         timeout = context.remote_connect_timeout_secs, context.remote_read_timeout_secs
-        resp = session.get(join_url(url, filename), params=params, headers=headers, proxies=session.proxies,
+        resp = session.get(join_url(url, filename),
+                           params=params,
+                           headers=headers,
+                           proxies=session.proxies,
                            timeout=timeout)
         if log.isEnabledFor(DEBUG):
             log.debug(stringify(resp, content_max_len=256))

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -265,7 +265,7 @@ class Channel(object):
                 return False
 
     def __hash__(self):
-        return hash((self.location, self.name))
+        return hash(self.url(with_credentials=True))
 
     def __nonzero__(self):
         return any((self.location, self.name))

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -434,6 +434,10 @@ class MatchSpec(object):
         return self.conda_build_form()
 
     @property
+    def to_query_param(self):
+        return self.get_exact_value('name')
+
+    @property
     def version(self):
         # in the old MatchSpec object, version was a VersionSpec, not a str
         # so we'll keep that API here

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -370,6 +370,7 @@ class PackageRecord(DictSafeMixin, Entity):
         #              channel_name/subdir:namespace:name-version-build_number-build_string
         return "%s/%s::%s-%s-%s" % (self.channel.name, self.subdir,
                                     self.name, self.version, self.build)
+
     def to_query_param(self):
         return self.name
 

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -370,6 +370,8 @@ class PackageRecord(DictSafeMixin, Entity):
         #              channel_name/subdir:namespace:name-version-build_number-build_string
         return "%s/%s::%s-%s-%s" % (self.channel.name, self.subdir,
                                     self.name, self.version, self.build)
+    def to_query_param(self):
+        return self.name
 
 
 class Md5Field(StringField):

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -44,8 +44,8 @@ def get_solver(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(), h
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    query_specs = specs_to_add + specs_to_remove + history_specs
-    get_index_r_1(context.subdir, query_specs=query_specs)
+    package_ref_or_match_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_1(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-1'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -58,8 +58,8 @@ def get_solver_2(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    query_specs = specs_to_add + specs_to_remove + history_specs
-    get_index_r_2(context.subdir, query_specs=query_specs)
+    package_ref_or_match_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_2(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-2'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -72,8 +72,8 @@ def get_solver_4(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    query_specs = specs_to_add + specs_to_remove + history_specs
-    get_index_r_4(context.subdir, query_specs=query_specs)
+    package_ref_or_match_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_4(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-4'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -86,8 +86,8 @@ def get_solver_5(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    query_specs = specs_to_add + specs_to_remove + history_specs
-    get_index_r_5(context.subdir, query_specs)
+    package_ref_or_match_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_5(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-5'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -100,9 +100,9 @@ def get_solver_aggregate_1(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_r
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    query_specs = specs_to_add + specs_to_remove + history_specs
-    get_index_r_2(context.subdir, query_specs=query_specs)
-    get_index_r_4(context.subdir, query_specs=query_specs)
+    package_ref_or_match_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_2(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
+    get_index_r_4(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-2'), Channel('channel-4'), ),
                         (context.subdir,), specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -115,9 +115,9 @@ def get_solver_aggregate_2(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_r
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    query_specs = specs_to_add + specs_to_remove + history_specs
-    get_index_r_2(context.subdir, query_specs=query_specs)
-    get_index_r_4(context.subdir, query_specs=query_specs)
+    package_ref_or_match_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_2(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
+    get_index_r_4(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-4'), Channel('channel-2')),
                         (context.subdir,), specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -130,8 +130,8 @@ def get_solver_must_unfreeze(tmpdir, specs_to_add=(), specs_to_remove=(), prefix
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    query_specs = specs_to_add + specs_to_remove + history_specs
-    get_index_must_unfreeze(context.subdir, query_specs=query_specs)
+    package_ref_or_match_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_must_unfreeze(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-freeze'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -144,8 +144,8 @@ def get_solver_cuda(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    query_specs = specs_to_add + specs_to_remove + history_specs
-    get_index_cuda(context.subdir, query_specs=query_specs)
+    package_ref_or_match_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_cuda(context.subdir, package_ref_or_match_specs=package_ref_or_match_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-1'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -44,7 +44,8 @@ def get_solver(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(), h
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    get_index_r_1(context.subdir)
+    query_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_1(context.subdir, query_specs=query_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-1'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -57,7 +58,8 @@ def get_solver_2(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    get_index_r_2(context.subdir)
+    query_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_2(context.subdir, query_specs=query_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-2'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -70,7 +72,8 @@ def get_solver_4(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    get_index_r_4(context.subdir)
+    query_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_4(context.subdir, query_specs=query_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-4'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -83,7 +86,8 @@ def get_solver_5(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    get_index_r_5(context.subdir)
+    query_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_5(context.subdir, query_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-5'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -96,8 +100,9 @@ def get_solver_aggregate_1(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_r
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    get_index_r_2(context.subdir)
-    get_index_r_4(context.subdir)
+    query_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_2(context.subdir, query_specs=query_specs)
+    get_index_r_4(context.subdir, query_specs=query_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-2'), Channel('channel-4'), ),
                         (context.subdir,), specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -110,8 +115,9 @@ def get_solver_aggregate_2(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_r
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    get_index_r_2(context.subdir)
-    get_index_r_4(context.subdir)
+    query_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_r_2(context.subdir, query_specs=query_specs)
+    get_index_r_4(context.subdir, query_specs=query_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-4'), Channel('channel-2')),
                         (context.subdir,), specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -124,7 +130,8 @@ def get_solver_must_unfreeze(tmpdir, specs_to_add=(), specs_to_remove=(), prefix
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    get_index_must_unfreeze(context.subdir)
+    query_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_must_unfreeze(context.subdir, query_specs=query_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-freeze'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -137,7 +144,8 @@ def get_solver_cuda(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=
     pd = PrefixData(tmpdir)
     pd._PrefixData__prefix_records = {rec.name: PrefixRecord.from_objects(rec) for rec in prefix_records}
     spec_map = {spec.name: spec for spec in history_specs}
-    get_index_cuda(context.subdir)
+    query_specs = specs_to_add + specs_to_remove + history_specs
+    get_index_cuda(context.subdir, query_specs=query_specs)
     with patch.object(History, 'get_requested_specs_map', return_value=spec_map):
         solver = Solver(tmpdir, (Channel('channel-1'),), (context.subdir,),
                         specs_to_add=specs_to_add, specs_to_remove=specs_to_remove)
@@ -902,7 +910,7 @@ def test_unfreeze_when_required(tmpdir):
     # if foobar is installed first it must be downgraded from 2.0.
     # If foobar is frozen then no solution exists.
 
-    specs = [MatchSpec("foobar"), MatchSpec('qux')]
+    specs = MatchSpec("foobar"), MatchSpec('qux'),
     with get_solver_must_unfreeze(tmpdir, specs) as solver:
         final_state_1 = solver.solve_final_state()
         print(convert_to_dist_str(final_state_1))
@@ -1258,7 +1266,6 @@ def test_python2_update(tmpdir):
             'channel-4::asn1crypto-0.24.0-py37_0',
             'channel-4::certifi-2018.8.13-py37_0',
             'channel-4::chardet-3.0.4-py37_1',
-            'channel-4::cryptography-vectors-2.3-py37_0',
             'channel-4::idna-2.7-py37_0',
             'channel-4::pycosat-0.6.3-py37h14c3975_0',
             'channel-4::pycparser-2.18-py37_1',
@@ -1266,7 +1273,7 @@ def test_python2_update(tmpdir):
             'channel-4::ruamel_yaml-0.15.46-py37h14c3975_0',
             'channel-4::six-1.11.0-py37_1',
             'channel-4::cffi-1.11.5-py37h9745a5d_0',
-            'channel-4::cryptography-2.3-py37hb7f436b_0',
+            'channel-4::cryptography-2.2.2-py37h14c3975_0',
             'channel-4::pyopenssl-18.0.0-py37_0',
             'channel-4::urllib3-1.23-py37_0',
             'channel-4::requests-2.19.1-py37_0',
@@ -1816,7 +1823,7 @@ def test_channel_priority_churn_minimized(tmpdir):
 
     pprint(convert_to_dist_str(final_state))
 
-    with get_solver_aggregate_2(tmpdir, [MatchSpec('itsdangerous')],
+    with get_solver_aggregate_2(tmpdir, (MatchSpec('itsdangerous'),),
                                 prefix_records=final_state, history_specs=specs) as solver:
         solver.channels.reverse()
         unlink_dists, link_dists = solver.solve_for_diff(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -156,12 +156,9 @@ def add_feature_records_legacy(index):
         rec = make_feature_record(feature_name)
         index[rec] = rec
 
-def specs_to_query_parameters(specs=[]):
-    return "?" + "&".join(specs) or ""
-
 
 @memoize
-def get_index_r_1(subdir=context.subdir, query_specs=[]):
+def get_index_r_1(subdir=context.subdir, package_ref_or_match_specs=[]):
     with open(join(dirname(__file__), 'data', 'index.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -175,11 +172,10 @@ def get_index_r_1(subdir=context.subdir, query_specs=[]):
 
 
     channel = Channel('https://conda.anaconda.org/channel-1/%s' % subdir)
-    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
+    sd = SubdirData(channel, package_ref_or_match_specs=package_ref_or_match_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
-    SubdirData._cache_[channel.url(with_credentials=True)] = sd
 
     index = {prec: prec for prec in sd._package_records}
     add_feature_records_legacy(index)
@@ -188,7 +184,7 @@ def get_index_r_1(subdir=context.subdir, query_specs=[]):
 
 
 @memoize
-def get_index_r_2(subdir=context.subdir, query_specs=[]):
+def get_index_r_2(subdir=context.subdir, package_ref_or_match_specs=[]):
     with open(join(dirname(__file__), 'data', 'index2.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -201,11 +197,10 @@ def get_index_r_2(subdir=context.subdir, query_specs=[]):
         }
 
     channel = Channel('https://conda.anaconda.org/channel-2/%s' % subdir)
-    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
+    sd = SubdirData(channel, package_ref_or_match_specs=package_ref_or_match_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
-    SubdirData._cache_[channel.url(with_credentials=True)] = sd
 
     index = {prec: prec for prec in sd._package_records}
     r = Resolve(index, channels=(channel,))
@@ -213,7 +208,7 @@ def get_index_r_2(subdir=context.subdir, query_specs=[]):
 
 
 @memoize
-def get_index_r_4(subdir=context.subdir, query_specs=[]):
+def get_index_r_4(subdir=context.subdir, package_ref_or_match_specs=[]):
     with open(join(dirname(__file__), 'data', 'index4.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -226,11 +221,10 @@ def get_index_r_4(subdir=context.subdir, query_specs=[]):
         }
 
     channel = Channel('https://conda.anaconda.org/channel-4/%s' % subdir)
-    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
+    sd = SubdirData(channel, package_ref_or_match_specs=package_ref_or_match_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
-    SubdirData._cache_[channel.url(with_credentials=True)] = sd
 
     index = {prec: prec for prec in sd._package_records}
     r = Resolve(index, channels=(channel,))
@@ -239,7 +233,7 @@ def get_index_r_4(subdir=context.subdir, query_specs=[]):
 
 
 @memoize
-def get_index_r_5(subdir=context.subdir, query_specs=[]):
+def get_index_r_5(subdir=context.subdir, package_ref_or_match_specs=[]):
     with open(join(dirname(__file__), 'data', 'index5.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -252,11 +246,10 @@ def get_index_r_5(subdir=context.subdir, query_specs=[]):
         }
 
     channel = Channel('https://conda.anaconda.org/channel-5/%s' % subdir)
-    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
+    sd = SubdirData(channel, package_ref_or_match_specs=package_ref_or_match_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
-    SubdirData._cache_[channel.url(with_credentials=True)] = sd
 
     index = {prec: prec for prec in sd._package_records}
     r = Resolve(index, channels=(channel,))
@@ -265,7 +258,7 @@ def get_index_r_5(subdir=context.subdir, query_specs=[]):
 
 
 @memoize
-def get_index_must_unfreeze(subdir=context.subdir, query_specs=[]):
+def get_index_must_unfreeze(subdir=context.subdir, package_ref_or_match_specs=[]):
     repodata = {
         "info": {
             "subdir": subdir,
@@ -362,11 +355,10 @@ def get_index_must_unfreeze(subdir=context.subdir, query_specs=[]):
         }
     }
     channel = Channel('https://conda.anaconda.org/channel-freeze/%s' % subdir)
-    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
+    sd = SubdirData(channel, package_ref_or_match_specs=package_ref_or_match_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
-    SubdirData._cache_[channel.url(with_credentials=True)] = sd
 
     index = {prec: prec for prec in sd._package_records}
     r = Resolve(index, channels=(channel,))
@@ -375,7 +367,7 @@ def get_index_must_unfreeze(subdir=context.subdir, query_specs=[]):
 
 
 # Do not memoize this get_index to allow different CUDA versions to be detected
-def get_index_cuda(subdir=context.subdir, query_specs=[]):
+def get_index_cuda(subdir=context.subdir, package_ref_or_match_specs=[]):
     with open(join(dirname(__file__), 'data', 'index.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -388,11 +380,10 @@ def get_index_cuda(subdir=context.subdir, query_specs=[]):
         }
 
     channel = Channel('https://conda.anaconda.org/channel-1/%s' % subdir)
-    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
+    sd = SubdirData(channel, package_ref_or_match_specs=package_ref_or_match_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", reset_context):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
-    SubdirData._cache_[channel.url(with_credentials=True)] = sd
 
     index = {prec: prec for prec in sd._package_records}
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -156,8 +156,12 @@ def add_feature_records_legacy(index):
         rec = make_feature_record(feature_name)
         index[rec] = rec
 
+def specs_to_query_parameters(specs=[]):
+    return "?" + "&".join(specs) or ""
+
+
 @memoize
-def get_index_r_1(subdir=context.subdir):
+def get_index_r_1(subdir=context.subdir, query_specs=[]):
     with open(join(dirname(__file__), 'data', 'index.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -169,8 +173,9 @@ def get_index_r_1(subdir=context.subdir):
             "packages": packages,
         }
 
+
     channel = Channel('https://conda.anaconda.org/channel-1/%s' % subdir)
-    sd = SubdirData(channel)
+    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
@@ -183,7 +188,7 @@ def get_index_r_1(subdir=context.subdir):
 
 
 @memoize
-def get_index_r_2(subdir=context.subdir):
+def get_index_r_2(subdir=context.subdir, query_specs=[]):
     with open(join(dirname(__file__), 'data', 'index2.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -196,7 +201,7 @@ def get_index_r_2(subdir=context.subdir):
         }
 
     channel = Channel('https://conda.anaconda.org/channel-2/%s' % subdir)
-    sd = SubdirData(channel)
+    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
@@ -208,7 +213,7 @@ def get_index_r_2(subdir=context.subdir):
 
 
 @memoize
-def get_index_r_4(subdir=context.subdir):
+def get_index_r_4(subdir=context.subdir, query_specs=[]):
     with open(join(dirname(__file__), 'data', 'index4.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -221,7 +226,7 @@ def get_index_r_4(subdir=context.subdir):
         }
 
     channel = Channel('https://conda.anaconda.org/channel-4/%s' % subdir)
-    sd = SubdirData(channel)
+    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
@@ -234,7 +239,7 @@ def get_index_r_4(subdir=context.subdir):
 
 
 @memoize
-def get_index_r_5(subdir=context.subdir):
+def get_index_r_5(subdir=context.subdir, query_specs=[]):
     with open(join(dirname(__file__), 'data', 'index5.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -247,7 +252,7 @@ def get_index_r_5(subdir=context.subdir):
         }
 
     channel = Channel('https://conda.anaconda.org/channel-5/%s' % subdir)
-    sd = SubdirData(channel)
+    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
@@ -260,7 +265,7 @@ def get_index_r_5(subdir=context.subdir):
 
 
 @memoize
-def get_index_must_unfreeze(subdir=context.subdir):
+def get_index_must_unfreeze(subdir=context.subdir, query_specs=[]):
     repodata = {
         "info": {
             "subdir": subdir,
@@ -357,7 +362,7 @@ def get_index_must_unfreeze(subdir=context.subdir):
         }
     }
     channel = Channel('https://conda.anaconda.org/channel-freeze/%s' % subdir)
-    sd = SubdirData(channel)
+    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True
@@ -370,7 +375,7 @@ def get_index_must_unfreeze(subdir=context.subdir):
 
 
 # Do not memoize this get_index to allow different CUDA versions to be detected
-def get_index_cuda(subdir=context.subdir):
+def get_index_cuda(subdir=context.subdir, query_specs=[]):
     with open(join(dirname(__file__), 'data', 'index.json')) as fi:
         packages = json.load(fi)
         repodata = {
@@ -383,7 +388,7 @@ def get_index_cuda(subdir=context.subdir):
         }
 
     channel = Channel('https://conda.anaconda.org/channel-1/%s' % subdir)
-    sd = SubdirData(channel)
+    sd = SubdirData(channel, package_ref_or_match_specs=query_specs)
     with env_var("CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY", "false", reset_context):
         sd._process_raw_repodata_str(json.dumps(repodata))
     sd._loaded = True

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -287,6 +287,8 @@ def run_command(command, prefix, *arguments, **kwargs):
 
 @contextmanager
 def make_temp_env(*packages, **kwargs):
+    from conda.core.subdir_data import SubdirData
+    SubdirData._cache_.clear()
     name = kwargs.pop('name', None)
     use_restricted_unicode = kwargs.pop('use_restricted_unicode', False)
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -287,8 +287,6 @@ def run_command(command, prefix, *arguments, **kwargs):
 
 @contextmanager
 def make_temp_env(*packages, **kwargs):
-    from conda.core.subdir_data import SubdirData
-    SubdirData._cache_.clear()
     name = kwargs.pop('name', None)
     use_restricted_unicode = kwargs.pop('use_restricted_unicode', False)
 
@@ -2235,8 +2233,8 @@ class IntegrationTests(TestCase):
 
     def test_use_index_cache(self):
         from conda.gateways.connection.session import CondaSession
-        from conda.core.subdir_data import SubdirData
-        SubdirData._cache_.clear()
+        from conda.core.subdir_data import SubdirDataType
+        SubdirDataType.get_or_create_subdir_data.cache_clear()
 
         prefix = make_temp_prefix("_" + str(uuid4())[:7])
         with make_temp_env(prefix=prefix, no_capture=True):
@@ -2258,7 +2256,7 @@ class IntegrationTests(TestCase):
                             del result.headers[header]
                     return result
 
-                SubdirData._cache_.clear()
+                SubdirDataType.get_or_create_subdir_data.cache_clear()
                 mock_method.side_effect = side_effect
                 stdout, stderr, _ = run_command(Commands.INFO, prefix, "flask", "--json")
                 assert mock_method.called
@@ -2276,8 +2274,8 @@ class IntegrationTests(TestCase):
                 run_command(Commands.INSTALL, prefix, "flask", "--json", "--use-index-cache")
 
     def test_offline_with_empty_index_cache(self):
-        from conda.core.subdir_data import SubdirData
-        SubdirData._cache_.clear()
+        from conda.core.subdir_data import SubdirDataType
+        SubdirDataType.get_or_create_subdir_data.cache_clear()
 
         try:
             with make_temp_env() as prefix:
@@ -2309,7 +2307,7 @@ class IntegrationTests(TestCase):
                         with patch.object(CondaSession, 'get', autospec=True) as mock_method:
                             mock_method.side_effect = side_effect
 
-                            SubdirData._cache_.clear()
+                            SubdirDataType.get_or_create_subdir_data.cache_clear()
 
                             # This first install passes because flask and its dependencies are in the
                             # package cache.
@@ -2325,7 +2323,7 @@ class IntegrationTests(TestCase):
                                 run_command(Commands.INSTALL, prefix, "-c", channel, "pytz", "--offline")
                             assert not package_is_installed(prefix, "pytz")
         finally:
-            SubdirData._cache_.clear()
+            SubdirDataType.get_or_create_subdir_data.cache_clear()
 
     def test_create_from_extracted(self):
         with make_temp_package_cache() as pkgs_dir:


### PR DESCRIPTION
Pass package names as query parameters to repodata GET request. This allows for channels that can do server side repodata filtering to enable that process.