### PR TITLE
Add RSA SecurID server support

### DIFF
--- a/conda/gateways/connection/adapters/rsa.py
+++ b/conda/gateways/connection/adapters/rsa.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os, pickle, re
+from urllib.parse import urlparse
+from logging import LoggerAdapter, getLogger
+from .. import BaseAdapter, Session, Response
+from ....common.compat import StringIO
+
+log = getLogger(__name__)
+stderrlog = LoggerAdapter(getLogger('conda.stderrlog'), extra=dict(terminator="\n"))
+
+class SecureIDAdapter(BaseAdapter):
+    def __init__(self):
+        super(SecureIDAdapter, self).__init__()
+
+    def send(self, request, stream=None, timeout=None, verify=None, cert=None, proxies=None):
+        session = Session()
+        request.url = request.url.replace('rsa', 'https')
+        fqdn = urlparse(request.url).hostname
+        cookie = getCookie(fqdn)
+        session.cookies.update(cookie)
+        response = session.get(request.url, verify=False)
+        return properResponse(response, request, fqdn)
+
+    def close(self):
+        pass
+
+def getCookie(fqdn):
+    cookie_file = '%s' % (os.path.sep).join([os.path.expanduser("~"),
+                                             '.RSASecureID_login',
+                                             fqdn])
+    cookie = {}
+    if os.path.exists(cookie_file):
+        with open(cookie_file, 'rb') as f:
+            cookie.update(pickle.load(f))
+    else:
+        log.warning('RSA Token not available, please sign in using: `rsasecure_login -s %s`' % (fqdn))
+    return cookie
+
+def properResponse(response, request, fqdn):
+    """ Return non exception causing response when certain conditions arise """
+    null_response = Response()
+    null_response.raw = StringIO()
+    null_response.url = request.url
+    null_response.request = request
+    null_response.status_code = 204
+
+    if len(response.cookies) == 1:
+        return null_response
+    elif re.search('RSA SECURID', response.text.upper()):
+        log.warning('RSA Token expired. Please sign in using: `rsasecure_login -s %s`' % (fqdn))
+        return null_response
+
+    return response

--- a/conda/gateways/connection/session.py
+++ b/conda/gateways/connection/session.py
@@ -11,6 +11,7 @@ from . import (AuthBase, BaseAdapter, HTTPAdapter, Session, _basic_auth_str,
 from .adapters.ftp import FTPAdapter
 from .adapters.localfs import LocalFSAdapter
 from .adapters.s3 import S3Adapter
+from .adapters.rsa import SecureIDAdapter
 from ..anaconda_client import read_binstar_tokens
 from ..._vendor.auxlib.ish import dals
 from ...base.constants import CONDA_HOMEPAGE_URL
@@ -29,6 +30,7 @@ CONDA_SESSION_SCHEMES = frozenset((
     "https",
     "ftp",
     "s3",
+    "rsa",
     "file",
 ))
 
@@ -79,6 +81,7 @@ class CondaSession(Session):
             self.mount("https://", unused_adapter)
             self.mount("ftp://", unused_adapter)
             self.mount("s3://", unused_adapter)
+            self.mount("rsa://", unused_adapter)
 
         else:
             # Configure retries
@@ -91,6 +94,7 @@ class CondaSession(Session):
             self.mount("https://", http_adapter)
             self.mount("ftp://", FTPAdapter())
             self.mount("s3://", S3Adapter())
+            self.mount("rsa://", SecureIDAdapter())
 
         self.mount("file://", LocalFSAdapter())
 


### PR DESCRIPTION
Initial commit to aid dealing with RSA SecurID protected servers.

Requires a third party script to facilitate authentication (the pickling
of authenticated cookie): https://github.com/milljm/rsasecure_login

With everyone's blessing, I will move the 3rd party helper script over to conda-forge.
Or do this first if that is a requirement?
