### PR TITLE
[Mamba POC] Control verbosity on tests where stdout is parsed

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1219,10 +1219,13 @@ dependencies:
             assert package_is_installed(prefix, 'python')
 
     def test_install_force_reinstall_flag(self):
-        with make_temp_env("python") as prefix:
-            stdout, stderr, _ = run_command(Commands.INSTALL, prefix,
-                                         "--json", "--dry-run", "--force-reinstall", "python",
-                                         use_exception_handler=True)
+        with env_var("CONDA_VERBOSITY", "0"):
+            # Some solvers print to stdout with VERBOSITY>=1
+            # and this pollutes the JSON output
+            with make_temp_env("python") as prefix:
+                stdout, stderr, _ = run_command(Commands.INSTALL, prefix,
+                                            "--json", "--dry-run", "--force-reinstall", "python",
+                                            use_exception_handler=True)
             output_obj = json.loads(stdout.strip())
             unlink_actions = output_obj['actions']['UNLINK']
             link_actions = output_obj['actions']['LINK']
@@ -1278,7 +1281,7 @@ dependencies:
             assert package_is_installed(prefix, "flask=0.12.2")
             assert package_is_installed(prefix, "jinja2=2.9")
 
-            run_command(Commands.INSTALL, prefix, "flask", "--only-deps")
+            run_command(Commands.INSTALL, prefix, "flask", "--only-deps", no_capture=True)
             assert package_is_installed(prefix, "python=3.6")
             assert package_is_installed(prefix, "flask=0.12.2")
             assert package_is_installed(prefix, "jinja2=2.9")

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1281,7 +1281,7 @@ dependencies:
             assert package_is_installed(prefix, "flask=0.12.2")
             assert package_is_installed(prefix, "jinja2=2.9")
 
-            run_command(Commands.INSTALL, prefix, "flask", "--only-deps", no_capture=True)
+            run_command(Commands.INSTALL, prefix, "flask", "--only-deps")
             assert package_is_installed(prefix, "python=3.6")
             assert package_is_installed(prefix, "flask=0.12.2")
             assert package_is_installed(prefix, "jinja2=2.9")


### PR DESCRIPTION
Finally an easy one. Libsolv will print logs to stdout if verbosity=3 is enabled, which pollutes the JSON output that needs to be parsed here. Note that the verbosity is set at first instantiation, so adjusting `CONDA_VERBOSITY` after won't have any effect. In other words, it needs to be done as early as possible.

This fixes `test_install_force_reinstall_flag`.