### PR TITLE
Add osx-arm64 support to 4.8.x release

### DIFF
--- a/conda/_vendor/cpuinfo.py
+++ b/conda/_vendor/cpuinfo.py
@@ -561,6 +561,9 @@ def parse_arch(raw_arch_string):
         arch = 'X86_64'
         bits = 64
     # ARM
+    elif re.match('^arm64$|^arm64[a-z]$|^arm64-[a-z]$', raw_arch_string):
+        arch = 'ARM_8'
+        bits = 64
     elif re.match('^armv8-a|aarch64$', raw_arch_string):
         arch = 'ARM_8'
         bits = 64

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -71,6 +71,7 @@ KNOWN_SUBDIRS = PLATFORM_DIRECTORIES = (
     "linux-ppc64le",
     "linux-s390x",
     "osx-64",
+    "osx-arm64",
     "win-32",
     "win-64",
     "zos-z",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -55,10 +55,11 @@ _platform_map = {
     'win32': 'win',
     'zos': 'zos',
 }
-non_x86_linux_machines = {
+non_x86_machines = {
     'armv6l',
     'armv7l',
     'aarch64',
+    'arm64',
     'ppc64',
     'ppc64le',
     's390x',
@@ -411,7 +412,7 @@ class Context(Configuration):
     @property
     def arch_name(self):
         m = platform.machine()
-        if self.platform == 'linux' and m in non_x86_linux_machines:
+        if m in non_x86_machines:
             return m
         else:
             return _arch_names[self.bits]
@@ -457,8 +458,8 @@ class Context(Configuration):
         if self._subdir:
             return self._subdir
         m = platform.machine()
-        if m in non_x86_linux_machines:
-            return 'linux-%s' % m
+        if m in non_x86_machines:
+            return '%s-%s' % (self.platform, m)
         elif self.platform == 'zos':
             return 'zos-z'
         else:

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -87,8 +87,8 @@ from .models.channel import Channel  # NOQA
 Channel = Channel  # NOQA
 
 import conda.base.context  # NOQA
-from .base.context import get_prefix, non_x86_linux_machines, reset_context, sys_rc_path  # NOQA
-non_x86_linux_machines, sys_rc_path = non_x86_linux_machines, sys_rc_path
+from .base.context import get_prefix, non_x86_machines, reset_context, sys_rc_path  # NOQA
+non_x86_linux_machines, sys_rc_path = non_x86_machines, sys_rc_path
 get_prefix = get_prefix
 reset_context = reset_context
 

--- a/conda/models/enums.py
+++ b/conda/models/enums.py
@@ -18,8 +18,11 @@ from ..exceptions import CondaUpgradeError
 class Arch(Enum):
     x86 = 'x86'
     x86_64 = 'x86_64'
+    # arm64 is for macOS only
+    arm64 = 'arm64'
     armv6l = 'armv6l'
     armv7l = 'armv7l'
+    # aarch64 is for Linux only
     aarch64 = 'aarch64'
     ppc64 = 'ppc64'
     ppc64le = 'ppc64le'


### PR DESCRIPTION
Needed since conda-build >=3.20.0 already support this platform, but we aren't ready for a full conda 4.9.0 release just yet.