### PR TITLE
[libmamba] Refactor integration test helpers

### DIFF
--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -9,7 +9,6 @@ from logging import DEBUG, ERROR, Filter, Formatter, INFO, StreamHandler, WARN, 
 from datetime import datetime
 import re
 import sys
-import os
 
 from .. import CondaError
 from ..auxlib.decorators import memoize

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -18,7 +18,7 @@ from .. import cli
 from ..auxlib.decorators import memoize
 from ..base.context import context, reset_context, conda_tests_ctxt_mgmt_def_pol
 from ..common.compat import iteritems, itervalues, encode_arguments
-from ..common.io import argv, captured, captured as common_io_captured, env_var
+from ..common.io import argv, captured as common_io_captured, env_var
 from ..core.subdir_data import SubdirData, make_feature_record
 from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.read import lexists
@@ -26,14 +26,6 @@ from ..gateways.logging import initialize_logging
 from ..models.channel import Channel
 from ..models.records import PackageRecord
 from ..resolve import Resolve
-
-
-try:
-    from unittest import mock
-    from unittest.mock import patch
-except ImportError:
-    import mock
-    from mock import patch
 
 # The default value will only work if we have installed conda in development mode!
 TEST_DATA_DIR = os.environ.get(
@@ -47,7 +39,7 @@ expected_error_prefix = "Using Anaconda Cloud api site https://api.anaconda.org"
 
 def strip_expected(stderr):
     if expected_error_prefix and stderr.startswith(expected_error_prefix):
-        stderr = stderr[len(expected_error_prefix) :].lstrip()
+        stderr = stderr[len(expected_error_prefix) :].lstrip()  # noqa
     return stderr
 
 

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -14,6 +14,15 @@ from tempfile import gettempdir, mkdtemp
 from uuid import uuid4
 from pathlib import Path
 
+# Some modules import from this one so they don't
+# have to try/except all the time.
+try:
+    from unittest import mock  # noqa: F401
+    from unittest.mock import patch  # noqa: F401
+except ImportError:
+    import mock  # noqa: F401
+    from mock import patch  # noqa: F401
+
 from .. import cli
 from ..auxlib.decorators import memoize
 from ..base.context import context, reset_context, conda_tests_ctxt_mgmt_def_pol

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -4,21 +4,15 @@ Helpers for the tests
 from __future__ import absolute_import, division, print_function
 
 from contextlib import contextmanager
-from functools import partial
 import json
 import os
 from os.path import dirname, join, abspath
 import re
-from shlex import split
 from conda.auxlib.compat import shlex_split_unicode
 import sys
 from tempfile import gettempdir, mkdtemp
-from unittest import mock
-from unittest.mock import patch
 from uuid import uuid4
 from pathlib import Path
-from time import time
-import collections
 
 from .. import cli
 from ..auxlib.decorators import memoize
@@ -33,7 +27,6 @@ from ..models.channel import Channel
 from ..models.records import PackageRecord
 from ..resolve import Resolve
 
-import pytest
 
 try:
     from unittest import mock

--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -110,7 +110,7 @@ def running_a_python_capable_of_unicode_subprocessing():
             if out.startswith("Hello World"):
                 return True
             return False
-        except Exception as _:
+        except Exception:
             return False
         finally:
             os.unlink(name)
@@ -156,7 +156,7 @@ def _get_temp_prefix(name=None, use_restricted_unicode=False):
 
     try:
         link(src, dst)
-    except (IOError, OSError) as e:
+    except (IOError, OSError):
         print(
             "\nWARNING :: You are testing `conda` with `tmpdir`:-\n           {}\n"
             "           not on the same FS as `sys.prefix`:\n           {}\n"
@@ -340,7 +340,7 @@ def make_temp_env(*packages, **kwargs):
             run_command(Commands.CREATE, prefix, *packages, **kwargs)
             yield prefix
         finally:
-            if not "CONDA_TEST_SAVE_TEMPS" in os.environ:
+            if "CONDA_TEST_SAVE_TEMPS" not in os.environ:
                 rmtree(prefix, ignore_errors=True)
             else:
                 log.warning("CONDA_TEST_SAVE_TEMPS :: retaining make_temp_env {}".format(prefix))

--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -1,0 +1,515 @@
+from __future__ import unicode_literals
+
+from contextlib import contextmanager
+
+import json
+import os
+from os.path import (
+    dirname,
+    exists,
+    isdir,
+    join,
+    lexists,
+)
+from random import sample
+from shutil import copyfile, rmtree
+from subprocess import check_output
+import sys
+from tempfile import gettempdir
+from uuid import uuid4
+from logging import getLogger
+
+import pytest
+
+from conda.auxlib.compat import Utf8NamedTemporaryFile
+from conda.auxlib.entity import EntityEncoder
+from conda.base.constants import PACKAGE_CACHE_MAGIC_FILE
+from conda.base.context import context, reset_context, conda_tests_ctxt_mgmt_def_pol
+from conda.cli.conda_argparse import do_call
+from conda.cli.main import generate_parser, init_loggers
+from conda.common.compat import encode_arguments, on_win
+from conda.common.io import (
+    argv,
+    captured,
+    disable_logger,
+    env_var,
+    stderr_log_level,
+    dashlist,
+)
+from conda.common.url import path_to_url, escape_channel_url
+from conda.core.prefix_data import PrefixData
+from conda.core.package_cache_data import PackageCacheData
+from conda.exceptions import conda_exception_handler
+from conda.gateways.disk.create import mkdir_p
+from conda.gateways.disk.delete import rm_rf
+from conda.gateways.disk.update import touch
+from conda.gateways.logging import DEBUG
+from conda.models.match_spec import MatchSpec
+from conda.models.records import PackageRecord
+from conda.utils import massage_arguments
+
+TEST_LOG_LEVEL = DEBUG
+PYTHON_BINARY = "python.exe" if on_win else "bin/python"
+BIN_DIRECTORY = "Scripts" if on_win else "bin"
+UNICODE_CHARACTERS = "ōγђ家固한áêñßôç"
+# UNICODE_CHARACTERS_RESTRICTED_PY2 = u"ÀÁÂÃÄÅ"
+UNICODE_CHARACTERS_RESTRICTED_PY2 = "abcdef"
+# UNICODE_CHARACTERS_RESTRICTED_PY3 = u"áêñßôç"
+UNICODE_CHARACTERS_RESTRICTED_PY3 = "abcdef"
+which_or_where = "which" if not on_win else "where"
+cp_or_copy = "cp" if not on_win else "copy"
+env_or_set = "env" if not on_win else "set"
+
+# UNICODE_CHARACTERS = u"12345678abcdef"
+# UNICODE_CHARACTERS_RESTRICTED = UNICODE_CHARACTERS
+
+# We basically do not work at all with Unicode on Python 2 still!
+# if sys.version_info[0] == 2:
+#     UNICODE_CHARACTERS = UNICODE_CHARACTERS_RESTRICTED
+
+# When testing for bugs, you may want to change this to a _,
+# for example to see if a bug is related to spaces in prefixes.
+SPACER_CHARACTER = " "
+
+log = getLogger(__name__)
+
+
+def escape_for_winpath(p):
+    return p.replace("\\", "\\\\")
+
+
+from conda.auxlib.decorators import memoize
+
+
+@memoize
+def running_a_python_capable_of_unicode_subprocessing():
+    name = None
+    # try:
+    # UNICODE_CHARACTERS + os.sep +
+    with Utf8NamedTemporaryFile(
+        mode="w", suffix=UNICODE_CHARACTERS + ".bat", delete=False
+    ) as batch_file:
+        batch_file.write("@echo Hello World\n")
+        batch_file.write("@exit 0\n")
+        name = batch_file.name
+    if name:
+        try:
+            out = check_output(name, cwd=dirname(name), stderr=None, shell=False)
+            out = out.decode("utf-8") if hasattr(out, "decode") else out
+            if out.startswith("Hello World"):
+                return True
+            return False
+        except Exception as _:
+            return False
+        finally:
+            os.unlink(name)
+    return False
+
+
+tmpdir_in_use = None
+
+
+@pytest.fixture(autouse=True)
+def set_tmpdir(tmpdir):
+    global tmpdir_in_use
+    if not tmpdir:
+        return tmpdir_in_use
+    td = tmpdir.strpath
+    assert os.sep in td
+    tmpdir_in_use = td
+
+
+def _get_temp_prefix(name=None, use_restricted_unicode=False):
+    tmpdir = tmpdir_in_use or gettempdir()
+    capable = running_a_python_capable_of_unicode_subprocessing()
+
+    if not capable or use_restricted_unicode:
+        RESTRICTED = (
+            UNICODE_CHARACTERS_RESTRICTED_PY2
+            if (sys.version_info[0] == 2)
+            else UNICODE_CHARACTERS_RESTRICTED_PY3
+        )
+        random_unicode = "".join(sample(RESTRICTED, len(RESTRICTED)))
+    else:
+        random_unicode = "".join(sample(UNICODE_CHARACTERS, len(UNICODE_CHARACTERS)))
+    tmpdir_name = os.environ.get(
+        "CONDA_TEST_TMPDIR_NAME",
+        (str(uuid4())[:4] + SPACER_CHARACTER + random_unicode) if name is None else name,
+    )
+    prefix = join(tmpdir, tmpdir_name)
+
+    # Exit immediately if we cannot use hardlinks, on Windows, we get permissions errors if we use
+    # sys.executable so instead use the pdb files.
+    src = sys.executable.replace(".exe", ".pdb") if on_win else sys.executable
+    dst = os.path.join(tmpdir, os.path.basename(sys.executable))
+    from conda.gateways.disk.link import link
+
+    try:
+        link(src, dst)
+    except (IOError, OSError) as e:
+        print(
+            "\nWARNING :: You are testing `conda` with `tmpdir`:-\n           {}\n"
+            "           not on the same FS as `sys.prefix`:\n           {}\n"
+            "           this will be slow and unlike the majority of end-user installs.\n"
+            "           Please pass `--basetemp=<somewhere-else>` instead.".format(
+                tmpdir, sys.prefix
+            )
+        )
+    try:
+        rm_rf(dst)
+    except Exception as e:
+        print(e)
+        pass
+
+    return prefix
+
+
+def make_temp_prefix(name=None, use_restricted_unicode=False, _temp_prefix=None):
+    """
+    When the env. you are creating will be used to install Python 2.7 on Windows
+    only a restricted amount of Unicode will work, and probably only those chars
+    in your current codepage, so the characters in UNICODE_CHARACTERS_RESTRICTED
+    should probably be randomly generated from that instead. The problem here is
+    that the current codepage needs to be able to handle 'sys.prefix' otherwise
+    ntpath will fall over.
+    """
+    if not _temp_prefix:
+        _temp_prefix = _get_temp_prefix(name=name, use_restricted_unicode=use_restricted_unicode)
+    try:
+        os.makedirs(_temp_prefix)
+    except:
+        pass
+    assert isdir(_temp_prefix)
+    return _temp_prefix
+
+
+def FORCE_temp_prefix(name=None, use_restricted_unicode=False):
+    _temp_prefix = _get_temp_prefix(name=name, use_restricted_unicode=use_restricted_unicode)
+    rm_rf(_temp_prefix)
+    os.makedirs(_temp_prefix)
+    assert isdir(_temp_prefix)
+    return _temp_prefix
+
+
+class Commands:
+    COMPARE = "compare"
+    CONFIG = "config"
+    CLEAN = "clean"
+    CREATE = "create"
+    INFO = "info"
+    INSTALL = "install"
+    LIST = "list"
+    REMOVE = "remove"
+    SEARCH = "search"
+    UPDATE = "update"
+    RUN = "run"
+
+
+@contextmanager
+def temp_chdir(target_dir):
+    curdir = os.getcwd()
+    if not target_dir:
+        target_dir = curdir
+    try:
+        os.chdir(target_dir)
+        yield
+    finally:
+        os.chdir(curdir)
+
+
+def run_command(command, prefix, *arguments, **kwargs):
+
+    assert isinstance(arguments, tuple), "run_command() arguments must be tuples"
+    arguments = massage_arguments(arguments)
+
+    use_exception_handler = kwargs.get("use_exception_handler", False)
+    # These commands require 'dev' mode to be enabled during testing because
+    # they end up calling run_script() in link.py and that uses wrapper scripts for e.g. activate.
+    # Setting `dev` means that, in these scripts, conda is executed via:
+    #   `sys.prefix/bin/python -m conda` (or the Windows equivalent).
+    # .. and the source code for `conda` is put on `sys.path` via `PYTHONPATH` (a bit gross but
+    # less so than always requiring `cwd` to be the root of the conda source tree in every case).
+    # If you do not want this to happen for some test you must pass dev=False as a kwarg, though
+    # for nearly all tests, you want to make sure you are running *this* conda and not some old
+    # conda (it was random which you'd get depending on the initial values of PATH and PYTHONPATH
+    # - and likely more variables - before `dev` came along). Setting CONDA_EXE is not enough
+    # either because in the 4.5 days that would just run whatever Python was found first on PATH.
+    command_defaults_to_dev = command in (
+        Commands.CREATE,
+        Commands.INSTALL,
+        Commands.REMOVE,
+        Commands.RUN,
+    )
+    dev = kwargs.get("dev", True if command_defaults_to_dev else False)
+    debug = kwargs.get("debug_wrapper_scripts", False)
+
+    p = generate_parser()
+
+    if command is Commands.CONFIG:
+        arguments.append("--file")
+        arguments.append(join(prefix, "condarc"))
+    if command in (
+        Commands.LIST,
+        Commands.COMPARE,
+        Commands.CREATE,
+        Commands.INSTALL,
+        Commands.REMOVE,
+        Commands.UPDATE,
+        Commands.RUN,
+    ):
+        arguments.insert(0, "-p")
+        arguments.insert(1, prefix)
+    if command in (Commands.CREATE, Commands.INSTALL, Commands.REMOVE, Commands.UPDATE):
+        arguments.extend(["-y", "-q"])
+
+    arguments.insert(0, command)
+    if dev:
+        arguments.insert(1, "--dev")
+    if debug:
+        arguments.insert(1, "--debug-wrapper-scripts")
+
+    # It would be nice at this point to re-use:
+    # from conda.cli.python_api import run_command as python_api_run_command
+    # python_api_run_command
+    # .. but that does not support no_capture and probably more stuff.
+
+    args = p.parse_args(arguments)
+    context._set_argparse_args(args)
+    init_loggers(context)
+    cap_args = tuple() if not kwargs.get("no_capture") else (None, None)
+    # list2cmdline is not exact, but it is only informational.
+    print("\n\nEXECUTING COMMAND >>> $ conda %s\n\n" % " ".join(arguments), file=sys.stderr)
+    with stderr_log_level(TEST_LOG_LEVEL, "conda"), stderr_log_level(TEST_LOG_LEVEL, "requests"):
+        arguments = encode_arguments(arguments)
+        is_run = arguments[0] == "run"
+        if is_run:
+            cap_args = (None, None)
+        with argv(["python_api"] + arguments), captured(*cap_args) as c:
+            if use_exception_handler:
+                result = conda_exception_handler(do_call, args, p)
+            else:
+                result = do_call(args, p)
+        if is_run:
+            stdout = result.stdout
+            stderr = result.stderr
+            result = result.rc
+        else:
+            stdout = c.stdout
+            stderr = c.stderr
+        print(stdout, file=sys.stdout)
+        print(stderr, file=sys.stderr)
+
+    # Unfortunately there are other ways to change context, such as Commands.CREATE --offline.
+    # You will probably end up playing whack-a-bug here adding more and more the tuple here.
+    if command in (Commands.CONFIG,):
+        reset_context([os.path.join(prefix + os.sep, "condarc")], args)
+    return stdout, stderr, result
+
+
+@contextmanager
+def make_temp_env(*packages, **kwargs):
+    name = kwargs.pop("name", None)
+    use_restricted_unicode = kwargs.pop("use_restricted_unicode", False)
+
+    prefix = kwargs.pop("prefix", None) or _get_temp_prefix(
+        name=name, use_restricted_unicode=use_restricted_unicode
+    )
+    clean_prefix = kwargs.pop("clean_prefix", None)
+    if clean_prefix:
+        if os.path.exists(prefix):
+            rm_rf(prefix)
+    if not isdir(prefix):
+        make_temp_prefix(name, use_restricted_unicode, prefix)
+    with disable_logger("fetch"), disable_logger("dotupdate"):
+        try:
+            # try to clear any config that's been set by other tests
+            # CAUTION :: This does not partake in the context stack management code
+            #            of env_{var,vars,unmodified} and, when used in conjunction
+            #            with that code, this *must* be called first.
+            reset_context([os.path.join(prefix + os.sep, "condarc")])
+            run_command(Commands.CREATE, prefix, *packages, **kwargs)
+            yield prefix
+        finally:
+            if not "CONDA_TEST_SAVE_TEMPS" in os.environ:
+                rmtree(prefix, ignore_errors=True)
+            else:
+                log.warning("CONDA_TEST_SAVE_TEMPS :: retaining make_temp_env {}".format(prefix))
+
+
+@contextmanager
+def make_temp_package_cache():
+    prefix = make_temp_prefix(use_restricted_unicode=on_win)
+    pkgs_dir = join(prefix, "pkgs")
+    mkdir_p(pkgs_dir)
+    touch(join(pkgs_dir, PACKAGE_CACHE_MAGIC_FILE))
+
+    try:
+        with env_var("CONDA_PKGS_DIRS", pkgs_dir, stack_callback=conda_tests_ctxt_mgmt_def_pol):
+            assert context.pkgs_dirs == (pkgs_dir,)
+            yield pkgs_dir
+    finally:
+        rmtree(prefix, ignore_errors=True)
+        if pkgs_dir in PackageCacheData._cache_:
+            del PackageCacheData._cache_[pkgs_dir]
+
+
+import urllib
+
+try:
+    import urllib.parse as urlparse
+except:
+    from urlparse import urlparse
+
+
+def fixurl(url):
+    # turn string into unicode
+    if not isinstance(url, str):
+        url = url.decode("utf8")
+
+    # parse it
+    parsed = urlparse.urlsplit(url)
+
+    # divide the netloc further
+    userpass, at, hostport = parsed.netloc.rpartition("@")
+    user, colon1, pass_ = userpass.partition(":")
+    host, colon2, port = hostport.partition(":")
+
+    # encode each component
+    scheme = parsed.scheme.encode("utf8")
+    user = urllib.quote(user.encode("utf8"))
+    colon1 = colon1.encode("utf8")
+    pass_ = urllib.quote(pass_.encode("utf8"))
+    at = at.encode("utf8")
+    host = host.encode("idna")
+    colon2 = colon2.encode("utf8")
+    port = port.encode("utf8")
+    path = "/".join(  # could be encoded slashes!
+        urllib.quote(urllib.unquote(pce).encode("utf8"), "") for pce in parsed.path.split("/")
+    )
+    query = urllib.quote(urllib.unquote(parsed.query).encode("utf8"), "=&?/")
+    fragment = urllib.quote(urllib.unquote(parsed.fragment).encode("utf8"))
+
+    # put it back together
+    netloc = "".join((user, colon1, pass_, at, host, colon2, port))
+    return urlparse.urlunsplit((scheme, netloc, path, query, fragment))
+
+
+@contextmanager
+def make_temp_channel(packages):
+    package_reqs = [pkg.replace("-", "=") for pkg in packages]
+    package_names = [pkg.split("-")[0] for pkg in packages]
+
+    with make_temp_env(*package_reqs) as prefix:
+        for package in packages:
+            assert package_is_installed(prefix, package.replace("-", "="))
+        data = [p for p in PrefixData(prefix).iter_records() if p["name"] in package_names]
+        run_command(Commands.REMOVE, prefix, *package_names)
+        for package in packages:
+            assert not package_is_installed(prefix, package.replace("-", "="))
+
+    repodata = {"info": {}, "packages": {}}
+    tarfiles = {}
+    for package_data in data:
+        pkg_data = package_data
+        fname = pkg_data["fn"]
+        tarfiles[fname] = join(PackageCacheData.first_writable().pkgs_dir, fname)
+
+        pkg_data = pkg_data.dump()
+        for field in ("url", "channel", "schannel"):
+            pkg_data.pop(field, None)
+        repodata["packages"][fname] = PackageRecord(**pkg_data)
+
+    with make_temp_env() as channel:
+        subchan = join(channel, context.subdir)
+        noarch_dir = join(channel, "noarch")
+        channel = path_to_url(channel)
+        os.makedirs(subchan)
+        os.makedirs(noarch_dir)
+        for fname, tar_old_path in tarfiles.items():
+            tar_new_path = join(subchan, fname)
+            copyfile(tar_old_path, tar_new_path)
+
+        with open(join(subchan, "repodata.json"), "w") as f:
+            f.write(json.dumps(repodata, cls=EntityEncoder))
+        with open(join(noarch_dir, "repodata.json"), "w") as f:
+            f.write(json.dumps({}, cls=EntityEncoder))
+
+        yield channel
+
+
+def create_temp_location():
+    return _get_temp_prefix()
+
+
+@contextmanager
+def tempdir():
+    prefix = create_temp_location()
+    try:
+        os.makedirs(prefix)
+        yield prefix
+    finally:
+        if lexists(prefix):
+            rm_rf(prefix)
+
+
+def reload_config(prefix):
+    prefix_condarc = join(prefix + os.sep, "condarc")
+    reset_context([prefix_condarc])
+
+
+def package_is_installed(prefix, spec):
+    is_installed = _package_is_installed(prefix, spec)
+
+    # Mamba needs to escape the URL (e.g. space -> %20)
+    # Which ends up rendered in the package spec
+    # Let's try query with a escaped spec in case we are
+    # testing for Mamba or other implementations that need this
+    if not is_installed and "::" in spec:
+        channel, pkg = spec.split("::", 1)
+        escaped_channel = escape_channel_url(channel)
+        escaped_spec = escaped_channel + "::" + pkg
+        is_installed = _package_is_installed(prefix, escaped_spec)
+
+        # Workaround for https://github.com/mamba-org/mamba/issues/1324
+        if not is_installed and channel.startswith("file:"):
+            components = channel.split("/")
+            lowercase_channel = "/".join(components[:-1] + [components[-1].lower()])
+            spec = lowercase_channel + "::" + pkg
+            is_installed = _package_is_installed(prefix, spec)
+
+    return is_installed
+
+
+def _package_is_installed(prefix, spec):
+    spec = MatchSpec(spec)
+    prefix_recs = tuple(PrefixData(prefix).query(spec))
+    if len(prefix_recs) > 1:
+        raise AssertionError(
+            "Multiple packages installed.%s" % (dashlist(prec.dist_str() for prec in prefix_recs))
+        )
+    return bool(len(prefix_recs))
+
+
+def get_conda_list_tuple(prefix, package_name):
+    stdout, stderr, _ = run_command(Commands.LIST, prefix)
+    stdout_lines = stdout.split("\n")
+    package_line = next(
+        (line for line in stdout_lines if line.lower().startswith(package_name + " ")), None
+    )
+    return package_line.split()
+
+
+def get_shortcut_dir():
+    assert on_win
+    user_mode = "user" if exists(join(sys.prefix, ".nonadmin")) else "system"
+    try:
+        from menuinst.win32 import dirs_src as win_locations
+
+        return win_locations[user_mode]["start"][0]
+    except ImportError:
+        try:
+            from menuinst.win32 import dirs as win_locations
+
+            return win_locations[user_mode]["start"]
+        except ImportError:
+            raise

--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -1,3 +1,8 @@
+"""
+These helpers were originally defined in tests/test_create.py,
+but were refactored here so downstream projects can benefit from
+them too.
+"""
 from __future__ import unicode_literals
 
 from contextlib import contextmanager

--- a/conda/testing/solver_helpers.py
+++ b/conda/testing/solver_helpers.py
@@ -188,7 +188,7 @@ class SolverTests:
 
     @pytest.fixture()
     def env(self):
-        with tempfile.TemporaryDirectory(prefix="conda-test-repo-") as tmpdir:
+        with TemporaryDirectory(prefix="conda-test-repo-") as tmpdir:
             self.env = SimpleEnvironment(tmpdir, self.solver_class)
             yield self.env
             self.env = None

--- a/conda/testing/solver_helpers.py
+++ b/conda/testing/solver_helpers.py
@@ -68,7 +68,8 @@ class SimpleEnvironment:
         self.subdirs = subdirs
         self.installed_packages = []
         # if repo_packages is a list, the packages will be put in a `test` channel
-        # if it is a dictionary, it the keys are the channel name and the value the channel packages
+        # if it is a dictionary, it the keys are the channel name and the value
+        # the channel packages
         self.repo_packages: list[str] | dict[str, list[str]] = []
 
     def solver(self, add, remove):
@@ -573,9 +574,9 @@ class SolverTests:
         )
 
     def test_nonexistent(self, env):
-        with pytest.raises((ResolvePackageNotFound, PackagesNotFoundError)) as exc_info:
+        with pytest.raises((ResolvePackageNotFound, PackagesNotFoundError)):
             env.install("notarealpackage 2.0*")
-        with pytest.raises((ResolvePackageNotFound, PackagesNotFoundError)) as exc_info:
+        with pytest.raises((ResolvePackageNotFound, PackagesNotFoundError)):
             env.install("numpy 1.5")
 
     def test_timestamps_and_deps(self, env):
@@ -603,11 +604,13 @@ class SolverTests:
         records_15 = env.install("libpng 1.5.*", "mypackage")
         assert "test::libpng-1.5.13-1" in records_15
         assert "test::mypackage-1.0-hash15_0" in records_15
-        # this is testing that previously installed reqs are not disrupted by newer timestamps.
-        #   regression test of sorts for https://github.com/conda/conda/issues/6271
+        # this is testing that previously installed reqs are not disrupted
+        # by newer timestamps. regression test of sorts for
+        #  https://github.com/conda/conda/issues/6271
         assert env.install("mypackage", *env.install("libpng 1.2.*", as_specs=True)) == records_12
         assert env.install("mypackage", *env.install("libpng 1.5.*", as_specs=True)) == records_15
-        # unspecified python version should maximize libpng (v1.5), even though it has a lower timestamp
+        # unspecified python version should maximize libpng (v1.5),
+        # even though it has a lower timestamp
         assert env.install("mypackage") == records_15
 
     def test_nonexistent_deps(self, env):
@@ -713,8 +716,9 @@ class SolverTests:
             "test::distribute-0.6.36-py33_1",
             "test::pip-1.3.1-py33_1",
         }
