### PR TITLE
Libmamba 0.19 investigation

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -383,9 +383,18 @@ def remove_auth(url):
 
 
 def escape_channel_url(channel):
+    if on_win and channel.startswith("file:"):
+        channel = channel.replace("\\", "/")
     parts = _urlparse(channel)
     if parts.scheme:
-        parts = parts._replace(path=quote(parts.path))
+        components = parts.path.split("/")
+        if on_win and len(parts.netloc) == 2 and parts.netloc[1] == ":":
+            # with absolute paths (e.g. C:/something), C:, D:, etc are parsed as netloc
+            path = "/".join([parts.netloc] + [quote(p) for p in components])
+            parts = parts._replace(netloc=None)
+        else:
+            path = "/".join([quote(p) for p in components])
+        parts = parts._replace(path=path)
         return _urlunparse(parts)
     return channel
 

--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -383,8 +383,11 @@ def remove_auth(url):
 
 
 def escape_channel_url(channel):
-    if on_win and channel.startswith("file:"):
-        channel = channel.replace("\\", "/")
+    if channel.startswith("file:"):
+        if "%" in channel:  # it's escaped already
+            return channel
+        if on_win:
+            channel = channel.replace("\\", "/")
     parts = _urlparse(channel)
     if parts.scheme:
         components = parts.path.split("/")

--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -388,10 +388,13 @@ def escape_channel_url(channel):
     parts = _urlparse(channel)
     if parts.scheme:
         components = parts.path.split("/")
-        if on_win and len(parts.netloc) == 2 and parts.netloc[1] == ":":
-            # with absolute paths (e.g. C:/something), C:, D:, etc are parsed as netloc
-            path = "/".join([parts.netloc] + [quote(p) for p in components])
-            parts = parts._replace(netloc=None)
+        if on_win:
+            if len(parts.netloc) == 2 and parts.netloc[1] == ":":
+                # with absolute paths (e.g. C:/something), C:, D:, etc might get parsed as netloc
+                path = "/".join([parts.netloc] + [quote(p) for p in components])
+                parts = parts._replace(netloc="")
+            else:
+                path = "/".join(components[:2] + [quote(p) for p in components[2:]])
         else:
             path = "/".join([quote(p) for p in components])
         parts = parts._replace(path=path)

--- a/conda/core/solve/libmamba.py
+++ b/conda/core/solve/libmamba.py
@@ -268,22 +268,16 @@ class LibMambaSolver(Solver):
 
     def _channel_urls(self):
         """
-        TODO: This collection of workarounds should be, ideally,
-        handled in libmamba:
-
-        - Escape URLs
-        - Handle `local` correctly
+        TODO: libmambapy could handle path to url, and escaping
+        but so far we are doing it ourselves
         """
         def _channel_to_url_or_name(channel):
             # This fixes test_activate_deactivate_modify_path_bash
             # and other local channels (path to url) issues
             urls = []
             for url in channel.urls():
-                if url.startswith((context._channel_alias,) + context.migrated_channel_aliases):
-                    urls.append(channel.name)
                 url = url.rstrip("/").rsplit("/", 1)[0]  # remove subdir
                 urls.append(escape_channel_url(url))
-
             # deduplicate
             urls = list(OrderedDict.fromkeys(urls))
             return urls

--- a/conda/core/solve/libmamba.py
+++ b/conda/core/solve/libmamba.py
@@ -289,12 +289,12 @@ class LibMambaSolver(Solver):
                 channel = subdir_url.rstrip("/").rsplit("/", 1)[0]
 
             if isinstance(channel, Channel):
-                channel = channel.base_url or channel.name
-            # absolute path C:/path/stuff, problematic with escaping
-            if on_win and channel[0] in ascii_letters and channel[1] == ":":
-                channel = path_to_url(channel)
-            else:
-                channel = escape_channel_url(channel)
+                channel = channel.url().rstrip("/").rsplit("/", 1)[0] or channel.name
+            # # absolute path C:/path/stuff, problematic with escaping
+            # if on_win and channel[0] in ascii_letters and channel[1] == ":":
+            #     channel = path_to_url(channel)
+            # else:
+            #     channel = escape_channel_url(channel)
             channels.append(channel)
         if context.restore_free_channel and "https://repo.anaconda.com/pkgs/free" not in channels:
             channels.append('https://repo.anaconda.com/pkgs/free')
