### PR TITLE
Ignore virtual packages when checking environment consistency

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -911,7 +911,9 @@ class Resolve(object):
         for prec in itervalues(self.index):
             nkey = C.Not(self.to_sat_name(prec))
             for ms in self.ms_depends(prec):
-                C.Require(C.Or, nkey, self.push_MatchSpec(C, ms))
+                # Virtual packages can't be installed, we ignore them
+                if not ms.name.startswith('__'):
+                    C.Require(C.Or, nkey, self.push_MatchSpec(C, ms))
 
         if log.isEnabledFor(DEBUG):
             log.debug("gen_clauses returning with clause count: %d", C.get_clause_count())

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -241,9 +241,20 @@ def test_virtual_package_solver(tmpdir):
 
     with env_var('CONDA_OVERRIDE_CUDA', '10.0'):
         with get_solver_cuda(tmpdir, specs) as solver:
-            final_state = solver.solve_final_state()
+            _ = solver.solve_final_state()
+            ssc = solver.ssc
             # Check the cuda virtual package is included in the solver
-            assert '__cuda' in solver.ssc.specs_map.keys()
+            assert '__cuda' in ssc.specs_map.keys()
+
+            # Check that the environment is consistent after installing a
+            # package which *depends* on a virtual package
+            for pkgs in ssc.solution_precs:
+                if pkgs.name == 'cudatoolkit':
+                    # make sure this package depends on the __cuda virtual
+                    # package as a dependency since this is requirement of the
+                    # test the test
+                    assert '__cuda' in pkgs.depends[0]
+            assert ssc.r.bad_installed(ssc.solution_precs, ())[1] is None
 
 
 def test_cuda_1(tmpdir):


### PR DESCRIPTION
In https://github.com/conda-forge/prismatic_split-feedstock/pull/10, I have added `__cuda` as a run dependency to restrict the installation of the GPU build on compatible system, which is working very well! A side effect of this is to make the environment inconsistent because the `__cuda` virtual package is not installed.

For example, on an CUDA capable linux system (there is no cuda package for windows):
```
$ conda install prismatic_cli -c conda-forge
$ conda update --all
Collecting package metadata (current_repodata.json): done
Solving environment: / 
The environment is inconsistent, please check the package plan carefully
The following packages are causing the inconsistency:

  - conda-forge/linux-64::prismatic_cli==1.2.1=gpu_h5deb2e2_108
done

# All requested packages already installed.
```