-        # XXX: We need UnsatisfiableError here because mamba does not have more granular exceptions yet.
-        with pytest.raises((ResolvePackageNotFound, UnsatisfiableError)) as exc_info:
+        # TODO: We need UnsatisfiableError here because mamba does not
+        # have more granular exceptions yet.
+        with pytest.raises((ResolvePackageNotFound, UnsatisfiableError)):
             env.install("mypackage 1.1")
         assert env.install("anotherpackage 1.0") == {
             "test::anotherpackage-1.0-0",
@@ -1010,15 +1014,11 @@ class SolverTests:
         monkeypatch.setenv("CONDA_CHANNEL_PRIORITY", "True")
         with pytest.raises(UnsatisfiableError) as exc_info:
             env.install("a", "b")
-        self.assert_unsatisfiable(
-            exc_info,
-            [
-                ("b", "c[version='>=2,<3']"),
-            ],
-        )
+        self.assert_unsatisfiable(exc_info, [("b", "c[version='>=2,<3']")])
 
     @pytest.mark.xfail(
-        reason="There is some weird global state making this test fail when the whole test suite is run"
+        reason="There is some weird global state making "
+        "this test fail when the whole test suite is run"
     )
     def test_remove(self, env):
         env.repo_packages = index_packages(1)

--- a/conda/testing/solver_helpers.py
+++ b/conda/testing/solver_helpers.py
@@ -4,7 +4,7 @@ import collections
 import functools
 import json
 import pathlib
-import tempfile
+from tempfile import TemporaryDirectory
 from typing import Type
 
 import pytest
@@ -156,6 +156,16 @@ class SimpleEnvironment:
                     }
                 )
             )
