### PR TITLE
base env python not accessible

### DIFF
--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -49,9 +49,7 @@ Use the terminal or an Anaconda Prompt for the following steps:
 
       proceed ([y]/n)?
 
-  This creates the myenv environment in ``/envs/``. This
-  environment uses the same version of Python that you are
-  currently using because you did not specify a version.
+  This creates the myenv environment in ``/envs/``. Note that by default this env will not have Python installed in it.
 
 3. To create an environment with a specific version of Python:
 


### PR DESCRIPTION
The previous version of the comment appears to be a hold-over from pre-v4.4, that is it assumes that the **base** env's `bin/` directory remains on `PATH` even after activating the empty env. This should not be the case. That is, users should only expect a Conda-installed Python if they request it to be in the env they are activating.