### PR TITLE
Use old filenames for "normal" repodata cache files

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -179,11 +179,11 @@ class SubdirData(object):
 
     @property
     def cache_path_json(self):
-        return self.cache_path_base + ('1' if context.use_only_tar_bz2 else '0') + '.json'
+        return self.cache_path_base + ('1' if context.use_only_tar_bz2 else '') + '.json'
 
     @property
     def cache_path_pickle(self):
-        return self.cache_path_base + ('1' if context.use_only_tar_bz2 else '0') + '.q'
+        return self.cache_path_base + ('1' if context.use_only_tar_bz2 else '') + '.q'
 
     def load(self):
         _internal_state = self._load()


### PR DESCRIPTION
Partially revert changes made in commit ad75abcad, so when the `use_only_tar_bz2` option is set to false (default), conda uses the same cache filenames it did before.  This helps avoid breaking certain applications that made assumptions about the repodata cache filenames.