### PR TITLE
Improve command line argument quoting

### DIFF
--- a/conda/utils.py
+++ b/conda/utils.py
@@ -282,14 +282,8 @@ if on_win:
     # https://ss64.com/nt/syntax-esc.html
     # https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
 
-    # cmd metachars
-    _CMD_ESCAPE_METACHARS = "()%!^<>&|"
-    _CMD_DBLESCAPE_METACHARS = '"'
-
-    _CMD_UNSAFE_RE = re.compile(fr"[\s{_CMD_ESCAPE_METACHARS}{_CMD_DBLESCAPE_METACHARS}]")
-
-    _CMD_ESCAPE_RE = re.compile(fr"([{_CMD_ESCAPE_METACHARS}])")
-    _CMD_DBLESCAPE_RE = re.compile(fr"([{_CMD_DBLESCAPE_METACHARS}])")
+    _RE_UNSAFE = re.compile(r'["%\s^<>&|]')
+    _RE_DBL = re.compile(r'(["%])')
 
     def _args_join(args):
         """Return a shell-escaped string from *args*."""
@@ -298,12 +292,12 @@ if on_win:
             # derived from shlex.quote
             if not s:
                 return '""'
-            if not _CMD_UNSAFE_RE.search(s):
+            # if any unsafe chars are present we must quote
+            if not _RE_UNSAFE.search(s):
                 return s
-            # escape (^) metacharacters
-            s = _CMD_ESCAPE_RE.sub(r"^\1", s)
-            # doubly escape (\\^) metacharacters to avoid case of, e.g., quotes inside quoted arg
-            s = _CMD_DBLESCAPE_RE.sub(r"\\^\1", s)
+            # double escape (" -> "")
+            s = _RE_DBL.sub(r"\1\1", s)
+            # quote entire string
             return f'"{s}"'
 
         return " ".join(quote(arg) for arg in args)

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -304,7 +304,7 @@ if on_win:
             s = _CMD_ESCAPE_RE.sub(r"^\1", s)
             # doubly escape (\\^) metacharacters to avoid case of, e.g., quotes inside quoted arg
             s = _CMD_DBLESCAPE_RE.sub(r"\\^\1", s)
-            return f'^"{s}^"'
+            return f'"{s}"'
 
         return " ".join(quote(arg) for arg in args)
 else:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -292,14 +292,14 @@ if on_win:
     def _args_join(args):
         """Return a shell-escaped string from a list of arguments.
 
-        Inspired by `subprocess.join`.
+        Inspired by `shlex.join`.
         """
         return " ".join(map(_cmd_quote, args))
 
     def _cmd_quote(s):
         """Return a shell-escaped version of the string.
 
-        Inspired by `subprocess.quote`.
+        Inspired by `shlex.quote`.
         """
         if not s:
             return '""'
@@ -313,7 +313,15 @@ if on_win:
 
 
 else:
-    from shlex import join as _args_join
+    try:
+        from shlex import join as _args_join
+    except ImportError:
+        # [backport] Python <3.8
+        def _args_join(args):
+            """Return a shell-escaped string from *args*."""
+            from shlex import quote
+
+            return " ".join(quote(arg) for arg in args)
 
 
 # Ensures arguments are a tuple or a list. Strings are converted

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -263,11 +263,12 @@ def sys_prefix_unfollowed():
 def quote_for_shell(*arguments):
     """Properly quote arguments for command line passing.
 
-    Extends `subprocess.list2cmdline` (which handles standard quoting for arguments with spacing
-    and escaped characters) with proper handling for redirects, file descriptors, and pipes.
+    Copy of `subprocess.list2cmdline` (which handles standard quoting for arguments with
+    spacing and escaped characters) with additional checks for redirects, file descriptors, and
+    pipes.
 
     :param arguments: Arguments to quote.
-    :type arguments: list
+    :type arguments: list of str
     :return: Quoted arguments.
     :rtype: str
     """
