### PR TITLE
Enable Windows Py27 tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,12 @@ environment:
        PYTHON_ROOT: "C:\\Miniconda36-x64"
        CONDA_INSTRUMENTATION_ENABLED: "true"
 
-    #  - PYTHON: "C:\\Python27_32"
-    #    PYTHON_VERSION: "2.7"
-    #    PYTHON_ARCH: "32"
-    #    PYTHON_ROOT: "C:\\Miniconda"
-    #    CONDA_INSTRUMENTATION_ENABLED: "true"
+     - PYTHON: "C:\\Python27_32"
+       PYTHON_VERSION: "2.7"
+       PYTHON_ARCH: "32"
+       PYTHON_ROOT: "C:\\Miniconda"
+       CONDA_INSTRUMENTATION_ENABLED: "true"
+       PYTHONIOENCODING: "UTF-8"
 
 init:
   - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %HOME%
@@ -31,7 +32,7 @@ init:
 
 install:
   - CALL "%PYTHON_ROOT%\\Scripts\\activate.bat"
-  - 'conda install -y -c conda-canary -c defaults -c conda-forge python=%PYTHON_VERSION% pycosat conda requests ruamel_yaml pytest pytest-cov pytest-timeout mock responses urllib3 pexpect pywin32 anaconda-client conda-package-handling'
+  - 'conda install -y python=%PYTHON_VERSION% pycosat conda requests ruamel_yaml pytest pytest-cov pytest-timeout mock responses urllib3 pexpect pywin32 anaconda-client conda-package-handling'
   - "conda install -yq conda-build=3.17"
   # conda install -y -c defaults -c conda-forge pytest pytest-cov pytest-timeout mock responses pexpect xonsh
   # TODO: add xonsh for PY3 builds

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from contextlib import contextmanager
 import os
 from pprint import pprint
+import platform
 import sys
 from textwrap import dedent
 import copy
@@ -275,7 +276,10 @@ def test_cuda_fail_1(tmpdir):
     elif sys.platform == "linux":
         plat = "linux-64"
     elif sys.platform == "win32":
-        plat = "win-64"
+        if platform.architecture()[0] == "32bit":
+            plat = "win-32"
+        else:
+            plat = "win-64"
     else:
         plat = "linux-64"
     assert str(exc.value).strip() == dals("""The following specifications were found to be incompatible with your CUDA driver:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2679,7 +2679,7 @@ class IntegrationTests(TestCase):
 
     # This test *was* very flaky on Python 2 when using `py_ver = sys.version_info[0]`. Changing it to `py_ver = '3'`
     # seems to work. I've done as much as I can to isolate this test.  It is a particularly tricky one.
-    # @pytest.mark.skipif(sys.version_info[0]==2, reason='Test is flaky on Python 2, errcode of -11 with no apparent error, some signal issue?')
+    @pytest.mark.skipif(on_win and sys.version_info[0]==2, reason='Test is flaky on Python 2, errcode of -11 with no apparent error, some signal issue?')
     def test_conda_downgrade(self):
         # Create an environment with the current conda under test, but include an earlier
         # version of conda and other packages in that environment.


### PR DESCRIPTION
This PR enables Python 2.7 tests on Windows.

Notes:

- test_create.test_conda_downgrade throws a C runtime error which pops a modal dialog on the host and halts test execution. Spent some time trying trying to resolve, but made no progress. Restoring the skip for 2.7 on Windows seemed like a reasonable approach. Specific error message is _"R6034 An application has made an attempt to load the C runtime library incorrectly. Please contact the application's support team for more information"_.
- The combination of channels in the intsall step created a non-functional pytest environment. The default settings work. Did not dig into which channel caused the issue.