### PR TITLE
Remove expensive conda-build autouse fixture

### DIFF
--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 @pytest.fixture
-def fix_cli_install(tmpdir):
+def prefix(tmpdir):
     prefix = tmpdir.mkdir("cli_install_prefix")
     test_env = tmpdir.mkdir("cli_install_test_env")
     run_command(Commands.CREATE, str(prefix), 'python=3.7')
@@ -29,18 +29,18 @@ def fix_cli_install(tmpdir):
 
 
 @pytest.mark.integration
-def test_pre_link_message(fix_cli_install, pre_link_messages_package):
-    prefix = fix_cli_install[0]
+def test_pre_link_message(prefix, pre_link_messages_package):
+    prefix, _ = prefix
     with patch("conda.cli.common.confirm_yn", return_value=True):
         stdout, _, _ = run_command(
-            Commands.INSTALL, prefix, "pre_link_messages_package", "--use-local"
+            Commands.INSTALL, prefix, pre_link_messages_package, "--use-local"
         )
         assert "Lorem ipsum dolor sit amet" in stdout
 
 
 @pytest.mark.integration
-def test_find_conflicts_called_once(fix_cli_install):
-    prefix, test_env = fix_cli_install
+def test_find_conflicts_called_once(prefix):
+    prefix, test_env = prefix
     bad_deps = {'python': {((MatchSpec("statistics"), MatchSpec("python[version='>=2.7,<2.8.0a0']")), 'python=3')}}
 
     with patch(

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -29,7 +29,7 @@ def fix_cli_install(tmpdir):
 
 
 @pytest.mark.integration
-def test_pre_link_message(fix_cli_install, conda_build_recipes):
+def test_pre_link_message(fix_cli_install, pre_link_messages_package):
     prefix = fix_cli_install[0]
     with patch("conda.cli.common.confirm_yn", return_value=True):
         stdout, _, _ = run_command(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,11 +29,22 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("shell", metafunc.config.option.shell)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def conda_build_recipes():
-    test_recipes = Path(__file__).resolve().parent / "test-recipes"
-    recipes_to_build = ["activate_deactivate_package", "pre_link_messages_package"]
-    packages = [str(test_recipes / pkg) for pkg in recipes_to_build]
-    cmd = ["conda-build"]
-    cmd.extend(packages)
-    subprocess.run(cmd, check=True)
+def _conda_build_recipe(pkg):
+    subprocess.run(
+        ["conda-build", Path(__file__).resolve().parent / "test-recipes" / pkg],
+        check=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def activate_deactivate_package():
+    pkg = "activate_deactivate_package"
+    _conda_build_recipe(pkg)
+    return pkg
+
+
+@pytest.fixture(scope="session")
+def pre_link_messages_package():
+    pkg = "pre_link_messages_package"
+    _conda_build_recipe(pkg)
+    return pkg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,30 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from pathlib import Path
 import subprocess
-import sys
 
 import pytest
-
-from conda.testing.fixtures import (
-    suppress_resource_warning,
-    tmpdir,
-    clear_subdir_cache,
-)
-
-win_default_shells = ["cmd.exe", "powershell", "git_bash", "cygwin"]
-shells = ["bash", "zsh"]
-if sys.platform == "win32":
-    shells = win_default_shells
-
-
-def pytest_addoption(parser):
-    parser.addoption("--shell", action="append", default=[],
-                     help="list of shells to run shell tests on")
-
-
-def pytest_generate_tests(metafunc):
-    if 'shell' in metafunc.fixturenames:
-        metafunc.parametrize("shell", metafunc.config.option.shell)
 
 
 def _conda_build_recipe(pkg):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,22 +7,19 @@ import subprocess
 import pytest
 
 
-def _conda_build_recipe(pkg):
+def _conda_build_recipe(recipe):
     subprocess.run(
-        ["conda-build", Path(__file__).resolve().parent / "test-recipes" / pkg],
+        ["conda-build", Path(__file__).resolve().parent / "test-recipes" / recipe],
         check=True,
     )
+    return recipe
 
 
 @pytest.fixture(scope="session")
 def activate_deactivate_package():
-    pkg = "activate_deactivate_package"
-    _conda_build_recipe(pkg)
-    return pkg
+    return _conda_build_recipe("activate_deactivate_package")
 
 
 @pytest.fixture(scope="session")
 def pre_link_messages_package():
-    pkg = "pre_link_messages_package"
-    _conda_build_recipe(pkg)
-    return pkg
+    return _conda_build_recipe("pre_link_messages_package")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 def _conda_build_recipe(recipe):
     subprocess.run(
-        ["conda-build", Path(__file__).resolve().parent / "test-recipes" / recipe],
+        ["conda-build", str(Path(__file__).resolve().parent / "test-recipes" / recipe)],
         check=True,
     )
     return recipe

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2647,6 +2647,7 @@ def prefix():
 
     rm_rf(root)
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     ["shell"],
     [

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2668,7 +2668,7 @@ class ActivationIntegrationTests(TestCase):
             ),
         ],
     )
-    def test_activate_deactivate_modify_path(self, shell):
+    def test_activate_deactivate_modify_path(self, shell, activate_deactivate_package):
         original_path = os.environ.get("PATH")
         run_command(Commands.INSTALL, self.prefix2, "activate_deactivate_package", "--use-local")
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2661,7 +2661,6 @@ def prefix():
     ],
 )
 def test_activate_deactivate_modify_path(shell, prefix, activate_deactivate_package):
