### PR TITLE
Mark `conda.lock` as pending deprecation

### DIFF
--- a/conda/lock.py
+++ b/conda/lock.py
@@ -19,8 +19,15 @@ import logging
 import os
 from os.path import abspath, basename, dirname, isdir, join
 import time
+import warnings
 
 from .exceptions import LockError
+
+warnings.warn(
+    "The `conda.lock` module is pending deprecation and will be removed in a future release. "
+    "Please use `filelock` instead.",
+    PendingDeprecationWarning,
+)
 
 LOCK_EXTENSION = 'conda_lock'
 

--- a/news/11571-pendingdeprecation-conda.lock
+++ b/news/11571-pendingdeprecation-conda.lock
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark conda.lock as pending deprecation. (#11571)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Woo-hoo! Found another unused submodule!

I have searched all Conda and friends repos and `mamba` and as far as I can tell `conda.lock` is not in use anywhere.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] ~Add / update necessary tests?~
- [X] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
