### PR TITLE
fix bug in setting environment variables

### DIFF
--- a/conda_env/cli/main_vars.py
+++ b/conda_env/cli/main_vars.py
@@ -126,7 +126,7 @@ def execute_set(args, parser):
     env_vars_to_add = {}
     for v in args.vars:
         var_def = v.split('=')
-        env_vars_to_add[var_def[0].strip()] = var_def[-1].strip()
+        env_vars_to_add[var_def[0].strip()] = "=".join(var_def[1:]).strip()
     pd.set_environment_env_vars(env_vars_to_add)
     if prefix == context.active_prefix:
         print("To make your changes take effect please reactivate your environment")

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -37,6 +37,8 @@ channels:
 variables:
   DUDE: woah
   SWEET: yaaa
+  API_KEY: AaBbCcDd===EeFf
+
 '''
 
 environment_2 = '''
@@ -284,7 +286,7 @@ class IntegrationTests(unittest.TestCase):
 
         o, e = run_env_command(Commands.ENV_CONFIG, test_env_name_1, "vars", "list", "--json", '-n', test_env_name_1)
         output_env_vars = json.loads(o)
-        assert output_env_vars == {'DUDE': 'woah', "SWEET": "yaaa"}
+        assert output_env_vars == {'DUDE': 'woah', "SWEET": "yaaa", "API_KEY": "AaBbCcDd===EeFf"}
 
         o, e = run_conda_command(Commands.INFO, None, "--json")
         parsed = json.loads(o)
@@ -423,12 +425,12 @@ class IntegrationTests(unittest.TestCase):
         create_env(environment_1)
         run_env_command(Commands.ENV_CREATE, None)
         env_name = 'env-1'
-        run_env_command(Commands.ENV_CONFIG, env_name, "vars", "set", "DUDE=woah", "SWEET=yaaa", "-n", env_name)
+        run_env_command(Commands.ENV_CONFIG, env_name, "vars", "set", "DUDE=woah", "SWEET=yaaa", "API_KEY=AaBbCcDd===EeFf", "-n", env_name)
         o, e = run_env_command(Commands.ENV_CONFIG, env_name, "vars", "list", "--json", '-n', env_name)
         output_env_vars = json.loads(o)
-        assert output_env_vars == {'DUDE': 'woah', "SWEET": "yaaa"}
+        assert output_env_vars == {'DUDE': 'woah', "SWEET": "yaaa", "API_KEY": "AaBbCcDd===EeFf"}
 
-        run_env_command(Commands.ENV_CONFIG, env_name, "vars", "unset", "DUDE", "SWEET", '-n', env_name)
+        run_env_command(Commands.ENV_CONFIG, env_name, "vars", "unset", "DUDE", "SWEET", "API_KEY", '-n', env_name)
         o, e = run_env_command(Commands.ENV_CONFIG, env_name, "vars", "list", "--json", '-n', env_name)
         output_env_vars = json.loads(o)
         assert output_env_vars == {}
@@ -438,7 +440,7 @@ class IntegrationTests(unittest.TestCase):
         run_env_command(Commands.ENV_CREATE, None)
         env_name = 'env-11'
         try:
-            run_env_command(Commands.ENV_CONFIG, env_name, "vars", "set", "DUDE=woah", "SWEET=yaaa", "-n", env_name)
+            run_env_command(Commands.ENV_CONFIG, env_name, "vars", "set", "DUDE=woah", "SWEET=yaaa", "API_KEY=AaBbCcDd===EeFf", "-n", env_name)
         except Exception as e:
             self.assertIsInstance(e, EnvironmentLocationNotFound)
 


### PR DESCRIPTION
This fixes the inability of conda to set an environment variable containing "`=`" signs.
`conda env config vars set API_KEY=AaBbCc==` should now set the API_KEY to `AaBbCc==`.