### PR TITLE
Make sure that `conda env update -f` sets env vars from the referenced yaml file

### DIFF
--- a/conda_env/cli/main_update.py
+++ b/conda_env/cli/main_update.py
@@ -7,6 +7,7 @@ import sys
 import textwrap
 
 from conda.cli.conda_argparse import add_parser_json, add_parser_prefix
+from conda.core.prefix_data import PrefixData
 from conda.misc import touch_nonadmin
 from .common import get_prefix, print_result, get_filename
 from .. import exceptions, specs as install_specs
@@ -121,6 +122,10 @@ def execute(args, parser):
     for installer_type, specs in env.dependencies.items():
         installer = installers[installer_type]
         result[installer_type] = installer.install(prefix, specs, args, env)
+
+    if env.variables:
+        pd = PrefixData(prefix)
+        pd.set_environment_env_vars(env.variables)
 
     touch_nonadmin(prefix)
     print_result(args, prefix, result)

--- a/tests/conda_env/support/example/environment_pinned.yml
+++ b/tests/conda_env/support/example/environment_pinned.yml
@@ -1,3 +1,7 @@
 name: test
 dependencies:
   - flask==0.12.2
+variables:
+  FIXED: fixed
+  CHANGES: original_value
+  GETS_DELETED: not_actually_removed_though

--- a/tests/conda_env/support/example/environment_pinned.yml
+++ b/tests/conda_env/support/example/environment_pinned.yml
@@ -5,3 +5,4 @@ variables:
   FIXED: fixed
   CHANGES: original_value
   GETS_DELETED: not_actually_removed_though
+  

--- a/tests/conda_env/support/example/environment_pinned.yml
+++ b/tests/conda_env/support/example/environment_pinned.yml
@@ -5,4 +5,4 @@ variables:
   FIXED: fixed
   CHANGES: original_value
   GETS_DELETED: not_actually_removed_though
-  
+

--- a/tests/conda_env/support/example/environment_pinned.yml
+++ b/tests/conda_env/support/example/environment_pinned.yml
@@ -5,4 +5,3 @@ variables:
   FIXED: fixed
   CHANGES: original_value
   GETS_DELETED: not_actually_removed_though
-

--- a/tests/conda_env/support/example/environment_pinned_updated.yml
+++ b/tests/conda_env/support/example/environment_pinned_updated.yml
@@ -1,3 +1,7 @@
 name: test
 dependencies:
   - flask==1.0.2
+variables:
+  FIXED: fixed
+  CHANGES: updated_value
+  NEW_VAR: new_var

--- a/tests/conda_env/support/example/environment_pinned_updated.yml
+++ b/tests/conda_env/support/example/environment_pinned_updated.yml
@@ -5,3 +5,4 @@ variables:
   FIXED: fixed
   CHANGES: updated_value
   NEW_VAR: new_var
+  

--- a/tests/conda_env/support/example/environment_pinned_updated.yml
+++ b/tests/conda_env/support/example/environment_pinned_updated.yml
@@ -5,4 +5,3 @@ variables:
   FIXED: fixed
   CHANGES: updated_value
   NEW_VAR: new_var
-

--- a/tests/conda_env/support/example/environment_pinned_updated.yml
+++ b/tests/conda_env/support/example/environment_pinned_updated.yml
@@ -5,4 +5,4 @@ variables:
   FIXED: fixed
   CHANGES: updated_value
   NEW_VAR: new_var
-  
+

--- a/tests/conda_env/test_create.py
+++ b/tests/conda_env/test_create.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 from logging import Handler, getLogger
+from os import environ
 from os.path import exists, join
 from shutil import rmtree
 from unittest import TestCase
@@ -83,10 +84,21 @@ class IntegrationTests(TestCase):
                 run_command(Commands.CREATE, env_name, support_file('example/environment_pinned.yml'))
                 assert exists(python_path)
                 assert package_is_installed(prefix, 'flask=0.12.2')
