### PR TITLE
Windows bugfix for artifact verification: URL pathsep issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix version detection for `__linux` virtual package (#10599)
 * Fix import from `conda_content_trust` (#10589)
+* Fix how URL for verification metadata files are constructed (#10617)
 * Partially fix profile `$PATH` setup on MSYS2 (#10459)
 * Remove `.empty` directory even when `rsync` is not installed (#10331)
 

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -641,7 +641,7 @@ def fetch_channel_signing_data(signing_data_url, filename, etag=None, mod_stamp=
 
     try:
         timeout = context.remote_connect_timeout_secs, context.remote_read_timeout_secs
-        file_url = join(signing_data_url, filename)
+        file_url = join_url(signing_data_url, filename)
 
         # The `auth` arugment below looks a bit weird, but passing `None` seems
         # insufficient for suppressing modifying the URL to add an Anaconda


### PR DESCRIPTION
This PR fixes an issue pulling trust metadata from the server on Windows when artifact verification is enabled.  The bug resulted in artifact verification not working.

join() was used instead of join_url(), causing singing metadata
URLs on Windows to use the wrong pathsep for a URL.