### PR TITLE
[Mamba POC] Research `conflicting requests` errors: --update-deps

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1361,7 +1361,7 @@ class LibSolvSolver(Solver):
             installed_names = set(rec.name for rec in state["installed_pkgs"])
             tasks["SOLVER_UPDATE"].update(
                 {
-                    pkg.name: MatchSpec(pkg.name)
+                    pkg.name: MatchSpec(pkg.name).conda_build_form()
                     for pkg in context.aggressive_update_packages
                     if pkg.name in installed_names
                 }

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -7,7 +7,6 @@ import copy
 from genericpath import exists
 from logging import DEBUG, getLogger
 from os.path import join
-from collections import defaultdict
 import sys
 from textwrap import dedent
 from itertools import chain
@@ -1536,7 +1535,6 @@ class LibSolvSolver(Solver):
             rec = to_package_record_from_subjson(sdir, pkg, jsn_s)
             final_precs.add(rec)
 
-
         # NOTE: We are exporting state back to the class! These are expected by
         # super().solve_for_diff() and super().solve_for_transaction() :/
         self.specs_to_add = [MatchSpec(m) for m in names_to_add]
@@ -1552,7 +1550,6 @@ class LibSolvSolver(Solver):
                           force_reinstall=NULL,
                           ignore_pinned=NULL,
                           force_remove=NULL):
-
         original_prefix_map = {pkg.name: pkg for pkg in state["conda_prefix_data"].iter_records()}
         final_prefix_map = {pkg.name: pkg for pkg in final_prefix_state}
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1268,21 +1268,10 @@ class LibSolvSolver(Solver):
         pool = state["pool"]
 
         # Set different solver options
-        solver_args = (prefix_data,) if force_reinstall else ()
         solver_options = [(api.SOLVER_FLAG_ALLOW_DOWNGRADE, 1)]
         if context.channel_priority is ChannelPriority.STRICT:
             solver_options.append((api.SOLVER_FLAG_STRICT_REPO_PRIORITY, 1))
-        solver_postsolve_flags = [
-            (api.MAMBA_NO_DEPS, deps_modifier == DepsModifier.NO_DEPS),
-            # We need to handle the special cases ourselves if ONLY_DEPS and UPDATE_DEPS
-            # are simultaneously used. See ._collect_specs_to_add()
-            (api.MAMBA_ONLY_DEPS, deps_modifier == DepsModifier.ONLY_DEPS and
-                update_modifier != UpdateModifier.UPDATE_DEPS),
-            (api.MAMBA_FORCE_REINSTALL, force_reinstall),
-        ]
-
-        solver = api.Solver(pool, solver_options, *solver_args)
-        solver.set_postsolve_flags(solver_postsolve_flags)
+        solver = api.Solver(pool, solver_options)
 
         # Configure jobs
 


### PR DESCRIPTION
Libsolv will provide this generic error for some of our tests, probably due to a misconfiguration on our end. Setting `CONDA_VERBOSITY=3` enables the libsolv debug logs, so we can dig the details up. 

I'll be writing my notes and findings here.

List of failing tests at the beginning of this PR:

  - [x] `test_install_only_deps_flag`
  - [x] `test_create_install_update_remove_smoketest`
  - [ ] `test_install_freezes_env_by_default`
  - [x] `test_json_create_install_update_remove`
  - [ ] `test_neutering_of_historic_specs`
  - [ ] `test_noarch_python_package_reinstall_on_pyver_change`
  - [ ] `test_transactional_rollback_upgrade_downgrade`