### PR TITLE
Don't make devenv dir when running `dev/start --dry-run`

### DIFF
--- a/dev/start
+++ b/dev/start
@@ -86,8 +86,10 @@ _DEVENV="${_DEVENV/#\~/${HOME}}"
 # include OS
 _DEVENV="${_DEVENV}/$(uname)"
 # ensure exists and absolute path
-mkdir -p "${_DEVENV}"
-_DEVENV="$( cd "${_DEVENV}" 2>&1 > /dev/null ; pwd -P)"
+if [ ${_DRYRUN} = 1 ]; then
+    mkdir -p "${_DEVENV}"
+    _DEVENV="$( cd "${_DEVENV}" 2>&1 > /dev/null ; pwd -P)"
+fi
 
 # fallback to default values
 _PYTHON="${_PYTHON:-3.8}"

--- a/dev/start
+++ b/dev/start
@@ -71,6 +71,11 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# fallback to default values
+_PYTHON="${_PYTHON:-3.8}"
+_UPDATE="${_UPDATE:-1}"
+_DRYRUN="${_DRYRUN:-1}"
+
 # get source path
 # since zsh is MacOS standard fallback to $0 if not in bash
 _SRC="$(cd "$(dirname "$(dirname "${BASH_SOURCE:-$0}")")" 2>&1 > /dev/null; pwd -P)"
@@ -90,11 +95,6 @@ if [ ${_DRYRUN} = 1 ]; then
     mkdir -p "${_DEVENV}"
     _DEVENV="$( cd "${_DEVENV}" 2>&1 > /dev/null ; pwd -P)"
 fi
-
-# fallback to default values
-_PYTHON="${_PYTHON:-3.8}"
-_UPDATE="${_UPDATE:-1}"
-_DRYRUN="${_DRYRUN:-1}"
 
 # other environment values
 _NAME="devenv-${_PYTHON}-c"

--- a/dev/start.bat
+++ b/dev/start.bat
@@ -60,7 +60,9 @@
 @REM include OS
 @SET "_DEVENV=%_DEVENV%\Windows"
 @REM ensure exists
-@IF NOT EXIST "%_DEVENV%" @MKDIR "%_DEVENV%"
+@IF %_DRYRUN%==1 (
+    @IF NOT EXIST "%_DEVENV%" @MKDIR "%_DEVENV%"
+)
 
 @REM fallback to default values
 @IF "%_PYTHON%"=="" @SET "_PYTHON=3.8"

--- a/dev/start.bat
+++ b/dev/start.bat
@@ -53,6 +53,11 @@
 @EXIT /B 1
 :ARGS_END
 
+@REM fallback to default values
+@IF "%_PYTHON%"=="" @SET "_PYTHON=3.8"
+@IF "%_UPDATE%"=="" @SET "_UPDATE=1"
+@IF "%_DRYRUN%"=="" @SET "_DRYRUN=1"
+
 @REM read devenv from ~\.condarc
 @IF "%_DEVENV%"=="" @FOR /F "usebackq delims=" %%I IN (`powershell.exe "(Select-String -Path '~\.condarc' -Pattern '^devenv:\s*(.+)' | Select-Object -Last 1).Matches.Groups[1].Value -replace '^~',$Env:UserProfile"`) DO @SET "_DEVENV=%%~fI"
 @REM fallback to devenv in source default
@@ -63,11 +68,6 @@
 @IF %_DRYRUN%==1 (
     @IF NOT EXIST "%_DEVENV%" @MKDIR "%_DEVENV%"
 )
-
-@REM fallback to default values
-@IF "%_PYTHON%"=="" @SET "_PYTHON=3.8"
-@IF "%_UPDATE%"=="" @SET "_UPDATE=1"
-@IF "%_DRYRUN%"=="" @SET "_DRYRUN=1"
 
 @REM other environment variables
 @SET "_NAME=devenv-%_PYTHON%-c"


### PR DESCRIPTION
When invoking `dev/start{,.bat}` as dry-run it shouldn't be making **any** system changes including any new directories.