### PR TITLE
[Mamba POC] Handle UpdateModifier.UPDATE_DEPS correctly (all graph, not just leaves)

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import OrderedDict
+from contextlib import contextmanager
 
 from errno import ENOENT
 from logging import getLogger
@@ -772,6 +773,16 @@ class Context(Configuration):
     @property
     def verbosity(self):
         return 2 if self.debug else self._verbosity
+
+    @contextmanager
+    def override(self, key, value):
+        old = getattr(self, key)
+        setattr(self, key, value)
+        try:
+            yield
+        finally:
+            setattr(self, key, old)
+
 
     @memoizedproperty
     def user_agent(self):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import OrderedDict
 from contextlib import contextmanager
-
 from errno import ENOENT
 from logging import getLogger
 import os
@@ -782,7 +781,6 @@ class Context(Configuration):
             yield
         finally:
             setattr(self, key, old)
-
 
     @memoizedproperty
     def user_agent(self):

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1411,6 +1411,8 @@ class LibSolvSolver(Solver):
             # Remove pinned_specs and any python spec (due to major-minor pinning business rule).
             for spec in self._pinned_specs():
                 specs_map.pop(spec.name, None)
+            # TODO: This kind of version constrain patching is done several times in different
+            # parts of the code, so it might be a good candidate for a dedicate utility function
             if "python" in specs_map:
                 python = next((p for p in state["installed_pkgs"] if p.name == "python"), None)
                 if python is not None:

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1177,7 +1177,7 @@ class LibSolvSolver(Solver):
         # Maybe conda already handles that beforehand
         # https://github.com/mamba-org/mamba/blob/fe4ecc5061a49c5b400fa7e7390b679e983e8456/mamba/mamba.py#L426-L485
 
-        # See https://github.com/mamba-org/mamba/blob/89174c0dc06398c99589/src/core/prefix_data.cpp#L13
+        # https://github.com/mamba-org/mamba/blob/89174c0dc06398c99589/src/core/prefix_data.cpp#L13
         # for the C++ implementation of PrefixData
         mamba_prefix_data = MambaPrefixData(self.prefix)
         mamba_prefix_data.load()
@@ -1277,7 +1277,7 @@ class LibSolvSolver(Solver):
             # We need to handle the special cases ourselves if ONLY_DEPS and UPDATE_DEPS
             # are simultaneously used. See ._collect_specs_to_add()
             (api.MAMBA_ONLY_DEPS, deps_modifier == DepsModifier.ONLY_DEPS and
-                                  update_modifier != UpdateModifier.UPDATE_DEPS),
+                update_modifier != UpdateModifier.UPDATE_DEPS),
             (api.MAMBA_FORCE_REINSTALL, force_reinstall),
         ]
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -27,7 +27,7 @@ from ..base.constants import (DepsModifier, UNKNOWN_CHANNEL, UpdateModifier, REP
 from ..base.context import context
 from ..common.compat import iteritems, itervalues, odict, text_type
 from ..common.constants import NULL
-from ..common.io import Spinner, dashlist, time_recorder, env_var
+from ..common.io import Spinner, dashlist, time_recorder
 from ..common.path import get_major_minor_version, paths_equal
 from ..common.url import escape_channel_url, split_anaconda_token, remove_auth
 from ..exceptions import (PackagesNotFoundError, SpecsConfigurationConflictError,
@@ -1233,12 +1233,12 @@ class LibSolvSolver(Solver):
         return channels
 
     def _configure_solver(self,
-            state,
-            update_modifier=NULL,
-            deps_modifier=NULL,
-            ignore_pinned=NULL,
-            force_remove=NULL,
-            force_reinstall=NULL):
+                          state,
+                          update_modifier=NULL,
+                          deps_modifier=NULL,
+                          ignore_pinned=NULL,
+                          force_remove=NULL,
+                          force_reinstall=NULL):
         if self.specs_to_remove:
             return self._configure_solver_for_remove(state)
         # ALl other operations are handled as an install operation
@@ -1248,22 +1248,20 @@ class LibSolvSolver(Solver):
         # - conda create -n empty
         # Take into account that early exit tasks (force remove, etc)
         # have been handled beforehand if needed
-        return self._configure_solver_for_install(
-            state,
-            update_modifier=update_modifier,
-            deps_modifier=deps_modifier,
-            ignore_pinned=ignore_pinned,
-            force_remove=force_remove,
-            force_reinstall=force_reinstall
-        )
+        return self._configure_solver_for_install(state,
+                                                  update_modifier=update_modifier,
+                                                  deps_modifier=deps_modifier,
+                                                  ignore_pinned=ignore_pinned,
+                                                  force_remove=force_remove,
+                                                  force_reinstall=force_reinstall)
 
     def _configure_solver_for_install(self,
-            state,
-            update_modifier=NULL,
-            deps_modifier=NULL,
-            ignore_pinned=NULL,
-            force_remove=NULL,
-            force_reinstall=NULL):
+                                      state,
+                                      update_modifier=NULL,
+                                      deps_modifier=NULL,
+                                      ignore_pinned=NULL,
+                                      force_remove=NULL,
+                                      force_reinstall=NULL):
         from mamba import mamba_api as api
 
         prefix_data = state["mamba_prefix_data"]
