### PR TITLE
Add concurrency group to cancel GHA runs on repeated pushes to branch/PR.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,15 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  # Concurrency group that uses the workflow name and PR nummer if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   windows:
     runs-on: windows-2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  # Concurrency group that uses the workflow name and PR nummer if available
+  # Concurrency group that uses the workflow name and PR number if available
   # or commit SHA as a fallback. If a new build is triggered under that
   # concurrency group while a previous build is running it will be canceled.
   # Repeated pushes to a PR will cancel all previous builds, while multiple


### PR DESCRIPTION
Concurrency group that uses the workflow name and PR number if available or commit SHA as a fallback. If a new build is triggered under that concurrency group while a previous build is running it will be canceled.

Repeated pushes to a PR will cancel all previous builds, while multiple merges to main will not cancel.


[Previously](https://github.com/pyca/cryptography/pull/6203), [previously](https://github.com/pyca/cryptography/pull/6221), [previously](https://github.com/pypa/pip/pull/10704).