### PR TITLE
Add Windows versions to system requirements

### DIFF
--- a/docs/source/user-guide/install/index.rst
+++ b/docs/source/user-guide/install/index.rst
@@ -35,6 +35,8 @@ System requirements
 
 * Windows, macOS, or Linux.
 
+* For Windows: Windows 8.1 or newer for Python 3.9, or Windows Vista or newer for Python 3.8.
+
 
 .. note::
    You do not need administrative or root permissions to


### PR DESCRIPTION
The Python 3.9-based installs fail in Win7 with a not-particularly-intuitive DLL error, and information about versions required is somewhat buried (i.e. in Python docs vs than Conda docs). Add Windows version requirements here.

Source:
https://docs.python.org/3.9/using/windows.html
https://bugs.python.org/issue40740