### PR TITLE
bump vendored tqdm version

### DIFF
--- a/conda/_vendor/tqdm/__init__.py
+++ b/conda/_vendor/tqdm/__init__.py
@@ -1,8 +1,10 @@
-# source: https://raw.githubusercontent.com/tqdm/tqdm/v4.19.8/tqdm/__init__.py
-# version: 4.48.0
-# date: 2020-07-20
-# The modules _tqdm_gui, _tqdm_notebook, and _tqdm_pandas are not included.
+# source: https://raw.githubusercontent.com/tqdm/tqdm/v4.50.2/tqdm/__init__.py
+# version: 4.50.2
+# date: 2020-10-07
+# These modules are omitted:
+#   gui, notebook, keras, contrib.bells, contrib.discord, contrib.telegram
 # Also removed syscall on import in _version module.
+# Also omitted man pages & shell completions.
 
 from .std import tqdm, trange
 # from .gui import tqdm as tqdm_gui  # TODO: remove in v5.0.0
@@ -38,8 +40,8 @@ __all__ = ['tqdm', 'trange', 'main', 'TMonitor',
 #          "Please use `tqdm.notebook.tqdm` instead of `tqdm.tqdm_notebook`",
 #          TqdmDeprecationWarning, stacklevel=2)
 #     return _tqdm_notebook(*args, **kwargs)
-# 
-# 
+#
+#
 # def tnrange(*args, **kwargs):  # pragma: no cover
 #     """
 #     A shortcut for `tqdm.notebook.tqdm(xrange(*args), **kwargs)`.

--- a/conda/_vendor/tqdm/__init__.py
+++ b/conda/_vendor/tqdm/__init__.py
@@ -1,6 +1,6 @@
 # source: https://raw.githubusercontent.com/tqdm/tqdm/v4.50.2/tqdm/__init__.py
 # version: 4.50.2
-# date: 2020-10-07
+# date: 2020-10-08
 # These modules are omitted:
 #   gui, notebook, keras, contrib.bells, contrib.discord, contrib.telegram
 # Also removed syscall on import in _version module.

--- a/conda/_vendor/tqdm/_monitor.py
+++ b/conda/_vendor/tqdm/_monitor.py
@@ -24,26 +24,16 @@ class TMonitor(Thread):
     sleep_interval  : fload
         Time to sleep between monitoring checks.
     """
-
-    # internal vars for unit testing
-    _time = None
-    _event = None
+    _test = {}  # internal vars for unit testing
 
     def __init__(self, tqdm_cls, sleep_interval):
         Thread.__init__(self)
         self.daemon = True  # kill thread when main killed (KeyboardInterrupt)
-        self.was_killed = Event()
         self.woken = 0  # last time woken up, to sync with monitor
         self.tqdm_cls = tqdm_cls
         self.sleep_interval = sleep_interval
-        if TMonitor._time is not None:
-            self._time = TMonitor._time
-        else:
-            self._time = time
-        if TMonitor._event is not None:
-            self._event = TMonitor._event
-        else:
-            self._event = Event
+        self._time = self._test.get("time", time)
+        self.was_killed = self._test.get("Event", Event)()
         atexit.register(self.exit)
         self.start()
 
@@ -90,10 +80,14 @@ class TMonitor(Thread):
                         instance.miniters = 1
                         # Refresh now! (works only for manual tqdm)
                         instance.refresh(nolock=True)
+                    # Remove accidental long-lived strong reference
+                    del instance
                 if instances != self.get_instances():  # pragma: nocover
                     warn("Set changed size during iteration" +
                          " (see https://github.com/tqdm/tqdm/issues/481)",
                          TqdmSynchronisationWarning, stacklevel=2)
+                # Remove accidental long-lived strong references
+                del instances
 
     def report(self):
         return not self.was_killed.is_set()

--- a/conda/_vendor/tqdm/_version.py
+++ b/conda/_vendor/tqdm/_version.py
@@ -5,7 +5,7 @@ from io import open as io_open
 __all__ = ["__version__"]
 
 # major, minor, patch, -extra
-version_info = 4, 48, 0
+version_info = 4, 50, 2
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/conda/_vendor/tqdm/_version.py
+++ b/conda/_vendor/tqdm/_version.py
@@ -15,45 +15,48 @@ __version__ = '.'.join(map(str, version_info))
 # scriptdir = os.path.dirname(__file__)
 # gitdir = os.path.abspath(os.path.join(scriptdir, "..", ".git"))
 # if os.path.isdir(gitdir):  # pragma: nocover
-#     extra = None
-#     # Open config file to check if we are in tqdm project
-#     with io_open(os.path.join(gitdir, "config"), 'r') as fh_config:
-#         if 'tqdm' in fh_config.read():
-#             # Open the HEAD file
-#             with io_open(os.path.join(gitdir, "HEAD"), 'r') as fh_head:
-#                 extra = fh_head.readline().strip()
-#             # in a branch => HEAD points to file containing last commit
-#             if 'ref:' in extra:
-#                 # reference file path
-#                 ref_file = extra[5:]
-#                 branch_name = ref_file.rsplit('/', 1)[-1]
+#     try:
+#         extra = None
+#         # Open config file to check if we are in tqdm project
+#         with io_open(os.path.join(gitdir, "config"), 'r') as fh_config:
+#             if 'tqdm' in fh_config.read():
+#                 # Open the HEAD file
+#                 with io_open(os.path.join(gitdir, "HEAD"), 'r') as fh_head:
+#                     extra = fh_head.readline().strip()
+#                 # in a branch => HEAD points to file containing last commit
+#                 if 'ref:' in extra:
+#                     # reference file path
+#                     ref_file = extra[5:]
+#                     branch_name = ref_file.rsplit('/', 1)[-1]
 #
-#                 ref_file_path = os.path.abspath(os.path.join(gitdir, ref_file))
-#                 # check that we are in git folder
-#                 # (by stripping the git folder from the ref file path)
-#                 if os.path.relpath(
-#                         ref_file_path, gitdir).replace('\\', '/') != ref_file:
-#                     # out of git folder
-#                     extra = None
+#                     ref_file_path = os.path.abspath(os.path.join(
+#                         gitdir, ref_file))
+#                     # check that we are in git folder
+#                     # (by stripping the git folder from the ref file path)
+#                     if os.path.relpath(ref_file_path, gitdir).replace(
+#                             '\\', '/') != ref_file:
+#                         # out of git folder
+#                         extra = None
+#                     else:
+#                         # open the ref file
+#                         with io_open(ref_file_path, 'r') as fh_branch:
+#                             commit_hash = fh_branch.readline().strip()
+#                             extra = commit_hash[:8]
+#                             if branch_name != "master":
+#                                 extra += '.' + branch_name
+#
+#                 # detached HEAD mode, already have commit hash
 #                 else:
-#                     # open the ref file
-#                     with io_open(ref_file_path, 'r') as fh_branch:
-#                         commit_hash = fh_branch.readline().strip()
-#                         extra = commit_hash[:8]
-#                         if branch_name != "master":
-#                             extra += '.' + branch_name
+#                     extra = extra[:8]
 #
-#             # detached HEAD mode, already have commit hash
-#             else:
-#                 extra = extra[:8]
-#
-#     # Append commit hash (and branch) to version string if not tagged
-#     if extra is not None:
-#         try:
+#         # Append commit hash (and branch) to version string if not tagged
+#         if extra is not None:
 #             with io_open(os.path.join(gitdir, "refs", "tags",
 #                                       'v' + __version__)) as fdv:
 #                 if fdv.readline().strip()[:8] != extra[:8]:
 #                     __version__ += '-' + extra
-#         except Exception as e:
-#             if "No such file" not in str(e):
-#                 raise
+#     except Exception as e:
+#         if "No such file" in str(e):
+#             __version__ += "-git.UNKNOWN"
+#         else:
+#             raise

--- a/conda/_vendor/tqdm/asyncio.py
+++ b/conda/_vendor/tqdm/asyncio.py
@@ -1,0 +1,75 @@
+"""
+Asynchronous progressbar decorator for iterators.
+Includes a default `range` iterator printing to `stderr`.
+
+Usage:
+>>> from tqdm.asyncio import trange, tqdm
+>>> async for i in trange(10):
+...     ...
+"""
+from .std import tqdm as std_tqdm
+import asyncio
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['tqdm_asyncio', 'tarange', 'tqdm', 'trange']
+
+
+class tqdm_asyncio(std_tqdm):
+    """
+    Asynchronous-friendly version of tqdm (Python 3.5+).
+    """
+    def __init__(self, iterable=None, *args, **kwargs):
+        super(tqdm_asyncio, self).__init__(iterable, *args, **kwargs)
+        self.iterable_awaitable = False
+        if iterable is not None:
+            if hasattr(iterable, "__anext__"):
+                self.iterable_next = iterable.__anext__
+                self.iterable_awaitable = True
+            elif hasattr(iterable, "__next__"):
+                self.iterable_next = iterable.__next__
+            else:
+                self.iterable_iterator = iter(iterable)
+                self.iterable_next = self.iterable_iterator.__next__
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            if self.iterable_awaitable:
+                res = await self.iterable_next()
+            else:
+                res = self.iterable_next()
+            self.update()
+            return res
+        except StopIteration:
+            self.close()
+            raise StopAsyncIteration
+        except:
+            self.close()
+            raise
+
+    def send(self, *args, **kwargs):
+        return self.iterable.send(*args, **kwargs)
+
+    @classmethod
+    def as_completed(cls, fs, *, loop=None, timeout=None, total=None,
+                     **tqdm_kwargs):
+        """
+        Wrapper for `asyncio.as_completed`.
+        """
+        if total is None:
+            total = len(fs)
+        yield from cls(asyncio.as_completed(fs, loop=loop, timeout=timeout),
+                       total=total, **tqdm_kwargs)
+
+
+def tarange(*args, **kwargs):
+    """
+    A shortcut for `tqdm.asyncio.tqdm(range(*args), **kwargs)`.
+    """
+    return tqdm_asyncio(range(*args), **kwargs)
+
+
+# Aliases
+tqdm = tqdm_asyncio
+trange = tarange

--- a/conda/_vendor/tqdm/auto.py
+++ b/conda/_vendor/tqdm/auto.py
@@ -1,0 +1,43 @@
+"""
+Enables multiple commonly used features.
+
+Method resolution order:
+
+- `tqdm.autonotebook` without import warnings
+- `tqdm.asyncio` on Python3.5+
+- `tqdm.std` base class
+
+Usage:
+>>> from tqdm.auto import trange, tqdm
+>>> for i in trange(10):
+...     ...
+"""
+# import sys
+# import warnings
+# from .std import TqdmExperimentalWarning
+# with warnings.catch_warnings():
+#     warnings.simplefilter("ignore", category=TqdmExperimentalWarning)
+#     from .autonotebook import tqdm as notebook_tqdm
+#     from .autonotebook import trange as notebook_trange
+#
+# if sys.version_info[:2] < (3, 5):
+#     tqdm = notebook_tqdm
+#     trange = notebook_trange
+# else:  # Python3.5+
+#     from .asyncio import tqdm as asyncio_tqdm
+#     from .std import tqdm as std_tqdm
+#
+#     if notebook_tqdm != std_tqdm:
+#         class tqdm(notebook_tqdm, asyncio_tqdm):
+#             pass
+#     else:
+#         tqdm = asyncio_tqdm
+#
+#     def trange(*args, **kwargs):
+#         """
+#         A shortcut for `tqdm.auto.tqdm(range(*args), **kwargs)`.
+#         """
+#         return tqdm(range(*args), **kwargs)
+from .std import tqdm, trange
+
+__all__ = ["tqdm", "trange"]

--- a/conda/_vendor/tqdm/cli.py
+++ b/conda/_vendor/tqdm/cli.py
@@ -3,14 +3,15 @@ Module version for monitoring CLI pipes (`... | python -m tqdm | ...`).
 """
 from .std import tqdm, TqdmTypeError, TqdmKeyError
 from ._version import __version__  # NOQA
-import sys
-import re
+from ast import literal_eval as numeric
 import logging
+import re
+import sys
 __all__ = ["main"]
+log = logging.getLogger(__name__)
 
 
 def cast(val, typ):
-    log = logging.getLogger(__name__)
     log.debug((val, typ))
     if " or " in typ:
         for t in typ.split(" or "):
@@ -32,24 +33,35 @@ def cast(val, typ):
         return eval(typ + '("' + val + '")')
     except:
         if typ == 'chr':
-            return chr(ord(eval('"' + val + '"')))
+            return chr(ord(eval('"' + val + '"'))).encode()
         else:
             raise TqdmTypeError(val + ' : ' + typ)
 
 
-def posix_pipe(fin, fout, delim='\n', buf_size=256,
-               callback=lambda int: None  # pragma: no cover
-               ):
+def isBytes(val):
+    """Equivalent of `isinstance(val, six.binary_type)`."""
+    try:
+        val.index(b'')
+    except TypeError:
+        return False
+    return True
+
+
+def posix_pipe(fin, fout, delim=b'\\n', buf_size=256,
+               callback=lambda float: None,  # pragma: no cover
+               callback_len=True):
     """
     Params
     ------
     fin  : file with `read(buf_size : int)` method
     fout  : file with `write` (and optionally `flush`) methods.
-    callback  : function(int), e.g.: `tqdm.update`
+    callback  : function(float), e.g.: `tqdm.update`
+    callback_len  : If (default: True) do `callback(len(buffer))`.
+      Otherwise, do `callback(data) for data in buffer.split(delim)`.
     """
     fp_write = fout.write
 
-    # tmp = ''
+    # tmp = b''
     if not delim:
         while True:
             tmp = fin.read(buf_size)
@@ -63,16 +75,32 @@ def posix_pipe(fin, fout, delim='\n', buf_size=256,
             callback(len(tmp))
         # return
 
-    buf = ''
+    buf = b''
+    check_bytes = True
+    write_bytes = True
     # n = 0
     while True:
         tmp = fin.read(buf_size)
+
+        if check_bytes:  # first time; check encoding
+            check_bytes = False
+            if not isBytes(tmp):
+                # currently only triggered by `tests_main.py`.
+                # TODO: mock stdin/out better so that this isn't needed
+                write_bytes = False
+                delim = delim.decode()
+                buf = buf.decode()
 
         # flush at EOF
         if not tmp:
             if buf:
                 fp_write(buf)
-                callback(1 + buf.count(delim))  # n += 1 + buf.count(delim)
+                if callback_len:
+                    # n += 1 + buf.count(delim)
+                    callback(1 + buf.count(delim))
+                else:
+                    for i in buf.split(delim):
+                        callback(i)
             getattr(fout, 'flush', lambda: None)()  # pragma: no cover
             return  # n
 
@@ -84,8 +112,9 @@ def posix_pipe(fin, fout, delim='\n', buf_size=256,
                 break
             else:
                 fp_write(buf + tmp[:i + len(delim)])
-                callback(1)  # n += 1
-                buf = ''
+                # n += 1
+                callback(1 if callback_len else (buf + tmp[:i]))
+                buf = b'' if write_bytes else ''
                 tmp = tmp[i + len(delim):]
 
 
@@ -112,6 +141,16 @@ CLI_EXTRA_DOC = r"""
         bytes  : bool, optional
             If true, will count bytes, ignore `delim`, and default
             `unit_scale` to True, `unit_divisor` to 1024, and `unit` to 'B'.
+        tee  : bool, optional
+            If true, passes `stdin` to both `stderr` and `stdout`.
+        update  : bool, optional
+            If true, will treat input as newly elapsed iterations,
+            i.e. numbers to pass to `update()`.
+        update_to  : bool, optional
+            If true, will treat input as total elapsed iterations,
+            i.e. numbers to assign to `self.n`.
+        null  : bool, optional
+            If true, will discard input (no stdout).
         manpath  : str, optional
             Directory in which to install tqdm man pages.
         comppath  : str, optional
@@ -131,7 +170,7 @@ def main(fp=sys.stderr, argv=None):
     if argv is None:
         argv = sys.argv[1:]
     try:
-        log = argv.index('--log')
+        log_idx = argv.index('--log')
     except ValueError:
         for i in argv:
             if i.startswith('--log='):
@@ -140,13 +179,12 @@ def main(fp=sys.stderr, argv=None):
         else:
             logLevel = 'INFO'
     else:
-        # argv.pop(log)
-        # logLevel = argv.pop(log)
-        logLevel = argv[log + 1]
+        # argv.pop(log_idx)
+        # logLevel = argv.pop(log_idx)
+        logLevel = argv[log_idx + 1]
     logging.basicConfig(
         level=getattr(logging, logLevel),
         format="%(levelname)s:%(module)s:%(lineno)d:%(message)s")
-    log = logging.getLogger(__name__)
 
     d = tqdm.__init__.__doc__ + CLI_EXTRA_DOC
 
@@ -161,16 +199,17 @@ def main(fp=sys.stderr, argv=None):
     # d = RE_OPTS.sub(r'  --\1=<\1>  : \2', d)
     split = RE_OPTS.split(d)
     opt_types_desc = zip(split[1::3], split[2::3], split[3::3])
-    d = ''.join('\n  --{0}=<{0}>  : {1}{2}'.format(*otd)
+    d = ''.join(('\n  --{0}  : {2}{3}' if otd[1] == 'bool' else
+                 '\n  --{0}=<{1}>  : {2}{3}').format(
+                     otd[0].replace('_', '-'), otd[0], *otd[1:])
                 for otd in opt_types_desc if otd[0] not in UNSUPPORTED_OPTS)
 
     d = """Usage:
   tqdm [--help | options]
 
 Options:
-  -h, --help     Print this help and exit
-  -v, --version  Print version and exit
-
+  -h, --help     Print this help and exit.
+  -v, --version  Print version and exit.
 """ + d.strip('\n') + '\n'
 
     # opts = docopt(d, version=__version__)
@@ -190,11 +229,19 @@ Options:
     tqdm_args = {'file': fp}
     try:
         for (o, v) in opts.items():
+            o = o.replace('-', '_')
             try:
                 tqdm_args[o] = cast(v, opt_types[o])
             except KeyError as e:
                 raise TqdmKeyError(str(e))
         log.debug('args:' + str(tqdm_args))
+
+        delim_per_char = tqdm_args.pop('bytes', False)
+        update = tqdm_args.pop('update', False)
+        update_to = tqdm_args.pop('update_to', False)
+        if sum((delim_per_char, update, update_to)) > 1:
+            raise TqdmKeyError(
+                "Can only have one of --bytes --update --update_to")
     except:
         fp.write('\nError:\nUsage:\n  tqdm [--help | options]\n')
         for i in sys.stdin:
@@ -202,12 +249,19 @@ Options:
         raise
     else:
         buf_size = tqdm_args.pop('buf_size', 256)
-        delim = tqdm_args.pop('delim', '\n')
-        delim_per_char = tqdm_args.pop('bytes', False)
+        delim = tqdm_args.pop('delim', b'\\n')
+        tee = tqdm_args.pop('tee', False)
         manpath = tqdm_args.pop('manpath', None)
         comppath = tqdm_args.pop('comppath', None)
+        if tqdm_args.pop('null', False):
+            class stdout(object):
+                @staticmethod
+                def write(_):
+                    pass
+        else:
+            stdout = sys.stdout
+            stdout = getattr(stdout, 'buffer', stdout)
         stdin = getattr(sys.stdin, 'buffer', sys.stdin)
-        stdout = getattr(sys.stdout, 'buffer', sys.stdout)
         if manpath or comppath:
             from os import path
             from shutil import copyfile
@@ -225,6 +279,16 @@ Options:
                                      'tqdm/completion.sh'),
                    path.join(comppath, 'tqdm_completion.sh'))
             sys.exit(0)
