### PR TITLE
Remove auth from maybe_unquote

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -365,7 +365,14 @@ def maybe_add_auth(url, auth, force=False):
 
 
 def maybe_unquote(url):
-    return unquote_plus(url) if url else url
+    return unquote_plus(remove_auth(url)) if url else url
+
+
+def remove_auth(url):
+    url_parts = parse_url(url)._asdict()
+    if url_parts['auth']:
+        del url_parts['auth']
+    return Url(**url_parts).url
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses https://github.com/conda/conda/issues/9278 at least partially.

There are a number of code paths that call `maybe_unquote` to construct exception messages that are logged. Some of these code paths include the password / auth header, which we want to strip out before logging.

Opening for discussion. There may be a better way, likely involving a refactor of how URLs are passed around (not as strings).