### PR TITLE
List CURL_CA_BUNDLE also

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -105,6 +105,7 @@ def get_info_dict(system=False):
         from requests import __version__ as requests_version
         # These environment variables can influence requests' behavior, along with configuration
         # in a .netrc file
+        #   CURL_CA_BUNDLE
         #   REQUESTS_CA_BUNDLE
         #   HTTP_PROXY
         #   HTTPS_PROXY
@@ -190,6 +191,7 @@ def get_info_dict(system=False):
 
     env_var_keys = {
         'CIO_TEST',
+        'CURL_CA_BUNDLE',
         'REQUESTS_CA_BUNDLE',
         'SSL_CERT_FILE',
     }

--- a/docs/source/user-guide/configuration/non-standard-certs.rst
+++ b/docs/source/user-guide/configuration/non-standard-certs.rst
@@ -8,7 +8,7 @@ set of certificates, which requires custom settings.
 If you are using a non-standard set of certificates, then the
 requests package requires the setting of ``REQUESTS_CA_BUNDLE``.
 If you receive an error with self-signed certifications, you may
-consider unsetting ``REQUESTS_CA_BUNDLE`` and `disabling SSL verification <https://conda.io/projects/conda/en/latest/user-guide/configuration/disable-ssl-verification.html>`_
+consider unsetting ``REQUESTS_CA_BUNDLE`` as well as ``CURL_CA_BUNDLE`` and `disabling SSL verification <https://conda.io/projects/conda/en/latest/user-guide/configuration/disable-ssl-verification.html>`_
 to create a conda environment over HTTP.
 
 You may need to set the conda environment to use the root certificate


### PR DESCRIPTION
`requests` accepts `CURL_CA_BUNDLE` in addition to `REQUESTS_CA_BUNDLE` per https://github.com/psf/requests/blob/2b3436e0e7831676044b57f6f2cc9eb7c188293e/requests/sessions.py#L707 so list that in troubleshooting details.