### PR TITLE
Try using maintained ruamel.yaml

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -102,7 +102,7 @@ ROOT_ENV_NAME = 'base'
 ROOT_NO_RM = (
     'python',
     'pycosat',
-    'ruamel_yaml',
+    'ruamel.yaml',
     'conda',
     'openssl',
     'requests',

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -44,9 +44,9 @@ from .._vendor.boltons.setutils import IndexedSet
 from .._vendor.toolz import concat, concatv, excepts, merge, merge_with, unique
 
 try:  # pragma: no cover
-    from ruamel_yaml.comments import CommentedSeq, CommentedMap
-    from ruamel_yaml.reader import ReaderError
-    from ruamel_yaml.scanner import ScannerError
+    from ruamel.yaml.comments import CommentedSeq, CommentedMap
+    from ruamel.yaml.reader import ReaderError
+    from ruamel.yaml.scanner import ScannerError
 except ImportError:  # pragma: no cover
     from ruamel.yaml.comments import CommentedSeq, CommentedMap  # pragma: no cover
     from ruamel.yaml.reader import ReaderError

--- a/conda/common/serialize.py
+++ b/conda/common/serialize.py
@@ -16,14 +16,14 @@ log = getLogger(__name__)
 @memoize
 def get_yaml():
     try:
-        import ruamel_yaml as yaml
+        import ruamel.yaml as yaml
     except ImportError:  # pragma: no cover
         try:
             import ruamel.yaml as yaml
         except ImportError:
             raise ImportError("No yaml library available.\n"
                               "To proceed, conda install "
-                              "ruamel_yaml")
+                              "ruamel.yaml")
     return yaml
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,10 @@ source.
 install_requires = [
     "pycosat >=0.6.3",
     "requests >=2.12.4",
+    "ruamel.yaml",
     "menuinst ; platform_system=='Windows'",
 ]
 
-if os.getenv('CONDA_BUILD', None) == '1':
-    install_requires.append("ruamel_yaml_conda >=0.11.14")
-else:
-    install_requires.append("ruamel_yaml_conda >=0.11.14")
 
 
 def package_files(*root_directories):

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -1,7 +1,5 @@
 import json
 import os
-import yaml
-
 import pytest
 import unittest
 
@@ -261,7 +259,7 @@ class IntegrationTests(unittest.TestCase):
         o, e = run_env_command(Commands.ENV_CREATE, None, '--dry-run')
         self.assertFalse(env_is_created(test_env_name_1))
 
-        output = yaml.safe_load('\n'.join(o.splitlines()[2:]))
+        output = yaml_safe_load('\n'.join(o.splitlines()[2:]))
         assert output['name'] == 'env-1'
         assert len(output['dependencies']) > 0
 


### PR DESCRIPTION
The conda specific fork is maintained as a conda package only
in
https://github.com/conda-forge/ruamel_yaml-feedstock/tree/master/recipe.
My understanding of what's being patched there seems to indicate it's
just the `__init__.py` file. I'm hoping just a rename of the
import will be enough, or at least surface what real problems exist.

Ref https://github.com/conda/conda/issues/10691