### PR TITLE
Fix conda init "--no-user" argument being ignored

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -636,7 +636,7 @@ def configure_parser_init(sub_parsers):
     )
     setup_type_group.add_argument(
         "--no-user",
-        action="store_false",
+        action="store_true",
         # help="Don't initialize conda for the current user (default).",
         help=SUPPRESS,
         default=NULL,


### PR DESCRIPTION
Currently it is being ignored, because option `no_user` in [https://github.com/conda/conda/blob/master/conda/cli/main_init.py#L46](main_init.py) is marked `False` when `--no-user` option is present. 

I picked `action="store_true"` instead of `dest="user"` because of existance of the reference to `args.no_user` in the code, probably it is left on intent.