### PR TITLE
Update docs

### DIFF
--- a/docs/source/user-guide/concepts/channels.rst
+++ b/docs/source/user-guide/concepts/channels.rst
@@ -18,7 +18,8 @@ from remote channels, which are URLs to directories
 containing conda packages.
 The ``conda`` command searches a set of channels. By default,
 packages are automatically downloaded and updated from
-the ``default`` channel https://repo.anaconda.com/pkgs/ which may require
+the ``default`` channel https://repo.anaconda.com/pkgs/ which may require a
+paid license, as described in the `repository terms of service`_
 a commercial license. The ``conda-forge`` channel is free for all to use.
 You can modify what remote channels are automatically searched.
 You might want to do this to maintain a private or internal channel.
@@ -31,6 +32,8 @@ analogous to PyPI but with a unified,
 automated build infrastructure and more peer review of
 recipes.
 
+.. _`repository terms of service`: https://www.anaconda.com/terms-of-service
+
 .. _specifying-channels:
 
 Specifying channels when installing packages
@@ -41,13 +44,13 @@ Specifying channels when installing packages
 .. code-block:: bash
 
   $ conda install scipy --channel conda-forge
-  
+
 You may specify multiple channels by passing the argument multiple times:
 
 .. code-block:: bash
 
   $ conda install scipy --channel conda-forge --channel bioconda
-  
+
 Priority decreases from left to right - the first argument is higher priority than the second.
 
 * From the command line use `--override-channels` to only search the specified channel(s), rather than any channels configured in .condarc. This also ignores conda's default channels.

--- a/docs/source/user-guide/concepts/channels.rst
+++ b/docs/source/user-guide/concepts/channels.rst
@@ -16,9 +16,10 @@ They serve as the base for hosting and managing packages.
 Conda :doc:`packages <../concepts/packages>` are downloaded
 from remote channels, which are URLs to directories
 containing conda packages.
-The ``conda`` command searches a default set of channels,
-and packages are automatically downloaded and updated from
-https://repo.anaconda.com/pkgs/.
+The ``conda`` command searches a set of channels. By default,
+packages are automatically downloaded and updated from
+the ``default`` channel https://repo.anaconda.com/pkgs/ which may require
+a commercial license. The ``conda-forge`` channel is free for all to use.
 You can modify what remote channels are automatically searched.
 You might want to do this to maintain a private or internal channel.
 For details, see how to :ref:`modify your channel lists <config-channels>`.

--- a/docs/source/user-guide/concepts/installing-with-conda.rst
+++ b/docs/source/user-guide/concepts/installing-with-conda.rst
@@ -41,9 +41,9 @@ Conda update versus conda install
  
 Example:
 
-* If Python 2.7.0 is currently installed, and the latest version of Python 2 is 2.7.5, then ``conda update python`` installs Python 2.7.5. It does not install Python 3.5.2.
+* If Python 2.7.0 is currently installed, and the latest version of Python 2 is 2.7.5, then ``conda update python`` installs Python 2.7.5. It does not install Python 3.
 
-* If Python 3.4.0 is currently installed, and the latest version of Python is 3.5.2, then ``conda install python=3`` installs Python 3.5.2.
+* If Python 3.7.0 is currently installed, and the latest version of Python is 3.9.0, then ``conda install python=3`` installs Python 3.9.0.
  
 Conda uses the same rules for other packages. ``conda update`` always installs the highest version with the same major version number, whereas ``conda install`` always installs the highest version.
 

--- a/docs/source/user-guide/concepts/pkg-specs.rst
+++ b/docs/source/user-guide/concepts/pkg-specs.rst
@@ -286,10 +286,10 @@ Package match specifications
 
 This match specification is not the same as the syntax used at
 the command line with ``conda install``, such as
-``conda install python=3.4``. Internally, conda translates the
+``conda install python=3.9``. Internally, conda translates the
 command line syntax to the spec defined in this section.
 
-EXAMPLE: python=3.4 is translated to python 3.4*.
+EXAMPLE: python=3.9 is translated to python 3.9*.
 
 Package dependencies are specified using a match specification.
 A match specification is a space-separated string of 1, 2, or 3

--- a/docs/source/user-guide/getting-started.rst
+++ b/docs/source/user-guide/getting-started.rst
@@ -199,11 +199,11 @@ used when you downloaded and installed Anaconda. If you want to use a different
 version of Python, for example Python 3.5, simply create a new environment and
 specify the version of Python that you want.
 
-#. Create a new environment named "snakes" that contains Python 3.5:
+#. Create a new environment named "snakes" that contains Python 3.9:
 
    .. code::
 
-      conda create --name snakes python=3.5
+      conda create --name snakes python=3.9
 
    When conda asks if you want to proceed, type "y" and press Enter.
 

--- a/docs/source/user-guide/install/download.rst
+++ b/docs/source/user-guide/install/download.rst
@@ -9,7 +9,8 @@ Downloading conda
 
 You have 3 conda download options:
 
-* `Download Anaconda <https://www.anaconda.com/download/>`_---free.
+* `Download Anaconda <https://www.anaconda.com/download/>`_---free for
+  non-commercial use.
 
 * `Download Miniconda <https://conda.io/miniconda.html>`_---free.
 
