### PR TITLE
Strip sysp from os.environ[PATH] (WIP)

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda
-  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  version: {{ GIT_DESCRIBE_TAG_PEP440 }}.{{ GIT_BUILD_STR }}
 
 source:
   # git_url is nice in that it won't capture devenv stuff.  However, it only

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda
-  version: {{ GIT_DESCRIBE_TAG_PEP440 }}.{{ GIT_BUILD_STR }}
+  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
 
 source:
   # git_url is nice in that it won't capture devenv stuff.  However, it only

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -166,16 +166,21 @@ def main(*args, **kwargs):
     from os import environ, getpid, pathsep, sep
     from psutil import Process
     pp = Process(Process(getpid()).ppid())
+    silent = 'hook' in args
+    silent = True
     if pp and pp.name() == 'conda.exe':
         pp = Process(Process(Process(getpid()).ppid()).ppid())
     if pp:
         cmdline = pp.cmdline()[0]
         if 'conda.bat' in pp.name():
-            print('conda.bat launched me')
+            if not silent:
+                print('conda.bat launched me')
         elif 'charm' in pp.name() or 'code' in pp.name():
-            print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
+            if not silent:
+                print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
         else:
-            print('unknowwn ({}) launched me: {}'.format(pp.name(), cmdline))
+            if not silent:
+                print('unknowwn ({}) launched22 me: {}'.format(pp.name(), cmdline))
     if sys.platform == 'win32' and 'CONDA_PREFIX' in environ:
         oep = environ['PATH']
         paths = oep.split(pathsep)

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -149,22 +149,48 @@ def main(*args, **kwargs):
     from ..exceptions import conda_exception_handler
 
     # Here we are detecting (badly) the case when conda.bat has been run but not
-    # to activate or deactivate. condabat will have added entries for sys.prefix
     # to the front of PATH (so that this conda executable can find its DLLs), but
-    # that is problematic for conda run, if executed through conda.bat.
-    import os
-    if 'CONDA_PREFIX' in os.environ:
-        oep = os.environ['PATH']
-        paths = oep.split(os.pathsep)
+    # we do not prefix PATH with the new prefixes entries; we swap them in-place
+    # (a-la reactivate) or may even do nothing at all when re-activating the
+    # currently active env.
+    #
+    # I do not want to be messing with PATH here at all though (at least not until
+    # conda has loaded every DLL it could possibly want). We need a new proxy for
+    # os.environ['PATH'] which gets used for any PATH qeuries made by conda and
+    # which strips sysp from the result (which would be emitted to all script files
+    # that need to set the PATH env var) and all subprocess envs.
+    #
+
+    from os import environ, getpid, pathsep, sep
+    from psutil import Process
+    pp = Process(Process(getpid()).ppid())
+    silent = 'hook' in args
+    silent = True
+    if pp and pp.name() == 'conda.exe':
+        pp = Process(Process(Process(getpid()).ppid()).ppid())
+    if pp:
+        cmdline = pp.cmdline()[0]
+        if 'conda.bat' in pp.name():
+            if not silent:
+                print('conda.bat launched me')
+        elif 'charm' in pp.name() or 'code' in pp.name():
+            if not silent:
+                print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
+        else:
+            if not silent:
+                print('unknowwn ({}) launched22 me: {}'.format(pp.name(), cmdline))
+    if sys.platform == 'win32' and 'CONDA_PREFIX' in environ:
+        oep = environ['PATH']
+        paths = oep.split(pathsep)
         # We do not catch the case of CONDA_PREFIX == sys.prefix. That just works.
-        if paths.index(sys.prefix) < paths.index(os.environ['CONDA_PREFIX']):
+        if sys.prefix in paths and environ['CONDA_PREFIX'] in paths and paths.index(sys.prefix) < paths.index(environ['CONDA_PREFIX']):
             from conda.cli.activate import get_activate_path
             res = get_activate_path(sys.prefix, 'cmd.exe')
-            if res in os.environ['PATH']:
+            if res in environ['PATH']:
                 oep = oep.replace(res, '', 1)
