### PR TITLE
fix some issues in conda.sh (injected in .bashrc)

### DIFF
--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -60,29 +60,19 @@ __conda_reactivate() {
 }
 
 conda() {
-    if [ "$#" -lt 1 ]; then
-        "$CONDA_EXE" $_CE_M $_CE_CONDA
-    else
-        \local cmd="$1"
-        shift
-        case "$cmd" in
-            activate|deactivate)
-                __conda_activate "$cmd" "$@"
-                ;;
-            install|update|upgrade|remove|uninstall)
-                __conda_exe "$cmd" "$@"
-                \local t1=$?
-                if [ $t1 = 0 ]; then
-                    __conda_reactivate
-                else
-                    return $t1
-                fi
-                ;;
-            *)
-                __conda_exe "$cmd" "$@"
-                ;;
-        esac
-    fi
+    \local cmd="${1-__missing__}"
+    case "$cmd" in
+        activate|deactivate)
+            __conda_activate "$@"
+            ;;
+        install|update|upgrade|remove|uninstall)
+            __conda_exe "$@" || \return
+            __conda_reactivate
+            ;;
+        *)
+            __conda_exe "$@"
+            ;;
+    esac
 }
 
 if [ -z "${CONDA_SHLVL+x}" ]; then


### PR DESCRIPTION
I found some strange behaviour in the shell script that's sourced into `.bashrc`. I may have overlooked or misunderstood some important details, so please triple-check whether the changes make sense.

There were some issues with the function `__conda_activate() `
```sh
    CONDA_INTERNAL_OLDPATH="${PATH}"
    __add_sys_prefix_to_path
    ask_conda="$(PS1="$PS1" "$CONDA_EXE" $_CE_M $_CE_CONDA shell.posix "$cmd" "$@")" || \return $?
    rc=$?
    PATH="${CONDA_INTERNAL_OLDPATH}"
```

1. `rc` is not local, and is useless, because `$?` is always `0` at that point
2. if the command inside `$( ... )` fails for some reason, the function returns without restoring `PATH`

The second problem was also present in function `__conda_reactivate()`.

Function `conda()` properly restored the `PATH` before returning, but the `save; modify; restore` pattern is so wordy and error-prone that I think it's worth replacing all its occurrences with a simple call to a function that runs in a subshell, so that env modification cannot leak by accident.

So that's the first commit.

And once it got less wordy, I was able to see that the function `conda()` doesn't need a special case for 0 arguments (the catch-all `case (*)` handles that just fine), so that's the second commit.
