### PR TITLE
Update reload from import deprecated since py=3.4

### DIFF
--- a/conda/auxlib/_vendor/five.py
+++ b/conda/auxlib/_vendor/five.py
@@ -46,7 +46,7 @@ PY3 = sys.version_info[0] == 3
 try:
     reload = reload                         # noqa
 except NameError:                           # pragma: no cover
-    from imp import reload                  # noqa
+    from importlib import reload            # noqa
 
 try:
     from collections import UserList        # noqa


### PR DESCRIPTION
The `from imp import reload` used in the vendored `five.py` has been deprecated since python 3.4.  This creates warnings that can be seen in third-party tests and the conda CI unit tests.  This PR fixes the import line.