### PR TITLE
Automatically handle milestoned/demilestoned/commented issues

### DIFF
--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -1,13 +1,13 @@
 name: Automate Boards
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, labeled, milestoned, demilestoned]
 jobs:
-  # move to triaging board if new
+  # move to Triaging board if new
   triaging:
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: alex-page/github-project-automation-plus@v0
         if: github.event.action == 'opened' && !contains(github.event.issue.labels.*.name, 'backlog')
         with:
           action: update
@@ -15,21 +15,53 @@ jobs:
           column: New
           repo-token: ${{ secrets.PROJECT_TOKEN }}
 
-  # move to backlog board if labeled as backlog
+  # move to Backlog board if labeled as [backlog]
   backlog:
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: alex-page/github-project-automation-plus@v0
         if: contains(github.event.issue.labels.*.name, 'backlog')
         with:
           action: delete
           project: Triaging
           column: Ready
           repo-token: ${{ secrets.PROJECT_TOKEN }}
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: alex-page/github-project-automation-plus@v0
         if: contains(github.event.issue.labels.*.name, 'backlog')
         with:
           action: update
           project: Backlog
           column: Unplanned
+          repo-token: ${{ secrets.PROJECT_TOKEN }}
+
+  # remove [backlog] (& remove from Backlog board) if milestoned
+  milestoned:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v2
+        if: github.event.action == 'milestoned'
+        with:
+          unlabel: backlog
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+      - uses: alex-page/github-project-automation-plus@v0
+        with:
+          action: delete
+          project: Backlog
+          column: Do Next
+          repo-token: ${{ secrets.PROJECT_TOKEN }}
+
+  # add [backlog] (& move back to Backlog board) if demilestoned
+  demilestoned:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v2
+        if: github.event.action == 'demilestoned'
+        with:
+          label: backlog
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+      - uses: alex-page/github-project-automation-plus@v0
+        with:
+          action: update
+          project: Backlog
+          column: Do Next
           repo-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -9,7 +9,7 @@ jobs:
   triaging:
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@v0
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         if: github.event.action == 'opened' && !contains(github.event.issue.labels.*.name, 'backlog')
         with:
           action: update
@@ -21,7 +21,7 @@ jobs:
   pending_feedback:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v2
+      - uses: dessant/label-actions@v2.2.0
         if: github.event_name == 'issue_comment' && github.event.action == 'created' && !github.event.issue.pull_request
         with:
           unlabel: pending::feedback
@@ -31,14 +31,14 @@ jobs:
   backlog:
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@v0
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         if: contains(github.event.issue.labels.*.name, 'backlog')
         with:
           action: delete
           project: Triaging
           column: Ready
           repo-token: ${{ secrets.PROJECT_TOKEN }}
-      - uses: alex-page/github-project-automation-plus@v0
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         if: contains(github.event.issue.labels.*.name, 'backlog')
         with:
           action: update
@@ -50,7 +50,7 @@ jobs:
   milestoned:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v2
+      - uses: dessant/label-actions@v2.2.0
         if: github.event.action == 'milestoned'
         with:
           unlabel: backlog
@@ -62,7 +62,7 @@ jobs:
           column: Do Next
           repo-token: ${{ secrets.PROJECT_TOKEN }}
       # just in case the issue is still on the Triaging board
-      - uses: alex-page/github-project-automation-plus@v0
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
           action: delete
           project: Triaging
@@ -73,12 +73,12 @@ jobs:
   demilestoned:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v2
+      - uses: dessant/label-actions@v2.2.0
         if: github.event.action == 'demilestoned'
         with:
           label: backlog
           github-token: ${{ secrets.PROJECT_TOKEN }}
-      - uses: alex-page/github-project-automation-plus@v0
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
           action: update
           project: Backlog

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -2,6 +2,8 @@ name: Automate Boards
 on:
   issues:
     types: [opened, labeled, milestoned, demilestoned]
+  issue_comment:
+    types: [created]
 jobs:
   # move to Triaging board if new
   triaging:
@@ -14,6 +16,16 @@ jobs:
           project: Triaging
           column: New
           repo-token: ${{ secrets.PROJECT_TOKEN }}
+
+  # remove [pending::feedback] if commented
+  pending_feedback:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v2
+        if: github.event_name == 'issue_comment' && github.event.action == 'created' && !github.event.issue.pull_request
+        with:
+          unlabel: pending::feedback
+          github-token: ${{ secrets.PROJECT_TOKEN }}
 
   # move to Backlog board if labeled as [backlog]
   backlog:

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -49,6 +49,13 @@ jobs:
           project: Backlog
           column: Do Next
           repo-token: ${{ secrets.PROJECT_TOKEN }}
