### PR TITLE
explicit install doesn't respect --download-only

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -22,7 +22,7 @@ from .core.index import get_index
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.package_cache_data import PackageCacheData, ProgressiveFetchExtract
 from .core.prefix_data import PrefixData
-from .exceptions import DisallowedPackageError, DryRunExit, PackagesNotFoundError, ParseError
+from .exceptions import DisallowedPackageError, DryRunExit, PackagesNotFoundError, ParseError, CondaExitZero
 from .gateways.disk.delete import rm_rf
 from .gateways.disk.link import islink, readlink, symlink
 from .models.match_spec import MatchSpec
@@ -82,6 +82,10 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
 
     pfe = ProgressiveFetchExtract(fetch_specs)
     pfe.execute()
+
+    if context.download_only:
+        raise CondaExitZero('Package caches prepared. UnlinkLinkTransaction cancelled with '
+                                '--download-only option.')
 
     # now make an UnlinkLinkTransaction with the PackageCacheRecords as inputs
     # need to add package name to fetch_specs so that history parsing keeps track of them correctly

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -22,7 +22,10 @@ from .core.index import get_index
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.package_cache_data import PackageCacheData, ProgressiveFetchExtract
 from .core.prefix_data import PrefixData
-from .exceptions import DisallowedPackageError, DryRunExit, PackagesNotFoundError, ParseError, CondaExitZero
+from .exceptions import ( 
+    DisallowedPackageError, DryRunExit, PackagesNotFoundError, 
+    ParseError, CondaExitZero
+)
 from .gateways.disk.delete import rm_rf
 from .gateways.disk.link import islink, readlink, symlink
 from .models.match_spec import MatchSpec
@@ -84,8 +87,8 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
     pfe.execute()
 
     if context.download_only:
-        raise CondaExitZero('Package caches prepared. UnlinkLinkTransaction cancelled with '
-                                '--download-only option.')
+        raise CondaExitZero('Package caches prepared. ' 
+                            'UnlinkLinkTransaction cancelled with --download-only option.')
 
     # now make an UnlinkLinkTransaction with the PackageCacheRecords as inputs
     # need to add package name to fetch_specs so that history parsing keeps track of them correctly

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -22,8 +22,8 @@ from .core.index import get_index
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.package_cache_data import PackageCacheData, ProgressiveFetchExtract
 from .core.prefix_data import PrefixData
-from .exceptions import ( 
-    DisallowedPackageError, DryRunExit, PackagesNotFoundError, 
+from .exceptions import (
+    DisallowedPackageError, DryRunExit, PackagesNotFoundError,
     ParseError, CondaExitZero
 )
 from .gateways.disk.delete import rm_rf
@@ -87,7 +87,7 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
     pfe.execute()
 
     if context.download_only:
-        raise CondaExitZero('Package caches prepared. ' 
+        raise CondaExitZero('Package caches prepared. '
                             'UnlinkLinkTransaction cancelled with --download-only option.')
 
     # now make an UnlinkLinkTransaction with the PackageCacheRecords as inputs


### PR DESCRIPTION
Currently an "explicit" install doesn't respect the `--download-only` flag.  

This PR takes the `install.py` logic of exiting with code zero when `--download-only` is set: https://github.com/conda/conda/blob/33a142c16530fcdada6c377486f1c1a385738a96/conda/cli/install.py#L343-L345

and applies it in `explicit` after the fetch and extract action has occurred.