### PR TITLE
Add type::installer & type::packaging, revert build::review

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -4,6 +4,14 @@
   color: "7B4052"
   aliases: ["build::review"]
 
+# Types
+- name: type::installer
+  description: indicates a request or issue pertaining to the installer
+  color: "fff2cc"
+- name: type::packaging
+  description: indicates a request regarding a package
+  color: "fff2cc"
+
 # Solver
 - name: solver
   description: pertains to the solver

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,8 +1,7 @@
 # Builds
-- name: build::canary
-  description: trigger a canary build for this PR
+- name: build::review
+  description: trigger a build for this PR
   color: "7B4052"
-  aliases: ["build::review"]
 
 # Types
 - name: type::installer


### PR DESCRIPTION
Adding missing labels:

| Label | Description |
|:-:|:--|
| ![`type::installer`](https://img.shields.io/badge/-type::installer-fff2cc) | indicates a request or issue pertaining to the installer |
| ![`type::packaging`](https://img.shields.io/badge/-type::packaging-fff2cc) | indicates a request regarding a package |
| ![`build::review`](https://img.shields.io/badge/-build::review-7B4052) | trigger a build for this PR |