### PR TITLE
Automate sprint

### DIFF
--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -1,29 +1,18 @@
 name: Automate Boards
 on:
   issues:
-    types: [opened, labeled, milestoned, demilestoned]
+    types: [opened, labeled]
   issue_comment:
     types: [created]
+  project_card:
+    types: [created, deleted]
 jobs:
-  # move to Triaging board if new
-  triaging:
-    if: >-
-      github.event_name == 'issues'
-      && github.event.action == 'opened'
-      && github.event.issue.state == 'open'
-      && !contains(github.event.issue.labels.*.name, 'backlog')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
-        with:
-          action: add
-          project: Triaging
-          column: New
-          repo-token: ${{ secrets.PROJECT_TOKEN }}
-
-  # if labeled as [pending::feedback] and the author responded remove [pending::feedback] and add [pending::support]
-  # clearly this will not catch cases where multiple users act as the author/reporter, this is just an effort to catch the majority of support cases
+  # NOTE: doesn't catch cases where multiple users act as the author/reporter,
+  # this is just an effort to catch the majority of support cases
+  # TODO: create conda-triaging team and modify this to toggle label based on
+  # whether a non-triaging engineer commented
   pending_support:
+    # if [pending::feedback] and the author responds
     if: >-
       github.event_name == 'issue_comment'
       && github.event.action == 'created'
@@ -32,80 +21,164 @@ jobs:
       && github.event.issue.user.login == github.event.comment.user.login
     runs-on: ubuntu-latest
     steps:
+      # remove [pending::feedback]
       - uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
           labels: pending::feedback
           github_token: ${{ secrets.PROJECT_TOKEN }}
+      # add [pending::feedback], if still open
       - uses: actions-ecosystem/action-add-labels@v1.1.0
-        # if the author closed out the issue we will not apply [pending::support]
         if: github.event.issue.state == 'open'
         with:
           labels: pending::support
           github_token: ${{ secrets.PROJECT_TOKEN }}
 
-  # move to Backlog board if labeled as [backlog]
-  backlog:
+  move_to_triaging:
+    # if new issue and not [backlog] or [sprint]
     if: >-
