### PR TITLE
doc/custom channels: fix formatting and typo

### DIFF
--- a/docs/source/user-guide/tasks/create-custom-channels.rst
+++ b/docs/source/user-guide/tasks/create-custom-channels.rst
@@ -53,7 +53,7 @@ To create a custom channel:
       you must rerun ``conda index`` for conda to see the update.
 
 #. To test custom channels, serve the custom channel using a web
-   server or using a ``file:// url`` to the channel directory.
+   server or using a ``file://`` URL to the channel directory.
    Test by sending a search command to the custom channel.
 
    EXAMPLE: If you want a file in the custom channel location
@@ -61,7 +61,7 @@ To create a custom channel:
   
    .. code::
 
-      conda search -c file://opt/channel/ --override-channels
+      conda search -c file:///opt/channel/ --override-channels
 
    .. note::
       The channel URL does not include the platform, as conda


### PR DESCRIPTION
The _Creating custom channels_ doc refers to "using a `file://` URL",
and the conda code uses `urllib.parse.urlsplit` to parse 'file://'
channel references.

A proper `file://`-URI-based reference to a local (linux) file should
include 3 back-to-back slashes (`/`), but the example only uses 2.

The parsing actually goes slightly wrong when used as in the example,
though in a way that (accidentally) doesn't matter:

```
>>> from conda.common.url import path_to_url

>>> path_to_url('/opt/channel')
'file:///opt/channel'

>>> from conda.common.path import url_to_path

>>> url_to_path('file:///opt/channel')
'/opt/channel'

>>> url_to_path('file://opt/channel')
'//opt/channel'                         <= note extra leading slash
```

Fix the example to specify the file URL properly, and make a minor
formatting tweak in the same section.