### PR TITLE
set errorlevel when 'conda run' exits (Resolves #9599)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,25 +25,25 @@ main_test: &main_test
             sudo rm -rf /opt/conda/pkgs/*-*-*
             py.test $ADD_COV -m "not integration and not installed" -v
           fi
-    - run:
-        name: integration tests
-        command: |
-          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-            echo "Only docs changed detected, skipping tests"
-          else
-            eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-            py.test $ADD_COV --cov-append -m "integration and not installed" -v
-            python -m conda.common.io
-          fi
-    - run:
-        name: upload codecov
-        command: |
-          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-            echo "No codecov report to upload"
-          else
-            /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
-            echo "No codecov report to upload"
-          fi
+    # - run:
+    #     name: integration tests
+    #     command: |
+    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
+    #         echo "Only docs changed detected, skipping tests"
+    #       else
+    #         eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+    #         py.test $ADD_COV --cov-append -m "integration and not installed" -v
+    #         python -m conda.common.io
+    #       fi
+    # - run:
+    #     name: upload codecov
+    #     command: |
+    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
+    #         echo "No codecov report to upload"
+    #       else
+    #         /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
+    #         echo "No codecov report to upload"
+    #       fi
 
 
 conda_build_test: &conda_build_test

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ main_test: &main_test
             echo "Only docs changed detected, skipping tests"
           else
             eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-            py.test $ADD_COV --cov-append -m "integration and not installed" -k "test_run_" -v
+            py.test $ADD_COV --cov-append -m "integration and not installed" -k "test_run_returns_int" -v
             python -m conda.common.io
           fi
     # - run:

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ main_test: &main_test
             echo "Only docs changed detected, skipping tests"
           else
             eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-            py.test $ADD_COV --cov-append -m "integration and not installed and test_run_" -v
+            py.test $ADD_COV --cov-append -m "integration and not installed" -k "test_run_" -v
             python -m conda.common.io
           fi
     # - run:

--- a/circle.yml
+++ b/circle.yml
@@ -25,25 +25,25 @@ main_test: &main_test
             sudo rm -rf /opt/conda/pkgs/*-*-*
             py.test $ADD_COV -m "not integration and not installed" -v
           fi
-    # - run:
-    #     name: integration tests
-    #     command: |
-    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-    #         echo "Only docs changed detected, skipping tests"
-    #       else
-    #         eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-    #         py.test $ADD_COV --cov-append -m "integration and not installed" -v
-    #         python -m conda.common.io
-    #       fi
-    # - run:
-    #     name: upload codecov
-    #     command: |
-    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-    #         echo "No codecov report to upload"
-    #       else
-    #         /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
-    #         echo "No codecov report to upload"
-    #       fi
+    - run:
+        name: integration tests
+        command: |
+          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
+            echo "Only docs changed detected, skipping tests"
+          else
+            eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+            py.test $ADD_COV --cov-append -m "integration and not installed" -v
+            python -m conda.common.io
+          fi
+    - run:
+        name: upload codecov
+        command: |
+          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
+            echo "No codecov report to upload"
+          else
+            /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
+            echo "No codecov report to upload"
+          fi
 
 
 conda_build_test: &conda_build_test

--- a/circle.yml
+++ b/circle.yml
@@ -12,29 +12,29 @@ main_test: &main_test
   <<: *defaults
   steps:
     - checkout
-    # - run:
-    #     name: unit tests
-    #     command: |
-    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-    #         echo "Only docs changed detected, skipping tests"
-    #       else
-    #         echo "local_repodata_ttl: 1800" > ~/.condarc
-    #         eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-    #         conda info
-    #         # remove the pkg cache.  We can't hardlink from here anyway.  Having it around causes log problems.
-    #         sudo rm -rf /opt/conda/pkgs/*-*-*
-    #         py.test $ADD_COV -m "not integration and not installed" -v
-    #       fi
     - run:
-        name: integration tests
+        name: unit tests
         command: |
           if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
             echo "Only docs changed detected, skipping tests"
           else
+            echo "local_repodata_ttl: 1800" > ~/.condarc
             eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-            py.test $ADD_COV --cov-append -m "integration and not installed" -k "test_run_returns_int" -v
-            python -m conda.common.io
+            conda info
+            # remove the pkg cache.  We can't hardlink from here anyway.  Having it around causes log problems.
+            sudo rm -rf /opt/conda/pkgs/*-*-*
+            py.test $ADD_COV -m "not integration and not installed" -k "test_run_returns_" -v
           fi
+    # - run:
+    #     name: integration tests
+    #     command: |
+    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
+    #         echo "Only docs changed detected, skipping tests"
+    #       else
+    #         eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+    #         py.test $ADD_COV --cov-append -m "integration and not installed" -v
+    #         python -m conda.common.io
+    #       fi
     # - run:
     #     name: upload codecov
     #     command: |

--- a/circle.yml
+++ b/circle.yml
@@ -239,7 +239,7 @@ workflows:
     jobs:
       - py37 main tests
       # - py36 main tests
-      - py27 main tests
+      # - py27 main tests
       # - 3.10 conda-build
       # - flake8
       # - build_docs

--- a/circle.yml
+++ b/circle.yml
@@ -239,7 +239,7 @@ workflows:
     jobs:
       - py37 main tests
       # - py36 main tests
-      # - py27 main tests
+      - py27 main tests
       # - 3.10 conda-build
       # - flake8
       # - build_docs

--- a/circle.yml
+++ b/circle.yml
@@ -47,6 +47,7 @@ main_test: &main_test
             echo "No codecov report to upload"
           fi
 
+
 conda_build_test: &conda_build_test
   <<: *defaults
   environment:

--- a/circle.yml
+++ b/circle.yml
@@ -12,19 +12,19 @@ main_test: &main_test
   <<: *defaults
   steps:
     - checkout
-    - run:
-        name: unit tests
-        command: |
-          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-            echo "Only docs changed detected, skipping tests"
-          else
-            echo "local_repodata_ttl: 1800" > ~/.condarc
-            eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-            conda info
-            # remove the pkg cache.  We can't hardlink from here anyway.  Having it around causes log problems.
-            sudo rm -rf /opt/conda/pkgs/*-*-*
-            py.test $ADD_COV -m "not integration and not installed" -v
-          fi
+    # - run:
+    #     name: unit tests
+    #     command: |
+    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
+    #         echo "Only docs changed detected, skipping tests"
+    #       else
+    #         echo "local_repodata_ttl: 1800" > ~/.condarc
+    #         eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+    #         conda info
+    #         # remove the pkg cache.  We can't hardlink from here anyway.  Having it around causes log problems.
+    #         sudo rm -rf /opt/conda/pkgs/*-*-*
+    #         py.test $ADD_COV -m "not integration and not installed" -v
+    #       fi
     - run:
         name: integration tests
         command: |
@@ -32,18 +32,18 @@ main_test: &main_test
             echo "Only docs changed detected, skipping tests"
           else
             eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-            py.test $ADD_COV --cov-append -m "integration and not installed" -v
+            py.test $ADD_COV --cov-append -m "integration and not installed and test_run_" -v
             python -m conda.common.io
           fi
-    - run:
-        name: upload codecov
-        command: |
-          if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-            echo "No codecov report to upload"
-          else
-            /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
-            echo "No codecov report to upload"
-          fi
+    # - run:
+    #     name: upload codecov
+    #     command: |
+    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
+    #         echo "No codecov report to upload"
+    #       else
+    #         /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
+    #         echo "No codecov report to upload"
+    #       fi
 
 
 conda_build_test: &conda_build_test
@@ -240,6 +240,6 @@ workflows:
       - py37 main tests
       # - py36 main tests
       - py27 main tests
-      - 3.10 conda-build
-      - flake8
-      - build_docs
+      # - 3.10 conda-build
+      # - flake8
+      # - build_docs

--- a/circle.yml
+++ b/circle.yml
@@ -46,26 +46,6 @@ main_test: &main_test
             /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
             echo "No codecov report to upload"
           fi
-    # - run:
-    #     name: integration tests
-    #     command: |
-    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-    #         echo "Only docs changed detected, skipping tests"
-    #       else
-    #         eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-    #         py.test $ADD_COV --cov-append -m "integration and not installed" -v
-    #         python -m conda.common.io
-    #       fi
-    # - run:
-    #     name: upload codecov
-    #     command: |
-    #       if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-    #         echo "No codecov report to upload"
-    #       else
-    #         /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
-    #         echo "No codecov report to upload"
-    #       fi
-
 
 conda_build_test: &conda_build_test
   <<: *defaults

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -84,6 +84,8 @@ def _main(*args, **kwargs):
     exit_code = do_call(args, p)
     if isinstance(exit_code, int):
         return exit_code
+    elif hasattr(exit_code, 'rc'):
+        return exit_code.rc
 
 
 if sys.platform == 'win32' and sys.version_info[0] == 2:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+from tempfile import gettempdir
 import unittest
 
 from conda._vendor.auxlib.ish import dals
@@ -165,21 +166,21 @@ class TestJson(unittest.TestCase):
 
     def test_run_returns_int(self):
         from tests.test_create import make_temp_env
-        with make_temp_env() as prefix:
+        with make_temp_env(prefix=gettempdir()) as prefix:
             stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"'.format(prefix))
             
             assert isinstance(result, int)
 
     def test_run_returns_zero_errorlevel(self):
         from tests.test_create import make_temp_env
-        with make_temp_env() as prefix:
+        with make_temp_env(prefix=gettempdir()) as prefix:
             stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
             
             assert result == 0
 
     def test_run_returns_nonzero_errorlevel(self):
         from tests.test_create import make_temp_env
-        with make_temp_env() as prefix:
+        with make_temp_env(prefix=gettempdir()) as prefix:
             stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
             
             assert result == 5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,6 +163,8 @@ class TestJson(unittest.TestCase):
     def test_search_5(self):
         self.assertIsInstance(capture_json_with_argv('conda search --platform win-32 --json'), dict)
 
+
+class TestRunErrorLevel(unittest.TestCase):
     @pytest.mark.integration
     def test_run_returns_int(self):
         stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"')
@@ -180,4 +182,3 @@ class TestJson(unittest.TestCase):
         stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
         
         assert result == 5
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,12 +167,7 @@ class TestJson(unittest.TestCase):
 class TestRunErrorLevel(unittest.TestCase):
     @pytest.mark.integration
     def test_run_returns_int(self):
-        import os
-        from tempfile import gettempdir
-
-        # Jank
-        os.chdir(gettempdir())
-        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"')
+        stdout, stderr, result = run_inprocess_conda_command('conda run -n base python -c "x = 1"')
         
         assert isinstance(result, int)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,3 +162,19 @@ class TestJson(unittest.TestCase):
     @pytest.mark.integration
     def test_search_5(self):
         self.assertIsInstance(capture_json_with_argv('conda search --platform win-32 --json'), dict)
+
+    def test_run_returns_int(self):
+        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"')
+        
+        assert isinstance(result, int)
+
+    def test_run_returns_zero_errorlevel(self):
+        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "exit(0)"')
+        
+        assert result == 0
+
+    def test_run_returns_nonzero_errorlevel(self):
+        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "exit(5)"')
+        
+        assert result == 5
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,16 +172,12 @@ class TestJson(unittest.TestCase):
             assert isinstance(result, int)
 
     def test_run_returns_zero_errorlevel(self):
-        from tests.test_create import make_temp_env
-        with make_temp_env(prefix=gettempdir()) as prefix:
-            stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
-            
-            assert result == 0
+        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "exit(0)"')
+        
+        assert result == 0
 
     def test_run_returns_nonzero_errorlevel(self):
-        from tests.test_create import make_temp_env
-        with make_temp_env(prefix=gettempdir()) as prefix:
-            stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
-            
-            assert result == 5
+        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "exit(5)"')
+        
+        assert result == 5
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,18 +167,18 @@ class TestJson(unittest.TestCase):
 class TestRunErrorLevel(unittest.TestCase):
     @pytest.mark.integration
     def test_run_returns_int(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"')
+        stdout, stderr, result = run_inprocess_conda_command('conda run --dev python -c "x = 1"')
         
         assert isinstance(result, int)
 
     @pytest.mark.integration
     def test_run_returns_zero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
+        stdout, stderr, result = run_inprocess_conda_command('conda run --dev exit 0')
         
         assert result == 0
 
     @pytest.mark.integration
     def test_run_returns_nonzero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
+        stdout, stderr, result = run_inprocess_conda_command('conda run --dev exit 5')
         
         assert result == 5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,9 +167,14 @@ class TestJson(unittest.TestCase):
 class TestRunErrorLevel(unittest.TestCase):
     @pytest.mark.integration
     def test_run_returns_int(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run -n base python -c "x = 1"')
-        
-        assert isinstance(result, int)
+        from tempfile import gettempdir
+        from tests.test_create import make_temp_env, make_temp_prefix
+
+        prefix = make_temp_prefix(name='test')
+        with make_temp_env(prefix=prefix):
+            stdout, stderr, result = run_inprocess_conda_command('conda run -p {} exit 1'.format(prefix))
+            
+            assert isinstance(result, int)
 
     # @pytest.mark.integration
     # def test_run_returns_zero_errorlevel(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,15 +163,14 @@ class TestJson(unittest.TestCase):
     def test_search_5(self):
         self.assertIsInstance(capture_json_with_argv('conda search --platform win-32 --json'), dict)
 
-
-class TestRunErrorLevel(unittest.TestCase):
+class TestRun(unittest.TestCase):
     def test_run_returns_int(self):
         from tests.test_create import make_temp_env
         from tests.test_create import make_temp_prefix
 
         prefix = make_temp_prefix(name='test')
         with make_temp_env(prefix=prefix):
-            stdout, stderr, result = run_inprocess_conda_command('conda run -p {} exit 1'.format(prefix))
+            stdout, stderr, result = run_inprocess_conda_command('conda run -p {} echo hi'.format(prefix))
             
             assert isinstance(result, int)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,18 +167,28 @@ class TestJson(unittest.TestCase):
 class TestRunErrorLevel(unittest.TestCase):
     @pytest.mark.integration
     def test_run_returns_int(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run --dev python -c "x = 1"')
+        import os
+        from tempfile import gettempdir
+
+        # Jank
+        os.chdir(gettempdir())
+        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"')
         
         assert isinstance(result, int)
 
-    @pytest.mark.integration
-    def test_run_returns_zero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run --dev exit 0')
-        
-        assert result == 0
+    # @pytest.mark.integration
+    # def test_run_returns_zero_errorlevel(self):
+    #     import os
+    #     from tempfile import gettempdir
 
-    @pytest.mark.integration
-    def test_run_returns_nonzero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run --dev exit 5')
+    #     # Jank
+    #     os.chdir(gettempdir())
+    #     stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
         
-        assert result == 5
+    #     assert result == 0
+
+    # @pytest.mark.integration
+    # def test_run_returns_nonzero_errorlevel(self):
+    #     stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
+        
+    #     assert result == 5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,17 +164,23 @@ class TestJson(unittest.TestCase):
         self.assertIsInstance(capture_json_with_argv('conda search --platform win-32 --json'), dict)
 
     def test_run_returns_int(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"')
-        
-        assert isinstance(result, int)
+        from tests.test_create import make_temp_env
+        with make_temp_env() as prefix:
+            stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"'.format(prefix))
+            
+            assert isinstance(result, int)
 
     def test_run_returns_zero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
-        
-        assert result == 0
+        from tests.test_create import make_temp_env
+        with make_temp_env() as prefix:
+            stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
+            
+            assert result == 0
 
     def test_run_returns_nonzero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
-        
-        assert result == 5
+        from tests.test_create import make_temp_env
+        with make_temp_env() as prefix:
+            stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
+            
+            assert result == 5
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import json
-from tempfile import gettempdir
 import unittest
 
 from conda._vendor.auxlib.ish import dals
@@ -164,18 +163,19 @@ class TestJson(unittest.TestCase):
     def test_search_5(self):
         self.assertIsInstance(capture_json_with_argv('conda search --platform win-32 --json'), dict)
 
+    @pytest.mark.integration
     def test_run_returns_int(self):
-        from tests.test_create import make_temp_env
-        with make_temp_env(prefix=gettempdir()) as prefix:
-            stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"'.format(prefix))
-            
-            assert isinstance(result, int)
+        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "x = 1"')
+        
+        assert isinstance(result, int)
 
+    @pytest.mark.integration
     def test_run_returns_zero_errorlevel(self):
         stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
         
         assert result == 0
 
+    @pytest.mark.integration
     def test_run_returns_nonzero_errorlevel(self):
         stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
         

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,12 +172,12 @@ class TestJson(unittest.TestCase):
             assert isinstance(result, int)
 
     def test_run_returns_zero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "exit(0)"')
+        stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
         
         assert result == 0
 
     def test_run_returns_nonzero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "exit(5)"')
+        stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
         
         assert result == 5
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,10 +165,9 @@ class TestJson(unittest.TestCase):
 
 
 class TestRunErrorLevel(unittest.TestCase):
-    @pytest.mark.integration
     def test_run_returns_int(self):
-        from tempfile import gettempdir
-        from tests.test_create import make_temp_env, make_temp_prefix
+        from tests.test_create import make_temp_env
+        from tests.test_create import make_temp_prefix
 
         prefix = make_temp_prefix(name='test')
         with make_temp_env(prefix=prefix):
@@ -176,19 +175,22 @@ class TestRunErrorLevel(unittest.TestCase):
             
             assert isinstance(result, int)
 
-    # @pytest.mark.integration
-    # def test_run_returns_zero_errorlevel(self):
-    #     import os
-    #     from tempfile import gettempdir
+    def test_run_returns_zero_errorlevel(self):
+        from tests.test_create import make_temp_env
+        from tests.test_create import make_temp_prefix
 
-    #     # Jank
-    #     os.chdir(gettempdir())
-    #     stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
-        
-    #     assert result == 0
+        prefix = make_temp_prefix(name='test')
+        with make_temp_env(prefix=prefix):
+            stdout, stderr, result = run_inprocess_conda_command('conda run -p {} exit 0'.format(prefix))
+            
+            assert result == 0
 
-    # @pytest.mark.integration
-    # def test_run_returns_nonzero_errorlevel(self):
-    #     stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
-        
-    #     assert result == 5
+    def test_run_returns_nonzero_errorlevel(self):
+        from tests.test_create import make_temp_env
+        from tests.test_create import make_temp_prefix
+
+        prefix = make_temp_prefix(name='test')
+        with make_temp_env(prefix=prefix) as prefix:
+            stdout, stderr, result = run_inprocess_conda_command('conda run -p "{}" exit 5'.format(prefix))
+            
+            assert result == 5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,12 +169,12 @@ class TestJson(unittest.TestCase):
         assert isinstance(result, int)
 
     def test_run_returns_zero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "exit(0)"')
+        stdout, stderr, result = run_inprocess_conda_command('conda run exit 0')
         
         assert result == 0
 
     def test_run_returns_nonzero_errorlevel(self):
-        stdout, stderr, result = run_inprocess_conda_command('conda run python -c "exit(5)"')
+        stdout, stderr, result = run_inprocess_conda_command('conda run exit 5')
         
         assert result == 5
 


### PR DESCRIPTION
Addresses #9599 by handling the namedtuple returned from conda.gateways.subprocess.subprocess_call.

Also, introduces three new "conda run" unit tests:
- returns an int
- properly returns zero exit codes
- properly returns non-zero exit codes

These three tests fail with conda 4.8.2 and pass with this PR
