### PR TITLE
Introduce `CONDA_SITE_PACKAGES`

### DIFF
--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -41,8 +41,13 @@ __url__ = "https://github.com/conda/conda"
 if os.getenv('CONDA_ROOT') is None:
     os.environ[str('CONDA_ROOT')] = sys.prefix
 
+#: The conda package directory.
 CONDA_PACKAGE_ROOT = abspath(dirname(__file__))
-CONDA_SITE_PACKAGES = dirname(CONDA_PACKAGE_ROOT)
+#: The path within which to find the conda package.
+#:
+#: If `conda` is statically installed this is the site-packages. If `conda` is an editable install
+#: or otherwise uninstalled this is the git repo.
+CONDA_SOURCE_ROOT = dirname(CONDA_PACKAGE_ROOT)
 
 def another_to_unicode(val):
     # ignore flake8 on this because it finds this as an error on py3 even though it is guarded

--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -42,6 +42,7 @@ if os.getenv('CONDA_ROOT') is None:
     os.environ[str('CONDA_ROOT')] = sys.prefix
 
 CONDA_PACKAGE_ROOT = abspath(dirname(__file__))
+CONDA_SITE_PACKAGES = dirname(CONDA_PACKAGE_ROOT)
 
 def another_to_unicode(val):
     # ignore flake8 on this because it finds this as an error on py3 even though it is guarded

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 
 # Since we have to have configuration context here, anything imported by
 #   conda.base.context is fair game, but nothing more.
-from . import CONDA_PACKAGE_ROOT, CondaError
+from . import CONDA_PACKAGE_ROOT, CONDA_SITE_PACKAGES, CondaError
 from ._vendor.toolz import concatv, drop
 from .auxlib.compat import Utf8NamedTemporaryFile
 from .base.constants import PREFIX_STATE_FILE, PACKAGE_ENV_VARS_DIR, CONDA_ENV_VARS_UNSET_VAR
@@ -911,18 +911,23 @@ class CshActivator(_Activator):
 
     def _hook_preamble(self):
         if on_win:
-            return ('setenv CONDA_EXE `cygpath %s`\n'
-                    'setenv _CONDA_ROOT `cygpath %s`\n'
-                    'setenv _CONDA_EXE `cygpath %s`\n'
-                    'setenv CONDA_PYTHON_EXE `cygpath %s`'
-                    % (context.conda_exe, context.conda_prefix, context.conda_exe, sys.executable))
+            return dedent(
+                f"""\
+                setenv CONDA_EXE `cygpath {context.conda_exe}`
+                setenv _CONDA_ROOT `cygpath {context.conda_prefix}`
+                setenv _CONDA_EXE `cygpath {context.conda_exe}`
+                setenv CONDA_PYTHON_EXE `cygpath {sys.executable}`
+                """
+            )
         else:
-            return ('setenv CONDA_EXE "%s"\n'
-                    'setenv _CONDA_ROOT "%s"\n'
-                    'setenv _CONDA_EXE "%s"\n'
-                    'setenv CONDA_PYTHON_EXE "%s"'
-                    % (context.conda_exe, context.conda_prefix, context.conda_exe,
-                       sys.executable))
+            return dedent(
+                f"""\
+                setenv CONDA_EXE "{context.conda_exe}"
+                setenv _CONDA_ROOT "{context.conda_prefix}"
+                setenv _CONDA_EXE "{context.conda_exe}"
+                setenv CONDA_PYTHON_EXE "{sys.executable}"
+                """
+            )
 
 
 class XonshActivator(_Activator):
@@ -1014,17 +1019,23 @@ class FishActivator(_Activator):
 
     def _hook_preamble(self):
         if on_win:
-            return ('set -gx CONDA_EXE (cygpath "%s")\n'
-                    'set _CONDA_ROOT (cygpath "%s")\n'
-                    'set _CONDA_EXE (cygpath "%s")\n'
-                    'set -gx CONDA_PYTHON_EXE (cygpath "%s")'
-                    % (context.conda_exe, context.conda_prefix, context.conda_exe, sys.executable))
+            return dedent(
+                f"""\
+                set -gx CONDA_EXE (cygpath "{context.conda_exe}")
+                set _CONDA_ROOT (cygpath "{context.conda_prefix}")
+                set _CONDA_EXE (cygpath "{context.conda_exe}")
+                set -gx CONDA_PYTHON_EXE (cygpath "{sys.executable}")
+                """
+            )
         else:
-            return ('set -gx CONDA_EXE "%s"\n'
-                    'set _CONDA_ROOT "%s"\n'
-                    'set _CONDA_EXE "%s"\n'
-                    'set -gx CONDA_PYTHON_EXE "%s"'
-                    % (context.conda_exe, context.conda_prefix, context.conda_exe, sys.executable))
+            return dedent(
+                f"""\
+                set -gx CONDA_EXE "{context.conda_exe}"
+                set _CONDA_ROOT "{context.conda_prefix}"
+                set _CONDA_EXE "{context.conda_exe}"
+                set -gx CONDA_PYTHON_EXE "{sys.executable}"
+                """
+            )
 
 
 class PowerShellActivator(_Activator):
@@ -1048,26 +1059,28 @@ class PowerShellActivator(_Activator):
 
     def _hook_preamble(self):
         if context.dev:
-            return dedent("""\
-                $Env:PYTHONPATH = "{python_path}"
-                $Env:CONDA_EXE = "{sys_exe}"
+            return dedent(
+                f"""\
+                $Env:PYTHONPATH = "{CONDA_SITE_PACKAGES}"
+                $Env:CONDA_EXE = "{sys.executable}"
                 $Env:_CE_M = "-m"
                 $Env:_CE_CONDA = "conda"
-                $Env:_CONDA_ROOT = "{python_path}{s}conda"
+                $Env:_CONDA_ROOT = "{CONDA_PACKAGE_ROOT}"
                 $Env:_CONDA_EXE = "{context.conda_exe}"
                 $CondaModuleArgs = @{{ChangePs1 = ${context.changeps1}}}
-                """.format(s=os.sep,
-                           python_path=dirname(CONDA_PACKAGE_ROOT),
-                           sys_exe=sys.executable, context=context))
+                """
+            )
         else:
-            return dedent("""\
+            return dedent(
+                f"""\
                 $Env:CONDA_EXE = "{context.conda_exe}"
                 $Env:_CE_M = ""
                 $Env:_CE_CONDA = ""
                 $Env:_CONDA_ROOT = "{context.conda_prefix}"
                 $Env:_CONDA_EXE = "{context.conda_exe}"
                 $CondaModuleArgs = @{{ChangePs1 = ${context.changeps1}}}
-                """.format(context=context))
+                """
+            )
 
     def _hook_postamble(self):
         return "Remove-Variable CondaModuleArgs"
