### PR TITLE
resolve #5562 support creating conda environments from web addresses

### DIFF
--- a/conda/gateways/connection/session.py
+++ b/conda/gateways/connection/session.py
@@ -24,6 +24,14 @@ log = getLogger(__name__)
 RETRIES = 3
 
 
+CONDA_SESSION_SCHEMES = frozenset((
+    "http",
+    "https",
+    "ftp",
+    "s3",
+    "file",
+))
+
 class EnforceUnusedAdapter(BaseAdapter):
 
     def send(self, request, *args, **kwargs):

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -76,8 +76,12 @@ def execute(args, parser):
     name = args.remote_definition or args.name
 
     try:
-        spec = specs.detect(name=name, filename=expand(args.file),
-                            directory=os.getcwd())
+        if not any(args.file.startswith(s) for s in ("https://", "http://")):
+            filename = expand(args.file)
+        else:
+            filename = args.file
+
+        spec = specs.detect(name=name, filename=filename, directory=os.getcwd())
         env = spec.environment
 
         # FIXME conda code currently requires args to have a name or prefix

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -11,6 +11,7 @@ import textwrap
 from conda._vendor.auxlib.path import expand
 from conda.cli import install as cli_install
 from conda.cli.conda_argparse import add_parser_json, add_parser_prefix, add_parser_networking
+from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
 from conda.gateways.disk.delete import rm_rf
 from conda.misc import touch_nonadmin
 from .common import get_prefix, print_result
@@ -76,10 +77,11 @@ def execute(args, parser):
     name = args.remote_definition or args.name
 
     try:
-        if not any(args.file.startswith(s) for s in ("https://", "http://")):
-            filename = expand(args.file)
-        else:
+        url_scheme = args.file.split("://", 1)[0]
+        if url_scheme in CONDA_SESSION_SCHEMES:
             filename = args.file
+        else:
+            filename = expand(args.file)
 
         spec = specs.detect(name=name, filename=filename, directory=os.getcwd())
         env = spec.environment

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -13,7 +13,8 @@ from conda.base.context import context
 from conda.cli import common  # TODO: this should never have to import form conda.cli
 from conda.common.serialize import yaml_load_standard
 from conda.core.prefix_data import PrefixData
-from conda.gateways.connection.session import CondaSession
+from conda.gateways.connection.download import download_text
+from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
 from conda.models.enums import PackageType
 from conda.models.match_spec import MatchSpec
 from conda.models.prefix_graph import PrefixGraph
@@ -145,10 +146,9 @@ def from_yaml(yamlstr, **kwargs):
 
 
 def from_file(filename):
-    if any(filename.startswith(prefix) for prefix in ("https://", "http://")):
-        response = CondaSession().get(filename)
-        response.raise_for_status()
-        yamlstr = response.text
+    url_scheme = filename.split("://", 1)[0]
+    if url_scheme in CONDA_SESSION_SCHEMES:
+        yamlstr = download_text(filename)
     elif not os.path.exists(filename):
         raise exceptions.EnvironmentFileNotFound(filename)
     else:

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -8,7 +8,7 @@ from itertools import chain
 import os
 import re
 import json
-import urllib
+from conda._vendor.auxlib._vendor.six.moves import urllib
 
 from conda.base.context import context
 from conda.cli import common  # TODO: this should never have to import form conda.cli

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -8,12 +8,12 @@ from itertools import chain
 import os
 import re
 import json
-from conda._vendor.auxlib._vendor.six.moves import urllib
 
 from conda.base.context import context
 from conda.cli import common  # TODO: this should never have to import form conda.cli
 from conda.common.serialize import yaml_load_standard
 from conda.core.prefix_data import PrefixData
+from conda.gateways.connection.session import CondaSession
 from conda.models.enums import PackageType
 from conda.models.match_spec import MatchSpec
 from conda.models.prefix_graph import PrefixGraph
@@ -146,10 +146,9 @@ def from_yaml(yamlstr, **kwargs):
 
 def from_file(filename):
     if any(filename.startswith(prefix) for prefix in ("https://", "http://")):
-        try:
-            yamlstr = urllib.request.urlopen(filename).read()
-        except urllib.error.HTTPError:
-            raise exceptions.EnvironmentFileNotFound(filename)
+        response = CondaSession().get(filename)
+        response.raise_for_status()
+        yamlstr = response.text
     elif not os.path.exists(filename):
         raise exceptions.EnvironmentFileNotFound(filename)
     else:

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -148,7 +148,7 @@ def from_file(filename):
     if any(filename.startswith(prefix) for prefix in ("https://", "http://")):
         try:
             yamlstr = urllib.request.urlopen(filename).read()
