### PR TITLE
Reorg main_clean

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -89,9 +89,6 @@ def find_pkgs():
     # TODO: This doesn't handle packages that have hard links to files within
     # themselves, like bin/python3.3 and bin/python3.3m in the Python package
     warnings = []
-
-    from ..gateways.disk.link import CrossPlatformStLink
-    cross_platform_st_nlink = CrossPlatformStLink()
     pkgs_dirs = {}
     for pkgs_dir in context.pkgs_dirs:
         if not exists(pkgs_dir):
@@ -104,7 +101,7 @@ def find_pkgs():
             for root, dir, files in walk(join(pkgs_dir, pkg)):
                 for fn in files:
                     try:
-                        st_nlink = cross_platform_st_nlink(join(root, fn))
+                        st_nlink = lstat(join(root, fn)).st_nlink
                     except OSError as e:
                         warnings.append((fn, e))
                         continue

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -19,7 +19,7 @@ def find_tarballs():
     from ..core.package_cache_data import PackageCacheData
 
     pkgs_dirs = {}
-    totalsize = 0
+    total_size = 0
     part_ext = tuple(e + '.part' for e in CONDA_PACKAGE_EXTENSIONS)
     for package_cache in PackageCacheData.writable_caches(context.pkgs_dirs):
         pkgs_dir = package_cache.pkgs_dir
@@ -29,12 +29,12 @@ def find_tarballs():
         for fn in filenames:
             if fn.endswith(CONDA_PACKAGE_EXTENSIONS) or fn.endswith(part_ext):
                 pkgs_dirs.setdefault(pkgs_dir, []).append(fn)
-                totalsize += getsize(join(root, fn))
+                total_size += getsize(join(root, fn))
 
-    return pkgs_dirs, totalsize
+    return pkgs_dirs, total_size
 
 
-def rm_tarballs(args, pkgs_dirs, totalsize, verbose=True):
+def rm_tarballs(args, pkgs_dirs, total_size, verbose=True):
     from .common import confirm_yn
     from ..gateways.disk.delete import rm_rf
     from ..utils import human_bytes
@@ -59,10 +59,10 @@ def rm_tarballs(args, pkgs_dirs, totalsize, verbose=True):
             for fn in pkgs_dirs[pkgs_dir]:
                 size = getsize(join(pkgs_dir, fn))
                 print(fmt % (fn, human_bytes(size)))
-            print('')
-        print('-' * 51)  # From 40 + 1 + 10 in fmt
-        print(fmt % ('Total:', human_bytes(totalsize)))
-        print('')
+            print("")
+        print("-" * 51)  # From 40 + 1 + 10 in fmt
+        print(fmt % ("Total:", human_bytes(total_size)))
+        print("")
 
     if not context.json or not context.always_yes:
         confirm_yn()
@@ -118,7 +118,7 @@ def find_pkgs():
             else:
                 pkgs_dirs.setdefault(pkgs_dir, []).append(pkg)
 
-    totalsize = 0
+    total_size = 0
     pkg_sizes = {}
     for pkgs_dir in pkgs_dirs:
         for pkg in pkgs_dirs[pkgs_dir]:
@@ -128,14 +128,14 @@ def find_pkgs():
                     # We don't have to worry about counting things twice:  by
                     # definition these files all have a link count of 1!
                     size = lstat(join(root, fn)).st_size
-                    totalsize += size
+                    total_size += size
                     pkgsize += size
             pkg_sizes.setdefault(pkgs_dir, {})[pkg] = pkgsize
 
-    return pkgs_dirs, warnings, totalsize, pkg_sizes
+    return pkgs_dirs, warnings, total_size, pkg_sizes
 
 
-def rm_pkgs(args, pkgs_dirs, warnings, totalsize, pkg_sizes, verbose=True):
+def rm_pkgs(args, pkgs_dirs, warnings, total_size, pkg_sizes, verbose=True):
     from .common import confirm_yn
     from ..gateways.disk.delete import rm_rf
     from ..utils import human_bytes
