### PR TITLE
Replace `conda.auxlib.collection.frozendict` with vendored `frozendict`

### DIFF
--- a/conda/auxlib/collection.py
+++ b/conda/auxlib/collection.py
@@ -7,7 +7,8 @@ try:
 except ImportError:
     from collections import Mapping, Set
 
-from .compat import isiterable, iteritems, odict, text_type
+from .compat import isiterable, iteritems, text_type
+from .._vendor.frozendict import frozendict
 
 
 def make_immutable(value):
@@ -44,23 +45,6 @@ class AttrDict(dict):
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
-
-
-class frozendict(odict):
-
-    def __key(self):
-        return tuple((k, self[k]) for k in sorted(self))
-
-    def __hash__(self):
-        return hash(self.__key())
-
-    def __eq__(self, other):
-        try:
-            return self.__key() == other.__key()
-        except AttributeError:
-            if isinstance(other, Mapping):
-                return self.__key() == frozendict(other).__key()
-            return False
 
 
 def first(seq, key=lambda x: bool(x), default=None, apply=lambda x: x):

--- a/conda/auxlib/entity.py
+++ b/conda/auxlib/entity.py
@@ -250,7 +250,8 @@ from enum import Enum
 
 from . import NULL
 from .._vendor.boltons.timeutils import isoparse
-from .collection import AttrDict, frozendict, make_immutable
+from .._vendor.frozendict import frozendict
+from .collection import AttrDict, make_immutable
 from .compat import (integer_types, isiterable, iteritems, itervalues, odict, string_types,
                      text_type)
 from .exceptions import Raise, ValidationError

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -7,8 +7,8 @@ from collections import defaultdict, OrderedDict, deque
 import copy
 from logging import DEBUG, getLogger
 
-from .auxlib.collection import frozendict
 from .auxlib.decorators import memoize, memoizemethod
+from ._vendor.frozendict import frozendict
 from ._vendor.toolz import concat, groupby
 from ._vendor.tqdm import tqdm
 from .base.constants import ChannelPriority, MAX_CHANNEL_PRIORITY, SatSolverChoice

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -8,7 +8,7 @@ import copy
 from logging import DEBUG, getLogger
 
 from .auxlib.decorators import memoize, memoizemethod
-from ._vendor.frozendict import frozendict
+from ._vendor.frozendict import FrozenOrderedDict as frozendict
 from ._vendor.toolz import concat, groupby
 from ._vendor.tqdm import tqdm
 from .base.constants import ChannelPriority, MAX_CHANNEL_PRIORITY, SatSolverChoice

--- a/news/11398-replace-conda.auxlib.collection.frozendict
+++ b/news/11398-replace-conda.auxlib.collection.frozendict
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Replace auxlib's frozendict with vendored frozendict. (#11398)

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from unittest import TestCase
 
-from conda.auxlib.collection import frozendict
 import pytest
 
 from conda import text_type


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Removes custom `conda.auxlib.collection.frozendict` in favor of the already vendored `frozendict`.

Resolves #11337

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
