### PR TITLE
Don't create an unused s3 client at import time.

### DIFF
--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -11,7 +11,6 @@ have_boto3 = have_boto = False
 try:
     import boto3
     have_boto3 = True
-    boto3.client('s3')  # https://github.com/conda/conda/issues/8993
 except ImportError:
     try:
         import boto


### PR DESCRIPTION
The deleted lines could cause issues when using a [credential process provider](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html).  

Specifically, during test discovery in vscode, conda info would run and import this module.  Creating the client would trigger the process provider to run.  This particular process provider would request credentials, but the prompt would not be visible as conda info was run in the background.

There's a number of places that things went wrong in this scenario, put this change appears to be a simple fix.  