### PR TITLE
Allow caching of repodata from file:/// channels

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -63,7 +63,7 @@ class SubdirDataType(type):
         assert not channel.package_filename
         assert type(channel) is Channel
         cache_key = channel.url(with_credentials=True), repodata_fn
-        if not cache_key[0].startswith('file://') and cache_key in SubdirData._cache_:
+        if cache_key in SubdirData._cache_:
             return SubdirData._cache_[cache_key]
 
         subdir_data_instance = super(SubdirDataType, cls).__call__(channel, repodata_fn)

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -75,6 +75,12 @@ class SubdirDataType(type):
 class SubdirData(object):
     _cache_ = {}
 
+    @classmethod
+    def clear_cached_local_channel_data(cls):
+        # This should only ever be needed during unit tests, when
+        # CONDA_USE_ONLY_TAR_BZ2 may change during process lifetime.
+        cls._cache_ = {k: v for k, v in cls._cache_.items() if not k[0].startswith('file://')}
+
     @staticmethod
     def query_all(package_ref_or_match_spec, channels=None, subdirs=None,
                   repodata_fn=REPODATA_FN):

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 from conda.common.compat import PY3
 from conda.gateways.disk.create import TemporaryDirectory
+from conda.core.subdir_data import SubdirData
 
 win_default_shells = ["cmd.exe", "powershell", "git_bash", "cygwin"]
 shells = ["bash", "zsh"]
@@ -63,6 +64,11 @@ def set_tmpdir(tmpdir):
     if sys.platform == 'win32' and sys.version_info.major == 2 and hasattr(td, 'encode'):
         os.environ['CONDA_TEST_TMPDIR'] = td.encode('utf-8')
     tmpdir_in_use = td
+
+
+@pytest.fixture(autouse=True)
+def clear_subdir_cache(tmpdir):
+    SubdirData.clear_cached_local_channel_data()
 
 
 # From: https://hackebrot.github.io/pytest-tricks/fixtures_as_class_attributes/

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -201,10 +201,12 @@ def test_subdir_data_prefers_conda_to_tar_bz2():
 
 def test_use_only_tar_bz2():
     channel = Channel(join(dirname(__file__), "..", "data", "conda_format_repo", context.subdir))
+    SubdirData.clear_cached_local_channel_data()
     with env_var('CONDA_USE_ONLY_TAR_BZ2', True, stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd = SubdirData(channel)
         precs = tuple(sd.query("zlib"))
         assert precs[0].fn.endswith(".tar.bz2")
+    SubdirData.clear_cached_local_channel_data()
     with env_var('CONDA_USE_ONLY_TAR_BZ2', False, stack_callback=conda_tests_ctxt_mgmt_def_pol):
         sd = SubdirData(channel)
         precs = tuple(sd.query("zlib"))

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from logging import getLogger
 from os.path import dirname, join
 from unittest import TestCase
+from time import sleep
 
 import pytest
 
@@ -211,6 +212,47 @@ def test_use_only_tar_bz2():
         sd = SubdirData(channel)
         precs = tuple(sd.query("zlib"))
         assert precs[0].fn.endswith(".conda")
+
+
+def test_metadata_cache_works():
+    channel = Channel(join(dirname(__file__), "..", "data", "conda_format_repo", context.subdir))
+    SubdirData.clear_cached_local_channel_data()
+
+    # Sadly, on Windows, st_mtime resolution is limited to 2 seconds. (See note in Python docs
+    # on os.stat_result.)  To ensure that the timestamp on the existing JSON file is safely
+    # in the past before this test starts, we need to wait for more than 2 seconds...
+
+    sleep(3)
+
+    with patch('conda.core.subdir_data.fetch_repodata_remote_request',
+               wraps=fetch_repodata_remote_request) as fetcher:
+        sd_a = SubdirData(channel)
+        precs_a = tuple(sd_a.query("zlib"))
+        assert fetcher.call_count == 1
+
+        sd_b = SubdirData(channel)
+        assert sd_b is sd_a
+        precs_b = tuple(sd_b.query("zlib"))
+        assert fetcher.call_count == 1
+
+
+def test_metadata_cache_clearing():
+    channel = Channel(join(dirname(__file__), "..", "data", "conda_format_repo", context.subdir))
+    SubdirData.clear_cached_local_channel_data()
+
+    with patch('conda.core.subdir_data.fetch_repodata_remote_request',
+               wraps=fetch_repodata_remote_request) as fetcher:
+        sd_a = SubdirData(channel)
+        precs_a = tuple(sd_a.query("zlib"))
+        assert fetcher.call_count == 1
+
+        SubdirData.clear_cached_local_channel_data()
+
+        sd_b = SubdirData(channel)
+        assert sd_b is not sd_a
+        precs_b = tuple(sd_b.query("zlib"))
+        assert fetcher.call_count == 2
+        assert precs_b == precs_a
 
 
 # @pytest.mark.integration


### PR DESCRIPTION
(This is the second attempt at this, sorry for any inconvenience.)

As discussed in issue #9661 the performance of "file:///" channels is very poor in some circumstances with the latest conda versions. This seems to be because the solver requests repodata about directories more often than it used to. There is a caching mechanism for repodata but it is explicitly disabled for local channels; this PR removes that check so that the caching mechanism works for file:/// channels in the same way as HTTP channels.

That broke some unit tests, because of the way that an environment variable can be set to force conda to use only .tar.bz2 files, not .conda files. The tests try both settings, which changes the repodata that is fetched and should therefore be cached. The tests fail because the wrong version of the data appears in the cache. This could never happen in production as the cache is in memory. So it starts out empty when the conda command is invoked, and the command will only see one setting of the environment variable, so the cache will only ever have the appropriate data. To fix the tests, I added a method to clear the cache and invoked it before each test.

This change makes a huge difference to my company's use of conda. We use large conda channels on relatively slow NFS volumes, and without this change the creation of a new environment takes minutes when it previously took a few seconds.

Fixes #9661