### PR TITLE
Enable ppc64 support

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -67,6 +67,7 @@ PLATFORM_DIRECTORIES = (
     "linux-aarch64",
     "linux-armv6l",
     "linux-armv7l",
+    "linux-ppc64",
     "linux-ppc64le",
     "osx-64",
     "win-32",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -59,6 +59,7 @@ non_x86_linux_machines = {
     'armv6l',
     'armv7l',
     'aarch64',
+    'ppc64',
     'ppc64le',
 }
 _arch_names = {

--- a/conda/models/enums.py
+++ b/conda/models/enums.py
@@ -21,6 +21,7 @@ class Arch(Enum):
     armv6l = 'armv6l'
     armv7l = 'armv7l'
     aarch64 = 'aarch64'
+    ppc64 = 'ppc64'
     ppc64le = 'ppc64le'
     z = 'z'
 


### PR DESCRIPTION
I built and started to use conda on ppc64 at work: https://gitlab.esss.lu.se/ics-infrastructure/conda4ppc64e6500
It would be nice to have this patch upstream.