### PR TITLE
fix MatchSpec roundtrip parsing

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -318,7 +318,10 @@ class MatchSpec(metaclass=MatchSpecType):
             elif version[-2:] == ".*":
                 builder.append("=" + version[:-2])
             elif version[-1] == "*":
-                builder.append("=" + version[:-1])
+                if len(version) == 1:
+                    builder.append("=*")
+                else:
+                    builder.append("=" + version[:-1])
             elif version.startswith("=="):
                 builder.append(version)
                 version_exact = True
@@ -532,6 +535,8 @@ def _parse_version_plus_build(v_plus_b):
         ('*', '*')
     """
     parts = re.search(r'((?:.+?)[^><!,|]?)(?:(?<![=!|,<>~])(?:[ =])([^-=,|<>~]+?))?$', v_plus_b)
+
+
     if parts:
         version, build = parts.groups()
         build = build and build.strip()

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -140,6 +140,13 @@ class MatchSpecTests(TestCase):
         assert c != d
         assert hash(c) != hash(d)
 
+    def test_roundtrip(self):
+        a = MatchSpec("numpy=*=*bla")
+        b = MatchSpec(a.__repr__())
+        assert (a == b)
+        assert (a.conda_build_form() == b.conda_build_form())
+        assert (a.__repr__() == b.__repr__())
+
     # def test_string_mcg1969(self):
     #     a = MatchSpec("foo1 >=1.3 2", optional=True, target="burg")
     #     b = MatchSpec('* [name="foo1", version=">=1.3", build="2"]', optional=True, target="burg")
@@ -228,6 +235,7 @@ class MatchSpecTests(TestCase):
         assert m("openssl=1.1.1_") == "openssl=1.1.1_"
         assert m("openssl>=1.1.1_,!=1.1.1c") == "openssl[version='>=1.1.1_,!=1.1.1c']"
 
+        assert m("numpy *") == "numpy=*"
         # # a full, exact spec looks like 'defaults/linux-64::numpy==1.8=py26_0'
         # # can we take an old dist str and reliably parse it with MatchSpec?
         # assert m("numpy-1.10-py38_0") == "numpy==1.10=py38_0"


### PR DESCRIPTION
We have an issue in mamba where the MatchSpec looses some information through the representation.

If you parse `libblas=*=*mkl`, the repr of that is `libblas=[build=*mkl]`
When parsing `libblas=[build=*mkl]` one hits a assert because the version is empty. 

I believe it would be better to have `libblas=*[build=*mkl]` and I attached a fix for this.