### PR TITLE
Removed extra newline from conda env export

### DIFF
--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -112,7 +112,7 @@ def execute(args, parser):
         env.add_channels(args.channel)
 
     if args.file is None:
-        stdout_json(env.to_dict()) if args.json else print(env.to_yaml())
+        stdout_json(env.to_dict()) if args.json else print(env.to_yaml(), end='')
     else:
         fp = open(args.file, 'wb')
         env.to_dict(stream=fp) if args.json else env.to_yaml(stream=fp)


### PR DESCRIPTION
Conda's cli command `conda env export` yields a YAML with an extra newline, and that's being an issue due to empty newline warnings on a CVS like Git.

I've wrote a solution that fixes it.

This is the line of code `stdout_json(env.to_dict()) if args.json else print(env.to_yaml())`, the problem I see is happening due to the `print()` function default behavior.

From Python 3 docs, [print()](https://docs.python.org/3/library/functions.html#print) accepts a `end` keyword argument, which determines the last character to be printed, setting it to `''` empty string to prevent extra newlines.

Following the [code source](https://github.com/conda/conda/blob/master/conda_env/cli/main_export.py#L115) to the [YAML dumper](https://github.com/conda/conda/blob/e9a50561880696e57ba80472dce332e08e58ee0b/conda/common/serialize.py#L79-L83), I've found out that [ruamel.yaml](https://pypi.org/project/ruamel.yaml/) is beign used.

Writting a simple snippet, using Condas implementation, shows that `ruamel.yaml.dump` already ends on a newline.
```python3
import ruamel.yaml as yaml
print(yaml.dump({'a': 123, 'b': { 'c': 3 }}, Dumper=yaml.RoundTripDumper,
  block_seq_indent=2, default_flow_style=False, indent=2))
```
Yields
```
a: 123
b:
  c: 3
//blank-line
```
However, adding the `end=''` argument to `print()` resolves this issue.
```python3
import ruamel.yaml as yaml
print(yaml.dump({'a': 123, 'b': { 'c': 3 }}, Dumper=yaml.RoundTripDumper,
  block_seq_indent=2, default_flow_style=False, indent=2),
  end='')
```
Yields
```
a: 123
b:
  c: 3
```

I've already signed the CLA, can I edit the .cla-signers file?