### PR TITLE
Fix failing codecov upload in CI test suite

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,8 @@ test_script:
   - conda-build tests\test-recipes\activate_deactivate_package
   - py.test %ADD_COV% -m "not integration and not installed" -v --basetemp=C:\tmp
   - py.test %ADD_COV% --cov-append -m "integration and not installed" -v --basetemp=C:\tmp
+  - curl -s https://codecov.io/bash > codecov_uploader.sh
+  - bash -c ". codecov_uploader.sh -f coverage.xml"
   - DEL /Q /F conda.egg-info
   - conda build conda.recipe
-  - codecov --env PYTHON_VERSION --required
   - python -m conda.common.io

--- a/circle.yml
+++ b/circle.yml
@@ -43,8 +43,7 @@ main_test: &main_test
           if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
             echo "No codecov report to upload"
           else
-            /opt/conda/bin/codecov --env PYTHON_VERSION --flags integration --required
-            echo "No codecov report to upload"
+            bash <(curl -s https://codecov.io/bash)
           fi
 
 


### PR DESCRIPTION
Codecov uploads are failing with an HTTP 400 client error.  This PR updates CI tests scripts to utilize the most up-to-date [codecov bash uploader](https://docs.codecov.io/docs/about-the-codecov-bash-uploader).

Moving to a newer version of pytest would address the problem as well, but using the bash uploader aligns with codecov [recommendations](https://github.com/codecov/example-python#whats-the-different-between-the-codecov-bash-and-codecov-python-uploader).