@@ -1086,13 +1099,12 @@ class JSONFormatMixin(_Activator):
     def _hook_preamble(self):
         if context.dev:
             return {
-                'PYTHONPATH': dirname(CONDA_PACKAGE_ROOT),
-                'CONDA_EXE': sys.executable,
-                '_CE_M': '-m',
-                '_CE_CONDA': 'conda',
-                '_CONDA_ROOT': '{python_path}{s}conda'.format(
-                    python_path=dirname(CONDA_PACKAGE_ROOT), s=os.sep),
-                '_CONDA_EXE': context.conda_exe,
+                "PYTHONPATH": CONDA_SITE_PACKAGES,
+                "CONDA_EXE": sys.executable,
+                "_CE_M": "-m",
+                "_CE_CONDA": "conda",
+                "_CONDA_ROOT": CONDA_PACKAGE_ROOT,
+                "_CONDA_EXE": context.conda_exe,
             }
         else:
             return {

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 
 # Since we have to have configuration context here, anything imported by
 #   conda.base.context is fair game, but nothing more.
-from . import CONDA_PACKAGE_ROOT, CONDA_SITE_PACKAGES, CondaError
+from . import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT, CondaError
 from ._vendor.toolz import concatv, drop
 from .auxlib.compat import Utf8NamedTemporaryFile
 from .base.constants import PREFIX_STATE_FILE, PACKAGE_ENV_VARS_DIR, CONDA_ENV_VARS_UNSET_VAR
@@ -1061,7 +1061,7 @@ class PowerShellActivator(_Activator):
         if context.dev:
             return dedent(
                 f"""
-                $Env:PYTHONPATH = "{CONDA_SITE_PACKAGES}"
+                $Env:PYTHONPATH = "{CONDA_SOURCE_ROOT}"
                 $Env:CONDA_EXE = "{sys.executable}"
                 $Env:_CE_M = "-m"
                 $Env:_CE_CONDA = "conda"
@@ -1080,7 +1080,7 @@ class PowerShellActivator(_Activator):
                 $Env:_CONDA_EXE = "{context.conda_exe}"
                 $CondaModuleArgs = @{{ChangePs1 = ${context.changeps1}}}
                 """
-            ).strip
+            ).strip()
 
     def _hook_postamble(self):
         return "Remove-Variable CondaModuleArgs"
@@ -1099,7 +1099,7 @@ class JSONFormatMixin(_Activator):
     def _hook_preamble(self):
         if context.dev:
             return {
-                "PYTHONPATH": CONDA_SITE_PACKAGES,
+                "PYTHONPATH": CONDA_SOURCE_ROOT,
                 "CONDA_EXE": sys.executable,
                 "_CE_M": "-m",
                 "_CE_CONDA": "conda",

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -912,22 +912,22 @@ class CshActivator(_Activator):
     def _hook_preamble(self):
         if on_win:
             return dedent(
-                f"""\
+                f"""
                 setenv CONDA_EXE `cygpath {context.conda_exe}`
                 setenv _CONDA_ROOT `cygpath {context.conda_prefix}`
                 setenv _CONDA_EXE `cygpath {context.conda_exe}`
                 setenv CONDA_PYTHON_EXE `cygpath {sys.executable}`
                 """
-            )
+            ).strip()
         else:
             return dedent(
-                f"""\
+                f"""
                 setenv CONDA_EXE "{context.conda_exe}"
                 setenv _CONDA_ROOT "{context.conda_prefix}"
                 setenv _CONDA_EXE "{context.conda_exe}"
                 setenv CONDA_PYTHON_EXE "{sys.executable}"
                 """
-            )
+            ).strip()
 
 
 class XonshActivator(_Activator):
@@ -1020,22 +1020,22 @@ class FishActivator(_Activator):
     def _hook_preamble(self):
         if on_win:
             return dedent(
-                f"""\
+                f"""
                 set -gx CONDA_EXE (cygpath "{context.conda_exe}")
                 set _CONDA_ROOT (cygpath "{context.conda_prefix}")
                 set _CONDA_EXE (cygpath "{context.conda_exe}")
                 set -gx CONDA_PYTHON_EXE (cygpath "{sys.executable}")
                 """
-            )
+            ).strip()
         else:
             return dedent(
-                f"""\
+                f"""
                 set -gx CONDA_EXE "{context.conda_exe}"
                 set _CONDA_ROOT "{context.conda_prefix}"
                 set _CONDA_EXE "{context.conda_exe}"
                 set -gx CONDA_PYTHON_EXE "{sys.executable}"
                 """
-            )
+            ).strip()
 
 
 class PowerShellActivator(_Activator):