+        if tee:
+            stdout_write = stdout.write
+            fp_write = getattr(fp, 'buffer', fp).write
+
+            class stdout(object):
+                @staticmethod
+                def write(x):
+                    with tqdm.external_write_mode(file=fp):
+                        fp_write(x)
+                    stdout_write(x)
         if delim_per_char:
             tqdm_args.setdefault('unit', 'B')
             tqdm_args.setdefault('unit_scale', True)
@@ -232,11 +296,34 @@ Options:
             log.debug(tqdm_args)
             with tqdm(**tqdm_args) as t:
                 posix_pipe(stdin, stdout, '', buf_size, t.update)
-        elif delim == '\n':
+        elif delim == b'\\n':
             log.debug(tqdm_args)
-            for i in tqdm(stdin, **tqdm_args):
-                stdout.write(i)
+            if update or update_to:
+                with tqdm(**tqdm_args) as t:
+                    if update:
+                        def callback(i):
+                            t.update(numeric(i))
+                    else:  # update_to
+                        def callback(i):
+                            t.update(numeric(i) - t.n)
+                    for i in stdin:
+                        stdout.write(i)
+                        callback(i)
+            else:
+                for i in tqdm(stdin, **tqdm_args):
+                    stdout.write(i)
         else:
             log.debug(tqdm_args)
             with tqdm(**tqdm_args) as t:
