### PR TITLE
Conda env create dry-run

### DIFF
--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 from argparse import RawDescriptionHelpFormatter
+import json
 import os
 import sys
 import textwrap
@@ -68,6 +69,12 @@ def configure_parser(sub_parsers):
         action='store_true',
         default=False,
     )
+    p.add_argument(
+        '-d', '--dry-run',
+        help='Only display what would have been done.',
+        action='store_true',
+        default=False
+    )
     add_parser_default_packages(p)
     add_parser_json(p)
     p.set_defaults(func='.main_create.execute')
@@ -102,36 +109,51 @@ def execute(args, parser):
     result = {"conda": None, "pip": None}
 
     args_packages = context.create_default_packages if not args.no_default_packages else []
-    if args_packages:
-        installer_type = "conda"
-        installer = get_installer(installer_type)
-        result[installer_type] = installer.install(prefix, args_packages, args, env)
 
-    if len(env.dependencies.items()) == 0:
-        installer_type = "conda"
-        pkg_specs = []
+    if args.dry_run:
+        installer_type = 'conda'
         installer = get_installer(installer_type)
-        result[installer_type] = installer.install(prefix, pkg_specs, args, env)
+
+        pkg_specs = env.dependencies.get(installer_type, [])
+        pkg_specs.extend(args_packages)
+
+        solved_env = installer.dry_run(pkg_specs, args, env)
+        if args.json:
+            print(json.dumps(solved_env.to_dict(), indent=2))
+        else:
+            print(solved_env.to_yaml(), end='')
+
     else:
-        for installer_type, pkg_specs in env.dependencies.items():
-            try:
-                installer = get_installer(installer_type)
-                result[installer_type] = installer.install(prefix, pkg_specs, args, env)
-            except InvalidInstaller:
-                sys.stderr.write(textwrap.dedent("""
-                    Unable to install package for {0}.
+        if args_packages:
+            installer_type = "conda"
+            installer = get_installer(installer_type)
+            result[installer_type] = installer.install(prefix, args_packages, args, env)
 
-                    Please double check and ensure your dependencies file has
-                    the correct spelling.  You might also try installing the
-                    conda-env-{0} package to see if provides the required
-                    installer.
-                    """).lstrip().format(installer_type)
-                )
-                return -1
+        if len(env.dependencies.items()) == 0:
+            installer_type = "conda"
+            pkg_specs = []
+            installer = get_installer(installer_type)
+            result[installer_type] = installer.install(prefix, pkg_specs, args, env)
+        else:
+            for installer_type, pkg_specs in env.dependencies.items():
+                try:
+                    installer = get_installer(installer_type)
+                    result[installer_type] = installer.install(prefix, pkg_specs, args, env)
+                except InvalidInstaller:
+                    sys.stderr.write(textwrap.dedent("""
+                        Unable to install package for {0}.
 
-    if env.variables:
-        pd = PrefixData(prefix)
-        pd.set_environment_env_vars(env.variables)
+                        Please double check and ensure your dependencies file has
+                        the correct spelling.  You might also try installing the
+                        conda-env-{0} package to see if provides the required
+                        installer.
+                        """).lstrip().format(installer_type)
+                    )
+                    return -1
 
-    touch_nonadmin(prefix)
-    print_result(args, prefix, result)
+        if env.variables:
+            pd = PrefixData(prefix)
+            pd.set_environment_env_vars(env.variables)
+
+        touch_nonadmin(prefix)
+        print_result(args, prefix, result)

--- a/conda_env/installers/conda.py
+++ b/conda_env/installers/conda.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import
 
+import tempfile
 from os.path import basename
 
 from conda._vendor.boltons.setutils import IndexedSet
@@ -13,8 +14,9 @@ from conda.core.solve import Solver
 from conda.exceptions import UnsatisfiableError
 from conda.models.channel import Channel, prioritize_channels
 
+from ..env import Environment
 
-def install(prefix, specs, args, env, *_, **kwargs):
+def _solve(prefix, specs, args, env, *_, **kwargs):
     # TODO: support all various ways this happens
     # Including 'nodefaults' in the channels list disables the defaults
     channel_urls = [chan for chan in env.channels if chan != 'nodefaults']
@@ -27,6 +29,23 @@ def install(prefix, specs, args, env, *_, **kwargs):
     subdirs = IndexedSet(basename(url) for url in _channel_priority_map)
 
     solver = Solver(prefix, channels, subdirs, specs_to_add=specs)
+    return solver
+
+
+def dry_run(specs, args, env, *_, **kwargs):
+    solver = _solve(tempfile.mkdtemp(), specs, args, env, *_, **kwargs)
+    pkgs = solver.solve_final_state()
+    solved_env = Environment(
+        name=env.name,
+        dependencies=[str(p) for p in pkgs],
+        channels=env.channels
+    )
+    return solved_env
+
+
+def install(prefix, specs, args, env, *_, **kwargs):
+    solver = _solve(prefix, specs, args, env, *_, **kwargs)
+
     try:
         unlink_link_transaction = solver.solve_for_transaction(
             prune=getattr(args, 'prune', False), update_modifier=UpdateModifier.FREEZE_INSTALLED)

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+import yaml
 
 import pytest
 import unittest
