### PR TITLE
Partially fix profile script PATH setup on MSYS2

### DIFF
--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -105,7 +105,7 @@ if [ -z "${CONDA_SHLVL+x}" ]; then
     \export CONDA_SHLVL=0
     # In dev-mode CONDA_EXE is python.exe and on Windows
     # it is in a different relative location to condabin.
-    if [ -n "${_CE_CONDA+x}" ] && [ -n "${WINDIR+x}" ]; then
+    if [ -n "${_CE_CONDA:+x}" ] && [ -n "${WINDIR+x}" ]; then
         PATH="$(\dirname "$CONDA_EXE")/condabin${PATH:+":${PATH}"}"
     else
         PATH="$(\dirname "$(\dirname "$CONDA_EXE")")/condabin${PATH:+":${PATH}"}"


### PR DESCRIPTION
[PosixActivator#_hook_preamble](https://github.com/conda/conda/blob/e37cf84a57f935c578cdcea6ea034c80d7677ccc/conda/activate.py#L867) sets `_CE_CONDA` to the empty string rather than unsetting it, so `[ -n "${_CE_CONDA+x}" ]` will always return true, resulting in the wrong branch being executed and PATH set incorrectly.

This commit changes `+x` to `:+x` to only return true if `_CE_CONDA` is set and non-empty.

Partially fixes #8693