+
+
+def empty_prefix():
+    return TemporaryDirectory(prefix="conda-test-repo-")
+
+
+@pytest.fixture()
+def temp_simple_env(solver_class=Solver) -> SimpleEnvironment:
+    with empty_prefix() as prefix:
+        yield SimpleEnvironment(prefix, solver_class)
 
 
 class SolverTests:

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -1,6 +1,5 @@
 import tempfile
 from unittest import TestCase
-from tests.test_create import run_command, Commands
 
 import pytest
 
@@ -9,6 +8,7 @@ from conda.exceptions import UnsatisfiableError
 from conda.gateways.disk.delete import rm_rf
 from conda.base.constants import SolverLogicChoice
 from conda.base.context import context
+from conda.testing.integration import run_command, Commands
 
 try:
     from unittest.mock import patch

--- a/tests/conda_env/test_create.py
+++ b/tests/conda_env/test_create.py
@@ -18,7 +18,7 @@ from conda.models.enums import PackageType
 from conda.models.match_spec import MatchSpec
 from . import support_file
 from .utils import make_temp_envs_dir, Commands, run_command
-from ..test_create import run_command as run_conda_command, \
+from conda.testing.integration import run_command as run_conda_command, \
     Commands as CondaCommands
 
 PYTHON_BINARY = 'python.exe' if on_win else 'bin/python'

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -16,7 +16,7 @@ from conda.gateways.disk.create import copy
 from conda.gateways.disk.permissions import make_read_only
 from conda.gateways.disk.read import isfile, listdir, yield_lines
 from conda.models.records import PackageRecord
