### PR TITLE
Remove unnecessary `on_win` arg for `conda.utils.wrap_subprocess_call`

### DIFF
--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -8,7 +8,7 @@ import sys
 from ..base.context import context
 from ..utils import wrap_subprocess_call
 from ..gateways.disk.delete import rm_rf
-from ..common.compat import on_win, encode_environment
+from ..common.compat import encode_environment
 from ..gateways.subprocess import subprocess_call
 from .common import validate_prefix
 
@@ -16,7 +16,6 @@ from .common import validate_prefix
 def execute(args, parser):
     # create run script
     script, command = wrap_subprocess_call(
-        on_win,
         context.root_prefix,
         validate_prefix(context.target_prefix or os.getenv("CONDA_PREFIX") or context.root_prefix),
         args.dev,

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1178,7 +1178,11 @@ def run_script(prefix, prec, action='post-link', env_prefix=None, activate=False
             return False
         if activate:
             script_caller, command_args = wrap_subprocess_call(
-                on_win, context.root_prefix, prefix, context.dev, False, ('@CALL', path)
+                context.root_prefix,
+                prefix,
+                context.dev,
+                False,
+                ("@CALL", path),
             )
         else:
             command_args = [comspec, '/d', '/c', path]
@@ -1186,7 +1190,11 @@ def run_script(prefix, prec, action='post-link', env_prefix=None, activate=False
         shell_path = 'sh' if 'bsd' in sys.platform else 'bash'
         if activate:
             script_caller, command_args = wrap_subprocess_call(
-                on_win, context.root_prefix, prefix, context.dev, False, (".", path)
+                context.root_prefix,
+                prefix,
+                context.dev,
+                False,
+                (".", path),
             )
         else:
             shell_path = 'sh' if 'bsd' in sys.platform else 'bash'

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -16,8 +16,13 @@ from ..utils import wrap_subprocess_call
 from .logging import TRACE
 from .. import ACTIVE_SUBPROCESSES
 from ..auxlib.ish import dals
-from ..common.compat import (ensure_binary, string_types, encode_arguments,
-                             on_win, encode_environment, isiterable)
+from ..common.compat import (
+    ensure_binary,
+    string_types,
+    encode_arguments,
+    encode_environment,
+    isiterable,
+)
 from ..gateways.disk.delete import rm_rf
 from ..base.context import context
 
@@ -39,11 +44,20 @@ def _format_output(command_str, cwd, rc, stdout, stderr):
 
 def any_subprocess(args, prefix, env=None, cwd=None):
     script_caller, command_args = wrap_subprocess_call(
-        on_win, context.root_prefix, prefix, context.dev, context.verbosity >= 2, args)
-    process = Popen(command_args,
-                    cwd=cwd or prefix,
-                    universal_newlines=False,
-                    stdout=PIPE, stderr=PIPE, env=env)
+        context.root_prefix,
+        prefix,
+        context.dev,
+        context.verbosity >= 2,
+        args,
+    )
+    process = Popen(
+        command_args,
+        cwd=cwd or prefix,
+        universal_newlines=False,
+        stdout=PIPE,
+        stderr=PIPE,
+        env=env,
+    )
     stdout, stderr = process.communicate()
     if script_caller is not None:
         if 'CONDA_TEST_SAVE_TEMPS' not in os.environ:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -324,7 +324,7 @@ def massage_arguments(arguments, errors='assert'):
     return arguments
 
 
-def wrap_subprocess_call(on_win, root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments):
+def wrap_subprocess_call(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments):
     arguments = massage_arguments(arguments)
     tmp_prefix = abspath(join(prefix, '.tmp'))
     script_caller = None


### PR DESCRIPTION
At no point does `on_win` deviate from whats detected from the current system so its unnecessary to explicitly pass this in.

If anything the `if on_win` clauses in `conda.utils.wrap_subprocess_call` should simply be moved outside the function but that's out of scope for this change.