### PR TITLE
Standardize tarball & pkg finding in `conda clean`

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -33,6 +33,14 @@ def _getsize(*parts: str, warnings: Optional[List[Tuple[str, Exception]]] = None
     return stat.st_size
 
 
+def _get_pkgs_dirs(pkg_sizes):
+    return {pkgs_dir: tuple(pkgs) for pkgs_dir, pkgs in pkg_sizes.items()}
+
+
+def _get_total_size(pkg_sizes):
+    return sum(sum(pkgs.values()) for pkgs in pkg_sizes.values())
+
+
 def find_tarballs() -> Dict[str, Any]:
     warnings: List[Tuple[str, Exception]] = []
     pkg_sizes: Dict[str, Dict[str, int]] = {}
@@ -55,8 +63,8 @@ def find_tarballs() -> Dict[str, Any]:
     return {
         "warnings": warnings,
         "pkg_sizes": pkg_sizes,
-        "pkgs_dirs": {pkgs_dir: tuple(pkgs) for pkgs_dir, pkgs in pkg_sizes.items()},
-        "total_size": sum(sum(pkgs.values()) for pkgs in pkg_sizes.values()),
+        "pkgs_dirs": _get_pkgs_dirs(pkg_sizes),
+        "total_size": _get_total_size(pkg_sizes),
     }
 
 
@@ -132,8 +140,8 @@ def find_pkgs() -> Dict[str, Any]:
     return {
         "warnings": warnings,
         "pkg_sizes": pkg_sizes,
-        "pkgs_dirs": {pkgs_dir: tuple(pkgs) for pkgs_dir, pkgs in pkg_sizes.items()},
-        "total_size": sum(sum(pkgs.values()) for pkgs in pkg_sizes.values()),
+        "pkgs_dirs": _get_pkgs_dirs(pkg_sizes),
+        "total_size": _get_total_size(pkg_sizes),
     }
 
 

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -16,7 +16,7 @@ log = getLogger(__name__)
 _EXTS = (*CONDA_PACKAGE_EXTENSIONS, *(f"{e}.part" for e in CONDA_PACKAGE_EXTENSIONS))
 
 
-def _getsize(*parts: str, warnings: Optional[List[Tuple[str, Exception]]] = None) -> int:
+def _get_size(*parts: str, warnings: Optional[List[Tuple[str, Exception]]] = None) -> int:
     path = join(*parts)
     try:
         stat = lstat(path)
@@ -54,7 +54,7 @@ def find_tarballs() -> Dict[str, Any]:
 
             # get size
             try:
-                size = _getsize(pkgs_dir, tar, warnings=warnings)
+                size = _get_size(pkgs_dir, tar, warnings=warnings)
             except NotImplementedError:
                 pass
             else:
@@ -128,7 +128,7 @@ def find_pkgs() -> Dict[str, Any]:
             # get size
             try:
                 size = sum(
-                    _getsize(root, file, warnings=warnings)
+                    _get_size(root, file, warnings=warnings)
                     for root, _, files in walk(join(pkgs_dir, pkg))
                     for file in files
                 )


### PR DESCRIPTION
This is in preparation for combining `rm_tarballs` and `rm_pkgs` since both are identically structured.

The primary changes here is to:
- move the `getsize` logic previously defined in `rm_tarballs` into `find_tarballs`
- combine the `pkgs_dirs` for-loop with the `pkg_sizes` for-loop in `find_pkgs`
- split out a `getsize` helper function shared between the two implementations