### PR TITLE
[WIP] Add ".json.bz2" to the strip_pkg_extension list

### DIFF
--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -345,6 +345,8 @@ def strip_pkg_extension(path):
         return path[:-8], ".tar.bz2"
     elif path[-5:] == ".json":
         return path[:-5], ".json"
+    elif path[-9:] == ".json.bz2":
+        return path[:-9], ".json.bz2"
     else:
         return path, None
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

I was working with the `Channel` class and discovered a really odd effect:
```
>>> Channel.from_url('https://conda.anaconda.org/mcg/noarch/repodata.json.bz2').url()
'https://conda.anaconda.org/mcg/repodata.json.bz2/noarch'
>>> Channel.from_url('https://conda.anaconda.org/mcg/noarch/repodata.json').url(
'https://conda.anaconda.org/mcg/noarch/repodata.json'
```
This is frustrating my attempt to use conda's authenticated download mechanism to grab repodata for a mirroring tool.

Frankly the Channel class tries to be too smart about figuring out how to parse an arbitrary URL. It is expected to handle a URL to a package, to a subdir, or to a channel. This is failing here. But I realized it can be fixed simply by adding `.json.bz2` to the list of file extensions supported.
