### PR TITLE
Remove expensive deepcopy call from resolve

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -709,11 +709,11 @@ class Resolve(object):
                 #    broadening check to apply across packages at the explicit level; only
                 #    at the level of deps below that explicit package.
                 seen_specs = set()
-                specs_by_name = copy.deepcopy(specs_by_name_seed)
+                specs_by_name = dict()
 
                 dep_specs = set(self.ms_depends(pkg))
                 for dep in dep_specs:
-                    specs = specs_by_name.get(dep.name, list())
+                    specs = specs_by_name_seed.get(dep.name, list())
                     if dep not in specs and (not specs or dep.strictness >= specs[0].strictness):
                         specs.insert(0, dep)
                     specs_by_name[dep.name] = specs
@@ -747,7 +747,9 @@ class Resolve(object):
                                 # reduced index helps. Of course, if _another_
                                 # package pulls it in by dependency, that's fine.
                                 if ('track_features' not in new_ms and not self._broader(
-                                        new_ms, tuple(specs_by_name.get(new_ms.name, tuple())))):
+                                        new_ms, tuple(specs_by_name.get(new_ms.name, 
+                                                      specs_by_name_seed.get(new_ms.name,
+                                                      tuple()))))):
                                     dep_specs.add(new_ms)
                                     # if new_ms not in dep_specs:
                                     #     specs_added.append(new_ms)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import defaultdict, OrderedDict, deque
-import copy
 from logging import DEBUG, getLogger
 
 from ._vendor.auxlib.collection import frozendict
@@ -747,9 +746,9 @@ class Resolve(object):
                                 # reduced index helps. Of course, if _another_
                                 # package pulls it in by dependency, that's fine.
                                 if ('track_features' not in new_ms and not self._broader(
-                                        new_ms, tuple(specs_by_name.get(new_ms.name, 
+                                        new_ms, tuple(specs_by_name.get(new_ms.name,
                                                       specs_by_name_seed.get(new_ms.name,
-                                                      tuple()))))):
+                                                                             tuple()))))):
                                     dep_specs.add(new_ms)
                                     # if new_ms not in dep_specs:
                                     #     specs_added.append(new_ms)


### PR DESCRIPTION
Profiling of some of my `conda create --dry-run` runs was showing that around 45% of the time was being spent in the `deepcopy` call within `get_reduced_index` in `resolve.py`. This PR removes the `deepcopy` call and replaces it with a dictionary containing only the values within `specs_by_name` that are different than the values in `specs_by_name_seed`. This has lead to the time it took to call `conda create --dry-run` being cut almost in half.