### PR TITLE
Remove duplicated instruction in manage-python.rst

### DIFF
--- a/docs/source/user-guide/tasks/manage-python.rst
+++ b/docs/source/user-guide/tasks/manage-python.rst
@@ -66,13 +66,6 @@ Python version into it:
         package, such as ``numpy=1.19``, or :ref:`multiple packages
         <installing multiple packages>`.
 
-   * To create the new environment for Python 3.9, in your terminal window
-     or an Anaconda Prompt, run:
-
-     .. code-block:: bash
-
-        conda create -n py39 python=3.9 anaconda
-
 #. :ref:`Activate the new environment <activate-env>`.
 
 #. Verify that the new environment is your :ref:`current


### PR DESCRIPTION
While reading the conda docs I noticed one of the instructions was written twice.  It looks like it wasn't intended so I thought it was a good idea to correct it.  See attached image below:

![image](https://user-images.githubusercontent.com/35660278/160845203-e70513d6-ca37-4c33-bbe4-98e0fabd3223.PNG)