### PR TITLE
Update Advanced Pip Example

### DIFF
--- a/tests/conda_env/support/advanced-pip/environment.yml
+++ b/tests/conda_env/support/advanced-pip/environment.yml
@@ -24,6 +24,6 @@ dependencies:
     # Use another requirements file.
     # Note that here also we can use relative paths.
     # pip will be run from the environment file directory, if provided.
-    - -r file:another-project-requirements.txt
+    - -r another-project-requirements.txt
 
     # Anything else that pip requirement files allows should work seamlessly...


### PR DESCRIPTION
## Overview
The Advanced Pip Example previously used an invalid `file` URI syntax. With Pip version 21.2.1, this syntax is no longer supported and results in `FileNotFoundError`. This PR updates the example to use a valid syntax.

## Related Issues
#10815 
https://github.com/pypa/pip/issues/10237
https://github.com/conda-forge/pip-feedstock/issues/76