### PR TITLE
Reorg + new tests for main_clean

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -152,6 +152,7 @@ CONDA_PACKAGE_EXTENSIONS = (
 )
 CONDA_TARBALL_EXTENSION = CONDA_PACKAGE_EXTENSION_V1  # legacy support for conda-build; remove this line  # NOQA
 CONDA_TEMP_EXTENSION = '.c~'
+CONDA_TEMP_EXTENSIONS = (CONDA_TEMP_EXTENSION, ".trash")
 
 UNKNOWN_CHANNEL = "<unknown>"
 REPODATA_FN = 'repodata.json'

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -7,9 +7,8 @@ from json import loads as json_loads
 from os import listdir
 from os.path import basename, isdir, join, exists
 from shutil import copy
-import pytest
 from conda.base.constants import CONDA_TEMP_EXTENSION
-from conda.core.subdir_data import create_cache_dir, SubdirData
+from conda.core.subdir_data import create_cache_dir
 from conda.testing.integration import make_temp_package_cache, run_command, Commands, make_temp_env
 
 
@@ -44,11 +43,6 @@ def _get_all(pkgs_dir):
 
 def _any_pkg(name, contents):
     return any(basename(c).startswith(f"{name}-") for c in contents)
-
-
-@pytest.fixture
-def clear_cache():
-    SubdirData._cache_.clear()
 
 
 # conda clean --force-pkgs-dirs

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -7,7 +7,7 @@ from json import loads as json_loads
 from os import listdir
 from os.path import basename, isdir, join, exists
 from shutil import copy
-from conda.base.constants import CONDA_TEMP_EXTENSION
+from conda.base.constants import CONDA_PACKAGE_EXTENSIONS, CONDA_TEMP_EXTENSIONS
 from conda.core.subdir_data import create_cache_dir
 from conda.testing.integration import make_temp_package_cache, run_command, Commands, make_temp_env
 
@@ -159,12 +159,12 @@ def test_clean_tempfiles(clear_cache):
 
         with make_temp_env(pkg):
             # mimic tempfiles being created
-            path = _get_tars(contents=glob(join(pkgs_dir, f"{pkg}-*")))[0]
-            copy(path, f"{path}{CONDA_TEMP_EXTENSION}")
-            copy(path, f"{path}.trash")
+            path = _get_tars(pkgs_dir)[0]  # grab any tarball
+            for ext in CONDA_TEMP_EXTENSIONS:
+                copy(path, f"{path}{ext}")
 
             # tempfiles exist
