### PR TITLE
Modify `quote_for_shell` signature

### DIFF
--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -50,10 +50,10 @@ def rmtree(path, *args, **kwargs):
                 from conda.utils import quote_for_shell
 
                 with Utf8NamedTemporaryFile(mode="w", suffix=".bat", delete=False) as batch_file:
-                    batch_file.write('RD /S {}\n'.format(quote_for_shell([path])))
-                    batch_file.write('chcp 65001\n')
-                    batch_file.write('RD /S {}\n'.format(quote_for_shell([path])))
-                    batch_file.write('EXIT 0\n')
+                    batch_file.write("RD /S {}\n".format(quote_for_shell(path)))
+                    batch_file.write("chcp 65001\n")
+                    batch_file.write("RD /S {}\n".format(quote_for_shell(path)))
+                    batch_file.write("EXIT 0\n")
                     name = batch_file.name
                 # If the above is bugged we can end up deleting hard-drives, so we check
                 # that 'path' appears in it. This is not bulletproof but it could save you (me).

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1776,7 +1776,8 @@ class InteractiveShell(object):
     init_command = None
     print_env_var = None
     from conda.utils import quote_for_shell
-    exe_quoted = quote_for_shell([sys.executable.replace('\\', '/') if on_win else sys.executable])
+
+    exe_quoted = quote_for_shell(sys.executable.replace("\\", "/") if on_win else sys.executable)
     shells = {
         'posix': {
             'activator': 'posix',
@@ -1893,10 +1894,17 @@ class InteractiveShell(object):
         shell_found = which(self.shell_name) or self.shell_name
         args = list(self.args) if hasattr(self, 'args') else list()
 
-        p = PopenSpawn(quote_for_shell([shell_found] + args, shell='cmd.exe' if on_win else 'bash'),
-                       timeout=12, maxread=5000, searchwindowsize=None,
-                       logfile=sys.stdout, cwd=os.getcwd(), env=env, encoding='utf-8',
-                       codec_errors='strict')
+        p = PopenSpawn(
+            quote_for_shell(shell_found, *args),
+            timeout=12,
+            maxread=5000,
+            searchwindowsize=None,
+            logfile=sys.stdout,
+            cwd=os.getcwd(),
+            env=env,
+            encoding="utf-8",
+            codec_errors="strict",
+        )
 
         # set state for context
         joiner = os.pathsep.join if self.shell_name == 'fish' else self.activator.pathsep_join


### PR DESCRIPTION
Change expected arguments for cleaner argument passing.

I have checked `conda-build` and it no longer utilizes `quote_for_shell` but if it did this change is designed to be backwards compatible.

Working towards #10972 