### PR TITLE
Clarify that Python is not by default included

### DIFF
--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -50,8 +50,7 @@ Use the terminal or an Anaconda Prompt for the following steps:
       proceed ([y]/n)?
 
   This creates the myenv environment in ``/envs/``. No
-  packages will be installed in this environment. Python
-  will be the Python of the base environment.
+  packages will be installed in this environment.
 
 3. To create an environment with a specific version of Python:
 

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -49,9 +49,9 @@ Use the terminal or an Anaconda Prompt for the following steps:
 
       proceed ([y]/n)?
 
-  This creates the myenv environment in ``/envs/``. This
-  environment uses the same version of Python that you are
-  currently using because you did not specify a version.
+  This creates the myenv environment in ``/envs/``. No
+  packages will be installed in this environment. Python
+  will be the Python of the base environment.
 
 3. To create an environment with a specific version of Python:
 


### PR DESCRIPTION
The documentation made it appear as if there will always be a version of Python included in the environment.
This might have been the case in the past; currently it is possible to create an environment without Python at al.
See #9982