### PR TITLE
Add python constraint back for `--update-deps --only-deps`

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -884,7 +884,7 @@ dependencies:
             result_before = subprocess_call_with_clean_env([python, "--version"])
             assert package_is_installed(prefix, "flask=2.0.1")
             assert package_is_installed(prefix, "jinja2=3.0.1")
-            run_command(Commands.INSTALL, prefix, "flask", "python", "--update-deps", "--only-deps")
+            run_command(Commands.INSTALL, prefix, "flask", "python=3.10", "--update-deps", "--only-deps")
             result_after = subprocess_call_with_clean_env([python, "--version"])
             assert result_before == result_after
             assert package_is_installed(prefix, "flask=2.0.1")


### PR DESCRIPTION
Due to recent updates to the available packages there seems to be a preference for Python 3.9 over Python 3.10 causing Python to be downgraded for the `--update-deps --only-deps` test:

```bash
# installs flask=2.0.1 & python=3.10.3
$ conda create -n deps flask=2.0.1

# is not supposed to update flask/python but it's downgrading python to 3.9.11
$ conda install -n deps flask python --update-deps --only-deps
```

This is yet another "short-term" fix for the larger issue of our testsuite depending on the everchanging defaults channel.