### PR TITLE
make frozendict JSON serializable

### DIFF
--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -7,6 +7,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from os.path import abspath, dirname
 import sys
+
+from json import JSONEncoder
+
 # This hack is from http://kmike.ru/python-with-strings-attached/
 # It is needed ro prevent str() conversion of %r. Against general
 # advice, we return `unicode` from various things on Python 2,
@@ -173,3 +176,11 @@ def conda_signal_handler(signum, frame):
 
     from .exceptions import CondaSignalInterrupt
     raise CondaSignalInterrupt(signum)
+
+
+def _default(self, obj):
+    return getattr(obj.__class__, "to_json", _default.default)(obj)
+
+
+_default.default = JSONEncoder().default
+JSONEncoder.default = _default

--- a/conda/_vendor/frozendict.py
+++ b/conda/_vendor/frozendict.py
@@ -78,6 +78,9 @@ class frozendict(Mapping):
         # Works with auxlib's EntityEncoder.
         return self._dict
 
+    def to_json(self):
+        return self.__json__()
+
 
 class FrozenOrderedDict(frozendict):
     """


### PR DESCRIPTION
This fixes issues when conda config has maps (such as conda-build) which leads to problems with `conda config --json`, which crashes navigator.