### PR TITLE
Prevent `conda create -d -y` from destroying existing environments

### DIFF
--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -21,6 +21,10 @@ def execute(args, parser):
     if is_conda_environment(context.target_prefix):
         if paths_equal(context.target_prefix, context.root_prefix):
             raise CondaValueError("The target prefix is the base prefix. Aborting.")
+        if context.dry_run:
+            # Taking the "easy" way out, rather than trying to fake removing
+            # the existing environment before creating a new one.
+            raise CondaValueError("Cannot `create --dry-run` with an existing conda environment")
         confirm_yn("WARNING: A conda environment already exists at '%s'\n"
                    "Remove existing environment" % context.target_prefix,
                    default='no',

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -53,7 +53,8 @@ from conda.core.package_cache_data import PackageCacheData
 from conda.core.subdir_data import create_cache_dir
 from conda.exceptions import CommandArgumentError, DryRunExit, OperationNotAllowed, \
     PackagesNotFoundError, RemoveError, conda_exception_handler, PackageNotInstalledError, \
-    DisallowedPackageError, DirectoryNotACondaEnvironmentError, EnvironmentLocationNotFound
+    DisallowedPackageError, DirectoryNotACondaEnvironmentError, EnvironmentLocationNotFound, \
+    CondaValueError
 from conda.gateways.anaconda_client import read_binstar_tokens
 from conda.gateways.disk.create import mkdir_p, extract_tarball
 from conda.gateways.disk.delete import rm_rf, path_is_clean
@@ -1759,6 +1760,12 @@ dependencies:
         names = set(d['name'] for d in loaded['actions']['LINK'])
         assert "python" in names
         assert "flask" in names
+
+    def test_create_dry_run_yes_safety(self):
+        with make_temp_env() as prefix:
+            with pytest.raises(CondaValueError):
+                run_command(Commands.CREATE, prefix, "--dry-run", "--yes")
+            assert exists(prefix)
 
     def test_packages_not_found(self):
         with make_temp_env() as prefix:


### PR DESCRIPTION
Fixes #9997