-                posix_pipe(stdin, stdout, delim, buf_size, t.update)
+                callback_len = False
+                if update:
+                    def callback(i):
+                        t.update(numeric(i))
+                elif update_to:
+                    def callback(i):
+                        t.update(numeric(i) - t.n)
+                else:
+                    callback = t.update
+                    callback_len = True
+                posix_pipe(stdin, stdout, delim, buf_size,
+                           callback, callback_len)

--- a/conda/_vendor/tqdm/contrib/__init__.py
+++ b/conda/_vendor/tqdm/contrib/__init__.py
@@ -1,0 +1,78 @@
+"""
+Thin wrappers around common functions.
+
+Subpackages contain potentially unstable extensions.
+"""
+from tqdm import tqdm
+from tqdm.auto import tqdm as tqdm_auto
+from tqdm.utils import ObjectWrapper
+from functools import wraps
+import sys
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['tenumerate', 'tzip', 'tmap']
+
+
+class DummyTqdmFile(ObjectWrapper):
+    """Dummy file-like that will write to tqdm"""
+    def write(self, x, nolock=False):
+        # Avoid print() second call (useless \n)
+        if len(x.rstrip()) > 0:
+            tqdm.write(x, file=self._wrapped, nolock=nolock)
+
+
+def builtin_iterable(func):
+    """Wraps `func()` output in a `list()` in py2"""
+    if sys.version_info[:1] < (3,):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            return list(func(*args, **kwargs))
+        return inner
+    return func
+
+
+def tenumerate(iterable, start=0, total=None, tqdm_class=tqdm_auto,
+               **tqdm_kwargs):
+    """
+    Equivalent of `numpy.ndenumerate` or builtin `enumerate`.
+
+    Parameters
+    ----------
+    tqdm_class  : [default: tqdm.auto.tqdm].
+    """
+    try:
+        import numpy as np
+    except ImportError:
+        pass
+    else:
+        if isinstance(iterable, np.ndarray):
+            return tqdm_class(np.ndenumerate(iterable),
+                              total=total or iterable.size, **tqdm_kwargs)
+    return enumerate(tqdm_class(iterable, total=total, **tqdm_kwargs), start)
+
+
+@builtin_iterable
+def tzip(iter1, *iter2plus, **tqdm_kwargs):
+    """
+    Equivalent of builtin `zip`.
+
+    Parameters
+    ----------
+    tqdm_class  : [default: tqdm.auto.tqdm].
+    """
+    kwargs = tqdm_kwargs.copy()
+    tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
+    for i in zip(tqdm_class(iter1, **tqdm_kwargs), *iter2plus):
+        yield i
+
+
+@builtin_iterable
+def tmap(function, *sequences, **tqdm_kwargs):
+    """
+    Equivalent of builtin `map`.
+
+    Parameters
+    ----------
+    tqdm_class  : [default: tqdm.auto.tqdm].
+    """
+    for i in tzip(*sequences, **tqdm_kwargs):
+        yield function(*i)

