### PR TITLE
Enable "some" tests for linux-{aarch64, ppc64le}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
         test-type: ['unit', 'integration']
         platform: ['amd64']
         test-group: ['1', '2', '3']
+        # be careful with including more non-native tests,
+        # they consume 10x the time of a native linux-amd64 run
         include:
           - python-version: '3.9'
             test-type: unit
@@ -99,7 +101,7 @@ jobs:
           - python-version: '3.10'
             test-type: unit
             platform: 'ppc64le'
-            test-group: 2
+            test-group: 1
     env:
       OS: linux-${{ matrix.platform }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,19 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         test-type: ['unit', 'integration']
+        platform: ['amd64']
         test-group: ['1', '2', '3']
+        include:
+          - python-version: '3.9'
+            test-type: unit
+            platform: 'arm64'
+            test-group: 1
+          - python-version: '3.10'
+            test-type: unit
+            platform: 'ppc64le'
+            test-group: 2
     env:
-      OS: Linux
+      OS: linux-${{ matrix.platform }}
       PYTHON: ${{ matrix.python-version }}
       TEST_SPLITS: 3
       TEST_GROUP: ${{ matrix.test-group }}
@@ -100,10 +110,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Python ${{ matrix.python-version }} ${{ matrix.test_type }} tests, group ${{ matrix.test-group }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Python linux-${{ matrix.platform }} ${{ matrix.python-version }} ${{ matrix.test_type }} tests, group ${{ matrix.test-group }}
         run: >
           docker run
           --rm -v ${PWD}:/opt/conda-src
+          --platform linux/${{ matrix.platform }}
           -e TEST_SPLITS
           -e TEST_GROUP
           ghcr.io/conda/conda-ci:master-linux-python${{ matrix.python-version }}
@@ -120,7 +134,7 @@ jobs:
         with:
           # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
           # when locally dowloading and comparing results of different workflow runs.
-          name: test-results-${{ github.sha }}-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.test-type }}-${{ matrix.test-group }}
+          name: test-results-${{ github.sha }}-linux-${{ matrix.platform }}-${{ matrix.python-version }}-${{ matrix.test-type }}-${{ matrix.test-group }}
           path: |
             .coverage
             test-report.xml


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

Running all linux test-types/groups multiplied by all python-versions (=24) on all linux platforms is maybe overkill, but enabling some tests on other platforms at least proves that the test can be run there if desired.

This got possible by the multi-platform containers via https://github.com/conda/conda/pull/11560

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
