### PR TITLE
Fix /usr/bin/env shebang replacement with options

### DIFF
--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -179,8 +179,9 @@ def replace_long_shebang(mode, data):
                 # Unescape spaces.
                 executable_name = executable_name.replace(r"\ ", " ")
                 # Note that options contains a leading space.
-                assert (options == b'') or (options.startswith(b' '))
-                new_shebang = '#!/usr/bin/env -S "%s"%s' % (executable_name, options.decode('utf-8'))
+                options = options.decode('utf-8')
+                assert (options == '') or (options.startswith(' '))
+                new_shebang = '#!/usr/bin/env -S "%s"%s' % (executable_name, options)
                 data = data.replace(whole_shebang, new_shebang.encode('utf-8'))
 
     else:

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -174,7 +174,12 @@ def replace_long_shebang(mode, data):
             whole_shebang, executable, options = shebang_match.groups()
             if len(whole_shebang) > 127:
                 executable_name = executable.decode('utf-8').split('/')[-1]
-                assert '"' not in executable_name
+                # Ensure there's no quote or escaping weirdness.
+                assert ('"' not in executable_name) and (r'\\' not in executable_name)
+                # Unescape spaces.
+                executable_name = executable_name.replace(r"\ ", " ")
+                # Note that options contains a leading space.
+                assert (options == b'') or (options.startswith(b' '))
                 new_shebang = '#!/usr/bin/env -S "%s"%s' % (executable_name, options.decode('utf-8'))
                 data = data.replace(whole_shebang, new_shebang.encode('utf-8'))
 

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -174,7 +174,8 @@ def replace_long_shebang(mode, data):
             whole_shebang, executable, options = shebang_match.groups()
             if len(whole_shebang) > 127:
                 executable_name = executable.decode('utf-8').split('/')[-1]
-                new_shebang = '#!/usr/bin/env %s%s' % (executable_name, options.decode('utf-8'))
+                assert '"' not in executable_name
+                new_shebang = '#!/usr/bin/env -S "%s"%s' % (executable_name, options.decode('utf-8'))
                 data = data.replace(whole_shebang, new_shebang.encode('utf-8'))
 
     else:

--- a/tests/core/test_portability.py
+++ b/tests/core/test_portability.py
@@ -58,21 +58,20 @@ class ReplaceShebangTests(TestCase):
         assert data == new_data
 
         # long shebang with truncation
-        #   executable name is 'escaped space'
         shebang = b"#!/" + b"shebang/" * 20 + b"python" + b" --and --flags -x"
         assert len(shebang) > 127
         data = b'\n'.join((shebang, content_line, content_line, content_line))
         new_data = replace_long_shebang(FileMode.text, data)
-        new_shebang = b"#!/usr/bin/env python --and --flags -x"
+        new_shebang = b'#!/usr/bin/env -S "python" --and --flags -x'
         new_expected_data = b'\n'.join((new_shebang, content_line, content_line, content_line))
         assert new_expected_data == new_data
 
         # long shebang with truncation
         #   executable name is 'escaped space'
-        shebang = b"#!/" + b"shebang/" * 20 + b"escaped\\ space" + b" --and --flags -x"
+        shebang = b"#!/" + b"shebang/" * 20 + rb"escaped\ space" + b" --and --flags -x"
         assert len(shebang) > 127
         data = b'\n'.join((shebang, content_line, content_line, content_line))
         new_data = replace_long_shebang(FileMode.text, data)
-        new_shebang = b"#!/usr/bin/env escaped\\ space --and --flags -x"
+        new_shebang = b'#!/usr/bin/env -S "escaped space" --and --flags -x'
         new_expected_data = b'\n'.join((new_shebang, content_line, content_line, content_line))
         assert new_expected_data == new_data

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -158,7 +158,7 @@ class FileTests(unittest.TestCase):
         update_prefix(self.tmpfname, new_prefix)
         with open(self.tmpfname, 'r') as fi:
             data = fi.read()
-            self.assertEqual(data, '#!/usr/bin/env python -O\n'
+            self.assertEqual(data, '#!/usr/bin/env -S "python" -O\n'
                                    'echo "Hello"\n')
 
     @pytest.mark.skipif(on_win, reason="no binary replacement done on win")


### PR DESCRIPTION
When `/usr/bin/env` is called within a shebang, and options are provided to the executable, it is necessary to add the `-S` parameter. Otherwise the options are interpreted as part of the executable name.