### PR TITLE
Put conda keyring to /usr/share/keyrings in Debian

### DIFF
--- a/docs/source/user-guide/install/rpm-debian.rst
+++ b/docs/source/user-guide/install/rpm-debian.rst
@@ -61,13 +61,14 @@ To install on Debian-based Linux distributions such as Ubuntu, download the publ
 .. code-block:: none
 
    # Install our public gpg key to trusted store
-   curl https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg -- 
-   dearmor > conda.gpg
-   install -o root -g root -m 644 conda.gpg /etc/apt/trusted.gpg.d/
+   curl https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor > conda.gpg
+   install -o root -g root -m 644 conda.gpg /usr/share/keyrings/conda-archive-keyring.gpg
+
+   # Check whether fingerprint is correct (will output an error message otherwise)
+   gpg --keyring /usr/share/keyrings/conda-archive-keyring.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806
 
    # Add our Debian repo
-   echo "deb [arch=amd64] https://repo.anaconda.com/pkgs/misc/debrepo/conda 
-   stable main" > /etc/apt/sources.list.d/conda.list
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/conda-archive-keyring.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
 
 Conda is ready to install on your Debian-based distribution.
 


### PR DESCRIPTION
Installing third party keys to /etc/apt/trusted.gpg.d/ is discouraged
because of security reasons. The commands follow the scheme proposed in
https://wiki.debian.org/DebianRepository/UseThirdParty#Sources.list_entry