@@ -1074,17 +1074,17 @@ class LibMambaSolver(Solver):
         # self.specs_to_remove = {MatchSpec(name) for name in state["names_to_remove"]
         #                         if not name.startswith("__")}
 
-        if on_win:
-            # TODO: We are manually decoding local paths in windows because the colon
-            # in paths like file:///C:/Users... gets html escaped as %3a in our workarounds
-            # There must be a better way to do this but we will find it while cleaning up
-            final_prefix_values = []
-            for pkg in final_prefix_map.values():
-                if pkg.url and pkg.url.startswith("file://") and "%" in pkg.url:
-                    pkg.url = percent_decode(pkg.url)
-                final_prefix_values.append(pkg)
-        else:
-            final_prefix_values = final_prefix_map.values()
+        # if on_win:
+        #     # TODO: We are manually decoding local paths in windows because the colon
+        #     # in paths like file:///C:/Users... gets html escaped as %3a in our workarounds
+        #     # There must be a better way to do this but we will find it while cleaning up
+        #     final_prefix_values = []
+        #     for pkg in final_prefix_map.values():
+        #         if pkg.url and pkg.url.startswith("file://") and "%" in pkg.url:
+        #             pkg.url = percent_decode(pkg.url)
+        #         final_prefix_values.append(pkg)
+        # else:
+        final_prefix_values = final_prefix_map.values()
 
         # TODO: Review performance here just in case
         return IndexedSet(PrefixGraph(final_prefix_values).graph)

--- a/conda/core/solve/libmamba.py
+++ b/conda/core/solve/libmamba.py
@@ -221,7 +221,7 @@ class LibMambaSolver(Solver):
 
     def _setup_state(self):
         import libmambapy as api
-        from mamba.utils import load_channels, get_installed_jsonfile, init_api_context
+        from .libmamba_utils import load_channels, get_installed_jsonfile, init_api_context
 
         init_api_context()
 
@@ -831,7 +831,7 @@ class LibMambaSolver(Solver):
 
     def _export_final_state(self, state):
         import libmambapy as api
-        from mamba.utils import to_package_record_from_subjson
+        from .libmamba_utils import to_package_record_from_subjson
 
         solver = state["solver"]
         index = state["index"]