--- a/conda/_vendor/tqdm/contrib/concurrent.py
+++ b/conda/_vendor/tqdm/contrib/concurrent.py
@@ -1,0 +1,105 @@
+"""
+Thin wrappers around `concurrent.futures`.
+"""
+from __future__ import absolute_import
+from tqdm import TqdmWarning
+from tqdm.auto import tqdm as tqdm_auto
+try:
+    from operator import length_hint
+except ImportError:
+    def length_hint(it, default=0):
+        """Returns `len(it)`, falling back to `default`"""
+        try:
+            return len(it)
+        except TypeError:
+            return default
+try:
+    from os import cpu_count
+except ImportError:
+    try:
+        from multiprocessing import cpu_count
+    except ImportError:
+        def cpu_count():
+            return 4
+import sys
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['thread_map', 'process_map']
+
+
+def _executor_map(PoolExecutor, fn, *iterables, **tqdm_kwargs):
+    """
+    Implementation of `thread_map` and `process_map`.
+
+    Parameters
+    ----------
+    tqdm_class  : [default: tqdm.auto.tqdm].
+    max_workers  : [default: min(32, cpu_count() + 4)].
+    chunksize  : [default: 1].
+    """
+    kwargs = tqdm_kwargs.copy()
+    if "total" not in kwargs:
+        kwargs["total"] = len(iterables[0])
+    tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
+    max_workers = kwargs.pop("max_workers", min(32, cpu_count() + 4))
+    chunksize = kwargs.pop("chunksize", 1)
+    pool_kwargs = dict(max_workers=max_workers)
+    sys_version = sys.version_info[:2]
+    if sys_version >= (3, 7):
+        # share lock in case workers are already using `tqdm`
+        pool_kwargs.update(
+            initializer=tqdm_class.set_lock, initargs=(tqdm_class.get_lock(),))
+    map_args = {}
+    if not (3, 0) < sys_version < (3, 5):
+        map_args.update(chunksize=chunksize)
+    with PoolExecutor(**pool_kwargs) as ex:
+        return list(tqdm_class(
+            ex.map(fn, *iterables, **map_args), **kwargs))
+
+
+def thread_map(fn, *iterables, **tqdm_kwargs):
+    """
+    Equivalent of `list(map(fn, *iterables))`
+    driven by `concurrent.futures.ThreadPoolExecutor`.
+
+    Parameters
+    ----------
+    tqdm_class : optional
+        `tqdm` class to use for bars [default: tqdm.auto.tqdm].
+    max_workers : int, optional
+        Maximum number of workers to spawn; passed to
+        `concurrent.futures.ThreadPoolExecutor.__init__`.
+        [default: max(32, cpu_count() + 4)].
+    """
+    from concurrent.futures import ThreadPoolExecutor
+    return _executor_map(ThreadPoolExecutor, fn, *iterables, **tqdm_kwargs)
+
+
+def process_map(fn, *iterables, **tqdm_kwargs):
+    """
+    Equivalent of `list(map(fn, *iterables))`
+    driven by `concurrent.futures.ProcessPoolExecutor`.
+
+    Parameters
+    ----------
+    tqdm_class  : optional
+        `tqdm` class to use for bars [default: tqdm.auto.tqdm].
+    max_workers : int, optional
+        Maximum number of workers to spawn; passed to
+        `concurrent.futures.ProcessPoolExecutor.__init__`.
+        [default: min(32, cpu_count() + 4)].
+    chunksize : int, optional
+        Size of chunks sent to worker processes; passed to
+        `concurrent.futures.ProcessPoolExecutor.map`. [default: 1].
+    """
+    from concurrent.futures import ProcessPoolExecutor
+    if iterables and "chunksize" not in tqdm_kwargs:
+        # default `chunksize=1` has poor performance for large iterables
+        # (most time spent dispatching items to workers).
+        longest_iterable_len = max(map(length_hint, iterables))
+        if longest_iterable_len > 1000:
+            from warnings import warn
+            warn("Iterable length %d > 1000 but `chunksize` is not set."
+                 " This may seriously degrade multiprocess performance."
+                 " Set `chunksize=1` or more." % longest_iterable_len,
+                 TqdmWarning, stacklevel=2)
+    return _executor_map(ProcessPoolExecutor, fn, *iterables, **tqdm_kwargs)

