### PR TITLE
'Accept', not 'Content-Type' in GET header

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -692,7 +692,7 @@ def fetch_repodata_remote_request(url, etag, mod_stamp, repodata_fn=REPODATA_FN)
         headers["If-Modified-Since"] = mod_stamp
 
     headers['Accept-Encoding'] = 'gzip, deflate, compress, identity'
-    headers['Content-Type'] = 'application/json'
+    headers['Accept'] = 'application/json'
     filename = repodata_fn
 
     try:


### PR DESCRIPTION
Unusual to specify Content-Type in a GET header. Invalid if the file is `repodata.json.bz2`? Or send no header.