### PR TITLE
Update git:// to git+https:// in tests (GitHub policy changed)

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1991,7 +1991,7 @@ dependencies:
                 # install an "editable" urllib3 that cannot be managed
                 output, err, _ = run_command(Commands.RUN, prefix, '--cwd', workdir,
                                              "python", "-m", "pip", "install", "-e",
-                                             "git://github.com/urllib3/urllib3.git@1.19.1#egg=urllib3")
+                                             "git+https://github.com/urllib3/urllib3.git@1.19.1#egg=urllib3")
                 assert isfile(join(workdir, "src", "urllib3", "urllib3", "__init__.py"))
                 assert not isfile(join("src", "urllib3", "urllib3", "__init__.py"))
                 PrefixData._cache_.clear()


### PR DESCRIPTION
`test_conda_pip_interop_conda_editable_package` will fail today because [GitHub is performing a brownout](https://github.blog/2021-09-01-improving-git-protocol-security-github/):

```
Obtaining urllib3 from git+git://github.com/urllib3/urllib3.git@1.19.1#egg=urllib3

  Cloning git://github.com/urllib3/urllib3.git (to revision 1.19.1) to c:\tmp\test_conda_pip_interop_conda_e0\tmpm948_oac\b183 dcbfae\src\urllib3

fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

We were fetching that package with `git://` on pip 10. Instead, we can use `git+https://`. No functionality is changed and the tests pass.