### PR TITLE
We rename ruamel_yaml to ruamel_yaml_conda in our ruamel_yaml package

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -2,10 +2,10 @@
 
 echo $PKG_VERSION > conda/.version
 $PYTHON setup.py install --single-version-externally-managed --record record.txt
-if [[ $(uname -o) != Msys ]]; then
+if [[ ! $(uname) =~ M.* ]]; then
   rm -rf "$SP_DIR/conda/shell/*.exe"
 fi
 $PYTHON -m conda init --install
-if [[ $(uname -o) == Msys ]]; then
+if [[ ! $(uname) =~ M.* ]]; then
   sed -i "s|CONDA_EXE=.*|CONDA_EXE=\'${PREFIXW//\\/\\\\}\\\\Scripts\\\\conda.exe\'|g" $PREFIX/etc/profile.d/conda.sh
 fi

--- a/conda.recipe/run_test.sh
+++ b/conda.recipe/run_test.sh
@@ -12,10 +12,11 @@ export TEST_PLATFORM=$(python -c "import sys; print('win' if sys.platform.starts
 export PYTHONHASHSEED=$(python -c "import random as r; print(r.randint(0,4294967296))") && echo "PYTHONHASHSEED=$PYTHONHASHSEED"
 env | sort
 conda info
-conda create -y -p ./built-conda-test-env python=3.5
+conda create -y -p ./built-conda-test-env python=3.9
 conda activate ./built-conda-test-env
 echo $CONDA_PREFIX
 [ "$CONDA_PREFIX" = "$PWD/built-conda-test-env" ] || exit 1
-[ $(python -c "import sys; print(sys.version_info[1])") = 5 ] || exit 1
+[ $(python -c "import sys; print(sys.version_info[1])") = 9 ] || exit 1
+python -c '__requires__ = ["ruamel_yaml_conda >= 0.11.14"]; import pkg_resources' || exit 1
 conda deactivate
 py.test tests -m "not integration and not installed" -vv

--- a/dev/start
+++ b/dev/start
@@ -28,6 +28,7 @@ if ! [ -f "$devenv/conda-meta/history" ]; then
         fi
         cmd.exe /c "start /wait \"\" miniconda${pyver}.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=%CD%\$(cygpath -w $devenv)"
         _CONDA="$devenv/Scripts/conda"
+        "$devenv/Scripts/conda" install -yq -p $devenv python=$pyver --file dev/test-requirements.txt -c defaults -c conda-forge
     fi
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ install_requires = [
 ]
 
 if os.getenv('CONDA_BUILD', None) == '1':
-    install_requires.append("ruamel_yaml >=0.11.14")
+    install_requires.append("ruamel_yaml_conda >=0.11.14")
 else:
-    install_requires.append("ruamel.yaml >=0.11.14")
+    install_requires.append("ruamel_yaml_conda >=0.11.14")
 
 
 def package_files(*root_directories):


### PR DESCRIPTION
Changes:

1. Attempting to install `conda-build` via `python setup.py develop` would result in:

```
  ..
  File "/opt/Shared.local/asrc/conda-build/conda_build/conda_interface.py", line 9, in <module>
    from pkg_resources import parse_version
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3239, in <module>
    def _initialize_master_working_set():
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3222, in _call_aside
    f(*args, **kwargs)
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3251, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 567, in _build_master
    ws.require(__requires__)
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 884, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/opt/conda/lib/python3.9/site-packages/pkg_resources/__init__.py", line 770, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'ruamel_yaml>=0.11.14' distribution was not found and is required by conda
```
.. this is fixed.

2. Fix Windows dev so that the `dev/test-requirements.txt` get installed, preferring defaults but falling back to CF.
3. Fix incorrect assumptions about `uname -o` working everywhere (which didn't cause an issue beyond ugly build logs).