### PR TITLE
Add and utilize a simplified fast unsatisfiable error message

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -606,6 +606,27 @@ class PackagesNotFoundError(CondaError):
         )
 
 
+class SimpleUnsatisfiableError(CondaError):
+    """
+    TODO(jeremyliu)
+    """
+
+    def __init__(self, bad_deps):
+
+        msg = '''
+The following required specifications were filtered to 0 in index reduction and thus the requested
+solve is unsatisfiable. If you would like to know which packages conflict ensure that you have
+enabled unsatisfiable hints.
+
+conda config --set unsatisfiable_hints True
+
+Specifications:
+'''
+        for dep in bad_deps:
+            msg += " - %s\n" % dep
+        super(SimpleUnsatisfiableError, self).__init__(msg)
+
+
 class UnsatisfiableError(CondaError):
     """An exception to report unsatisfiable dependencies.
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -19,7 +19,7 @@ from .common.logic import (Clauses, PycoSatSolver, PyCryptoSatSolver, PySatSolve
                            minimal_unsatisfiable_subset)
 from .common.toposort import toposort
 from .exceptions import (CondaDependencyError, InvalidSpec, ResolvePackageNotFound,
-                         UnsatisfiableError)
+                         SimpleUnsatisfiableError, UnsatisfiableError)
 from .models.channel import Channel, MultiChannel
 from .models.enums import NoarchType, PackageType
 from .models.match_spec import MatchSpec
@@ -681,7 +681,7 @@ class Resolve(object):
                     pruned_to_zero.add(s)
 
         if pruned_to_zero and exit_on_conflict:
-            return {}
+            raise SimpleUnsatisfiableError(pruned_to_zero)
 
         # Determine all valid packages in the dependency graph
         reduced_index2 = {prec: prec for prec in (make_feature_record(fstr) for fstr in features)}

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -10,7 +10,7 @@ import pytest
 from conda.base.context import context, conda_tests_ctxt_mgmt_def_pol
 from conda.common.compat import iteritems, itervalues
 from conda.common.io import env_var
-from conda.exceptions import UnsatisfiableError
+from conda.exceptions import SimpleUnsatisfiableError, UnsatisfiableError
 from conda.gateways.disk.read import read_python_record
 from conda.models.channel import Channel
 from conda.models.enums import PackageType
@@ -366,7 +366,7 @@ def test_unsat_simple_dont_find_conflicts():
     )
     with env_var("CONDA_UNSATISFIABLE_HINTS", "False", stack_callback=conda_tests_ctxt_mgmt_def_pol):
         r = Resolve(OrderedDict((prec, prec) for prec in index))
-        with pytest.raises(UnsatisfiableError) as excinfo:
+        with pytest.raises(SimpleUnsatisfiableError) as excinfo:
             r.install(['a', 'b '])
         assert "a -> c[version='>=1,<2']" not in str(excinfo.value)
         assert "b -> c[version='>=2,<3']" not in str(excinfo.value)
@@ -1924,7 +1924,7 @@ def test_fast_error_on_unsat():
 
     r._reduced_index_cache.clear()
     with env_var("CONDA_UNSATISFIABLE_HINTS", "False", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with pytest.raises(UnsatisfiableError):
+        with pytest.raises(SimpleUnsatisfiableError):
             _installed = r.install(["python 2.7*"], installed=installed)
 
 


### PR DESCRIPTION
Opening for discussion. This helps the case where unsatisfiable hints may take longer to generate than the actual index reduction or solve itself. Users who then turn off unsatisfiable hints are given no usable error message. This provides a simplified unsatisfiable error to provide at least some information about the underlying unsatisfiability.