### PR TITLE
The RE used to split tokens is too narrow

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -268,7 +268,7 @@ def split_anaconda_token(url):
         >>> split_anaconda_token("https://10.2.3.4:8080/conda/t/tk-123-45")
         (u'https://10.2.3.4:8080/conda', u'tk-123-45')
     """
-    _token_match = re.search(r'/t/([a-zA-Z0-9-]*)', url)
+    _token_match = re.search(r'/t/([^/]*)', url)
     token = _token_match.groups()[0] if _token_match else None
     cleaned_url = url.replace('/t/' + token, '', 1) if token is not None else url
     return cleaned_url.rstrip('/'), token


### PR DESCRIPTION
I noticed that when using conda WITH tokens sometimes the token part is not recognized if it contains also the char '_' (underscore). 
This patch enlarge regular expression to split the token to all chars different from '/'