### PR TITLE
fix `escape_channel_url` logic on windows

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -520,7 +520,7 @@ def escape_channel_url(channel):
     if parts.scheme:
         components = parts.path.split("/")
         if on_win:
-            if len(parts.netloc) == 2 and parts.netloc[1] == ":":
+            if parts.netloc and len(parts.netloc) == 2 and parts.netloc[1] == ":":
                 # with absolute paths (e.g. C:/something), C:, D:, etc might get parsed as netloc
                 path = "/".join([parts.netloc] + [quote(p) for p in components])
                 parts = parts.replace(netloc="")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->


Seeing this on `conda-libmamba-solver` [CI](https://github.com/conda-incubator/conda-libmamba-solver/runs/6022786027?check_suite_focus=true#step:8:746):

```
_____________________________ test_update_deps_2 ______________________________
Traceback (most recent call last):
  File "C:\conda_bin\envs\conda-test-env\lib\site-packages\conda_libmamba_solver\solver.py", line 233, in solve_final_state
    subdirs=self.subdirs,
  File "C:\conda_bin\envs\conda-test-env\lib\site-packages\conda_libmamba_solver\solver.py", line 90, in __init__
    channels=self._channel_urls(channels),
  File "C:\conda_bin\envs\conda-test-env\lib\site-packages\conda_libmamba_solver\solver.py", line 118, in _channel_urls
    channels = [url for c in channels for url in _channel_to_url_or_name(Channel(c))]
  File "C:\conda_bin\envs\conda-test-env\lib\site-packages\conda_libmamba_solver\solver.py", line 118, in <listcomp>
    channels = [url for c in channels for url in _channel_to_url_or_name(Channel(c))]
  File "C:\conda_bin\envs\conda-test-env\lib\site-packages\conda_libmamba_solver\solver.py", line 113, in _channel_to_url_or_name
    urls.append(escape_channel_url(url))
  File "C:\conda_src\conda\common\url.py", line 523, in escape_channel_url
    if len(parts.netloc) == 2 and parts.netloc[1] == ":":
TypeError: object of type 'NoneType' has no len()

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\conda_src\tests\core\test_solve.py", line 1391, in test_update_deps_2
    final_state_1 = solver.solve_final_state()
  File "C:\conda_bin\envs\conda-test-env\lib\site-packages\conda_libmamba_solver\solver.py", line 233, in solve_final_state
    subdirs=self.subdirs,
  File "C:\conda_bin\envs\conda-test-env\lib\site-packages\conda_libmamba_solver\utils.py", line 86, in __exit__
    raise exc_type(exc_value)
TypeError: object of type 'NoneType' has no len()
```