### PR TITLE
Remove extra argv processing for Python2 win32 unicode

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -88,49 +88,13 @@ def _main(*args, **kwargs):
         return exit_code.rc
 
 
-if sys.platform == 'win32' and sys.version_info[0] == 2:
-    def win32_unicode_argv():
-        """Uses shell32.GetCommandLineArgvW to get sys.argv as a list of Unicode
-        strings.
-
-        Versions 2.x of Python don't support Unicode in sys.argv on
-        Windows, with the underlying Windows API instead replacing multi-byte
-        characters with '?'.
-        """
-
-        from ctypes import POINTER, byref, cdll, c_int, windll
-        from ctypes.wintypes import LPCWSTR, LPWSTR
-
-        GetCommandLineW = cdll.kernel32.GetCommandLineW
-        GetCommandLineW.argtypes = []
-        GetCommandLineW.restype = LPCWSTR
-
-        CommandLineToArgvW = windll.shell32.CommandLineToArgvW
-        CommandLineToArgvW.argtypes = [LPCWSTR, POINTER(c_int)]
-        CommandLineToArgvW.restype = POINTER(LPWSTR)
-
-        cmd = GetCommandLineW()
-        argc = c_int(0)
-        argv = CommandLineToArgvW(cmd, byref(argc))
-        if argc.value > 0:
-            # Remove Python executable and commands if present
-            start = argc.value - len(sys.argv)
-            return [argv[i] for i in range(start, argc.value)]
-
-
 def main(*args, **kwargs):
     # conda.common.compat contains only stdlib imports
     from ..common.compat import ensure_text_type, init_std_stream_encoding
 
     init_std_stream_encoding()
 
-    if not args:
-        if sys.platform == 'win32' and sys.version_info[0] == 2:
-            args = sys.argv = win32_unicode_argv()
-        else:
-            args = sys.argv
-
-    args = tuple(ensure_text_type(s) for s in args)
+    args = tuple(ensure_text_type(s) for s in args or sys.argv)
 
     if len(args) > 1:
         try:


### PR DESCRIPTION
This is a remnant of Python2 days and since conda is now (at least) Python3.6+ theres no need to keep the hack around.