### PR TITLE
Remove Repeated `dashlist` Function from `resolve.py`

### DIFF
--- a/conda/plan.py
+++ b/conda/plan.py
@@ -20,7 +20,7 @@ from ._vendor.boltons.setutils import IndexedSet
 from ._vendor.toolz import concatv
 from .base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
 from .base.context import context, stack_context_default
-from .common.io import env_vars, time_recorder
+from .common.io import dashlist, env_vars, time_recorder
 from .core.index import LAST_CHANNEL_URLS, _supplement_index_with_prefix
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.solve import diff_for_unlink_link_precs
@@ -34,7 +34,7 @@ from .models.match_spec import ChannelMatch
 from .models.prefix_graph import PrefixGraph
 from .models.records import PackageRecord
 from .models.version import normalized_version
-from .resolve import MatchSpec, dashlist
+from .resolve import MatchSpec
 from .utils import human_bytes
 
 log = getLogger(__name__)

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -14,7 +14,7 @@ from ._vendor.tqdm import tqdm
 from .base.constants import ChannelPriority, MAX_CHANNEL_PRIORITY, SatSolverChoice
 from .base.context import context
 from .common.compat import on_win
-from .common.io import time_recorder
+from .common.io import dashlist, time_recorder
 from .common.logic import (Clauses, PycoSatSolver, PyCryptoSatSolver, PySatSolver, TRUE,
                            minimal_unsatisfiable_subset)
 from .common.toposort import toposort
@@ -69,10 +69,6 @@ def _get_sat_solver_cls(sat_solver_choice=SatSolverChoice.PYCOSAT):
             log.debug("Falling back to SAT solver interface '%s'.", sat_solver_choice)
             return sat_solver
     raise CondaDependencyError("Cannot run solver. No functioning SAT implementations available.")
-
-
-def dashlist(iterable, indent=2):
-    return ''.join('\n' + ' ' * indent + '- ' + str(x) for x in iterable)
 
 
 def exactness_and_number_of_deps(resolve_obj, ms):

--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -47,10 +47,10 @@ from conda.common.compat import encode_arguments, on_win
 from conda.common.io import (
     argv,
     captured,
+    dashlist,
     disable_logger,
     env_var,
     stderr_log_level,
-    dashlist,
 )
 from conda.common.url import path_to_url, escape_channel_url
 from conda.core.prefix_data import PrefixData


### PR DESCRIPTION
`dashlist()` was defined in both `conda/resolve.py` and `conda/common/io.py`; this PR removes that function from `resolve.py` and imports it from `common.io` instead to remove redundancy.