@@ -1060,7 +1060,7 @@ class PowerShellActivator(_Activator):
     def _hook_preamble(self):
         if context.dev:
             return dedent(
-                f"""\
+                f"""
                 $Env:PYTHONPATH = "{CONDA_SITE_PACKAGES}"
                 $Env:CONDA_EXE = "{sys.executable}"
                 $Env:_CE_M = "-m"
@@ -1069,10 +1069,10 @@ class PowerShellActivator(_Activator):
                 $Env:_CONDA_EXE = "{context.conda_exe}"
                 $CondaModuleArgs = @{{ChangePs1 = ${context.changeps1}}}
                 """
-            )
+            ).strip()
         else:
             return dedent(
-                f"""\
+                f"""
                 $Env:CONDA_EXE = "{context.conda_exe}"
                 $Env:_CE_M = ""
                 $Env:_CE_CONDA = ""
@@ -1080,7 +1080,7 @@ class PowerShellActivator(_Activator):
                 $Env:_CONDA_EXE = "{context.conda_exe}"
                 $CondaModuleArgs = @{{ChangePs1 = ${context.changeps1}}}
                 """
-            )
+            ).strip
 
     def _hook_postamble(self):
         return "Remove-Variable CondaModuleArgs"

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -34,7 +34,7 @@ from ..common.path import expand, paths_equal
 from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..common.decorators import env_override
 
-from .. import CONDA_PACKAGE_ROOT
+from .. import CONDA_SITE_PACKAGES
 
 try:
     os.getcwd()
