### PR TITLE
revert breaking changes to configuration API

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -27,7 +27,7 @@ from .._vendor.frozendict import frozendict
 from .._vendor.toolz import concat, concatv, unique
 from ..common.compat import NoneType, iteritems, itervalues, odict, on_win, string_types
 from ..common.configuration import (Configuration, ConfigurationLoadError, MapParameter,
-                                    ParameterLoader, PrimitiveParameter, SequenceParameter,
+                                    PrimitiveParameter, SequenceParameter,
                                     ValidationError)
 from ..common._os.linux import linux_get_libc_version
 from ..common.path import expand, paths_equal
@@ -125,207 +125,173 @@ def ssl_verify_validation(value):
 
 class Context(Configuration):
 
-    add_pip_as_python_dependency = ParameterLoader(PrimitiveParameter(True))
-    allow_conda_downgrades = ParameterLoader(PrimitiveParameter(False))
+    add_pip_as_python_dependency = PrimitiveParameter(True)
+    allow_conda_downgrades = PrimitiveParameter(False)
     # allow cyclical dependencies, or raise
-    allow_cycles = ParameterLoader(PrimitiveParameter(True))
-    allow_softlinks = ParameterLoader(PrimitiveParameter(False))
-    auto_update_conda = ParameterLoader(PrimitiveParameter(True), aliases=('self_update',))
-    auto_activate_base = ParameterLoader(PrimitiveParameter(True))
-    auto_stack = ParameterLoader(PrimitiveParameter(0))
-    notify_outdated_conda = ParameterLoader(PrimitiveParameter(True))
-    clobber = ParameterLoader(PrimitiveParameter(False))
-    changeps1 = ParameterLoader(PrimitiveParameter(True))
-    env_prompt = ParameterLoader(PrimitiveParameter("({default_env}) "))
-    create_default_packages = ParameterLoader(
-        SequenceParameter(PrimitiveParameter("", element_type=string_types)))
-    default_python = ParameterLoader(
-        PrimitiveParameter(default_python_default(),
-                           element_type=string_types + (NoneType,),
-                           validation=default_python_validation))
-    download_only = ParameterLoader(PrimitiveParameter(False))
-    enable_private_envs = ParameterLoader(PrimitiveParameter(False))
-    force_32bit = ParameterLoader(PrimitiveParameter(False))
-    non_admin_enabled = ParameterLoader(PrimitiveParameter(True))
+    allow_cycles = PrimitiveParameter(True)
+    allow_softlinks = PrimitiveParameter(False)
+    auto_update_conda = PrimitiveParameter(True, aliases=('self_update',))
+    auto_activate_base = PrimitiveParameter(True)
+    auto_stack = PrimitiveParameter(0)
+    notify_outdated_conda = PrimitiveParameter(True)
+    clobber = PrimitiveParameter(False)
+    changeps1 = PrimitiveParameter(True)
+    env_prompt = PrimitiveParameter("({default_env}) ")
+    create_default_packages = SequenceParameter(string_types)
+    default_python = PrimitiveParameter(
+        default_python_default(),
+        element_type=string_types + (NoneType,),
+        validation=default_python_validation
+    )
+    download_only = PrimitiveParameter(False)
+    enable_private_envs = PrimitiveParameter(False)
+    force_32bit = PrimitiveParameter(False)
+    non_admin_enabled = PrimitiveParameter(True)
 
-    pip_interop_enabled = ParameterLoader(PrimitiveParameter(False))
+    pip_interop_enabled = PrimitiveParameter(False)
 
     # multithreading in various places
-    _default_threads = ParameterLoader(PrimitiveParameter(0, element_type=int),
-                                       aliases=('default_threads',))
-    _repodata_threads = ParameterLoader(PrimitiveParameter(0, element_type=int),
-                                        aliases=('repodata_threads',))
-    _verify_threads = ParameterLoader(PrimitiveParameter(0, element_type=int),
-                                      aliases=('verify_threads',))
+    _default_threads = PrimitiveParameter(0, element_type=int, aliases=('default_threads',))
+    _repodata_threads = PrimitiveParameter(0, element_type=int, aliases=('repodata_threads',))
+    _verify_threads = PrimitiveParameter(0, element_type=int, aliases=('verify_threads',))
     # this one actually defaults to 1 - that is handled in the property below
-    _execute_threads = ParameterLoader(PrimitiveParameter(0, element_type=int),
-                                       aliases=('execute_threads',))
+    _execute_threads = PrimitiveParameter(0, element_type=int, aliases=('execute_threads',))
 
     # Safety & Security
-    _aggressive_update_packages = ParameterLoader(
-        SequenceParameter(
-            PrimitiveParameter("", element_type=string_types),
-            DEFAULT_AGGRESSIVE_UPDATE_PACKAGES),
-        aliases=('aggressive_update_packages',))
-    safety_checks = ParameterLoader(PrimitiveParameter(SafetyChecks.warn))
-    extra_safety_checks = ParameterLoader(PrimitiveParameter(False))
-    path_conflict = ParameterLoader(PrimitiveParameter(PathConflict.clobber))
+    _aggressive_update_packages = SequenceParameter(
+        string_types, DEFAULT_AGGRESSIVE_UPDATE_PACKAGES, aliases=('aggressive_update_packages',)
+    )
+    safety_checks = PrimitiveParameter(SafetyChecks.warn)
+    extra_safety_checks = PrimitiveParameter(False)
+    path_conflict = PrimitiveParameter(PathConflict.clobber)
 
-    pinned_packages = ParameterLoader(SequenceParameter(
-        PrimitiveParameter("", element_type=string_types),
-        string_delimiter='&'))  # TODO: consider a different string delimiter  # NOQA
-    disallowed_packages = ParameterLoader(
-        SequenceParameter(
-            PrimitiveParameter("", element_type=string_types), string_delimiter='&'),
-        aliases=('disallow',))
-    rollback_enabled = ParameterLoader(PrimitiveParameter(True))
-    track_features = ParameterLoader(
-        SequenceParameter(PrimitiveParameter("", element_type=string_types)))
-    use_index_cache = ParameterLoader(PrimitiveParameter(False))
+    pinned_packages = SequenceParameter(string_types, string_delimiter='&')  # TODO: consider a different string delimiter  # NOQA
+    disallowed_packages = SequenceParameter(
+        string_types, aliases=('disallow',), string_delimiter='&'
+    )
+    rollback_enabled = PrimitiveParameter(True)
+    track_features = SequenceParameter(string_types)
+    use_index_cache = PrimitiveParameter(False)
 
-    separate_format_cache = ParameterLoader(PrimitiveParameter(False))
+    separate_format_cache = PrimitiveParameter(False)
 
-    _root_prefix = ParameterLoader(PrimitiveParameter(""), aliases=('root_dir', 'root_prefix'))
-    _envs_dirs = ParameterLoader(
-        SequenceParameter(PrimitiveParameter("", element_type=string_types),
-                          string_delimiter=os.pathsep),
-        aliases=('envs_dirs', 'envs_path'),
-        expandvars=True)
-    _pkgs_dirs = ParameterLoader(SequenceParameter(PrimitiveParameter("", string_types)),
-                                 aliases=('pkgs_dirs',),
-                                 expandvars=True)
-    _subdir = ParameterLoader(PrimitiveParameter(''), aliases=('subdir',))
-    _subdirs = ParameterLoader(
-        SequenceParameter(PrimitiveParameter("", string_types)), aliases=('subdirs',))
+    _root_prefix = PrimitiveParameter("", aliases=('root_dir', 'root_prefix'))
+    _envs_dirs = SequenceParameter(
+        string_types, aliases=('envs_dirs', 'envs_path'),
+        string_delimiter=os.pathsep, expandvars=True
+    )
+    _pkgs_dirs = SequenceParameter(
+        string_types, aliases=('pkgs_dirs',), expandvars=True
+    )
+    _subdir = PrimitiveParameter('', aliases=('subdir',))
+    _subdirs = SequenceParameter(string_types, aliases=('subdirs',))
 
-    local_repodata_ttl = ParameterLoader(PrimitiveParameter(1, element_type=(bool, int)))
+    local_repodata_ttl = PrimitiveParameter(1, element_type=(bool, int))
     # number of seconds to cache repodata locally
     #   True/1: respect Cache-Control max-age header
     #   False/0: always fetch remote repodata (HTTP 304 responses respected)
 
     # remote connection details
