### PR TITLE
Prevent `conda remove --all` from deleting non-environments

### DIFF
--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+from os.path import isfile, join
 import sys
 
 from .common import check_non_admin, specs_from_args
@@ -13,7 +14,7 @@ from ..core.envs_manager import unregister_env
 from ..core.link import PrefixSetup, UnlinkLinkTransaction
 from ..core.prefix_data import PrefixData
 from ..core.solve import Solver
-from ..exceptions import CondaEnvironmentError, CondaValueError
+from ..exceptions import CondaEnvironmentError, CondaValueError, DirectoryNotACondaEnvironmentError
 from ..gateways.disk.delete import rm_rf, path_is_clean
 from ..models.match_spec import MatchSpec
 from ..exceptions import PackagesNotFoundError
@@ -54,6 +55,8 @@ def execute(args, parser):
         if prefix == context.root_prefix:
             raise CondaEnvironmentError('cannot remove root environment,\n'
                                         '       add -n NAME or -p PREFIX option')
+        if not isfile(join(prefix, 'conda-meta', 'history')):
+            raise DirectoryNotACondaEnvironmentError(prefix)
         print("\nRemove all packages in environment %s:\n" % prefix, file=sys.stderr)
 
         if 'package_names' in args:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -22,7 +22,7 @@ import re
 from shutil import copyfile, rmtree
 from subprocess import check_call, check_output, Popen, PIPE
 import sys
-from tempfile import gettempdir
+from tempfile import gettempdir, TemporaryDirectory
 from textwrap import dedent
 from unittest import TestCase
 from uuid import uuid4
@@ -2877,6 +2877,22 @@ dependencies:
         with make_temp_env() as prefix:
             run_command(Commands.CREATE, prefix)
             run_command(Commands.REMOVE, prefix, '--all')
+
+    def test_remove_ignore_nonenv(self):
+        with TemporaryDirectory() as test_root:
+            prefix = join(test_root, "not-an-env")
+            filename = join(prefix, "file.dat")
+
+            os.mkdir(prefix)
+            with open(filename, "wb") as empty:
+                pass
+
+            with pytest.raises(DirectoryNotACondaEnvironmentError):
+                run_command(Commands.REMOVE, prefix, "--all")
+
+            assert(exists(filename))
+            assert(exists(prefix))
+
 
 @pytest.mark.skipif(True, reason="get the rest of Solve API worked out first")
 @pytest.mark.integration

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -22,7 +22,7 @@ import re
 from shutil import copyfile, rmtree
 from subprocess import check_call, check_output, Popen, PIPE
 import sys
-from tempfile import gettempdir, TemporaryDirectory
+from tempfile import gettempdir
 from textwrap import dedent
 from unittest import TestCase
 from uuid import uuid4
@@ -2879,7 +2879,7 @@ dependencies:
             run_command(Commands.REMOVE, prefix, '--all')
 
     def test_remove_ignore_nonenv(self):
-        with TemporaryDirectory() as test_root:
+        with tempdir() as test_root:
             prefix = join(test_root, "not-an-env")
             filename = join(prefix, "file.dat")
 


### PR DESCRIPTION
Add check to prevent `conda remove` from deleting prefixes (i.e.,
directories) that do not look like conda environments.

Fixes #9755