@@ -613,12 +613,18 @@ class Context(Configuration):
         '''
 
         if context.dev:
-            return OrderedDict([('CONDA_EXE', sys.executable),
-                                ('PYTHONPATH', os.path.dirname(CONDA_PACKAGE_ROOT) + '{}{}'.format(
-                                    os.pathsep, os.environ.get('PYTHONPATH', ''))),
-                                ('_CE_M', '-m'),
-                                ('_CE_CONDA', 'conda'),
-                                ('CONDA_PYTHON_EXE', sys.executable)])
+            return OrderedDict(
+                [
+                    ("CONDA_EXE", sys.executable),
+                    (
+                        "PYTHONPATH",
+                        os.pathsep.join((CONDA_SITE_PACKAGES, os.environ.get("PYTHONPATH", ""))),
+                    ),
+                    ("_CE_M", "-m"),
+                    ("_CE_CONDA", "conda"),
+                    ("CONDA_PYTHON_EXE", sys.executable),
+                ]
+            )
         else:
             bin_dir = 'Scripts' if on_win else 'bin'
             exe = 'conda.exe' if on_win else 'conda'

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -34,7 +34,7 @@ from ..common.path import expand, paths_equal
 from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..common.decorators import env_override
 
-from .. import CONDA_SITE_PACKAGES
+from .. import CONDA_SOURCE_ROOT
 
 try:
     os.getcwd()
@@ -618,7 +618,9 @@ class Context(Configuration):
                     ("CONDA_EXE", sys.executable),
                     (
                         "PYTHONPATH",
-                        os.pathsep.join((CONDA_SITE_PACKAGES, os.environ.get("PYTHONPATH", ""))),
+                        # [warning] Do not confuse with os.path.join, we are joining paths
+                        # with ; or : delimiters.
+                        os.pathsep.join((CONDA_SOURCE_ROOT, os.environ.get("PYTHONPATH", ""))),
                     ),
                     ("_CE_M", "-m"),
                     ("_CE_CONDA", "conda"),

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -348,12 +348,12 @@ def wrap_subprocess_call(on_win, root_prefix, prefix, dev_mode, debug_wrapper_sc
             fh.write('{}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'.format(silencer))  # NOQA
             fh.write("{}chcp 65001 > NUL\n".format(silencer))
             if dev_mode:
-                from . import CONDA_SITE_PACKAGES
+                from . import CONDA_SOURCE_ROOT
                 fh.write("{}SET CONDA_DEV=1\n".format(silencer))
                 # In dev mode, conda is really:
                 # 'python -m conda'
                 # *with* PYTHONPATH set.
-                fh.write("{}SET PYTHONPATH={}\n".format(silencer, CONDA_SITE_PACKAGES))
+                fh.write("{}SET PYTHONPATH={}\n".format(silencer, CONDA_SOURCE_ROOT))
                 fh.write("{}SET CONDA_EXE={}\n".format(silencer, sys.executable))
                 fh.write("{}SET _CE_M=-m\n".format(silencer))
                 fh.write("{}SET _CE_CONDA=conda\n".format(silencer))
@@ -405,9 +405,9 @@ def wrap_subprocess_call(on_win, root_prefix, prefix, dev_mode, debug_wrapper_sc
             dev_args = []
         with Utf8NamedTemporaryFile(mode='w', prefix=tmp_prefix, delete=False) as fh:
             if dev_mode:
-                from . import CONDA_SITE_PACKAGES
+                from . import CONDA_SOURCE_ROOT
 
-                fh.write(">&2 export PYTHONPATH=" + CONDA_SITE_PACKAGES + "\n")
+                fh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + "\n")
             hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment before ***'\n" ">&2 env\n")

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -348,12 +348,12 @@ def wrap_subprocess_call(on_win, root_prefix, prefix, dev_mode, debug_wrapper_sc
             fh.write('{}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'.format(silencer))  # NOQA
             fh.write("{}chcp 65001 > NUL\n".format(silencer))
             if dev_mode:
-                from conda.core.initialize import CONDA_PACKAGE_ROOT
+                from . import CONDA_SITE_PACKAGES
                 fh.write("{}SET CONDA_DEV=1\n".format(silencer))
                 # In dev mode, conda is really:
                 # 'python -m conda'
                 # *with* PYTHONPATH set.
-                fh.write("{}SET PYTHONPATH={}\n".format(silencer, dirname(CONDA_PACKAGE_ROOT)))
+                fh.write("{}SET PYTHONPATH={}\n".format(silencer, CONDA_SITE_PACKAGES))
                 fh.write("{}SET CONDA_EXE={}\n".format(silencer, sys.executable))
                 fh.write("{}SET _CE_M=-m\n".format(silencer))
                 fh.write("{}SET _CE_CONDA=conda\n".format(silencer))
@@ -405,9 +405,9 @@ def wrap_subprocess_call(on_win, root_prefix, prefix, dev_mode, debug_wrapper_sc
             dev_args = []
         with Utf8NamedTemporaryFile(mode='w', prefix=tmp_prefix, delete=False) as fh:
             if dev_mode:
-                from conda.core.initialize import CONDA_PACKAGE_ROOT
+                from . import CONDA_SITE_PACKAGES
 
-                fh.write(">&2 export PYTHONPATH=" + dirname(CONDA_PACKAGE_ROOT) + "\n")
+                fh.write(">&2 export PYTHONPATH=" + CONDA_SITE_PACKAGES + "\n")
             hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment before ***'\n" ">&2 env\n")

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -11,7 +11,7 @@ from unittest import TestCase
 
 import pytest
 
-from conda import CONDA_PACKAGE_ROOT, CONDA_SITE_PACKAGES
+from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT
 from conda.auxlib.ish import dals
 from conda.base.context import context, reset_context, conda_tests_ctxt_mgmt_def_pol
 from conda.cli.common import stdout_json
@@ -576,7 +576,7 @@ class InitializeTests(TestCase):
                     initialize_dev(
                         "bash",
                         dev_env_prefix=conda_temp_prefix,
-                        conda_source_root=CONDA_SITE_PACKAGES,
+                        conda_source_root=CONDA_SOURCE_ROOT,
                     )
 
         print(c.stdout)
@@ -648,7 +648,7 @@ class InitializeTests(TestCase):
                     initialize_dev(
                         "cmd.exe",
                         dev_env_prefix=conda_temp_prefix,
-                        conda_source_root=CONDA_SITE_PACKAGES,
+                        conda_source_root=CONDA_SOURCE_ROOT,
                     )
 
         print(c.stdout)

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -11,7 +11,7 @@ from unittest import TestCase
 
 import pytest
 
-from conda import CONDA_PACKAGE_ROOT
+from conda import CONDA_PACKAGE_ROOT, CONDA_SITE_PACKAGES
 from conda.auxlib.ish import dals
 from conda.base.context import context, reset_context, conda_tests_ctxt_mgmt_def_pol
 from conda.cli.common import stdout_json
@@ -573,7 +573,11 @@ class InitializeTests(TestCase):
                 mkdir_p(dirname(new_py))
                 create_link(abspath(sys.executable), new_py, LinkType.hardlink if on_win else LinkType.softlink)
                 with captured() as c:
-                    initialize_dev('bash', dev_env_prefix=conda_temp_prefix, conda_source_root=dirname(CONDA_PACKAGE_ROOT))
+                    initialize_dev(
+                        "bash",
+                        dev_env_prefix=conda_temp_prefix,
+                        conda_source_root=CONDA_SITE_PACKAGES,
+                    )
 
         print(c.stdout)
         print(c.stderr, file=sys.stderr)
@@ -641,7 +645,11 @@ class InitializeTests(TestCase):
                 mkdir_p(dirname(new_py))
                 create_link(abspath(sys.executable), new_py, LinkType.hardlink if on_win else LinkType.softlink)
                 with captured() as c:
-                    initialize_dev('cmd.exe', dev_env_prefix=conda_temp_prefix, conda_source_root=dirname(CONDA_PACKAGE_ROOT))
+                    initialize_dev(
+                        "cmd.exe",
+                        dev_env_prefix=conda_temp_prefix,
+                        conda_source_root=CONDA_SITE_PACKAGES,
+                    )
 
         print(c.stdout)
         print(c.stderr, file=sys.stderr)

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 import json
 
 from conda import __version__ as conda_version
-from conda import CONDA_PACKAGE_ROOT
+from conda import CONDA_PACKAGE_ROOT, CONDA_SITE_PACKAGES
 from conda.auxlib.ish import dals
 from conda._vendor.toolz.itertoolz import concatv
 from conda.activate import CmdExeActivator, CshActivator, FishActivator, PosixActivator, \
@@ -1914,9 +1914,9 @@ class InteractiveShell(object):
         )))
         self.original_path = PATH
         env = {
-            'CONDA_AUTO_ACTIVATE_BASE': 'false',
-            'PYTHONPATH': self.activator.path_conversion(dirname(CONDA_PACKAGE_ROOT)),
-            'PATH': PATH,
+            "CONDA_AUTO_ACTIVATE_BASE": "false",
+            "PYTHONPATH": self.activator.path_conversion(CONDA_SITE_PACKAGES),
+            "PATH": PATH,
         }
         for ev in ('CONDA_TEST_SAVE_TEMPS', 'CONDA_TEST_TMPDIR', 'CONDA_TEST_USER_ENVIRONMENTS_TXT_FILE'):
             if ev in os.environ: env[ev] = os.environ[ev]

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 import json
 
 from conda import __version__ as conda_version
-from conda import CONDA_PACKAGE_ROOT, CONDA_SITE_PACKAGES
+from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT
 from conda.auxlib.ish import dals
 from conda._vendor.toolz.itertoolz import concatv
 from conda.activate import CmdExeActivator, CshActivator, FishActivator, PosixActivator, \
@@ -1915,7 +1915,7 @@ class InteractiveShell(object):
         self.original_path = PATH
         env = {
             "CONDA_AUTO_ACTIVATE_BASE": "false",
-            "PYTHONPATH": self.activator.path_conversion(CONDA_SITE_PACKAGES),
+            "PYTHONPATH": self.activator.path_conversion(CONDA_SOURCE_ROOT),
             "PATH": PATH,
         }
         for ev in ('CONDA_TEST_SAVE_TEMPS', 'CONDA_TEST_TMPDIR', 'CONDA_TEST_USER_ENVIRONMENTS_TXT_FILE'):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -37,7 +37,7 @@ from conda import (
     plan,
     __version__ as CONDA_VERSION,
     CONDA_PACKAGE_ROOT,
-    CONDA_SITE_PACKAGES,
+    CONDA_SOURCE_ROOT,
 )
 from conda.auxlib.entity import EntityEncoder
 from conda.auxlib.ish import dals
@@ -2657,7 +2657,7 @@ dependencies:
 
                 # When we run `conda run -p prefix python -m conda init` we are explicitly wishing to run the
                 # old Python 3.6.7 in prefix, but against the development sources of conda. Those are found
-                # via `workdir=CONDA_SITE_PACKAGES`.
+                # via `workdir=CONDA_SOURCE_ROOT`.
                 #
                 # This was beyond complicated to deal with and led to adding a new 'dev' flag which modifies
                 # what the script wrappers emit for `CONDA_EXE`.
@@ -2669,7 +2669,7 @@ dependencies:
                 #
 
                 '''
