### PR TITLE
Refactor docs logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.head_ref }}
@@ -104,18 +108,6 @@ jobs:
         flags: ${{ matrix.test_type }}
         env_vars: OS,PYTHON
         directory: 'C:\conda_src\junit'
-
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: build the docs
-        uses: docker://ghcr.io/conda/conda:master-python3.8
-        with:
-          entrypoint: /bin/bash
-          args: ./ci/build_docs.sh
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: CI docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+     - 'docs/**'
+  pull_request:
+    paths:
+     - 'docs/**'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: build the docs
+        run : |
+          source "${CONDA}/etc/profile.d/conda.sh"
+          make env-docs
+          conda activate conda-docs
+          cd docs
+          make html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,5 @@
 version: 2
 python:
-  version: 3
+  version: "3"
   install:
   - requirements: docs/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ toolz:
 	    && rm -rf toolz
 	rm -rf conda/_vendor/toolz/curried conda/_vendor/toolz/sandbox conda/_vendor/toolz/tests
 
+env-docs:
+	conda create --name conda-docs --channel defaults python=3.8 --yes
+	conda run --name conda-docs pip install -r ./docs/requirements.txt
 
 pytest-version:
 	$(PYTEST) --version
@@ -86,4 +89,4 @@ html:
 
 
 .PHONY : clean clean-all anaconda-submit anaconda-submit-upload auxlib boltons toolz \
-         pytest-version smoketest unit integration test-installed html
+         env-docs pytest-version smoketest unit integration test-installed html

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errtrace -o pipefail -o errexit
-
-pip install -r docs/requirements.txt
-cd docs
-make html

--- a/ci/integration_tests.sh
+++ b/ci/integration_tests.sh
@@ -2,12 +2,8 @@
 
 set -o errtrace -o pipefail -o errexit
 
-if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-    echo "Only docs changed detected, skipping tests"
-else
-    eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-    sudo su root -c "/opt/conda/bin/conda install -yq conda-build"
-    conda-build tests/test-recipes/activate_deactivate_package
-    pytest $ADD_COV --cov-append -m "integration and not installed" -v
-    python -m conda.common.io
-fi
+eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+sudo su root -c "/opt/conda/bin/conda install -yq conda-build"
+conda-build tests/test-recipes/activate_deactivate_package
+pytest $ADD_COV --cov-append -m "integration and not installed" -v
+python -m conda.common.io

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -2,12 +2,8 @@
 
 set -o errtrace -o pipefail -o errexit
 
-if [[ $(git diff origin/master --name-only | wc -l) == $(git diff origin/master --name-only | grep docs | wc -l) && $(git diff origin/master --name-only | grep docs) ]]; then
-    echo "Only docs changed detected, skipping tests"
-else
-    eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-    conda info
-    # remove the pkg cache.  We can't hardlink from here anyway.  Having it around causes log problems.
-    sudo rm -rf /opt/conda/pkgs/*-*-*
-    pytest $ADD_COV -m "not integration and not installed" -v
-fi
+eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+conda info
+# remove the pkg cache.  We can't hardlink from here anyway.  Having it around causes log problems.
+sudo rm -rf /opt/conda/pkgs/*-*-*
+pytest $ADD_COV -m "not integration and not installed" -v

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,4 @@
 # Minimal makefile for Sphinx documentation
-#
 
 # You can set these variables from the command line.
 SPHINXOPTS    =


### PR DESCRIPTION
* Move to own workflow to trigger only on docs changes
* Remove git docs detect magic from ./ci/*_tests.sh that was used previously to avoid test runs on docs only changes.
* Move ci/build_docs.sh logic to docs/Makefile
* Use dedicated env for doc builds to avoid base env polution on local runs
* Use docs/Makefile targets during docs.yml flow run
* Convert Python version in .readthedocs.yml to string according to https://raw.githubusercontent.com/readthedocs/readthedocs.org/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.json