### PR TITLE
ci-skip.yml to circumvent skipped required checks

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -1,0 +1,36 @@
+# NOTE: jobs in this workflow are required checks (see https://github.com/conda/conda/settings/branch_protection_rules/773550)
+# remember to mirror changes here in ci.yml to circumvent skipped required checks issue
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: CI tests
+
+on:
+  # NOTE: github.event context is pull_request payload:
+  # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+  pull_request:
+    paths:
+      - 'docs/**'
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  windows:
+    runs-on: windows-2019
+    steps:
+      - run: 'echo "No build required"'
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# NOTE: jobs in this workflow are required checks (see https://github.com/conda/conda/settings/branch_protection_rules/773550)
+# remember to mirror changes here in ci-skip.yml to circumvent skipped required checks issue
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 name: CI tests
 
 on:


### PR DESCRIPTION
When checks are marked as required but also skipped (e.g. when only docs are modified) we get into a catch 22 state. We address this issue by defining a dummy workflow to satisfy the checks.

See [GitHub docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks)

Should resolve merging block for https://github.com/conda/conda/pull/11278