### PR TITLE
Honor --download-only flag for env creation using file explicit spec closes #10299

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import sys
 
+from conda import CondaExitZero
 from .base.context import context
 from .common.compat import itervalues, on_win, open, scandir
 from .common.path import expand
@@ -82,6 +83,10 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
 
     pfe = ProgressiveFetchExtract(fetch_specs)
     pfe.execute()
+
+    if context.download_only:
+        raise CondaExitZero('Package caches prepared. UnlinkLinkTransaction cancelled with '
+                            '--download-only option.')
 
     # now make an UnlinkLinkTransaction with the PackageCacheRecords as inputs
     # need to add package name to fetch_specs so that history parsing keeps track of them correctly

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2550,6 +2550,15 @@ dependencies:
         rm_rf(prefix, clean_empty_parents=True)
         run_command(Commands.REMOVE, prefix, "--all")
 
+    def test_download_only_flag_file(self):
+        from conda.core.link import UnlinkLinkTransaction
+        with patch.object(UnlinkLinkTransaction, 'execute') as mock_method:
+            file_location = "C:/testenvfile.yml"
+        with make_temp_env('--download-only', "--file", file_location, use_exception_handler=True) as prefix:
+            assert mock_method.call_count == 0
+        with make_temp_env("--file", file_location, use_exception_handler=True) as prefix:
+            assert mock_method.call_count == 1
+
     def test_download_only_flag(self):
         from conda.core.link import UnlinkLinkTransaction
         with patch.object(UnlinkLinkTransaction, 'execute') as mock_method:


### PR DESCRIPTION
Do not run the LinkUnlinkTransaction if --download-only is specified, even if using a file to create environment



┆Issue is synchronized with this [Jira Task](https://anaconda.atlassian.net/browse/CONDAORG-242)
