### PR TITLE
Bugfix import typo, allow conda-content-trust use

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -54,7 +54,7 @@ try:
     from conda_content_trust.common import (
         SignatureError,
         load_metadata_from_file as load_trust_metadata_from_file,
-        write_metdata_to_file as write_trust_metadata_to_file,
+        write_metadata_to_file as write_trust_metadata_to_file,
     )
     from conda_content_trust.authentication import (
         verify_root as verify_trust_root,


### PR DESCRIPTION
Fixes a typo in subdir_data.py in a canary tag (4.10.0) that is notable only when artifact verification is turned on.

Prior to this, `conda-content-trust` was always treated as not installed.  See https://github.com/conda/conda/commit/e670fdab4951397079a156aee2f58aa5bba061c6.