-    print(shell, activate_deactivate_package)
     original_path = os.environ.get("PATH")
     run_command(Commands.INSTALL, prefix, activate_deactivate_package, "--use-local")
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from re import escape
 from collections import OrderedDict
-from itertools import chain
 from logging import getLogger
 import os
 from os.path import dirname, isdir, join
@@ -54,11 +53,6 @@ from conda.gateways.disk.update import touch
 from conda.testing.helpers import tempdir
 from conda.testing.integration import Commands, run_command, SPACER_CHARACTER
 from conda.auxlib.decorators import memoize
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
 
 log = getLogger(__name__)
 
@@ -2635,47 +2629,46 @@ class ShellWrapperIntegrationTests(TestCase):
             conda_shlvl = shell.get_env_var('CONDA_SHLVL')
             assert conda_shlvl == '0', conda_shlvl
 
-@pytest.mark.integration
-class ActivationIntegrationTests(TestCase):
+@pytest.fixture(scope="module")
+def prefix():
+    tempdirdir = gettempdir()
 
-    def setUp(self):
-        tempdirdir = gettempdir()
+    root_dirname = str(uuid4())[:4] + SPACER_CHARACTER + str(uuid4())[:4]
+    root = join(tempdirdir, root_dirname)
+    mkdir_p(join(root, "conda-meta"))
+    assert isdir(root)
+    touch(join(root, "conda-meta", "history"))
 
-        prefix_dirname = str(uuid4())[:4] + SPACER_CHARACTER + str(uuid4())[:4]
-        self.prefix = join(tempdirdir, prefix_dirname)
-        mkdir_p(join(self.prefix, 'conda-meta'))
-        assert isdir(self.prefix)
-        touch(join(self.prefix, 'conda-meta', 'history'))
+    prefix = join(root, "envs", "charizard")
+    mkdir_p(join(prefix, "conda-meta"))
+    touch(join(prefix, "conda-meta", "history"))
 
-        self.prefix2 = join(self.prefix, 'envs', 'charizard')
-        mkdir_p(join(self.prefix2, 'conda-meta'))
-        touch(join(self.prefix2, 'conda-meta', 'history'))
+    yield prefix
 
-    def tearDown(self):
-        rm_rf(self.prefix)
-        rm_rf(self.prefix2)
+    rm_rf(root)
 
-    @pytest.mark.parametrize(
-        ["shell"],
-        [
-            pytest.param(
-                "bash",
-                marks=pytest.mark.skipif(bash_unsupported(), reason=bash_unsupported_because()),
-            ),
-            pytest.param(
-                "cmd.exe",
-                marks=pytest.mark.skipif(not which("cmd.exe"), reason="cmd.exe not installed"),
-            ),
-        ],
-    )
-    def test_activate_deactivate_modify_path(self, shell, activate_deactivate_package):
-        original_path = os.environ.get("PATH")
-        run_command(Commands.INSTALL, self.prefix2, "activate_deactivate_package", "--use-local")
+@pytest.mark.parametrize(
+    ["shell"],
+    [
+        pytest.param(
+            "bash",
+            marks=pytest.mark.skipif(bash_unsupported(), reason=bash_unsupported_because()),
+        ),
+        pytest.param(
+            "cmd.exe",
+            marks=pytest.mark.skipif(not which("cmd.exe"), reason="cmd.exe not installed"),
+        ),
+    ],
+)
+def test_activate_deactivate_modify_path(shell, prefix, activate_deactivate_package):
+    print(shell, activate_deactivate_package)
+    original_path = os.environ.get("PATH")
+    run_command(Commands.INSTALL, prefix, activate_deactivate_package, "--use-local")
 
-        with InteractiveShell(shell) as shell:
-            shell.sendline('conda activate "%s"' % self.prefix2)
-            activated_env_path = shell.get_env_var("PATH")
-            shell.sendline('conda deactivate')
+    with InteractiveShell(shell) as sh:
+        sh.sendline('conda activate "%s"' % prefix)
+        activated_env_path = sh.get_env_var("PATH")
+        sh.sendline("conda deactivate")
 
-        assert "teststringfromactivate/bin/test" in activated_env_path
-        assert original_path == os.environ.get("PATH")
+    assert "teststringfromactivate/bin/test" in activated_env_path
+    assert original_path == os.environ.get("PATH")


### PR DESCRIPTION
The packages built by this autouse fixture are only used in two places. Blindly building these packages for any test run is unnecessarily expensive (e.g. when trying to run individual tests locally).