### PR TITLE
Change apt-get to apt

### DIFF
--- a/docs/source/user-guide/install/rpm-debian.rst
+++ b/docs/source/user-guide/install/rpm-debian.rst
@@ -1,7 +1,7 @@
 -----------------------------------------
 RPM and Debian Repositories for Miniconda
 -----------------------------------------
-Conda, the package manager from Anaconda, is available as either a RedHat RPM or as a Debian package. The packages are the equivalent to the Miniconda installer which only contains conda and its dependencies. You can use yum or apt-get to install, uninstall and manage conda on your system. To install conda, follow the instructions for your Linux distribution.
+Conda, the package manager from Anaconda, is available as either a RedHat RPM or as a Debian package. The packages are the equivalent to the Miniconda installer which only contains conda and its dependencies. You can use yum or apt to install, uninstall and manage conda on your system. To install conda, follow the instructions for your Linux distribution.
  
 To install the RPM on RedHat, CentOS, Fedora distributions, and other RPM-based distributions such as openSUSE, download the GPG key and add a repository configuration file for conda.
 
@@ -75,8 +75,8 @@ Conda is ready to install on your Debian-based distribution.
 .. code-block:: none
 
    # Install it!
-   apt-get update
-   apt-get install conda
+   apt update
+   apt install conda
    Reading package lists... Done
    Building dependency tree
    Reading state information... Done

--- a/docs/source/user-guide/tasks/use-conda-with-travis-ci.rst
+++ b/docs/source/user-guide/tasks/use-conda-with-travis-ci.rst
@@ -8,7 +8,7 @@ Using conda with Travis CI
 
 
 If you are already using Travis CI, using conda is a preferable
-alternative to using apt-get and pip to install packages. The
+alternative to using apt and pip to install packages. The
 Debian repos provided by Travis may not include packages for all
 versions of Python or may not be updated as quickly. Installing
 such packages with pip may also be undesirable, as this can take
@@ -37,7 +37,7 @@ project that supports Python 2.7, 3.5, and 3.6:
      - "3.5"
      - "3.6"
    install:
-     - sudo apt-get update
+     - sudo apt update
      # We do this conditionally because it saves us some downloading if the
      # version is the same.
      - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then


### PR DESCRIPTION
Since apt command-line was introduced in 2014, apt become a better way for user to install packages because users don't have to worry about shifting between apt-get and apt-cache. Therefore, I would suggest we to make this change in the conda project