### PR TITLE
Add creation of the conda-ci-linux-64 container

### DIFF
--- a/.github/workflows/ci_image.yml
+++ b/.github/workflows/ci_image.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: lint
+        uses: hadolint/hadolint-action@v1.5.0
+        with:
+          dockerfile: ./ci/Dockerfile
+
       - name: build-push conda-ci-linux-64-python-${{ matrix.python }}
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/ci_image.yml
+++ b/.github/workflows/ci_image.yml
@@ -5,11 +5,11 @@ on:
   pull_request:
     paths:
       - 'ci/Dockerfile'
-      - '.github/workflows/conda_ci_container_cicd.yml'
+      - '.github/workflows/ci_image.yml'
   push:
     paths:
       - 'ci/Dockerfile'
-      - '.github/workflows/conda_ci_container_cicd.yml'
+      - '.github/workflows/ci_image.yml'
   workflow_dispatch:
 
 jobs:
@@ -20,25 +20,11 @@ jobs:
         python: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        if: github.ref == 'refs/heads/master'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-          driver-opts: network=host
 
       - name: build-push conda-ci-linux-64-python-${{ matrix.python }}
         uses: docker/build-push-action@v2
         with:
           context: ./ci
-          builder: ${{ steps.buildx.outputs.name }}
           file: ./ci/Dockerfile
           build-args: PYTHON_VERSION=${{ matrix.python }}
           tags: conda/conda-ci-linux-64:python${{ matrix.python }}-latest

--- a/.github/workflows/conda_ci_container_cicd.yml
+++ b/.github/workflows/conda_ci_container_cicd.yml
@@ -1,0 +1,46 @@
+name: Build and Publish Conda CI Images
+on:
+  schedule:
+    - cron:  '0 0 * * 0'
+  pull_request:
+    paths:
+      - 'ci/Dockerfile'
+      - '.github/workflows/conda_ci_container_cicd.yml'
+  push:
+    paths:
+      - 'ci/Dockerfile'
+      - '.github/workflows/conda_ci_container_cicd.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.7, 3.8, 3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/master'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          driver-opts: network=host
+
+      - name: build-push conda-ci-linux-64-python-${{ matrix.python }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ./ci
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./ci/Dockerfile
+          build-args: PYTHON_VERSION=${{ matrix.python }}
+          tags: conda/conda-ci-linux-64:python${{ matrix.python }}-latest
+          push: ${{ github.ref == 'refs/heads/master' }}
+

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:buster-slim
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
+
+# hadolint ignore=DL3008
+RUN apt-get update --fix-missing && \
+    apt-get install -y --no-install-recommends wget build-essential bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 git mercurial subversion sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -m -s /bin/bash test_user && \
+    usermod -u 1001 test_user && \
+    groupmod -g 1001 test_user && \
+    echo "test_user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda clean -tipsy
+
+ARG PYTHON_VERSION=3.8
+
+# conda and test dependencies
+RUN /opt/conda/bin/conda install --update-all -y -c defaults \
+    conda conda-package-handling \
+    python=$PYTHON_VERSION pip pycosat requests ruamel_yaml cytoolz \
+    anaconda-client nbformat make \
+    pytest pytest-cov codecov radon pytest-timeout mock responses pexpect \
+    flake8 && \
+    /opt/conda/bin/conda clean --all --yes
+
+# conda-build and test dependencies
+RUN /opt/conda/bin/conda install --update-all -y -c defaults \
+        conda-build patch git \
+        perl pytest-xdist pytest-mock \
+        anaconda-client \
+        filelock jinja2 conda-verify pkginfo \
+        glob2 beautifulsoup4 chardet pycrypto \
+    && /opt/conda/bin/conda clean --all --yes
+
+USER test_user
+
+ENTRYPOINT [ "/bin/bash" ]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH /opt/conda/bin:$PATH
 
 # hadolint ignore=DL3008
 RUN apt-get update --fix-missing && \
-    apt-get install -y --no-install-recommends wget build-essential bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 git mercurial subversion sudo && \
+    apt-get install -y --no-install-recommends tini wget build-essential bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 git mercurial subversion sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -m -s /bin/bash test_user && \
@@ -15,7 +15,7 @@ RUN apt-get update --fix-missing && \
     wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
-    /opt/conda/bin/conda clean -tipsy
+    /opt/conda/bin/conda clean --all --yes
 
 ARG PYTHON_VERSION=3.8
 
@@ -39,4 +39,5 @@ RUN /opt/conda/bin/conda install --update-all -y -c defaults \
 
 USER test_user
 
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
The logic moved from https://github.com/ContinuumIO/docker-images

While the Dockerfile is untouched, the github action was updated to use
a build matrix, to publish to ghcr.io and to specify the Python version in
the image tag instead of the image name.