### PR TITLE
Fix ValueError: invalid literal for int() with base 10: '' in _screen_shape_linux

### DIFF
--- a/conda/_vendor/tqdm/utils.py
+++ b/conda/_vendor/tqdm/utils.py
@@ -366,8 +366,10 @@ def _screen_shape_linux(fp):  # pragma: no cover
         except:
             try:
                 return [int(os.environ[i]) - 1 for i in ("COLUMNS", "LINES")]
-            except KeyError, ValueError:
+            except KeyError:
                 return None, None
+            except ValueError:
+                return [0, 0]
 
 
 def _environ_cols_wrapper():  # pragma: no cover

--- a/conda/_vendor/tqdm/utils.py
+++ b/conda/_vendor/tqdm/utils.py
@@ -365,7 +365,7 @@ def _screen_shape_linux(fp):  # pragma: no cover
             return cols, rows
         except:
             try:
-                return [int(os.environ[i]) - 1 for i in ("COLUMNS", "LINES")]
+                return [int(os.environ.get(i, 1)) - 1 for i in ("COLUMNS", "LINES")]
             except KeyError:
                 return None, None
 

--- a/conda/_vendor/tqdm/utils.py
+++ b/conda/_vendor/tqdm/utils.py
@@ -365,8 +365,8 @@ def _screen_shape_linux(fp):  # pragma: no cover
             return cols, rows
         except:
             try:
-                return [int(os.environ.get(i, 1)) - 1 for i in ("COLUMNS", "LINES")]
-            except KeyError:
+                return [int(os.environ[i]) - 1 for i in ("COLUMNS", "LINES")]
+            except KeyError, ValueError:
                 return None, None
 
 


### PR DESCRIPTION
Fixes #10673.

This PR fixes a bug in `tqdm/utils.py`
For conda version > 4.8.3
At https://github.com/conda/conda/commit/db380cc9a1fbeedb5efab84750d4437f1ab72d45#diff-a2e083f5ce1f74db5268f51073df0c2cdb07b7e2d64f65be3e65f5964e023417R336), os.environ is called which returns an empty string and thus fails with value error when int() is called on it.

In the previous code, a default value of 1 was used (line-204 in _vendors/tqdm/_utils.py ).

I suggest that the line-336 in `_vendors/tqdm/utils.py` should be changed to return `[int(os.environ.get(i, 1)) - 1 for i in ("COLUMNS", "LINES")]`