@@ -280,7 +281,7 @@ def quote_for_shell(*arguments):
     for arg in map(fsdecode, arguments):
         bs_buf = []
 
-        # Add a space to separate this argument from the others
+        # Add a space to separate this argument from the others.
         if result:
             result.append(" ")
 
@@ -311,7 +312,7 @@ def quote_for_shell(*arguments):
                 bs_buf = []
                 result.append('\\"')
             else:
-                # Normal char
+                # Normal char.
                 if bs_buf:
                     result.extend(bs_buf)
                     bs_buf = []

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -285,8 +285,9 @@ def quote_for_shell(*arguments):
             result.append(" ")
 
         needquote = (
+            not arg
             # redirects
-            ("<" in arg)
+            or ("<" in arg)
             or (">" in arg)
             # file descriptor
             or ("&" in arg)
@@ -295,7 +296,7 @@ def quote_for_shell(*arguments):
             # spacing
             or (" " in arg)
             or ("\t" in arg)
-            or not arg
+            or ("\n" in arg)
         )
         if needquote:
             result.append('"')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,6 @@ import sys
 from conda.common.compat import on_win
 
 import pytest
-import subprocess
 
 
 SOME_PREFIX = "/some/prefix"
@@ -167,7 +166,7 @@ _quotes = _win_quotes if on_win else _posix_quotes
         pytest.param("#", "#" if on_win else "'#'"),
         pytest.param("$", "$" if on_win else "'$'"),
         pytest.param("%", '"%%"' if on_win else "%"),
-        pytest.param("&", '"&"' if on_win else "'&'"),
+        pytest.param("&", _quotes("&")),
         pytest.param("'", "'" if on_win else "''\"'\"''"),
         pytest.param("(", "(" if on_win else "'('"),
         pytest.param(")", ")" if on_win else "')'"),
@@ -179,17 +178,17 @@ _quotes = _win_quotes if on_win else _posix_quotes
         pytest.param("/", "/"),
         pytest.param(":", ":"),
         pytest.param(";", ";" if on_win else "';'"),
-        pytest.param("<", '"<"' if on_win else "'<'"),
+        pytest.param("<", _quotes("<")),
         pytest.param("=", "="),
-        pytest.param(">", '">"' if on_win else "'>'"),
+        pytest.param(">", _quotes(">")),
         pytest.param("?", "?" if on_win else "'?'"),
         pytest.param("@", "@"),
         pytest.param("[", "[" if on_win else "'['"),
         pytest.param("\\", "\\" if on_win else "'\\'"),
         pytest.param("]", "]" if on_win else "']'"),
-        pytest.param("^", '"^"' if on_win else "'^'"),
+        pytest.param("^", _quotes("^")),
         pytest.param("{", "{" if on_win else "'{'"),
-        pytest.param("|", '"|"' if on_win else "'|'"),
+        pytest.param("|", _quotes("|")),
         pytest.param("}", "}" if on_win else "'}'"),
         pytest.param("~", "~" if on_win else "'~'"),
         pytest.param('"', '""""' if on_win else "'\"'"),


### PR DESCRIPTION
Not in love with this implementation so alternative ideas would be very welcome.

We have already been relying on `subprocess.list2cmdline` to convert our list of str into a str on Windows. Unfortunately the implementation does not identify and handle what may look like redirects, file descriptors, or pipes. This resulted in:

<table>
<tr>
<td>End user input</td>
<td><code>conda run -n NAME pip install "numpy<1.22"</code></td>
</tr>
<tr>
<td>In <code>.tmp</code> script</td>
<td><code>pip install numpy<1.22</code></td>
</tr>
<tr>
<td>Expected</td>
<td><code>pip install "numpy<1.22"</code></td>
</tr>
</table>

So in addition to handling quotes and escape chars as `subprocess.list2cmd` does we also ensure we quote anything that looks like a redirect (`<` or `>`), a file descriptors (`&1` or `&2`), or a pipe (`|`).

This is the magical PR that solves #10972