### PR TITLE
Add concurrency to CI images workflow.

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -6,12 +6,16 @@ on:
   pull_request:
     paths:
       - 'ci/Dockerfile'
-      - '.github/workflows/ci_images.yml'
+      - '.github/workflows/ci-images.yml'
   push:
     paths:
       - 'ci/Dockerfile'
-      - '.github/workflows/ci_images.yml'
+      - '.github/workflows/ci-images.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@
     :target: https://github.com/conda/conda/actions/workflows/ci.yml
     :alt: CI Tests (GitHub Actions)
 
-.. image:: https://github.com/conda/conda/actions/workflows/ci_images.yml/badge.svg
-    :target: https://github.com/conda/conda/actions/workflows/ci_images.yml
+.. image:: https://github.com/conda/conda/actions/workflows/ci-images.yml/badge.svg
+    :target: https://github.com/conda/conda/actions/workflows/ci-images.yml
     :alt: CI Images (GitHub Actions)
 
 .. image:: https://img.shields.io/codecov/c/github/conda/conda/master.svg?label=coverage


### PR DESCRIPTION
This reduces the number of active workers when lots of changes are pushed in a short time by auto-cancelling previous runs.