-    ssl_verify = ParameterLoader(
-        PrimitiveParameter(True,
-                           element_type=string_types + (bool,),
-                           validation=ssl_verify_validation),
-        aliases=('verify_ssl',),
-        expandvars=True)
-    client_ssl_cert = ParameterLoader(
-        PrimitiveParameter(None, element_type=string_types + (NoneType,)),
-        aliases=('client_cert',),
-        expandvars=True)
-    client_ssl_cert_key = ParameterLoader(
-        PrimitiveParameter(None, element_type=string_types + (NoneType,)),
-        aliases=('client_cert_key',),
-        expandvars=True)
-    proxy_servers = ParameterLoader(
-        MapParameter(PrimitiveParameter(None, string_types + (NoneType,))),
-        expandvars=True)
-    remote_connect_timeout_secs = ParameterLoader(PrimitiveParameter(9.15))
-    remote_read_timeout_secs = ParameterLoader(PrimitiveParameter(60.))
-    remote_max_retries = ParameterLoader(PrimitiveParameter(3))
-    remote_backoff_factor = ParameterLoader(PrimitiveParameter(1))
+    ssl_verify = PrimitiveParameter(
+        True, element_type=string_types + (bool,), aliases=('verify_ssl',),
+        validation=ssl_verify_validation, expandvars=True
+    )
+    client_ssl_cert = PrimitiveParameter(
+        None, aliases=('client_cert',), element_type=string_types + (NoneType,), expandvars=True
+    )
+    client_ssl_cert_key = PrimitiveParameter(
+        None, aliases=('client_cert_key',), element_type=string_types + (NoneType,),
+        expandvars=True
+    )
+    proxy_servers = MapParameter(string_types + (NoneType,), expandvars=True)
+    remote_connect_timeout_secs = PrimitiveParameter(9.15)
+    remote_read_timeout_secs = PrimitiveParameter(60.)
+    remote_max_retries = PrimitiveParameter(3)
+    remote_backoff_factor = PrimitiveParameter(1)
 
-    add_anaconda_token = ParameterLoader(PrimitiveParameter(True), aliases=('add_binstar_token',))
+    add_anaconda_token = PrimitiveParameter(True, aliases=('add_binstar_token',))
 
     # #############################
     # channels
     # #############################
-    allow_non_channel_urls = ParameterLoader(PrimitiveParameter(False))
-    _channel_alias = ParameterLoader(
-        PrimitiveParameter(DEFAULT_CHANNEL_ALIAS,
-                           validation=channel_alias_validation),
-        aliases=('channel_alias',))
-    channel_priority = ParameterLoader(PrimitiveParameter(ChannelPriority.FLEXIBLE))
-    _channels = ParameterLoader(
-        SequenceParameter(PrimitiveParameter(
-            "", element_type=string_types), default=(DEFAULTS_CHANNEL_NAME,)),
-        aliases=('channels', 'channel',),
-        expandvars=True)  # channel for args.channel
-    _custom_channels = ParameterLoader(
-        MapParameter(PrimitiveParameter("", element_type=string_types), DEFAULT_CUSTOM_CHANNELS),
-        aliases=('custom_channels',),
-        expandvars=True)
-    _custom_multichannels = ParameterLoader(
-        MapParameter(SequenceParameter(PrimitiveParameter("", element_type=string_types))),
-        aliases=('custom_multichannels',),
-        expandvars=True)
-    _default_channels = ParameterLoader(
-        SequenceParameter(PrimitiveParameter("", element_type=string_types), DEFAULT_CHANNELS),
-        aliases=('default_channels',),
-        expandvars=True)
-    _migrated_channel_aliases = ParameterLoader(
-        SequenceParameter(PrimitiveParameter("", element_type=string_types)),
-        aliases=('migrated_channel_aliases',))
-    migrated_custom_channels = ParameterLoader(
-        MapParameter(PrimitiveParameter("", element_type=string_types)),
-        expandvars=True)  # TODO: also take a list of strings
-    override_channels_enabled = ParameterLoader(PrimitiveParameter(True))
-    show_channel_urls = ParameterLoader(PrimitiveParameter(None, element_type=(bool, NoneType)))
-    use_local = ParameterLoader(PrimitiveParameter(False))
-    whitelist_channels = ParameterLoader(
-        SequenceParameter(PrimitiveParameter("", element_type=string_types)),
-        expandvars=True)
-    restore_free_channel = ParameterLoader(PrimitiveParameter(False))
-    repodata_fns = ParameterLoader(
-        SequenceParameter(
-            PrimitiveParameter("", element_type=string_types),
-            ("current_repodata.json", REPODATA_FN)))
-    _use_only_tar_bz2 = ParameterLoader(PrimitiveParameter(None, element_type=(bool, NoneType)),
-                                        aliases=('use_only_tar_bz2',))
-
-    always_softlink = ParameterLoader(PrimitiveParameter(False), aliases=('softlink',))
-    always_copy = ParameterLoader(PrimitiveParameter(False), aliases=('copy',))
-    always_yes = ParameterLoader(
-        PrimitiveParameter(None, element_type=(bool, NoneType)), aliases=('yes',))
-    debug = ParameterLoader(PrimitiveParameter(False))
-    dev = ParameterLoader(PrimitiveParameter(False))
-    dry_run = ParameterLoader(PrimitiveParameter(False))
-    error_upload_url = ParameterLoader(PrimitiveParameter(ERROR_UPLOAD_URL))
-    force = ParameterLoader(PrimitiveParameter(False))
-    json = ParameterLoader(PrimitiveParameter(False))
-    offline = ParameterLoader(PrimitiveParameter(False))
-    quiet = ParameterLoader(PrimitiveParameter(False))
-    ignore_pinned = ParameterLoader(PrimitiveParameter(False))
-    report_errors = ParameterLoader(PrimitiveParameter(None, element_type=(bool, NoneType)))
-    shortcuts = ParameterLoader(PrimitiveParameter(True))
-    _verbosity = ParameterLoader(
-        PrimitiveParameter(0, element_type=int), aliases=('verbose', 'verbosity'))
+    allow_non_channel_urls = PrimitiveParameter(False)
+    _channel_alias = PrimitiveParameter(
+        DEFAULT_CHANNEL_ALIAS, aliases=('channel_alias',), validation=channel_alias_validation
+    )
+    channel_priority = PrimitiveParameter(ChannelPriority.FLEXIBLE)
+    _channels = SequenceParameter(
+        string_types, default=(DEFAULTS_CHANNEL_NAME,),
+        aliases=('channels', 'channel',), expandvars=True
+    )  # channel for args.channel
+    _custom_channels = MapParameter(
+        string_types, DEFAULT_CUSTOM_CHANNELS, aliases=('custom_channels',), expandvars=True
+    )
+    _custom_multichannels = MapParameter(
+        list, aliases=('custom_multichannels',), expandvars=True
+    )
+    _default_channels = SequenceParameter(
+        string_types, DEFAULT_CHANNELS, aliases=('default_channels',), expandvars=True
+    )
+    _migrated_channel_aliases = SequenceParameter(
+        string_types, aliases=('migrated_channel_aliases',)
+    )
+    migrated_custom_channels = MapParameter(string_types, expandvars=True)  # TODO: also take a list of strings  # NOQA
+    override_channels_enabled = PrimitiveParameter(True)
+    show_channel_urls = PrimitiveParameter(None, element_type=(bool, NoneType))
+    use_local = PrimitiveParameter(False)
+    whitelist_channels = SequenceParameter(string_types, expandvars=True)
+    restore_free_channel = PrimitiveParameter(False)
+    repodata_fns = SequenceParameter(string_types, ("current_repodata.json", REPODATA_FN))
+    _use_only_tar_bz2 = PrimitiveParameter(
+        None, element_type=(bool, NoneType), aliases=('use_only_tar_bz2',)
+    )
+    always_softlink = PrimitiveParameter(False, aliases=('softlink',))
+    always_copy = PrimitiveParameter(False, aliases=('copy',))
+    always_yes = PrimitiveParameter(None, element_type=(bool, NoneType), aliases=('yes',))
+    debug = PrimitiveParameter(False)
+    dev = PrimitiveParameter(False)
+    dry_run = PrimitiveParameter(False)
+    error_upload_url = PrimitiveParameter(ERROR_UPLOAD_URL)
+    force = PrimitiveParameter(False)
+    json = PrimitiveParameter(False)
+    offline = PrimitiveParameter(False)
+    quiet = PrimitiveParameter(False)
+    ignore_pinned = PrimitiveParameter(False)
+    report_errors = PrimitiveParameter(None, element_type=(bool, NoneType))
+    shortcuts = PrimitiveParameter(True)
+    _verbosity = PrimitiveParameter(0, aliases=('verbose', 'verbosity'), element_type=int)
 
     # ######################################################
     # ##               Solver Configuration               ##
     # ######################################################
-    deps_modifier = ParameterLoader(PrimitiveParameter(DepsModifier.NOT_SET))
-    update_modifier = ParameterLoader(PrimitiveParameter(UpdateModifier.UPDATE_SPECS))
-    sat_solver = ParameterLoader(PrimitiveParameter(SatSolverChoice.PYCOSAT))
-    solver_ignore_timestamps = ParameterLoader(PrimitiveParameter(False))
+    deps_modifier = PrimitiveParameter(DepsModifier.NOT_SET)
+    update_modifier = PrimitiveParameter(UpdateModifier.UPDATE_SPECS)
+    sat_solver = PrimitiveParameter(SatSolverChoice.PYCOSAT)
+    solver_ignore_timestamps = PrimitiveParameter(False)
 
-    # # CLI-only
-    # no_deps = ParameterLoader(PrimitiveParameter(NULL, element_type=(type(NULL), bool)))
-    # # CLI-only
-    # only_deps = ParameterLoader(PrimitiveParameter(NULL, element_type=(type(NULL), bool)))
+    # no_deps = PrimitiveParameter(NULL, element_type=(type(NULL), bool))  # CLI-only
+    # only_deps = PrimitiveParameter(NULL, element_type=(type(NULL), bool))   # CLI-only
     #
