### PR TITLE
[Mamba POC] Deal with JSON output errors

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1388,13 +1388,13 @@ class LibSolvSolver(Solver):
 
         for _, pkg in to_unlink:
             for i_rec in installed_pkgs:
-                # Do not try to unlink virtual pkgs
+                # Do not try to unlink virtual pkgs, virtual eggs, etc
                 if not i_rec.is_unmanageable and i_rec.fn == pkg:
                     final_precs.remove(i_rec)
                     to_unlink_records.append(i_rec)
                     break
             else:
-                print("No package record found!")
+                log.warn("Tried to unlink %s but it is not listed as installed or manageable?", pkg)
 
         for c, pkg, jsn_s in to_link:
             if c.startswith("file://"):

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1066,7 +1066,8 @@ class LibSolvSolver(Solver):
         # Logic heavily based on Mamba's implementation (solver parts):
         # https://github.com/mamba-org/mamba/blob/fe4ecc5061a49c5b400fa7e7390b679e983e8456/mamba/mamba.py#L289
 
-        print("------ USING EXPERIMENTAL MAMBA INTEGRATIONS ------")
+        if not context.json:
+            print("------ USING EXPERIMENTAL MAMBA INTEGRATIONS ------")
 
         # 0. Identify strategies
         kwargs = self._merge_signature_flags_with_context(

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1394,7 +1394,7 @@ class LibSolvSolver(Solver):
                     to_unlink_records.append(i_rec)
                     break
             else:
-                log.warn("Tried to unlink %s but it is not listed as installed or manageable?", pkg)
+                log.warn("Tried to unlink %s but it is not installed or manageable?", pkg)
 
         for c, pkg, jsn_s in to_link:
             if c.startswith("file://"):


### PR DESCRIPTION
Built on top of #10901 

***

This PR will uncover the issues behind `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. Affected tests are:

- [ ] `IntegrationTests.test_conda_pip_interop_conda_editable_package`
  - This has to do with pip interoperability, not implemented yet. This [block](https://github.com/conda/conda/blob/poc-libsolv-json/conda/core/solve.py#L1389-L1397) is relevant.
- [x] `IntegrationTests.test_conda_pip_interop_dependency_satisfied_by_pip`
- [ ] `IntegrationTests.test_conda_recovery_of_pip_inconsistent_env`
  - Won't fix here. This has to do with [inconsistency](https://github.com/conda/conda/blob/9e9461760bbd71a178220982e8da85637aa2f699/conda/core/solve.py#L479) analysis, which Mamba does not perform yet.
- [x] `IntegrationTests.test_create_dry_run_json`
- [ ] `IntegrationTests.test_install_force_reinstall_flag`
  - This fails with a JSON error, but it is actually different issue: the solver complains about a conflicting request when we try to force reinstall Python (or any other package). Will fix in a later PR.
- [ ] `IntegrationTests.test_json_create_install_update_remove`
  - This one also uses `--force-reinstall`, which causes the problem above.
- [x] `IntegrationTests.test_create_dry_run_json`
- [x] `IntegrationTests.test_create_valid_env_json_output`
- [x] `IntegrationTests.test_create_valid_env_with_conda_and_pip_json_output`
- [x] `IntegrationTests.test_update_env_json_output`
- [x] `IntegrationTests.test_update_env_no_action_json_output`
- [x] `IntegrationTests.test_update_env_only_pip_json_output`
