### PR TITLE
Fix https://github.com/conda/conda/issues/9724

### DIFF
--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -53,7 +53,7 @@ def validate_keys(data, kwargs):
 
     deps = data.get('dependencies', [])
     depsplit = re.compile(r"[<>~\s=]")
-    lists_pip = any('pip' in depsplit.split(_)[0].split(':') for _ in deps if not hasattr(_, 'keys')))
+    lists_pip = any('pip' in depsplit.split(_)[0].split(':') for _ in deps if not hasattr(_, 'keys'))
     for dep in deps:
         if (isinstance(dep, dict) and 'pip' in dep and not lists_pip):
             print("Warning: you have pip-installed dependencies in your environment file, "

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -53,9 +53,9 @@ def validate_keys(data, kwargs):
 
     deps = data.get('dependencies', [])
     depsplit = re.compile(r"[<>~\s=]")
+    lists_pip = any('pip' in depsplit.split(_)[0].split(':') for _ in deps if not hasattr(_, 'keys')))
     for dep in deps:
-        if (isinstance(dep, dict) and 'pip' in dep and not
-                any(depsplit.split(_)[0] == 'pip' for _ in deps if not hasattr(_, 'keys'))):
+        if (isinstance(dep, dict) and 'pip' in dep and not lists_pip):
             print("Warning: you have pip-installed dependencies in your environment file, "
                   "but you do not list pip itself as one of your conda dependencies.  Conda "
                   "may not use the correct pip to install your packages, and they may end up "

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -53,7 +53,8 @@ def validate_keys(data, kwargs):
 
     deps = data.get('dependencies', [])
     depsplit = re.compile(r"[<>~\s=]")
-    lists_pip = any('pip' in depsplit.split(_)[0].split(':') for _ in deps if not hasattr(_, 'keys'))
+    is_pip = lambda dep : 'pip' in depsplit.split(dep)[0].split(':')
+    lists_pip = any(is_pip(_) for _ in deps if not hasattr(_, 'keys'))
     for dep in deps:
         if (isinstance(dep, dict) and 'pip' in dep and not lists_pip):
             print("Warning: you have pip-installed dependencies in your environment file, "

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -53,7 +53,7 @@ def validate_keys(data, kwargs):
 
     deps = data.get('dependencies', [])
     depsplit = re.compile(r"[<>~\s=]")
-    is_pip = lambda dep : 'pip' in depsplit.split(dep)[0].split(':')
+    is_pip = lambda dep: 'pip' in depsplit.split(dep)[0].split(':')
     lists_pip = any(is_pip(_) for _ in deps if not hasattr(_, 'keys'))
     for dep in deps:
         if (isinstance(dep, dict) and 'pip' in dep and not lists_pip):


### PR DESCRIPTION
Fixes parsing when searching for explicit 'pip' dependency to correctly parse both 'channel::pip' and 'pip'