-    # freeze_installed = ParameterLoader(PrimitiveParameter(False))
-    # update_deps = ParameterLoader(PrimitiveParameter(False), aliases=('update_dependencies',))
-    # update_specs = ParameterLoader(PrimitiveParameter(False))
-    # update_all = ParameterLoader(PrimitiveParameter(False))
+    # freeze_installed = PrimitiveParameter(False)
+    # update_deps = PrimitiveParameter(False, aliases=('update_dependencies',))
+    # update_specs = PrimitiveParameter(False)
+    # update_all = PrimitiveParameter(False)
 
-    force_remove = ParameterLoader(PrimitiveParameter(False))
-    force_reinstall = ParameterLoader(PrimitiveParameter(False))
+    force_remove = PrimitiveParameter(False)
+    force_reinstall = PrimitiveParameter(False)
 
-    target_prefix_override = ParameterLoader(PrimitiveParameter(''))
+    target_prefix_override = PrimitiveParameter('')
 
-    unsatisfiable_hints = ParameterLoader(PrimitiveParameter(True))
-    unsatisfiable_hints_check_depth = ParameterLoader(PrimitiveParameter(2))
+    unsatisfiable_hints = PrimitiveParameter(True)
+    unsatisfiable_hints_check_depth = PrimitiveParameter(2)
 
     # conda_build
