### PR TITLE
Add environment variables to environment.yml files

### DIFF
--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -11,6 +11,7 @@ import textwrap
 from conda._vendor.auxlib.path import expand
 from conda.cli import install as cli_install
 from conda.cli.conda_argparse import add_parser_json, add_parser_prefix, add_parser_networking
+from conda.core.prefix_data import PrefixData
 from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
 from conda.gateways.disk.delete import rm_rf
 from conda.misc import touch_nonadmin
@@ -126,6 +127,10 @@ def execute(args, parser):
                     """).lstrip().format(installer_type)
                 )
                 return -1
+
+    if env.variables:
+        pd = PrefixData(prefix)
+        pd.set_environment_env_vars(env.variables)
 
     touch_nonadmin(prefix)
     print_result(args, prefix, result)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -132,7 +132,8 @@ def from_environment(name, prefix, no_builds=False, ignore_channels=False, from_
             canonical_name = prec.channel.canonical_name
             if canonical_name not in channels:
                 channels.insert(0, canonical_name)
-    return Environment(name=name, dependencies=dependencies, channels=channels, prefix=prefix)
+    return Environment(name=name, dependencies=dependencies, channels=channels, prefix=prefix,
+                       variables=variables)
 
 
 def from_yaml(yamlstr, **kwargs):

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -28,7 +28,7 @@ except ImportError:  # pragma: no cover
     from conda._vendor.toolz.itertoolz import concatv, groupby  # NOQA
 
 
-VALID_KEYS = ('name', 'dependencies', 'prefix', 'channels')
+VALID_KEYS = ('name', 'dependencies', 'prefix', 'channels', 'variables')
 
 
 def validate_keys(data, kwargs):
@@ -95,12 +95,14 @@ def from_environment(name, prefix, no_builds=False, ignore_channels=False, from_
     Returns:     Environment object
     """
     # requested_specs_map = History(prefix).get_requested_specs_map()
+    pd = PrefixData(prefix, pip_interop_enabled=True)
+    variables = pd.get_environment_env_vars()
+
     if from_history:
         history = History(prefix).get_requested_specs_map()
         deps = [str(package) for package in history.values()]
         return Environment(name=name, dependencies=deps, channels=list(context.channels),
-                           prefix=prefix)
-    pd = PrefixData(prefix, pip_interop_enabled=True)
+                           prefix=prefix, variables=variables)
 
     precs = tuple(PrefixGraph(pd.iter_records()).graph)
     grouped_precs = groupby(lambda x: x.package_type, precs)
@@ -215,11 +217,12 @@ def unique(seq, key=None):
 
 class Environment(object):
     def __init__(self, name=None, filename=None, channels=None,
-                 dependencies=None, prefix=None):
+                 dependencies=None, prefix=None, variables=None):
         self.name = name
         self.filename = filename
         self.prefix = prefix
         self.dependencies = Dependencies(dependencies)
+        self.variables = variables
 
         if channels is None:
             channels = []
@@ -237,6 +240,8 @@ class Environment(object):
             d['channels'] = self.channels
         if self.dependencies:
             d['dependencies'] = self.dependencies.raw
+        if self.variables:
+            d['variables'] = self.variables
         if self.prefix:
             d['prefix'] = self.prefix
         if stream is None:

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -651,8 +651,8 @@ as shown here::
       - python=3.7
       - codecov
     variables:
-      - VAR1: valueA
-      - VAR2: valueB
+      VAR1: valueA
+      VAR2: valueB
 
 
 Saving environment variables

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -639,6 +639,21 @@ When you deactivate your environment, you can see that environment variable goes
 ``echo my_var`` or ``conda env config vars list`` to show that the variable name
 is no longer present.
 
+Environment variables set using ``conda env config vars`` will be retained in the output of
+``conda env export``. Further, you can declare environment variables in the environment.yml file
+as shown here::
+
+    name: env-name
+    channels:
+      - conda-forge
+      - defaults
+    dependencies:
+      - python=3.7
+      - codecov
+    variables:
+      - VAR1: valueA
+      - VAR2: valueB
+
 
 Saving environment variables
 ============================

--- a/tests/conda_env/support/valid_keys.yml
+++ b/tests/conda_env/support/valid_keys.yml
@@ -3,4 +3,6 @@ channels:
   - anaconda
 dependencies:
   - nltk
+variables:
+  VARIABLE: value
 prefix: /something/miniconda/envs/test


### PR DESCRIPTION
This PR enables creation and export of conda environments that have environment variable created with [`conda env config vars`](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html?highlight=variables#setting-environment-variables).

Tests have been included for this behavior.

Here' an example

## Create and export

First create a new env and set two variables and confirm

```
> conda create -y -n env_with_vars python=3.7
> conda env config vars set DUDE=woah SWEET=yaaa -n env_with_vars
> conda run -n env_with_vars env | grep -E "DUDE|SWEET"
DUDE=woah
SWEET=yaaa
```


When the env is exported the variables are retained in a key called `variables:`

```
> conda env export -n env_with_vars --from-history
name: env_with_vars
channels:
  - defaults
dependencies:
  - python=3.7
variables:
  DUDE: woah
  SWEET: yaaa
prefix: /Users/adefusco/Development/Conda/conda/devenv/envs/env_with_vars
```

And also with the full dependency spec

```
> name: env_with_vars
channels:
  - defaults
dependencies:
  - ca-certificates=2020.6.24=0
  - certifi=2020.6.20=py37_0
  - libcxx=10.0.0=1
  - libedit=3.1.20191231=h1de35cc_1
  - libffi=3.3=hb1e8313_2
  - ncurses=6.2=h0a44026_1
  - openssl=1.1.1g=h1de35cc_0
  - pip=20.2.2=py37_0
  - python=3.7.7=hf48f09d_4
  - readline=8.0=h1de35cc_0
  - setuptools=49.6.0=py37_0
  - sqlite=3.32.3=hffcf06c_0
  - tk=8.6.10=hb0a8c7a_0
  - wheel=0.34.2=py37_0
  - xz=5.2.5=h1de35cc_0
  - zlib=1.2.11=h1de35cc_3
variables:
  DUDE: woah
  SWEET: yaaa
prefix: /Users/adefusco/Development/Conda/conda/devenv/envs/env_with_vars
```

## Create from yaml

The environment.yml spec will allow variables to be set when the env is created.

```yaml
# environment.yml
name: new_env
dependencies:
  - python=3.8
variables:
  DUDE: woah
  SWEET: yaaa
```

Confirm that the variables have been set.

```
> conda env create -f environment.yml
> conda run -n new_env env | grep -E "DUDE|SWEET"
DUDE=woah
SWEET=yaaa
```