### PR TITLE
error out faster when unsatisfiable_hints message set to False

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2123,7 +2123,7 @@ class IntegrationTests(TestCase):
                 # TODO: this should match the specs above.  It does, at least as far as I can tell from text
                 #    comparison.   Unfortunately, it doesn't evaluate as a match, even though the text all matches.
                 #    I suspect some strange equality of objects issue.
-                mock_method.assert_called_with(specs)
+                mock_method.assert_called_with(specs, exit_on_conflict=False)
 
     @pytest.mark.skipif(on_win, reason="gawk is a windows only package")
     def test_search_gawk_not_win_filter(self):

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1873,6 +1873,42 @@ def test_update_deps():
     ])
 
 
+def test_fast_error_on_unsat():
+    installed = r.install(["zope.interface=4.1.1"])
+    result = [rec.dist_str() for rec in installed]
+
+    assert result == add_subdir_to_iter([
+        'channel-1::nose-1.3.0-py33_0',
+        'channel-1::openssl-1.0.1c-0',
+        'channel-1::python-3.3.2-0',
+        'channel-1::readline-6.2-0',
+        'channel-1::sqlite-3.7.13-0',
+        'channel-1::system-5.8-1',
+        'channel-1::tk-8.5.13-0',
+        'channel-1::zlib-1.2.7-0',
+        "channel-1::zope.interface-4.1.1.1-py33_0",
+    ])
+
+    _installed = r.install(['python 2.7*'], installed=installed)
+    result = [rec.dist_str() for rec in _installed]
+    assert result == add_subdir_to_iter([
+        'channel-1::nose-1.3.0-py27_0',
+        'channel-1::openssl-1.0.1c-0',
+        'channel-1::python-2.7.5-0',
+        'channel-1::readline-6.2-0',
+        'channel-1::sqlite-3.7.13-0',
+        'channel-1::system-5.8-1',
+        'channel-1::tk-8.5.13-0',
+        'channel-1::zlib-1.2.7-0',
+        'channel-1::zope.interface-4.0.5-py27_0',
+    ])
+
+    r._reduced_index_cache.clear()
+    with env_var("CONDA_UNSATISFIABLE_HINTS", "False", stack_callback=conda_tests_ctxt_mgmt_def_pol):
+        with pytest.raises(UnsatisfiableError):
+            _installed = r.install(["python 2.7*"], installed=installed)
+
+
 def test_surplus_features_1():
     index = (
         PackageRecord(**{


### PR DESCRIPTION
This is primarily used for Navigator, to error out faster when a user tries to install rstudio in an env with an incompatible Qt.  The unsatisfiable_hints setting is a condarc setting, and can also be set with CONDA_UNSATISFIABLE_HINTS env var.  It defaults to True.  Setting it to False will enable this fast-error behavior.