### PR TITLE
Update PR template to match rever.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,12 +13,13 @@
 <!-- If any of the following items aren't relevant for your contribution
      please still tick them so we know you've gone through the checklist. -->
 
-- [ ] Add `news` entry to be included in the next release's `CHANGELOG`?
+- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
      <!-- All "significant" changes should get an entry:
-            - user-facing changes
-            - new feature implementation
-            - major/long outstanding bugfix
-            - code deprecation -->
+            - user-facing changes or enhancements
+            - bug fixes
+            - deprecations
+            - documentation updates
+            - other changes -->
 - [ ] Add / update necessary tests?
 - [ ] Add / update outdated documentation?
 


### PR DESCRIPTION
This just updates the template to match with the current release process, we can change it once we're doing this fully.