### PR TITLE
Cleanup Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,19 @@
-PYTEST_EXE ?= $(shell which pytest)
-PYTHON_EXE ?= $(shell sed 's/^\#!//' $(PYTEST_EXE) | head -1 | sed "s|$HOME|~|")
-PYTHON_MAJOR_VERSION := $(shell $(PYTHON_EXE) -c "import sys; print(sys.version_info[0])")
-TEST_PLATFORM := $(shell $(PYTHON_EXE) -c "import sys; print('win' if sys.platform.startswith('win') else 'unix')")
-SYS_PREFIX := $(shell $(PYTHON_EXE) -c "import sys; print(sys.prefix)")
-PYTHONHASHSEED := $(shell python -c "import random as r; print(r.randint(0,4294967296))")
-
-
-PYTEST_VARS := PYTHONHASHSEED=$(PYTHONHASHSEED) PYTHON_MAJOR_VERSION=$(PYTHON_MAJOR_VERSION) TEST_PLATFORM=$(TEST_PLATFORM)
-# --basetemp is so that our environments are created via hardlinks, the most common way.
-PYTEST := $(PYTEST_VARS) $(PYTEST_EXE) --basetemp=$(SYS_PREFIX)/../conda.tmp
+SHELL := /bin/bash -o pipefail -o errexit
 
 
 clean:
-	@find . -name \*.py[cod] -delete
-	@find . -name __pycache__ -delete
-	@rm -rf .cache build
-	@rm -f .coverage .coverage.* junit.xml tmpfile.rc conda/.version tempfile.rc coverage.xml
-	@rm -rf auxlib bin conda/progressbar
-	@rm -rf conda-build conda_build_test_recipe record.txt
-	@rm -rf .pytest_cache
+	find . -name \*.py[cod] -delete
+	find . -name __pycache__ -delete
+	rm -rf .cache build
+	rm -f .coverage .coverage.* junit.xml tmpfile.rc conda/.version tempfile.rc coverage.xml
+	rm -rf auxlib bin conda/progressbar
+	rm -rf conda-build conda_build_test_recipe record.txt
+	rm -rf .pytest_cache
 
 
-clean-all: clean
-	@rm -rf *.egg-info*
-	rm -rf dist env ve
+clean-all:
+	@echo Deleting everything not belonging to the git repo:
+	git clean -fdx
 
 
 anaconda-submit-test: clean-all
@@ -58,39 +48,42 @@ toolz:
 	    && rm -rf toolz
 	rm -rf conda/_vendor/toolz/curried conda/_vendor/toolz/sandbox conda/_vendor/toolz/tests
 
+
 env-docs:
 	conda create --name conda-docs --channel defaults python=3.8 --yes
 	conda run --name conda-docs pip install -r ./docs/requirements.txt
 
+
 env-lint:
 	conda create --name conda-lint --channel defaults python=3.8 flake8 --yes
+
 
 lint:
 	flake8 --statistics
 
+
 pytest-version:
-	$(PYTEST) --version
+	pytest --version
 
 
 smoketest:
-	$(PYTEST) tests/test_create.py -k test_create_install_update_remove
+	pytest tests/test_create.py -k test_create_install_update_remove
 
 
 unit:
-	$(PYTEST) $(ADD_COV) -m "not integration and not installed"
+	pytest -m "not integration and not installed"
 
 
 integration: clean pytest-version
-	$(PYTEST) $(ADD_COV) -m "integration and not installed"
+	pytest -m "integration and not installed"
 
 
 test-installed:
-	$(PYTEST) $(ADD_COV) -m "installed" --shell=bash --shell=zsh
+	pytest -m "installed" --shell=bash --shell=zsh
 
 
 html:
-	@cd docs && make html
+	cd docs && make html
 
 
-.PHONY : clean clean-all anaconda-submit anaconda-submit-upload auxlib boltons toolz \
-         env-docs pytest-version smoketest unit integration test-installed html
+.PHONY: $(MAKECMDGOALS)


### PR DESCRIPTION
* Always print to be executed commands for easier understanding while calling targets (removing the "@" prefix).
* Specify the shell to be bash with error handling so that errors in multi-line bash code with pipes are not masked.
* Setting all targets to be phony (producing no out file/folder with the same name for caching)
* Remove pytest args that are anyway not used anymore or set differently (the github workflows are not setting those and some are set via setup.cfg)
* Make clean-all more generic
* Don't define variables that only work inside test environments, as the Makefile is also used outside to e.g. create the docs or lint env. Fixes the message `/bin/sh: 0: Illegal option -` shown 3x on CI for each make call.