### PR TITLE
[Mamba POC] Fix YAML parsing in `test_create_dry_run_yaml`

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1172,9 +1172,9 @@ class LibSolvSolver(Solver):
 
         # TODO: Check if this update-related logic is needed here too
         # Maybe conda already handles that beforehand
-        # https://github.com/mamba-org/mamba/blob/fe4ecc5061a49c5b400fa7e7390b679e983e8456/mamba/mamba.py#L426-L485
+        # https://github.com/mamba-org/mamba/blob/fe4ecc5061a49c5b400fa7/mamba/mamba.py#L426-L485
 
-        # See https://github.com/mamba-org/mamba/blob/89174c0dc06398c99589/src/core/prefix_data.cpp#L13
+        # See https://github.com/mamba-org/mamba/blob/89174c0dc06398/src/core/prefix_data.cpp#L13
         # for the C++ implementation of PrefixData
         mamba_prefix_data = MambaPrefixData(self.prefix)
         mamba_prefix_data.load()

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -258,8 +258,15 @@ class IntegrationTests(unittest.TestCase):
         create_env(environment_1)
         o, e = run_env_command(Commands.ENV_CREATE, None, '--dry-run')
         self.assertFalse(env_is_created(test_env_name_1))
+        # Find line where the YAML output starts (might be different across solvers)
+        lines = o.splitlines()
+        for i, line in enumerate(lines):
+            if line.startswith("name:"):
+                break
+        else:
+            pytest.fail("Didn't find YAML data in output")
 
-        output = yaml.safe_load('\n'.join(o.splitlines()[2:]))
+        output = yaml.safe_load('\n'.join(lines[i:]))
         assert output['name'] == 'env-1'
         assert len(output['dependencies']) > 0
 
@@ -519,7 +526,7 @@ class NewIntegrationTests(unittest.TestCase):
             assert len(env_description['dependencies'])
             for spec_str in env_description['dependencies']:
                 assert spec_str.count('=') == 1
-            
+
 
         run_env_command(Commands.ENV_REMOVE, test_env_name_2)
         assert not env_is_created(test_env_name_2)


### PR DESCRIPTION
Conda and Mamba have different standard outputs in CLI. This test hardcoded a line number to begin the YAML parsing; instead we find the first token without assuming any particular output before that line.