### PR TITLE
Run lint on all 3 platforms to prove that used make targets are generic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,14 @@ jobs:
         directory: 'junit'
 
   lint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        if: ${{ matrix.platform }} != "ubuntu-latest"
       - name: Setup
         run : |
           make env-lint


### PR DESCRIPTION
The lint target itself only needs to run on one platform, but by running it on all three it is continuously proven that the according make targets to create the lint environment and the lint commands run on all platforms for a greater developer experience, when linting locally during development.