+      # just in case the issue is still on the Triaging board
+      - uses: alex-page/github-project-automation-plus@v0
+        with:
+          action: delete
+          project: Triaging
+          column: Ready
+          repo-token: ${{ secrets.PROJECT_TOKEN }}
 
   # add [backlog] (& move back to Backlog board) if demilestoned
   demilestoned:

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -7,55 +7,77 @@ on:
 jobs:
   # move to Triaging board if new
   triaging:
+    if: >-
+      github.event_name == 'issues'
+      && github.event.action == 'opened'
+      && github.event.issue.state == 'open'
+      && !contains(github.event.issue.labels.*.name, 'backlog')
     runs-on: ubuntu-latest
     steps:
       - uses: alex-page/github-project-automation-plus@v0.8.1
-        if: github.event.action == 'opened' && !contains(github.event.issue.labels.*.name, 'backlog')
         with:
-          action: update
+          action: add
           project: Triaging
           column: New
           repo-token: ${{ secrets.PROJECT_TOKEN }}
 
-  # remove [pending::feedback] if commented
-  pending_feedback:
+  # if labeled as [pending::feedback] and the author responded remove [pending::feedback] and add [pending::support]
+  # clearly this will not catch cases where multiple users act as the author/reporter, this is just an effort to catch the majority of support cases
+  pending_support:
+    if: >-
+      github.event_name == 'issue_comment'
+      && github.event.action == 'created'
+      && !github.event.issue.pull_request
+      && contains(github.event.issue.labels.*.name, 'pending::feedback')
+      && github.event.issue.user.login == github.event.comment.user.login
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v2.2.0
-        if: github.event_name == 'issue_comment' && github.event.action == 'created' && !github.event.issue.pull_request
+      - uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
-          unlabel: pending::feedback
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+          labels: pending::feedback
+          github_token: ${{ secrets.PROJECT_TOKEN }}
+      - uses: actions-ecosystem/action-add-labels@v1.1.0
+        # if the author closed out the issue we will not apply [pending::support]
+        if: github.event.issue.state == 'open'
+        with:
+          labels: pending::support
+          github_token: ${{ secrets.PROJECT_TOKEN }}
 
   # move to Backlog board if labeled as [backlog]
   backlog:
+    if: >-
+      github.event_name == 'issues'
+      && github.event.action == 'labeled'
+      && github.event.issue.state == 'open'
+      && contains(github.event.issue.labels.*.name, 'backlog')
     runs-on: ubuntu-latest
     steps:
       - uses: alex-page/github-project-automation-plus@v0.8.1
-        if: contains(github.event.issue.labels.*.name, 'backlog')
         with:
           action: delete
           project: Triaging
           column: Ready
           repo-token: ${{ secrets.PROJECT_TOKEN }}
       - uses: alex-page/github-project-automation-plus@v0.8.1
-        if: contains(github.event.issue.labels.*.name, 'backlog')
         with:
-          action: update
+          action: add
           project: Backlog
           column: Unplanned
           repo-token: ${{ secrets.PROJECT_TOKEN }}
 
   # remove [backlog] (& remove from Backlog board) if milestoned
   milestoned:
+    if: >-
+      github.event_name == 'issues'
+      && github.event.action == 'milestoned'
+      && github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v2.2.0
-        if: github.event.action == 'milestoned'
+      - uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
-          unlabel: backlog
-          github-token: ${{ secrets.PROJECT_TOKEN }}
-      - uses: alex-page/github-project-automation-plus@v0
+          labels: backlog
+          github_token: ${{ secrets.PROJECT_TOKEN }}
+      - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
           action: delete
           project: Backlog
@@ -71,16 +93,19 @@ jobs:
 
   # add [backlog] (& move back to Backlog board) if demilestoned
   demilestoned:
+    if: >-
+      github.event_name == 'issues'
+      && github.event.action == 'demilestoned'
+      && github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v2.2.0
-        if: github.event.action == 'demilestoned'
+      - uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
-          label: backlog
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+          labels: backlog
+          github_token: ${{ secrets.PROJECT_TOKEN }}
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
-          action: update
+          action: add
           project: Backlog
           column: Do Next
           repo-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
Adds the following automations:

- If an issue is milestoned:
  - the `backlog` label will be removed
  - the issue will be removed from the Backlog board
  - (fail-safe) the issue will be removed from the Triaging board
- If an issue is demilestoned:
  - the `backlog` label will be added
  - the issue will be added to the Backlog board in the `Do Next` column
- If an issue is commented by the author:
  - the `pending::feedback` label will be removed
  - the `pending::support` label is added