@@ -252,6 +253,24 @@ class IntegrationTests(unittest.TestCase):
         self.assertNotEqual(
             len([env for env in parsed['envs'] if env.endswith(test_env_name_1)]), 0
         )
+
+    def test_create_dry_run_yaml(self):
+        create_env(environment_1)
+        o, e = run_env_command(Commands.ENV_CREATE, None, '--dry-run')
+        self.assertFalse(env_is_created(test_env_name_1))
+
+        output = yaml.safe_load('\n'.join(o.splitlines()[2:]))
+        assert output['name'] == 'env-1'
+        assert len(output['dependencies']) > 0
+
+    def test_create_dry_run_json(self):
+        create_env(environment_1)
+        o, e = run_env_command(Commands.ENV_CREATE, None, '--dry-run', '--json')
+        self.assertFalse(env_is_created(test_env_name_1))
+
+        output = json.loads(o)
+        assert output.get('name') == 'env-1'
+        assert len(output['dependencies'])
 
     def test_create_valid_env_with_variables(self):
         '''


### PR DESCRIPTION
This adds a `--dry-run` flag to `conda env create` that creates YAML for JSON output of the solved environment without installing it.

Question: Without `--json` but with `--quiet` this will still display the spinner. Would another PR to more easily quiet the spinner be appreciated just by using `--quiet`?

By using the `CONDA_SUBDIR` environment variable this flag can also be used to check environment solves cross platform.

## YAML

Here's an example

```
conda env create --dry-run defusco/py376
Collecting package metadata (repodata.json): done
Solving environment: done
name: py376
channels:
  - defaults
dependencies:
  - defaults/osx-64::ca-certificates==2021.1.19=hecd8cb5_1
  - defaults/osx-64::libcxx==10.0.0=1
  - defaults/osx-64::xz==5.2.5=h1de35cc_0
  - defaults/osx-64::yaml==0.1.7=hc338f04_2
  - defaults/osx-64::zlib==1.2.11=h1de35cc_3
  - defaults/osx-64::libffi==3.2.1=h0a44026_1007
  - defaults/osx-64::ncurses==6.2=h0a44026_1
  - defaults/osx-64::openssl==1.1.1g=h1de35cc_0
  - defaults/osx-64::tk==8.6.10=hb0a8c7a_0
  - defaults/osx-64::libedit==3.1.20191231=h1de35cc_1
  - defaults/osx-64::readline==7.0=h1de35cc_5
  - defaults/osx-64::sqlite==3.33.0=hffcf06c_0
  - defaults/osx-64::python==3.7.6=h359304d_2
  - defaults/osx-64::certifi==2020.12.5=py37hecd8cb5_0
  - defaults/osx-64::pyyaml==5.3.1=py37h1de35cc_0
  - defaults/osx-64::rope==0.10.7=py37_0
  - defaults/noarch::wheel==0.36.2=pyhd3eb1b0_0
  - defaults/osx-64::setuptools==52.0.0=py37hecd8cb5_0
  - defaults/osx-64::pip==20.3.3=py37hecd8cb5_0
 ```

## JSON

```
>conda env create --dry-run --json defusco/py376
{
  "name": "py376",
  "channels": [
    "defaults"
  ],
  "dependencies": [
    "defaults/osx-64::ca-certificates==2021.1.19=hecd8cb5_1",
    "defaults/osx-64::libcxx==10.0.0=1",
    "defaults/osx-64::xz==5.2.5=h1de35cc_0",
    "defaults/osx-64::yaml==0.1.7=hc338f04_2",
    "defaults/osx-64::zlib==1.2.11=h1de35cc_3",
    "defaults/osx-64::libffi==3.2.1=h0a44026_1007",
    "defaults/osx-64::ncurses==6.2=h0a44026_1",
    "defaults/osx-64::openssl==1.1.1g=h1de35cc_0",
    "defaults/osx-64::tk==8.6.10=hb0a8c7a_0",
    "defaults/osx-64::libedit==3.1.20191231=h1de35cc_1",
    "defaults/osx-64::readline==7.0=h1de35cc_5",
    "defaults/osx-64::sqlite==3.33.0=hffcf06c_0",
    "defaults/osx-64::python==3.7.6=h359304d_2",
    "defaults/osx-64::certifi==2020.12.5=py37hecd8cb5_0",
    "defaults/osx-64::pyyaml==5.3.1=py37h1de35cc_0",
    "defaults/osx-64::rope==0.10.7=py37_0",
    "defaults/noarch::wheel==0.36.2=pyhd3eb1b0_0",
    "defaults/osx-64::setuptools==52.0.0=py37hecd8cb5_0",
    "defaults/osx-64::pip==20.3.3=py37hecd8cb5_0"
  ]
}
```