-                env_path_etc, errs_etc, _ = run_command(Commands.RUN, prefix, '--cwd', CONDA_SITE_PACKAGES, dedent("""
+                env_path_etc, errs_etc, _ = run_command(Commands.RUN, prefix, '--cwd', CONDA_SOURCE_ROOT, dedent("""
                     declare -f
                     env | sort
                     which conda
@@ -2687,20 +2687,20 @@ dependencies:
                     Commands.RUN,
                     prefix,
                     "--cwd",
-                    CONDA_SITE_PACKAGES,
+                    CONDA_SOURCE_ROOT,
                     sys.executable,
                     "-c",
                     "import conda, os, sys; " "sys.stdout.write(os.path.abspath(conda.__file__))",
                     dev=True,
                 )
-                assert dirname(dirname(conda__file__)) == CONDA_SITE_PACKAGES
+                assert dirname(dirname(conda__file__)) == CONDA_SOURCE_ROOT
 
                 # (and the same thing for Python)
                 python_v2, _, _ = run_command(
                     Commands.RUN,
                     prefix,
                     "--cwd",
-                    CONDA_SITE_PACKAGES,
+                    CONDA_SOURCE_ROOT,
                     "python",
                     "-c",
                     "import os, sys; "
@@ -2715,7 +2715,7 @@ dependencies:
                     Commands.RUN,
                     prefix,
                     "--cwd",
-                    CONDA_SITE_PACKAGES,
+                    CONDA_SOURCE_ROOT,
                     *args,
                     dev=True,
                 )

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -31,8 +31,14 @@ from uuid import uuid4
 import pytest
 import requests
 
-from conda import CondaError, CondaMultiError, plan, __version__ as CONDA_VERSION, \
-    CONDA_PACKAGE_ROOT
+from conda import (
+    CondaError,
+    CondaMultiError,
+    plan,
+    __version__ as CONDA_VERSION,
+    CONDA_PACKAGE_ROOT,
+    CONDA_SITE_PACKAGES,
+)
 from conda.auxlib.entity import EntityEncoder
 from conda.auxlib.ish import dals
 from conda._vendor.toolz import concatv
@@ -1982,7 +1988,6 @@ dependencies:
     def test_conda_pip_interop_conda_editable_package(self):
         with env_var('CONDA_RESTORE_FREE_CHANNEL', True, stack_callback=conda_tests_ctxt_mgmt_def_pol):
             with make_temp_env("python=2.7", "pip=10", "git", use_restricted_unicode=on_win) as prefix:
-                conda_dev_srcdir = dirname(CONDA_PACKAGE_ROOT)
                 workdir = prefix
 
                 run_command(Commands.CONFIG, prefix, "--set", "pip_interop_enabled", "true")
@@ -2630,7 +2635,6 @@ dependencies:
         with make_temp_env("conda="+conda_v, "python="+python_v, "git",
                            "conda-package-handling", "--copy",
                            name='_' + str(uuid4())[:8]) as prefix:
-            conda_dev_srcdir = dirname(CONDA_PACKAGE_ROOT)
             # We cannot naively call $SOME_PREFIX/bin/conda and expect it to run the right conda because we
             # respect PATH (i.e. our conda shell script (in 4.5 days at least) has the following shebang:
             # `#!/usr/bin/env python`). Now it may be that `PYTHONPATH` or something was meant to account
@@ -2653,7 +2657,7 @@ dependencies:
 
                 # When we run `conda run -p prefix python -m conda init` we are explicitly wishing to run the
                 # old Python 3.6.7 in prefix, but against the development sources of conda. Those are found
-                # via `workdir=conda_dev_srcdir`.
+                # via `workdir=CONDA_SITE_PACKAGES`.
                 #
                 # This was beyond complicated to deal with and led to adding a new 'dev' flag which modifies
                 # what the script wrappers emit for `CONDA_EXE`.
@@ -2665,7 +2669,7 @@ dependencies:
                 #
 
                 '''
-                env_path_etc, errs_etc, _ = run_command(Commands.RUN, prefix, '--cwd', conda_dev_srcdir, dedent("""
+                env_path_etc, errs_etc, _ = run_command(Commands.RUN, prefix, '--cwd', CONDA_SITE_PACKAGES, dedent("""
                     declare -f
                     env | sort
                     which conda
@@ -2679,16 +2683,26 @@ dependencies:
 
                 # Let us test that the conda we expect to be running in that scenario
                 # is the conda that actually runs:
-                conda__file__, stderr, _ = run_command(Commands.RUN, prefix, '--cwd', conda_dev_srcdir,
-                    sys.executable, "-c",
-                    "import conda, os, sys; "
-                    "sys.stdout.write(os.path.abspath(conda.__file__))",
-                    dev=True)
-                assert dirname(dirname(conda__file__)) == conda_dev_srcdir
+                conda__file__, stderr, _ = run_command(
+                    Commands.RUN,
+                    prefix,
+                    "--cwd",
+                    CONDA_SITE_PACKAGES,
+                    sys.executable,
+                    "-c",
+                    "import conda, os, sys; " "sys.stdout.write(os.path.abspath(conda.__file__))",
+                    dev=True,
+                )
+                assert dirname(dirname(conda__file__)) == CONDA_SITE_PACKAGES
 
                 # (and the same thing for Python)
-                python_v2, _, _ = run_command(Commands.RUN, prefix, '--cwd', conda_dev_srcdir,
-                    "python", "-c",
+                python_v2, _, _ = run_command(
+                    Commands.RUN,
+                    prefix,
+                    "--cwd",
+                    CONDA_SITE_PACKAGES,
+                    "python",
+                    "-c",
                     "import os, sys; "
                     "sys.stdout.write(str(sys.version_info[0]) + '.' + "
                     "                 str(sys.version_info[1]) + '.' + "
@@ -2696,9 +2710,15 @@ dependencies:
                 assert python_v2 == python_v
 
                 # install a dev version with our current source checkout into prefix
-                args = ["python", "-m", "conda", "init"] + (["cmd.exe", "--dev"] if on_win else ["--dev"])
-                result, stderr, _ = run_command(Commands.RUN, prefix, '--cwd', conda_dev_srcdir,
-                                              *args, dev=True)
+                args = ["python", "-m", "conda", "init", *(["cmd.exe"] if on_win else []), "--dev"]
+                result, stderr, _ = run_command(
+                    Commands.RUN,
+                    prefix,
+                    "--cwd",
+                    CONDA_SITE_PACKAGES,
+                    *args,
+                    dev=True,
+                )
 
                 result = subprocess_call_with_clean_env("%s --version" % conda_exe)
                 assert result.rc == 0


### PR DESCRIPTION
`dirname(CONDA_PACKAGE_ROOT)` is used a number of times in various corners of `conda`. Introducing a new global variable eliminating any repeat `dirname` calls.

Not set on the variable name or the necessity of this change so def up for a discussion.