@@ -1277,7 +1275,7 @@ class LibSolvSolver(Solver):
         solver_postsolve_flags = [
             (api.MAMBA_NO_DEPS, deps_modifier == DepsModifier.NO_DEPS),
             # We need to handle the special cases ourselves if ONLY_DEPS and UPDATE_DEPS
-            # are simultaneously used. See ._collect_specs_to_add()
+            # are simultaneously used. See ._collect_specs_to_add()
             (api.MAMBA_ONLY_DEPS, deps_modifier == DepsModifier.ONLY_DEPS and
                                   update_modifier != UpdateModifier.UPDATE_DEPS),
             (api.MAMBA_FORCE_REINSTALL, force_reinstall),
@@ -1293,13 +1291,12 @@ class LibSolvSolver(Solver):
             solver.add_jobs([p for p in prefix_data.package_records], api.SOLVER_LOCK)
 
         # 2. Install/update user requested packages
-        tasks_and_specs = self._collect_specs_to_add(
-            state,
-            update_modifier=update_modifier,
-            deps_modifier=deps_modifier,
-            ignore_pinned=ignore_pinned,
-            force_remove=force_remove,
-            force_reinstall=force_reinstall)
+        tasks_and_specs = self._collect_specs_to_add(state,
+                                                     update_modifier=update_modifier,
+                                                     deps_modifier=deps_modifier,
+                                                     ignore_pinned=ignore_pinned,
+                                                     force_remove=force_remove,
+                                                     force_reinstall=force_reinstall)
         for task, specs in tasks_and_specs.items():
             solver.add_jobs(list(specs.values()), getattr(api, task))
 
@@ -1348,12 +1345,12 @@ class LibSolvSolver(Solver):
         return solver
 
     def _collect_specs_to_add(self,
-            state,
-            update_modifier=NULL,
-            deps_modifier=NULL,
-            ignore_pinned=NULL,
-            force_remove=NULL,
-            force_reinstall=NULL):
+                              state,
+                              update_modifier=NULL,
+                              deps_modifier=NULL,
+                              ignore_pinned=NULL,
+                              force_remove=NULL,
+                              force_reinstall=NULL):
         """
         Reimplement the logic found in super()._add_specs(), but simplified.
         """
@@ -1382,9 +1379,9 @@ class LibSolvSolver(Solver):
             # We need a pre-solve to find the full chain of dependencies
             # for the requested specs (1) This first pre-solve will give us
             # the packages that would be installed normally. We take
-            # that list and process their dependencies too so we can add
+            # that list and process their dependencies too so we can add
             # those explicitly to the list of packages to be updated.
-            # If additionally DEPS_ONLY is set, we need to remove the
+            # If additionally DEPS_ONLY is set, we need to remove the
             # originally requested specs from the final list of explicit
             # packages.
 
@@ -1398,7 +1395,6 @@ class LibSolvSolver(Solver):
                     force_remove=force_remove,
                     force_reinstall=force_reinstall)
             specs_to_add_plus_deps = self.specs_to_add
-
 
             # (2) Get the dependency tree for each dependency
             graph = PrefixGraph(solved_pkgs)


### PR DESCRIPTION
This tries to fix `test_update_deps_flag_present`. Mamba code only handled the leave nodes I think. In this case we take conda's approach and do a pre-solve to obtain the full chain.

I've also reworked how the solver tasks are precomputed here. This might affect other tests too. Keep an eye on regressions.