### PR TITLE
Enabling "conda run" to display real time output for the subprocess

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1097,6 +1097,14 @@ def configure_parser_run(sub_parsers):
         help="Executable name, with additional arguments to be passed to the executable "
              "on invocation.",
     )
+
+    p.add_argument(
+        '--live-stream',
+        action="store_true",
+        default=False,
+        help="Display the output for the subprocess stdout and stderr on real time.",
+    )
+
     p.set_defaults(func='.main_run.execute')
 
 

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -25,7 +25,7 @@ def execute(args, parser):
                                                        args.dev, args.debug_wrapper_scripts, call)
     env = encode_environment(os.environ.copy())
 
-    response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False)
+    response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False, live_stream=args.live_stream)
     if response.rc != 0:
         log = getLogger(__name__)
         log.error("Subprocess for 'conda run {}' command failed.  (See above for error)"
@@ -37,8 +37,9 @@ def execute(args, parser):
             log = getLogger(__name__)
             log.warning('CONDA_TEST_SAVE_TEMPS :: retaining main_run script_caller {}'.format(
                 script_caller))
-    if response.stdout:
-        print(response.stdout, file=sys.stdout)
-    if response.stderr:
-        print(response.stderr, file=sys.stderr)
+    if not args.live_stream:
+        if response.stdout:
+            print(response.stdout, file=sys.stdout)
+        if response.stderr:
+            print(response.stderr, file=sys.stderr)
     return response

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -25,7 +25,8 @@ def execute(args, parser):
                                                        args.dev, args.debug_wrapper_scripts, call)
     env = encode_environment(os.environ.copy())
 
-    response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False, live_stream=args.live_stream)
+    response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False,
+                               live_stream=args.live_stream)
     if response.rc != 0:
         log = getLogger(__name__)
         log.error("Subprocess for 'conda run {}' command failed.  (See above for error)"

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -58,7 +58,8 @@ def any_subprocess(args, prefix, env=None, cwd=None):
     return stdout, stderr, process.returncode
 
 
-def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=True, live_stream=False):
+def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=True,
+                    live_stream=False):
     """This utility function should be preferred for all conda subprocessing.
     It handles multiple tricky details.
     """

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -71,7 +71,8 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
     log.debug("executing>> %s", command_str)
 
     if capture_output:
-        p = Popen(encode_arguments(command), cwd=cwd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env)
+        p = Popen(encode_arguments(command), cwd=cwd, stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                  env=env)
         ACTIVE_SUBPROCESSES.add(p)
         stdin = ensure_binary(stdin) if isinstance(stdin, string_types) else stdin
 

--- a/tests/gateways/test_subprocess.py
+++ b/tests/gateways/test_subprocess.py
@@ -1,0 +1,32 @@
+from conda.gateways.subprocess import subprocess_call
+
+try:
+    from unittest.mock import patch, call
+except ImportError:
+    from mock import patch, call
+
+
+@patch("sys.stderr", spec=True)
+@patch("sys.stdout", spec=True)
+def test_subprocess_call_with_live_stream(mock_stdout, mock_stderr):
+    resp = subprocess_call(
+        ('python -c "import sys, time; sys.stdout.write(\'1\\n\'); '
+         'sys.stderr.write(\'2\\n\'); time.sleep(.3); sys.stdout.write(\'end\\n\')"'),
+        live_stream=True,
+    )
+
+    mock_stdout.write.assert_has_calls([
+        call('1\n'),
+        call(''),
+        call('end\n'),
+        call(''),
+    ])
+
+    mock_stderr.write.assert_has_calls([
+        call('2\n'),
+        call(''),
+    ])
+
+    assert resp.stdout == '1\nend\n'
+    assert resp.stderr == "2\n"
+    assert resp.rc == 0

--- a/tests/gateways/test_subprocess.py
+++ b/tests/gateways/test_subprocess.py
@@ -15,17 +15,14 @@ def test_subprocess_call_with_live_stream(mock_stdout, mock_stderr):
         live_stream=True,
     )
 
-    mock_stdout.write.assert_has_calls([
-        call('1\n'),
-        call(''),
-        call('end\n'),
-        call(''),
-    ])
+    def get_write_calls(mock_stream):
+        return [args[0].replace('\r\n', '\n') for args, kwargs in mock_stream.write.call_args_list]
 
-    mock_stderr.write.assert_has_calls([
-        call('2\n'),
-        call(''),
-    ])
+    stdout_calls = get_write_calls(mock_stdout)
+    stderr_calls = get_write_calls(mock_stderr)
+
+    assert ['1\n', '', 'end\n', ''] == stdout_calls
+    assert ['2\n', ''] == stderr_calls
 
     assert resp.stdout == '1\nend\n'
     assert resp.stderr == "2\n"

--- a/tests/gateways/test_subprocess.py
+++ b/tests/gateways/test_subprocess.py
@@ -16,7 +16,7 @@ def test_subprocess_call_with_live_stream(mock_stdout, mock_stderr):
     )
 
     def get_write_calls(mock_stream):
-        return [args[0].replace('\r\n', '\n') for args, kwargs in mock_stream.write.call_args_list]
+        return [args[0].replace('\r\n', '\n') for args, kw in mock_stream.write.call_args_list]
 
     stdout_calls = get_write_calls(mock_stdout)
     stderr_calls = get_write_calls(mock_stderr)
@@ -24,6 +24,6 @@ def test_subprocess_call_with_live_stream(mock_stdout, mock_stderr):
     assert ['1\n', '', 'end\n', ''] == stdout_calls
     assert ['2\n', ''] == stderr_calls
 
-    assert resp.stdout == '1\nend\n'
-    assert resp.stderr == "2\n"
+    assert resp.stdout.replace('\r\n', '\n') == '1\nend\n'
+    assert resp.stderr.replace('\r\n', '\n') == "2\n"
     assert resp.rc == 0


### PR DESCRIPTION
This enables the command `conda run` to display the live output from the subprocess's stdout and stderr, in real time.

The current behaviour-- which prints the stdout and stderr only after the process has finished --remains unchanged. 

The `conda run` command now can take a flag `--live-stream` which would flip the behaviour to provide the real time output.

I believe this is related to: https://github.com/conda/conda/issues/9412
