### PR TITLE
Add news items for 4.11.

### DIFF
--- a/news/gh-10436-powershell-activator
+++ b/news/gh-10436-powershell-activator
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix the PowerShell activator to not show an error when unsetting environment
+  variables.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10628-interpolate-channel_alias
+++ b/news/gh-10628-interpolate-channel_alias
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Allow channel_alias to interpolate environment variables.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10696-fish-eval
+++ b/news/gh-10696-fish-eval
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Remove superfluous `eval` statements in fish shell integration.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10772-pypy-windows
+++ b/news/gh-10772-pypy-windows
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Support running conda with PyPy on Windows.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10795-conda-ci
+++ b/news/gh-10795-conda-ci
@@ -1,10 +1,6 @@
 ### Enhancements
 
-* Build Docker images periodically on GitHub Actions for the continuous
-  integration testing on Linux, storing them on GitHub Packages's registry
-  for reduced latency and cost when using Docker Hub.
-
-* Simplify the Linux GitHub actions workflows by combining used shell scripts.
+* <news item>
 
 ### Bug fixes
 
@@ -20,4 +16,8 @@
 
 ### Other
 
-* <news item>
+* Build Docker images periodically on GitHub Actions for the continuous
+  integration testing on Linux, storing them on GitHub Packages's registry
+  for reduced latency and cost when using Docker Hub.
+
+* Simplify the Linux GitHub actions workflows by combining used shell scripts.

--- a/news/gh-10795-conda-ci
+++ b/news/gh-10795-conda-ci
@@ -1,0 +1,23 @@
+### Enhancements
+
+* Build Docker images periodically on GitHub Actions for the continuous
+  integration testing on Linux, storing them on GitHub Packages's registry
+  for reduced latency and cost when using Docker Hub.
+
+* Simplify the Linux GitHub actions workflows by combining used shell scripts.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10799-conda-path-rhel
+++ b/news/gh-10799-conda-path-rhel
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Update path of conda repo in RHEL based systems to `/etc/yum.repos.d/conda.repo`.
+
+### Other
+
+* <news item>

--- a/news/gh-10815-fix-pip-advanced-docs
+++ b/news/gh-10815-fix-pip-advanced-docs
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Fix the advanced pip example to stop using the now invalid `file:` prefix.
+
+### Other
+
+* <news item>

--- a/news/gh-10831-stale-github-action
+++ b/news/gh-10831-stale-github-action
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Add periodic GitHub Actions workflow to review old issues in the conda
+  issue tracker and mark them as stale if no feedback is provided in a
+  sensible amount of time, eventually closing them.

--- a/news/gh-10832-lock-threads-github-action
+++ b/news/gh-10832-lock-threads-github-action
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Add periodic GitHub Actions workflow to lock the comment threads of
+  old issues and pull requests in the conda GitHub repository to surface
+  regressions with new issues instead.

--- a/news/gh-10864-ci-refactor
+++ b/news/gh-10864-ci-refactor
@@ -1,7 +1,6 @@
 ### Enhancements
 
-* Refactor test suite to use more GitHub Actions runners in parallel,
-  reducing total run time by 50%.
+* <news item>
 
 ### Bug fixes
 
@@ -17,4 +16,5 @@
 
 ### Other
 
-* <news item>
+* Refactor test suite to use more GitHub Actions runners in parallel,
+  reducing total run time by 50%.

--- a/news/gh-10864-ci-refactor
+++ b/news/gh-10864-ci-refactor
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Refactor test suite to use more GitHub Actions runners in parallel,
+  reducing total run time by 50%.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10878-github-issue-forms
+++ b/news/gh-10878-github-issue-forms
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Switched the issue tracker to use forms with additional questions for
+  bug reporters to help in ticket triage.

--- a/news/gh-10896-indent-fish
+++ b/news/gh-10896-indent-fish
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Indent the conda fish integration file using fish_indent.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10898-docs-cleanup
+++ b/news/gh-10898-docs-cleanup
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Minor docs cleanup and adding Code of Conduct.
+
+### Other
+
+* <news item>

