### PR TITLE
Automate moving to/from boards

### DIFF
--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -25,7 +25,7 @@ jobs:
           action: delete
           project: Triaging
           column: Ready
-          repo-token: ${{ secrets.PROJECT_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: alex-page/github-project-automation-plus@v0.8.1
         if: contains(github.event.issue.labels.*.name, 'backlog')
         with:

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -1,0 +1,35 @@
+name: Automate Boards
+on:
+  issues:
+    types: [opened, labeled]
+jobs:
+  # move to triaging board if new
+  triaging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        if: github.event.action == 'opened' && !contains(github.event.issue.labels.*.name, 'backlog')
+        with:
+          action: update
+          project: Triaging
+          column: New
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # move to backlog board if labeled as backlog
+  backlog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        if: contains(github.event.issue.labels.*.name, 'backlog')
+        with:
+          action: delete
+          project: Triaging
+          column: Ready
+          repo-token: ${{ secrets.PROJECT_TOKEN }}
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        if: contains(github.event.issue.labels.*.name, 'backlog')
+        with:
+          action: update
+          project: Backlog
+          column: Unplanned
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Implements workflow to auto add new issues to the triaging project board and once the backlog label is added to move the issue from triaging to the backlog project board.

I have successfully tested this with a personal dummy repo & projects.

In working on these automations I found that these GH Actions do not appear to work with beta projects and maintainers of said actions are hesitant to dig into it since beta projects promise builtin workflows/automation. So we will just need to keep any eye on the developments and at some point we will be able to switch from old projects to the beta projects.