### PR TITLE
Update appdirs.py

### DIFF
--- a/conda/_vendor/appdirs.py
+++ b/conda/_vendor/appdirs.py
@@ -334,7 +334,7 @@ def _get_win_folder_with_ctypes(csidl_name):
 
 if sys.platform == "win32":
     try:
-        import win32com.shell
+        from win32com.shell import shellcon, shell
         _get_win_folder = _get_win_folder_with_pywin32
     except ImportError:
         try:


### PR DESCRIPTION
At some point after some update, I am honestly not sure which, I started receiving the error below when using conda.
After making the proposed change, conda works properly.  I think an ImportError that was supposed to get caught was not getting caught.

```
# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "E:\ProgramData\Anaconda3\lib\site-packages\conda\exceptions.py", line 1079, in __call__
        return func(*args, **kwargs)
      File "E:\ProgramData\Anaconda3\lib\site-packages\conda\cli\main.py", line 84, in _main
        exit_code = do_call(args, p)
      File "E:\ProgramData\Anaconda3\lib\site-packages\conda\cli\conda_argparse.py", line 82, in do_call
        return getattr(module, func_name)(args, parser)
      File "E:\ProgramData\Anaconda3\lib\site-packages\conda\cli\main_info.py", line 314, in execute
        info_dict = get_info_dict(args.system)
      File "E:\ProgramData\Anaconda3\lib\site-packages\conda\cli\main_info.py", line 163, in get_info_dict
        pkgs_dirs=context.pkgs_dirs,
      File "E:\ProgramData\Anaconda3\lib\site-packages\conda\base\context.py", line 516, in pkgs_dirs
        fixed_dirs += user_data_dir(APP_NAME, APP_NAME),
      File "E:\ProgramData\Anaconda3\lib\site-packages\conda\_vendor\appdirs.py", line 67, in user_data_dir
        path = os.path.join(_get_win_folder(const), appauthor, appname)
      File "E:\ProgramData\Anaconda3\lib\site-packages\conda\_vendor\appdirs.py", line 284, in _get_win_folder_with_pywin32
        from win32com.shell import shellcon, shell
    ImportError: DLL load failed: The specified procedure could not be found.
```