### PR TITLE
Remove extra evals in fish shell

### DIFF
--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -63,18 +63,18 @@ end
 
 function conda --inherit-variable CONDA_EXE
     if [ (count $argv) -lt 1 ]
-        eval $CONDA_EXE
+        $CONDA_EXE
     else
         set -l cmd $argv[1]
         set -e argv[1]
         switch $cmd
             case activate deactivate
-                eval (eval $CONDA_EXE shell.fish $cmd $argv)
+                eval ($CONDA_EXE shell.fish $cmd $argv)
             case install update upgrade remove uninstall
-                eval $CONDA_EXE $cmd $argv
-                and eval (eval $CONDA_EXE shell.fish reactivate)
+                $CONDA_EXE $cmd $argv
+                and eval ($CONDA_EXE shell.fish reactivate)
             case '*'
-                eval $CONDA_EXE $cmd $argv
+                $CONDA_EXE $cmd $argv
         end
     end
 end


### PR DESCRIPTION
Solve issues with shell interpretation and escaping characters in `fish` shell by removing superfluous `eval`s.

This fix is the same as discussed in #9145.

Fixes #9145
Fixes #7611
Fixes #10643