-        except urllib.error.HTTPError as e:
+        except urllib.error.HTTPError:
             raise exceptions.EnvironmentFileNotFound(filename)
     elif not os.path.exists(filename):
         raise exceptions.EnvironmentFileNotFound(filename)

--- a/conda_env/installers/pip.py
+++ b/conda_env/installers/pip.py
@@ -27,10 +27,13 @@ def _pip_install_via_requirements(prefix, specs, args, *_, **kwargs):
       See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
            https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
     """
-    try:
-        pip_workdir = op.dirname(op.abspath(args.file))
-    except AttributeError:
+    if any(args.file.startswith(prefix) for prefix in ("http://", "https://")):
         pip_workdir = None
+    else:
+        try:
+            pip_workdir = op.dirname(op.abspath(args.file))
+        except AttributeError:
+            pip_workdir = None
     requirements = None
     try:
         # Generate the temporary requirements file

--- a/conda_env/installers/pip.py
+++ b/conda_env/installers/pip.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import os
 import os.path as op
 from conda._vendor.auxlib.compat import Utf8NamedTemporaryFile
+from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
 from conda_env.pip_util import pip_subprocess, get_pip_installed_packages
 from logging import getLogger
 
@@ -27,7 +28,8 @@ def _pip_install_via_requirements(prefix, specs, args, *_, **kwargs):
       See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
            https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
     """
-    if any(args.file.startswith(prefix) for prefix in ("http://", "https://")):
+    url_scheme = args.file.split("://", 1)[0]
+    if url_scheme in CONDA_SESSION_SCHEMES:
         pip_workdir = None
     else:
         try:

--- a/conda_env/specs/__init__.py
+++ b/conda_env/specs/__init__.py
@@ -21,7 +21,10 @@ def detect(**kwargs):
     fname, ext = os.path.splitext(filename)
 
     # First check if file exists and test the known valid extension for specs
-    file_exists = filename and os.path.isfile(filename)
+    file_exists = (
+        filename and os.path.isfile(filename) or
+        any(filename.startswith(prefix) for prefix in ("https://", "http://"))
+    )
     if file_exists:
         if ext == '' or ext not in all_valid_exts:
             raise EnvironmentFileExtensionNotValid(filename)

--- a/conda_env/specs/__init__.py
+++ b/conda_env/specs/__init__.py
@@ -4,6 +4,7 @@
 
 import os
 
+from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
 from .binstar import BinstarSpec
 from .notebook import NotebookSpec
 from .requirements import RequirementsSpec
@@ -13,7 +14,7 @@ from ..exceptions import (EnvironmentFileExtensionNotValid, EnvironmentFileNotFo
 
 
 def detect(**kwargs):
-    filename = kwargs.get('filename')
+    filename = kwargs.get('filename', '')
     remote_definition = kwargs.get('name')
 
     # Check extensions
@@ -22,12 +23,11 @@ def detect(**kwargs):
 
     # First check if file exists and test the known valid extension for specs
     file_exists = (
-        filename and os.path.isfile(filename) or
-        any(filename.startswith(prefix) for prefix in ("https://", "http://"))
+        os.path.isfile(filename) or filename.split("://", 1)[0] in CONDA_SESSION_SCHEMES
     )
     if file_exists:
         if ext == '' or ext not in all_valid_exts:
-            raise EnvironmentFileExtensionNotValid(filename)
+            raise EnvironmentFileExtensionNotValid(filename or None)
         elif ext in YamlFileSpec.extensions:
             specs = [YamlFileSpec]
         elif ext in RequirementsSpec.extensions:
@@ -44,7 +44,7 @@ def detect(**kwargs):
             return spec
 
     if not file_exists and remote_definition is None:
-        raise EnvironmentFileNotFound(filename=filename)
+        raise EnvironmentFileNotFound(filename=filename or None)
     else:
         raise SpecNotFound(build_message(spec_instances))
 

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -244,6 +244,13 @@ class IntegrationTests(unittest.TestCase):
             len([env for env in parsed['envs'] if env.endswith(test_env_name_1)]), 0
         )
 
