### PR TITLE
Remove broken link in tab completion documentation

### DIFF
--- a/docs/source/user-guide/configuration/enable-tab-completion.rst
+++ b/docs/source/user-guide/configuration/enable-tab-completion.rst
@@ -3,7 +3,7 @@ Enabling tab completion
 =======================
 
 Conda versions up to 4.3 supports tab completion in bash shells via the argcomplete
-package. Tab completion is deprecated starting with version 4.4. See `issue #415 <https://github.com/conda/conda-docs/issues/415>`_.
+package. Tab completion is deprecated starting with version 4.4. 
 
 To enable tab completion:
 

--- a/docs/source/user-guide/configuration/enable-tab-completion.rst
+++ b/docs/source/user-guide/configuration/enable-tab-completion.rst
@@ -2,10 +2,10 @@
 Enabling tab completion
 =======================
 
-Conda versions up to 4.3 supports tab completion in bash shells via the argcomplete
-package. Tab completion is deprecated starting with version 4.4. 
+Conda versions up to 4.3 supports tab completion in Bash shells via the argcomplete
+package. Bash tab completion is deprecated starting with version 4.4. 
 
-To enable tab completion:
+To enable tab completion in your Bash shell:
 
 #. Make sure that argcomplete is installed:
 
@@ -31,5 +31,5 @@ To enable tab completion:
 
          conda install
 
-To get tab completion in zsh, see `conda-zsh-completion
+To get tab completion in Zsh, see `conda-zsh-completion
 <https://github.com/esc/conda-zsh-completion>`_.


### PR DESCRIPTION
I do not know what happened to the issue 415 in the `conda-docs` repo (it might have gotten lost in the migration of documentation to this repository), but the link is broken.

Perhaps a new link to https://github.com/conda/conda/issues/3140 is warranted?

And is the existing Fish autocompletion in https://github.com/conda/conda/blob/master/conda/shell/etc/fish/conf.d/conda.fish missing documentation? Reference: https://github.com/conda/conda/issues/8191

Also, this page will need to be updated if #9158 (rebased version of #9139) is merged for new Bash tab completion in the v4.8.0 release. See https://github.com/conda/conda/issues/9178 