### PR TITLE
Define optional exception attribute to bypass the retry logic

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -285,6 +285,10 @@ def install(args, parser, command='install'):
                     raise PackagesNotFoundError(e._formatted_chains, channels_urls)
 
         except (UnsatisfiableError, SystemExit, SpecsConfigurationConflictError) as e:
+            if not getattr(e, "allow_retry", True):
+                # TODO: This is a temporary workaround to allow downstream libraries 
+                # to inject this attribute set to False and skip the retry logic
+                raise e
             # Quick solve with frozen env or trimmed repodata failed.  Try again without that.
             if not hasattr(args, 'update_modifier'):
                 if repodata_fn == repodata_fns[-1]:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -289,13 +289,13 @@ def install(args, parser, command='install'):
                 # TODO: This is a temporary workaround to allow downstream libraries
                 # to inject this attribute set to False and skip the retry logic
                 # Other solvers might implement their own internal retry logic without
-                # depending --freeze-install implicitly like conda classic does. Example
+                # depending --freeze-install implicitly like conda classic does. Example
                 # retry loop in conda-libmamba-solver:
                 # https://github.com/conda-incubator/conda-libmamba-solver/blob/da5b1ba/conda_libmamba_solver/solver.py#L254-L299
                 # If we end up raising UnsatisfiableError, we annotate it with `allow_retry`
                 # so we don't have go through all the repodatas and freeze-installed logic
-                # unnecessarily (see https://github.com/conda/conda/issues/11294)
-                # ref: https://github.com/conda-incubator/conda-libmamba-solver/blob/7c698209/conda_libmamba_solver/solver.py#L617
+                # unnecessarily (see https://github.com/conda/conda/issues/11294). see also:
+                # https://github.com/conda-incubator/conda-libmamba-solver/blob/7c698209/conda_libmamba_solver/solver.py#L617
                 raise e
             # Quick solve with frozen env or trimmed repodata failed.  Try again without that.
             if not hasattr(args, 'update_modifier'):

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -286,8 +286,16 @@ def install(args, parser, command='install'):
 
         except (UnsatisfiableError, SystemExit, SpecsConfigurationConflictError) as e:
             if not getattr(e, "allow_retry", True):
-                # TODO: This is a temporary workaround to allow downstream libraries 
+                # TODO: This is a temporary workaround to allow downstream libraries
                 # to inject this attribute set to False and skip the retry logic
+                # Other solvers might implement their own internal retry logic without
+                # depending --freeze-install implicitly like conda classic does. Example
+                # retry loop in conda-libmamba-solver:
+                # https://github.com/conda-incubator/conda-libmamba-solver/blob/da5b1ba/conda_libmamba_solver/solver.py#L254-L299
+                # If we end up raising UnsatisfiableError, we annotate it with `allow_retry`
+                # so we don't have go through all the repodatas and freeze-installed logic
+                # unnecessarily (see https://github.com/conda/conda/issues/11294)
+                # ref: https://github.com/conda-incubator/conda-libmamba-solver/blob/7c698209/conda_libmamba_solver/solver.py#L617
                 raise e
             # Quick solve with frozen env or trimmed repodata failed.  Try again without that.
             if not hasattr(args, 'update_modifier'):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->

This would close https://github.com/conda/conda/issues/11294.

*** 

I am not sure this is the best solution though. It's arguably the minimum change to make this work (we would only need to set that attribute in the exception raised by libmamba), but it also extends the role of exceptions in flow control, and without a well-defined API. 

Alternatives:
* Some default behaviour in `conda.cli.install` is only defined for `solver=classic` (but this makes everything messier and harder to reason about)
* The retry logic is passed to `conda.core.solve.Solver` directly (but then this would be inherited by other tools in the conda ecosystem like conda-build, conda-smithy, constructor...)
* Essentially, some other refactor that allows us to define CLI behaviours per solver type

Other alternatives:
* Make conda-libmamba-solver behave more like conda classic, using repodatas and retries. I don't like this because we would be doing unnecessary work imo (loading the index twice, etc).