@@ -159,10 +159,10 @@ def rm_pkgs(args, pkgs_dirs, warnings, totalsize, pkg_sizes, verbose=True):
             fmt = "%-40s %10s"
             for pkg, pkgsize in pkgs.items():
                 print(fmt % (pkg, human_bytes(pkgsize)))
-            print('')
-        print('-' * 51)  # 40 + 1 + 10 in fmt
-        print(fmt % ('Total:', human_bytes(totalsize)))
-        print('')
+            print("")
+        print("-" * 51)  # 40 + 1 + 10 in fmt
+        print(fmt % ("Total:", human_bytes(total_size)))
+        print("")
 
     if not context.json or not context.always_yes:
         confirm_yn()
@@ -239,9 +239,9 @@ def _execute(args, parser):
         raise ArgumentError("At least one removal target must be given. See 'conda clean --help'.")
 
     if args.tarballs or args.all:
-        pkgs_dirs, totalsize = find_tarballs()
-        json_result["tarballs"] = {"pkgs_dirs": pkgs_dirs, "total_size": totalsize}
-        rm_tarballs(args, pkgs_dirs, totalsize, verbose=not (context.json or context.quiet))
+        pkgs_dirs, total_size = find_tarballs()
+        json_result["tarballs"] = {"pkgs_dirs": pkgs_dirs, "total_size": total_size}
+        rm_tarballs(args, pkgs_dirs, total_size, verbose=not (context.json or context.quiet))
 
     if args.index_cache or args.all:
         json_result['index_cache'] = {
@@ -250,10 +250,10 @@ def _execute(args, parser):
         rm_index_cache()
 
     if args.packages or args.all:
-        pkgs_dirs, warnings, totalsize, pkg_sizes = find_pkgs()
+        pkgs_dirs, warnings, total_size, pkg_sizes = find_pkgs()
         json_result["packages"] = {
             "pkgs_dirs": pkgs_dirs,
-            "total_size": totalsize,
+            "total_size": total_size,
             "warnings": warnings,
             "pkg_sizes": pkg_sizes,
         }
@@ -261,7 +261,7 @@ def _execute(args, parser):
             args,
             pkgs_dirs,
             warnings,
-            totalsize,
+            total_size,
             pkg_sizes,
             verbose=not (context.json or context.quiet),
         )

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -240,11 +240,8 @@ def _execute(args, parser):
 
     if args.tarballs or args.all:
         pkgs_dirs, totalsize = find_tarballs()
-        first = sorted(pkgs_dirs)[0] if pkgs_dirs else ''
         json_result['tarballs'] = {
-            'pkgs_dir': first,  # Backwards compatibility
             'pkgs_dirs': dict(pkgs_dirs),
-            'files': pkgs_dirs[first],  # Backwards compatibility
             'total_size': totalsize
         }
         rm_tarballs(args, pkgs_dirs, totalsize, verbose=not (context.json or context.quiet))
@@ -257,11 +254,8 @@ def _execute(args, parser):
 
     if args.packages or args.all:
         pkgs_dirs, warnings, totalsize, pkgsizes = find_pkgs()
