### PR TITLE
remove .empty directory even when rsync is not installed

### DIFF
--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -85,15 +85,19 @@ def rmtree(path, *args, **kwargs):
         # yes, this looks strange.  See
         #    https://unix.stackexchange.com/a/79656/34459
         #    https://web.archive.org/web/20130929001850/http://linuxnote.net/jianingy/en/linux/a-fast-way-to-remove-huge-number-of-files.html  # NOQA
-        rsync = which('rsync')
-        if rsync and isdir('.empty'):
-            try:
-                out = check_output(
-                    [rsync, '-a', '--force', '--delete', join(getcwd(), '.empty') + "/",
-                     path + "/"],
-                    stderr=STDOUT)
-            except CalledProcessError:
-                log.debug("removing dir contents the fast way failed.  Output was: {}".format(out))
+
+        if isdir('.empty'):
+            rsync = which('rsync')
+
+            if rsync:
+                try:
+                    out = check_output(
+                        [rsync, '-a', '--force', '--delete', join(getcwd(), '.empty') + "/",
+                        path + "/"],
+                        stderr=STDOUT)
+                except CalledProcessError:
+                    log.debug("removing dir contents the fast way failed.  Output was: {}".format(out))
+
             shutil.rmtree('.empty')
     shutil.rmtree(path)
 

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -93,10 +93,10 @@ def rmtree(path, *args, **kwargs):
                 try:
                     out = check_output(
                         [rsync, '-a', '--force', '--delete', join(getcwd(), '.empty') + "/",
-                        path + "/"],
+                         path + "/"],
                         stderr=STDOUT)
                 except CalledProcessError:
-                    log.debug("removing dir contents the fast way failed.  Output was: {}".format(out))
+                    log.debug(f"removing dir contents the fast way failed.  Output was: {out}")
 
             shutil.rmtree('.empty')
     shutil.rmtree(path)


### PR DESCRIPTION
after calling rmtree(), .empty directory still exist if rsync is not installed.

so i modified to remove .empty directory regardless of with or without rsync.