### PR TITLE
Stream output when calling conda cli

### DIFF
--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -25,7 +25,8 @@ def execute(args, parser):
                                                        args.dev, args.debug_wrapper_scripts, call)
     env = encode_environment(os.environ.copy())
 
-    response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False, stdout=sys.stdout, stderr=sys.stderr, stdin=sys.stdin)
+    response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False,
+                               stdout=sys.stdout, stderr=sys.stderr, stdin=sys.stdin)
     if response.rc != 0:
         log = getLogger(__name__)
         log.error("Subprocess for 'conda run {}' command failed.  (See above for error)"

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -25,7 +25,7 @@ def execute(args, parser):
                                                        args.dev, args.debug_wrapper_scripts, call)
     env = encode_environment(os.environ.copy())
 
-    response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False)
+    response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False, stdout=sys.stdout, stderr=sys.stderr, stdin=sys.stdin)
     if response.rc != 0:
         log = getLogger(__name__)
         log.error("Subprocess for 'conda run {}' command failed.  (See above for error)"
@@ -37,8 +37,4 @@ def execute(args, parser):
             log = getLogger(__name__)
             log.warning('CONDA_TEST_SAVE_TEMPS :: retaining main_run script_caller {}'.format(
                 script_caller))
-    if response.stdout:
-        print(response.stdout, file=sys.stdout)
-    if response.stderr:
-        print(response.stderr, file=sys.stderr)
     return response

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -68,7 +68,7 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
         command = shlex_split_unicode(command)
     command_str = command if isinstance(command, string_types) else ' '.join(command)
     log.debug("executing>> %s", command_str)
-	stdin = ensure_binary(stdin) if isinstance(stdin, string_types) else stdin
+    stdin = ensure_binary(stdin) if isinstance(stdin, string_types) else stdin
     p = Popen(encode_arguments(command), cwd=cwd, stdin=stdin, stdout=stdout,
               stderr=stderr, env=env)
     ACTIVE_SUBPROCESSES.add(p)

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -57,7 +57,7 @@ def any_subprocess(args, prefix, env=None, cwd=None):
     return stdout, stderr, process.returncode
 
 
-def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=True):
+def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=True, stdout=PIPE, stderr=PIPE):
     """This utility function should be preferred for all conda subprocessing.
     It handles multiple tricky details.
     """
@@ -67,10 +67,13 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
         command = shlex_split_unicode(command)
     command_str = command if isinstance(command, string_types) else ' '.join(command)
     log.debug("executing>> %s", command_str)
-    p = Popen(encode_arguments(command), cwd=cwd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env)
+    p = Popen(encode_arguments(command), cwd=cwd, stdin=stdin, stdout=stdout, stderr=stderr, env=env)
     ACTIVE_SUBPROCESSES.add(p)
-    stdin = ensure_binary(stdin) if isinstance(stdin, string_types) else stdin
-    stdout, stderr = p.communicate(input=stdin)
+    if stdin is None:
+        stdin = ensure_binary(stdin) if isinstance(stdin, string_types) else stdin
+        stdout, stderr = p.communicate(input=stdin)
+    else:
+        stdout, stderr = p.communicate()
     if hasattr(stdout, "decode"):
         stdout = stdout.decode('utf-8', errors='replace')
     if hasattr(stderr, "decode"):

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -15,7 +15,7 @@ from ..utils import wrap_subprocess_call
 from .logging import TRACE
 from .. import ACTIVE_SUBPROCESSES
 from .._vendor.auxlib.ish import dals
