### PR TITLE
Combine `--no-capture-output` with `--live-stream`

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1113,9 +1113,10 @@ def configure_parser_run(sub_parsers):
     )
     p.add_argument(
         "--no-capture-output",
-        help="Don't capture stdout/stderr",
-        action=NullCountAction,
-        default=NULL,
+        "--live-stream",
+        action="store_true",
+        help="Don't capture stdout/stderr.",
+        default=False,
     )
 
     p.add_argument(
@@ -1123,13 +1124,6 @@ def configure_parser_run(sub_parsers):
         nargs=REMAINDER,
         help="Executable name, with additional arguments to be passed to the executable "
              "on invocation.",
-    )
-
-    p.add_argument(
-        '--live-stream',
-        action="store_true",
-        default=False,
-        help="Display the output for the subprocess stdout and stderr on real time.",
     )
 
     p.set_defaults(func='.main_run.execute')

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -34,8 +34,16 @@ def execute(args, parser):
         path=args.cwd,
         raise_on_error=False,
         capture_output=not args.no_capture_output,
-        live_stream=args.live_stream,
     )
+
+    # display stdout/stderr if it was captured
+    if not args.no_capture_output:
+        if response.stdout:
+            print(response.stdout, file=sys.stdout)
+        if response.stderr:
+            print(response.stderr, file=sys.stderr)
+
+    # log error
     if response.rc != 0:
         log = getLogger(__name__)
         log.error(f"`conda run {' '.join(args.executable_call)}` failed. (See above for error)")
@@ -46,11 +54,5 @@ def execute(args, parser):
     else:
         log = getLogger(__name__)
         log.warning(f"CONDA_TEST_SAVE_TEMPS :: retaining main_run script {script}")
-
-    if not args.live_stream:
-        if response.stdout:
-            print(response.stdout, file=sys.stdout)
-        if response.stderr:
-            print(response.stderr, file=sys.stderr)
 
     return response

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -91,7 +91,7 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
         stdin = None
 
     # spawn subprocess
-    p = Popen(
+    process = Popen(
         encode_arguments(command),
         cwd=cwd,
         stdin=pipe,
@@ -99,16 +99,16 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
         stderr=pipe,
         env=env,
     )
-    ACTIVE_SUBPROCESSES.add(p)
+    ACTIVE_SUBPROCESSES.add(process)
 
     # decode output, if not PIPE, stdout/stderr will be None
-    stdout, stderr = p.communicate(input=stdin)
+    stdout, stderr = process.communicate(input=stdin)
     if hasattr(stdout, "decode"):
         stdout = stdout.decode('utf-8', errors='replace')
     if hasattr(stderr, "decode"):
         stderr = stderr.decode('utf-8', errors='replace')
-    rc = p.returncode
-    ACTIVE_SUBPROCESSES.remove(p)
+    rc = process.returncode
+    ACTIVE_SUBPROCESSES.remove(process)
 
     if (raise_on_error and rc != 0) or log.isEnabledFor(TRACE):
         formatted_output = _format_output(command_str, cwd, rc, stdout, stderr)

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import namedtuple
-from io import StringIO
 from logging import getLogger
 import os
 from os.path import abspath
@@ -121,36 +120,6 @@ def subprocess_call(command, env=None, path=None, stdin=None, raise_on_error=Tru
         log.trace(formatted_output)
 
     return Response(stdout, stderr, int(rc))
-
-
-def _realtime_output_for_subprocess(p):
-    """Consumes the stdout and stderr streams from the subprocess in real-time.
-    """
-    stdout_io = StringIO()
-    stderr_io = StringIO()
-    while True:
-        buff = p.stdout.readline()
-        if hasattr(buff, "decode"):
-            buff = buff.decode('utf-8', errors='replace')
-        if buff == '' and p.poll() is not None:
-            break
-        if buff:
-            stdout_io.write(buff)
-            print(buff, file=sys.stdout, end='')
-
-        errbuff = p.stderr.readline()
-        if hasattr(errbuff, "decode"):
-            errbuff = errbuff.decode('utf-8', errors='replace')
-        if errbuff:
-            stderr_io.write(errbuff)
-            print(errbuff, file=sys.stderr, end='')
-
-    p.wait()
-
-    stdout = stdout_io.getvalue()
-    stderr = stderr_io.getvalue()
-
-    return stdout, stderr
 
 
 def _subprocess_clean_env(env, clean_python=True, clean_conda=True):

--- a/news/11422-conda-run-live-stream-alias
+++ b/news/11422-conda-run-live-stream-alias
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* `conda run --live-stream` aliases `conda run --no-capture-output`. (#11422)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/gateways/test_subprocess.py
+++ b/tests/gateways/test_subprocess.py
@@ -4,29 +4,25 @@
 
 from conda.gateways.subprocess import subprocess_call
 
-try:
-    from unittest.mock import patch, call
-except ImportError:
-    from mock import patch, call
 
-
-@patch("sys.stderr", spec=True)
-@patch("sys.stdout", spec=True)
-def test_subprocess_call_with_live_stream(mock_stdout, mock_stderr):
+def test_subprocess_call_with_capture_output(capfd):
     resp = subprocess_call(
         ('python -c "import sys, time; sys.stdout.write(\'1\\n\'); '
          'sys.stderr.write(\'2\\n\'); time.sleep(.3); sys.stdout.write(\'end\\n\')"'),
-        live_stream=True,
+        capture_output=False,
     )
 
-    def get_write_calls(mock_stream):
-        return [args[0].replace('\r\n', '\n') for args, kw in mock_stream.write.call_args_list]
+    captured = capfd.readouterr()
+    assert captured.out.replace('\r\n', '\n') == '1\nend\n'
+    assert captured.err.replace('\r\n', '\n') == '2\n'
+    assert resp.rc == 0
 
-    stdout_calls = get_write_calls(mock_stdout)
-    stderr_calls = get_write_calls(mock_stderr)
-
-    assert ['1\n', '', 'end\n', ''] == stdout_calls
-    assert ['2\n', ''] == stderr_calls
+def test_subprocess_call_without_capture_output():
+    resp = subprocess_call(
+        ('python -c "import sys, time; sys.stdout.write(\'1\\n\'); '
+         'sys.stderr.write(\'2\\n\'); time.sleep(.3); sys.stdout.write(\'end\\n\')"'),
+        capture_output=True,
+    )
 
     assert resp.stdout.replace('\r\n', '\n') == '1\nend\n'
     assert resp.stderr.replace('\r\n', '\n') == "2\n"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Resolves #11209

`conda run` offers redundant functionality by providing both `--no-capture-output` and `--live-stream` arguments. Both are valid implementations but they've resulted in weirdly nested logic that is completely unnecessary. This change favors the simpler `--no-capture-output` implementation (less overall code and no precarious stream handling). `--live-stream` is now simply an alias for `--no-capture-output`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
