### PR TITLE
Add `cpuinfo` support for `loongarch64`

### DIFF
--- a/conda/_vendor/cpuinfo.py
+++ b/conda/_vendor/cpuinfo.py
@@ -591,6 +591,13 @@ def parse_arch(raw_arch_string):
     elif re.match('^sparc64$|^sun4u$|^sun4v$', raw_arch_string):
         arch = 'SPARC_64'
         bits = 64
+    # LOONG
+    elif re.match('^loongarch32$', raw_arch_string):
+        arch = 'LOONG_32'
+        bits = 32
+    elif re.match('^loongarch64$', raw_arch_string):
+        arch = 'LOONG_64'
+        bits = 64
 
     return (arch, bits)
 
@@ -2168,8 +2175,8 @@ def get_cpu_info():
 # Make sure we are running on a supported system
 def _check_arch():
     arch, bits = parse_arch(DataSource.raw_arch_string)
-    if not arch in ['X86_32', 'X86_64', 'ARM_7', 'ARM_8', 'PPC_64', 'S390X']:
-        raise Exception("py-cpuinfo currently only works on X86 and some PPC, S390X and ARM CPUs.")
+if not arch in ['X86_32', 'X86_64', 'ARM_7', 'ARM_8', 'PPC_64', 'S390X', 'LOONG_32', 'LOONG_64']:
+        raise Exception("py-cpuinfo currently only works on X86 and some PPC, S390X, LOONG and ARM CPUs.")
 
 def main():
     try:

--- a/conda/_vendor/cpuinfo.py
+++ b/conda/_vendor/cpuinfo.py
@@ -2175,7 +2175,7 @@ def get_cpu_info():
 # Make sure we are running on a supported system
 def _check_arch():
     arch, bits = parse_arch(DataSource.raw_arch_string)
-if not arch in ['X86_32', 'X86_64', 'ARM_7', 'ARM_8', 'PPC_64', 'S390X', 'LOONG_32', 'LOONG_64']:
+    if not arch in ['X86_32', 'X86_64', 'ARM_7', 'ARM_8', 'PPC_64', 'S390X', 'LOONG_32', 'LOONG_64']:
         raise Exception("py-cpuinfo currently only works on X86 and some PPC, S390X, LOONG and ARM CPUs.")
 
 def main():


### PR DESCRIPTION
This is verified on a native machine with the following:

```
$conda/conda/_vendor$ python3 cpuinfo.py 

python version: 3.7.3.final.0 (64 bit)
cpuinfo version: (4, 0, 0)
Arch: LOONG_64
Bits: 64
Count: 4
Raw Arch String: loongarch64
```