### PR TITLE
fixup the documentation for the --channel option

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1414,7 +1414,8 @@ def add_parser_channels(p):
         # TODO: if you ever change 'channel' to 'channels', make sure you modify the context.channels property accordingly # NOQA
         action="append",
         help="""Additional channel to search for packages. These are URLs searched in the order
-        they are given (including file:// for local directories).  Then, the defaults
+        they are given (including local directories using the 'file://'  syntax or
+        simply a path like '/home/conda/mychan' or '../mychan').  Then, the defaults
         or channels from .condarc are searched (unless --override-channels is given).  You can use
         'defaults' to get the default packages for conda.  You can also use any name and the
         .condarc channel_alias value will be prepended.  The default channel_alias


### PR DESCRIPTION
This improves the documentation for the `--channel` argument to `conda build`.
The `file://` syntax is not the only way to specify local
directories. It turns out that you can simply list an absolute or
relative path. This can come in handy when building with a Unix shell,
like git-bash, on Windows where drive letter and forward-/back-slash
conventions might lead to confusion due to the insertion of spurious
characters and/or protective escapes.