### PR TITLE
add networking args to conda env create

### DIFF
--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -10,7 +10,7 @@ import textwrap
 
 from conda._vendor.auxlib.path import expand
 from conda.cli import install as cli_install
-from conda.cli.conda_argparse import add_parser_json, add_parser_prefix
+from conda.cli.conda_argparse import add_parser_json, add_parser_prefix, add_parser_networking
 from conda.gateways.disk.delete import rm_rf
 from conda.misc import touch_nonadmin
 from .common import get_prefix, print_result
@@ -49,6 +49,9 @@ def configure_parser(sub_parsers):
 
     # Add name and prefix args
     add_parser_prefix(p)
+
+    # Add networking args
+    add_parser_networking(p)
 
     p.add_argument(
         'remote_definition',


### PR DESCRIPTION
This PR adds networking args to `conda env create` as requested by https://github.com/conda/conda/issues/9523