### PR TITLE
ignore virtual packages when searching for constrained packages

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -369,6 +369,8 @@ class Solver(object):
             return update_constrained
 
         for pkg in self.specs_to_add:
+            if pkg.name.startswith('__'):  # ignore virtual packages
+                continue
             current_version = max(i[1] for i in pre_packages[pkg.name])
             if current_version == max(i.version for i in index_keys if i.name == pkg.name):
                 continue

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2881,6 +2881,12 @@ dependencies:
             #    If this command runs successfully (does not raise), then all is well.
             stdout, stderr, _ = run_command(Commands.INSTALL, prefix, "imagesize")
 
+    # https://github.com/conda/conda/issues/10116
+    @pytest.mark.skipif(not context.subdir.startswith('linux'), reason="__glibc only available on linux")
+    def test_install_bound_virtual_package(self):
+        with make_temp_env("__glibc>0") as prefix:
+            pass
+
     @pytest.mark.integration
     def test_remove_empty_env(self):
         with make_temp_env() as prefix:


### PR DESCRIPTION
Virtual packages cannot be remove if there are conflicts and therefore
should not be included in a list of constrained packages.

fixes #10116