### PR TITLE
Fix GIT_DESCRIBE_REGEX to strip non-numeric characters at beginning

### DIFF
--- a/conda/auxlib/packaging.py
+++ b/conda/auxlib/packaging.py
@@ -82,7 +82,7 @@ import sys
 log = getLogger(__name__)
 
 Response = namedtuple('Response', ['stdout', 'stderr', 'rc'])
-GIT_DESCRIBE_REGEX = compile(r"(?:[_-a-zA-Z]*)"
+GIT_DESCRIBE_REGEX = compile(r"(?:[_\-a-zA-Z]*)"
                              r"(?P<version>[a-zA-Z0-9.]+)"
                              r"(?:-(?P<post>\d+)-g(?P<hash>[0-9a-f]{7,}))$")
 

--- a/news/11576-fix-get-describe-regex
+++ b/news/11576-fix-get-describe-regex
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix GIT_DESCRIBE_TAG_PEP440 (and GIT_DESCRIBE_REGEX internally) to correctly strip leading non-numeric characters from git tag, e.g. "v1.0.0" to "1.0.0".
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This fixes `GIT_DESCRIBE_TAG_PEP440` when the tag includes a prefix composed of lowercase letters, e.g. "v1.0.0" -> "1.0.0".

This regex is used to parse the output of `git describe` and turn it into a version, post commit number, and commit hash that can be formatted into a PEP440-compliant version number. The first part of this regex was presumably intended to match letters, '_', or '-' at the beginning of the string to strip them off exclusive of the version number. The pattern was incorrect, however, with an unescaped '-' being interpreted as a character range instead of the literal dash character. The result was that all lowercase letters except 'z' would not be stripped from the version.

The common case that this fixes is a git version tag that has a 'v' prefix, like "v1.0.0". Previously, this would result in an invalid version number of "v1.0.0". With this fix, the version number becomes "1.0.0".

The following test case shows the change:
```
import re
import conda.auxlib.packaging
print(conda.auxlib.packaging.GIT_DESCRIBE_REGEX.match('v1.0.0-52-gc50417f').groupdict())
```
produces `{'version': 'v1.0.0', 'post': '52', 'hash': 'c50417f'}` before the change and `{'version': '1.0.0', 'post': '52', 'hash': 'c50417f'}` after the change, correctly stripping the 'v' prefix.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
