### PR TITLE
Fix `labels.yml` syntax error

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -86,7 +86,7 @@
   color: "86C579"
   aliases: []
 - name: tag::auth
-  description:
+  # description:
   color: "86C579"
   aliases: []
 - name: tag::artifact-verification


### PR DESCRIPTION
`description` cannot be `null`