### PR TITLE
`conda env export` failing for envs in non-default path

### DIFF
--- a/conda_env/cli/main_export.py
+++ b/conda_env/cli/main_export.py
@@ -95,14 +95,13 @@ def execute(args, parser):
                 * Re-run this command inside an activated conda environment.""").lstrip()
             # TODO Add json support
             raise CondaEnvException(msg)
-        if name:
-            if os.sep in name:
-                # assume "names" with a path seperator are actually paths
-                args.prefix = name
-            else:
-                args.name = name
-        else:
+        if prefix:
             args.prefix = prefix
+        elif os.sep in name:
+            # assume "names" with a path seperator are actually paths
+            args.prefix = name
+        if name:
+            args.name = name
     else:
         name = args.name
     prefix = get_prefix(args)


### PR DESCRIPTION
Running `conda env export` on env that is not in default conda installation path would result in empty environment

```
(pmce) C:\Users\bart\PycharmProjects\poor_mans_camera_effects>conda env export
name: pmce
channels:
  - defaults
prefix: C:\Programs\Miniconda3\envs\pmce
```

this change fixes args.prefix value in case -p is not explicitly provided - value from the env variable was ommited

after change:


```
(pmce) C:\Users\bart\PycharmProjects\poor_mans_camera_effects>conda env export
name: pmce
channels:
  - defaults
dependencies:
  - ca-certificates=2021.4.13=haa95532_1
  - certifi=2020.12.5=py38haa95532_0
  - openssl=1.1.1k=h2bbff1b_0
  - pip=21.0.1=py38haa95532_0
  - python=3.8.5=h5fd99cc_1
  - setuptools=52.0.0=py38haa95532_0
  - sqlite=3.35.4=h2bbff1b_0
  - vc=14.2=h21ff451_1
  - vs2015_runtime=14.27.29016=h5e58377_2
  - wheel=0.36.2=pyhd3eb1b0_0
  - wincertstore=0.2=py38_0
  - pip:
    - absl-py==0.12.0
    - astunparse==1.6.3
    - cachetools==4.2.1
    - click==7.1.2
    - flatbuffers==1.12
    - gast==0.3.3
    - google-auth==1.29.0
    - google-auth-oauthlib==0.4.4
    - google-pasta==0.2.0
    - grpcio==1.32.0
    - h5py==2.10.0
    - keras-preprocessing==1.1.2
    - markdown==3.3.4
    - numpy==1.19.3
    - oauthlib==3.1.0
    - onnx==1.8.1
    - onnx-tf==1.8.0
    - onnxruntime==1.7.0
    - opencv-contrib-python==4.5.1.48
    - opencv-python==4.5.1.48
    - opt-einsum==3.3.0
    - protobuf==3.15.8
    - py-cui==0.1.3
    - pyasn1==0.4.8
    - pyasn1-modules==0.2.8
    - pyfakewebcam==0.1.0
    - requests-oauthlib==1.3.0
    - rsa==4.7.2
    - scipy==1.6.2
    - six==1.15.0
    - tensorboard==2.4.1
    - tensorboard-plugin-wit==1.8.0
    - tensorflow==2.4.1
    - tensorflow-addons==0.12.1
    - tensorflow-estimator==2.4.0
    - termcolor==1.1.0
    - typeguard==2.12.0
    - typing==3.7.4.3
    - typing-extensions==3.7.4.3
    - watchdog==2.0.2
    - werkzeug==1.0.1
    - windows-curses==2.2.0
prefix: C:\Users\bart\PycharmProjects\poor_mans_camera_effects\envs\pmce
```

