### PR TITLE
Avoid warning "Distutils was imported before Setuptools..."

### DIFF
--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -14,6 +14,7 @@ from .compat import on_win, string_types
 from .. import CondaError
 from .._vendor.auxlib.decorators import memoize
 from .._vendor.toolz import accumulate, concat, take
+import setuptools
 from distutils.spawn import find_executable
 
 try:

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -14,7 +14,7 @@ from .compat import on_win, string_types
 from .. import CondaError
 from .._vendor.auxlib.decorators import memoize
 from .._vendor.toolz import accumulate, concat, take
-import setuptools
+import setuptools  # NOQA
 from distutils.spawn import find_executable
 
 try:


### PR DESCRIPTION
Running conda build comand imports conda.common.path along the way.
Currently this leads to mentioned warning.

The detailed import hierarchy is:
- conda_build.cli.main_build
- conda_build.api
- conda_build.config
- conda_build.conda_interface
- conda.cli.common
- conda.base.context
- conda.common.configuration
- conda.common.path

