### PR TITLE
Instantiate separate S3 session for thread-safety.

### DIFF
--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -11,7 +11,6 @@ have_boto3 = have_boto = False
 try:
     import boto3
     have_boto3 = True
-    boto3.client('s3')  # https://github.com/conda/conda/issues/8993
 except ImportError:
     try:
         import boto
@@ -54,8 +53,13 @@ class S3Adapter(BaseAdapter):
     def _send_boto3(self, boto3, resp, request):
         from botocore.exceptions import BotoCoreError, ClientError
         bucket_name, key_string = url_to_s3_info(request.url)
-
-        key = boto3.resource('s3').Object(bucket_name, key_string[1:])
+        # https://github.com/conda/conda/issues/8993
+        # creating a seaprate boto3 session to make this threadsafe
+        session = boto3.session.Session()
+        # create a resource client using this thread's session object
+        s3 = session.resource('s3')
+        # finally get the S3 object
+        key = s3.Object(bucket_name, key_string[1:])
 
         try:
             response = key.get()

--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -54,7 +54,7 @@ class S3Adapter(BaseAdapter):
         from botocore.exceptions import BotoCoreError, ClientError
         bucket_name, key_string = url_to_s3_info(request.url)
         # https://github.com/conda/conda/issues/8993
-        # creating a seaprate boto3 session to make this threadsafe
+        # creating a separate boto3 session to make this thread safe
         session = boto3.session.Session()
         # create a resource client using this thread's session object
         s3 = session.resource('s3')


### PR DESCRIPTION
Following the official docs using the boto3's S3 resources in a thread-safe manner (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html#multithreading-or-multiprocessing-with-resources) this instantiates a separate S3 session per call of this function to make sure the used S3 resource instance derived from it is properly thread-safe.

References:

- #8993 (original ticket)
- #10516 (original patch)
- #10756 (regression ticket)
- #10759 (regression fix)