-        first = sorted(pkgs_dirs)[0] if pkgs_dirs else ''
         json_result['packages'] = {
-            'pkgs_dir': first,  # Backwards compatibility
             'pkgs_dirs': dict(pkgs_dirs),
-            'files': pkgs_dirs[first],  # Backwards compatibility
             'total_size': totalsize,
             'warnings': warnings,
             'pkg_sizes': {i: dict(zip(pkgs_dirs[i], pkgsizes[i])) for i in pkgs_dirs},

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -13,6 +13,7 @@ from ..base.constants import CONDA_PACKAGE_EXTENSIONS, CONDA_TEMP_EXTENSION
 from ..base.context import context
 
 log = getLogger(__name__)
+_EXTS = (*CONDA_PACKAGE_EXTENSIONS, *(f"{e}.part" for e in CONDA_PACKAGE_EXTENSIONS))
 
 
 def find_tarballs():
@@ -20,14 +21,13 @@ def find_tarballs():
 
     pkgs_dirs = {}
     total_size = 0
-    part_ext = tuple(e + '.part' for e in CONDA_PACKAGE_EXTENSIONS)
     for package_cache in PackageCacheData.writable_caches(context.pkgs_dirs):
         pkgs_dir = package_cache.pkgs_dir
         if not isdir(pkgs_dir):
             continue
         root, _, filenames = next(walk(pkgs_dir))
         for fn in filenames:
-            if fn.endswith(CONDA_PACKAGE_EXTENSIONS) or fn.endswith(part_ext):
+            if fn.endswith(_EXTS):
                 pkgs_dirs.setdefault(pkgs_dir, []).append(fn)
                 total_size += getsize(join(root, fn))
 

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -123,8 +123,6 @@ LinkError = LinkError
 CondaOSError = CondaOSError
 # PathNotFoundError is the conda 4.4.x name for it - let's plan ahead.
 PathNotFoundError = CondaFileNotFoundError = PathNotFoundError
-from .gateways.disk.link import CrossPlatformStLink  # NOQA
-CrossPlatformStLink = CrossPlatformStLink
 
 from .models.enums import FileMode  # NOQA
 FileMode = FileMode

--- a/conda/gateways/disk/link.py
+++ b/conda/gateways/disk/link.py
@@ -7,14 +7,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from logging import getLogger
-from os import chmod as os_chmod, lstat
+from os import chmod as os_chmod
 from os.path import abspath, isdir, islink as os_islink, lexists as os_lexists
 import sys
 
 from ...common.compat import PY2, on_win
 from ...exceptions import CondaOSError, ParseError
 
-__all__ = ('islink', 'lchmod', 'lexists', 'link', 'readlink', 'stat_nlink', 'symlink')
+__all__ = ("islink", "lchmod", "lexists", "link", "readlink", "symlink")
 
 log = getLogger(__name__)
 PYPY = sys.implementation.name == 'pypy'
@@ -410,94 +410,3 @@ else:  # pragma: no cover
         handle_nonzero_success(res)
         handle_nonzero_success(returned_bytes)
         return out_buffer[:returned_bytes.value]
-
-
-# work-around for python bug on Windows prior to python 3.2
-# https://bugs.python.org/issue10027
-# Adapted from the ntfsutils package, Copyright (c) 2012, the Mozilla Foundation
-class CrossPlatformStLink(object):
-    _st_nlink = None
-
-    def __call__(self, path):
-        return self.st_nlink(path)
-
-    @classmethod
-    def st_nlink(cls, path):
-        if cls._st_nlink is None:
-            cls._initialize()
-        return cls._st_nlink(path)
-
-    @classmethod
-    def _standard_st_nlink(cls, path):
-        return lstat(path).st_nlink
-
-    @classmethod
-    def _windows_st_nlink(cls, path):  # pragma: unix no cover
-        st_nlink = cls._standard_st_nlink(path)
-        if st_nlink != 0:
-            return st_nlink
-        else:
-            # cannot trust python on Windows when st_nlink == 0
-            # get value using windows libraries to be sure of its true value
-            # Adapted from the ntfsutils package, Copyright (c) 2012, the Mozilla Foundation
-            GENERIC_READ = 0x80000000
-            FILE_SHARE_READ = 0x00000001
-            OPEN_EXISTING = 3
-            hfile = cls.CreateFile(path, GENERIC_READ, FILE_SHARE_READ, None,
-                                   OPEN_EXISTING, 0, None)
-            if hfile is None:
-                from ctypes import WinError
-                raise WinError()
-            info = cls.BY_HANDLE_FILE_INFORMATION()
-            rv = cls.GetFileInformationByHandle(hfile, info)
-            cls.CloseHandle(hfile)
-            if rv == 0:
-                from ctypes import WinError
-                raise WinError()
-            return info.nNumberOfLinks
-
-    @classmethod
-    def _initialize(cls):
-        if not on_win:
-            cls._st_nlink = cls._standard_st_nlink
-        else:  # pragma: unix no cover
-            # http://msdn.microsoft.com/en-us/library/windows/desktop/aa363858
-            from ctypes import POINTER, Structure, c_void_p, c_wchar_p
-            from ctypes.wintypes import DWORD, HANDLE, BOOL
-
-            cls.CreateFile = windll.kernel32.CreateFileW
-            cls.CreateFile.argtypes = [c_wchar_p, DWORD, DWORD, c_void_p,
-                                       DWORD, DWORD, HANDLE]
-            cls.CreateFile.restype = HANDLE
-
-            # http://msdn.microsoft.com/en-us/library/windows/desktop/ms724211
-            cls.CloseHandle = windll.kernel32.CloseHandle
-            cls.CloseHandle.argtypes = [HANDLE]
-            cls.CloseHandle.restype = BOOL
-
-            class FILETIME(Structure):
-                _fields_ = [("dwLowDateTime", DWORD),
-                            ("dwHighDateTime", DWORD)]
-
-            class BY_HANDLE_FILE_INFORMATION(Structure):
-                _fields_ = [("dwFileAttributes", DWORD),
-                            ("ftCreationTime", FILETIME),
-                            ("ftLastAccessTime", FILETIME),
-                            ("ftLastWriteTime", FILETIME),
-                            ("dwVolumeSerialNumber", DWORD),
-                            ("nFileSizeHigh", DWORD),
-                            ("nFileSizeLow", DWORD),
-                            ("nNumberOfLinks", DWORD),
-                            ("nFileIndexHigh", DWORD),
-                            ("nFileIndexLow", DWORD)]
-            cls.BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION
-
-            # http://msdn.microsoft.com/en-us/library/windows/desktop/aa364952
-            cls.GetFileInformationByHandle = windll.kernel32.GetFileInformationByHandle
-            cls.GetFileInformationByHandle.argtypes = [HANDLE, POINTER(BY_HANDLE_FILE_INFORMATION)]
-            cls.GetFileInformationByHandle.restype = BOOL
-
-            cls._st_nlink = cls._windows_st_nlink
-
-
-stat_nlink = CrossPlatformStLink()

--- a/news/11351-reorg-conda.cli.main_clean
+++ b/news/11351-reorg-conda.cli.main_clean
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Removed `conda.exports.CrossPlatformStLink`, a Windows Python <3.2 fix for `os.lstat.st_nlink`. (#11351)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from logging import getLogger
+import os
 from os.path import basename, dirname, isdir, isfile, join, lexists, getsize
 import sys
 from tempfile import gettempdir
@@ -24,7 +25,7 @@ from conda.core.path_actions import CompileMultiPycAction, CreatePythonEntryPoin
 from conda.exceptions import ParseError
 from conda.gateways.disk.create import create_link, mkdir_p
 from conda.gateways.disk.delete import rm_rf
-from conda.gateways.disk.link import islink, stat_nlink
+from conda.gateways.disk.link import islink
 from conda.gateways.disk.permissions import is_executable
 from conda.gateways.disk.read import compute_md5sum, compute_sha256sum
 from conda.gateways.disk.test import softlink_supported
@@ -282,7 +283,7 @@ class PathActionsTests(TestCase):
         axn.execute()
         assert isfile(axn.target_full_path)
         assert not islink(axn.target_full_path)
-        assert stat_nlink(axn.target_full_path) == 2
+        assert os.lstat(axn.target_full_path).st_nlink == 2
 
         axn.reverse()
         assert not lexists(axn.target_full_path)
@@ -313,7 +314,7 @@ class PathActionsTests(TestCase):
         axn.execute()
         assert isfile(axn.target_full_path)
         assert islink(axn.target_full_path)
-        assert stat_nlink(axn.target_full_path) == 1
+        assert os.lstat(axn.target_full_path).st_nlink == 1
 
         axn.reverse()
         assert not lexists(axn.target_full_path)
@@ -358,7 +359,7 @@ class PathActionsTests(TestCase):
         axn.execute()
         assert isfile(axn.target_full_path)
         assert not islink(axn.target_full_path)
-        assert stat_nlink(axn.target_full_path) == 1
+        assert os.lstat(axn.target_full_path).st_nlink == 1
 
         axn.reverse()
         assert not lexists(axn.target_full_path)

--- a/tests/gateways/disk/test_link.py
+++ b/tests/gateways/disk/test_link.py
@@ -15,7 +15,7 @@ import pytest
 from conda.common.compat import on_win, PY2
 from conda.gateways.disk.create import mkdir_p
 from conda.gateways.disk.delete import rm_rf
-from conda.gateways.disk.link import link, islink, readlink, stat_nlink, symlink
+from conda.gateways.disk.link import link, islink, readlink, symlink
 from conda.gateways.disk.test import softlink_supported
 from conda.gateways.disk.update import touch
 
@@ -45,15 +45,14 @@ class LinkSymlinkUnlinkIslinkReadlinkTests(TestCase):
         assert isfile(path2_second_inode)
         assert not islink(path2_second_inode)
 
-        path1_stat = os.stat(path1_real_file)
-        path2_stat = os.stat(path2_second_inode)
-
+        path1_stat = os.lstat(path1_real_file)
+        path2_stat = os.lstat(path2_second_inode)
         assert path1_stat.st_ino == path2_stat.st_ino
-        assert stat_nlink(path1_real_file) == stat_nlink(path2_second_inode)
+        assert path1_stat.st_nlink == path2_stat.st_nlink
 
         os.unlink(path2_second_inode)
         assert not lexists(path2_second_inode)
-        assert stat_nlink(path1_real_file) == 1
+        assert os.lstat(path1_real_file).st_nlink == 1
 
         os.unlink(path1_real_file)
         assert not lexists(path1_real_file)
@@ -75,10 +74,10 @@ class LinkSymlinkUnlinkIslinkReadlinkTests(TestCase):
         assert islink(path2_symlink)
 
         assert readlink(path2_symlink).endswith(path1_real_file)
-        # for win py27, readlink actually gives something that starts with \??\
-        # \??\c:\users\appveyor\appdata\local\temp\1\c571cb0c\path1_real_file
+        # Windows Python >3.7, readlink actually gives something that starts with \\?\
+        # \\?\C:\users\appveyor\appdata\local\temp\1\c571cb0c\path1_real_file
 
-        assert stat_nlink(path1_real_file) == stat_nlink(path2_symlink) == 1
+        assert os.lstat(path1_real_file).st_nlink == os.lstat(path2_symlink).st_nlink == 1
 
         os.unlink(path1_real_file)
         assert not isfile(path1_real_file)


### PR DESCRIPTION
Preparing for #11345, no functional change

- Removes `one_target_ran` in favor of a simpler check
- Removes 7 year old backport (introduced https://github.com/conda/conda/pull/1231, released with conda 3.18)
- Removes `defaultdict` usage in favor of `dict.setdefault`
- Instead of redefining `pkg_sizes` before returning it/using a zip logic just implement it correctly from the start and use `dict.items`
- Convert all `totalsize` variables to `total_size` to match the keyword we return with `--json`
- Change `find_*` functions to return `dict` instead of `tuple`
- Make `.part` extension tuple into a global const
- Remove unnecessary `os.lstat.st_nlink` fix for Windows Python <3.2 (conda-build [implements this fix as well](https://github.com/conda/conda-build/blob/806c3f0c12fd4f0177b396887ba84e1c5f4a1e15/conda_build/conda_interface.py#L161-L247) so I see this as a low risk removal)