### PR TITLE
[Mamba POC] Implement early exit strategies

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -17,10 +17,12 @@ from .._vendor.urllib3.util.url import Url, parse_url
 
 try:  # pragma: py2 no cover
     # Python 3
-    from urllib.parse import (quote, quote_plus, unquote, unquote_plus)
+    from urllib.parse import (quote, quote_plus, unquote, unquote_plus,  # NOQA
+                              urlparse as _urlparse, urlunparse as _urlunparse)
 except ImportError:  # pragma: py3 no cover
     # Python 2
-    from urllib import (quote, quote_plus, unquote, unquote_plus)  # NOQA
+    from urllib import (quote, quote_plus, unquote, unquote_plus,  # NOQA
+                        urlparse as _urlparse, urlunparse as _urlunparse)
 
 
 def hex_octal_to_int(ho):
@@ -378,6 +380,14 @@ def remove_auth(url):
     if url_parts['auth']:
         del url_parts['auth']
     return Url(**url_parts).url
+
+
+def escape_channel_url(channel):
+    parts = _urlparse(channel)
+    if parts.scheme:
+        parts = parts._replace(path=quote(parts.path))
+        return _urlunparse(parts)
+    return channel
 
 
 if __name__ == "__main__":

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1095,21 +1095,31 @@ class LibSolvSolver(Solver):
         # 4. Export back to conda
         return self._export_final_state(state)
 
-    def _merge_signature_flags_with_context(self, update_modifier=NULL, deps_modifier=NULL, prune=NULL,
-                                            ignore_pinned=NULL, force_remove=NULL, force_reinstall=NULL,
-                                            should_retry_solve=False):
+    def _merge_signature_flags_with_context(
+            self,
+            update_modifier=NULL,
+            deps_modifier=NULL,
+            prune=NULL,
+            ignore_pinned=NULL,
+            force_remove=NULL,
+            force_reinstall=NULL,
+            should_retry_solve=False,
+        ):
         """
         Context options can be overriden with the signature flags.
 
         We need this, at least, for some unit tests that change this behaviour through
         the function signature instead of the context / env vars.
         """
+        def context_if_null(var, varname):
+            return getattr(context, varname) if var is NULL else var
+
         return {
-            "update_modifier": update_modifier if update_modifier is not NULL else context.update_modifier,
-            "deps_modifier": deps_modifier if deps_modifier is not NULL else context.deps_modifier,
-            "ignore_pinned": ignore_pinned if ignore_pinned is not NULL else context.ignore_pinned,
-            "force_remove": force_remove if force_remove is not NULL else context.force_remove,
-            "force_reinstall": force_reinstall if force_reinstall is not NULL else context.force_reinstall,
+            "update_modifier": context_if_null(update_modifier, "update_modifier"),
+            "deps_modifier": context_if_null(deps_modifier, "deps_modifier"),
+            "ignore_pinned": context_if_null(ignore_pinned, "ignore_pinned"),
+            "force_remove": context_if_null(force_remove, "force_remove"),
+            "force_reinstall": context_if_null(force_reinstall, "force_reinstall"),
             # We don't use these flags in mamba
             # "prune": prune,
             # "should_retry_solve": should_retry_solve,

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -568,7 +568,7 @@ def test_prune_1(tmpdir):
 
 
 def test_force_remove_1(tmpdir):
-    specs = MatchSpec("numpy[build=*py27*]"),
+    specs = MatchSpec("numpy[version=*,build=*py27*]"),
     with get_solver(tmpdir, specs) as solver:
         final_state_1 = solver.solve_final_state()
         # PrefixDag(final_state_1, specs).open_url()
@@ -694,7 +694,7 @@ def test_no_deps_1(tmpdir):
 
 
 def test_only_deps_1(tmpdir):
-    specs = MatchSpec("numba[build=*py27*]"),
+    specs = MatchSpec("numba[version=*,build=*py27*]"),
     with get_solver(tmpdir, specs) as solver:
         final_state_1 = solver.solve_final_state(deps_modifier=DepsModifier.ONLY_DEPS)
         # PrefixDag(final_state_1, specs).open_url()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -47,7 +47,7 @@ from conda.common.io import argv, captured, disable_logger, env_var, stderr_log_
 from conda.common.path import get_bin_directory_short_path, get_python_site_packages_short_path, \
     pyc_path
 from conda.common.serialize import yaml_round_trip_load, json_dump
-from conda.common.url import path_to_url
+from conda.common.url import path_to_url, escape_channel_url
 from conda.core.index import get_reduced_index, get_index
 from conda.core.prefix_data import PrefixData, get_python_version_for_prefix
 from conda.core.package_cache_data import PackageCacheData
@@ -454,6 +454,21 @@ def reload_config(prefix):
 
 
 def package_is_installed(prefix, spec):
+    is_installed = _package_is_installed(prefix, spec)
+
+    # Mamba needs to escape the URL (e.g. space -> %20)
+    # Which end up rendered in the package spec
+    # Let's try query with a escaped spec in case we are
+    # testing for Mamba or other implementations that need this
+    if not is_installed and "::" in spec:
+        channel, pkg = spec.split("::", 1)
+        channel = escape_channel_url(channel)
+        escaped_spec = channel + "::" + pkg
+        is_installed = _package_is_installed(prefix, escaped_spec)
+    return is_installed
+
+
+def _package_is_installed(prefix, spec):
     spec = MatchSpec(spec)
     prefix_recs = tuple(PrefixData(prefix).query(spec))
     if len(prefix_recs) > 1:


### PR DESCRIPTION
Built on top of #10894 -- review that one first!

***

This implements early exit strategies that do not require the solver:

* conda remove --force-remove <pkg>
* conda update --satisfied-skip-solve

Uncovering this required adapting two small parts in a test, which required merging global context state (coming from the CLI or env vars) with the signature-level flags.