--- a/news/gh-10905-envvars
+++ b/news/gh-10905-envvars
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix handling of environment variables containing equal signs (`=`).
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10933-architecture-docs
+++ b/news/gh-10933-architecture-docs
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Add auto-built architecture documentation for conda based on the
+  [C4 Model](https://c4model.com). See the conda documentation for more
+  information.
+
+### Other
+
+* <news item>

--- a/news/gh-10950-permissionerror
+++ b/news/gh-10950-permissionerror
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Handle permission errors when listing all known prefixes.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10952-config-sequences
+++ b/news/gh-10952-config-sequences
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Add ability to add, append and prepend to sequence values when using
+  the conda config subcommand.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10970-python310
+++ b/news/gh-10970-python310
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Support Python 3.10 in version parser.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-10982-XDG_CONFIG_HOME
+++ b/news/gh-10982-XDG_CONFIG_HOME
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Add `XDG_CONFIG_HOME` to the conda search path following
+  the [XDG Base Directory Specification (XDGBDS)](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-11009-styles
+++ b/news/gh-11009-styles
@@ -1,0 +1,29 @@
+### Enhancements
+
+* Add and automatically run pre-commit as part of the CI system
+  to improve the code quality continuously and raise issues
+  in contributed patches early on.
+
+  The used code linters are: [flake8](https://flake8.pycqa.org/),
+  [pylint](https://pylint.org/) and [bandit](https://bandit.readthedocs.io/).
+
+  The [Python code formatter black](https://black.readthedocs.io/) is used
+  as well but is only enforced on changed code in a commit and not to the
+  whole code base at once.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Expand the contributing documentation with a section about
+  static code analysis and code linting.
+
+### Other
+
+* <news item>

--- a/news/gh-11009-styles
+++ b/news/gh-11009-styles
@@ -1,15 +1,6 @@
 ### Enhancements
 
-* Add and automatically run pre-commit as part of the CI system
-  to improve the code quality continuously and raise issues
-  in contributed patches early on.
-
-  The used code linters are: [flake8](https://flake8.pycqa.org/),
-  [pylint](https://pylint.org/) and [bandit](https://bandit.readthedocs.io/).
-
-  The [Python code formatter black](https://black.readthedocs.io/) is used
-  as well but is only enforced on changed code in a commit and not to the
-  whole code base at once.
+* <news item>
 
 ### Bug fixes
 
@@ -26,4 +17,13 @@
 
 ### Other
 
-* <news item>
+* Add and automatically run pre-commit as part of the CI system
+  to improve the code quality continuously and raise issues
+  in contributed patches early on.
+
+  The used code linters are: [flake8](https://flake8.pycqa.org/),
+  [pylint](https://pylint.org/) and [bandit](https://bandit.readthedocs.io/).
+
+  The [Python code formatter black](https://black.readthedocs.io/) is used
+  as well but is only enforced on changed code in a commit and not to the
+  whole code base at once.

--- a/news/gh-11012-conda-canary
+++ b/news/gh-11012-conda-canary
@@ -1,13 +1,6 @@
 ### Enhancements
 
-* Automatically build the conda package upon the successful merge into the
-  master branch and upload it to the conda-canary channel on anaconda.org.
-
-  To try conda out simply run:
-
-  ```
-  conda install -c conda-canary conda
-  ```
+* <news item>
 
 ### Bug fixes
 
@@ -23,4 +16,11 @@
 
 ### Other
 
-* <news item>
+* Automatically build the conda package upon the successful merge into the
+  master branch and upload it to the conda-canary channel on anaconda.org.
+
+  To try conda out simply run:
+
+  ```
+  conda install -c conda-canary/label/dev conda
+  ```

--- a/news/gh-11012-conda-canary
+++ b/news/gh-11012-conda-canary
@@ -1,0 +1,26 @@
+### Enhancements
+
+* Automatically build the conda package upon the successful merge into the
+  master branch and upload it to the conda-canary channel on anaconda.org.
+
+  To try conda out simply run:
+
+  ```
+  conda install -c conda-canary conda
+  ```
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-11029-triaging
+++ b/news/gh-11029-triaging
@@ -1,0 +1,22 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Automate adding new issues to [public GitHub project board](https://github.com/orgs/conda/projects/4)
+  to facilitate issue triage.
+
+* Update GitHub issue and pull request labels to be more consistent.

--- a/news/gh-11036-unicode-conda-meta
+++ b/news/gh-11036-unicode-conda-meta
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Catch Unicode decoding errors when parsing conda-meta files.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-11039-rever
+++ b/news/gh-11039-rever
@@ -1,7 +1,6 @@
 ### Enhancements
 
-* Start using [rever](https://regro.github.io/rever-docs/) for release
-  management.
+* <news item>
 
 ### Bug fixes
 
@@ -17,4 +16,5 @@
 
 ### Other
 
-* <news item>
+* Start using [rever](https://regro.github.io/rever-docs/) for release
+  management.

--- a/news/gh-11039-rever
+++ b/news/gh-11039-rever
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Start using [rever](https://regro.github.io/rever-docs/) for release
+  management.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-11040-gitpod-codespaces
+++ b/news/gh-11040-gitpod-codespaces
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Enable one-click gitpod and GitHub Codespaces setup for Linux development.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/gh-11040-gitpod-codespaces
+++ b/news/gh-11040-gitpod-codespaces
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Enable one-click gitpod and GitHub Codespaces setup for Linux development.
+* <news item>
 
 ### Bug fixes
 
@@ -16,4 +16,4 @@
 
 ### Other
 
-* <news item>
+* (preview) Enable one-click gitpod and GitHub Codespaces setup for Linux development.

--- a/news/gh-11041-dev-guide
+++ b/news/gh-11041-dev-guide
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Add [developer guide section](https://docs.conda.io/projects/conda/en/latest/dev-guide/) to the documentation, including a conda [architecture overview](https://docs.conda.io/projects/conda/en/latest/architecture.html).
+
+### Other
+
+* <news item>

--- a/news/gh-11045-update-help
+++ b/news/gh-11045-update-help
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Stop referring to updating anaconda when `conda update`
+  fails with an error.
+
+### Other
+
+* <news item>

--- a/news/gh-9789-set-errno
+++ b/news/gh-9789-set-errno
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix handling write errors when trying to create package cache
+  or env directories.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
These are the news items that we would usually have included in PRs but since we've introduced [rever](https://regro.github.io/rever-docs/) only recently in #11039 this had to be added afterwards.

I used https://github.com/conda/conda/compare/4.10.3...master as the basis and skipped a few not as noteworthy commits. Please let me know if there is anything that doesn't make sense.