### PR TITLE
Change overly verbose info log to debug.

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -243,7 +243,7 @@ def captured(stdout=CaptureTarget.STRING, stderr=CaptureTarget.STRING):
         if errfile is not None:
             sys.stderr = errfile
     c = CapturedText()
-    log.info("overtaking stderr and stdout")
+    log.debug("overtaking stderr and stdout")
     try:
         yield c
     finally:
@@ -258,7 +258,7 @@ def captured(stdout=CaptureTarget.STRING, stderr=CaptureTarget.STRING):
         else:
             c.stderr = errfile
         sys.stdout, sys.stderr = saved_stdout, saved_stderr
-        log.info("stderr and stdout yielding back")
+        log.debug("stderr and stdout yielding back")
 
 
 @contextmanager


### PR DESCRIPTION
When using the `conda` package in python to inspect package versions, we get lots of logs like:
```
conda.common.io INFO: overtaking stderr and stdout
conda.common.io INFO: stderr and stdout yielding back
```
These logs do not seem actionable and seem unnecessarily verbose.  This PR changes them to `debug` level logs.