-from ..common.compat import (ensure_binary, string_types, encode_arguments,
+from ..common.compat import (string_types, encode_arguments,
                              on_win, encode_environment, isiterable)
 from ..gateways.disk.delete import rm_rf
 from ..base.context import context
@@ -69,11 +69,7 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
     log.debug("executing>> %s", command_str)
     p = Popen(encode_arguments(command), cwd=cwd, stdin=stdin, stdout=stdout, stderr=stderr, env=env)
     ACTIVE_SUBPROCESSES.add(p)
-    if stdin is None:
-        stdin = ensure_binary(stdin) if isinstance(stdin, string_types) else stdin
-        stdout, stderr = p.communicate(input=stdin)
-    else:
-        stdout, stderr = p.communicate()
+	stdout, stderr = p.communicate()
     if hasattr(stdout, "decode"):
         stdout = stdout.decode('utf-8', errors='replace')
     if hasattr(stderr, "decode"):

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -69,7 +69,7 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
     log.debug("executing>> %s", command_str)
     p = Popen(encode_arguments(command), cwd=cwd, stdin=stdin, stdout=stdout, stderr=stderr, env=env)
     ACTIVE_SUBPROCESSES.add(p)
-	stdout, stderr = p.communicate()
+    stdout, stderr = p.communicate()
     if hasattr(stdout, "decode"):
         stdout = stdout.decode('utf-8', errors='replace')
     if hasattr(stderr, "decode"):

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -57,7 +57,8 @@ def any_subprocess(args, prefix, env=None, cwd=None):
     return stdout, stderr, process.returncode
 
 
-def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=True, stdout=PIPE, stderr=PIPE):
+def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=True,
+                    stdout=PIPE, stderr=PIPE):
     """This utility function should be preferred for all conda subprocessing.
     It handles multiple tricky details.
     """
@@ -67,7 +68,8 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
         command = shlex_split_unicode(command)
     command_str = command if isinstance(command, string_types) else ' '.join(command)
     log.debug("executing>> %s", command_str)
-    p = Popen(encode_arguments(command), cwd=cwd, stdin=stdin, stdout=stdout, stderr=stderr, env=env)
+    p = Popen(encode_arguments(command), cwd=cwd, stdin=stdin, stdout=stdout,
+              stderr=stderr, env=env)
     ACTIVE_SUBPROCESSES.add(p)
     stdout, stderr = p.communicate()
     if hasattr(stdout, "decode"):

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -15,7 +15,7 @@ from ..utils import wrap_subprocess_call
 from .logging import TRACE
 from .. import ACTIVE_SUBPROCESSES
 from .._vendor.auxlib.ish import dals
-from ..common.compat import (string_types, encode_arguments,
+from ..common.compat import (ensure_binary, string_types, encode_arguments,
                              on_win, encode_environment, isiterable)
 from ..gateways.disk.delete import rm_rf
 from ..base.context import context
@@ -68,6 +68,7 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
         command = shlex_split_unicode(command)
     command_str = command if isinstance(command, string_types) else ' '.join(command)
     log.debug("executing>> %s", command_str)
+	stdin = ensure_binary(stdin) if isinstance(stdin, string_types) else stdin
     p = Popen(encode_arguments(command), cwd=cwd, stdin=stdin, stdout=stdout,
               stderr=stderr, env=env)
     ACTIVE_SUBPROCESSES.add(p)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
+from _pytest.monkeypatch import MonkeyPatch
 
 from contextlib import contextmanager
 from datetime import datetime
@@ -71,6 +72,11 @@ try:
     from unittest.mock import Mock, patch, ANY
 except ImportError:
     from mock import Mock, patch, ANY
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 log = getLogger(__name__)
@@ -482,6 +488,13 @@ class IntegrationTests(TestCase):
 
     def setUp(self):
         PackageCacheData.clear()
+		# Lets mock sys.stdin with a mock stream (ensure to add `fileno` to treat like a real string)
+        self.monkeypatch = MonkeyPatch()
+        stdin = StringIO()
+        def fileno():
+            return 0
+        stdin.fileno = fileno
+        self.monkeypatch.setattr('sys.stdin', stdin)
 
     def test_install_python2_and_search(self):
         with Utf8NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as env_txt:


### PR DESCRIPTION
When calling the conda cli this will:
* Stream output into stdout & stderr
* Stdin is passed into the subprocess

Basically, when using the CLI we won't be capturing the output, we will write output directly into stdout and stderr. If there's an error we throw the error as per usual and error info has already been written out to the corresponding streams.

Resolves #9572
Resolves #9412