### PR TITLE
Fixed path of conda repo in RHEL based systems

### DIFF
--- a/docs/source/user-guide/install/rpm-debian.rst
+++ b/docs/source/user-guide/install/rpm-debian.rst
@@ -11,7 +11,7 @@ To install the RPM on RedHat, CentOS, Fedora distributions, and other RPM-based 
    rpm --import https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc
  
    # Add the Anaconda repository
-   cat <<EOF > /etc/yum/repos.d/conda.repo
+   cat <<EOF > /etc/yum.repos.d/conda.repo
    [conda]
    name=Conda
    baseurl=https://repo.anaconda.com/pkgs/misc/rpmrepo/conda


### PR DESCRIPTION
This is a quick fix of the documentation.

I didn't bother to read the contributor's guidelines, so sorry if I don't follow them.