+                assert environ['FIXED'] == 'fixed'
+                assert environ['CHANGES'] == 'original_value'
+                assert environ['GETS_DELETED'] == 'not_actually_removed_though'
+                assert environ.get('NEW_VAR') is None
 
                 run_command(Commands.UPDATE, env_name, support_file('example/environment_pinned_updated.yml'))
                 assert package_is_installed(prefix, 'flask=1.0.2')
                 assert not package_is_installed(prefix, 'flask=0.12.2')
+                assert environ['FIXED'] == 'fixed'
+                assert environ['CHANGES'] == 'updated_value'
+                assert environ['NEW_VAR'] == 'new_var'
+                
+                # This ends up sticking around since there is no real way of knowing that an environment
+                # variable _used_ to be in the variables dict, but isn't any more.
+                assert environ['GETS_DELETED'] == 'not_actually_removed_though'
 
     def test_create_update_remote_env_file(self):
         with make_temp_envs_dir() as envs_dir:
@@ -98,10 +110,21 @@ class IntegrationTests(TestCase):
                 run_command(Commands.CREATE, env_name, support_file('example/environment_pinned.yml', remote=True))
                 assert exists(python_path)
                 assert package_is_installed(prefix, 'flask=0.12.2')
+                assert environ['FIXED'] == 'fixed'
+                assert environ['CHANGES'] == 'original_value'
+                assert environ['GETS_DELETED'] == 'not_actually_removed_though'
+                assert environ.get('NEW_VAR') is None
 
                 run_command(Commands.UPDATE, env_name, support_file('example/environment_pinned_updated.yml', remote=True))
                 assert package_is_installed(prefix, 'flask=1.0.2')
                 assert not package_is_installed(prefix, 'flask=0.12.2')
+                assert environ['FIXED'] == 'fixed'
+                assert environ['CHANGES'] == 'updated_value'
+                assert environ['NEW_VAR'] == 'new_var'
+                
+                # This ends up sticking around since there is no real way of knowing that an environment
+                # variable _used_ to be in the variables dict, but isn't any more.
+                assert environ['GETS_DELETED'] == 'not_actually_removed_though'
 
     @pytest.mark.skip(reason="Need to find an appropriate server to test this on.")
     def test_create_host_port(self):

--- a/tests/conda_env/test_create.py
+++ b/tests/conda_env/test_create.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function
 
 from logging import Handler, getLogger
-from os import environ
 from os.path import exists, join
 from shutil import rmtree
 from unittest import TestCase
@@ -64,6 +63,13 @@ def package_is_installed(prefix, spec, pip=None):
         )
     return is_installed
 
+def get_env_vars(prefix):
+    pd = PrefixData(prefix)
+
+    env_vars = pd.get_environment_env_vars()
+
+    return env_vars
+
 
 @pytest.mark.integration
 class IntegrationTests(TestCase):
@@ -84,21 +90,25 @@ class IntegrationTests(TestCase):
                 run_command(Commands.CREATE, env_name, support_file('example/environment_pinned.yml'))
                 assert exists(python_path)
                 assert package_is_installed(prefix, 'flask=0.12.2')
-                assert environ['FIXED'] == 'fixed'
-                assert environ['CHANGES'] == 'original_value'
-                assert environ['GETS_DELETED'] == 'not_actually_removed_though'
-                assert environ.get('NEW_VAR') is None
+
+                env_vars = get_env_vars(prefix)
+                assert env_vars['FIXED'] == 'fixed'
+                assert env_vars['CHANGES'] == 'original_value'
+                assert env_vars['GETS_DELETED'] == 'not_actually_removed_though'
+                assert env_vars.get('NEW_VAR') is None
 
                 run_command(Commands.UPDATE, env_name, support_file('example/environment_pinned_updated.yml'))
                 assert package_is_installed(prefix, 'flask=1.0.2')
                 assert not package_is_installed(prefix, 'flask=0.12.2')
-                assert environ['FIXED'] == 'fixed'
-                assert environ['CHANGES'] == 'updated_value'
-                assert environ['NEW_VAR'] == 'new_var'
+
+                env_vars = get_env_vars(prefix)
+                assert env_vars['FIXED'] == 'fixed'
+                assert env_vars['CHANGES'] == 'updated_value'
+                assert env_vars['NEW_VAR'] == 'new_var'
                 
                 # This ends up sticking around since there is no real way of knowing that an environment
                 # variable _used_ to be in the variables dict, but isn't any more.
