### PR TITLE
Remove `conda.common.url.is_ipv6_address_win_py27`

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -286,32 +286,10 @@ def is_ipv6_address(string_ip):
         [False, False]
     """
     try:
-        inet_pton = socket.inet_pton
-    except AttributeError:
-        return is_ipv6_address_win_py27(string_ip)
-    try:
-        inet_pton(socket.AF_INET6, string_ip)
+        socket.inet_pton(socket.AF_INET6, string_ip)
     except socket.error:
         return False
     return True
-
-
-def is_ipv6_address_win_py27(string_ip):
-    """
-    Examples:
-        >>> [is_ipv6_address_win_py27(ip) for ip in ('::1', '1234:'*7+'1234')]
-        [True, True]
-        >>> [is_ipv6_address_win_py27(ip) for ip in ('192.168.10.10', '1234:'*8+'1234')]
-        [False, False]
-    """
-    # python 2.7 on windows does not have socket.inet_pton
-    return bool(re.match(r""  # lgtm [py/regex/unmatchable-dollar]
-                         r"^(((?=.*(::))(?!.*\3.+\3))\3?|[\dA-F]{1,4}:)"
-                         r"([\dA-F]{1,4}(\3|:\b)|\2){5}"
-                         r"(([\dA-F]{1,4}(\3|:\b|$)|\2){2}|"
-                         r"(((2[0-4]|1\d|[1-9])?\d|25[0-5])\.?\b){4})\Z",
-                         string_ip,
-                         flags=re.DOTALL | re.IGNORECASE))
 
 
 def is_ip_address(string_ip):

--- a/news/11573-remove-is_ipv6_address_win_py27
+++ b/news/11573-remove-is_ipv6_address_win_py27
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove Python 2.7 `conda.common.url.is_ipv6_address_win_py27` implementation. (#11573)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Removing yet another Python 2.7 remnant.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] ~Add / update necessary tests?~
- [X] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