-    bld_path = ParameterLoader(PrimitiveParameter(''))
-    anaconda_upload = ParameterLoader(
-        PrimitiveParameter(None, element_type=(bool, NoneType)), aliases=('binstar_upload',))
-    _croot = ParameterLoader(PrimitiveParameter(''), aliases=('croot',))
-    _conda_build = ParameterLoader(
-        MapParameter(PrimitiveParameter("", element_type=string_types)),
-        aliases=('conda-build', 'conda_build'))
+    bld_path = PrimitiveParameter('')
+    anaconda_upload = PrimitiveParameter(
+        None, element_type=(bool, NoneType), aliases=('binstar_upload',)
+    )
+    _croot = PrimitiveParameter('', aliases=('croot',))
+    _conda_build = MapParameter(string_types, aliases=('conda-build', 'conda_build'))
 
     def __init__(self, search_path=None, argparse_args=None):
         if search_path is None:

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -3,15 +3,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """
 A generalized application configuration utility.
-
 Features include:
   - lazy eval
   - merges configuration files
   - parameter type validation, with custom validation
   - parameter aliases
-
 Easily extensible to other source formats, e.g. json and ini
-
+Limitations:
+  - at the moment only supports a "flat" config structure; no nested data structures
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
@@ -21,7 +20,6 @@ try:
     from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
-import copy
 from glob import glob
 from itertools import chain
 from logging import getLogger
@@ -39,10 +37,10 @@ from .serialize import yaml_load
 from .. import CondaError, CondaMultiError
 from .._vendor.auxlib.collection import AttrDict, first, last, make_immutable
 from .._vendor.auxlib.exceptions import ThisShouldNeverHappenError
-from .._vendor.auxlib.type_coercion import TypeCoercionError, typify, typify_data_structure
+from .._vendor.auxlib.type_coercion import TypeCoercionError, typify_data_structure
 from .._vendor.frozendict import frozendict
 from .._vendor.boltons.setutils import IndexedSet
-from .._vendor.toolz import concat, concatv, excepts, merge, merge_with, unique
+from .._vendor.toolz import concat, concatv, excepts, merge, unique
 
 try:  # pragma: no cover
     from ruamel_yaml.comments import CommentedSeq, CommentedMap
@@ -216,15 +214,13 @@ class EnvRawParameter(RawParameter):
     source = 'envvars'
 
     def value(self, parameter_obj):
-        # note: this assumes that EnvRawParameters will only have flat configuration of either
-        # primitive or sequential type
         if hasattr(parameter_obj, 'string_delimiter'):
             assert isinstance(self._raw_value, string_types)
             string_delimiter = getattr(parameter_obj, 'string_delimiter')
             # TODO: add stripping of !important, !top, and !bottom
-            return tuple(EnvRawParameter(EnvRawParameter.source, self.key, v)
-                         for v in (vv.strip() for vv in self._raw_value.split(string_delimiter))
-                         if v)
+            return tuple(v for v in (
+                vv.strip() for vv in self._raw_value.split(string_delimiter)
+            ) if v)
         else:
             return self.__important_split_value[0].strip()
 
@@ -255,22 +251,13 @@ class ArgParseRawParameter(RawParameter):
     source = 'cmd_line'
 
     def value(self, parameter_obj):
-        # note: this assumes ArgParseRawParameter will only have flat configuration of either
-        # primitive or sequential type
-        if isiterable(self._raw_value):
-            children_values = []
-            for i in range(len(self._raw_value)):
-                children_values.append(ArgParseRawParameter(
-                    self.source, self.key, self._raw_value[i]))
-            return tuple(children_values)
-        else:
-            return make_immutable(self._raw_value)
+        return make_immutable(self._raw_value)
 
     def keyflag(self):
         return None
 
     def valueflags(self, parameter_obj):
-        return None if isinstance(parameter_obj, PrimitiveLoadedParameter) else ()
+        return None if isinstance(parameter_obj, PrimitiveParameter) else ()
 
     @classmethod
     def make_raw_parameters(cls, args_from_argparse):
@@ -281,40 +268,38 @@ class ArgParseRawParameter(RawParameter):
 class YamlRawParameter(RawParameter):
     # this class should encapsulate all direct use of ruamel.yaml in this module
 
-    def __init__(self, source, key, raw_value, key_comment):
-        self._key_comment = key_comment
+    def __init__(self, source, key, raw_value, keycomment):
+        self._keycomment = keycomment
         super(YamlRawParameter, self).__init__(source, key, raw_value)
 
-        if isinstance(self._raw_value, CommentedSeq):
-            value_comments = self._get_yaml_list_comments(self._raw_value)
-            self._value_flags = tuple(ParameterFlag.from_string(s) for s in value_comments)
-            children_values = []
-            for i in range(len(self._raw_value)):
-                children_values.append(YamlRawParameter(
-                    self.source, self.key, self._raw_value[i], value_comments[i]))
-            self._value = tuple(children_values)
-        elif isinstance(self._raw_value, CommentedMap):
-            value_comments = self._get_yaml_map_comments(self._raw_value)
-            self._value_flags = dict((k, ParameterFlag.from_string(v))
-                                     for k, v in iteritems(value_comments) if v is not None)
-            children_values = {}
-            for k, v in self._raw_value.items():
-                children_values[k] = YamlRawParameter(self.source, self.key, v, value_comments[k])
-            self._value = frozendict(children_values)
-        elif isinstance(self._raw_value, primitive_types):
-            self._value_flags = None
-            self._value = self._raw_value
-        else:
-            raise ThisShouldNeverHappenError()  # pragma: no cover
-
     def value(self, parameter_obj):
+        self.__process(parameter_obj)
         return self._value
 
     def keyflag(self):
-        return ParameterFlag.from_string(self._key_comment)
+        return ParameterFlag.from_string(self._keycomment)
 
     def valueflags(self, parameter_obj):
-        return self._value_flags
+        self.__process(parameter_obj)
+        return self._valueflags
+
+    def __process(self, parameter_obj):
+        if hasattr(self, '_value'):
+            return
+        elif isinstance(self._raw_value, CommentedSeq):
+            valuecomments = self._get_yaml_list_comments(self._raw_value)
+            self._valueflags = tuple(ParameterFlag.from_string(s) for s in valuecomments)
+            self._value = tuple(self._raw_value)
+        elif isinstance(self._raw_value, CommentedMap):
+            valuecomments = self._get_yaml_map_comments(self._raw_value)
+            self._valueflags = dict((k, ParameterFlag.from_string(v))
+                                    for k, v in iteritems(valuecomments) if v is not None)
+            self._value = frozendict(self._raw_value)
+        elif isinstance(self._raw_value, primitive_types):
+            self._valueflags = None
+            self._value = self._raw_value
+        else:
+            raise ThisShouldNeverHappenError()  # pragma: no cover
 
     @staticmethod
     def _get_yaml_key_comment(commented_dict, key):
@@ -326,30 +311,20 @@ class YamlRawParameter(RawParameter):
     @staticmethod
     def _get_yaml_list_comments(value):
         items = value.ca.items
-        raw_comment_lines = tuple(excepts((AttributeError, IndexError, KeyError, TypeError),
-                                          lambda q: YamlRawParameter._get_yaml_list_comment_item(
-                                              items[q]),
+        raw_comment_lines = tuple(excepts((AttributeError, KeyError, TypeError),
+                                          lambda q: items.get(q)[0].value.strip() or None,
                                           lambda _: None  # default value on exception
                                           )(q)
                                   for q in range(len(value)))
         return raw_comment_lines
 
     @staticmethod
-    def _get_yaml_list_comment_item(item):
-        # take the pre_item comment if available
-        # if not, take the first post_item comment if available
-        if item[0]:
-            return item[0].value.strip() or None
-        else:
-            return item[1][0].value.strip() or None
-
-    @staticmethod
-    def _get_yaml_map_comments(value):
+    def _get_yaml_map_comments(rawvalue):
         return dict((key, excepts((AttributeError, KeyError),
-                                  lambda k: value.ca.items[k][2].value.strip() or None,
+                                  lambda k: rawvalue.ca.items[k][2].value.strip() or None,
                                   lambda _: None  # default value on exception
                                   )(key))
-                    for key in value)
+                    for key in rawvalue)
 
     @classmethod
     def make_raw_parameters(cls, source, from_map):
@@ -377,59 +352,6 @@ class YamlRawParameter(RawParameter):
                                              "  reason: invalid yaml at position %(position)s",
                                              position=err.position)
             return cls.make_raw_parameters(filepath, ruamel_yaml) or EMPTY_MAP
-
-
-class DefaultValueRawParameter(RawParameter):
-    """
-    Wraps a default value as a RawParameter, for usage in ParameterLoader.
-    """
-
-    def __init__(self, source, key, raw_value):
-        super(DefaultValueRawParameter, self).__init__(source, key, raw_value)
-
-        if isinstance(self._raw_value, Mapping):
-            children_values = {}
-            for k, v in self._raw_value.items():
-                children_values[k] = DefaultValueRawParameter(self.source, self.key, v)
-            self._value = frozendict(children_values)
-        elif isiterable(self._raw_value):
-            children_values = []
-            for i in range(len(self._raw_value)):
-                children_values.append(DefaultValueRawParameter(
-                    self.source, self.key, self._raw_value[i]))
-            self._value = tuple(children_values)
-        elif isinstance(self._raw_value, ConfigurationObject):
-            self._value = self._raw_value
-            for attr_name, attr_value in vars(self._raw_value).items():
-                self._value.__setattr__(
-                    attr_name,
-                    DefaultValueRawParameter(self.source, self.key, attr_value))
-        elif isinstance(self._raw_value, Enum):
-            self._value = self._raw_value
-        elif isinstance(self._raw_value, primitive_types):
-            self._value = self._raw_value
-        else:
-            raise ThisShouldNeverHappenError()  # pragma: no cover
-
-    def value(self, parameter_obj):
-        return self._value
-
-    def keyflag(self):
-        return None
-
-    def valueflags(self, parameter_obj):
-        if isinstance(self._raw_value, Mapping):
-            return frozendict()
-        elif isiterable(self._raw_value):
-            return tuple()
-        elif isinstance(self._raw_value, ConfigurationObject):
-            return None
-        elif isinstance(self._raw_value, Enum):
-            return None
-        elif isinstance(self._raw_value, primitive_types):
-            return None
-        else:
-            raise ThisShouldNeverHappenError()  # pragma: no cover
 
 
 def load_file_configs(search_path):
@@ -467,708 +389,16 @@ def load_file_configs(search_path):
 
 
 @with_metaclass(ABCMeta)
-class LoadedParameter(object):
-    # (type) describes the type of parameter
-    _type = None
-    # (Parameter or type) if the LoadedParameter holds a collection, describes the element held in
-    # the collection. if not, describes the primitive type held by the LoadedParameter.
-    _element_type = None
-
-    def __init__(self, name, value, key_flag, value_flags, validation=None):
-        """
-        Represents a Parameter that has been loaded with configuration value.
-
-        Args:
-            name (str): name of the loaded parameter
-            value (LoadedParameter or primitive): the value of the loaded parameter
-            key_flag (ParameterFlag or None): priority flag for the parameter itself
-            value_flags (Any or None): priority flags for the parameter values
-            validation (callable): Given a parameter value as input, return a boolean indicating
-                validity, or alternately return a string describing an invalid value.
-        """
-        self._name = name
-        self.value = value
-        self.key_flag = key_flag
-        self.value_flags = value_flags
-        self._validation = validation
-
-    def __eq__(self, other):
-        if type(other) is type(self):
-            return self.value == other.value
-        return False
-
-    def __hash__(self):
-        return hash(self.value)
-
-    def collect_errors(self, instance, typed_value, source="<<merged>>"):
-        """
-        Validate a LoadedParameter typed value.
-
-        Args:
-            instance (Configuration): the instance object used to create the LoadedParameter.
-            typed_value (Any): typed value to validate.
-            source (str): string description for the source of the typed_value.
-        """
-        errors = []
-        if not isinstance(typed_value, self._type):
-            errors.append(InvalidTypeError(self._name, typed_value, source, type(self.value),
-                                           self._type))
-        elif self._validation is not None:
-            result = self._validation(typed_value)
-            if result is False:
-                errors.append(ValidationError(self._name, typed_value, source))
-            elif isinstance(result, string_types):
-                errors.append(CustomValidationError(self._name, typed_value, source, result))
-        return errors
-
-    def expand(self):
-        """
-        Recursively expands any environment values in the Loaded Parameter.
-
-        Returns: LoadedParameter
-        """
-        # This is similar to conda._vendor.auxlib.type_coercion.typify_data_structure
-        # It could be DRY-er but that would break SRP.
-        if isinstance(self.value, Mapping):
-            new_value = type(self.value)((k, v.expand()) for k, v in iteritems(self.value))
-        elif isiterable(self.value):
-            new_value = type(self.value)(v.expand() for v in self.value)
-        elif isinstance(self.value, ConfigurationObject):
-            for attr_name, attr_value in vars(self.value).items():
-                if isinstance(attr_value, LoadedParameter):
-                    self.value.__setattr__(attr_name, attr_value.expand())
-            return self.value
-        else:
-            new_value = expand_environment_variables(self.value)
-        self.value = new_value
-        return self
-
-    @abstractmethod
-    def merge(self, matches):
-        """
-        Recursively merges matches into one LoadedParameter.
-
-        Args:
-            matches (List<LoadedParameter>): list of matches of this parameter.
-
-        Returns: LoadedParameter
-        """
-        raise NotImplementedError()
-
-    def typify(self, source):
-        """
-        Recursively types a LoadedParameter.
-
-        Args:
-            source (str): string describing the source of the LoadedParameter.
-
-        Returns: a primitive, sequence, or map representing the typed value.
-        """
-        element_type = self._element_type
-        try:
-            return LoadedParameter._typify_data_structure(self.value, source, element_type)
-        except TypeCoercionError as e:
-            # if name is None:
-            #     name = self.name
-            msg = text_type(e)
-            if issubclass(element_type, Enum):
-                choices = ", ".join(map("'{}'".format, element_type.__members__.values()))
-                msg += "\nValid choices for {}: {}".format(self._name, choices)
-            raise CustomValidationError(self._name, e.value, source, msg)
-
-    @staticmethod
-    def _typify_data_structure(value, source, type_hint=None):
-        if isinstance(value, Mapping):
-            return type(value)((k, v.typify(source)) for k, v in iteritems(value))
-        elif isiterable(value):
-            return type(value)(v.typify(source) for v in value)
-        elif isinstance(value, ConfigurationObject):
-            for attr_name, attr_value in vars(value).items():
-                if isinstance(attr_value, LoadedParameter):
-                    value.__setattr__(attr_name, attr_value.typify(source))
-            return value
-        elif (isinstance(value, string_types)
-              and isinstance(type_hint, type) and issubclass(type_hint, string_types)):
-            # This block is necessary because if we fall through to typify(), we end up calling
-            # .strip() on the str, when sometimes we want to preserve preceding and trailing
-            # whitespace.
-            return type_hint(value)
-        else:
-            return typify(value, type_hint)
-
-    @staticmethod
-    def _match_key_is_important(loaded_parameter):
-        return loaded_parameter.key_flag is ParameterFlag.final
-
-    @staticmethod
-    def _first_important_matches(matches):
-        idx = first(enumerate(matches),
-                    lambda x: LoadedParameter._match_key_is_important(x[1]),
-                    apply=lambda x: x[0])
-        return matches if idx is None else matches[:idx+1]
-
-
-class PrimitiveLoadedParameter(LoadedParameter):
-    """
-    LoadedParameter type that holds a single python primitive value.
-
-    The python primitive types are str, int, float, complex, bool, and NoneType. In addition,
-    python 2 has long and unicode types.
-    """
-
-    def __init__(self, name, element_type, value, key_flag, value_flags, validation=None):
-        """
-        Args:
-            element_type (type or Tuple[type]): Type-validation of parameter's value.
-            value (primitive value): primitive python value.
-        """
-        self._type = element_type
-        self._element_type = element_type
-        super(PrimitiveLoadedParameter, self).__init__(
-            name, value, key_flag, value_flags, validation)
-
-    def __eq__(self, other):
-        if type(other) is type(self):
-            return self.value == other.value
-        return False
-
-    def __hash__(self):
-        return hash(self.value)
-
-    def merge(self, matches):
-        important_match = first(matches, LoadedParameter._match_key_is_important, default=None)
-        if important_match is not None:
-            return important_match
-
-        last_match = last(matches, lambda x: x is not None, default=None)
-        if last_match is not None:
-            return last_match
-        raise ThisShouldNeverHappenError()  # pragma: no cover
-
-
-class MapLoadedParameter(LoadedParameter):
-    """
-    LoadedParameter type that holds a map (i.e. dict) of LoadedParameters.
-    """
-    _type = frozendict
-
-    def __init__(self, name, value, element_type, key_flag, value_flags, validation=None):
-        """
-        Args:
-            value (Mapping): Map of string keys to LoadedParameter values.
-            element_type (Parameter): The Parameter type that is held in value.
-            value_flags (Mapping): Map of priority value flags.
-        """
-        self._element_type = element_type
-        super(MapLoadedParameter, self).__init__(name, value, key_flag, value_flags, validation)
-
-    def collect_errors(self, instance, typed_value, source="<<merged>>"):
-        errors = super(MapLoadedParameter, self).collect_errors(instance, typed_value, self.value)
-
-        # recursively validate the values in the map
-        if isinstance(self.value, Mapping):
-            for key, value in iteritems(self.value):
-                errors.extend(value.collect_errors(instance, typed_value[key], source))
-        return errors
-
-    def merge(self, matches):
-
-        # get matches up to and including first important_match
-        # but if no important_match, then all matches are important_matches
-        relevant_matches_and_values = tuple((match, match.value) for match in
-                                            LoadedParameter._first_important_matches(matches))
-
-        for match, value in relevant_matches_and_values:
-            if not isinstance(value, Mapping):
-                raise InvalidTypeError(self.name, value, match.source, value.__class__.__name__,
-                                       self._type.__name__)
-
-        # map keys with important values
-        def key_is_important(match, key):
-            return match.value_flags.get(key) == ParameterFlag.final
-        important_maps = tuple(dict((k, v)
-                                    for k, v in iteritems(match_value)
-                                    if key_is_important(match, k))
-                               for match, match_value in relevant_matches_and_values)
-
-        # map each value by recursively calling merge on any entries with the same key
-        merged_values = frozendict(merge_with(
-            lambda value_matches: value_matches[0].merge(value_matches),
-            (match_value for _, match_value in relevant_matches_and_values)))
-
-        # dump all matches in a dict
-        # then overwrite with important matches
-        merged_values_important_overwritten = frozendict(merge(
-            concatv([merged_values], reversed(important_maps))))
-
-        # create new parameter for the merged values
-        return MapLoadedParameter(
-            self._name,
-            merged_values_important_overwritten,
-            self._element_type,
-            self.key_flag,
-            self.value_flags,
-            validation=self._validation)
-
-
-class SequenceLoadedParameter(LoadedParameter):
-    """
-    LoadedParameter type that holds a sequence (i.e. list) of LoadedParameters.
-    """
-    _type = tuple
-
-    def __init__(self, name, value, element_type, key_flag, value_flags, validation=None):
-        """
-        Args:
-            value (Sequence): Sequence of LoadedParameter values.
-            element_type (Parameter): The Parameter type that is held in the sequence.
-            value_flags (Sequence): Sequence of priority value_flags.
-        """
-        self._element_type = element_type
-        super(SequenceLoadedParameter, self).__init__(
-            name, value, key_flag, value_flags, validation)
-
-    def collect_errors(self, instance, typed_value, source="<<merged>>"):
-        errors = super(SequenceLoadedParameter, self).collect_errors(
-            instance, typed_value, self.value)
-        # recursively collect errors on the elements in the sequence
-        for idx, element in enumerate(self.value):
-            errors.extend(element.collect_errors(instance, typed_value[idx], source))
-        return errors
-
-    def merge(self, matches):
-
-        # get matches up to and including first important_match
-        # but if no important_match, then all matches are important_matches
-        relevant_matches_and_values = tuple((match, match.value) for match in
-                                            LoadedParameter._first_important_matches(matches))
-        for match, value in relevant_matches_and_values:
-            if not isinstance(value, tuple):
-                raise InvalidTypeError(self.name, value, match.source, value.__class__.__name__,
-                                       self._type.__name__)
-
-        # get individual lines from important_matches that were marked important
-        # these will be prepended to the final result
-        def get_marked_lines(match, marker):
-            return tuple(line
-                         for line, flag in zip(match.value,
-                                               match.value_flags)
-                         if flag is marker) if match else ()
-        top_lines = concat(get_marked_lines(m, ParameterFlag.top) for m, _ in
-                           relevant_matches_and_values)
-
-        # also get lines that were marked as bottom, but reverse the match order so that lines
-        # coming earlier will ultimately be last
-        bottom_lines = concat(get_marked_lines(m, ParameterFlag.bottom) for m, _ in
-                              reversed(relevant_matches_and_values))
-
-        # now, concat all lines, while reversing the matches
-        #   reverse because elements closer to the end of search path take precedence
-        all_lines = concat(v for _, v in reversed(relevant_matches_and_values))
-
-        # stack top_lines + all_lines, then de-dupe
-        top_deduped = tuple(unique(concatv(top_lines, all_lines)))
-
-        # take the top-deduped lines, reverse them, and concat with reversed bottom_lines
-        # this gives us the reverse of the order we want, but almost there
-        # NOTE: for a line value marked both top and bottom, the bottom marker will win out
-        #       for the top marker to win out, we'd need one additional de-dupe step
-        bottom_deduped = unique(concatv(reversed(tuple(bottom_lines)), reversed(top_deduped)))
-        # just reverse, and we're good to go
-        merged_values = tuple(reversed(tuple(bottom_deduped)))
-
-        return SequenceLoadedParameter(
-            self._name,
-            merged_values,
-            self._element_type,
-            self.key_flag,
-            self.value_flags,
-            validation=self._validation)
-
-
-class ObjectLoadedParameter(LoadedParameter):
-    """
-    LoadedParameter type that holds a sequence (i.e. list) of LoadedParameters.
-    """
-    _type = object
-
-    def __init__(self, name, value, element_type, key_flag, value_flags, validation=None):
-        """
-        Args:
-            value (Sequence): Object with LoadedParameter fields.
-            element_type (object): The Parameter type that is held in the sequence.
-            value_flags (Sequence): Sequence of priority value_flags.
-        """
-        self._element_type = element_type
-        super(ObjectLoadedParameter, self).__init__(
-            name, value, key_flag, value_flags, validation)
-
-    def collect_errors(self, instance, typed_value, source="<<merged>>"):
-        errors = super(ObjectLoadedParameter, self).collect_errors(
-            instance, typed_value, self.value)
-
-        # recursively validate the values in the object fields
-        if isinstance(self.value, ConfigurationObject):
-            for key, value in vars(self.value).items():
-                if isinstance(value, LoadedParameter):
-                    errors.extend(value.collect_errors(instance, typed_value[key], source))
-        return errors
-
-    def merge(self, matches):
-        # get matches up to and including first important_match
-        # but if no important_match, then all matches are important_matches
-        relevant_matches_and_values = tuple((match,
-                                             {k: v for k, v
-                                              in vars(match.value).items()
-                                              if isinstance(v, LoadedParameter)})
-                                            for match
-                                            in LoadedParameter._first_important_matches(matches))
-
-        for match, value in relevant_matches_and_values:
-            if not isinstance(value, Mapping):
-                raise InvalidTypeError(self.name, value, match.source, value.__class__.__name__,
-                                       self._type.__name__)
-
-        # map keys with important values
-        def key_is_important(match, key):
-            return match.value_flags.get(key) == ParameterFlag.final
-        important_maps = tuple(dict((k, v)
-                                    for k, v in iteritems(match_value)
-                                    if key_is_important(match, k))
-                               for match, match_value in relevant_matches_and_values)
-
-        # map each value by recursively calling merge on any entries with the same key
-        merged_values = frozendict(merge_with(
-            lambda value_matches: value_matches[0].merge(value_matches),
-            (match_value for _, match_value in relevant_matches_and_values)))
-
-        # dump all matches in a dict
-        # then overwrite with important matches
-        merged_values_important_overwritten = frozendict(merge(
-            concatv([merged_values], reversed(important_maps))))
-
-        # copy object and replace Parameter with LoadedParameter fields
-        object_copy = copy.deepcopy(self._element_type)
-        for attr_name, loaded_child_parameter in merged_values_important_overwritten.items():
-            object_copy.__setattr__(attr_name, loaded_child_parameter)
-
-        # create new parameter for the merged values
-        return ObjectLoadedParameter(
-            self._name,
-            object_copy,
-            self._element_type,
-            self.key_flag,
-            self.value_flags,
-            validation=self._validation)
-
-
-class ConfigurationObject(object):
-    """
-    Dummy class to mark whether a Python object has config parameters within.
-    """
-    pass
-
-
-@with_metaclass(ABCMeta)
 class Parameter(object):
-    # (type) describes the type of parameter
     _type = None
-    # (Parameter or type) if the Parameter is holds a collection, describes the element held in
-    # the collection. if not, describes the primitive type held by the Parameter.
     _element_type = None
 
-    def __init__(self, default, validation=None):
-        """
-        The Parameter class represents an unloaded configuration parameter, holding type, default
-        and validation information until the parameter is loaded with a configuration.
-
-        Args:
-            default (Any): the typed, python representation default value given if the Parameter
-                is not found in a Configuration.
-            validation (callable): Given a parameter value as input, return a boolean indicating
-                validity, or alternately return a string describing an invalid value.
-        """
-        self._default = default
-        self._validation = validation
-
-    @property
-    def default(self):
-        """
-        Returns a DefaultValueRawParameter that wraps the actual default value.
-        """
-        wrapped_default = DefaultValueRawParameter("default", "default", self._default)
-        return self.load("default", wrapped_default)
-
-    def get_all_matches(self, name, names, instance):
-        """
-        Finds all matches of a Parameter in a Configuration instance
-
-        Args:
-            name (str): canonical name of the parameter to search for
-            names (tuple(str)): alternative aliases of the parameter
-            instance (Configuration): instance of the configuration to search within
-
-        Returns (List(RawParameter)): matches of the parameter found in the configuration.
-        """
-        matches = []
-        multikey_exceptions = []
-        for filepath, raw_parameters in iteritems(instance.raw_data):
-            match, error = ParameterLoader.raw_parameters_from_single_source(
-                name, names, raw_parameters)
-            if match is not None:
-                matches.append(match)
-            if error:
-                multikey_exceptions.append(error)
-        return matches, multikey_exceptions
-
-    @abstractmethod
-    def load(self, name, match):
-        """
-        Loads a Parameter with the value in a RawParameter.
-
-        Args:
-            name (str): name of the parameter to pass through
-            match (RawParameter): the value of the RawParameter match
-
-        Returns a LoadedParameter
-        """
-        raise NotImplementedError()
-
-    def typify(self, name, source, value):
-        element_type = self._element_type
-        try:
-            return typify_data_structure(value, element_type)
-        except TypeCoercionError as e:
-            # if name is None:
-            #     name = self.name
-            msg = text_type(e)
-            if issubclass(element_type, Enum):
-                choices = ", ".join(map("'{}'".format, element_type.__members__.values()))
-                msg += "\nValid choices for {}: {}".format(name, choices)
-            raise CustomValidationError(name, e.value, source, msg)
-
-
-class PrimitiveParameter(Parameter):
-    """
-    Parameter type for a Configuration class that holds a single python primitive value.
-
-    The python primitive types are str, int, float, complex, bool, and NoneType. In addition,
-    python 2 has long and unicode types.
-    """
-
-    def __init__(self, default, element_type=None, validation=None):
-        """
-        Args:
-            default (primitive value): default value if the Parameter is not found.
-            element_type (type or Tuple[type]): Type-validation of parameter's value. If None,
-                type(default) is used.
-        """
-        self._type = type(default) if element_type is None else element_type
-        self._element_type = self._type
-        super(PrimitiveParameter, self).__init__(default, validation)
-
-    def load(self, name, match):
-        return PrimitiveLoadedParameter(
-            name,
-            self._type,
-            match.value(self._element_type),
-            match.keyflag(),
-            match.valueflags(self._element_type),
-            validation=self._validation)
-
-
-class MapParameter(Parameter):
-    """
-    Parameter type for a Configuration class that holds a map (i.e. dict) of Parameters.
-    """
-    _type = frozendict
-
-    def __init__(self, element_type, default=frozendict(), validation=None):
-        """
-        Args:
-            element_type (Parameter): The Parameter type held in the MapParameter.
-            default (Mapping):  The parameter's default value. If None, will be an empty dict.
-        """
-        self._element_type = element_type
-        default = default and frozendict(default) or frozendict()
-        super(MapParameter, self).__init__(default, validation=validation)
-
-    def get_all_matches(self, name, names, instance):
-        # it also config settings like `proxy_servers: ~`
-        matches, exceptions = super(MapParameter, self).get_all_matches(name, names, instance)
-        matches = tuple(m for m in matches if m._raw_value is not None)
-        return matches, exceptions
-
-    def load(self, name, match):
-
-        value = match.value(self._element_type)
-        if value is None:
-            return MapLoadedParameter(
-                name,
-                frozendict(),
-                self._element_type,
-                match.keyflag(),
-                frozendict(),
-                validation=self._validation)
-
-        if not isinstance(value, Mapping):
-            raise InvalidTypeError(name, value, match.source, value.__class__.__name__,
-                                   self._type.__name__)
-
-        loaded_map = {}
-        for key, child_value in match.value(self._element_type).items():
-            loaded_child_value = self._element_type.load(name, child_value)
-            loaded_map[key] = loaded_child_value
-
-        return MapLoadedParameter(
-            name,
-            frozendict(loaded_map),
-            self._element_type,
-            match.keyflag(),
-            match.valueflags(self._element_type),
-            validation=self._validation)
-
-
-class SequenceParameter(Parameter):
-    """
-    Parameter type for a Configuration class that holds a sequence (i.e. list) of Parameters.
-    """
-    _type = tuple
-
-    def __init__(self, element_type, default=(), validation=None, string_delimiter=','):
-        """
-        Args:
-            element_type (Parameter): The Parameter type that is held in the sequence.
-            default (Sequence): default value, empty tuple if not given.
-            string_delimiter (str): separation string used to parse string into sequence.
-        """
-        self._element_type = element_type
-        self.string_delimiter = string_delimiter
-        super(SequenceParameter, self).__init__(default, validation)
-
-    def get_all_matches(self, name, names, instance):
-        # this is necessary to handle argparse `action="append"`, which can't be set to a
-        #   default value of NULL
-        # it also config settings like `channels: ~`
-        matches, exceptions = super(SequenceParameter, self).get_all_matches(name, names, instance)
-        matches = tuple(m for m in matches if m._raw_value is not None)
-        return matches, exceptions
-
-    def load(self, name, match):
-
-        value = match.value(self)
-        if value is None:
-            return SequenceLoadedParameter(
-                name,
-                tuple(),
-                self._element_type,
-                match.keyflag(),
-                tuple(),
-                validation=self._validation)
-
-        if not isiterable(value):
-            raise InvalidTypeError(name, value, match.source, value.__class__.__name__,
-                                   self._type.__name__)
-
-        loaded_sequence = []
-        for child_value in value:
-            loaded_child_value = self._element_type.load(name, child_value)
-            loaded_sequence.append(loaded_child_value)
-
-        return SequenceLoadedParameter(
-            name,
-            tuple(loaded_sequence),
-            self._element_type,
-            match.keyflag(),
-            match.valueflags(self._element_type),
-            validation=self._validation)
-
-
-class ObjectParameter(Parameter):
-    """
-    Parameter type for a Configuration class that holds an object with Parameter fields.
-    """
-    _type = object
-
-    def __init__(self, element_type, default=ConfigurationObject(), validation=None):
-        """
-        Args:
-            element_type (object): The object type with parameter fields held in ObjectParameter.
-            default (Sequence): default value, empty tuple if not given.
-        """
-        self._element_type = element_type
-        super(ObjectParameter, self).__init__(default, validation)
-
-    def get_all_matches(self, name, names, instance):
-        # it also config settings like `proxy_servers: ~`
-        matches, exceptions = super(ObjectParameter, self).get_all_matches(name, names, instance)
-        matches = tuple(m for m in matches if m._raw_value is not None)
-        return matches, exceptions
-
-    def load(self, name, match):
-
-        value = match.value(self._element_type)
-        if value is None:
-            return ObjectLoadedParameter(
-                name,
-                None,
-                self._element_type,
-                match.keyflag(),
-                None,
-                validation=self._validation)
-
-        if not (isinstance(value, Mapping) or isinstance(value, ConfigurationObject)):
-            raise InvalidTypeError(name, value, match.source, value.__class__.__name__,
-                                   self._type.__name__)
-
-        # for a default object, extract out the instance variables
-        if isinstance(value, ConfigurationObject):
-            value = vars(value)
-
-        object_parameter_attrs = {attr_name: parameter_type
-                                  for attr_name, parameter_type
-                                  in vars(self._element_type).items()
-                                  if isinstance(parameter_type, Parameter)
-                                  and attr_name in value.keys()}
-
-        # recursively load object fields
-        loaded_attrs = {}
-        for attr_name, parameter_type in object_parameter_attrs.items():
-            raw_child_value = value.get(attr_name)
-            loaded_child_value = parameter_type.load(name, raw_child_value)
-            loaded_attrs[attr_name] = loaded_child_value
-
-        # copy object and replace Parameter with LoadedParameter fields
-        object_copy = copy.deepcopy(self._element_type)
-        for attr_name, loaded_child_parameter in loaded_attrs.items():
-            object_copy.__setattr__(attr_name, loaded_child_parameter)
-
-        return ObjectLoadedParameter(
-            name,
-            object_copy,
-            self._element_type,
-            match.keyflag(),
-            match.valueflags(self._element_type),
-            validation=self._validation)
-
-
-class ParameterLoader(object):
-    """
-    ParameterLoader class contains the top level logic needed to load a parameter from start to
-    finish.
-    """
-
-    def __init__(self, parameter_type, aliases=(), expandvars=False):
-        """
-        Args:
-            parameter_type (Parameter): the type of Parameter that is stored in the loader.
-            aliases (tuple(str)): alternative aliases for the Parameter
-            expandvars (bool): whether or not to recursively expand environmental variables.
-        """
+    def __init__(self, default, aliases=(), validation=None, expandvars=False):
         self._name = None
         self._names = None
-        self.type = parameter_type
+        self.default = default
         self.aliases = aliases
+        self._validation = validation
         self._expandvars = expandvars
 
     def _set_name(self, name):
@@ -1193,6 +423,52 @@ class ParameterLoader(object):
             raise ThisShouldNeverHappenError()  # pragma: no cover
         return self._names
 
+    def _raw_parameters_from_single_source(self, raw_parameters):
+        # while supporting parameter name aliases, we enforce that only one definition is given
+        # per data source
+        keys = self.names & frozenset(raw_parameters.keys())
+        matches = {key: raw_parameters[key] for key in keys}
+        numkeys = len(keys)
+        if numkeys == 0:
+            return None, None
+        elif numkeys == 1:
+            return next(itervalues(matches)), None
+        elif self.name in keys:
+            return matches[self.name], MultipleKeysError(raw_parameters[next(iter(keys))].source,
+                                                         keys, self.name)
+        else:
+            return None, MultipleKeysError(raw_parameters[next(iter(keys))].source,
+                                           keys, self.name)
+
+    def _get_all_matches(self, instance):
+        # a match is a raw parameter instance
+        matches = []
+        multikey_exceptions = []
+        for filepath, raw_parameters in iteritems(instance.raw_data):
+            match, error = self._raw_parameters_from_single_source(raw_parameters)
+            if match is not None:
+                matches.append(match)
+            if error:
+                multikey_exceptions.append(error)
+        return matches, multikey_exceptions
+
+    @abstractmethod
+    def _merge(self, matches):
+        raise NotImplementedError()
+
+    def _expand(self, data):
+        if self._expandvars:
+            # This is similar to conda._vendor.auxlib.type_coercion.typify_data_structure
+            # It could be DRY-er but that would break SRP.
+            if isinstance(data, Mapping):
+                return type(data)((k, expand_environment_variables(v)) for k, v in iteritems(data))
+            elif isiterable(data):
+                return type(data)(expand_environment_variables(v) for v in data)
+            else:
+                return expand_environment_variables(data)
+        else:
+            return data
+
     def __get__(self, instance, instance_type):
         # strategy is "extract and merge," which is actually just map and reduce
         # extract matches from each source in SEARCH_PATH
@@ -1200,50 +476,268 @@ class ParameterLoader(object):
         if self.name in instance._cache_:
             return instance._cache_[self.name]
 
-        # step 1/2: load config and find top level matches
-        raw_matches, errors = self.type.get_all_matches(self.name, self.names, instance)
-
-        # step 3: parse RawParameters into LoadedParameters
-        matches = [self.type.load(self.name, match) for match in raw_matches]
-
-        # step 4: merge matches
-        merged = matches[0].merge(matches) if matches else self.type.default
-
-        # step 5: typify
+        matches, errors = self._get_all_matches(instance)
+        merged = self._merge(matches) if matches else self.default
         # We need to expand any environment variables before type casting.
         # Otherwise e.g. `my_bool_var: $BOOL` with BOOL=True would raise a TypeCoercionError.
-        expanded = merged.expand() if self._expandvars else merged
+        expanded = self._expand(merged)
         try:
-            result = expanded.typify("<<merged>>")
+            result = self.typify(expanded, "<<merged>>")
         except CustomValidationError as e:
             errors.append(e)
         else:
-            errors.extend(expanded.collect_errors(instance, result, "<<merged>>"))
+            errors.extend(self.collect_errors(instance, result))
         raise_errors(errors)
         instance._cache_[self.name] = result  # lgtm [py/uninitialized-local-variable]
         return result  # lgtm [py/uninitialized-local-variable]
 
-    def _raw_parameters_from_single_source(self, raw_parameters):
-        return ParameterLoader.raw_parameters_from_single_source(
-            self.name, self.names, raw_parameters)
+    def collect_errors(self, instance, value, source="<<merged>>"):
+        """Validate a Parameter value.
+        Args:
+            instance (Configuration): The instance object to which the Parameter descriptor is
+                attached.
+            value: The value to be validated.
+        """
+        errors = []
+        if not isinstance(value, self._type):
+            errors.append(InvalidTypeError(self.name, value, source, type(value),
+                                           self._type))
+        elif self._validation is not None:
+            result = self._validation(value)
+            if result is False:
+                errors.append(ValidationError(self.name, value, source))
+            elif isinstance(result, string_types):
+                errors.append(CustomValidationError(self.name, value, source, result))
+        return errors
+
+    def _match_key_is_important(self, raw_parameter):
+        return raw_parameter.keyflag() is ParameterFlag.final
+
+    def _first_important_matches(self, matches):
+        idx = first(enumerate(matches), lambda x: self._match_key_is_important(x[1]),
+                    apply=lambda x: x[0])
+        return matches if idx is None else matches[:idx+1]
 
     @staticmethod
-    def raw_parameters_from_single_source(name, names, raw_parameters):
-        # while supporting parameter name aliases, we enforce that only one definition is given
-        # per data source
-        keys = names & frozenset(raw_parameters.keys())
-        matches = {key: raw_parameters[key] for key in keys}
-        numkeys = len(keys)
-        if numkeys == 0:
-            return None, None
-        elif numkeys == 1:
-            return next(itervalues(matches)), None
-        elif name in keys:
-            return matches[name], MultipleKeysError(
-                raw_parameters[next(iter(keys))].source, keys, name)
-        else:
-            return None, MultipleKeysError(raw_parameters[next(iter(keys))].source,
-                                           keys, name)
+    def _str_format_flag(flag):
+        return "  #!%s" % flag if flag is not None else ''
+
+    @staticmethod
+    def _str_format_value(value):
+        if value is None:
+            return 'None'
+        return value
+
+    @classmethod
+    def repr_raw(cls, raw_parameter):
+        raise NotImplementedError()
+
+    def typify(self, value, source, name=None):
+        element_type = self._element_type
+        try:
+            return typify_data_structure(value, element_type)
+        except TypeCoercionError as e:
+            if name is None:
+                name = self.name
+            msg = text_type(e)
+            if issubclass(element_type, Enum):
+                choices = ", ".join(map("'{}'".format, element_type.__members__.values()))
+                msg += "\nValid choices for {}: {}".format(name, choices)
+            raise CustomValidationError(name, e.value, source, msg)
+
+
+class PrimitiveParameter(Parameter):
+    """Parameter type for a Configuration class that holds a single python primitive value.
+    The python primitive types are str, int, float, complex, bool, and NoneType. In addition,
+    python 2 has long and unicode types.
+    """
+
+    def __init__(self, default, aliases=(), validation=None, element_type=None, expandvars=False):
+        """
+        Args:
+            default (Any):  The parameter's default value.
+            aliases (Iterable[str]): Alternate names for the parameter.
+            validation (callable): Given a parameter value as input, return a boolean indicating
+                validity, or alternately return a string describing an invalid value. Returning
+                `None` also indicates a valid value.
+            element_type (type or Tuple[type]): Type-validation of parameter's value. If None,
+                type(default) is used.
+        """
+        self._type = type(default) if element_type is None else element_type
+        self._element_type = self._type
+        super(PrimitiveParameter, self).__init__(default, aliases, validation, expandvars)
+
+    def _merge(self, matches):
+        important_match = first(matches, self._match_key_is_important, default=None)
+        if important_match is not None:
+            return important_match.value(self)
+
+        last_match = last(matches, lambda x: x is not None, default=None)
+        if last_match is not None:
+            return last_match.value(self)
+        raise ThisShouldNeverHappenError()  # pragma: no cover
+
+    def repr_raw(self, raw_parameter):
+        return "%s: %s%s" % (raw_parameter.key,
+                             self._str_format_value(raw_parameter.value(self)),
+                             self._str_format_flag(raw_parameter.keyflag()))
+
+
+class SequenceParameter(Parameter):
+    """Parameter type for a Configuration class that holds a sequence (i.e. list) of python
+    primitive values.
+    """
+    _type = tuple
+
+    def __init__(self, element_type, default=(), aliases=(), validation=None,
+                 string_delimiter=',', expandvars=False):
+        """
+        Args:
+            element_type (type or Iterable[type]): The generic type of each element in
+                the sequence.
+            default (Iterable[str]):  The parameter's default value.
+            aliases (Iterable[str]): Alternate names for the parameter.
+            validation (callable): Given a parameter value as input, return a boolean indicating
+                validity, or alternately return a string describing an invalid value.
+        """
+        self._element_type = element_type
+        self.string_delimiter = string_delimiter
+        super(SequenceParameter, self).__init__(default, aliases, validation, expandvars)
+
+    def collect_errors(self, instance, value, source="<<merged>>"):
+        errors = super(SequenceParameter, self).collect_errors(instance, value)
+        element_type = self._element_type
+        for idx, element in enumerate(value):
+            if not isinstance(element, element_type):
+                errors.append(InvalidElementTypeError(self.name, element, source,
+                                                      type(element), element_type, idx))
+        return errors
+
+    def _merge(self, matches):
+        # get matches up to and including first important_match
+        #   but if no important_match, then all matches are important_matches
+        relevant_matches_and_values = tuple((match, match.value(self)) for match in
+                                            self._first_important_matches(matches))
+        for match, value in relevant_matches_and_values:
+            if not isinstance(value, tuple):
+                raise InvalidTypeError(self.name, value, match.source, value.__class__.__name__,
+                                       self._type.__name__)
+
+        # get individual lines from important_matches that were marked important
+        # these will be prepended to the final result
+        def get_marked_lines(match, marker, parameter_obj):
+            return tuple(line
+                         for line, flag in zip(match.value(parameter_obj),
+                                               match.valueflags(parameter_obj))
+                         if flag is marker) if match else ()
+        top_lines = concat(get_marked_lines(m, ParameterFlag.top, self) for m, _ in
+                           relevant_matches_and_values)
+
+        # also get lines that were marked as bottom, but reverse the match order so that lines
+        # coming earlier will ultimately be last
+        bottom_lines = concat(get_marked_lines(m, ParameterFlag.bottom, self) for m, _ in
+                              reversed(relevant_matches_and_values))
+
+        # now, concat all lines, while reversing the matches
+        #   reverse because elements closer to the end of search path take precedence
+        all_lines = concat(v for _, v in reversed(relevant_matches_and_values))
+
+        # stack top_lines + all_lines, then de-dupe
+        top_deduped = tuple(unique(concatv(top_lines, all_lines)))
+
+        # take the top-deduped lines, reverse them, and concat with reversed bottom_lines
+        # this gives us the reverse of the order we want, but almost there
+        # NOTE: for a line value marked both top and bottom, the bottom marker will win out
+        #       for the top marker to win out, we'd need one additional de-dupe step
+        bottom_deduped = unique(concatv(reversed(tuple(bottom_lines)), reversed(top_deduped)))
+        # just reverse, and we're good to go
+        return tuple(reversed(tuple(bottom_deduped)))
+
+    def repr_raw(self, raw_parameter):
+        lines = list()
+        lines.append("%s:%s" % (raw_parameter.key,
+                                self._str_format_flag(raw_parameter.keyflag())))
+        for q, value in enumerate(raw_parameter.value(self)):
+            valueflag = raw_parameter.valueflags(self)[q]
+            lines.append("  - %s%s" % (self._str_format_value(value),
+                                       self._str_format_flag(valueflag)))
+        return '\n'.join(lines)
+
+    def _get_all_matches(self, instance):
+        # this is necessary to handle argparse `action="append"`, which can't be set to a
+        #   default value of NULL
+        # it also config settings like `channels: ~`
+        matches, exceptions = super(SequenceParameter, self)._get_all_matches(instance)
+        matches = tuple(m for m in matches if m._raw_value is not None)
+        return matches, exceptions
+
+
+class MapParameter(Parameter):
+    """Parameter type for a Configuration class that holds a map (i.e. dict) of python
+    primitive values.
+    """
+    _type = frozendict
+
+    def __init__(self, element_type, default=None, aliases=(), validation=None, expandvars=False):
+        """
+        Args:
+            element_type (type or Iterable[type]): The generic type of each element.
+            default (Mapping):  The parameter's default value. If None, will be an empty dict.
+            aliases (Iterable[str]): Alternate names for the parameter.
+            validation (callable): Given a parameter value as input, return a boolean indicating
+                validity, or alternately return a string describing an invalid value.
+        """
+        self._element_type = element_type
+        default = default and frozendict(default) or frozendict()
+        super(MapParameter, self).__init__(default, aliases, validation, expandvars)
+
+    def collect_errors(self, instance, value, source="<<merged>>"):
+        errors = super(MapParameter, self).collect_errors(instance, value)
+        if isinstance(value, Mapping):
+            element_type = self._element_type
+            errors.extend(InvalidElementTypeError(self.name, val, source, type(val),
+                                                  element_type, key)
+                          for key, val in iteritems(value) if not isinstance(val, element_type))
+
+        return errors
+
+    def _merge(self, matches):
+        # get matches up to and including first important_match
+        #   but if no important_match, then all matches are important_matches
+        relevant_matches_and_values = tuple((match, match.value(self)) for match in
+                                            self._first_important_matches(matches))
+        for match, value in relevant_matches_and_values:
+            if not isinstance(value, Mapping):
+                raise InvalidTypeError(self.name, value, match.source, value.__class__.__name__,
+                                       self._type.__name__)
+
+        # mapkeys with important matches
+        def key_is_important(match, key):
+            return match.valueflags(self).get(key) == ParameterFlag.final
+        important_maps = tuple(dict((k, v)
+                                    for k, v in iteritems(match_value)
+                                    if key_is_important(match, k))
+                               for match, match_value in relevant_matches_and_values)
+        # dump all matches in a dict
+        # then overwrite with important matches
+        return frozendict(merge(concatv((v for _, v in relevant_matches_and_values),
+                                        reversed(important_maps))))
+
+    def repr_raw(self, raw_parameter):
+        lines = list()
+        lines.append("%s:%s" % (raw_parameter.key,
+                                self._str_format_flag(raw_parameter.keyflag())))
+        for valuekey, value in iteritems(raw_parameter.value(self)):
+            valueflag = raw_parameter.valueflags(self).get(valuekey)
+            lines.append("  %s: %s%s" % (valuekey, self._str_format_value(value),
+                                         self._str_format_flag(valueflag)))
+        return '\n'.join(lines)
+
+    def _get_all_matches(self, instance):
+        # it also config settings like `proxy_servers: ~`
+        matches, exceptions = super(MapParameter, self)._get_all_matches(instance)
+        matches = tuple(m for m in matches if m._raw_value is not None)
+        return matches, exceptions
 
 
 class ConfigurationType(type):
@@ -1254,7 +748,7 @@ class ConfigurationType(type):
 
         # call _set_name for each parameter
         cls.parameter_names = tuple(p._set_name(name) for name, p in iteritems(cls.__dict__)
-                                    if isinstance(p, ParameterLoader))
+                                    if isinstance(p, Parameter))
 
 
 @with_metaclass(ConfigurationType)
@@ -1335,24 +829,22 @@ class Configuration(object):
                 validation_errors.append(multikey_error)
 
             if match is not None:
-                loaded_parameter = parameter.type.load(key, match)
-                # untyped_value = loaded_parameter.value
-                # if untyped_value is None:
-                #     if isinstance(parameter, SequenceLoadedParameter):
-                #         untyped_value = ()
-                #     elif isinstance(parameter, MapLoadedParameter):
-                #         untyped_value = {}
+                untyped_value = match.value(parameter)
+                if untyped_value is None:
+                    if isinstance(parameter, SequenceParameter):
+                        untyped_value = ()
+                    elif isinstance(parameter, MapParameter):
+                        untyped_value = {}
                 try:
-                    typed_value = loaded_parameter.typify(match.source)
+                    typed_value = parameter.typify(untyped_value, match.source, name=match.key)
                 except CustomValidationError as e:
                     validation_errors.append(e)
                 else:
-                    collected_errors = loaded_parameter.collect_errors(
-                        self, typed_value, match.source)
+                    collected_errors = parameter.collect_errors(self, typed_value, match.source)
                     if collected_errors:
                         validation_errors.extend(collected_errors)
                     else:
-                        typed_values[match.key] = typed_value
+                        typed_values[match.key] = typed_value  # parameter.repr_raw(match)
             else:
                 # this situation will happen if there is a multikey_error and none of the
                 # matched keys is the primary key
@@ -1394,13 +886,12 @@ class Configuration(object):
         # TODO, in Parameter base class, rename element_type to value_type
         if parameter_name not in self.parameter_names:
             parameter_name = '_' + parameter_name
-        parameter_loader = self.__class__.__dict__[parameter_name]
-        parameter = parameter_loader.type
+        parameter = self.__class__.__dict__[parameter_name]
         assert isinstance(parameter, Parameter)
 
         # dedupe leading underscore from name
-        name = parameter_loader.name.lstrip('_')
-        aliases = tuple(alias for alias in parameter_loader.aliases if alias != name)
+        name = parameter.name.lstrip('_')
+        aliases = tuple(alias for alias in parameter.aliases if alias != name)
 
         description = self.get_descriptions().get(name, '')
         et = parameter._element_type
@@ -1408,19 +899,14 @@ class Configuration(object):
             et = [et]
         if not isiterable(et):
             et = [et]
-
-        if isinstance(parameter._element_type, Parameter):
-            element_types = tuple(
-                _et.__class__.__name__.lower().replace("parameter", "") for _et in et)
-        else:
-            element_types = tuple(_et.__name__ for _et in et)
+        element_types = tuple(_et.__name__ for _et in et)
 
         details = {
             'parameter_type': parameter.__class__.__name__.lower().replace("parameter", ""),
             'name': name,
             'aliases': aliases,
             'element_types': element_types,
-            'default_value': parameter.default.typify("<<describe>>"),
+            'default_value': parameter.default,
             'description': description.replace('\n', ' ').strip(),
         }
         if isinstance(parameter, SequenceParameter):
@@ -1434,11 +920,10 @@ class Configuration(object):
         # return a tuple with correct parameter name and typed-value
         if parameter_name not in self.parameter_names:
             parameter_name = '_' + parameter_name
-        parameter_loader = self.__class__.__dict__[parameter_name]
-        parameter = parameter_loader.type
+        parameter = self.__class__.__dict__[parameter_name]
         assert isinstance(parameter, Parameter)
 
-        return parameter.typify(parameter_name, source, value)
+        return parameter.typify(value, source)
 
     def get_descriptions(self):
         raise NotImplementedError()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2033,7 +2033,9 @@ class IntegrationTests(TestCase):
                 assert package_is_installed(prefix, "urllib3>=1.21")
                 assert not stderr
                 json_obj = json_loads(stdout)
-                unlink_dists = json_obj["actions"]["UNLINK"]
+                unlink_dists = [
+                    dist_obj for dist_obj in json_obj["actions"]["UNLINK"] if dist_obj.get("platform") == "pypi"
+                ]  # filter out conda package upgrades like python and libffi
                 assert len(unlink_dists) == 1
                 assert unlink_dists[0]["name"] == "urllib3"
                 assert unlink_dists[0]["channel"] == "pypi"


### PR DESCRIPTION
The PRs #9449 and #9465 were submitted in the spirit of moving forward #9368. The purpose of the PRs was to enhance conda's configuration engine with the ability to handle nested types in configuration parameters. However, to accomplish this, there was a major change introduced in the configuration API. We can accomplish nested configuration without breaking the existing API. We can do better.

The composition of config parameters hasn't yet been used in practice, so reverting here to go back for a second try shouldn't break existing functionality, and instead only restore the long-established API.

In the spirit of moving metachannels forward, I think that's an area that we can make some great progress on with some additional discussion.