### PR TITLE
Fix #10614 - Conda prints pip warning over and over again

### DIFF
--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -63,6 +63,7 @@ def validate_keys(data, kwargs):
                   "in the wrong place.  Please add an explicit pip dependency.  I'm adding one"
                   " for you, but still nagging you.")
             new_data['dependencies'].insert(0, 'pip')
+            break
     return new_data
 
 

--- a/tests/conda_env/support/add-pip.yml
+++ b/tests/conda_env/support/add-pip.yml
@@ -1,0 +1,6 @@
+name: pip
+dependencies:
+  - car
+  - pip:
+    - foo
+    - baz

--- a/tests/conda_env/test_env.py
+++ b/tests/conda_env/test_env.py
@@ -78,6 +78,15 @@ class from_file_TestCase(unittest.TestCase):
         assert 'foo' in e.dependencies['pip']
         assert 'baz' in e.dependencies['pip']
 
+    @pytest.mark.timeout(20)
+    def test_add_pip(self):
+        e = env.from_file(support_file('add-pip.yml'))
+        expected = OrderedDict([
+            ('conda', ['pip', 'car']),
+            ('pip', ['foo', 'baz'])
+        ])
+        self.assertEqual(e.dependencies, expected)
+
     @pytest.mark.integration
     def test_http(self):
         e = get_simple_environment()


### PR DESCRIPTION
When creating an environment with pip-dependencies but without pip explicitly listed conda prints the warning
> Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.

over and over again and gets stuck in an infinite loop.

This pull request fixes this bug by adding a `break` after the `pip` dependency was added to the list of dependencies. Details on why the infinite loop happens can be found in the commit message.
I also added a simple unit test for this.

We can also use a `deepcopy` in line 37 (this is probably what caused the confusion and led to the bug).