### PR TITLE
Build Docker image for Linux with Python 3.10.

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -27,7 +27,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Just the Docker image part of #10992 so we can use the image in the PR.