### PR TITLE
Remove `conda.cli.common.ensure_name_or_prefix`

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -69,7 +69,7 @@ def confirm_yn(message="Proceed", default='yes', dry_run=NULL):
 
 def ensure_name_or_prefix(args, command):
     warn(
-        f"{__name__}.ensure_name_or_prefix is pending deprecation in 5.0.0.",
+        "conda.cli.common.ensure_name_or_prefix is pending deprecation in a future release.",
         PendingDeprecationWarning,
     )
     if not (args.name or args.prefix):

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -7,6 +7,7 @@ from logging import getLogger
 from os.path import basename, dirname, isdir, isfile, join
 import re
 import sys
+from warnings import warn
 
 from ..auxlib.ish import dals
 from ..base.constants import ROOT_ENV_NAME
@@ -67,6 +68,10 @@ def confirm_yn(message="Proceed", default='yes', dry_run=NULL):
 
 
 def ensure_name_or_prefix(args, command):
+    warn(
+        f"{__name__}.ensure_name_or_prefix is pending deprecation in 5.0.0.",
+        PendingDeprecationWarning,
+    )
     if not (args.name or args.prefix):
         from ..exceptions import CondaValueError
         raise CondaValueError('either -n NAME or -p PREFIX option required,\n'

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -576,7 +576,9 @@ def configure_parser_create(sub_parsers):
         help='Path to (or name of) existing local environment.',
         metavar='ENV',
     )
-    solver_mode_options, package_install_options = add_parser_create_install_update(p)
+    solver_mode_options, package_install_options = add_parser_create_install_update(
+        p, prefix_required=True
+    )
     add_parser_default_packages(solver_mode_options)
     add_parser_experimental_solver(solver_mode_options)
     p.add_argument(
@@ -1303,8 +1305,8 @@ def configure_parser_update(sub_parsers, name='update'):
 #
 # #############################################################################################
 
-def add_parser_create_install_update(p):
-    add_parser_prefix(p)
+def add_parser_create_install_update(p, prefix_required=False):
+    add_parser_prefix(p, prefix_required)
     add_parser_channels(p)
     solver_mode_options = add_parser_solver_mode(p)
     package_install_options = add_parser_package_install_options(p)
@@ -1382,9 +1384,9 @@ def add_parser_help(p):
     )
 
 
-def add_parser_prefix(p):
+def add_parser_prefix(p, prefix_required=False):
     target_environment_group = p.add_argument_group("Target Environment Specification")
-    npgroup = target_environment_group.add_mutually_exclusive_group()
+    npgroup = target_environment_group.add_mutually_exclusive_group(required=prefix_required)
     npgroup.add_argument(
         '-n', "--name",
         action="store",

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -119,8 +119,6 @@ def install(args, parser, command='install'):
     isupdate = bool(command == 'update')
     isinstall = bool(command == 'install')
     isremove = bool(command == 'remove')
-    if newenv:
-        common.ensure_name_or_prefix(args, command)
     prefix = context.target_prefix
     if newenv:
         check_prefix(prefix, json=context.json)

--- a/news/11490-deprecate-conda.cli.common.ensure_name_or_prefix
+++ b/news/11490-deprecate-conda.cli.common.ensure_name_or_prefix
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* `conda.cli.common.ensure_name_or_prefix` is pending deprecation in 5.0.0. (#11490)
+* `conda.cli.common.ensure_name_or_prefix` is pending deprecation in a future release. (#11490)
 
 ### Docs
 

--- a/news/11490-deprecate-conda.cli.common.ensure_name_or_prefix
+++ b/news/11490-deprecate-conda.cli.common.ensure_name_or_prefix
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* `conda.cli.common.ensure_name_or_prefix` is pending deprecation in 5.0.0. (#11490)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Previously an explicit check/exception is defined to ensure that `conda create` includes either `--name` or `--prefix`. These two arguments are already defined as a mutex group in `argparse`. Just set this group to required and `argparse` will do the rest for us.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] ~Add / update necessary tests?~
- [X] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
