### PR TITLE
Don't load binstar_client until needed.

### DIFF
--- a/conda_env/specs/binstar.py
+++ b/conda_env/specs/binstar.py
@@ -29,10 +29,11 @@ def import_binstar():
         from binstar_client import errors
         import binstar_client.utils
 
-        get_server_api = utils.get_server_api
+        get_server_api = binstar_client.utils.get_server_api
         NotFound = errors.NotFound
     except ImportError:
         pass
+
 
 ENVIRONMENT_TYPE = 'env'
 # TODO: isolate binstar related code into conda_env.utils.binstar


### PR DESCRIPTION
This PR substantially reduces the time required for many conda commands (`conda env list` runs about 1s faster on my dev machine, for instance) by making sure that the `binstar_client` package is not imported until it is actually used. As per the report obtained by setting the [`PYTHONPROFILEIMPORTTIME` environment variable](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPROFILEIMPORTTIME) to `"True"`, the `binstar_client` package is one of the most expensive to import (0.8 seconds on my machine), accounting for a significant chunk of the time required for commands such as `conda env list`.