### PR TITLE
More local labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -101,3 +101,14 @@
   description: related to shared/multi-user installs
   color: "86C579"
   aliases: []
+
+# Deprecated
+- name: epic
+  description: "[deprecated] use milestones"
+  color: "888888"
+- name: priority-high
+  description: "[deprecated] use severity::*"
+  color: "888888"
+- name: priority-low
+  description: "[deprecated] use severity::*"
+  color: "888888"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,9 @@
+# Builds
+- name: build::canary
+  description: trigger a canary build for this PR
+  color: "7B4052"
+  aliases: ["build::review"]
+
 # Solver
 - name: solver
   description: pertains to the solver


### PR DESCRIPTION
Further standardizing our `labels.yml` to reflect what was learned from [label sync dry runs](https://github.com/conda/conda/runs/4873761672?check_suite_focus=true#step:5:615)

| Label | Description |
|:-:|:--|
| ![`build::canary`](https://img.shields.io/badge/-build::canary-7B4052) | trigger a canary build for this PR |

cc: @jezdez 