### PR TITLE
Add http support to conda env update

### DIFF
--- a/conda_env/cli/common.py
+++ b/conda_env/cli/common.py
@@ -9,6 +9,8 @@ from conda._vendor.auxlib.entity import EntityEncoder
 from conda.base.context import context
 from conda.cli import install as cli_install
 from conda.cli import common as cli_common
+from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
+from conda._vendor.auxlib.path import expand
 
 base_env_name = 'base'
 
@@ -50,3 +52,12 @@ def print_result(args, prefix, result):
             cli_common.stdout_json_success(prefix=prefix, actions=actions)
     else:
         cli_install.print_activate(args.name if args.name else prefix)
+
+
+def get_filename(filename):
+    """Expand filename if local path or return the url"""
+    url_scheme = filename.split("://", 1)[0]
+    if url_scheme in CONDA_SESSION_SCHEMES:
+        return filename
+    else:
+        return expand(filename)

--- a/conda_env/cli/common.py
+++ b/conda_env/cli/common.py
@@ -6,11 +6,11 @@ from os.path import isdir, join
 import sys
 
 from conda._vendor.auxlib.entity import EntityEncoder
+from conda._vendor.auxlib.path import expand
 from conda.base.context import context
 from conda.cli import install as cli_install
 from conda.cli import common as cli_common
 from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
-from conda._vendor.auxlib.path import expand
 
 base_env_name = 'base'
 

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -8,14 +8,12 @@ import os
 import sys
 import textwrap
 
-from conda._vendor.auxlib.path import expand
 from conda.cli import install as cli_install
 from conda.cli.conda_argparse import add_parser_json, add_parser_prefix, add_parser_networking
 from conda.core.prefix_data import PrefixData
-from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
 from conda.gateways.disk.delete import rm_rf
 from conda.misc import touch_nonadmin
-from .common import get_prefix, print_result
+from .common import get_prefix, print_result, get_filename
 from .. import exceptions, specs
 from ..installers.base import InvalidInstaller, get_installer
 
@@ -78,13 +76,7 @@ def execute(args, parser):
     name = args.remote_definition or args.name
 
     try:
-        url_scheme = args.file.split("://", 1)[0]
-        if url_scheme in CONDA_SESSION_SCHEMES:
-            filename = args.file
-        else:
-            filename = expand(args.file)
-
-        spec = specs.detect(name=name, filename=filename, directory=os.getcwd())
+        spec = specs.detect(name=name, filename=get_filename(args.file), directory=os.getcwd())
         env = spec.environment
 
         # FIXME conda code currently requires args to have a name or prefix

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -6,7 +6,6 @@ import os
 import sys
 import textwrap
 
-from conda._vendor.auxlib.path import expand
 from conda.cli.conda_argparse import add_parser_json, add_parser_prefix
 from conda.misc import touch_nonadmin
 from .common import get_prefix, print_result, get_filename

--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -9,7 +9,7 @@ import textwrap
 from conda._vendor.auxlib.path import expand
 from conda.cli.conda_argparse import add_parser_json, add_parser_prefix
 from conda.misc import touch_nonadmin
-from .common import get_prefix, print_result
+from .common import get_prefix, print_result, get_filename
 from .. import exceptions, specs as install_specs
 from ..exceptions import CondaEnvException
 from ..installers.base import InvalidInstaller, get_installer
@@ -64,7 +64,7 @@ def execute(args, parser):
     name = args.remote_definition or args.name
 
     try:
-        spec = install_specs.detect(name=name, filename=expand(args.file),
+        spec = install_specs.detect(name=name, filename=get_filename(args.file),
                                     directory=os.getcwd())
         env = spec.environment
     except exceptions.SpecNotFound:

--- a/tests/conda_env/__init__.py
+++ b/tests/conda_env/__init__.py
@@ -1,5 +1,7 @@
 from os.path import dirname, join
 
 
-def support_file(filename):
+def support_file(filename, remote=False):
+    if remote:
+        return 'https://raw.githubusercontent.com/conda/conda/master/tests/conda_env/support/' + filename
     return join(dirname(__file__), 'support', filename)

--- a/tests/conda_env/test_create.py
+++ b/tests/conda_env/test_create.py
@@ -84,6 +84,21 @@ class IntegrationTests(TestCase):
                 assert package_is_installed(prefix, 'flask=1.0.2')
                 assert not package_is_installed(prefix, 'flask=0.12.2')
 
+    def test_create_update_remote_env_file(self):
+        with make_temp_envs_dir() as envs_dir:
+            with env_var('CONDA_ENVS_DIRS', envs_dir, stack_callback=conda_tests_ctxt_mgmt_def_pol):
+                env_name = str(uuid4())[:8]
+                prefix = join(envs_dir, env_name)
+                python_path = join(prefix, PYTHON_BINARY)
+
+                run_command(Commands.CREATE, env_name, support_file('example/environment_pinned.yml', remote=True))
+                assert exists(python_path)
+                assert package_is_installed(prefix, 'flask=0.12.2')
+
+                run_command(Commands.UPDATE, env_name, support_file('example/environment_pinned_updated.yml', remote=True))
+                assert package_is_installed(prefix, 'flask=1.0.2')
+                assert not package_is_installed(prefix, 'flask=0.12.2')
+
     @pytest.mark.skip(reason="Need to find an appropriate server to test this on.")
     def test_create_host_port(self):
         with make_temp_envs_dir() as envs_dir:


### PR DESCRIPTION
`conda env create` already supported using an environment file from url but `conda env update` did not.
The following command will now work:

```bash
conda env update -f https://domain.com/my-environment.yml
```

I didn't really like to copy/paste the `test_create_update` test. It would have been nicer to use `@pytest.mark.parametrize` but this test is still using a class from unittest with setup/teardown.