### PR TITLE
Fix `conda search` for Python 3.9

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -783,7 +783,7 @@ class Context(Configuration):
         #   'Windows', '10.0.17134'
         platform_name = self.platform_system_release[0]
         if platform_name == 'Linux':
-            from .._vendor.distro import id, version
+            from conda._vendor.distro import id, version
             try:
                 distinfo = id(), version(best=True)
             except Exception as e:


### PR DESCRIPTION
Make `_vendor.distro` import absolute to avoid thread safety problems
that were seemingly introduced by change in Python 3.9.

Fixes #10490