### PR TITLE
Fix CUDA solver hint

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -478,16 +478,15 @@ class Resolve(object):
         conflicting_pkgs_pkgs = {}
         for k, v in dep_list.items():
             set_v = frozenset(v)
-            # Packages probably conflict if it's cuda
-            if k == '__cuda':
+            # Packages probably conflicts if many specs depend on it
+            if len(set_v) > 1:
+                if conflicting_pkgs_pkgs.get(set_v) is None:
+                    conflicting_pkgs_pkgs[set_v] = [k]
+                else:
+                    conflicting_pkgs_pkgs[set_v].append(k)
+            # Conflict if required virtual package is not present
+            elif k.startswith("__") and any(s for s in set_v if s.name != k):
                 conflicting_pkgs_pkgs[set_v] = [k]
-            else:
-                # Packages probably conflicts if many specs depend on it
-                if len(set_v) > 1:
-                    if conflicting_pkgs_pkgs.get(set_v) is None:
-                        conflicting_pkgs_pkgs[set_v] = [k]
-                    else:
-                        conflicting_pkgs_pkgs[set_v].append(k)
 
         with tqdm(total=len(specs), desc="Determining conflicts",
                   leave=False, disable=context.json) as t:

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -260,7 +260,7 @@ def test_virtual_package_solver(tmpdir):
 
 def test_solve_msgs_exclude_vp(tmpdir):
     # Sovler hints should exclude virtual packages that are not dependencies
-    specs = MatchSpec("python =2.7.5"), MatchSpec("readline =7.0"),
+    specs = MatchSpec("python =2.7.5"), MatchSpec("readline =5.0"),
 
     with env_var('CONDA_OVERRIDE_CUDA', '10.0'):
         with get_solver_cuda(tmpdir, specs) as solver:

--- a/tests/data/index.json
+++ b/tests/data/index.json
@@ -16769,6 +16769,15 @@
     "requires": [],
     "version": "6.2"
   },
+  "readline-7.0-0.tar.bz2": {
+    "build": "0",
+    "build_number": 0,
+    "depends": [],
+    "md5": "7802f80168494982f4f72fff244f72d5",
+    "name": "readline",
+    "requires": [],
+    "version": "7.0"
+  },
   "redis-2.4.15-0.tar.bz2": {
     "build": "0",
     "build_number": 0,
@@ -20971,6 +20980,45 @@
       "python 3.3"
     ],
     "version": "4.1.1.1"
+  },
+  "cuda-glibc-10.0-0.tar.bz2": {
+    "build": "0",
+    "build_number": 0,
+    "constrains": [
+      "__glibc>=2.17"
+    ],
+    "depends": [
+      "__cuda>=10.0,<11"
+    ],
+    "md5": "57833caff02605fb87946d8758c6cc99",
+    "name": "cuda-glibc",
+    "pub_date": "2020-09-08",
+    "size": 1,
+    "version": "10.0"
+  },
+  "cuda-constrain-10.0-0.tar.bz2": {
+    "build": "0",
+    "build_number": 0,
+    "constrains": [
+      "__cuda>=10.0,<11"
+    ],
+    "md5": "3c83ba17a3bb9de3e4f13e62a909fb7e",
+    "name": "cuda-constrain",
+    "pub_date": "2020-09-01",
+    "size": 1,
+    "version": "10.0"
+  },
+  "cuda-constrain-11.0-0.tar.bz2": {
+    "build": "0",
+    "build_number": 0,
+    "constrains": [
+      "__cuda>=11.0,<12"
+    ],
+    "md5": "8ef4b9b28da3c107676450ff0461deb3",
+    "name": "cuda-constrain",
+    "pub_date": "2020-09-01",
+    "size": 1,
+    "version": "11.0"
   },
   "cudatoolkit-9.0-0.tar.bz2": {
     "build": "0",

--- a/tests/data/index.json
+++ b/tests/data/index.json
@@ -16769,14 +16769,14 @@
     "requires": [],
     "version": "6.2"
   },
-  "readline-7.0-0.tar.bz2": {
+  "readline-5.0-0.tar.bz2": {
     "build": "0",
     "build_number": 0,
     "depends": [],
     "md5": "7802f80168494982f4f72fff244f72d5",
     "name": "readline",
     "requires": [],
-    "version": "7.0"
+    "version": "5.0"
   },
   "redis-2.4.15-0.tar.bz2": {
     "build": "0",


### PR DESCRIPTION
Don't show hints about CUDA for packages that don't actually depend on it.