### PR TITLE
Update documentation from bare conda.io domain to docs.conda.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Installation
 ------------
 
 Conda is a part of the `Anaconda Distribution <https://repo.anaconda.com>`_.
-Use `Miniconda <https://conda.io/en/latest/miniconda.html>`_ to bootstrap a minimal installation
+Use `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ to bootstrap a minimal installation
 that only includes conda and its dependencies.
 
 
@@ -108,7 +108,7 @@ You can easily build your own packages for conda, and upload them
 to `anaconda.org <https://anaconda.org>`_, a free service for hosting
 packages for conda, as well as other package managers.
 To build a package, create a recipe. Package building documentation is available
-`here <https://conda.io/projects/conda-build/en/latest/>`_.
+`here <https://docs.conda.io/projects/conda-build/en/latest/>`_.
 See https://github.com/AnacondaRecipes for the recipes that make up the Anaconda Distribution
 and ``defaults`` channel. `Conda-forge <https://conda-forge.org/feedstocks/>`_ and
 `Bioconda <https://github.com/bioconda/bioconda-recipes>`_ are community-driven
@@ -143,7 +143,7 @@ to add).
 Getting Help
 ------------
 
-The documentation for conda is at https://conda.io/en/latest/. You can
+The documentation for conda is at https://docs.conda.io/projects/conda/en/latest/. You can
 subscribe to the `conda mailing list
 <https://groups.google.com/a/continuum.io/forum/#!forum/conda>`_.  The source
 code and issue tracker for conda are on `GitHub <https://github.com/conda/conda>`_.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The bare conda.io domain redirects to docs.conda.io while direct links to pages on conda.io are not redirected, leading to ambiguity about what is the authoritative URL for conda documentation.  This updates increases consistency toward the doc.conda.io subdomain. Closes #9100

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
