### PR TITLE
resolve #9819 post-link script output formatting

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1222,7 +1222,7 @@ def messages(prefix):
                 m = fi.read()
                 if hasattr(m, "decode"):
                     m = m.decode('utf-8')
-                print(m.encode('utf-8'), file=sys.stderr if context.json else sys.stdout)
+                print(m, file=sys.stderr if context.json else sys.stdout)
                 return m
     finally:
         rm_rf(path)


### PR DESCRIPTION
Fixes [9819](https://github.com/conda/conda/issues/9819)

Formatting is a little nicer by removing the byte encoding

On a Linux system:

![Screenshot from 2020-04-14 00-02-37](https://user-images.githubusercontent.com/6901046/79188030-98a1a500-7de3-11ea-807d-877e64a30d1a.png)
