### PR TITLE
Refactor `is_valid_prefix` into `validate_prefix`

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -220,9 +220,18 @@ def check_non_admin():
             on your system for non-privileged users.
         """))
 
-def is_valid_prefix(prefix):
+def validate_prefix(prefix):
+    """Verifies the prefix is a valid conda environment.
+
+    :raises EnvironmentLocationNotFound: Non-existent path or not a directory.
+    :raises DirectoryNotACondaEnvironmentError: Directory is not a conda environment.
+    :returns: Valid prefix.
+    :rtype: str
+    """
     if isdir(prefix):
         if not isfile(join(prefix, 'conda-meta', 'history')):
             raise DirectoryNotACondaEnvironmentError(prefix)
     else:
         raise EnvironmentLocationNotFound(prefix)
+
+    return prefix

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -10,7 +10,7 @@ from ..utils import wrap_subprocess_call
 from ..gateways.disk.delete import rm_rf
 from ..common.compat import encode_environment
 from ..gateways.subprocess import subprocess_call
-from .common import is_valid_prefix
+from .common import validate_prefix
 
 
 def execute(args, parser):
@@ -19,11 +19,15 @@ def execute(args, parser):
     call = args.executable_call
     cwd = args.cwd
     no_capture_output = args.no_capture_output
-    prefix = context.target_prefix or os.getenv("CONDA_PREFIX") or context.root_prefix
-    is_valid_prefix(prefix)
 
-    script_caller, command_args = wrap_subprocess_call(on_win, context.root_prefix, prefix,
-                                                       args.dev, args.debug_wrapper_scripts, call)
+    script_caller, command_args = wrap_subprocess_call(
+        on_win,
+        context.root_prefix,
+        validate_prefix(context.target_prefix or os.getenv("CONDA_PREFIX") or context.root_prefix),
+        args.dev,
+        args.debug_wrapper_scripts,
+        call,
+    )
     env = encode_environment(os.environ.copy())
 
     response = subprocess_call(command_args, env=env, path=cwd, raise_on_error=False,

--- a/news/gh-11172-validate-prefix
+++ b/news/gh-11172-validate-prefix
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Refactored `is_valid_prefix` into `validate_prefix`.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
Another cleanup. This function is also unused in conda-build.

The big change with this function is adding the prefix as a passthrough which helps streamline usage.

Working towards #10972 