### PR TITLE
Update README to use GH Actions Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,13 +7,9 @@
 
 ----------------------------------------
 
-.. image:: https://img.shields.io/circleci/project/github/conda/conda/master.svg?maxAge=900&label=Unix
-    :target: https://circleci.com/gh/conda/workflows/conda/tree/master
-    :alt: Unix tests (CircleCI)
-
-.. image:: https://img.shields.io/github/workflow/status/conda/conda/CondaCI?label=Windows
+.. image:: https://github.com/conda/conda/workflows/CondaCI/badge.svg
     :target: https://github.com/conda/conda/actions?query=workflow%3ACondaCI+branch%3Amaster
-    :alt: Windows tests (GitHub Actions)
+    :alt: CI Tests (GitHub Actions)
 
 .. image:: https://img.shields.io/codecov/c/github/conda/conda/master.svg?label=coverage
    :alt: Codecov Status


### PR DESCRIPTION
CircleCI badge is still being used for CI. Removing that badge in favor of a badge for all CI tests

![image](https://user-images.githubusercontent.com/6901046/94598127-1d7a6100-0254-11eb-9e39-c757115a6871.png)