-from tests.test_create import make_temp_package_cache
+from conda.testing.integration import make_temp_package_cache
 from conda.common.compat import on_win
 import datetime
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -33,9 +33,8 @@ from conda.gateways.disk.delete import rm_rf
 from conda.gateways.disk.update import touch
 import pytest
 from conda.testing.helpers import tempdir
-from tests.test_create import Commands, run_command
+from conda.testing.integration import Commands, run_command, SPACER_CHARACTER
 from conda.auxlib.decorators import memoize
-from .test_create import SPACER_CHARACTER
 
 try:
     from unittest.mock import patch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from conda.base.context import context
 from conda.common.io import captured
 from conda.gateways.disk.delete import rm_rf
 from conda.testing.helpers import capture_json_with_argv, run_inprocess_conda_command
+from conda.testing.integration import make_temp_env, run_command, Commands, make_temp_prefix
 from conda.common.compat import text_type
 
 import os
@@ -144,9 +145,6 @@ class TestJson(unittest.TestCase):
 
     @pytest.mark.integration
     def test_search_2(self):
-        from tests.test_create import make_temp_env
-        from tests.test_create import run_command
-        from tests.test_create import Commands
         with make_temp_env() as prefix:
             stdout, stderr, _ = run_command(Commands.SEARCH, prefix, "nose", use_exception_handler=True)
             result = stdout.replace("Loading channels: ...working... done", "")
