### PR TITLE
change bare `conda update` error message

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -130,10 +130,8 @@ def install(args, parser, command='install'):
     if isupdate and not (args.file or args.packages
                          or context.update_modifier == UpdateModifier.UPDATE_ALL):
         raise CondaValueError("""no package names supplied
-# If you want to update to a newer version of Anaconda, type:
-#
-# $ conda update --prefix %s anaconda
-""" % prefix)
+# Example: conda update -n myenv scipy
+""")
 
     if not newenv:
         if isdir(prefix):


### PR DESCRIPTION
The conda update error message is confusing. It says something that only works in anaconda, not miniconda, and this upgrade path doesn't work very well / is not recommended.

Instead, copy an example from `conda update --help`

```
$ conda update

CondaValueError: no package names supplied
# If you want to update to a newer version of Anaconda, type:
#
# $ conda update --prefix /Users/dholth/miniconda3/envs/sbomtool anaconda
```