-      github.event_name == 'issues'
-      && github.event.action == 'labeled'
-      && github.event.issue.state == 'open'
-      && contains(github.event.issue.labels.*.name, 'backlog')
+      github.event.issue.state == 'open' && (
+        (
+          github.event_name == 'issues'
+          && github.event.action == 'opened'
+          && !contains(github.event.issue.labels.*.name, 'backlog')
+          && !contains(github.event.issue.labels.*.name, 'sprint')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
+      # add to Triaging board
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
-          action: delete
+          action: add  # if not present
           project: Triaging
-          column: Ready
-          repo-token: ${{ secrets.PROJECT_TOKEN }}
-      - uses: alex-page/github-project-automation-plus@v0.8.1
-        with:
-          action: add
-          project: Backlog
-          column: Unplanned
+          column: New
           repo-token: ${{ secrets.PROJECT_TOKEN }}
 
-  # remove [backlog] (& remove from Backlog board) if milestoned
-  milestoned:
+  move_to_backlog:
+    # if new issue with [backlog]
+    # if labeled [backlog]
+    # if added to Backlog board
+    # if unlabeled [sprint]
+    # if removed from Sprint board
     if: >-
-      github.event_name == 'issues'
-      && github.event.action == 'milestoned'
-      && github.event.issue.state == 'open'
+      github.event.issue.state == 'open' && (
+        (
+          github.event_name == 'issues'
+          && github.event.action == 'opened'
+          && contains(github.event.issue.labels.*.name, 'backlog')
+          && !contains(github.event.issue.labels.*.name, 'sprint')
+        ) || (
+          github.event_name == 'issues'
+          && github.event.action == 'labeled'
+          && github.event.label.name == 'backlog'
+        ) || (
+          github.event_name == 'project_card'
+          && github.event.action == 'created'
+          && github.event.project_card.project_url == 'https://api.github.com/projects/13697370'
+        ) || (
+          github.event_name == 'issues'
+          && github.event.action == 'unlabeled'
+          && github.event.label.name == 'sprint'
+        ) || (
+          github.event_name == 'project_card'
+          && github.event.action == 'deleted'
+          && github.event.project_card.project_url == 'https://api.github.com/projects/13829490'
+        )
+      )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-remove-labels@v1.3.0
-        with:
-          labels: backlog
-          github_token: ${{ secrets.PROJECT_TOKEN }}
+      # (fail-safe) remove from Triaging board
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
-          action: delete
-          project: Backlog
-          column: Do Next
-          repo-token: ${{ secrets.PROJECT_TOKEN }}
-      # just in case the issue is still on the Triaging board
-      - uses: alex-page/github-project-automation-plus@v0.8.1
-        with:
-          action: delete
+          action: delete  # if present
           project: Triaging
-          column: Ready
+          column: Unused
           repo-token: ${{ secrets.PROJECT_TOKEN }}
-
-  # add [backlog] (& move back to Backlog board) if demilestoned
-  demilestoned:
-    if: >-
-      github.event_name == 'issues'
-      && github.event.action == 'demilestoned'
-      && github.event.issue.state == 'open'
-    runs-on: ubuntu-latest
-    steps:
+      # add [backlog] label
       - uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
           labels: backlog
           github_token: ${{ secrets.PROJECT_TOKEN }}
+      # add to Backlog board
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
-          action: add
+          action: add  # if not present
           project: Backlog
-          column: Do Next
+          column: Unplanned
+          repo-token: ${{ secrets.PROJECT_TOKEN }}
+      # remove [sprint] label
+      - uses: actions-ecosystem/action-remove-labels@v1.1.0
+        with:
+          labels: sprint
+          github_token: ${{ secrets.PROJECT_TOKEN }}
+      # remove from Sprint board
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          action: delete  # if present
+          project: Sprint
+          column: Unused
+          repo-token: ${{ secrets.PROJECT_TOKEN }}
+
+  move_to_sprint:
+    # if new issue with [sprint]
+    # if unlabeled [backlog]
+    # if removed from Backlog board
+    # if labeled [sprint]
+    # if added to Sprint board
+    if: >-
+      github.event.issue.state == 'open' && (
+        (
+          github.event_name == 'issues'
+          && github.event.action == 'opened'
+          && contains(github.event.issue.labels.*.name, 'sprint')
+        ) || (
+          github.event_name == 'issues'
+          && github.event.action == 'unlabeled'
+          && github.event.label.name == 'backlog'
+        ) || (
+          github.event_name == 'project_card'
+          && github.event.action == 'deleted'
+          && github.event.project_card.project_url == 'https://api.github.com/projects/13697370'
+        ) || (
+          github.event_name == 'issues'
+          && github.event.action == 'labeled'
+          && github.event.label.name == 'sprint'
+        ) || (
+          github.event_name == 'project_card'
+          && github.event.action == 'created'
+          && github.event.project_card.project_url == 'https://api.github.com/projects/13829490'
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      # (fail-safe) remove from Triaging board
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          action: delete  # if present
+          project: Triaging
+          column: Unused
+          repo-token: ${{ secrets.PROJECT_TOKEN }}
+      # remove [backlog] label
+      - uses: actions-ecosystem/action-remove-labels@v1.1.0
+        with:
+          labels: backlog
+          github_token: ${{ secrets.PROJECT_TOKEN }}
+      # remove from Backlog board
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          action: delete  # if present
+          project: Backlog
+          column: Unused
+          repo-token: ${{ secrets.PROJECT_TOKEN }}
+      # add [sprint] label
+      - uses: actions-ecosystem/action-add-labels@v1.1.0
+        with:
+          labels: sprint
+          github_token: ${{ secrets.PROJECT_TOKEN }}
+      # add to Sprint board
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          action: add  # if not present
+          project: Sprint
+          column: To Do
           repo-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -75,6 +75,8 @@ jobs:
           github.event_name == 'project_card'
           && github.event.action == 'created'
           && github.event.project_card.project_url == 'https://api.github.com/projects/13697370'
+          && !github.event.project_card.note
+          && github.event.project_card.content_url
         ) || (
           github.event_name == 'issues'
           && github.event.action == 'unlabeled'
@@ -83,10 +85,20 @@ jobs:
           github.event_name == 'project_card'
           && github.event.action == 'deleted'
           && github.event.project_card.project_url == 'https://api.github.com/projects/13829490'
+          && !github.event.project_card.note
+          && github.event.project_card.content_url
         )
       )
     runs-on: ubuntu-latest
     steps:
+      # (if project_card) get issue number
+      - name: number
+        if: github.event_name == 'project_card'
+        uses: frabert/replace-string-action@v2.0
+        with:
+          pattern: '.+/(\d+)'
+          string: ${{ github.event.project_card.content_url }}
+          replace-with: '$1'
       # (fail-safe) remove from Triaging board
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
@@ -98,6 +110,7 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
           labels: backlog
+          number: ${{ github.issue.number || steps.number.outputs.replaced }}
           github_token: ${{ secrets.PROJECT_TOKEN }}
       # add to Backlog board
       - uses: alex-page/github-project-automation-plus@v0.8.1
@@ -110,6 +123,7 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@v1.1.0
         with:
           labels: sprint
+          number: ${{ github.issue.number || steps.number.outputs.replaced }}
           github_token: ${{ secrets.PROJECT_TOKEN }}
       # remove from Sprint board
       - uses: alex-page/github-project-automation-plus@v0.8.1
@@ -139,6 +153,8 @@ jobs:
           github.event_name == 'project_card'
           && github.event.action == 'deleted'
           && github.event.project_card.project_url == 'https://api.github.com/projects/13697370'
+          && !github.event.project_card.note
+          && github.event.project_card.content_url
         ) || (
           github.event_name == 'issues'
           && github.event.action == 'labeled'
@@ -147,10 +163,20 @@ jobs:
           github.event_name == 'project_card'
           && github.event.action == 'created'
           && github.event.project_card.project_url == 'https://api.github.com/projects/13829490'
+          && !github.event.project_card.note
+          && github.event.project_card.content_url
         )
       )
     runs-on: ubuntu-latest
     steps:
+      # (if project_card) get issue number
+      - name: number
+        if: github.event_name == 'project_card'
+        uses: frabert/replace-string-action@v2.0
+        with:
+          pattern: '.+/(\d+)'
+          string: ${{ github.event.project_card.content_url }}
+          replace-with: '$1'
       # (fail-safe) remove from Triaging board
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
@@ -162,6 +188,7 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@v1.1.0
         with:
           labels: backlog
+          number: ${{ github.issue.number || steps.number.outputs.replaced }}
           github_token: ${{ secrets.PROJECT_TOKEN }}
       # remove from Backlog board
       - uses: alex-page/github-project-automation-plus@v0.8.1
@@ -174,6 +201,7 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
           labels: sprint
+          number: ${{ github.issue.number || steps.number.outputs.replaced }}
           github_token: ${{ secrets.PROJECT_TOKEN }}
       # add to Sprint board
       - uses: alex-page/github-project-automation-plus@v0.8.1


### PR DESCRIPTION
This adds automations to move issues from the backlog board to the sprint board. This does undo the milestone automation introduced in #11068 as I found that even if an issue has been earmarked for a specific milestone it doesn't mean anything with regards to where in the planning process the issue resides.

The sprint automation introduced here creates a circular effect between the backlog and sprint boards, e.g.:
- adding the backlog label (or removing the sprint label) will move it to the Backlog board (and add the backlog label)
- adding the sprint label (or removing the backlog label) will move it to the Sprint board (and add the sprint label)
- adding to the Backlog board (or removing from the Sprint board) will add the backlog label (and move it to the Backlog board)
- adding to the Sprint board (or removing from the Backlog board) will add the sprint label (and move it to the Sprint board)