### PR TITLE
Combine main_clean's `rm_tarballs` with `rm_pkgs`

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -33,13 +33,29 @@ def _get_size(*parts: str, warnings: Optional[List[Tuple[str, Exception]]] = Non
     return stat.st_size
 
 
-def _get_pkgs_dirs(pkg_sizes):
+def _get_pkgs_dirs(pkg_sizes: Dict[str, Dict[str, int]]) -> Dict[str, Tuple[str]]:
     return {pkgs_dir: tuple(pkgs) for pkgs_dir, pkgs in pkg_sizes.items()}
 
 
-def _get_total_size(pkg_sizes):
+def _get_total_size(pkg_sizes: Dict[str, Dict[str, int]]) -> int:
     return sum(sum(pkgs.values()) for pkgs in pkg_sizes.values())
 
+
+def _rm_rf(args, *parts: str, verbose: bool) -> None:
+    from ..gateways.disk.delete import rm_rf
+
+    path = join(*parts)
+    try:
+        if rm_rf(path):
+            if verbose and args.verbosity:
+                print(f"Removed {path}")
+        elif verbose:
+            print(f"WARNING: cannot remove, file permissions: {path}")
+    except (IOError, OSError) as e:
+        if verbose:
+            print(f"WARNING: cannot remove, file permissions: {path}\n{e!r}")
+        else:
+            log.info("%r", e)
 
 def find_tarballs() -> Dict[str, Any]:
     warnings: List[Tuple[str, Exception]] = []
@@ -66,52 +82,6 @@ def find_tarballs() -> Dict[str, Any]:
         "pkgs_dirs": _get_pkgs_dirs(pkg_sizes),
         "total_size": _get_total_size(pkg_sizes),
     }
-
-
-def rm_tarballs(args, pkgs_dirs, warnings, total_size, pkg_sizes, verbose=True):
-    from .common import confirm_yn
-    from ..gateways.disk.delete import rm_rf
-    from ..utils import human_bytes
-
-    if not any(pkgs_dirs[i] for i in pkgs_dirs):
-        if verbose:
-            print("There are no tarballs to remove")
-        return
-
-    if verbose:
-        print("Will remove the following tarballs:")
-        print('')
-
-        for pkgs_dir, pkgs in pkg_sizes.items():
-            print(pkgs_dir)
-            print('-'*len(pkgs_dir))
-            fmt = "%-40s %10s"
-            for fn, size in pkgs.items():
-                print(fmt % (fn, human_bytes(size)))
-            print("")
-        print("-" * 51)  # From 40 + 1 + 10 in fmt
-        print(fmt % ("Total:", human_bytes(total_size)))
-        print("")
-
-    if args.dry_run:
-        return
-    if not context.json or not context.always_yes:
-        confirm_yn()
-
-    for pkgs_dir in pkgs_dirs:
-        for fn in pkgs_dirs[pkgs_dir]:
-            try:
-                if rm_rf(join(pkgs_dir, fn)):
-                    if verbose:
-                        print("Removed %s" % fn)
-                else:
-                    if verbose:
-                        print("WARNING: cannot remove, file permissions: %s" % fn)
-            except (IOError, OSError) as e:
-                if verbose:
-                    print("WARNING: cannot remove, file permissions: %s\n%r" % (fn, e))
-                else:
-                    log.info("%r", e)
 
 
 def find_pkgs() -> Dict[str, Any]:
@@ -145,44 +115,51 @@ def find_pkgs() -> Dict[str, Any]:
     }
 
 
-def rm_pkgs(args, pkgs_dirs, warnings, total_size, pkg_sizes, verbose=True):
+def rm_pkgs(
+    args,
+    pkgs_dirs: Dict[str, Tuple[str]],
+    warnings: List[Tuple[str, Exception]],
+    total_size: int,
+    pkg_sizes: Dict[str, Dict[str, int]],
+    verbose: bool,
+    name: str,
+) -> None:
     from .common import confirm_yn
-    from ..gateways.disk.delete import rm_rf
     from ..utils import human_bytes
 
     if verbose and warnings:
         for fn, exception in warnings:
             print(exception)
 
-    if not any(pkgs_dirs[i] for i in pkgs_dirs):
+    if not any(pkgs for pkgs in pkg_sizes.values()):
         if verbose:
-            print("There are no unused packages to remove")
+            print(f"There are no unused {name} to remove")
         return
 
     if verbose:
