### PR TITLE
Feature/configure headers

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -151,7 +151,7 @@ UNKNOWN_CHANNEL = "<unknown>"
 REPODATA_FN = 'repodata.json'
 
 # headers that cannot be modified by the condarc
-RESERVED_HEADERS = set(['content-type', 'last-modified', 'content-length', 'etag',])
+RESERVED_HEADERS = set(['content-type', 'last-modified', 'content-length', 'etag'])
 
 class SafetyChecks(Enum):
     disabled = 'disabled'

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -150,6 +150,8 @@ CONDA_TEMP_EXTENSION = '.c~'
 UNKNOWN_CHANNEL = "<unknown>"
 REPODATA_FN = 'repodata.json'
 
+# headers that cannot be modified by the condarc
+RESERVED_HEADERS = set(['content-type', 'last-modified', 'content-length', 'etag',])
 
 class SafetyChecks(Enum):
     disabled = 'disabled'

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -17,7 +17,8 @@ from .constants import (APP_NAME, ChannelPriority, DEFAULTS_CHANNEL_NAME, REPODA
                         DEFAULT_AGGRESSIVE_UPDATE_PACKAGES, DEFAULT_CHANNELS,
                         DEFAULT_CHANNEL_ALIAS, DEFAULT_CUSTOM_CHANNELS, DepsModifier,
                         ERROR_UPLOAD_URL, KNOWN_SUBDIRS, PREFIX_MAGIC_FILE, PathConflict,
-                        ROOT_ENV_NAME, SEARCH_PATH, SafetyChecks, SatSolverChoice, UpdateModifier)
+                        ROOT_ENV_NAME, SEARCH_PATH, SafetyChecks, SatSolverChoice,
+                        UpdateModifier, RESERVED_HEADERS)
 from .. import __version__ as CONDA_VERSION
 from .._vendor.appdirs import user_data_dir
 from .._vendor.auxlib.decorators import memoize, memoizedproperty
@@ -117,10 +118,10 @@ def default_python_validation(value):
 
 
 def headers_validation(map_):
-    reserved_headers = set(['content-type', 'last-modified', 'content-length', 'etag',])
+
     for k, v in map_.items():
-        if k.lower() in reserved_headers:
-            return "headers may not contain these reserved headers: %s" % (reserved_headers,)
+        if k.lower() in RESERVED_HEADERS:
+            return "headers may not contain these reserved headers: %s" % (RESERVED_HEADERS,)
     return True
 
 
@@ -240,8 +241,7 @@ class Context(Configuration):
 
     headers = ParameterLoader(
         MapParameter(PrimitiveParameter("", string_types), {},
-                     validation=headers_validation), aliases=('headers',),
-        expandvars=True)
+                     validation=headers_validation), expandvars=True)
 
     # #############################
     # channels

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -116,6 +116,14 @@ def default_python_validation(value):
     return "default_python value '%s' not of the form '[23].[0-9]' or ''" % value
 
 
+def headers_validation(map_):
+    reserved_headers = set(['content-type', 'last-modified', 'content-length', 'etag',])
+    for k, v in map_.items():
+        if k.lower() in reserved_headers:
+            return "headers may not contain these reserved headers: %s" % (reserved_headers,)
+    return True
+
+
 def ssl_verify_validation(value):
     if isinstance(value, string_types):
         if not isfile(value) and not isdir(value):
@@ -229,6 +237,11 @@ class Context(Configuration):
     remote_backoff_factor = ParameterLoader(PrimitiveParameter(1))
 
     add_anaconda_token = ParameterLoader(PrimitiveParameter(True), aliases=('add_binstar_token',))
+
+    headers = ParameterLoader(
+        MapParameter(PrimitiveParameter("", string_types), {},
+                     validation=headers_validation), aliases=('headers',),
+        expandvars=True)
 
     # #############################
     # channels
@@ -845,6 +858,7 @@ class Context(Configuration):
             ('Network Configuration', (
                 'client_ssl_cert',
                 'client_ssl_cert_key',
+                'headers',
                 'local_repodata_ttl',
                 'offline',
                 'proxy_servers',
@@ -1126,6 +1140,9 @@ class Context(Configuration):
             #     to build 32-bit packages on a 64-bit system).  We don't want to mention it
             #     in the documentation, because it can mess up a lot of things.
             #     """),
+            'headers': dals("""
+                A map of key-value pairs to use as HTTP headers that are added to web requests
+                """),
             'json': dals("""
                 Ensure all output written to stdout is structured json.
                 """),

--- a/conda/gateways/connection/session.py
+++ b/conda/gateways/connection/session.py
@@ -95,6 +95,7 @@ class CondaSession(Session):
         self.mount("file://", LocalFSAdapter())
 
         self.headers['User-Agent'] = context.user_agent
+        self.headers.update(context.headers)
 
         self.verify = context.ssl_verify
 

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -333,7 +333,7 @@ class ContextCustomRcTests(TestCase):
 
         string = dals("""
         headers:
-          X-User: {}
+          X-User: "{}"
           X-Location: anywhere
         """.format(username_str))
 

--- a/tests/gateways/test_connection.py
+++ b/tests/gateways/test_connection.py
@@ -85,6 +85,10 @@ class CondaSessionTests(TestCase):
         rd = odict(testdata=YamlRawParameter.make_raw_parameters('testdata', yaml_round_trip_load(string)))
         context._set_raw_data(rd)
 
+        for k, v in headers.items():
+            assert(k in context.headers)
+            assert(v == context.headers.get(k))
+
         session = CondaSession()
         req = Request('GET', 'https://anaconda.org')
         prepared_req = session.prepare_request(req)


### PR DESCRIPTION
This adds a feature to the .condarc, so conda can add user-defined headers to all web requests:

> headers: A map of key-value pairs to use as HTTP headers that are added to web requests

1.  These headers can be pulled out of expanded environment variables
1.  It is strongly validated against a list of headers that are reserved to reduce the ability to break HTTP connections.
1. Tests have been added against both the configuration values and to verify that headers are added to the connection.



┆Issue is synchronized with this [Jira Task](https://anaconda.atlassian.net/browse/CONDAORG-215)
