### PR TITLE
fix url parsing

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -187,7 +187,7 @@ class MatchSpec(object):
                 channel_str, subdir = channel_subdir_str.rsplit('/', 1)
                 if subdir not in context.known_subdirs:
                     channel_str = channel_subdir_str
-                    subdir = context.subdir
+                    subdir = None
                 parts.update({
                     'channel': channel_str,
                     'subdir': subdir,

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -27,6 +27,7 @@ from ..common.io import dashlist
 from ..common.path import expand, url_to_path, strip_pkg_extension, is_package_file
 from ..common.url import is_url, path_to_url, unquote
 from ..exceptions import CondaValueError, InvalidMatchSpec
+from ..base.context import context
 
 log = getLogger(__name__)
 
@@ -184,6 +185,9 @@ class MatchSpec(object):
             channel_subdir_str, dist_str = dist_str.split("::", 1)
             if '/' in channel_subdir_str:
                 channel_str, subdir = channel_subdir_str.rsplit('/', 1)
+                if subdir not in context.known_subdirs:
+                    channel_str = channel_subdir_str
+                    subdir = context.subdir
                 parts.update({
                     'channel': channel_str,
                     'subdir': subdir,

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -188,10 +188,9 @@ class MatchSpec(object):
                 if subdir not in context.known_subdirs:
                     channel_str = channel_subdir_str
                     subdir = None
-                parts.update({
-                    'channel': channel_str,
-                    'subdir': subdir,
-                })
+                parts['channel'] = channel_str
+                if subdir:
+                    parts['subdir'] = subdir
             else:
                 parts['channel'] = channel_subdir_str
 

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -20,7 +20,7 @@ from .version import BuildNumberMatch, VersionSpec
 from .._vendor.auxlib.collection import frozendict
 from .._vendor.auxlib.decorators import memoizedproperty
 from .._vendor.toolz import concat, concatv, groupby
-from ..base.constants import CONDA_PACKAGE_EXTENSION_V1
+from ..base.constants import CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2
 from ..common.compat import (isiterable, iteritems, itervalues, string_types, text_type,
                              with_metaclass)
 from ..common.io import dashlist
@@ -179,7 +179,9 @@ class MatchSpec(object):
     @classmethod
     def from_dist_str(cls, dist_str):
         parts = {}
-        if dist_str.endswith(CONDA_PACKAGE_EXTENSION_V1):
+        if dist_str[-len(CONDA_PACKAGE_EXTENSION_V2):] == CONDA_PACKAGE_EXTENSION_V2:
+            dist_str = dist_str[:-len(CONDA_PACKAGE_EXTENSION_V2)]
+        elif dist_str[-len(CONDA_PACKAGE_EXTENSION_V1):] == CONDA_PACKAGE_EXTENSION_V1:
             dist_str = dist_str[:-len(CONDA_PACKAGE_EXTENSION_V1)]
         if '::' in dist_str:
             channel_subdir_str, dist_str = dist_str.split("::", 1)

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -183,7 +183,7 @@ class MatchSpec(object):
         if '::' in dist_str:
             channel_subdir_str, dist_str = dist_str.split("::", 1)
             if '/' in channel_subdir_str:
-                channel_str, subdir = channel_subdir_str.split('/', 2)
+                channel_str, subdir = channel_subdir_str.rsplit('/', 1)
                 parts.update({
                     'channel': channel_str,
                     'subdir': subdir,

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -7,6 +7,7 @@ from conda._vendor.auxlib.collection import frozendict
 import pytest
 
 from conda import text_type
+from conda.base.constants import CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2
 from conda.base.context import context, conda_tests_ctxt_mgmt_def_pol
 from conda.cli.common import arg2spec, spec_from_line
 from conda.common.io import env_unmodified
@@ -826,33 +827,33 @@ class SpecStrParsingTests(TestCase):
         # }
 
     def test_dist_str(self):
-        m1 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0.tar.bz2".format(context.subdir))
-        m2 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0".format(context.subdir))
-        m3 = MatchSpec.from_dist_str("https://someurl.org/anaconda/{0}::python-3.6.6-0.tar.bz2".format(context.subdir))
-        m4 = MatchSpec.from_dist_str("python-3.6.6-0.tar.bz2")
-        m5 = MatchSpec.from_dist_str("https://someurl.org/anaconda::python-3.6.6-0.tar.bz2")
+        for ext in (CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2):
+            m1 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0{1}".format(context.subdir, ext))
+            m2 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0".format(context.subdir))
+            m3 = MatchSpec.from_dist_str("https://someurl.org/anaconda/{0}::python-3.6.6-0{1}".format(context.subdir, ext))
+            m4 = MatchSpec.from_dist_str("python-3.6.6-0{0}".format(ext))
+            m5 = MatchSpec.from_dist_str("https://someurl.org/anaconda::python-3.6.6-0{0}".format(ext))
 
-        pref = DPkg("anaconda::python-3.6.6-0.tar.bz2")
-        pref.url = "https://someurl.org/anaconda/{}".format(context.subdir)
+            pref = DPkg("anaconda::python-3.6.6-0{0}".format(ext))
+            pref.url = "https://someurl.org/anaconda/{0}".format(context.subdir)
 
-        assert m1.match(pref)
-        assert m2.match(pref)
-        assert m3.match(pref)
-        assert m4.match(pref)
-        pref.url = "https://someurl.org/anaconda"
+            assert m1.match(pref)
+            assert m2.match(pref)
+            assert m3.match(pref)
+            assert m4.match(pref)
+            pref.url = "https://someurl.org/anaconda"
 
-        pref_dict = {
+            pref_dict = {
                 'name': 'python',
                 'version': '3.6.6',
                 'build': '0',
                 'build_number': 0,
                 'channel': Channel("anaconda"),
-                'fn': 'python-3.6.6-0.tar.bz2',
+                'fn': 'python-3.6.6-0{0}'.format(ext),
                 'md5': '012345789',
                 'url': 'https://someurl.org/anaconda'
-                }
-
-        assert m5.match(pref_dict)
+            }
+            assert m5.match(pref_dict)
 
 
 class MatchSpecMergeTests(TestCase):

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -964,3 +964,18 @@ class MatchSpecMergeTests(TestCase):
         assert str(merged[0]) in str_specs
         assert str(merged[1]) in str_specs
         assert str(merged[0]) != str(merged[1])
+
+
+    def test_dist_str(self):
+        m1 = MatchSpec.from_dist_str("anaconda/{}::python-3.6.6-0.tar.bz2".format(context.subdir))
+        m2 = MatchSpec.from_dist_str("anaconda/{}::python-3.6.6-0".format(context.subdir))
+        m3 = MatchSpec.from_dist_str("https://someurl.org/anaconda/{}::python-3.6.6-0.tar.bz2".format(context.subdir))
+        m4 = MatchSpec.from_dist_str("python-3.6.6-0.tar.bz2")
+
+        pref = DPkg("anaconda::python-3.6.6-0.tar.bz2")
+        pref.url = "https://someurl.org/anaconda/{}::python-3.6.6-0.tar.bz2".format(context.subdir)
+
+        assert m1.match(pref)
+        assert m2.match(pref)
+        assert m3.match(pref)
+        assert m4.match(pref)

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -967,15 +967,18 @@ class MatchSpecMergeTests(TestCase):
 
 
     def test_dist_str(self):
-        m1 = MatchSpec.from_dist_str("anaconda/{}::python-3.6.6-0.tar.bz2".format(context.subdir))
-        m2 = MatchSpec.from_dist_str("anaconda/{}::python-3.6.6-0".format(context.subdir))
-        m3 = MatchSpec.from_dist_str("https://someurl.org/anaconda/{}::python-3.6.6-0.tar.bz2".format(context.subdir))
+        m1 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0.tar.bz2".format(context.subdir))
+        m2 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0".format(context.subdir))
+        m3 = MatchSpec.from_dist_str("https://someurl.org/anaconda/{0}::python-3.6.6-0.tar.bz2".format(context.subdir))
         m4 = MatchSpec.from_dist_str("python-3.6.6-0.tar.bz2")
+        m5 = MatchSpec.from_dist_str("https://someurl.org/anaconda::python-3.6.6-0.tar.bz2")
 
         pref = DPkg("anaconda::python-3.6.6-0.tar.bz2")
-        pref.url = "https://someurl.org/anaconda/{}::python-3.6.6-0.tar.bz2".format(context.subdir)
+        pref.url = "https://someurl.org/anaconda/{}".format(context.subdir)
 
         assert m1.match(pref)
         assert m2.match(pref)
         assert m3.match(pref)
         assert m4.match(pref)
+        pref.url = "https://someurl.org/anaconda"
+        assert m5.match(pref)

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -825,6 +825,35 @@ class SpecStrParsingTests(TestCase):
         #     "build_number": '>=3',
         # }
 
+    def test_dist_str(self):
+        m1 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0.tar.bz2".format(context.subdir))
+        m2 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0".format(context.subdir))
+        m3 = MatchSpec.from_dist_str("https://someurl.org/anaconda/{0}::python-3.6.6-0.tar.bz2".format(context.subdir))
+        m4 = MatchSpec.from_dist_str("python-3.6.6-0.tar.bz2")
+        m5 = MatchSpec.from_dist_str("https://someurl.org/anaconda::python-3.6.6-0.tar.bz2")
+
+        pref = DPkg("anaconda::python-3.6.6-0.tar.bz2")
+        pref.url = "https://someurl.org/anaconda/{}".format(context.subdir)
+
+        assert m1.match(pref)
+        assert m2.match(pref)
+        assert m3.match(pref)
+        assert m4.match(pref)
+        pref.url = "https://someurl.org/anaconda"
+
+        pref_dict = {
+                'name': 'python',
+                'version': '3.6.6',
+                'build': '0',
+                'build_number': 0,
+                'channel': Channel("anaconda"),
+                'fn': 'python-3.6.6-0.tar.bz2',
+                'md5': '012345789',
+                'url': 'https://someurl.org/anaconda'
+                }
+
+        assert m5.match(pref_dict)
+
 
 class MatchSpecMergeTests(TestCase):
 
@@ -964,21 +993,3 @@ class MatchSpecMergeTests(TestCase):
         assert str(merged[0]) in str_specs
         assert str(merged[1]) in str_specs
         assert str(merged[0]) != str(merged[1])
-
-
-    def test_dist_str(self):
-        m1 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0.tar.bz2".format(context.subdir))
-        m2 = MatchSpec.from_dist_str("anaconda/{0}::python-3.6.6-0".format(context.subdir))
-        m3 = MatchSpec.from_dist_str("https://someurl.org/anaconda/{0}::python-3.6.6-0.tar.bz2".format(context.subdir))
-        m4 = MatchSpec.from_dist_str("python-3.6.6-0.tar.bz2")
-        m5 = MatchSpec.from_dist_str("https://someurl.org/anaconda::python-3.6.6-0.tar.bz2")
-
-        pref = DPkg("anaconda::python-3.6.6-0.tar.bz2")
-        pref.url = "https://someurl.org/anaconda/{}".format(context.subdir)
-
-        assert m1.match(pref)
-        assert m2.match(pref)
-        assert m3.match(pref)
-        assert m4.match(pref)
-        pref.url = "https://someurl.org/anaconda"
-        assert m5.match(pref)


### PR DESCRIPTION
This fixes https://github.com/conda/conda/issues/9814

Instead of `split` we use `rsplit` to correctly parse a url. We also change the max split to 1 instead of 2