### PR TITLE
Speedup flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: flake8
-        uses: docker://ghcr.io/conda/conda:master-python3.8
-        with:
-          entrypoint: /bin/bash
-          args: -c "/opt/conda/bin/flake8 --statistics"
+        run : |
+          source "${CONDA}/etc/profile.d/conda.sh"
+          make env-lint
+          conda activate env-lint
+          make lint
 
   linux:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ env-docs:
 	conda create --name conda-docs --channel defaults python=3.8 --yes
 	conda run --name conda-docs pip install -r ./docs/requirements.txt
 
+env-lint:
+	conda create --name env-lint --channel defaults python=3.8 flake8 --yes
+
+lint:
+	flake8 --statistics
+
 pytest-version:
 	$(PYTEST) --version
 


### PR DESCRIPTION
* Clone without history
* Don't pull the huge conda ci image
* Use a dedicated lint env