### PR TITLE
Update supported and default versions of Python3

### DIFF
--- a/docs/source/user-guide/tasks/manage-python.rst
+++ b/docs/source/user-guide/tasks/manage-python.rst
@@ -10,14 +10,14 @@ Managing Python
 Conda treats Python the same as any other package, so it is easy
 to manage and update multiple installations.
 
-Anaconda supports Python 2.7, 3.6, and 3.7. The default is Python
-2.7 or 3.7, depending on which installer you used:
+Anaconda supports Python 2.7, 3.6, 3.7, and 3.8. The default is Python
+2.7 or 3.8, depending on which installer you used:
 
 * For the installers "Anaconda" and "Miniconda," the default is
   2.7.
 
 * For the installers "Anaconda3" or "Miniconda3," the default is
-  3.7.
+  3.8.
 
 
 Viewing a list of available Python versions


### PR DESCRIPTION
This part of the documentation is out of date with respect to the default version of Python 3 which is installed via Anaconda3 and Miniconda3, as of the 2020.11 release. However, I am not sure what the standard is for "supported versions" for this part of the documentation. If we only consider the latest version of the distribution, only 3.8 and 3.7 should be listed as supported. 
If we consider all previous installers, my impression is that 3.5, 3.4, ... 2.6 should also be included (which seems unlikely): https://docs.anaconda.com/anaconda/packages/oldpkglists/