### PR TITLE
Fixed Intializtion of Zsh if ZDOTDIR env present

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -450,7 +450,10 @@ def make_initialize_plan(conda_prefix, shells, for_user, for_system, anaconda_pr
             })
 
         if 'zsh' in shells and for_user:
-            zshrc_path = expand(join('~', '.zshrc'))
+            if 'ZDOTDIR' in os.environ:
+                zshrc_path = expand(join("$ZDOTDIR", ".zshrc"))
+            else:
+                zshrc_path = expand(join('~', '.zshrc'))
             plan.append({
                 'function': init_sh_user.__name__,
                 'kwargs': {


### PR DESCRIPTION
Currently `conda init zsh` generates the configuration file as $HOME/.zshrc. However, this is a bug as zsh gives preference to $ZDOTDIR/.zshrc if present. This pull request fixes the issue and will also close #9362 