### PR TITLE
License file to be included into metadata dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,6 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
     def __repr__
-slow: marks tests as slow (deselect with '-m "not slow"')
 
 [metadata]
 license_file = LICENSE.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,3 +62,7 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
     def __repr__
+slow: marks tests as slow (deselect with '-m "not slow"')
+
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
Hi,
Please, add the LICENSE.txt file into metadata dir of your package (e.g. by accepting this pull request).
I understand you probably hate software laws etc., so I will be short.

You are using BSD 3-clause license. It says also: "Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer." But your whole package distributed on PyPI.org does not contain even one. This short change will add the file LICENSE.txt (with text of BSD license) into metadata of your package (= into e.g. .../site-packages/conda-4.10.3-py3.9.egg-info/LICENSE.txt of your virtualenv/ condaenv /...). This way you are 100% clear and comply with your chosen license.

Thank you for your time and the conda! Nice software.
Pax et bonum ;-)