### PR TITLE
Try utf16 decoding if utf8 fails when reading environment yml file

### DIFF
--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -155,8 +155,12 @@ def from_file(filename):
     elif not os.path.exists(filename):
         raise exceptions.EnvironmentFileNotFound(filename)
     else:
-        with open(filename, 'r') as fp:
-            yamlstr = fp.read()
+        with open(filename, 'rb') as fp:
+            yamlb = fp.read()
+            try:
+                yamlstr = yamlb.decode('utf-8')
+            except UnicodeDecodeError:
+                yamlstr = yamlb.decode('utf-16')
     return from_yaml(yamlstr, filename=filename)
 
 


### PR DESCRIPTION
this would fix #9749

Changes the decoding used to get the yaml string when reading from file, from the default from open() in text mode, to explicitly using utf8 and utf16

The default .to_yaml() uses utf8, but on windows platforms, redirecting the
stdout to a file using `>`, which is a common way to export the environment,
outputs a utf16 file instead, and so fails to be read when you try to
recreate the environment