### PR TITLE
support default-packages in conda env create 

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -536,11 +536,7 @@ def configure_parser_create(sub_parsers):
         metavar='ENV',
     )
     solver_mode_options, package_install_options = add_parser_create_install_update(p)
-    solver_mode_options.add_argument(
-        "--no-default-packages",
-        action="store_true",
-        help='Ignore create_default_packages in the .condarc file.',
-    )
+    add_parser_default_packages(solver_mode_options)
     p.add_argument(
         '-m', "--mkdir",
         action="store_true",
@@ -1668,4 +1664,11 @@ def add_parser_known(p):
         default=False,
         dest='unknown',
         help=SUPPRESS,
+    )
+
+def add_parser_default_packages(p):
+    p.add_argument(
+        "--no-default-packages",
+        action="store_true",
+        help='Ignore create_default_packages in the .condarc file.',
     )

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -10,7 +10,8 @@ import textwrap
 
 from conda._vendor.auxlib.path import expand
 from conda.cli import install as cli_install
-from conda.cli.conda_argparse import add_parser_json, add_parser_prefix, add_parser_networking
+from conda.cli.conda_argparse import add_parser_default_packages, add_parser_json, \
+    add_parser_prefix, add_parser_networking
 from conda.core.prefix_data import PrefixData
 from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
 from conda.gateways.disk.delete import rm_rf
@@ -69,6 +70,7 @@ def configure_parser(sub_parsers):
         action='store_true',
         default=False,
     )
+    add_parser_default_packages(p)
     add_parser_json(p)
     p.set_defaults(func='.main_create.execute')
 
@@ -106,6 +108,13 @@ def execute(args, parser):
     # channel_urls = args.channel or ()
 
     result = {"conda": None, "pip": None}
+
+    args_packages = context.create_default_packages if not args.no_default_packages else []
+    if args_packages:
+        installer_type = "conda"
+        installer = get_installer(installer_type)
+        result[installer_type] = installer.install(prefix, args_packages, args, env)
+
     if len(env.dependencies.items()) == 0:
         installer_type = "conda"
         pkg_specs = []

--- a/tests/conda_env/support/env_with_dependencies.yml
+++ b/tests/conda_env/support/env_with_dependencies.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=2
+  - pytz


### PR DESCRIPTION
resolves #9580 
Supports default-packages from condarc when creating a new environment via `conda env create` 