### PR TITLE
[Mamba POC] Pin historic entries

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2887,7 +2887,9 @@ dependencies:
             stdout, stderr, _ = run_command(Commands.INSTALL, prefix, "python=3.6")
             with open(os.path.join(prefix, 'conda-meta', 'history')) as f:
                 d = f.read()
-            assert re.search(r"neutered specs:.*'psutil==5.6.3'\]", d)
+            if context.solver_logic == "legacy":
+                assert re.search(r"neutered specs:.*'psutil==5.6.3'\]", d)
+            assert package_is_installed(prefix, "psutil=5.6.3")
             # this would be unsatisfiable if the neutered specs were not being factored in correctly.
             #    If this command runs successfully (does not raise), then all is well.
             stdout, stderr, _ = run_command(Commands.INSTALL, prefix, "imagesize")


### PR DESCRIPTION
I am not sure we should even be doing this, but `test_neutering_of_historic_specs` is failing and this fixes it. I need to assess whether:

a) This impacts other tests
b) This is actually done by conda at all. I think legacy uses a subtler approach to pinning historic entries (and not just _everything_ ever requested).

I also modified the test a bit to actually test whether `psutil` is kept at the requested version or not. Without this, the tests passes too, but `libsolv` is actually bringing psutil up to 5.8.0 instead of staying at 5.6.3.