-                if oep.startswith(os.sep):
-                    oep.replace(os.sep, '', 1)
-                os.environ['PATH'] = oep
+                if oep.startswith(sep):
+                    oep.replace(sep, '', 1)
+                environ['PATH'] = oep
             from logging import getLogger
             log = getLogger(__name__)
             log.warning("WARNING: Stripping sys.prefix from PATH as it comes before CONDA_PREFIX.\n"

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -163,17 +163,20 @@ def main(*args, **kwargs):
 
     from os import environ, getpid, pathsep, sep
     from psutil import Process
-    pp = Process(Process(getpid()).ppid())
-    if pp and pp.name() == 'conda.exe':
-        pp = Process(Process(Process(getpid()).ppid()).ppid())
-    if pp:
-        cmdline = pp.cmdline()[0]
-        if 'conda.bat' in pp.name():
-            print('conda.bat launched me')
-        elif 'charm' in pp.name() or 'code' in pp.name():
-            print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
-        else:
-            print('unknowwn ({}) launched me: {}'.format(pp.name(), cmdline))
+    try:
+        pp = Process(Process(getpid()).ppid())
+        if pp and pp.name() == 'conda.exe':
+            pp = Process(Process(Process(getpid()).ppid()).ppid())
+        if pp:
+            cmdline = pp.cmdline()[0]
+            if 'conda.bat' in pp.name():
+                print('conda.bat launched me')
+            elif 'charm' in pp.name() or 'code' in pp.name():
+                print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
+            else:
+                print('unknowwn ({}) launched me: {}'.format(pp.name(), cmdline))
+    except:
+        pass
     if sys.platform == 'win32' and 'CONDA_PREFIX' in environ:
         oep = environ['PATH']
         paths = oep.split(pathsep)

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -162,8 +162,8 @@ def main(*args, **kwargs):
     #
 
     from os import environ, getpid, pathsep, sep
-    from psutil import Process
     try:
+        from psutil import Process
         pp = Process(Process(getpid()).ppid())
         if pp and pp.name() == 'conda.exe':
             pp = Process(Process(Process(getpid()).ppid()).ppid())

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -163,8 +163,20 @@ def main(*args, **kwargs):
     # (that need to set the PATH env var) and all subprocess envs.
     #
 
-    from os import environ, pathsep, sep
-    if 'CONDA_PREFIX' in environ:
+    from os import environ, getpid, pathsep, sep
+    from psutil import Process
+    pp = Process(Process(getpid()).ppid())
+    if pp and pp.name() == 'conda.exe':
+        pp = Process(Process(Process(getpid()).ppid()).ppid())
+    if pp:
+        cmdline = pp.cmdline()[0]
+        if 'conda.bat' in pp.name():
+            print('conda.bat launched me')
+        elif 'charm' in pp.name() or 'code' in pp.name():
+            print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
+        else:
+            print('unknowwn ({}) launched me: {}'.format(pp.name(), cmdline))
+    if sys.platform == 'win32' and 'CONDA_PREFIX' in environ:
         oep = environ['PATH']
         paths = oep.split(pathsep)
         # We do not catch the case of CONDA_PREFIX == sys.prefix. That just works.
@@ -175,7 +187,7 @@ def main(*args, **kwargs):
                 oep = oep.replace(res, '', 1)
                 if oep.startswith(sep):
                     oep.replace(sep, '', 1)
-                os.environ['PATH'] = oep
+                environ['PATH'] = oep
             from logging import getLogger
             log = getLogger(__name__)
             log.warning("WARNING: Stripping sys.prefix from PATH as it comes before CONDA_PREFIX.\n"

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -161,7 +161,6 @@ def main(*args, **kwargs):
     # that need to set the PATH env var) and all subprocess envs.
     #
 
-    from os import environ, getpid, pathsep, sep
     from psutil import Process
     pp = Process(Process(getpid()).ppid())
     silent = 'hook' in args
@@ -178,8 +177,7 @@ def main(*args, **kwargs):
                 print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
         else:
             if not silent:
-                print('unknowwn ({}) launched22 me: {}'.format(pp.name(), cmdline))
-    if sys.platform == 'win32' and 'CONDA_PREFIX' in environ:
+    if 'CONDA_PREFIX' in environ:
         oep = environ['PATH']
         paths = oep.split(pathsep)
         # We do not catch the case of CONDA_PREFIX == sys.prefix. That just works.
@@ -190,7 +188,7 @@ def main(*args, **kwargs):
                 oep = oep.replace(res, '', 1)
                 if oep.startswith(sep):
                     oep.replace(sep, '', 1)
-                environ['PATH'] = oep
+                os.environ['PATH'] = oep
             from logging import getLogger
             log = getLogger(__name__)
             log.warning("WARNING: Stripping sys.prefix from PATH as it comes before CONDA_PREFIX.\n"

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -161,23 +161,20 @@ def main(*args, **kwargs):
     # that need to set the PATH env var) and all subprocess envs.
     #
 
+    from os import environ, getpid, pathsep, sep
     from psutil import Process
     pp = Process(Process(getpid()).ppid())
-    silent = 'hook' in args
-    silent = True
     if pp and pp.name() == 'conda.exe':
         pp = Process(Process(Process(getpid()).ppid()).ppid())
     if pp:
         cmdline = pp.cmdline()[0]
         if 'conda.bat' in pp.name():
-            if not silent:
-                print('conda.bat launched me')
+            print('conda.bat launched me')
         elif 'charm' in pp.name() or 'code' in pp.name():
-            if not silent:
-                print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
+            print('IDE ({}) launched me: {}'.format(pp.name(), cmdline))
         else:
-            if not silent:
-    if 'CONDA_PREFIX' in environ:
+            print('unknowwn ({}) launched me: {}'.format(pp.name(), cmdline))
+    if sys.platform == 'win32' and 'CONDA_PREFIX' in environ:
         oep = environ['PATH']
         paths = oep.split(pathsep)
         # We do not catch the case of CONDA_PREFIX == sys.prefix. That just works.
@@ -188,7 +185,7 @@ def main(*args, **kwargs):
                 oep = oep.replace(res, '', 1)
                 if oep.startswith(sep):
                     oep.replace(sep, '', 1)
-                os.environ['PATH'] = oep
+                environ['PATH'] = oep
             from logging import getLogger
             log = getLogger(__name__)
             log.warning("WARNING: Stripping sys.prefix from PATH as it comes before CONDA_PREFIX.\n"

--- a/conda/cli/main_pip.py
+++ b/conda/cli/main_pip.py
@@ -15,7 +15,7 @@ log = getLogger(__name__)
 
 
 def pip_installed_post_parse_hook(args, p):
-    if args.cmd not in ('init', 'info'):
+    if args.cmd not in ('init', 'info', 'run'):
         raise CondaError(dals("""
         Conda has not been initialized.
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -527,6 +527,18 @@ class PackageNotInstalledError(CondaError):
                                                        package_name=package_name)
 
 
+class BuildToolPackageNotInstalledError(CondaError):
+    def __init__(self, prefix, build_tool_package_name):
+        message = dals("""
+        Could not find build tool package.
+           prefix: %(prefix)s
+           package name: %(package_name)s
+        Nor could a system-installed fallback be found.
+        """)
+        super(BuildToolPackageNotInstalledError, self).__init__(message, prefix=prefix,
+                                                                package_name=build_tool_package_name)
+
+
 class CondaHTTPError(CondaError):
     def __init__(self, message, url, status_code, reason, elapsed_time, response=None,
                  caused_by=None):

--- a/dev/start
+++ b/dev/start
@@ -7,6 +7,7 @@
 devenv="${1:-./devenv}"
 pyver="${2:-3}"
 _CONDA="$devenv/bin/conda"
+[[ -f ${_CONDA} ]] || _CONDA="$denvenv/Scripts/conda"
 
 if ! [ -f "$devenv/conda-meta/history" ]; then
     if [ "$(uname)" = Darwin ]; then

--- a/dev/start
+++ b/dev/start
@@ -7,7 +7,7 @@
 devenv="${1:-./devenv}"
 pyver="${2:-3}"
 _CONDA="$devenv/bin/conda"
-[[ -f ${_CONDA} ]] || _CONDA="$denvenv/Scripts/conda"
+[[ -f ${_CONDA} ]] || _CONDA="$devenv/Scripts/conda"
 
 if ! [ -f "$devenv/conda-meta/history" ]; then
     if [ "$(uname)" = Darwin ]; then


### PR DESCRIPTION
We also prevent main_pip from excepting in the case of conda run being called
directly (though I am not sure where the other half of the logic around this
feature is!)