### PR TITLE
add arm64 to non_x86_machines

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -59,6 +59,7 @@ non_x86_machines = {
     'armv6l',
     'armv7l',
     'aarch64',
+    'arm64',
     'ppc64',
     'ppc64le',
     's390x',


### PR DESCRIPTION
On ARM based macOS systems platform.machines() returns arm64