--- a/conda/_vendor/tqdm/contrib/itertools.py
+++ b/conda/_vendor/tqdm/contrib/itertools.py
@@ -1,0 +1,33 @@
+"""
+Thin wrappers around `itertools`.
+"""
+from __future__ import absolute_import
+from tqdm.auto import tqdm as tqdm_auto
+import itertools
+__author__ = {"github.com/": ["casperdcl"]}
+__all__ = ['product']
+
+
+def product(*iterables, **tqdm_kwargs):
+    """
+    Equivalent of `itertools.product`.
+
+    Parameters
+    ----------
+    tqdm_class  : [default: tqdm.auto.tqdm].
+    """
+    kwargs = tqdm_kwargs.copy()
+    tqdm_class = kwargs.pop("tqdm_class", tqdm_auto)
+    try:
+        lens = list(map(len, iterables))
+    except TypeError:
+        total = None
+    else:
+        total = 1
+        for i in lens:
+            total *= i
+        kwargs.setdefault("total", total)
+    with tqdm_class(**kwargs) as t:
+        for i in itertools.product(*iterables):
+            yield i
+            t.update()

--- a/conda/_vendor/tqdm/utils.py
+++ b/conda/_vendor/tqdm/utils.py
@@ -342,8 +342,7 @@ def _screen_shape_windows(fp):  # pragma: no cover
 def _screen_shape_tput(*_):  # pragma: no cover
     """cygwin xterm (windows)"""
     try:
-        # import shlex
-        # return [int(subprocess.check_call(shlex.split('tput ' + i))) - 1
+        # from shlex import split as ss
         from conda._vendor.auxlib.compat import shlex_split_unicode as ss
         return [int(subprocess.check_call(ss('tput ' + i))) - 1
                 for i in ('cols', 'lines')]

--- a/conda/_vendor/tqdm/utils.py
+++ b/conda/_vendor/tqdm/utils.py
@@ -342,8 +342,10 @@ def _screen_shape_windows(fp):  # pragma: no cover
 def _screen_shape_tput(*_):  # pragma: no cover
     """cygwin xterm (windows)"""
     try:
-        import shlex
-        return [int(subprocess.check_call(shlex.split('tput ' + i))) - 1
+        # import shlex
+        # return [int(subprocess.check_call(shlex.split('tput ' + i))) - 1
+        from conda._vendor.auxlib.compat import shlex_split_unicode as ss
+        return [int(subprocess.check_call(ss('tput ' + i))) - 1
                 for i in ('cols', 'lines')]
     except:
         pass

--- a/conda/_vendor/tqdm/utils.py
+++ b/conda/_vendor/tqdm/utils.py
@@ -2,18 +2,15 @@
 General helpers required for `tqdm.std`.
 """
 from functools import wraps
-import os
-from platform import system as _curos
-import re
-import subprocess
 from warnings import warn
+import os
+import re
+import sys
+import subprocess
 
-CUR_OS = _curos()
-IS_WIN = CUR_OS in ['Windows', 'cli']
-IS_NIX = (not IS_WIN) and any(
-    CUR_OS.startswith(i) for i in
-    ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS',
-     'FreeBSD', 'NetBSD', 'OpenBSD'])
+CUR_OS = sys.platform
+IS_WIN = any(CUR_OS.startswith(i) for i in ['win32', 'cygwin'])
+IS_NIX = any(CUR_OS.startswith(i) for i in ['aix', 'linux', 'darwin'])
 RE_ANSI = re.compile(r"\x1b\[[;\d]*[A-Za-z]")
 
 
@@ -212,6 +209,41 @@ class SimpleTextIOWrapper(ObjectWrapper):
         return self._wrapped == getattr(other, '_wrapped', other)
 
 
+class DisableOnWriteError(ObjectWrapper):
+    """
+    Disable the given `tqdm_instance` upon `write()` or `flush()` errors.
+    """
+    @staticmethod
+    def disable_on_exception(tqdm_instance, func):
+        """
+        Quietly set `tqdm_instance.miniters=inf` if `func` raises `errno=5`.
+        """
+        def inner(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except (IOError, OSError) as e:
+                if e.errno != 5:
+                    raise
+                tqdm_instance.miniters = float('inf')
+            except ValueError as e:
+                if 'closed' not in str(e):
+                    raise
+                tqdm_instance.miniters = float('inf')
+        return inner
+
+    def __init__(self, wrapped, tqdm_instance):
+        super(DisableOnWriteError, self).__init__(wrapped)
+        if hasattr(wrapped, 'write'):
+            self.wrapper_setattr('write', self.disable_on_exception(
+                tqdm_instance, wrapped.write))
+        if hasattr(wrapped, 'flush'):
+            self.wrapper_setattr('flush', self.disable_on_exception(
+                tqdm_instance, wrapped.flush))
+
+    def __eq__(self, other):
+        return self._wrapped == getattr(other, '_wrapped', other)
+
+
 class CallbackIOWrapper(ObjectWrapper):
     def __init__(self, callback, stream, method="read"):
         """
@@ -311,8 +343,7 @@ def _screen_shape_tput(*_):  # pragma: no cover
     """cygwin xterm (windows)"""
     try:
         import shlex
-        from conda._vendor.auxlib.compat import shlex_split_unicode
-        return [int(subprocess.check_call(shlex_split_unicode('tput ' + i))) - 1
+        return [int(subprocess.check_call(shlex.split('tput ' + i))) - 1
                 for i in ('cols', 'lines')]
     except:
         pass


### PR DESCRIPTION
- Fixes various threading and I/O bugs (see https://tqdm.github.io/releases). The previous vendored version was based on https://tqdm.github.io/releases/#v4480-2020-07-16. Since then, there's been about 2 releases/month often with various fixes, e.g.:
  + https://github.com/tqdm/tqdm/pull/1041, https://github.com/tqdm/tqdm/pull/1036 <- https://github.com/tqdm/tqdm/issues/1033
  + https://github.com/tqdm/tqdm/pull/1046 <- https://github.com/tqdm/tqdm/issues/920, https://github.com/tqdm/tqdm/issues/691
  + also re-patches #10115 (re-fixing #9589)
    * as per https://github.com/conda/conda/pull/10115#issuecomment-703991446
    * https://github.com/tqdm/tqdm/pull/1044 <- https://github.com/tqdm/tqdm/pull/617
- also includes previous patches (#7157 <- #7040, #8435)

If you want to check the diff, it's easiest to use your preferred folder diff tool to compare the upstream folder (https://github.com/tqdm/tqdm/tree/v4.50.2/tqdm) to the one in this PR (https://github.com/tqdm/conda/tree/bump-vendor-tqdm/conda/_vendor/tqdm). Pasted below for convenience:

<details>

```diff
Only in tqdm/tqdm: autonotebook.py
diff tqdm/tqdm/auto.py conda/conda/_vendor/tqdm/auto.py
15,40c15,41
< import sys
< import warnings
< from .std import TqdmExperimentalWarning
< with warnings.catch_warnings():
<     warnings.simplefilter("ignore", category=TqdmExperimentalWarning)
<     from .autonotebook import tqdm as notebook_tqdm
<     from .autonotebook import trange as notebook_trange
< 
< if sys.version_info[:2] < (3, 5):
<     tqdm = notebook_tqdm
<     trange = notebook_trange
< else:  # Python3.5+
<     from .asyncio import tqdm as asyncio_tqdm
<     from .std import tqdm as std_tqdm
< 
<     if notebook_tqdm != std_tqdm:
<         class tqdm(notebook_tqdm, asyncio_tqdm):
<             pass
<     else:
<         tqdm = asyncio_tqdm
< 
<     def trange(*args, **kwargs):
<         """
<         A shortcut for `tqdm.auto.tqdm(range(*args), **kwargs)`.
<         """
<         return tqdm(range(*args), **kwargs)
---
> # import sys
> # import warnings
> # from .std import TqdmExperimentalWarning
> # with warnings.catch_warnings():
> #     warnings.simplefilter("ignore", category=TqdmExperimentalWarning)
> #     from .autonotebook import tqdm as notebook_tqdm
> #     from .autonotebook import trange as notebook_trange
> #
> # if sys.version_info[:2] < (3, 5):
> #     tqdm = notebook_tqdm
> #     trange = notebook_trange
> # else:  # Python3.5+
> #     from .asyncio import tqdm as asyncio_tqdm
> #     from .std import tqdm as std_tqdm
> #
> #     if notebook_tqdm != std_tqdm:
> #         class tqdm(notebook_tqdm, asyncio_tqdm):
> #             pass
> #     else:
> #         tqdm = asyncio_tqdm
> #
> #     def trange(*args, **kwargs):
> #         """
> #         A shortcut for `tqdm.auto.tqdm(range(*args), **kwargs)`.
> #         """
> #         return tqdm(range(*args), **kwargs)
> from .std import tqdm, trange
Only in tqdm/tqdm: completion.sh
Common subdirectories: tqdm/tqdm/contrib and conda/conda/_vendor/tqdm/contrib
Only in tqdm/tqdm: gui.py
diff tqdm/tqdm/__init__.py conda/conda/_vendor/tqdm/__init__.py
0a1,8
> # source: https://raw.githubusercontent.com/tqdm/tqdm/v4.50.2/tqdm/__init__.py
> # version: 4.50.2
> # date: 2020-10-08
> # These modules are omitted:
> #   gui, notebook, keras, contrib.bells, contrib.discord, contrib.telegram
> # Also removed syscall on import in _version module.
> # Also omitted man pages & shell completions.
> 
2,4c10,12
< from .gui import tqdm as tqdm_gui  # TODO: remove in v5.0.0
< from .gui import trange as tgrange  # TODO: remove in v5.0.0
< from ._tqdm_pandas import tqdm_pandas
---
> # from .gui import tqdm as tqdm_gui  # TODO: remove in v5.0.0
> # from .gui import trange as tgrange  # TODO: remove in v5.0.0
> # from ._tqdm_pandas import tqdm_pandas
12,13c20,27
< __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
<            'tqdm_notebook', 'tnrange', 'main', 'TMonitor',
---
> # __all__ = ['tqdm', 'tqdm_gui', 'trange', 'tgrange', 'tqdm_pandas',
> #            'tqdm_notebook', 'tnrange', 'main', 'TMonitor',
> #            'TqdmTypeError', 'TqdmKeyError',
> #            'TqdmWarning', 'TqdmDeprecationWarning',
> #            'TqdmExperimentalWarning',
> #            'TqdmMonitorWarning', 'TqdmSynchronisationWarning',
> #            '__version__']
> __all__ = ['tqdm', 'trange', 'main', 'TMonitor',
21,40c35,54
< def tqdm_notebook(*args, **kwargs):  # pragma: no cover
<     """See tqdm.notebook.tqdm for full documentation"""
<     from .notebook import tqdm as _tqdm_notebook
<     from warnings import warn
<     warn("This function will be removed in tqdm==5.0.0\n"
<          "Please use `tqdm.notebook.tqdm` instead of `tqdm.tqdm_notebook`",
<          TqdmDeprecationWarning, stacklevel=2)
<     return _tqdm_notebook(*args, **kwargs)
< 
< 
< def tnrange(*args, **kwargs):  # pragma: no cover
<     """
<     A shortcut for `tqdm.notebook.tqdm(xrange(*args), **kwargs)`.
<     On Python3+, `range` is used instead of `xrange`.
<     """
<     from .notebook import trange as _tnrange
<     from warnings import warn
<     warn("Please use `tqdm.notebook.trange` instead of `tqdm.tnrange`",
<          TqdmDeprecationWarning, stacklevel=2)
<     return _tnrange(*args, **kwargs)
---
> # def tqdm_notebook(*args, **kwargs):  # pragma: no cover
> #     """See tqdm.notebook.tqdm for full documentation"""
> #     from .notebook import tqdm as _tqdm_notebook
> #     from warnings import warn
> #     warn("This function will be removed in tqdm==5.0.0\n"
> #          "Please use `tqdm.notebook.tqdm` instead of `tqdm.tqdm_notebook`",
> #          TqdmDeprecationWarning, stacklevel=2)
> #     return _tqdm_notebook(*args, **kwargs)
> #
> #
> # def tnrange(*args, **kwargs):  # pragma: no cover
> #     """
> #     A shortcut for `tqdm.notebook.tqdm(xrange(*args), **kwargs)`.
> #     On Python3+, `range` is used instead of `xrange`.
> #     """
> #     from .notebook import trange as _tnrange
> #     from warnings import warn
> #     warn("Please use `tqdm.notebook.trange` instead of `tqdm.tnrange`",
> #          TqdmDeprecationWarning, stacklevel=2)
> #     return _tnrange(*args, **kwargs)
Only in tqdm/tqdm: keras.py
Only in conda/conda/_vendor/tqdm: LICENSE
Only in tqdm/tqdm: notebook.py
Only in tqdm/tqdm: tests
Only in tqdm/tqdm: tqdm.1
Only in tqdm/tqdm: _tqdm_gui.py
Only in tqdm/tqdm: _tqdm_notebook.py
Only in tqdm/tqdm: _tqdm_pandas.py
diff tqdm/tqdm/utils.py conda/conda/_vendor/tqdm/utils.py
345,346c345,347
<         import shlex
<         return [int(subprocess.check_call(shlex.split('tput ' + i))) - 1
---
>         # from shlex import split as ss
>         from conda._vendor.auxlib.compat import shlex_split_unicode as ss
>         return [int(subprocess.check_call(ss('tput ' + i))) - 1
diff tqdm/tqdm/_version.py conda/conda/_vendor/tqdm/_version.py
14,62c14,62
< # auto -extra based on commit hash (if not tagged as release)
< scriptdir = os.path.dirname(__file__)
< gitdir = os.path.abspath(os.path.join(scriptdir, "..", ".git"))
< if os.path.isdir(gitdir):  # pragma: nocover
<     try:
<         extra = None
<         # Open config file to check if we are in tqdm project
<         with io_open(os.path.join(gitdir, "config"), 'r') as fh_config:
<             if 'tqdm' in fh_config.read():
<                 # Open the HEAD file
<                 with io_open(os.path.join(gitdir, "HEAD"), 'r') as fh_head:
<                     extra = fh_head.readline().strip()
<                 # in a branch => HEAD points to file containing last commit
<                 if 'ref:' in extra:
<                     # reference file path
<                     ref_file = extra[5:]
<                     branch_name = ref_file.rsplit('/', 1)[-1]
< 
<                     ref_file_path = os.path.abspath(os.path.join(
<                         gitdir, ref_file))
<                     # check that we are in git folder
<                     # (by stripping the git folder from the ref file path)
<                     if os.path.relpath(ref_file_path, gitdir).replace(
<                             '\\', '/') != ref_file:
<                         # out of git folder
<                         extra = None
<                     else:
<                         # open the ref file
<                         with io_open(ref_file_path, 'r') as fh_branch:
<                             commit_hash = fh_branch.readline().strip()
<                             extra = commit_hash[:8]
<                             if branch_name != "master":
<                                 extra += '.' + branch_name
< 
<                 # detached HEAD mode, already have commit hash
<                 else:
<                     extra = extra[:8]
< 
<         # Append commit hash (and branch) to version string if not tagged
<         if extra is not None:
<             with io_open(os.path.join(gitdir, "refs", "tags",
<                                       'v' + __version__)) as fdv:
<                 if fdv.readline().strip()[:8] != extra[:8]:
<                     __version__ += '-' + extra
<     except Exception as e:
<         if "No such file" in str(e):
<             __version__ += "-git.UNKNOWN"
<         else:
<             raise
---
> # # auto -extra based on commit hash (if not tagged as release)
> # scriptdir = os.path.dirname(__file__)
> # gitdir = os.path.abspath(os.path.join(scriptdir, "..", ".git"))
> # if os.path.isdir(gitdir):  # pragma: nocover
> #     try:
> #         extra = None
> #         # Open config file to check if we are in tqdm project
> #         with io_open(os.path.join(gitdir, "config"), 'r') as fh_config:
> #             if 'tqdm' in fh_config.read():
> #                 # Open the HEAD file
> #                 with io_open(os.path.join(gitdir, "HEAD"), 'r') as fh_head:
> #                     extra = fh_head.readline().strip()
> #                 # in a branch => HEAD points to file containing last commit
> #                 if 'ref:' in extra:
> #                     # reference file path
> #                     ref_file = extra[5:]
> #                     branch_name = ref_file.rsplit('/', 1)[-1]
> #
> #                     ref_file_path = os.path.abspath(os.path.join(
> #                         gitdir, ref_file))
> #                     # check that we are in git folder
> #                     # (by stripping the git folder from the ref file path)
> #                     if os.path.relpath(ref_file_path, gitdir).replace(
> #                             '\\', '/') != ref_file:
> #                         # out of git folder
> #                         extra = None
> #                     else:
> #                         # open the ref file
> #                         with io_open(ref_file_path, 'r') as fh_branch:
> #                             commit_hash = fh_branch.readline().strip()
> #                             extra = commit_hash[:8]
> #                             if branch_name != "master":
> #                                 extra += '.' + branch_name
> #
> #                 # detached HEAD mode, already have commit hash
> #                 else:
> #                     extra = extra[:8]
> #
> #         # Append commit hash (and branch) to version string if not tagged
> #         if extra is not None:
> #             with io_open(os.path.join(gitdir, "refs", "tags",
> #                                       'v' + __version__)) as fdv:
> #                 if fdv.readline().strip()[:8] != extra[:8]:
> #                     __version__ += '-' + extra
> #     except Exception as e:
> #         if "No such file" in str(e):
> #             __version__ += "-git.UNKNOWN"
> #         else:
> #             raise
```

</details>