### PR TITLE
Fix bug in python 2.7 64-bit platforms

### DIFF
--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -8,12 +8,18 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from array import array
 from itertools import combinations
 from logging import DEBUG, getLogger
-from sys import maxsize
+import sys
 
 log = getLogger(__name__)
 
 
-_BIG_NUMBER = maxsize
+# maxsize transitions to type(long) on 2.7 64-bit machines and breaks int
+# type checks in logic.py
+if sys.version_info.major == 2:
+    _BIG_NUMBER = sys.maxint
+else:
+    _BIG_NUMBER = sys.maxsize
+
 TRUE = _BIG_NUMBER
 FALSE = -TRUE
 


### PR DESCRIPTION
Detected bug while migrating python 2.7 windows unit tests to Azure Pipelines. Previous CI platform ran windows unit tests in a 32-bit environment which does not exhibit this bug.

Recall, python 2 has int and long types, while python 3 has only int. logic.py contains int specific logic which does properly handle longs.

sys.maxsize is an int on win-32 platform, but a long on win-64. This change uses sys.maxint when running under python 2, and sys.maxisze otherwise.

(cherry picked from commit d1aecbdc98537d36f6de9f664606360a1414aa5c)

Split from PR #9954 per @mcg1969 request