### PR TITLE
Plugin system implementation

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -38,11 +38,11 @@ from ..common.configuration import (Configuration, ConfigurationLoadError, MapPa
 from ..common._os.linux import linux_get_libc_version
 from ..common.path import expand, paths_equal
 from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
-from ..common.decorators import env_override
 
 from .. import CONDA_SOURCE_ROOT
 
 from .. import plugins
+from ..plugins import archspec, cuda, linux, osx, windows  # noqa: F401
 
 try:
     os.getcwd()
@@ -136,6 +136,11 @@ def ssl_verify_validation(value):
 @functools.lru_cache(maxsize=None)  # XXX: Replace with functools.cache once we drop 3.8.
 def get_plugin_manager():
     pm = pluggy.PluginManager('conda')
+    pm.register(plugins.archspec)
+    pm.register(plugins.cuda)
+    pm.register(plugins.linux)
+    pm.register(plugins.osx)
+    pm.register(plugins.windows)
     pm.add_hookspecs(plugins)
     pm.load_setuptools_entrypoints('conda')
     return pm
@@ -907,12 +912,6 @@ class Context(Configuration):
         # DANGER: This is rather slow
         info = _get_cpu_info()
         return info['flags']
-
-    @memoizedproperty
-    @env_override('CONDA_OVERRIDE_CUDA', convert_empty_to_none=True)
-    def cuda_version(self):
-        from conda.common.cuda import cuda_detect
-        return cuda_detect()
 
     @property
     def category_map(self):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -15,6 +15,8 @@ import struct
 from contextlib import contextmanager
 from datetime import datetime
 
+import pluggy
+
 from .constants import (APP_NAME, ChannelPriority, DEFAULTS_CHANNEL_NAME, REPODATA_FN,
                         DEFAULT_AGGRESSIVE_UPDATE_PACKAGES, DEFAULT_CHANNELS,
                         DEFAULT_CHANNEL_ALIAS, DEFAULT_CUSTOM_CHANNELS, DepsModifier,
@@ -38,6 +40,8 @@ from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..common.decorators import env_override
 
 from .. import CONDA_SOURCE_ROOT
+
+from .. import plugins
 
 try:
     os.getcwd()
@@ -126,6 +130,13 @@ def ssl_verify_validation(value):
                     "certificate bundle file, or a path to a directory containing "
                     "certificates of trusted CAs." % value)
     return True
+
+
+def get_plugin_manager():
+    pm = pluggy.PluginManager('conda')
+    pm.add_hookspecs(plugins)
+    pm.load_setuptools_entrypoints('conda')
+    return pm
 
 
 class Context(Configuration):
@@ -360,6 +371,13 @@ class Context(Configuration):
 
         super(Context, self).__init__(search_path=search_path, app_name=APP_NAME,
                                       argparse_args=argparse_args)
+
+        # plugin support
+        self._plugin_manager = get_plugin_manager()
+
+    @property
+    def plugin_manager(self):
+        return self._plugin_manager
 
     def post_build_validation(self):
         errors = []

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import OrderedDict
 
+import functools
 from errno import ENOENT
 from logging import getLogger
 import os
@@ -132,6 +133,7 @@ def ssl_verify_validation(value):
     return True
 
 
+@functools.lru_cache(maxsize=None)  # XXX: Replace with functools.cache once we drop 3.8.
 def get_plugin_manager():
     pm = pluggy.PluginManager('conda')
     pm.add_hookspecs(plugins)

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -6,16 +6,21 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from argparse import (ArgumentParser as ArgumentParserBase, REMAINDER, RawDescriptionHelpFormatter,
                       SUPPRESS, _CountAction, _HelpAction)
 from logging import getLogger
+import itertools
+import operator
 import os
 from os.path import abspath, expanduser, join
 from subprocess import Popen
 import sys
 from textwrap import dedent
+import warnings
 
 from .. import __version__
+from ..base import context
 from ..base.constants import COMPATIBLE_SHELLS, CONDA_HOMEPAGE_URL, DepsModifier, \
     UpdateModifier, ExperimentalSolverChoice
 from ..common.constants import NULL
+from ..exceptions import PluginError
 
 log = getLogger(__name__)
 
@@ -107,6 +112,30 @@ class ArgumentParser(ArgumentParserBase):
         if self.description:
             self.description += "\n\nOptions:\n"
 
+        pm = context.get_plugin_manager()
+        self._subcommands = sorted(itertools.chain(
+            *pm.hook.conda_cli_register_subcommands()
+        ), key=operator.attrgetter('name'))
+
+        # check conflicts
+        seen = []
+        for subcommand in self._subcommands:
+            if subcommand.name in seen:
+                raise PluginError(
+                    'Conflicting subcommand entries found for the '
+                    f'`{subcommand.name}` subcommand. Multiple Conda plugins '
+                    'are registering this subcommand via the '
+                    '`conda_cli_register_subcommands` hook, please make sure '
+                    'you don\'t have any incompatible plugins installed.'
+                )
+            seen.append(subcommand.name)
+
+        if self._subcommands:
+            self.epilog = 'conda commands available from other packages:' + ''.join(
+                f'\n  {subcommand.name} - {subcommand.summary}'
+                for subcommand in self._subcommands
+            )
+
     def _get_action_from_name(self, name):
         """Given a name, get the Action instance registered with this parser.
         If only it were made available in the ArgumentError object. It is
@@ -142,6 +171,16 @@ class ArgumentParser(ArgumentParserBase):
                         self.print_help()
                         sys.exit(0)
                     else:
+                        # run subcommand (from plugins)
+                        for subcommand in self._subcommands:
+                            if cmd == subcommand.name:
+                                sys.exit(subcommand.action(sys.argv[2:]))
+                        # run subcommand (from executables) - legacy path
+                        warnings.warn(PendingDeprecationWarning(
+                            'Loading conda subcommands via executables is '
+                            'pending deprecation, in favor of the plugin system. '
+                            'See https://github.com/conda/conda/issues/XXX.'
+                        ))
                         executable = find_executable('conda-' + cmd)
                         if not executable:
                             from ..exceptions import CommandNotFoundError
@@ -153,6 +192,8 @@ class ArgumentParser(ArgumentParserBase):
         super(ArgumentParser, self).error(message)
 
     def print_help(self):
+        # code path pending deprecation, should be removed when subcommands via
+        # executables go away
         super(ArgumentParser, self).print_help()
 
         if sys.argv[1:] in ([], [''], ['help'], ['-h'], ['--help']):
@@ -160,7 +201,7 @@ class ArgumentParser(ArgumentParserBase):
             other_commands = find_commands()
             if other_commands:
                 builder = ['']
-                builder.append("conda commands available from other packages:")
+                builder.append("conda commands available from other packages (legacy):")
                 builder.extend('  %s' % cmd for cmd in sorted(other_commands))
                 print('\n'.join(builder))
 

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -36,19 +36,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 
-PARSER = None
-
-
-def generate_parser():
-    # Generally using `global` is an anti-pattern.  But it's the lightest-weight way to memoize
-    # or do a singleton.  I'd normally use the `@memoize` decorator here, but I don't want
-    # to copy in the code or take the import hit.
-    global PARSER
-    if PARSER is not None:
-        return PARSER
-    from .conda_argparse import generate_parser
-    PARSER = generate_parser()
-    return PARSER
+from .conda_argparse import generate_parser
 
 
 def init_loggers(context=None):

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1007,6 +1007,10 @@ class NoSpaceLeftError(CondaError):
         super(NoSpaceLeftError, self).__init__(message, caused_by=caused_by, **kwargs)
 
 
+class PluginError(CondaError):
+    pass
+
+
 def maybe_raise(error, context):
     if isinstance(error, CondaMultiError):
         groups = groupby(lambda e: isinstance(e, ClobberError), error.errors)

--- a/conda/plugins.py
+++ b/conda/plugins.py
@@ -1,0 +1,8 @@
+from collections.abc import Iterable
+from typing import Callable, List, NamedTuple, Optional, Tuple
+
+import pluggy
+
+
+_hookspec = pluggy.HookspecMarker('conda')
+hookimp = pluggy.HookimplMarker('conda')

--- a/conda/plugins.py
+++ b/conda/plugins.py
@@ -1,8 +1,38 @@
-from collections.abc import Iterable
-from typing import Callable, List, NamedTuple, Optional, Tuple
+import sys
+
+from typing import Callable, List, NamedTuple, Optional
 
 import pluggy
 
 
+if sys.version_info < (3, 9):
+    from typing import Iterable
+else:
+    from collections.abc import Iterable
+
+
 _hookspec = pluggy.HookspecMarker('conda')
 hookimp = pluggy.HookimplMarker('conda')
+
+
+class CondaSubcommand(NamedTuple):
+    """Conda subcommand entry.
+
+    :param name: Subcommand name (as-in ``conda my-subcommand-name``).
+    :param summary: Subcommand summary, will be shown in ``conda --help``.
+    :param action: Callable that will be run when the subcommand is invoked.
+    """
+    name: str
+    summary: str
+    action: Callable[
+        [List[str]],  # arguments
+        Optional[int],  # return code
+    ]
+
+
+@_hookspec
+def conda_cli_register_subcommands() -> Iterable[CondaSubcommand]:
+    """Register external subcommands in Conda.
+
+    :return: An iterable of subcommand entries.
+    """

--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -36,3 +36,16 @@ def conda_cli_register_subcommands() -> Iterable[CondaSubcommand]:
 
     :return: An iterable of subcommand entries.
     """
+
+
+class CondaVirtualPackage(NamedTuple):
+    name: str
+    version: Optional[str]
+
+
+@_hookspec
+def conda_cli_register_virtual_packages() -> Iterable[CondaVirtualPackage]:
+    """Register virtual packages in Conda.
+
+    :return: An iterable of virtual package entries.
+    """

--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 import sys
 
 from typing import Callable, List, NamedTuple, Optional

--- a/conda/plugins/archspec.py
+++ b/conda/plugins/archspec.py
@@ -1,0 +1,8 @@
+from conda import plugins
+
+
+@plugins.hookimp
+def conda_cli_register_virtual_packages():
+    from conda.core.index import get_archspec_name
+
+    yield plugins.CondaVirtualPackage('archspec', get_archspec_name())

--- a/conda/plugins/archspec.py
+++ b/conda/plugins/archspec.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 from conda import plugins
 
 

--- a/conda/plugins/cuda.py
+++ b/conda/plugins/cuda.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2021 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+import functools
+
+from conda import plugins
+from conda.common.decorators import env_override
+
+
+@functools.lru_cache(maxsize=1)
+@env_override('CONDA_OVERRIDE_CUDA', convert_empty_to_none=True)
+def cuda_version():
+    '''Attempt to detect the version of CUDA present in the operating system.
+
+    On Windows and Linux, the CUDA library is installed by the NVIDIA
+    driver package, and is typically found in the standard library path,
+    rather than with the CUDA SDK (which is optional for running CUDA apps).
+
+    On macOS, the CUDA library is only installed with the CUDA SDK, and
+    might not be in the library path.
+
+    Returns: version string (Ex: '9.2') or None if CUDA not found.
+    '''
+    # platform specific libcuda location
+    import platform
+    system = platform.system()
+    if system == 'Darwin':
+        lib_filenames = [
+            'libcuda.dylib',  # check library path first
+            '/usr/local/cuda/lib/libcuda.dylib'
+        ]
+    elif system == 'Linux':
+        lib_filenames = [
+            'libcuda.so',  # check library path first
+            '/usr/lib64/nvidia/libcuda.so',  # Redhat/CentOS/Fedora
+            '/usr/lib/x86_64-linux-gnu/libcuda.so',  # Ubuntu
+        ]
+    elif system == 'Windows':
+        lib_filenames = ['nvcuda.dll']
+    else:
+        return None  # CUDA not available for other operating systems
+
+    # open library
+    import ctypes
+    if system == 'Windows':
+        dll = ctypes.windll
+    else:
+        dll = ctypes.cdll
+    libcuda = None
+    for lib_filename in lib_filenames:
+        try:
+            libcuda = dll.LoadLibrary(lib_filename)
+            break
+        except:
+            pass
+    if libcuda is None:
+        return None
+
+    # Get CUDA version
+    try:
+        cuInit = libcuda.cuInit
+        flags = ctypes.c_uint(0)
+        ret = cuInit(flags)
+        if ret != 0:
+            return None
+
+        cuDriverGetVersion = libcuda.cuDriverGetVersion
+        version_int = ctypes.c_int(0)
+        ret = cuDriverGetVersion(ctypes.byref(version_int))
+        if ret != 0:
+            return None
+
+        # Convert version integer to version string
+        value = version_int.value
+        return '%d.%d' % (value // 1000, (value % 1000) // 10)
+    except:
+        return None
+
+
+@plugins.hookimp
+def conda_cli_register_virtual_packages():
+    yield plugins.CondaVirtualPackage('cuda', cuda_version())

--- a/conda/plugins/cuda.py
+++ b/conda/plugins/cuda.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Copyright (C) 2021 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/conda/plugins/linux.py
+++ b/conda/plugins/linux.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+import platform
+import os
+
+from conda import plugins
+from conda.common._os.linux import linux_get_libc_version
+
+
+@plugins.hookimp
+def conda_cli_register_virtual_packages():
+    if platform.system != 'Linux':
+        return
+
+    yield plugins.CondaVirtualPackage('unix', None)
+
+    # By convention, the kernel release string should be three or four
+    # numeric components, separated by dots, followed by vendor-specific
+    # bits.  For the purposes of versioning the `__linux` virtual package,
+    # discard everything after the last digit of the third or fourth
+    # numeric component; note that this breaks version ordering for
+    # development (`-rcN`) kernels, but we'll deal with that later.
+    dist_version = os.environ.get('CONDA_OVERRIDE_LINUX', platform.release())
+    m = re.match(r'\d+\.\d+(\.\d+)?(\.\d+)?', dist_version)
+    yield plugins.CondaVirtualPackage('linux', m.group() if m else '0')
+
+    libc_family, libc_version = linux_get_libc_version()
+    if not (libc_family and libc_version):
+        # Default to glibc when using CONDA_SUBDIR var
+        libc_family = 'glibc'
+    libc_version = os.getenv(f'CONDA_OVERRIDE_{libc_family.upper()}', libc_version)
+    yield plugins.CondaVirtualPackage(libc_family, libc_version)

--- a/conda/plugins/osx.py
+++ b/conda/plugins/osx.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+import platform
+
+from conda import plugins
+from conda.common._os.linux import linux_get_libc_version
+
+
+@plugins.hookimp
+def conda_cli_register_virtual_packages():
+    if platform.system != 'Darwin':
+        return
+
+    yield plugins.CondaVirtualPackage('unix', None)
+    yield plugins.CondaVirtualPackage(
+        'osx',
+        os.environ.get('CONDA_OVERRIDE_OSX', platform.mac_ver()[0]),
+    )

--- a/conda/plugins/windows.py
+++ b/conda/plugins/windows.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+import platform
+
+from conda import plugins
+
+
+@plugins.hookimp
+def conda_cli_register_virtual_packages():
+    if platform.system != 'Windows':
+        return
+
+    yield plugins.CondaVirtualPackage('win', None)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,6 +57,7 @@ that approach may not be as up to date.
    configuration
    api/index
    commands
+   plugin-api/index
    glossary
    dev-guide/index
    release-notes

--- a/docs/source/plugin-api/index.rst
+++ b/docs/source/plugin-api/index.rst
@@ -52,6 +52,7 @@ Hooks
    :maxdepth: 1
 
    subcommands
+   virtual_packages
 
 .. _pluggy: https://pluggy.readthedocs.io/en/stable/
 .. _`Python package entrypoints`: https://packaging.python.org/en/latest/specifications/entry-points/

--- a/docs/source/plugin-api/index.rst
+++ b/docs/source/plugin-api/index.rst
@@ -1,0 +1,57 @@
+================
+Conda Plugin API
+================
+
+As of X.Y, Conda has support for user plugins, enabling them to extend and/or
+change some of its functionality.
+
+Plugins are implemented via pluggy_ and discovered using
+`Python package entrypoints`_. You may refeer to pluggy_'s documentation
+for a full description of its features, but in summary, you will want to define
+the hooks you want to register and register your plugin under the ``conda``
+entrypoint namespace.
+
+Example:
+
+
+.. code-block:: python
+   :caption: my_plugin.py
+
+   import conda.plugins
+
+
+   @conda.plugins.hookimpl
+   def conda_cli_register_subcommands():
+       ...
+
+
+.. code-block:: python
+   :caption: setup.py
+
+   from setuptools import setup
+
+   setup(
+       name="my-conda-plugin",
+       install_requires="conda",
+       entry_points={"conda": ["my-conda-plugin = my_plugin"]},
+       py_modules=["my_plugin"],
+   )
+
+
+API Reference
+-------------
+
+.. py:module:: conda.plugins
+
+
+Hooks
+~~~~~
+
+
+.. toctree::
+   :maxdepth: 1
+
+   subcommands
+
+.. _pluggy: https://pluggy.readthedocs.io/en/stable/
+.. _`Python package entrypoints`: https://packaging.python.org/en/latest/specifications/entry-points/

--- a/docs/source/plugin-api/subcommands.rst
+++ b/docs/source/plugin-api/subcommands.rst
@@ -1,0 +1,40 @@
+=================
+Conda Subcommands
+=================
+
+The Conda CLI can be extended with the ``conda_cli_register_subcommands`` plugin
+hook. Registered subcommands will be available under the ``conda <subcommand>``
+command.
+
+
+Reference
+---------
+
+
+.. py:module:: conda.plugins
+   :noindex:
+
+.. autofunction:: conda_cli_register_subcommands
+
+.. autoclass:: CondaSubcommand
+   :members:
+   :undoc-members:
+
+
+Example
+-------
+
+
+.. code-block:: python
+
+   def example_command(args):
+       print("Example command!")
+
+
+   @conda.plugins.hookimp
+   def conda_cli_register_subcommands(self):
+       yield plugins.CondaSubcommand(
+           name="example",
+           summary="example command",
+           action=example_command,
+       )

--- a/docs/source/plugin-api/virtual_packages.rst
+++ b/docs/source/plugin-api/virtual_packages.rst
@@ -1,0 +1,39 @@
+======================
+Conda Virtual Packages
+======================
+
+Conda allow registering virtual packages in the index data via the plugin
+system. This allows users to write plugins that provide version identification
+for proprieties only known at runtime for example, like OS information, etc.
+
+
+Reference
+---------
+
+
+.. py:module:: conda.plugins
+   :noindex:
+
+.. autofunction:: conda_cli_register_virtual_packages
+
+.. autoclass:: CondaVirtualPackage
+   :members:
+   :undoc-members:
+
+
+Example
+-------
+
+
+.. code-block:: python
+
+   def example_command(args):
+       print("Example command!")
+
+
+   @conda.plugins.hookimp
+   def conda_cli_register_subcommands(self):
+       yield plugins.CondaVirtualPackage(
+           name="my_custom_os",
+           version="1.2.3",
+       )

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,12 +13,6 @@ addopts =
     --tb native
     --strict-markers
     --durations 16
-    --xdoctest-modules
-    --xdoctest-style=google
-    --cov-report xml
-    --cov-report term-missing
-    --cov conda
-    --cov-append
 doctest_optionflags =
     NORMALIZE_WHITESPACE
     IGNORE_EXCEPTION_DETAIL

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,0 +1,26 @@
+import sys
+
+import conda.cli
+
+from conda import plugins
+
+import pluggy
+import pytest
+
+
+@pytest.fixture()
+def plugin_manager(mocker):
+    pm = pluggy.PluginManager('conda')
+    pm.add_hookspecs(plugins)
+
+    mocker.patch('conda.base.context.get_plugin_manager', return_value=pm)
+
+    return pm
+
+
+@pytest.fixture()
+def cli_main(monkeypatch):
+    def run_main(*args):
+        monkeypatch.setattr(sys, 'argv', ['conda', *args])
+        conda.cli.main()
+    return run_main

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 import sys
 
 import conda.cli

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -1,0 +1,67 @@
+import re
+import textwrap
+
+import conda.exceptions
+from conda import plugins
+
+import pytest
+
+
+class SubcommandPlugin:
+        def __init__(self):
+            self.invoked = False
+            self.args = None
+
+        def custom_command(self, args):
+            pass
+
+        @plugins.hookimp
+        def conda_cli_register_subcommands(self):
+            yield plugins.CondaSubcommand(
+                name='custom',
+                summary='test custom command',
+                action=self.custom_command,
+            )
+
+
+@pytest.fixture()
+def plugin(mocker, plugin_manager):
+    mocker.patch.object(SubcommandPlugin, 'custom_command')
+
+    plugin = SubcommandPlugin()
+    plugin_manager.register(plugin)
+    return plugin
+
+
+def test_invoked(plugin, cli_main):
+    cli_main('custom', 'some-arg', 'some-other-arg')
+
+    plugin.custom_command.assert_called_with(['some-arg', 'some-other-arg'])
+
+
+def test_help(plugin, cli_main, capsys):
+    cli_main('--help')
+
+    stdout, stderr = capsys.readouterr()
+
+    assert textwrap.dedent('''
+        conda commands available from other packages:
+          custom - test custom command
+    ''') in stdout
+
+
+def test_duplicated(plugin_manager, cli_main, capsys):
+    plugin_manager.register(SubcommandPlugin())
+    plugin_manager.register(SubcommandPlugin())
+
+    cli_main()
+
+    stdout, stderr = capsys.readouterr()
+
+    assert (
+        'Conflicting subcommand entries found for the '
+        '`custom` subcommand. Multiple Conda plugins '
+        'are registering this subcommand via the '
+        '`conda_cli_register_subcommands` hook, please make sure '
+        'you don\'t have any incompatible plugins installed.'
+    ) in stderr

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 import re
 import textwrap
 

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -1,0 +1,67 @@
+import re
+import textwrap
+
+import conda.core.index
+import conda.exceptions
+from conda.base.context import context
+from conda import plugins
+
+import pytest
+
+
+class VirtualPackagesPlugin:
+        @plugins.hookimp
+        def conda_cli_register_virtual_packages(self):
+            yield plugins.CondaVirtualPackage(
+                name='abc',
+                version='123',
+            )
+            yield plugins.CondaVirtualPackage(
+                name='def',
+                version='456',
+            )
+            yield plugins.CondaVirtualPackage(
+                name='ghi',
+                version='789',
+            )
+
+
+@pytest.fixture()
+def plugin(plugin_manager):
+    plugin = VirtualPackagesPlugin()
+    plugin_manager.register(plugin)
+    return plugin
+
+
+def test_invoked(plugin, cli_main):
+    index = conda.core.index.get_reduced_index(
+        context.default_prefix,
+        context.default_channels,
+        context.subdirs,
+        (),
+        context.repodata_fns[0],
+    )
+
+    assert index['__abc'].version == '123'
+    assert index['__def'].version == '456'
+    assert index['__ghi'].version == '789'
+
+
+def test_duplicated(plugin_manager, cli_main, capsys):
+    plugin_manager.register(VirtualPackagesPlugin())
+    plugin_manager.register(VirtualPackagesPlugin())
+
+    with pytest.raises(conda.exceptions.PluginError, match=re.escape(
+        'Conflicting virtual package entries found for the '
+        '`custom` subcommand. Multiple Conda plugins '
+        'are registering this virtual package via the '
+        '`conda_cli_register_virtual_packages` hook, please make sure '
+        'you don\'t have any incompatible plugins installed.'
+    )):
+        conda.core.index.get_reduced_index(
+            context.default_prefix,
+            context.default_channels,
+            context.subdirs,
+            (),
+            context.repodata_fns[0],
+        )

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
 import re
 import textwrap
 


### PR DESCRIPTION
This got a bit delayed with Christmas, and then I fell ill, but it is here at last.

The plugin system itself is fairly simple, it essentially consists of a few definitions in a new `conda.plugins` module.
Initially, I planned to only expose the plugin manager instance to the rest of the conda codebase via the context object, but that proved insufficient right on the first plugin implementation, as the argument parsing happens before the context object is created, and the context object creation is currently inherently dependent on the argument parsing. As such, the plugin manager is also exposed via a helper function in the context module. This might limit us in the future, but that could potentially be solved by refactoring the context object a bit.
Instead of exposing the plugin manager directly, I think we might benefit of having a wrapper around it that does all the data necessary gathering, but this is not clear to me at this point, hopefully it will become clearer as we implement more plugins and get an idea of their needs.

Overall, I think the code size is pretty small, which was my goal. It demonstrates how easily plugins can be implemented in the conda codebase.

Regarding the actual subcommand plugin implementation, I did explore improving things a little bit more in regards to the `argparse` API usage and how to plug this functionality into it, but ultimately settled on just setting `epilog` instead of overwriting `print_help`. Part of the reasoning was that jezdez expressed the wish to move away from `argparse` to a different module, like `click`, so spending more time trying to improve this design did not seem worth it. For the same reason, and backwards compatibility, I decided to give plugin users full control over the argument parsing, instead of locking them into a specific API, like integrating the hook directly into `argparse`

I still need to add the tests, but I think I am reasonably happy with the end result so far.
