### PR TITLE
Add less opaque error message when repos fail to host data properly

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -346,8 +346,11 @@ class SubdirData(object):
         return _pickled_state
 
     def _process_raw_repodata_str(self, raw_repodata_str):
-        json_obj = json.loads(raw_repodata_str or '{}')
-
+        try:
+            json_obj = json.loads(raw_repodata_str or '{}')
+        except json.decoder.JSONDecodeError:
+            log.debug("Conda repository may be experiencing issues, please try again later or use another mirror")
+            raise
         subdir = json_obj.get('info', {}).get('subdir') or self.channel.subdir
         assert subdir == self.channel.subdir
         add_pip = context.add_pip_as_python_dependency

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -349,7 +349,7 @@ class SubdirData(object):
         try:
             json_obj = json.loads(raw_repodata_str or '{}')
         except json.decoder.JSONDecodeError:
-            log.debug("Conda repository may be experiencing issues, " 
+            log.debug("Conda repository may be experiencing issues, "
                       + "please try again later or use another mirror")
             raise
         subdir = json_obj.get('info', {}).get('subdir') or self.channel.subdir

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -349,7 +349,8 @@ class SubdirData(object):
         try:
             json_obj = json.loads(raw_repodata_str or '{}')
         except json.decoder.JSONDecodeError:
-            log.debug("Conda repository may be experiencing issues, please try again later or use another mirror")
+            log.debug("Conda repository may be experiencing issues, " 
+                      + "please try again later or use another mirror")
             raise
         subdir = json_obj.get('info', {}).get('subdir') or self.channel.subdir
         assert subdir == self.channel.subdir


### PR DESCRIPTION
When the conda repos are experiencing high load or internal errors, users of conda will see a really opaque "JSONDecodeError", which is difficult to debug. See #9590 for other users who have seen this error.