### PR TITLE
Stop `conda env remove --dry-run` from actually removing environments

### DIFF
--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -73,8 +73,9 @@ def execute(args, parser):
                 handle_txn(txn, prefix, args, False, True)
             except PackagesNotFoundError:
                 print("No packages found in %s. Continuing environment removal" % prefix)
-        rm_rf(prefix, clean_empty_parents=True)
-        unregister_env(prefix)
+        if not context.dry_run:
+            rm_rf(prefix, clean_empty_parents=True)
+            unregister_env(prefix)
 
         return
 

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -361,6 +361,14 @@ class IntegrationTests(unittest.TestCase):
         output = json.loads(stdout)
         assert output["message"] == "All requested packages already installed."
 
+    def test_remove_dry_run(self):
+        # Test for GH-10231
+        create_env(environment_1)
+        run_env_command(Commands.ENV_CREATE, None)
+        env_name = "env-1"
+        run_env_command(Commands.ENV_REMOVE, env_name, "--dry-run")
+        self.assertTrue(env_is_created(env_name))
+
     def test_set_unset_env_vars(self):
         create_env(environment_1)
         run_env_command(Commands.ENV_CREATE, None)


### PR DESCRIPTION
Fixes #10231 