### PR TITLE
Fix csh path

### DIFF
--- a/conda/shell/etc/profile.d/conda.csh
+++ b/conda/shell/etc/profile.d/conda.csh
@@ -1,7 +1,3 @@
-setenv CONDA_EXE "/apps/user/cdd/dev/miniconda3/4.8.3/bin/conda"
-setenv _CONDA_ROOT "/apps/user/cdd/dev/miniconda3/4.8.3"
-setenv _CONDA_EXE "/apps/user/cdd/dev/miniconda3/4.8.3/bin/conda"
-setenv CONDA_PYTHON_EXE "/apps/user/cdd/dev/miniconda3/4.8.3/bin/python"
 echo "Copyright (C) 2012 Anaconda, Inc" > /dev/null
 echo "SPDX-License-Identifier: BSD-3-Clause" > /dev/null
 

--- a/conda/shell/etc/profile.d/conda.csh
+++ b/conda/shell/etc/profile.d/conda.csh
@@ -1,3 +1,7 @@
+setenv CONDA_EXE "/apps/user/cdd/dev/miniconda3/4.8.3/bin/conda"
+setenv _CONDA_ROOT "/apps/user/cdd/dev/miniconda3/4.8.3"
+setenv _CONDA_EXE "/apps/user/cdd/dev/miniconda3/4.8.3/bin/conda"
+setenv CONDA_PYTHON_EXE "/apps/user/cdd/dev/miniconda3/4.8.3/bin/python"
 echo "Copyright (C) 2012 Anaconda, Inc" > /dev/null
 echo "SPDX-License-Identifier: BSD-3-Clause" > /dev/null
 
@@ -26,26 +30,37 @@ if ("`alias conda`" == "") then
         set prompt=""
     endif
 else
+    set conda_tmp_path=$PATH
     setenv PATH "`dirname ${_CONDA_EXE}`:$PATH"
     switch ( "${1}" )
         case "activate":
-            set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh activate '${2}' ${argv[3-]})`" || exit ${status}
+            set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh activate '${2}' ${argv[3-]})`"
+            set conda_tmp_status=$status
+            setenv PATH $conda_tmp_path
+            if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
             breaksw
         case "deactivate":
-            set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh deactivate '${2}' ${argv[3-]})`" || exit ${status}
+            set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh deactivate '${2}' ${argv[3-]})`"
+            set conda_tmp_status=$status
+            setenv PATH $conda_tmp_path
+            if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
             breaksw
         case "install" | "update" | "upgrade" | "remove" | "uninstall":
             $_CONDA_EXE $argv[1-]
-            set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh reactivate)`" || exit ${status}
+            set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh reactivate)`"
+            set conda_tmp_status=$status
+            setenv PATH $conda_tmp_path
+            if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
             breaksw
         default:
             $_CONDA_EXE $argv[1-]
+            setenv PATH $conda_tmp_path
             breaksw
     endsw
 endif

--- a/conda/shell/etc/profile.d/conda.csh
+++ b/conda/shell/etc/profile.d/conda.csh
@@ -26,13 +26,13 @@ if ("`alias conda`" == "") then
         set prompt=""
     endif
 else
-    set conda_tmp_path=$PATH
+    set conda_tmp_path="$PATH"
     setenv PATH "`dirname ${_CONDA_EXE}`:$PATH"
     switch ( "${1}" )
         case "activate":
             set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh activate '${2}' ${argv[3-]})`"
             set conda_tmp_status=$status
-            setenv PATH $conda_tmp_path
+            setenv PATH "$conda_tmp_path"
             if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
@@ -40,7 +40,7 @@ else
         case "deactivate":
             set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh deactivate '${2}' ${argv[3-]})`"
             set conda_tmp_status=$status
-            setenv PATH $conda_tmp_path
+            setenv PATH "$conda_tmp_path"
             if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
@@ -49,14 +49,14 @@ else
             $_CONDA_EXE $argv[1-]
             set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh reactivate)`"
             set conda_tmp_status=$status
-            setenv PATH $conda_tmp_path
+            setenv PATH "$conda_tmp_path"
             if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
             breaksw
         default:
             $_CONDA_EXE $argv[1-]
-            setenv PATH $conda_tmp_path
+            setenv PATH "$conda_tmp_path"
             breaksw
     endsw
 endif


### PR DESCRIPTION
## Current Behavior
When using csh or tcsh only
After using "conda activate env" for the first time issuing "conda env list" adds the conda/bin directory as a prefix to the PATH variable causeing future python execution to use a non-intended python version. 
Even worse: every time "conda env list is issued a new "conda/bin" is prefixed to the PATH variable.
The same issue happens when an conda command is executed the results in an error e.g "conda activate non_existing".

### Steps to Reproduce
- setup conda for csh
- create a new environment "py"
- conda activate py
- 'which python` gives correct path to py/python executable
- conda env list
- 'which python` gives incorrect path to conda/bin/python


## Expected Behavior
"conda env list" or any informational or invalid conda com and should not affect the PATH variable

## Cause
This problem is caused by conda.csh line 29
https://github.com/conda/conda/blob/aed799b56d9ee16a3653928527e2af6e41394e85/conda/shell/etc/profile.d/conda.csh#L29
It modifies the path environment variable. That change is reversed in cases when the 
eval statements are executed (line 33,38 or 44) but if an error happens in lines (32, 37 or 43) 
or if the "default:" statement is executed the path variable is left unchanged with the altered value.

## Solution
The proposed solution stores the value of the Path variable and restores it in case of error or in the default branch of the switch statement when no "eval" statement is executed that would set the PATH variable correctly.