+    def test_conda_env_create_http(self):
+        '''
+        Test `conda env create --file=https://some-website.com/environment.yml`
+        '''
+        run_env_command(Commands.ENV_CREATE, None, '--file', 'https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/simple.yml')
+        self.assertTrue(env_is_created("nlp"))
+
     def test_update(self):
         create_env(environment_1)
         run_env_command(Commands.ENV_CREATE, None)

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -244,6 +244,7 @@ class IntegrationTests(unittest.TestCase):
             len([env for env in parsed['envs'] if env.endswith(test_env_name_1)]), 0
         )
 
+    @pytest.mark.integration
     def test_conda_env_create_http(self):
         '''
         Test `conda env create --file=https://some-website.com/environment.yml`

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -248,8 +248,16 @@ class IntegrationTests(unittest.TestCase):
         '''
         Test `conda env create --file=https://some-website.com/environment.yml`
         '''
-        run_env_command(Commands.ENV_CREATE, None, '--file', 'https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/simple.yml')
-        self.assertTrue(env_is_created("nlp"))
+        run_env_command(
+            Commands.ENV_CREATE,
+            None,
+            '--file',
+            'https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/simple.yml',
+        )
+        try:
+            self.assertTrue(env_is_created("nlp"))
+        finally:
+            run_env_command(Commands.ENV_REMOVE, "nlp")
 
     def test_update(self):
         create_env(environment_1)

--- a/tests/conda_env/test_env.py
+++ b/tests/conda_env/test_env.py
@@ -78,12 +78,14 @@ class from_file_TestCase(unittest.TestCase):
         assert 'foo' in e.dependencies['pip']
         assert 'baz' in e.dependencies['pip']
 
+    @pytest.mark.integration
     def test_http(self):
         e = get_simple_environment()
         f = env.from_file("https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/simple.yml")
         self.assertEqual(e.dependencies, f.dependencies)
         assert e.dependencies == f.dependencies
 
+    @pytest.mark.integration
     def test_http_raises(self):
         with self.assertRaises(HTTPError):
             env.from_file("https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/does-not-exist.yml")

--- a/tests/conda_env/test_env.py
+++ b/tests/conda_env/test_env.py
@@ -77,6 +77,16 @@ class from_file_TestCase(unittest.TestCase):
         assert 'foo' in e.dependencies['pip']
         assert 'baz' in e.dependencies['pip']
 
+    def test_http(self):
+        e = get_simple_environment()
+        f = env.from_file("https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/simple.yml")
+        self.assertEqual(e.dependencies, f.dependencies)
+        assert e.dependencies == f.dependencies
+
+    def test_http_raises(self):
+        with self.assertRaises(exceptions.EnvironmentFileNotFound):
+            env.from_file("https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/does-not-exist.yml")
+
 
 class EnvironmentTestCase(unittest.TestCase):
     def test_has_empty_filename_by_default(self):

--- a/tests/conda_env/test_env.py
+++ b/tests/conda_env/test_env.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from conda.core.prefix_data import PrefixData
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol
-from conda.gateways.connection import HTTPError
+from conda.exceptions import CondaHTTPError
 from conda.models.match_spec import MatchSpec
 from conda.common.io import env_vars
 from conda.common.serialize import yaml_load
@@ -87,7 +87,7 @@ class from_file_TestCase(unittest.TestCase):
 
     @pytest.mark.integration
     def test_http_raises(self):
-        with self.assertRaises(HTTPError):
+        with self.assertRaises(CondaHTTPError):
             env.from_file("https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/does-not-exist.yml")
 
 

--- a/tests/conda_env/test_env.py
+++ b/tests/conda_env/test_env.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from conda.core.prefix_data import PrefixData
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol
+from conda.gateways.connection import HTTPError
 from conda.models.match_spec import MatchSpec
 from conda.common.io import env_vars
 from conda.common.serialize import yaml_load
@@ -84,7 +85,7 @@ class from_file_TestCase(unittest.TestCase):
         assert e.dependencies == f.dependencies
 
     def test_http_raises(self):
-        with self.assertRaises(exceptions.EnvironmentFileNotFound):
+        with self.assertRaises(HTTPError):
             env.from_file("https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/does-not-exist.yml")
 
 


### PR DESCRIPTION
Fixes https://github.com/conda/conda/issues/5562

This allows for passing web addresses through to conda env create,
like the following:

    conda env create -f https://domain.com/my-environment.yml

This uses the urllib module to download the file
and then passes things on as normal.

There are a few cases where we need to avoid explicit checks
about if this is a file or if we want to prepend the directory to the
filename.  In these cases we avoid these operations by checking if
the filename starts with "https://" or "http://"