@@ -23,7 +24,7 @@ installer.
 
 .. tip::
    If you are unsure which option to download, choose the
-   most recent version of Anaconda3, which includes Python 3.7.
+   most recent version of Anaconda3.
    If you are on Windows or macOS, choose the version with the
    GUI installer.
 
@@ -42,6 +43,8 @@ Choose Anaconda if you:
 
 * Do not want to individually install each of the packages you
   want to use.
+
+* Wish to use a curated and vetted set of packages.
 
 Choose Miniconda if you:
 
@@ -86,9 +89,9 @@ Choosing a version of Python
 
 * The last version of Python 2 is 2.7, which is included with
   Anaconda and Miniconda.
-* The newest stable version of Python is 3.7, which is included
+* The newest stable version of Python is quickly included
   with Anaconda3 and Miniconda3.
-* You can easily set up additional versions of Python such as 3.5
+* You can easily set up additional versions of Python such as 3.9
   by downloading any version and creating a new environment with
   just a few clicks. See :doc:`../getting-started`.
 

--- a/docs/source/user-guide/install/download.rst
+++ b/docs/source/user-guide/install/download.rst
@@ -9,8 +9,7 @@ Downloading conda
 
 You have 3 conda download options:
 
-* `Download Anaconda <https://www.anaconda.com/download/>`_---free for
-  non-commercial use.
+* `Download Anaconda <https://www.anaconda.com/download/>`_---free.
 
 * `Download Miniconda <https://conda.io/miniconda.html>`_---free.
 

--- a/docs/source/user-guide/tasks/manage-channels.rst
+++ b/docs/source/user-guide/tasks/manage-channels.rst
@@ -8,8 +8,8 @@ Conda packages are downloaded from remote channels, which are URLs to
 directories containing conda packages. The conda command searches a default
 set of channels and packages are automatically downloaded and updated
 from https://repo.anaconda.com/pkgs/. Read more about
-:doc:`conda channels <../concepts/channels>`. Note that this default channel
-may require a license for commercial use.
+:doc:`conda channels <../concepts/channels>` and the various terms of service
+for their use.
 
 Different channels can have the same package, so conda must handle these
 channel collisions.

--- a/docs/source/user-guide/tasks/manage-channels.rst
+++ b/docs/source/user-guide/tasks/manage-channels.rst
@@ -8,7 +8,8 @@ Conda packages are downloaded from remote channels, which are URLs to
 directories containing conda packages. The conda command searches a default
 set of channels and packages are automatically downloaded and updated
 from https://repo.anaconda.com/pkgs/. Read more about
-:doc:`conda channels <../concepts/channels>`.
+:doc:`conda channels <../concepts/channels>`. Note that this default channel
+may require a license for commercial use.
 
 Different channels can have the same package, so conda must handle these
 channel collisions.

--- a/docs/source/user-guide/tasks/manage-python.rst
+++ b/docs/source/user-guide/tasks/manage-python.rst
@@ -85,6 +85,16 @@ Python version into it:
 
       python --version
 
+Installing PyPy
+===============
+
+To use the PyPy builds you can do the following::
+
+    conda config conda config --add channels confa-forge
+    conda config --set channel_priority strict
+    conda create -n pypy pypy
+    conda activate pypy
+
 
 Using a different version of Python
 ====================================

--- a/docs/source/user-guide/tasks/manage-python.rst
+++ b/docs/source/user-guide/tasks/manage-python.rst
@@ -50,20 +50,20 @@ Python version into it:
 
 #. Create the new environment:
 
-   * To create the new environment for Python 3.6, in your terminal
+   * To create the new environment for Python 3.9, in your terminal
      window or an Anaconda Prompt, run:
 
      .. code-block:: bash
 
-        conda create -n py36 python=3.6 anaconda
+        conda create -n py39 python=3.9 anaconda
 
      .. note::
         Replace ``py36`` with the name of the environment you
         want to create. ``anaconda`` is the metapackage that
         includes all of the Python packages comprising the Anaconda
-        distribution. ``python=3.6`` is the package and version you
+        distribution. ``python=3.9`` is the package and version you
         want to install in this new environment. This could be any
-        package, such as ``numpy=1.7``, or :ref:`multiple packages
+        package, such as ``numpy=1.19``, or :ref:`multiple packages
         <installing multiple packages>`.
 
    * To create the new environment for Python 2.7, in your terminal window
@@ -107,8 +107,11 @@ version in the 3.4 branch:
     conda update python
 
 The following command upgrades Python to another
-branch---3.6---by installing that version of Python:
+branch---3.8---by installing that version of Python. It is not recommended,
+rather it is preferable to create a new environment. The resolver has to work
+very hard to determine exactly which packages to upgrade. But it is possible,
+and the command is::
 
 .. code-block:: bash
 
-    conda install python=3.6
+    conda install python=3.8


### PR DESCRIPTION
- Add blurb about PyPy
- Change some examples of python use to python3.9
- Soften the commitment about latest Python versions
- Mention the commercial nature of the default channel

The last point could use some careful review: I am not sure I got the content and tone right.