@@ -155,9 +153,6 @@ class TestJson(unittest.TestCase):
 
     @pytest.mark.integration
     def test_search_3(self):
-        from tests.test_create import make_temp_env
-        from tests.test_create import run_command
-        from tests.test_create import Commands
         with make_temp_env() as prefix:
             stdout, stderr, _ = run_command(Commands.SEARCH, prefix, "*/linux-64::nose==1.3.7[build=py37_2]", "--info", use_exception_handler=True)
             result = stdout.replace("Loading channels: ...working... done", "")
@@ -176,9 +171,6 @@ class TestJson(unittest.TestCase):
 
 class TestRun(object):
     def test_run_returns_int(self):
-        from tests.test_create import make_temp_env
-        from tests.test_create import make_temp_prefix
-
         prefix = make_temp_prefix(name='test')
         with make_temp_env(prefix=prefix):
             stdout, stderr, result = run_inprocess_conda_command('conda run -p {} echo hi'.format(prefix))
@@ -186,9 +178,6 @@ class TestRun(object):
             assert isinstance(result, int)
 
     def test_run_returns_zero_errorlevel(self):
-        from tests.test_create import make_temp_env
-        from tests.test_create import make_temp_prefix
-
         prefix = make_temp_prefix(name='test')
         with make_temp_env(prefix=prefix):
             stdout, stderr, result = run_inprocess_conda_command('conda run -p {} exit 0'.format(prefix))
@@ -196,9 +185,6 @@ class TestRun(object):
             assert result == 0
 
     def test_run_returns_nonzero_errorlevel(self):
-        from tests.test_create import make_temp_env
-        from tests.test_create import make_temp_prefix
-
         prefix = make_temp_prefix(name='test')
         with make_temp_env(prefix=prefix) as prefix:
             stdout, stderr, result = run_inprocess_conda_command('conda run -p "{}" exit 5'.format(prefix))
@@ -206,9 +192,6 @@ class TestRun(object):
             assert result == 5
 
     def test_run_uncaptured(self, capfd):
-        from tests.test_create import make_temp_env
-        from tests.test_create import make_temp_prefix
-
         prefix = make_temp_prefix(name='test')
         with make_temp_env(prefix=prefix):
             random_text = uuid.uuid4().hex

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from contextlib import contextmanager
-from datetime import datetime
 from glob import glob
 
 from conda.auxlib.compat import Utf8NamedTemporaryFile
@@ -28,15 +26,13 @@ from os.path import (
     relpath,
     islink,
 )
-from random import sample
 import re
 from shutil import copyfile, rmtree
 from subprocess import check_call, check_output, Popen, PIPE
 import sys
-from tempfile import gettempdir
 from textwrap import dedent
 from unittest import TestCase
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -45,40 +41,28 @@ import requests
 from conda import (
     CondaError,
     CondaMultiError,
-    plan,
     __version__ as CONDA_VERSION,
     CONDA_PACKAGE_ROOT,
 )
-from conda.auxlib.entity import EntityEncoder
 from conda.auxlib.ish import dals
-from conda._vendor.toolz import concatv
 from conda.base.constants import (
     CONDA_PACKAGE_EXTENSIONS,
-    PACKAGE_CACHE_MAGIC_FILE,
     SafetyChecks,
     PREFIX_MAGIC_FILE,
-    DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
     SolverLogicChoice,
 )
 from conda.base.context import Context, context, reset_context, conda_tests_ctxt_mgmt_def_pol
