### PR TITLE
Fix calling python api run_command with list and string arguments

### DIFF
--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -81,6 +81,9 @@ def run_command(command, *arguments, **kwargs):
     stderr = kwargs.pop('stderr', STRING)
     p = generate_parser()
 
+    if isinstance(arguments[0], list):
+        arguments = arguments[0]
+
     arguments = list(arguments)
     arguments.insert(0, command)
 

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -81,7 +81,7 @@ def run_command(command, *arguments, **kwargs):
     stderr = kwargs.pop('stderr', STRING)
     p = generate_parser()
 
-    if isinstance(arguments[0], list):
+    if len(arguments) > 0 and isinstance(arguments[0], list):
         arguments = arguments[0]
 
     arguments = list(arguments)

--- a/tests/cli/test_common.py
+++ b/tests/cli/test_common.py
@@ -14,6 +14,7 @@ from conda.cli.common import check_non_admin
 from conda.common.compat import on_win, StringIO
 from conda.common.io import captured, env_var
 from conda.exceptions import CondaSystemExit, DryRunExit, OperationNotAllowed
+from conda.cli.python_api import run_command, Commands
 
 log = getLogger(__name__)
 
@@ -45,6 +46,18 @@ def test_check_non_admin_enabled_true():
     with env_var('CONDA_NON_ADMIN_ENABLED', 'true', stack_callback=conda_tests_ctxt_mgmt_def_pol):
         check_non_admin()
         assert True
+
+
+def test_cli_args_as_list():
+    with env_var('CONDA_ADD_ANACONDA_TOKEN', 'false'):
+        out, err, rc = run_command(Commands.CONFIG, ["--show", "add_anaconda_token"])
+    assert out == 'add_anaconda_token: False\n'
+
+
+def test_cli_args_as_strings():
+    with env_var('CONDA_ADD_ANACONDA_TOKEN', 'false'):
+        out, err, rc = run_command(Commands.CONFIG, "--show", "add_anaconda_token")
+    assert out == 'add_anaconda_token: False\n'
 
 
 class ConfirmTests(TestCase):

--- a/tests/cli/test_common.py
+++ b/tests/cli/test_common.py
@@ -14,7 +14,6 @@ from conda.cli.common import check_non_admin
 from conda.common.compat import on_win, StringIO
 from conda.common.io import captured, env_var
 from conda.exceptions import CondaSystemExit, DryRunExit, OperationNotAllowed
-from conda.cli.python_api import run_command, Commands
 
 log = getLogger(__name__)
 
@@ -46,18 +45,6 @@ def test_check_non_admin_enabled_true():
     with env_var('CONDA_NON_ADMIN_ENABLED', 'true', stack_callback=conda_tests_ctxt_mgmt_def_pol):
         check_non_admin()
         assert True
-
-
-def test_cli_args_as_list():
-    with env_var('CONDA_ADD_ANACONDA_TOKEN', 'false'):
-        out, err, rc = run_command(Commands.CONFIG, ["--show", "add_anaconda_token"])
-    assert out == 'add_anaconda_token: False\n'
-
-
-def test_cli_args_as_strings():
-    with env_var('CONDA_ADD_ANACONDA_TOKEN', 'false'):
-        out, err, rc = run_command(Commands.CONFIG, "--show", "add_anaconda_token")
-    assert out == 'add_anaconda_token: False\n'
 
 
 class ConfirmTests(TestCase):

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -35,3 +35,13 @@ def test_parser_basics():
 
     args = p.parse_args(["install", "-vv"])
     assert args.verbosity == 2
+
+
+def test_cli_args_as_list():
+    out, err, rc = run_command(Commands.CONFIG, ["--show", "add_anaconda_token"])
+    assert rc == 0
+
+
+def test_cli_args_as_strings():
+    out, err, rc = run_command(Commands.CONFIG, "--show", "add_anaconda_token")
+    assert rc == 0


### PR DESCRIPTION
Addresses https://github.com/conda/conda/issues/9329