### PR TITLE
Fix `unsatisfiable_hints=false` bug (misreported conflicts)

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -565,7 +565,7 @@ class Resolve(object):
 
         strict_channel_priority = context.channel_priority == ChannelPriority.STRICT
 
-        cache_key = strict_channel_priority, tuple(explicit_specs)
+        cache_key = strict_channel_priority, tuple(sorted(explicit_specs, key=str))
         if cache_key in self._reduced_index_cache:
             return self._reduced_index_cache[cache_key]
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1260,8 +1260,7 @@ class Resolve(object):
         log.debug("Solve: Getting reduced index of compliant packages")
         len0 = len(specs)
 
-        reduced_index = self.get_reduced_index(
-            specs, exit_on_conflict=not context.unsatisfiable_hints)
+        reduced_index = self.get_reduced_index(specs)
         if not reduced_index:
             # something is intrinsically unsatisfiable - either not found or
             # not the right version

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1260,8 +1260,8 @@ class Resolve(object):
         log.debug("Solve: Getting reduced index of compliant packages")
         len0 = len(specs)
 
-        reduced_index = self.get_reduced_index(specs,
-            exit_on_conflict=not context.unsatisfiable_hints)
+        reduced_index = self.get_reduced_index(
+            specs, exit_on_conflict=not context.unsatisfiable_hints)
         if not reduced_index:
             # something is intrinsically unsatisfiable - either not found or
             # not the right version

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1260,7 +1260,8 @@ class Resolve(object):
         log.debug("Solve: Getting reduced index of compliant packages")
         len0 = len(specs)
 
-        reduced_index = self.get_reduced_index(specs)
+        reduced_index = self.get_reduced_index(specs,
+            exit_on_conflict=not context.unsatisfiable_hints)
         if not reduced_index:
             # something is intrinsically unsatisfiable - either not found or
             # not the right version

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -376,6 +376,21 @@ def test_unsat_simple_dont_find_conflicts():
         assert "b -> c[version='>=2,<3']" not in str(excinfo.value)
 
 
+@pytest.mark.parametrize("hints", ("True", "False"))
+def test_unsat_simple_should_not_find_conflicts(hints):
+    # a and b depend on compatible versions of c
+    index = (
+        simple_rec(name='a', depends=['c >=1,<2']),
+        simple_rec(name='b', depends=['c']),
+        simple_rec(name='c', version='1.0'),
+        simple_rec(name='c', version='2.0'),
+    )
+
+    with env_var("CONDA_UNSATISFIABLE_HINTS", hints, stack_callback=conda_tests_ctxt_mgmt_def_pol):
+        r = Resolve(OrderedDict((prec, prec) for prec in index))
+        r.install(['a', 'b '])
+
+
 def test_unsat_shortest_chain_1():
     index = (
         simple_rec(name='a', depends=['d', 'c <1.3.0']),


### PR DESCRIPTION
Comes from https://github.com/conda/conda/issues/9862

I don't know what's wrong but at least I found a way to reproduce in the unit tests. I'll edit as a find more details.