### PR TITLE
[Mamba POC] Do not drop python if it was requested along with --only-deps

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1338,7 +1338,7 @@ class LibSolvSolver(Solver):
             solver_options.append((api.SOLVER_FLAG_STRICT_REPO_PRIORITY, 1))
         solver = api.Solver(state["pool"], solver_options)
 
-        installed_names = [rec.name for rec in state["installed_pkgs"]]
+        installed_names = set(rec.name for rec in state["installed_pkgs"])
         # pkgs in aggresive_update_packages should be protected too (even if not
         # requested explicitly by the user)
         # see https://github.com/conda/conda/blob/9e9461760bb/tests/core/test_solve.py#L520-L521
@@ -1348,6 +1348,13 @@ class LibSolvSolver(Solver):
             list(set(chain(self._history_specs(), aggresive_updates))),
             api.SOLVER_USERINSTALLED,
         )
+        # This fixes test_create.py::test_remove_all, which tests #2154.
+        # TODO: Raise issue on mamba-org/mamba too
+        not_installed = [spec.name for spec in self.specs_to_remove
+                         if spec.name not in installed_names]
+        if not_installed:
+            raise PackagesNotFoundError(not_installed)
+
         specs = [s.conda_build_form() for s in self.specs_to_remove]
         solver.add_jobs(specs, api.SOLVER_ERASE | api.SOLVER_CLEANDEPS)
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1585,8 +1585,9 @@ class LibSolvSolver(Solver):
                 if spec.name in original_prefix_map:
                     final_prefix_map[spec.name] = original_prefix_map[spec.name]
                 # Case B: it was never installed, make sure we don't add it.
-                # Note that we special-case python, otherwise there's no path
-                # we can still packages to. This makes `test_create_only_deps_flag` pass.
+                # Python is special-cased here because otherwise the directory
+                # tree for other packages is not available for the dependencies.
+                # This makes test_create.py::test_create_only_deps_flag pass.
                 elif spec.name != "python":
                     final_prefix_map.pop(spec.name, None)
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1578,7 +1578,9 @@ class LibSolvSolver(Solver):
                 if spec.name in original_prefix_map:
                     final_prefix_map[spec.name] = original_prefix_map[spec.name]
                 # Case B: it was never installed, make sure we don't add it.
-                else:
+                # Note that we special-case python, otherwise there's no path
+                # we can still packages to. This makes `test_create_only_deps_flag` pass.
+                elif spec.name != "python":
                     final_prefix_map.pop(spec.name, None)
 
         # TODO: Review performance here just in case


### PR DESCRIPTION
Built on top of https://github.com/conda/conda/pull/10946

***

Python is special-cased here because otherwise the directory tree for other packages is not available for the dependencies. This makes `test_create.py::test_create_only_deps_flag ` pass.