### PR TITLE
Typo in condarc key envs_dirs

### DIFF
--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -628,7 +628,7 @@ EXAMPLE:
     - ~/my-envs
     - /opt/anaconda/envs
 
-The CONDA_ENVS_PATH environment variable overwrites the ``env_dirs`` setting:
+The CONDA_ENVS_PATH environment variable overwrites the ``envs_dirs`` setting:
 
 * For macOS and Linux:
   ``CONDA_ENVS_PATH=~/my-envs:/opt/anaconda/envs``


### PR DESCRIPTION
`env_dirs` > `envs_dirs`