### PR TITLE
Un-suppressed init argument help for --no-user, --system, and --user.

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -671,22 +671,19 @@ def configure_parser_init(sub_parsers):
     setup_type_group.add_argument(
         "--user",
         action="store_true",
-        # help="Initialize conda for the current user (default).",
-        help=SUPPRESS,
+        help="Initialize conda for the current user (default).",
         default=NULL,
     )
     setup_type_group.add_argument(
         "--no-user",
         action="store_false",
-        # help="Don't initialize conda for the current user (default).",
-        help=SUPPRESS,
+        help="Don't initialize conda for the current user (default).",
         default=NULL,
     )
     setup_type_group.add_argument(
         "--system",
         action="store_true",
-        # help="Initialize conda for all users on the system.",
-        help=SUPPRESS,
+        help="Initialize conda for all users on the system.",
         default=NULL,
     )
     setup_type_group.add_argument(

--- a/docs/source/commands/init.rst
+++ b/docs/source/commands/init.rst
@@ -1,0 +1,10 @@
+``conda init``
+***************
+
+.. argparse::
+   :module: conda.cli.conda_argparse
+   :func: generate_parser
+   :prog: conda
+   :path: init
+   :nodefault:
+   :nodefaultconst:

--- a/news/8135-conda-init-undocumented-arguments
+++ b/news/8135-conda-init-undocumented-arguments
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Updated docs and CLI help to include information on ``conda init`` arguments.
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

The help for the --no-user, --system, and --user arguments under init were suppressed and commented out. I removed those things so they'll show up in the CLI. Also added init command to the docs.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