-            assert len(_get_tempfiles(pkgs_dir)) == 2
+            assert len(_get_tempfiles(pkgs_dir)) == len(CONDA_TEMP_EXTENSIONS)
 
             # --json flag is regression test for #5451
             stdout, _, _ = run_command(

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -4,7 +4,7 @@
 
 from glob import glob
 from json import loads as json_loads
-from os import listdir, makedirs
+from os import listdir
 from os.path import basename, isdir, join, exists
 from shutil import copy
 import pytest

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -4,53 +4,232 @@
 
 from glob import glob
 from json import loads as json_loads
-from os import listdir
-from os.path import basename, isdir, join
-from conda.core.subdir_data import create_cache_dir
+from os import listdir, makedirs
+from os.path import basename, isdir, join, exists
+from shutil import copy
+import pytest
+from conda.base.constants import CONDA_TEMP_EXTENSION
+from conda.core.subdir_data import create_cache_dir, SubdirData
 from conda.testing.integration import make_temp_package_cache, run_command, Commands, make_temp_env
 
 
-def test_clean_index_cache():
-    prefix = ""
-
-    # make sure we have something in the index cache
-    stdout, _, _ = run_command(Commands.INFO, prefix, "bzip2", "--json")
-    assert "bzip2" in json_loads(stdout)
-    index_cache_dir = create_cache_dir()
-    assert glob(join(index_cache_dir, "*.json"))
-
-    # now clear it
-    run_command(Commands.CLEAN, prefix, "--index-cache")
-    assert not glob(join(index_cache_dir, "*.json"))
+def _get_contents(pkgs_dir):
+    return [join(pkgs_dir, d) for d in listdir(pkgs_dir)]
 
 
-def test_clean_tarballs_and_packages():
+def _get_pkgs(pkgs_dir=None, *, contents=None):
+    return [d for d in contents or _get_contents(pkgs_dir) if isdir(d)]
+
+
+def _get_tars(pkgs_dir=None, *, contents=None):
+    return [t for t in contents or _get_contents(pkgs_dir) if t.endswith((".tar.bz2", ".conda"))]
+
+
+def _get_index_cache():
+    return glob(join(create_cache_dir(), "*.json"))
+
+
+def _get_tempfiles(pkgs_dir=None, *, contents=None):
+    return [
+        t
+        for t in contents or _get_contents(pkgs_dir)
+        if t.endswith((".trash", CONDA_TEMP_EXTENSION))
+    ]
+
+
+def _get_all(pkgs_dir):
+    contents = _get_contents(pkgs_dir)
+    return _get_pkgs(contents=contents), _get_tars(contents=contents), _get_index_cache()
+
+
+def _any_pkg(name, contents):
+    return any(basename(c).startswith(f"{name}-") for c in contents)
+
+
+@pytest.fixture
+def clear_cache():
+    SubdirData._cache_.clear()
+
+
+# conda clean --force-pkgs-dirs
+def test_clean_force_pkgs_dirs(clear_cache):
+    pkg = "bzip2"
+
     with make_temp_package_cache() as pkgs_dir:
-        filter_pkgs = lambda x: [f for f in x if f.endswith((".tar.bz2", ".conda"))]
-        with make_temp_env("bzip2") as prefix:
-            pkgs_dir_contents = [join(pkgs_dir, d) for d in listdir(pkgs_dir)]
-            pkgs_dir_dirs = [d for d in pkgs_dir_contents if isdir(d)]
-            pkgs_dir_tarballs = filter_pkgs(pkgs_dir_contents)
-            assert any(basename(d).startswith("bzip2-") for d in pkgs_dir_dirs)
-            assert any(basename(f).startswith("bzip2-") for f in pkgs_dir_tarballs)
+        # pkgs_dir is a directory
+        assert isdir(pkgs_dir)
+
+        with make_temp_env(pkg):
+            stdout, _, _ = run_command(Commands.CLEAN, "", "--force-pkgs-dirs", "--yes", "--json")
+            json_loads(stdout)  # assert valid json
+
+            # pkgs_dir is removed
+            assert not exists(pkgs_dir)
+
+        # pkgs_dir is still removed
+        assert not exists(pkgs_dir)
+
+
+# conda clean --packages
+def test_clean_and_packages(clear_cache):
+    pkg = "bzip2"
+
+    with make_temp_package_cache() as pkgs_dir:
+        # pkg doesn't exist ahead of time
+        assert not _any_pkg(pkg, _get_pkgs(pkgs_dir))
+
+        with make_temp_env(pkg) as prefix:
+            # pkg exists
+            assert _any_pkg(pkg, _get_pkgs(pkgs_dir))
 
             # --json flag is regression test for #5451
-            run_command(Commands.CLEAN, prefix, "--packages", "--yes", "--json")
+            stdout, _, _ = run_command(Commands.CLEAN, "", "--packages", "--yes", "--json")
+            json_loads(stdout)  # assert valid json
+
+            # pkg still exists since its in use by temp env
+            assert _any_pkg(pkg, _get_pkgs(pkgs_dir))
+
+            run_command(Commands.REMOVE, prefix, pkg, "--yes", "--json")
+            stdout, _, _ = run_command(Commands.CLEAN, "", "--packages", "--yes", "--json")
+            json_loads(stdout)  # assert valid json
+
+            # pkg is removed
+            assert not _any_pkg(pkg, _get_pkgs(pkgs_dir))
+
+        # pkg is still removed
+        assert not _any_pkg(pkg, _get_pkgs(pkgs_dir))
+
+
+# conda clean --tarballs
+def test_clean_tarballs(clear_cache):
+    pkg = "bzip2"
+
+    with make_temp_package_cache() as pkgs_dir:
+        # tarball doesn't exist ahead of time
+        assert not _any_pkg(pkg, _get_tars(pkgs_dir))
+
+        with make_temp_env(pkg):
+            # tarball exists
+            assert _any_pkg(pkg, _get_tars(pkgs_dir))
 
             # --json flag is regression test for #5451
-            run_command(Commands.CLEAN, prefix, "--tarballs", "--yes", "--json")
+            stdout, _, _ = run_command(Commands.CLEAN, "", "--tarballs", "--yes", "--json")
+            json_loads(stdout)  # assert valid json
 
-            pkgs_dir_contents = [join(pkgs_dir, d) for d in listdir(pkgs_dir)]
-            pkgs_dir_dirs = [d for d in pkgs_dir_contents if isdir(d)]
-            pkgs_dir_tarballs = filter_pkgs(pkgs_dir_contents)
+            # tarball is removed
+            assert not _any_pkg(pkg, _get_tars(pkgs_dir))
 
-            assert any(basename(d).startswith("bzip2-") for d in pkgs_dir_dirs)
-            assert not any(basename(f).startswith("bzip2-") for f in pkgs_dir_tarballs)
+        # tarball is still removed
+        assert not _any_pkg(pkg, _get_tars(pkgs_dir))
 
-            run_command(Commands.REMOVE, prefix, "bzip2", "--yes", "--json")
 
-        run_command(Commands.CLEAN, prefix, "--packages", "--yes")
+# conda clean --index-cache
+def test_clean_index_cache(clear_cache):
+    pkg = "bzip2"
 
-        pkgs_dir_contents = [join(pkgs_dir, d) for d in listdir(pkgs_dir)]
-        pkgs_dir_dirs = [d for d in pkgs_dir_contents if isdir(d)]
-        assert not any(basename(d).startswith("bzip2-") for d in pkgs_dir_dirs)
+    with make_temp_package_cache():
+        # index cache doesn't exist ahead of time
+        assert not _get_index_cache()
+
+        with make_temp_env(pkg):
+            # index cache exists
+            assert _get_index_cache()
+
+            stdout, _, _ = run_command(Commands.CLEAN, "", "--index-cache", "--yes", "--json")
+            json_loads(stdout)  # assert valid json
+
+            # index cache is cleared
+            assert not _get_index_cache()
+
+        # index cache is still cleared
+        assert not _get_index_cache()
+
+
+# conda clean --tempfiles
+def test_clean_tempfiles(clear_cache):
+    """Tempfiles are either suffixed with .c~ or .trash.
+
+    .c~ is used to indicate that conda is actively using that file. If the conda process is
+    terminated unexpectedly these .c~ files may remain and hence can be cleaned up after the fact.
+
+    .trash appears to be a legacy suffix that is no longer used by conda.
+
+    Since the presence of .c~ and .trash files are dependent upon irregular termination we create
+    our own temporary files to confirm they get cleaned up.
+    """
+    pkg = "bzip2"
+
+    with make_temp_package_cache() as pkgs_dir:
+        # tempfiles don't exist ahead of time
+        assert not _get_tempfiles(pkgs_dir)
+
+        with make_temp_env(pkg):
+            # mimic tempfiles being created
+            path = _get_tars(contents=glob(join(pkgs_dir, f"{pkg}-*")))[0]
+            copy(path, f"{path}{CONDA_TEMP_EXTENSION}")
+            copy(path, f"{path}.trash")
+
+            # tempfiles exist
+            assert len(_get_tempfiles(pkgs_dir)) == 2
+
+            # --json flag is regression test for #5451
+            stdout, _, _ = run_command(
+                Commands.CLEAN, "", "--tempfiles", pkgs_dir, "--yes", "--json"
+            )
+            json_loads(stdout)  # assert valid json
+
+            # tempfiles removed
+            assert not _get_tempfiles(pkgs_dir)
+
+        # tempfiles still removed
+        assert not _get_tempfiles(pkgs_dir)
+
+
+# conda clean --all
+def test_clean_all(clear_cache):
+    pkg = "bzip2"
+
+    with make_temp_package_cache() as pkgs_dir:
+        # pkg, tarball, & index cache doesn't exist ahead of time
+        pkgs, tars, cache = _get_all(pkgs_dir)
+        assert not _any_pkg(pkg, pkgs)
+        assert not _any_pkg(pkg, tars)
+        assert not cache
+
+        with make_temp_env(pkg) as prefix:
+            # pkg, tarball, & index cache exists
+            pkgs, tars, cache = _get_all(pkgs_dir)
+            assert _any_pkg(pkg, pkgs)
+            assert _any_pkg(pkg, tars)
+            assert cache
+
+            stdout, _, _ = run_command(Commands.CLEAN, "", "--all", "--yes", "--json")
+            json_loads(stdout)  # assert valid json
+
+            # pkg still exists since its in use by temp env
+            # tarball is removed
+            # index cache is cleared
+            pkgs, tars, cache = _get_all(pkgs_dir)
+            assert _any_pkg(pkg, pkgs)
+            assert not _any_pkg(pkg, tars)
+            assert not cache
+
+            run_command(Commands.REMOVE, prefix, pkg, "--yes", "--json")
+            stdout, _, _ = run_command(Commands.CLEAN, "", "--packages", "--yes", "--json")
+            json_loads(stdout)  # assert valid json
+
+            # pkg is removed
+            # tarball is still removed
+            # index cache is still cleared
+            pkgs, tars, index_cache = _get_all(pkgs_dir)
+            assert not _any_pkg(pkg, pkgs)
+            assert not _any_pkg(pkg, tars)
+            assert not cache
+
+        # pkg is still removed
+        # tarball is still removed
+        # index cache is still cleared
+        pkgs, tars, index_cache = _get_all(pkgs_dir)
+        assert not _any_pkg(pkg, pkgs)
+        assert not _any_pkg(pkg, tars)
+        assert not cache

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+from glob import glob
+from json import loads as json_loads
+from os import listdir
+from os.path import basename, isdir, join
+from conda.core.subdir_data import create_cache_dir
+from conda.testing.integration import make_temp_package_cache, run_command, Commands, make_temp_env
+
+
+def test_clean_index_cache():
+    prefix = ""
+
+    # make sure we have something in the index cache
+    stdout, _, _ = run_command(Commands.INFO, prefix, "bzip2", "--json")
+    assert "bzip2" in json_loads(stdout)
+    index_cache_dir = create_cache_dir()
+    assert glob(join(index_cache_dir, "*.json"))
+
+    # now clear it
+    run_command(Commands.CLEAN, prefix, "--index-cache")
+    assert not glob(join(index_cache_dir, "*.json"))
+
+
+def test_clean_tarballs_and_packages():
+    with make_temp_package_cache() as pkgs_dir:
+        filter_pkgs = lambda x: [f for f in x if f.endswith((".tar.bz2", ".conda"))]
+        with make_temp_env("bzip2") as prefix:
+            pkgs_dir_contents = [join(pkgs_dir, d) for d in listdir(pkgs_dir)]
+            pkgs_dir_dirs = [d for d in pkgs_dir_contents if isdir(d)]
+            pkgs_dir_tarballs = filter_pkgs(pkgs_dir_contents)
+            assert any(basename(d).startswith("bzip2-") for d in pkgs_dir_dirs)
+            assert any(basename(f).startswith("bzip2-") for f in pkgs_dir_tarballs)
+
+            # --json flag is regression test for #5451
+            run_command(Commands.CLEAN, prefix, "--packages", "--yes", "--json")
+
+            # --json flag is regression test for #5451
+            run_command(Commands.CLEAN, prefix, "--tarballs", "--yes", "--json")
+
+            pkgs_dir_contents = [join(pkgs_dir, d) for d in listdir(pkgs_dir)]
+            pkgs_dir_dirs = [d for d in pkgs_dir_contents if isdir(d)]
+            pkgs_dir_tarballs = filter_pkgs(pkgs_dir_contents)
+
+            assert any(basename(d).startswith("bzip2-") for d in pkgs_dir_dirs)
+            assert not any(basename(f).startswith("bzip2-") for f in pkgs_dir_tarballs)
+
+            run_command(Commands.REMOVE, prefix, "bzip2", "--yes", "--json")
+
+        run_command(Commands.CLEAN, prefix, "--packages", "--yes")
+
+        pkgs_dir_contents = [join(pkgs_dir, d) for d in listdir(pkgs_dir)]
+        pkgs_dir_dirs = [d for d in pkgs_dir_contents if isdir(d)]
+        assert not any(basename(d).startswith("bzip2-") for d in pkgs_dir_dirs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,3 +23,10 @@ def activate_deactivate_package():
 @pytest.fixture(scope="session")
 def pre_link_messages_package():
     return _conda_build_recipe("pre_link_messages_package")
+
+
+@pytest.fixture
+def clear_cache():
+    from conda.core.subdir_data import SubdirData
+
+    SubdirData._cache_.clear()


### PR DESCRIPTION
Depends on ~#11351~ & #11356

Discovered while writing tests for the untested functionality that:
- The `.trash` directory and `.trash` suffix no longer appear to be in use and we need to investigate removing it altogether
- Only the `--tempfiles` function requires a prefix but it doesn't check to ensure a prefix is passed but rather simply accepts any valid path, this is inconsistent and should be revisited