### PR TITLE
Fix PowerShellActivator unsetting env

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -1037,7 +1037,7 @@ class PowerShellActivator(_Activator):
         self.tempfile_extension = None  # write instructions to stdout rather than a temp file
         self.command_join = '\n'
 
-        self.unset_var_tmpl = 'Remove-Item Env:/%s'
+        self.unset_var_tmpl = '$Env:%s = ""'
         self.export_var_tmpl = '$Env:%s = "%s"'
         self.set_var_tmpl = '$Env:%s = "%s"'
         self.run_script_tmpl = '. "%s"'

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1650,9 +1650,9 @@ class ShellWrapperUnitTests(TestCase):
             assert deactivate_data == dals("""
             $Env:PATH = "%(new_path)s"
             . "%(deactivate1)s"
-            Remove-Item Env:/CONDA_PREFIX
-            Remove-Item Env:/CONDA_DEFAULT_ENV
-            Remove-Item Env:/CONDA_PROMPT_MODIFIER
+            $Env:CONDA_PREFIX = ""
+            $Env:CONDA_DEFAULT_ENV = ""
+            $Env:CONDA_PROMPT_MODIFIER = ""
             $Env:CONDA_SHLVL = "0"
             %(conda_exe_export)s
             """) % {


### PR DESCRIPTION
This PR is going to fix #10436

## Detail

Issue #10436 occurred because of an unique behavior of PowerShell - **setting an environment variable to a blank string is the prescribed way to delete it**. (ref. https://ss64.com/ps/syntax-env.html)

Conda gets the value of `CONDA_PROMPT_MODIFIER` by calling [`_prompt_modifier()`](https://github.com/conda/conda/blob/0d9f24b80febf198e0b77f617cf779d7d5d74a11/conda/activate.py#L654), 

https://github.com/conda/conda/blob/0d9f24b80febf198e0b77f617cf779d7d5d74a11/conda/activate.py#L654-L698

The function returns an empty string *when `changeps1` set to false*. Then in the activator,  env `CONDA_PROMPT_MODIFIER` is set to the empty string by invoking `$Env:CONDA_PROMPT_MODIFIER = ""`, which is actually unsetting/deleting the env because of PowerShell's unique behavior.

`CONDA_PROMPT_MODIFIER` was unset during the env activation. Then in the deactivator, it's trying to delete the env again by calling `Remove-Item Env:/CONDA_PROMPT_MODIFIER`, which causes the error.

I fix the issue by simply replacing `Remove-Item Env:/%s` with `$Env:%s = ""`, they do the same job of unsetting env but the latter doesn't throw errors when it tries to unset a non-exist env.