### PR TITLE
Add a 0 or 1 to repodata cache and pickle filenames

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -164,11 +164,11 @@ class SubdirData(object):
 
     @property
     def cache_path_json(self):
-        return self.cache_path_base + '.json'
+        return self.cache_path_base + ('1' if context.use_only_tar_bz2 else '0') + '.json'
 
     @property
     def cache_path_pickle(self):
-        return self.cache_path_base + '.q'
+        return self.cache_path_base + ('1' if context.use_only_tar_bz2 else '0') + '.q'
 
     def load(self):
         _internal_state = self._load()


### PR DESCRIPTION
.. to distinguish between those post-processed with context.use_only_tar_bz2 set
and those post-processed without it set.

Otherwise we end up considering both .conda and .tar.bz2 packages when loaded
from the cache or pickle file when we've set context.use_only_tar_bz2