### PR TITLE
Including strategy matrix in skipped checks

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -22,15 +22,31 @@ concurrency:
 jobs:
   windows:
     runs-on: windows-2019
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9']
+        conda-subdir: ['win-64']
+        test-type: ['unit', 'integration']
+        test-group: ['1', '2', '3']
     steps:
       - run: 'echo "No build required"'
 
   linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9']
+        test-type: ['unit', 'integration']
+        test-group: ['1', '2', '3']
     steps:
       - run: 'echo "No build required"'
 
   macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ['3.9']
+        test-type: ['unit', 'integration']
+        test-group: ['1', '2', '3']
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
Followup to https://github.com/conda/conda/pull/11286

Looks like we need the matrix to be defined as well to properly match the check names.