### PR TITLE
Add flake8-variables-names to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,8 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-variables-names
   - repo: https://github.com/PyCQA/pylint
     rev: v2.13.7
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,9 @@ exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_ven
 
 [flake8]
 max-line-length = 99
+extend-select = VNE
 ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821
-exclude =  .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
+exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 
 [coverage:report]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,6 +13,7 @@ conda-verify
 cytoolz
 filelock
 flake8
+flake8-variables-names
 git
 mock
 nbformat


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

Since we don't like having single char variables let's add a linter for that!

FYI since this isn't related to `conda` itself I haven't included a news file, let me know if you feel differently!

cc @jezdez 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [X] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] ~Add / update necessary tests?~
- [X] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
