### PR TITLE
Add post env-create hooks

### DIFF
--- a/conda_env/cli/common.py
+++ b/conda_env/cli/common.py
@@ -59,7 +59,7 @@ def print_result(args, prefix, result):
                 actions["PIP"] = result["pip"]
             stdout_json_success(prefix=prefix, actions=actions)
     else:
-        cli_install.print_activate(args.name or prefix)
+        cli_install.post_create_hook(args, prefix)
 
 
 def get_filename(filename):

--- a/news/10567-post-create-hooks
+++ b/news/10567-post-create-hooks
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add post env-create hooks. (#10567)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
Add a hook to run all executables placed in `$CONDA_ROOT/etc/conda/create.d/` on `conda create` and `conda env create` command (on create or clone a new env).

This feature allows users to manage conda envrionments in a more flexible way. For example, automatic set env-vars by hooks instead of by `conda env config` command by user. Or do cleanup after env creation.

I know `conda` provides a command `conda env config vars set` to set environment variables on env activation. But this command does not support append and/or prepend operation, and it arbitrarily set the variable to a specific value. For example, I want to insert `CONDA_PREFIX` to the front of a non-empty `CMAKE_PREFIX_PATH` and keep the current value.


```bash
# Expected
export CMAKE_PREFIX_PATH="${CONDA_PREFIX}${CMAKE_PREFIX_PATH:+:"$CMAKE_PREFIX_PATH"}"

# `conda env config set var=value` does not support append and prepend
export CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
```

Of course, I can use `env-vars.sh` in `etc/conda/activate.d/` and `etc/conda/deactivate.d/`, but I need to rewrite these script again and again every time.

- - -
Here is an example for this feature:
Add a script file `$CONDA_ROOT/etc/conda/create.d/init-env.sh` with `u+x` flag:

```bash
#!/usr/bin/env bash

set -e

# Hardcode env vars
"${CONDA_EXE}" env config vars set CONDA_ENV_INITIALIZED=true --prefix "${CONDA_PREFIX}"

mkdir -p "${CONDA_PREFIX}/etc/conda/activate.d"
mkdir -p "${CONDA_PREFIX}/etc/conda/deactivate.d"

# Create hook script on conda activate
cat >"${CONDA_PREFIX}/etc/conda/activate.d/env-vars.sh" <<'EOF'
#!/usr/bin/env bash

export CONDA_C_INCLUDE_PATH_BACKUP="${C_INCLUDE_PATH}"
export CONDA_CPLUS_INCLUDE_PATH_BACKUP="${CPLUS_INCLUDE_PATH}"
export CONDA_LIBRARY_PATH_BACKUP="${LIBRARY_PATH}"
export CONDA_LD_LIBRARY_PATH_BACKUP="${LD_LIBRARY_PATH}"
export CONDA_CMAKE_PREFIX_PATH_BACKUP="${CMAKE_PREFIX_PATH}"
export CONDA_CUDA_HOME_BACKUP="${CUDA_HOME}"

export C_INCLUDE_PATH="${CONDA_PREFIX}/include${C_INCLUDE_PATH:+:"${C_INCLUDE_PATH}"}"
export CPLUS_INCLUDE_PATH="${CONDA_PREFIX}/include${CPLUS_INCLUDE_PATH:+:"${CPLUS_INCLUDE_PATH}"}"
export LIBRARY_PATH="${CONDA_PREFIX}/lib${LIBRARY_PATH:+:"${LIBRARY_PATH}"}"
export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:"${LD_LIBRARY_PATH}"}"
export CMAKE_PREFIX_PATH="${CONDA_PREFIX}${CMAKE_PREFIX_PATH:+:"${CMAKE_PREFIX_PATH}"}"
if [[ -d "${CONDA_PREFIX}/pkgs/cuda-toolkit" ]]; then
	export CUDA_HOME="${CONDA_PREFIX}/pkgs/cuda-toolkit"
	export C_INCLUDE_PATH="${CUDA_HOME}/include:${CUDA_HOME}/extras/CUPTI/include${C_INCLUDE_PATH:+:"${C_INCLUDE_PATH}"}"
	export CPLUS_INCLUDE_PATH="${CUDA_HOME}/include:${CUDA_HOME}/extras/CUPTI/include${CPLUS_INCLUDE_PATH:+:"${CPLUS_INCLUDE_PATH}"}"
	export LIBRARY_PATH="${CUDA_HOME}/lib64:${CUDA_HOME}/extras/CUPTI/lib64${LIBRARY_PATH:+:"${LIBRARY_PATH}"}"
	export LD_LIBRARY_PATH="${CUDA_HOME}/lib64:${CUDA_HOME}/extras/CUPTI/lib64${LD_LIBRARY_PATH:+:"${LD_LIBRARY_PATH}"}"
fi
EOF

# Create hook script on conda deactivate
cat >"${CONDA_PREFIX}/etc/conda/deactivate.d/env-vars.sh" <<'EOF'
#!/usr/bin/env bash

export C_INCLUDE_PATH="${CONDA_C_INCLUDE_PATH_BACKUP}"
export CPLUS_INCLUDE_PATH="${CONDA_CPLUS_INCLUDE_PATH_BACKUP}"
export LIBRARY_PATH="${CONDA_LIBRARY_PATH_BACKUP}"
export LD_LIBRARY_PATH="${CONDA_LD_LIBRARY_PATH_BACKUP}"
export CMAKE_PREFIX_PATH="${CONDA_CMAKE_PREFIX_PATH_BACKUP}"
export CUDA_HOME="${CONDA_CUDA_HOME_BACKUP}"

unset CONDA_C_INCLUDE_PATH_BACKUP
unset CONDA_CPLUS_INCLUDE_PATH_BACKUP
unset CONDA_LIBRARY_PATH_BACKUP
unset CONDA_LD_LIBRARY_PATH_BACKUP
unset CONDA_CMAKE_PREFIX_PATH_BACKUP
unset CONDA_CUDA_HOME_BACKUP

[[ -z "${C_INCLUDE_PATH}" ]] && unset C_INCLUDE_PATH
[[ -z "${CPLUS_INCLUDE_PATH}" ]] && unset CPLUS_INCLUDE_PATH
[[ -z "${LIBRARY_PATH}" ]] && unset LIBRARY_PATH
[[ -z "${LD_LIBRARY_PATH}" ]] && unset LD_LIBRARY_PATH
[[ -z "${CMAKE_PREFIX_PATH}" ]] && unset CMAKE_PREFIX_PATH
[[ -z "${CUDA_HOME}" ]] && unset CUDA_HOME
EOF

# Exit for non-Python environment
[[ -x "${CONDA_PREFIX}/bin/python" ]] || exit

# Create usercustomize.py in USER_SITE directory
USER_SITE="$("${CONDA_PREFIX}/bin/python" -c 'from __future__ import print_function; import site; print(site.getusersitepackages())')"
mkdir -p "${USER_SITE}"
if [[ ! -s "${USER_SITE}/usercustomize.py" ]]; then
	touch "${USER_SITE}/usercustomize.py"
fi
if ! grep -qE '^\s*(import|from)\s+rich' "${USER_SITE}/usercustomize.py"; then
	[[ -s "${USER_SITE}/usercustomize.py" ]] && echo >>"${USER_SITE}/usercustomize.py"
	cat >>"${USER_SITE}/usercustomize.py" <<'EOS'
try:
    import rich.pretty
    import rich.traceback
except ImportError:
    pass
else:
    rich.pretty.install()
    rich.traceback.install()
EOS
fi
```

And this file will be executed on every conda env creation. This file will add two script files in new env's `$CONDA_PREFIX/etc/conda` folder and update the `usercustomize.py` in `~/.local/bin` automatically.



┆Issue is synchronized with this [Jira Task](https://anaconda.atlassian.net/browse/CONDAORG-413)