-from conda.cli.conda_argparse import do_call
-from conda.cli.main import generate_parser, init_loggers
 from conda.common.compat import (
     ensure_text_type,
     iteritems,
     string_types,
     text_type,
-    encode_arguments,
     on_win,
     on_mac,
 )
 from conda.common.io import (
-    argv,
-    captured,
-    disable_logger,
     env_var,
     stderr_log_level,
-    dashlist,
     env_vars,
 )
 from conda.common.path import (
@@ -99,7 +83,6 @@ from conda.exceptions import (
     PackagesNotFoundError,
     RawStrUnsatisfiableError,
     RemoveError,
-    conda_exception_handler,
     PackageNotInstalledError,
     DisallowedPackageError,
     DirectoryNotACondaEnvironmentError,
@@ -107,491 +90,39 @@ from conda.exceptions import (
     CondaValueError,
 )
 from conda.gateways.anaconda_client import read_binstar_tokens
-from conda.gateways.disk.create import mkdir_p, extract_tarball
 from conda.gateways.disk.delete import rm_rf, path_is_clean
 from conda.gateways.disk.update import touch
 from conda.gateways.logging import TRACE
 from conda.gateways.subprocess import subprocess_call, subprocess_call_with_clean_env, Response
 from conda.models.match_spec import MatchSpec
-from conda.models.records import PackageRecord
 from conda.models.version import VersionOrder
-from conda.resolve import exactness_and_number_of_deps
-from conda.utils import massage_arguments
 
 from conda.testing.cases import BaseTestCase
-
+from conda.testing.integration import (
+    BIN_DIRECTORY,
+    PYTHON_BINARY,
+    TEST_LOG_LEVEL,
+    create_temp_location,
+    get_shortcut_dir,
+    make_temp_channel,
+    make_temp_package_cache,
+    make_temp_prefix,
+    reload_config,
+    run_command,
+    Commands,
+    package_is_installed,
+    make_temp_env,
+    tempdir,
+    which_or_where,
+    cp_or_copy,
+    env_or_set,
+)
 
 log = getLogger(__name__)
-TRACE, DEBUG, INFO = (
-    TRACE,
-    DEBUG,
-    INFO,
-)  # these are so the imports aren't cleared, but it's easy to switch back and forth
-TEST_LOG_LEVEL = DEBUG
+# these are so the imports aren't cleared, but it's easy to switch back and forth
+TRACE, DEBUG, INFO = TRACE, DEBUG, INFO
 stderr_log_level(TEST_LOG_LEVEL, "conda")
 stderr_log_level(TEST_LOG_LEVEL, "requests")
-PYTHON_BINARY = "python.exe" if on_win else "bin/python"
-BIN_DIRECTORY = "Scripts" if on_win else "bin"
-UNICODE_CHARACTERS = "ōγђ家固한áêñßôç"
-# UNICODE_CHARACTERS_RESTRICTED_PY2 = u"ÀÁÂÃÄÅ"
-UNICODE_CHARACTERS_RESTRICTED_PY2 = "abcdef"
-# UNICODE_CHARACTERS_RESTRICTED_PY3 = u"áêñßôç"
-UNICODE_CHARACTERS_RESTRICTED_PY3 = "abcdef"
-which_or_where = "which" if not on_win else "where"
-cp_or_copy = "cp" if not on_win else "copy"
-env_or_set = "env" if not on_win else "set"
-
-# UNICODE_CHARACTERS = u"12345678abcdef"
-# UNICODE_CHARACTERS_RESTRICTED = UNICODE_CHARACTERS
-
-# We basically do not work at all with Unicode on Python 2 still!
-# if sys.version_info[0] == 2:
-#     UNICODE_CHARACTERS = UNICODE_CHARACTERS_RESTRICTED
-
-# When testing for bugs, you may want to change this to a _,
-# for example to see if a bug is related to spaces in prefixes.
-SPACER_CHARACTER = " "
-
-
-def escape_for_winpath(p):
-    return p.replace("\\", "\\\\")
-
-
-from conda.auxlib.decorators import memoize
-
-
-@memoize
-def running_a_python_capable_of_unicode_subprocessing():
-    name = None
-    # try:
-    # UNICODE_CHARACTERS + os.sep +
-    with Utf8NamedTemporaryFile(
-        mode="w", suffix=UNICODE_CHARACTERS + ".bat", delete=False
-    ) as batch_file:
-        batch_file.write("@echo Hello World\n")
-        batch_file.write("@exit 0\n")
-        name = batch_file.name
-    if name:
-        try:
-            out = check_output(name, cwd=dirname(name), stderr=None, shell=False)
-            out = out.decode("utf-8") if hasattr(out, "decode") else out
-            if out.startswith("Hello World"):
-                return True
-            return False
-        except Exception as _:
-            return False
-        finally:
-            os.unlink(name)
-    return False
-
-
-tmpdir_in_use = None
-
-
-@pytest.fixture(autouse=True)
-def set_tmpdir(tmpdir):
-    global tmpdir_in_use
-    if not tmpdir:
-        return tmpdir_in_use
-    td = tmpdir.strpath
-    assert os.sep in td
-    tmpdir_in_use = td
-
-
-def _get_temp_prefix(name=None, use_restricted_unicode=False):
-    tmpdir = tmpdir_in_use or gettempdir()
-    capable = running_a_python_capable_of_unicode_subprocessing()
-
-    if not capable or use_restricted_unicode:
-        RESTRICTED = (
-            UNICODE_CHARACTERS_RESTRICTED_PY2
-            if (sys.version_info[0] == 2)
-            else UNICODE_CHARACTERS_RESTRICTED_PY3
-        )
-        random_unicode = "".join(sample(RESTRICTED, len(RESTRICTED)))
-    else:
-        random_unicode = "".join(sample(UNICODE_CHARACTERS, len(UNICODE_CHARACTERS)))
-    tmpdir_name = os.environ.get(
-        "CONDA_TEST_TMPDIR_NAME",
-        (str(uuid4())[:4] + SPACER_CHARACTER + random_unicode) if name is None else name,
-    )
-    prefix = join(tmpdir, tmpdir_name)
-
-    # Exit immediately if we cannot use hardlinks, on Windows, we get permissions errors if we use
-    # sys.executable so instead use the pdb files.
-    src = sys.executable.replace(".exe", ".pdb") if on_win else sys.executable
-    dst = os.path.join(tmpdir, os.path.basename(sys.executable))
-    from conda.gateways.disk.link import link
-
-    try:
-        link(src, dst)
-    except (IOError, OSError) as e:
-        print(
-            "\nWARNING :: You are testing `conda` with `tmpdir`:-\n           {}\n"
-            "           not on the same FS as `sys.prefix`:\n           {}\n"
-            "           this will be slow and unlike the majority of end-user installs.\n"
-            "           Please pass `--basetemp=<somewhere-else>` instead.".format(
-                tmpdir, sys.prefix
-            )
-        )
-    try:
-        rm_rf(dst)
-    except Exception as e:
-        print(e)
-        pass
-
-    return prefix
-
-
-def make_temp_prefix(name=None, use_restricted_unicode=False, _temp_prefix=None):
-    """
-    When the env. you are creating will be used to install Python 2.7 on Windows
-    only a restricted amount of Unicode will work, and probably only those chars
-    in your current codepage, so the characters in UNICODE_CHARACTERS_RESTRICTED
-    should probably be randomly generated from that instead. The problem here is
-    that the current codepage needs to be able to handle 'sys.prefix' otherwise
-    ntpath will fall over.
-    """
-    if not _temp_prefix:
-        _temp_prefix = _get_temp_prefix(name=name, use_restricted_unicode=use_restricted_unicode)
-    try:
-        os.makedirs(_temp_prefix)
-    except:
-        pass
-    assert isdir(_temp_prefix)
-    return _temp_prefix
-
-
-def FORCE_temp_prefix(name=None, use_restricted_unicode=False):
-    _temp_prefix = _get_temp_prefix(name=name, use_restricted_unicode=use_restricted_unicode)
-    rm_rf(_temp_prefix)
-    os.makedirs(_temp_prefix)
-    assert isdir(_temp_prefix)
-    return _temp_prefix
-
-
-class Commands:
-    COMPARE = "compare"
-    CONFIG = "config"
-    CLEAN = "clean"
-    CREATE = "create"
-    INFO = "info"
-    INSTALL = "install"
-    LIST = "list"
-    REMOVE = "remove"
-    SEARCH = "search"
-    UPDATE = "update"
-    RUN = "run"
-
-
-@contextmanager
-def temp_chdir(target_dir):
-    curdir = os.getcwd()
-    if not target_dir:
-        target_dir = curdir
-    try:
-        os.chdir(target_dir)
-        yield
-    finally:
-        os.chdir(curdir)
-
-
-def run_command(command, prefix, *arguments, **kwargs):
-
-    assert isinstance(arguments, tuple), "run_command() arguments must be tuples"
-    arguments = massage_arguments(arguments)
-
-    use_exception_handler = kwargs.get("use_exception_handler", False)
-    # These commands require 'dev' mode to be enabled during testing because
-    # they end up calling run_script() in link.py and that uses wrapper scripts for e.g. activate.
-    # Setting `dev` means that, in these scripts, conda is executed via:
-    #   `sys.prefix/bin/python -m conda` (or the Windows equivalent).
-    # .. and the source code for `conda` is put on `sys.path` via `PYTHONPATH` (a bit gross but
-    # less so than always requiring `cwd` to be the root of the conda source tree in every case).
-    # If you do not want this to happen for some test you must pass dev=False as a kwarg, though
-    # for nearly all tests, you want to make sure you are running *this* conda and not some old
-    # conda (it was random which you'd get depending on the initial values of PATH and PYTHONPATH
-    # - and likely more variables - before `dev` came along). Setting CONDA_EXE is not enough
-    # either because in the 4.5 days that would just run whatever Python was found first on PATH.
-    command_defaults_to_dev = command in (
-        Commands.CREATE,
-        Commands.INSTALL,
-        Commands.REMOVE,
-        Commands.RUN,
-    )
-    dev = kwargs.get("dev", True if command_defaults_to_dev else False)
-    debug = kwargs.get("debug_wrapper_scripts", False)
-
-    p = generate_parser()
-
-    if command is Commands.CONFIG:
-        arguments.append("--file")
-        arguments.append(join(prefix, "condarc"))
-    if command in (
-        Commands.LIST,
-        Commands.COMPARE,
-        Commands.CREATE,
-        Commands.INSTALL,
-        Commands.REMOVE,
-        Commands.UPDATE,
-        Commands.RUN,
-    ):
-        arguments.insert(0, "-p")
-        arguments.insert(1, prefix)
-    if command in (Commands.CREATE, Commands.INSTALL, Commands.REMOVE, Commands.UPDATE):
-        arguments.extend(["-y", "-q"])
-
-    arguments.insert(0, command)
-    if dev:
-        arguments.insert(1, "--dev")
-    if debug:
-        arguments.insert(1, "--debug-wrapper-scripts")
-
-    # It would be nice at this point to re-use:
-    # from conda.cli.python_api import run_command as python_api_run_command
-    # python_api_run_command
-    # .. but that does not support no_capture and probably more stuff.
-
-    args = p.parse_args(arguments)
-    context._set_argparse_args(args)
-    init_loggers(context)
-    cap_args = tuple() if not kwargs.get("no_capture") else (None, None)
-    # list2cmdline is not exact, but it is only informational.
-    print("\n\nEXECUTING COMMAND >>> $ conda %s\n\n" % " ".join(arguments), file=sys.stderr)
-    with stderr_log_level(TEST_LOG_LEVEL, "conda"), stderr_log_level(TEST_LOG_LEVEL, "requests"):
-        arguments = encode_arguments(arguments)
-        is_run = arguments[0] == "run"
-        if is_run:
-            cap_args = (None, None)
-        with argv(["python_api"] + arguments), captured(*cap_args) as c:
-            if use_exception_handler:
-                result = conda_exception_handler(do_call, args, p)
-            else:
-                result = do_call(args, p)
-        if is_run:
-            stdout = result.stdout
-            stderr = result.stderr
-            result = result.rc
-        else:
-            stdout = c.stdout
-            stderr = c.stderr
-        print(stdout, file=sys.stdout)
-        print(stderr, file=sys.stderr)
-
-    # Unfortunately there are other ways to change context, such as Commands.CREATE --offline.
-    # You will probably end up playing whack-a-bug here adding more and more the tuple here.
-    if command in (Commands.CONFIG,):
-        reset_context([os.path.join(prefix + os.sep, "condarc")], args)
-    return stdout, stderr, result
-
-
-@contextmanager
-def make_temp_env(*packages, **kwargs):
-    name = kwargs.pop("name", None)
-    use_restricted_unicode = kwargs.pop("use_restricted_unicode", False)
-
-    prefix = kwargs.pop("prefix", None) or _get_temp_prefix(
-        name=name, use_restricted_unicode=use_restricted_unicode
-    )
-    clean_prefix = kwargs.pop("clean_prefix", None)
-    if clean_prefix:
-        if os.path.exists(prefix):
-            rm_rf(prefix)
-    if not isdir(prefix):
-        make_temp_prefix(name, use_restricted_unicode, prefix)
-    with disable_logger("fetch"), disable_logger("dotupdate"):
-        try:
-            # try to clear any config that's been set by other tests
-            # CAUTION :: This does not partake in the context stack management code
-            #            of env_{var,vars,unmodified} and, when used in conjunction
-            #            with that code, this *must* be called first.
-            reset_context([os.path.join(prefix + os.sep, "condarc")])
-            run_command(Commands.CREATE, prefix, *packages, **kwargs)
-            yield prefix
-        finally:
-            if not "CONDA_TEST_SAVE_TEMPS" in os.environ:
-                rmtree(prefix, ignore_errors=True)
-            else:
-                log.warning("CONDA_TEST_SAVE_TEMPS :: retaining make_temp_env {}".format(prefix))
-
-
-@contextmanager
-def make_temp_package_cache():
-    prefix = make_temp_prefix(use_restricted_unicode=on_win)
-    pkgs_dir = join(prefix, "pkgs")
-    mkdir_p(pkgs_dir)
-    touch(join(pkgs_dir, PACKAGE_CACHE_MAGIC_FILE))
-
-    try:
-        with env_var("CONDA_PKGS_DIRS", pkgs_dir, stack_callback=conda_tests_ctxt_mgmt_def_pol):
-            assert context.pkgs_dirs == (pkgs_dir,)
-            yield pkgs_dir
-    finally:
-        rmtree(prefix, ignore_errors=True)
-        if pkgs_dir in PackageCacheData._cache_:
-            del PackageCacheData._cache_[pkgs_dir]
-
-
-import urllib
-
-try:
-    import urllib.parse as urlparse
-except:
-    from urlparse import urlparse
-
-
-def fixurl(url):
-    # turn string into unicode
-    if not isinstance(url, unicode):
-        url = url.decode("utf8")
-
-    # parse it
-    parsed = urlparse.urlsplit(url)
-
-    # divide the netloc further
-    userpass, at, hostport = parsed.netloc.rpartition("@")
-    user, colon1, pass_ = userpass.partition(":")
-    host, colon2, port = hostport.partition(":")
-
-    # encode each component
-    scheme = parsed.scheme.encode("utf8")
-    user = urllib.quote(user.encode("utf8"))
-    colon1 = colon1.encode("utf8")
-    pass_ = urllib.quote(pass_.encode("utf8"))
-    at = at.encode("utf8")
-    host = host.encode("idna")
-    colon2 = colon2.encode("utf8")
-    port = port.encode("utf8")
-    path = "/".join(  # could be encoded slashes!
-        urllib.quote(urllib.unquote(pce).encode("utf8"), "") for pce in parsed.path.split("/")
-    )
-    query = urllib.quote(urllib.unquote(parsed.query).encode("utf8"), "=&?/")
-    fragment = urllib.quote(urllib.unquote(parsed.fragment).encode("utf8"))
-
-    # put it back together
-    netloc = "".join((user, colon1, pass_, at, host, colon2, port))
-    return urlparse.urlunsplit((scheme, netloc, path, query, fragment))
-
-
-@contextmanager
-def make_temp_channel(packages):
-    package_reqs = [pkg.replace("-", "=") for pkg in packages]
-    package_names = [pkg.split("-")[0] for pkg in packages]
-
-    with make_temp_env(*package_reqs) as prefix:
-        for package in packages:
-            assert package_is_installed(prefix, package.replace("-", "="))
-        data = [p for p in PrefixData(prefix).iter_records() if p["name"] in package_names]
-        run_command(Commands.REMOVE, prefix, *package_names)
-        for package in packages:
-            assert not package_is_installed(prefix, package.replace("-", "="))
-
-    repodata = {"info": {}, "packages": {}}
-    tarfiles = {}
-    for package_data in data:
-        pkg_data = package_data
-        fname = pkg_data["fn"]
-        tarfiles[fname] = join(PackageCacheData.first_writable().pkgs_dir, fname)
-
-        pkg_data = pkg_data.dump()
-        for field in ("url", "channel", "schannel"):
-            pkg_data.pop(field, None)
-        repodata["packages"][fname] = PackageRecord(**pkg_data)
-
-    with make_temp_env() as channel:
-        subchan = join(channel, context.subdir)
-        noarch_dir = join(channel, "noarch")
-        channel = path_to_url(channel)
-        os.makedirs(subchan)
-        os.makedirs(noarch_dir)
-        for fname, tar_old_path in tarfiles.items():
-            tar_new_path = join(subchan, fname)
-            copyfile(tar_old_path, tar_new_path)
-
-        with open(join(subchan, "repodata.json"), "w") as f:
-            f.write(json.dumps(repodata, cls=EntityEncoder))
-        with open(join(noarch_dir, "repodata.json"), "w") as f:
-            f.write(json.dumps({}, cls=EntityEncoder))
-
-        yield channel
-
-
-def create_temp_location():
-    return _get_temp_prefix()
-
-
-@contextmanager
-def tempdir():
-    prefix = create_temp_location()
-    try:
-        os.makedirs(prefix)
-        yield prefix
-    finally:
-        if lexists(prefix):
-            rm_rf(prefix)
-
-
-def reload_config(prefix):
-    prefix_condarc = join(prefix + os.sep, "condarc")
-    reset_context([prefix_condarc])
-
-
-def package_is_installed(prefix, spec):
-    is_installed = _package_is_installed(prefix, spec)
-
-    # Mamba needs to escape the URL (e.g. space -> %20)
-    # Which ends up rendered in the package spec
-    # Let's try query with a escaped spec in case we are
-    # testing for Mamba or other implementations that need this
-    if not is_installed and "::" in spec:
-        channel, pkg = spec.split("::", 1)
-        escaped_channel = escape_channel_url(channel)
-        escaped_spec = escaped_channel + "::" + pkg
-        is_installed = _package_is_installed(prefix, escaped_spec)
-
-        # Workaround for https://github.com/mamba-org/mamba/issues/1324
-        if not is_installed and channel.startswith("file:"):
-            components = channel.split("/")
-            lowercase_channel = "/".join(components[:-1] + [components[-1].lower()])
-            spec = lowercase_channel + "::" + pkg
-            is_installed = _package_is_installed(prefix, spec)
-
-    return is_installed
-
-
-def _package_is_installed(prefix, spec):
-    spec = MatchSpec(spec)
-    prefix_recs = tuple(PrefixData(prefix).query(spec))
-    if len(prefix_recs) > 1:
-        raise AssertionError(
-            "Multiple packages installed.%s" % (dashlist(prec.dist_str() for prec in prefix_recs))
-        )
-    return bool(len(prefix_recs))
-
-
-def get_conda_list_tuple(prefix, package_name):
-    stdout, stderr, _ = run_command(Commands.LIST, prefix)
-    stdout_lines = stdout.split("\n")
-    package_line = next(
-        (line for line in stdout_lines if line.lower().startswith(package_name + " ")), None
-    )
-    return package_line.split()
-
-
-def get_shortcut_dir():
-    assert on_win
-    user_mode = "user" if exists(join(sys.prefix, ".nonadmin")) else "system"
-    try:
-        from menuinst.win32 import dirs_src as win_locations
-
-        return win_locations[user_mode]["start"][0]
-    except ImportError:
-        try:
-            from menuinst.win32 import dirs as win_locations
-
-            return win_locations[user_mode]["start"]
-        except ImportError:
-            raise
 
 
 @pytest.mark.integration

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from conda.gateways.disk.delete import rm_rf
 import pytest
 
-from .test_create import Commands, PYTHON_BINARY, make_temp_env, make_temp_prefix, \
+from conda.testing.integration import Commands, PYTHON_BINARY, make_temp_env, make_temp_prefix, \
     package_is_installed, run_command
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -5,7 +5,7 @@ import unittest
 from conda.testing.cases import BaseTestCase
 from conda.testing.decorators import skip_if_no_mock
 from conda.testing.helpers import mock
-from .test_create import make_temp_prefix
+from conda.testing.integration import make_temp_prefix
 
 from conda.history import History
 from conda.common.compat import text_type

--- a/tests/test_link_order.py
+++ b/tests/test_link_order.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import tempfile
 
-from .test_create import run_command, Commands
+from conda.testing.integration import run_command, Commands
 
 try:
     from unittest.mock import patch

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -7,7 +7,7 @@ import pytest
 from conda.base.context import context, conda_tests_ctxt_mgmt_def_pol
 from conda.common.compat import on_win
 from conda.common.io import env_var
-from .test_create import Commands, package_is_installed, get_conda_list_tuple, \
+from conda.testing.integration import Commands, package_is_installed, get_conda_list_tuple, \
     make_temp_env, run_command
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,7 +131,7 @@ def is_prefix_activated_PATHwise(prefix=sys.prefix, test_programs=()):
 # from conda.common.configuration import YamlRawParameter
 # from conda.common.serialize import yaml_safe_load
 # from conda.models.channel import Channel
-# from .test_create import make_temp_prefix
+# from conda.testing.integration import make_temp_prefix
 # from os.path import join
 # from shutil import rmtree
 # is what I ended up with instead.


### PR DESCRIPTION
We'll need these too downstream, so let's refactor a bit. I wouldn't pay much attention to `conda/testing/integration.py` because that's essentially a copy-pasted chunk and it needs plenty of work. For now, just check that the new imports are ok and tests still pass.