### PR TITLE
Fix changeps1 implementation for Powershell

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -1055,6 +1055,7 @@ class PowerShellActivator(_Activator):
                 $Env:_CE_CONDA = "conda"
                 $Env:_CONDA_ROOT = "{python_path}{s}conda"
                 $Env:_CONDA_EXE = "{context.conda_exe}"
+                $CondaModuleArgs = @{{ChangePs1 = ${context.changeps1}}}
                 """.format(s=os.sep,
                            python_path=dirname(CONDA_PACKAGE_ROOT),
                            sys_exe=sys.executable, context=context))
@@ -1065,12 +1066,11 @@ class PowerShellActivator(_Activator):
                 $Env:_CE_CONDA = ""
                 $Env:_CONDA_ROOT = "{context.conda_prefix}"
                 $Env:_CONDA_EXE = "{context.conda_exe}"
+                $CondaModuleArgs = @{{ChangePs1 = ${context.changeps1}}}
                 """.format(context=context))
 
     def _hook_postamble(self):
-        if context.changeps1:
-            return "Add-CondaEnvironmentToPrompt"
-        return None
+        return "Remove-Variable CondaModuleArgs"
 
 
 class JSONFormatMixin(_Activator):

--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -1,3 +1,9 @@
+param([parameter(Position=0,Mandatory=$false)] [Hashtable] $CondaModuleArgs=@{})
+
+# Defaults from before we had arguments.
+if (-not $CondaModuleArgs.ContainsKey('ChangePs1')) {
+    $CondaModuleArgs.ChangePs1 = $True
+}
 
 ## ENVIRONMENT MANAGEMENT ######################################################
 
@@ -263,18 +269,17 @@ function TabExpansion($line, $lastWord) {
         Causes the current session's prompt to display the currently activated
         conda environment.
 #>
-
-# We use the same procedure to nest prompts as we did for nested tab completion.
-if (Test-Path Function:\prompt) {
-    Rename-Item Function:\prompt CondaPromptBackup
-} else {
-    function CondaPromptBackup() {
-        # Restore a basic prompt if the definition is missing.
-        "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
+if ($CondaModuleArgs.ChangePs1) {
+    # We use the same procedure to nest prompts as we did for nested tab completion.
+    if (Test-Path Function:\prompt) {
+        Rename-Item Function:\prompt CondaPromptBackup
+    } else {
+        function CondaPromptBackup() {
+            # Restore a basic prompt if the definition is missing.
+            "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
+        }
     }
-}
 
-function Add-CondaEnvironmentToPrompt() {
     function global:prompt() {
         if ($Env:CONDA_PROMPT_MODIFIER) {
             $Env:CONDA_PROMPT_MODIFIER | Write-Host -NoNewline
@@ -296,6 +301,6 @@ Export-ModuleMember `
     -Alias * `
     -Function `
         Invoke-Conda, `
-        Get-CondaEnvironment, Add-CondaEnvironmentToPrompt, `
+        Get-CondaEnvironment, `
         Enter-CondaEnvironment, Exit-CondaEnvironment, `
         TabExpansion, prompt

--- a/conda/shell/condabin/conda-hook.ps1
+++ b/conda/shell/condabin/conda-hook.ps1
@@ -1,1 +1,1 @@
-Import-Module "$Env:_CONDA_ROOT\shell\condabin\Conda.psm1"
+Import-Module "$Env:_CONDA_ROOT\shell\condabin\Conda.psm1" -ArgumentList $CondaModuleArgs


### PR DESCRIPTION
Since commit ca16da40 using changeps1=false just results in
Add-CondaEnvironmentToPrompt not being called, but still unconditionally
renaming the global prompt function so the end result is the user
ends up with no prompt at all (well, just 'PS>').
Fix this by making everything related to the prompt conditional, but
execute all of that in the module itself (and add arguments to the
module in order to achieve that); see previous issues related to the
prompt function: it should be altered in the global scope and not
in function scope.

Fixes https://github.com/conda/conda/issues/10326, also see https://github.com/conda/conda/pull/8774.