### PR TITLE
Fix inconsistencies with `conda clean --dryrun`

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -3,8 +3,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from argparse import (ArgumentParser as ArgumentParserBase, REMAINDER, RawDescriptionHelpFormatter,
-                      SUPPRESS, _CountAction, _HelpAction)
+from argparse import (
+    ArgumentParser as ArgumentParserBase,
+    REMAINDER,
+    RawDescriptionHelpFormatter,
+    SUPPRESS,
+    Action,
+    _copy_items,
+    _CountAction,
+    _HelpAction,
+)
 from logging import getLogger
 import os
 from os.path import abspath, expanduser, join
@@ -195,6 +203,39 @@ class NullCountAction(_CountAction):
         setattr(namespace, self.dest, new_count)
 
 
+class ExtendConstAction(Action):
+    # a derivative of _AppendConstAction and Python 3.8's _ExtendAction
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        const,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs="*",
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest, None)
+        items = _copy_items(items)
+        items.extend(values or [self.const])
+        setattr(namespace, self.dest, items)
+
 # #############################################################################################
 #
 # sub-parsers
@@ -255,8 +296,10 @@ def configure_parser_clean(sub_parsers):
              "back to the package cache.",
     )
     removal_target_options.add_argument(
-        "-c", "--tempfiles",
-        nargs="+",
+        "-c",  # for tempfile extension (.c~)
+        "--tempfiles",
+        const=sys.prefix,
+        action=ExtendConstAction,
         help=("Remove temporary files that could not be deleted earlier due to being in-use.  "
               "Argument is path(s) to prefix(es) where files should be found and removed."),
     )

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -276,13 +276,6 @@ def configure_parser_clean(sub_parsers):
              "symlinks back to the package cache.",
     )
     removal_target_options.add_argument(
-        '-s', '--source-cache',
-        action='store_true',
-        # help="Remove files from the source cache of conda build.",
-        help=SUPPRESS,
-        # TODO: Deprecation warning issued. Remove in future release.
-    )
-    removal_target_options.add_argument(
         "-t", "--tarballs",
         action="store_true",
         help="Remove cached package tarballs.",

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -9,7 +9,6 @@ from argparse import (
     RawDescriptionHelpFormatter,
     SUPPRESS,
     Action,
-    _copy_items,
     _CountAction,
     _HelpAction,
 )
@@ -232,7 +231,7 @@ class ExtendConstAction(Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
-        items = _copy_items(items)
+        items = [] if items is None else items[:]
         items.extend(values or [self.const])
         setattr(namespace, self.dest, items)
 

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from logging import getLogger
 from os import listdir, lstat, walk
 from os.path import getsize, isdir, join
-from typing import Iterable, Tuple
+from typing import Iterable, List
 import sys
 
 from ..base.constants import CONDA_PACKAGE_EXTENSIONS, CONDA_TEMP_EXTENSIONS
@@ -27,6 +27,7 @@ def find_tarballs():
                 total_size += getsize(join(root, fn))
 
     return {"pkgs_dirs": pkgs_dirs, "total_size": total_size}
+
 
 def rm_tarballs(args, pkgs_dirs, total_size, verbose=True):
     from .common import confirm_yn
@@ -73,6 +74,7 @@ def rm_tarballs(args, pkgs_dirs, total_size, verbose=True):
                     print("WARNING: cannot remove, file permissions: %s\n%r" % (fn, e))
                 else:
                     log.info("%r", e)
+
 
 def find_pkgs():
     # TODO: This doesn't handle packages that have hard links to files within
@@ -121,6 +123,7 @@ def find_pkgs():
         "pkg_sizes": pkg_sizes,
     }
 
+
 def rm_pkgs(args, pkgs_dirs, warnings, total_size, pkg_sizes, verbose=True):
     from .common import confirm_yn
     from ..gateways.disk.delete import rm_rf
@@ -160,7 +163,8 @@ def rm_pkgs(args, pkgs_dirs, warnings, total_size, pkg_sizes, verbose=True):
                 print("removing %s" % pkg)
             rm_rf(join(pkgs_dir, pkg))
 
-def find_index_cache() -> Tuple[str]:
+
+def find_index_cache() -> List[str]:
     files = []
     for pkgs_dir in find_pkgs_dirs():
         # caches are directories in pkgs_dir
@@ -169,13 +173,14 @@ def find_index_cache() -> Tuple[str]:
             files.append(path)
     return files
 
-def find_pkgs_dirs() -> Tuple[str]:
+
+def find_pkgs_dirs() -> List[str]:
     from ..core.package_cache_data import PackageCacheData
 
-    return tuple(pc.pkgs_dir for pc in PackageCacheData.writable_caches() if isdir(pc.pkgs_dir))
+    return [pc.pkgs_dir for pc in PackageCacheData.writable_caches() if isdir(pc.pkgs_dir)]
 
 
-def find_tempfiles(paths: Iterable[str]) -> Tuple[str]:
+def find_tempfiles(paths: Iterable[str]) -> List[str]:
     tempfiles = []
     for path in sorted(set(paths or [sys.prefix])):
         # tempfiles are files in path
@@ -190,7 +195,7 @@ def find_tempfiles(paths: Iterable[str]) -> Tuple[str]:
     return tempfiles
 
 
-def rm_items(args, items: Tuple[str], verbose: bool, name: str) -> None:
+def rm_items(args, items: List[str], verbose: bool, name: str) -> None:
     from .common import confirm_yn
     from ..gateways.disk.delete import rm_rf
 
@@ -215,6 +220,7 @@ def rm_items(args, items: Tuple[str], verbose: bool, name: str) -> None:
 
     for item in items:
         rm_rf(item)
+
 
 def _execute(args, parser):
     json_result = {"success": True}
@@ -256,6 +262,7 @@ def _execute(args, parser):
         rm_items(args, tmps, verbose=verbose, name="tempfile(s)")
 
     return json_result
+
 
 def execute(args, parser):
     from .common import stdout_json

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -179,11 +179,7 @@ def find_tempfiles(paths: Iterable[str]) -> Tuple[str]:
     tempfiles = []
     for path in sorted(set(paths or [sys.prefix])):
         # tempfiles are files in path
-        for (
-            root,
-            _,
-            files,
-        ) in walk(path):
+        for root, _, files in walk(path):
             for file in files:
                 # tempfiles also end in .c~ or .trash
                 if not file.endswith(CONDA_TEMP_EXTENSIONS):

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -33,10 +33,6 @@ def rm_tarballs(args, pkgs_dirs, total_size, verbose=True):
     from ..gateways.disk.delete import rm_rf
     from ..utils import human_bytes
 
-    if verbose:
-        for pkgs_dir in pkgs_dirs:
-            print('Cache location: %s' % pkgs_dir)
-
     if not any(pkgs_dirs[i] for i in pkgs_dirs):
         if verbose:
             print("There are no tarballs to remove")
@@ -129,11 +125,10 @@ def rm_pkgs(args, pkgs_dirs, warnings, total_size, pkg_sizes, verbose=True):
     from .common import confirm_yn
     from ..gateways.disk.delete import rm_rf
     from ..utils import human_bytes
-    if verbose:
-        for pkgs_dir in pkgs_dirs:
-            print('Cache location: %s' % pkgs_dir)
-            for fn, exception in warnings:
-                print(exception)
+
+    if verbose and warnings:
+        for fn, exception in warnings:
+            print(exception)
 
     if not any(pkgs_dirs[i] for i in pkgs_dirs):
         if verbose:

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -256,7 +256,7 @@ def _execute(args, parser):
         rm_pkgs(args, **pkgs, verbose=verbose)
 
     if args.tempfiles or args.all:
-        tmps = find_tempfiles(args.tempfiles)
+        json_result["tempfiles"] = tmps = find_tempfiles(args.tempfiles)
         rm_items(args, tmps, verbose=verbose, name="tempfile(s)")
 
     return json_result

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -64,10 +64,10 @@ def rm_tarballs(args, pkgs_dirs, total_size, verbose=True):
         print(fmt % ("Total:", human_bytes(total_size)))
         print("")
 
+    if args.dry_run:
+        return
     if not context.json or not context.always_yes:
         confirm_yn()
-    if context.json and args.dry_run:
-        return
 
     for pkgs_dir in pkgs_dirs:
         for fn in pkgs_dirs[pkgs_dir]:
@@ -166,10 +166,10 @@ def rm_pkgs(args, pkgs_dirs, warnings, total_size, pkg_sizes, verbose=True):
         print(fmt % ("Total:", human_bytes(total_size)))
         print("")
 
+    if args.dry_run:
+        return
     if not context.json or not context.always_yes:
         confirm_yn()
-    if context.json and args.dry_run:
-        return
 
     for pkgs_dir in pkgs_dirs:
         for pkg in pkgs_dirs[pkgs_dir]:
@@ -268,3 +268,7 @@ def execute(args, parser):
     json_result = _execute(args, parser)
     if context.json:
         stdout_json(json_result)
+    if args.dry_run:
+        from ..exceptions import DryRunExit
+
+        raise DryRunExit

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -226,11 +226,6 @@ def _execute(args, parser):
     json_result = {"success": True}
     verbose = not (context.json or context.quiet)
 
-    if verbose and args.source_cache:
-        print("WARNING: 'conda clean --source-cache' is deprecated.\n"
-              "    Use 'conda build purge-all' to remove source cache files.",
-              file=sys.stderr)
-
     if args.force_pkgs_dirs:
         json_result["pkgs_dirs"] = pkgs_dirs = find_pkgs_dirs()
         rm_items(args, pkgs_dirs, verbose=verbose, name="package cache(s)")

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1901,7 +1901,7 @@ dependencies:
         with make_temp_env(prefix=prefix, no_capture=True):
             # First, clear the index cache to make sure we start with an empty cache.
             index_cache_dir = create_cache_dir()
-            run_command(Commands.CLEAN, '', "--index-cache")
+            run_command(Commands.CLEAN, "", "--index-cache", "--yes")
             assert not glob(join(index_cache_dir, "*.json"))
 
             # Then, populate the index cache.
@@ -1945,7 +1945,7 @@ dependencies:
                     with make_temp_channel(['flask-0.12.2']) as channel:
                         # Clear the index cache.
                         index_cache_dir = create_cache_dir()
-                        run_command(Commands.CLEAN, '', "--index-cache")
+                        run_command(Commands.CLEAN, "", "--index-cache", "--yes")
                         assert not exists(index_cache_dir)
 
                         # Then attempt to install a package with --offline. The package (flask) is


### PR DESCRIPTION
There are 6 kinds of `conda clean`:
- `--tarballs`
- `--packages`
- `--index-cache`
- `--tempfiles`
- `--all`: all of the above
- `--force-pkgs-dirs`: nuclear option removing the entire package cache

Previously if running as dry-run only the tarball and package removal checks for the dry-run condition. So running the following had no impact with `--dry-run`:
- `--index-cache`
- `--tempfiles`
- `--force-pkgs_dirs`: this is of particular concern given the potentially corrupting nature of this removal

Further if running `--all` with `--dry-run` the way the dry-run check is implemented the program exists after only processing the tarballs. So effectively an incomplete dry-run report.

This addresses all of these inconsistencies.

Also removes `--source-cache` argument deprecated 5 years ago in conda 4.6.0.