-                assert environ['GETS_DELETED'] == 'not_actually_removed_though'
+                assert env_vars['GETS_DELETED'] == 'not_actually_removed_though'
 
     def test_create_update_remote_env_file(self):
         with make_temp_envs_dir() as envs_dir:
@@ -110,21 +120,25 @@ class IntegrationTests(TestCase):
                 run_command(Commands.CREATE, env_name, support_file('example/environment_pinned.yml', remote=True))
                 assert exists(python_path)
                 assert package_is_installed(prefix, 'flask=0.12.2')
-                assert environ['FIXED'] == 'fixed'
-                assert environ['CHANGES'] == 'original_value'
-                assert environ['GETS_DELETED'] == 'not_actually_removed_though'
-                assert environ.get('NEW_VAR') is None
+
+                env_vars = get_env_vars(prefix)
+                assert env_vars['FIXED'] == 'fixed'
+                assert env_vars['CHANGES'] == 'original_value'
+                assert env_vars['GETS_DELETED'] == 'not_actually_removed_though'
+                assert env_vars.get('NEW_VAR') is None
 
                 run_command(Commands.UPDATE, env_name, support_file('example/environment_pinned_updated.yml', remote=True))
                 assert package_is_installed(prefix, 'flask=1.0.2')
                 assert not package_is_installed(prefix, 'flask=0.12.2')
-                assert environ['FIXED'] == 'fixed'
-                assert environ['CHANGES'] == 'updated_value'
-                assert environ['NEW_VAR'] == 'new_var'
+
+                env_vars = get_env_vars(prefix)
+                assert env_vars['FIXED'] == 'fixed'
+                assert env_vars['CHANGES'] == 'updated_value'
+                assert env_vars['NEW_VAR'] == 'new_var'
                 
                 # This ends up sticking around since there is no real way of knowing that an environment
                 # variable _used_ to be in the variables dict, but isn't any more.
-                assert environ['GETS_DELETED'] == 'not_actually_removed_though'
+                assert env_vars['GETS_DELETED'] == 'not_actually_removed_though'
 
     @pytest.mark.skip(reason="Need to find an appropriate server to test this on.")
     def test_create_host_port(self):

--- a/tests/conda_env/test_create.py
+++ b/tests/conda_env/test_create.py
@@ -105,7 +105,7 @@ class IntegrationTests(TestCase):
                 assert env_vars['FIXED'] == 'fixed'
                 assert env_vars['CHANGES'] == 'updated_value'
                 assert env_vars['NEW_VAR'] == 'new_var'
-                
+
                 # This ends up sticking around since there is no real way of knowing that an environment
                 # variable _used_ to be in the variables dict, but isn't any more.
                 assert env_vars['GETS_DELETED'] == 'not_actually_removed_though'
@@ -135,7 +135,7 @@ class IntegrationTests(TestCase):
                 assert env_vars['FIXED'] == 'fixed'
                 assert env_vars['CHANGES'] == 'updated_value'
                 assert env_vars['NEW_VAR'] == 'new_var'
-                
+
                 # This ends up sticking around since there is no real way of knowing that an environment
                 # variable _used_ to be in the variables dict, but isn't any more.
                 assert env_vars['GETS_DELETED'] == 'not_actually_removed_though'


### PR DESCRIPTION
Assume an environment file called `foo.yaml` that looks like:

```yaml
name: foo
dependencies:
    - python
variables:
    MY_VAR: bar
```

When the user runs `conda env create -f foo.yaml`, conda will create an environment named `foo`, install Python in that environment, and set an env var `MY_VAR=bar`.

Now imagine the user modifies the file:

```yaml
name: foo
dependencies:
    - python
    - ipython
variables:
    MY_VAR: bar
    MY_VAR2: baz
```

And then runs: `conda env update -f foo.yaml`. The expectation is that IPython would be installed, and `MY_VAR2` would be set to `baz`. However, currently the `conda env update` command ignores any env variables specified in the yaml file. This PR attempts to remedy that.

Potential issue: This doesn't attempt to track env vars that are removed from the file.