### PR TITLE
Remove fetch repodata reponse logging

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -12,7 +12,7 @@ from genericpath import getmtime, isfile
 import hashlib
 from io import open as io_open
 import json
-from logging import DEBUG, getLogger
+from logging import getLogger
 from mmap import ACCESS_READ, mmap
 from os.path import dirname, isdir, join, splitext
 import re
@@ -21,7 +21,6 @@ import warnings
 
 from .. import CondaError
 from .._vendor.auxlib.ish import dals
-from .._vendor.auxlib.logz import stringify
 from .._vendor.boltons.setutils import IndexedSet
 from .._vendor.toolz import concat, take, groupby
 from ..base.constants import CONDA_HOMEPAGE_URL, CONDA_PACKAGE_EXTENSION_V1, REPODATA_FN
@@ -427,6 +426,7 @@ class SubdirData(object):
                 package_record = PackageRecord(**info)
 
                 _package_records.append(package_record)
+
                 _names_index[package_record.name].append(package_record)
                 for ftr_name in package_record.track_features:
                     _track_features_index[ftr_name].append(package_record)

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -483,8 +483,6 @@ def fetch_repodata_remote_request(url, etag, mod_stamp, repodata_fn=REPODATA_FN)
         timeout = context.remote_connect_timeout_secs, context.remote_read_timeout_secs
         resp = session.get(join_url(url, filename), headers=headers, proxies=session.proxies,
                            timeout=timeout)
-        if log.isEnabledFor(DEBUG):
-            log.debug(stringify(resp, content_max_len=256))
         resp.raise_for_status()
 
     except RequestsProxyError:


### PR DESCRIPTION
Repodata response logging logs all http headers, including authentication headers which should not be logged.

If this logging is diagnostically critical, would also be open to implementing a header whitelist though it would be more work.