### PR TITLE
#9531 Fix __conda_activate function to correctly return exit code

### DIFF
--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -47,7 +47,7 @@ __conda_activate() {
     \local ask_conda
     CONDA_INTERNAL_OLDPATH="${PATH}"
     __add_sys_prefix_to_path
-    ask_conda="$(PS1="$PS1" "$CONDA_EXE" $_CE_M $_CE_CONDA shell.posix "$cmd" "$@")" || $?
+    ask_conda="$(PS1="$PS1" "$CONDA_EXE" $_CE_M $_CE_CONDA shell.posix "$cmd" "$@")" || \return $?
     rc=$?
     PATH="${CONDA_INTERNAL_OLDPATH}"
     \eval "$ask_conda"


### PR DESCRIPTION
Restore return statement. Should address  #9531