### PR TITLE
account for channel in specs

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -500,7 +500,7 @@ class MatchSpec(object):
                 if union:
                     try:
                         final = this_component.union(that_component)
-                    except (AttributeError, ValueError):
+                    except (AttributeError, ValueError, TypeError):
                         final = '%s|%s' % (this_component, that_component)
                 else:
                     final = this_component.merge(that_component)


### PR DESCRIPTION
This fixes an issue that has been causing a traceback during `breadth_first_search_for_dep_graph()` such as:
```
      File "/Users/fwaters/git/conda/conda/models/match_spec.py", line 766, in union
        return '|'.join(options)
    TypeError: sequence item 0: expected str instance, Channel found
```
Minimal repro:
```
conda install defaults::statistics defaults::python=3.7
```