### PR TITLE
Add note about disabling adding to PATH during AllUsers installation (on Windows)

### DIFF
--- a/docs/source/user-guide/install/windows.rst
+++ b/docs/source/user-guide/install/windows.rst
@@ -36,6 +36,9 @@ Installing in silent mode
    The following instructions are for Miniconda. For Anaconda,
    substitute ``Anaconda`` for ``Miniconda`` in all of the commands.
 
+.. note::
+   As of ``Anaconda Distribution 2022.05`` and ``Miniconda 4.12.0``, the option to add Anaconda to the PATH environment variable during an **All Users** installation has been disabled. This was done to address `a security exploit <https://nvd.nist.gov/vuln/detail/CVE-2022-26526>`_. You can still add Anaconda to the PATH environment variable during a **Just Me** installation.
+
 To run the the Windows installer for Miniconda in
 :ref:`silent mode <silent-mode-glossary>`, use the ``/S``
 argument. The following optional arguments are supported:


### PR DESCRIPTION
### Description

Add note to inform Windows users that they can no longer add to PATH when running in AllUsers mode. This note should help avoid more issues like this: https://github.com/ContinuumIO/anaconda-issues/issues/12956

The commit where the security fix was implemented: https://github.com/ContinuumIO/anaconda-distribution-installer/commit/301e84f84b63d654045d4d7871b726de39fc9bb5

### Checklist - did you ...
- [x] Add / update outdated documentation?