-        print("Will remove the following packages:")
-        for pkgs_dir, pkgs in pkg_sizes.items():
-            print(pkgs_dir)
-            print('-' * len(pkgs_dir))
-            print('')
-            fmt = "%-40s %10s"
-            for pkg, pkgsize in pkgs.items():
-                print(fmt % (pkg, human_bytes(pkgsize)))
-            print("")
-        print("-" * 51)  # 40 + 1 + 10 in fmt
-        print(fmt % ("Total:", human_bytes(total_size)))
-        print("")
+        if args.verbosity:
+            print(f"Will remove the following {name}:")
+            for pkgs_dir, pkgs in pkg_sizes.items():
+                print(f"  {pkgs_dir}")
+                print(f"  {'-' * len(pkgs_dir)}")
+                for pkg, size in pkgs.items():
+                    print(f"  - {pkg:<40} {human_bytes(size):>10}")
+                print()
+            print("-" * 17)
+            print(f"Total: {human_bytes(total_size):>10}")
+            print()
+        else:
+            count = sum(len(pkgs) for pkgs in pkg_sizes.values())
+            print(f"Will remove {count} ({human_bytes(total_size)}) {name}.")
 
     if args.dry_run:
         return
     if not context.json or not context.always_yes:
         confirm_yn()
 
-    for pkgs_dir in pkgs_dirs:
-        for pkg in pkgs_dirs[pkgs_dir]:
-            if verbose:
-                print("removing %s" % pkg)
-            rm_rf(join(pkgs_dir, pkg))
+    for pkgs_dir, pkgs in pkg_sizes.items():
+        for pkg in pkgs:
+            _rm_rf(args, pkgs_dir, pkg, verbose=verbose)
 
 
 def find_index_cache() -> List[str]:
@@ -233,7 +210,6 @@ def find_logfiles() -> List[str]:
 
 def rm_items(args, items: List[str], verbose: bool, name: str) -> None:
     from .common import confirm_yn
-    from ..gateways.disk.delete import rm_rf
 
     if not items:
         if verbose:
@@ -255,7 +231,7 @@ def rm_items(args, items: List[str], verbose: bool, name: str) -> None:
         confirm_yn()
 
     for item in items:
-        rm_rf(item)
+        _rm_rf(args, item, verbose=verbose)
 
 
 def _execute(args, parser):
@@ -284,7 +260,7 @@ def _execute(args, parser):
 
     if args.tarballs or args.all:
         json_result["tarballs"] = tars = find_tarballs()
-        rm_tarballs(args, **tars, verbose=verbose)
+        rm_pkgs(args, **tars, verbose=verbose, name="tarball(s)")
 
     if args.index_cache or args.all:
         cache = find_index_cache()
@@ -293,7 +269,7 @@ def _execute(args, parser):
 
     if args.packages or args.all:
         json_result["packages"] = pkgs = find_pkgs()
-        rm_pkgs(args, **pkgs, verbose=verbose)
+        rm_pkgs(args, **pkgs, verbose=verbose, name="package(s)")
 
     if args.tempfiles or args.all:
         json_result["tempfiles"] = tmps = find_tempfiles(args.tempfiles)


### PR DESCRIPTION
The culmination of all recent `conda clean` work:
- https://github.com/conda/conda/pull/11351
- https://github.com/conda/conda/pull/11360
- https://github.com/conda/conda/pull/11385
- https://github.com/conda/conda/pull/11386
- https://github.com/conda/conda/pull/11387

Removes/combines `rm_tarballs` in favor of `rm_pkgs`. In addition to abstracting/reusing code this change also makes `conda clean` a little more user friendly by not dumping tons of extra info to the screen:

#### Normal run

```bash
$ conda clean --all --dry-run
Will remove 93 (222.3 MB) tarball(s).
Will remove 1 index cache(s).
Will remove 77 (1.25 GB) package(s).
There are no tempfile(s) to remove.

DryRunExit: Dry run. Exiting.
```

#### Verbose run

```bash
$ conda clean --all --dry-run -v
Will remove the following tarball(s):
  ~/anaconda/devenv/Darwin/envs/devenv-3.8-c/pkgs
  -------------------------------------------------------------
  - ruamel_yaml-0.15.100-py36h9ed2024_0.conda     244 KB
  - openssl-1.1.1n-hca72f7f_0.conda              2.2 MB
  - certifi-2021.10.8-py39hecd8cb5_2.conda       152 KB
  ...

-----------------
Total:   222.3 MB

Will remove the following index cache(s):
  - ~/anaconda/devenv/Darwin/envs/devenv-3.8-c/pkgs/cache

Will remove the following package(s):
  ~/anaconda/devenv/Darwin/envs/devenv-3.8-c/pkgs
  -------------------------------------------------------------
  - libcurl-7.80.0-h6dfd666_0                    893 KB
  - opt_einsum-3.3.0-pyhd3eb1b0_1                248 KB
  - icu-58.2-h0a44026_3                         67.5 MB
  ...

-----------------
Total:    1.25 GB

There are no tempfile(s) to remove.

DryRunExit: Dry run. Exiting.
```