### PR TITLE
Remove the double quotations in env path

### DIFF
--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -63,7 +63,7 @@ function Add-Sys-Prefix-To-Path() {
     } else {
         $Env:PATH = $sysp + '/bin:' + $Env:PATH;
     }
-    return $OldPath;
+    return $OldPath.Replace('"','');
 }
 
 <#


### PR DESCRIPTION
An error will block the script if there are double quotations in env path. Just tried it in my windows 10 power shell. This can pass if I removed the double quotations.



┆Issue is synchronized with this [Jira Task](https://anaconda.atlassian.net/browse/CONDAORG2-471)
