### PR TITLE
Fix(doc): use /bin/sh to interprete miniconda installation scripts

### DIFF
--- a/docs/source/user-guide/install/linux.rst
+++ b/docs/source/user-guide/install/linux.rst
@@ -16,13 +16,13 @@ Installing on Linux
 
      .. code::
 
-        bash Miniconda3-latest-Linux-x86_64.sh
+        /bin/sh Miniconda3-latest-Linux-x86_64.sh
 
    * Anaconda:
 
      .. code::
 
-        bash Anaconda-latest-Linux-x86_64.sh
+        /bin/sh Anaconda-latest-Linux-x86_64.sh
 
 #. Follow the prompts on the installer screens.
 
@@ -42,7 +42,7 @@ Installing on Linux
 Using with fish shell
 =========================
 
-To use conda with fish shell, run the following in your terminal: 
+To use conda with fish shell, run the following in your terminal:
 
   ``conda init fish``
 

--- a/docs/source/user-guide/install/macos.rst
+++ b/docs/source/user-guide/install/macos.rst
@@ -16,7 +16,7 @@ Installing on macOS
 
      .. code::
 
-        bash Miniconda3-latest-MacOSX-x86_64.sh
+        /bin/sh Miniconda3-latest-MacOSX-x86_64.sh
 
    * Anaconda---Double-click the ``.pkg`` file.
 
@@ -57,7 +57,7 @@ EXAMPLE:
 .. code-block:: bash
 
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh
-    bash ~/miniconda.sh -b -p $HOME/miniconda
+    /bin/sh ~/miniconda.sh -b -p $HOME/miniconda
 
 The installer prompts “Do you wish the installer to initialize Miniconda3 by running ``conda init``?” We recommend “yes”.
 


### PR DESCRIPTION
The official miniconda installer script fails on new version of `bash` (installed by Homebrew as `/usr/local/bin/bash`).

```console
$ bash Miniconda3-latest-MacOSX-x86_64.sh -b -p ~/Miniconda3
PREFIX=/Users/PanXuehai/Miniconda3
Unpacking payload ...
dyld: Library not loaded: @rpath/libz.1.dylib
  Referenced from: /Users/PanXuehai/Miniconda3/conda.exe
  Reason: image not found
Miniconda3-latest-MacOSX-x86_64.sh: line 411:  4155 Exit 141                { dd if="$THIS_PATH" bs=1 skip=14834446 count=9458 2> /dev/null; dd if="$THIS_PATH" bs=16384 skip=906 count=2579 2> /dev/null; dd if="$THIS_PATH" bs=1 skip=57098240 count=14103 2> /dev/null; }
      4156 Abort trap: 6           | "$CONDA_EXEC" constructor --extract-tar --prefix "$PREFIX"
dyld: Library not loaded: @rpath/libz.1.dylib
  Referenced from: /Users/PanXuehai/Miniconda3/conda.exe
  Reason: image not found
Miniconda3-latest-MacOSX-x86_64.sh: line 413:  4160 Abort trap: 6           "$CONDA_EXEC" constructor --prefix "$PREFIX" --extract-conda-pkgs

$ bash --version
GNU bash, version 5.1.4(1)-release (x86_64-apple-darwin19.6.0)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

The shebang of this installer script is `/bin/sh`:
```console
$ head -7 Miniconda3-latest-MacOSX-x86_64.sh
#!/bin/sh
#
# NAME:  Miniconda3
# VER:   py38_4.9.2
# PLAT:  osx-64
# LINES: 577
# MD5:   6e21e31f666558d485dfdab74c1bc1c8
```

And the script installs successfully with `/bin/sh`.