--- a/conda/core/solve/libmamba_utils.py
+++ b/conda/core/solve/libmamba_utils.py
@@ -57,7 +57,7 @@ def get_index(
             spec = (
                 spec[:first_at]
                 + urllib.parse.quote(spec[first_at])
-                + spec[first_at + 1 :]
+                + spec[first_at + 1:]
             )
         if platform:
             spec = spec + "[" + ",".join(platform) + "]"

--- a/conda/core/solve/libmamba_utils.py
+++ b/conda/core/solve/libmamba_utils.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2019, QuantStack
 # SPDX-License-Identifier: BSD-3-Clause
 
+# TODO: Temporarily vendored from mamba.utils v0.19 on 2021.12.02
+# Decide what to do with it when we split into a plugin
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
@@ -141,6 +144,9 @@ def load_channels(
         else:
             priority = 0
         if has_priority:
+            # NOTE: -- this is the whole reason we are vendoring this file --
+            # We are patching this from 0 to 1, starting with mamba 0.19
+            # Otherwise, test_create::test_force_remove fails :shrug:
             subpriority = 1
         else:
             subpriority = subprio_index

--- a/conda/core/solve/libmamba_utils.py
+++ b/conda/core/solve/libmamba_utils.py
@@ -1,0 +1,317 @@
+# Copyright (C) 2019, QuantStack
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+import os
+import tempfile
+import urllib.parse
+from collections import OrderedDict
+
+from ...base.constants import ChannelPriority
+from ...base.context import context
+from ...common.serialize import json_dump
+from ...common.url import join_url
+from ..index import _supplement_index_with_system, check_whitelist
+from ..prefix_data import PrefixData
+from ...gateways.connection.session import CondaHttpAuth
+from ...models.channel import Channel as CondaChannel
+from ...models.records import PackageRecord
+
+import libmambapy as api
+
+
+def get_index(
+    channel_urls=(),
+    prepend=True,
+    platform=None,
+    use_local=False,
+    use_cache=False,
+    unknown=None,
+    prefix=None,
+    repodata_fn="repodata.json",
+):
+    if isinstance(platform, str):
+        platform = [platform, "noarch"]
+
+    all_channels = []
+    if use_local:
+        all_channels.append("local")
+    all_channels.extend(channel_urls)
+    if prepend:
+        all_channels.extend(context.channels)
+    check_whitelist(all_channels)
+
+    # Remove duplicates but retain order
+    all_channels = list(OrderedDict.fromkeys(all_channels))
+
+    dlist = api.DownloadTargetList()
+
+    index = []
+
+    def fixup_channel_spec(spec):
+        at_count = spec.count("@")
+        if at_count > 1:
+            first_at = spec.find("@")
+            spec = (
+                spec[:first_at]
+                + urllib.parse.quote(spec[first_at])
+                + spec[first_at + 1 :]
+            )
+        if platform:
+            spec = spec + "[" + ",".join(platform) + "]"
+        return spec
+
+    all_channels = list(map(fixup_channel_spec, all_channels))
+    pkgs_dirs = api.MultiPackageCache(context.pkgs_dirs)
+    api.create_cache_dir(str(pkgs_dirs.first_writable_path))
+
+    for channel in api.get_channels(all_channels):
+        for channel_platform, url in channel.platform_urls(with_credentials=True):
+            full_url = CondaHttpAuth.add_binstar_token(url + "/" + repodata_fn)
+            name = None
+            if channel.name:
+                name = channel.name + "/" + channel_platform
+            else:
+                name = channel.platform_url(channel_platform, with_credentials=False)
+
+            sd = api.SubdirData(
+                name,
+                full_url,
+                api.cache_fn_url(full_url),
+                pkgs_dirs,
+                channel_platform == "noarch",
+            )
+            sd.load()
+
+            index.append(
+                (sd, {"platform": channel_platform, "url": url, "channel": channel})
+            )
+            dlist.add(sd)
+
+    is_downloaded = dlist.download(True)
+
+    if not is_downloaded:
+        raise RuntimeError("Error downloading repodata.")
+
+    return index
+
+
+def load_channels(
+    pool,
+    channels,
+    repos,
+    has_priority=None,
+    prepend=True,
+    platform=None,
+    use_local=False,
+    use_cache=True,
+    repodata_fn="repodata.json",
+):
+    index = get_index(
+        channel_urls=channels,
+        prepend=prepend,
+        platform=platform,
+        use_local=use_local,
+        repodata_fn=repodata_fn,
+        use_cache=use_cache,
+    )
+
+    if has_priority is None:
+        has_priority = context.channel_priority in [
+            ChannelPriority.STRICT,
+            ChannelPriority.FLEXIBLE,
+        ]
+
+    subprio_index = len(index)
+    if has_priority:
+        # first, count unique channels
+        n_channels = len(set([entry["channel"].canonical_name for _, entry in index]))
+        current_channel = index[0][1]["channel"].canonical_name
+        channel_prio = n_channels
+
+    for subdir, entry in index:
+        # add priority here
+        if has_priority:
+            if entry["channel"].canonical_name != current_channel:
+                channel_prio -= 1
+                current_channel = entry["channel"].canonical_name
+            priority = channel_prio
+        else:
+            priority = 0
+        if has_priority:
+            subpriority = 0
+        else:
+            subpriority = subprio_index
+            subprio_index -= 1
+
+        if not subdir.loaded() and entry["platform"] != "noarch":
+            # ignore non-loaded subdir if channel is != noarch
+            continue
+
+        if context.verbosity != 0 and not context.json:
+            print(
+                "Channel: {}, platform: {}, prio: {} : {}".format(
+                    entry["channel"], entry["platform"], priority, subpriority
+                )
+            )
+            print("Cache path: ", subdir.cache_path())
+
+        repo = subdir.create_repo(pool)
+        repo.set_priority(priority, subpriority)
+        repos.append(repo)
+
+    return index
+
+
+def init_api_context(use_mamba_experimental=False):
+    api_ctx = api.Context()
+
+    api_ctx.json = context.json
+    api_ctx.dry_run = context.dry_run
+    if context.json:
+        context.always_yes = True
+        context.quiet = True
+        if use_mamba_experimental:
+            context.json = False
+
+    api_ctx.verbosity = context.verbosity
+    api_ctx.set_verbosity(context.verbosity)
+    api_ctx.quiet = context.quiet
+    api_ctx.offline = context.offline
+    api_ctx.local_repodata_ttl = context.local_repodata_ttl
+    api_ctx.use_index_cache = context.use_index_cache
+    api_ctx.always_yes = context.always_yes
+    api_ctx.channels = context.channels
+    api_ctx.platform = context.subdir
+
+    if "MAMBA_EXTRACT_THREADS" in os.environ:
+        try:
+            max_threads = int(os.environ["MAMBA_EXTRACT_THREADS"])
+            api_ctx.extract_threads = max_threads
+        except ValueError:
+            v = os.environ["MAMBA_EXTRACT_THREADS"]
+            raise ValueError(
+                f"Invalid conversion of env variable 'MAMBA_EXTRACT_THREADS' from value '{v}'"
+            )
+
+    def get_base_url(url, name=None):
+        tmp = url.rsplit("/", 1)[0]
+        if name:
+            if tmp.endswith(name):
+                return tmp.rsplit("/", 1)[0]
+        return tmp
+
+    api_ctx.channel_alias = str(
+        get_base_url(context.channel_alias.url(with_credentials=True))
+    )
+
+    additional_custom_channels = {}
+    for el in context.custom_channels:
+        if context.custom_channels[el].canonical_name not in ["local", "defaults"]:
+            additional_custom_channels[el] = get_base_url(
+                context.custom_channels[el].url(with_credentials=True), el
+            )
+    api_ctx.custom_channels = additional_custom_channels
+
+    additional_custom_multichannels = {}
+    for el in context.custom_multichannels:
+        if el not in ["defaults", "local"]:
+            additional_custom_multichannels[el] = []
+            for c in context.custom_multichannels[el]:
+                additional_custom_multichannels[el].append(
+                    get_base_url(c.url(with_credentials=True))
+                )
+    api_ctx.custom_multichannels = additional_custom_multichannels
+
+    api_ctx.default_channels = [x.base_url for x in context.default_channels]
+
+    if context.ssl_verify is False:
+        api_ctx.ssl_verify = "<false>"
+    elif context.ssl_verify is not True:
+        api_ctx.ssl_verify = context.ssl_verify
+    api_ctx.target_prefix = context.target_prefix
+    api_ctx.root_prefix = context.root_prefix
+    api_ctx.conda_prefix = context.conda_prefix
+    api_ctx.pkgs_dirs = context.pkgs_dirs
+    api_ctx.envs_dirs = context.envs_dirs
+
+    api_ctx.connect_timeout_secs = int(round(context.remote_connect_timeout_secs))
+    api_ctx.max_retries = context.remote_max_retries
+    api_ctx.retry_backoff = context.remote_backoff_factor
+    api_ctx.add_pip_as_python_dependency = context.add_pip_as_python_dependency
+    api_ctx.use_only_tar_bz2 = context.use_only_tar_bz2
+
+    if context.channel_priority is ChannelPriority.STRICT:
+        api_ctx.channel_priority = api.ChannelPriority.kStrict
+    elif context.channel_priority is ChannelPriority.FLEXIBLE:
+        api_ctx.channel_priority = api.ChannelPriority.kFlexible
+    elif context.channel_priority is ChannelPriority.DISABLED:
+        api_ctx.channel_priority = api.ChannelPriority.kDisabled
+
+
+def to_conda_channel(channel, platform):
+    if channel.scheme == "file":
+        return CondaChannel.from_value(
+            channel.platform_url(platform, with_credentials=False)
+        )
+
+    return CondaChannel(
+        channel.scheme,
+        channel.auth,
+        channel.location,
+        channel.token,
+        channel.name,
+        platform,
+        channel.package_filename,
+    )
+
+
+def to_package_record_from_subjson(entry, pkg, jsn_string):
+    channel_url = entry["url"]
+    info = json.loads(jsn_string)
+    info["fn"] = pkg
+    info["channel"] = to_conda_channel(entry["channel"], entry["platform"])
+    info["url"] = join_url(channel_url, pkg)
+    package_record = PackageRecord(**info)
+    return package_record
+
+
+def get_installed_packages(prefix, show_channel_urls=None):
+    result = {"packages": {}}
+
+    # Currently, we need to have pip interop disabled :/
+    installed = {
+        rec: rec for rec in PrefixData(prefix, pip_interop_enabled=False).iter_records()
+    }
+
+    # add virtual packages as installed packages
+    # they are packages installed on the system that conda can do nothing
+    # about (e.g. glibc)
+    # if another version is needed, installation just fails
+    # they don't exist anywhere (they start with __)
+    _supplement_index_with_system(installed)
+    installed = list(installed)
+
+    for prec in installed:
+        json_rec = prec.dist_fields_dump()
+        json_rec["depends"] = prec.depends
+        json_rec["constrains"] = prec.constrains
+        json_rec["build"] = prec.build
+        result["packages"][prec.fn] = json_rec
+
+    return installed, result
+
+
+installed_pkg_recs = None
+
+
+def get_installed_jsonfile(prefix):
+    global installed_pkg_recs
+    installed_pkg_recs, output = get_installed_packages(prefix, show_channel_urls=True)
+    installed_json_f = tempfile.NamedTemporaryFile("w", delete=False)
+    installed_json_f.write(json_dump(output))
+    installed_json_f.flush()
+    return installed_json_f, installed_pkg_recs
+

--- a/conda/core/solve/libmamba_utils.py
+++ b/conda/core/solve/libmamba_utils.py
@@ -141,7 +141,7 @@ def load_channels(
         else:
             priority = 0
         if has_priority:
-            subpriority = 0
+            subpriority = 1
         else:
             subpriority = subprio_index
             subprio_index -= 1

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -144,8 +144,7 @@ def _get_temp_prefix(name=None, use_restricted_unicode=False):
     tmpdir = tmpdir_in_use or gettempdir()
     capable = running_a_python_capable_of_unicode_subprocessing()
 
-    # TODO: Remove libmamba check once https://github.com/mamba-org/mamba/issues/1201 is fixed
-    if not capable or use_restricted_unicode or context.solver_logic == SolverLogicChoice.LIBMAMBA:
+    if not capable or use_restricted_unicode:
         RESTRICTED = UNICODE_CHARACTERS_RESTRICTED_PY2 \
             if (sys.version_info[0] == 2) \
             else UNICODE_CHARACTERS_RESTRICTED_PY3

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1252,8 +1252,4 @@ class TestLibMambaSolver(SolverTests):
             'LibMambaSolver installs numpy with mkl while we were expecting no-mkl numpy': [
                 'test_remove',
             ],
-            'Known bug in mamba, see #10995': [
-                'test_noarch_preferred_over_arch_when_build_greater',
-                'test_noarch_preferred_over_arch_when_build_greater_dep',
-            ]
         }


### PR DESCRIPTION
The new version includes a patch for channel/subdir subpriorities that fixes some tests but makes another fail. It also includes Unicode fixes that might help with our windows issues. We'll take a look here.

Changes:

* Vendored `mamba.utils` into `conda.core.solve.libmamba_utils` as a temporary workaround to try different subpriorities.
* Escape local channels more robustly.