### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -19,8 +19,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   windows:
+    permissions:
+      contents: none
     runs-on: windows-2019
     strategy:
       matrix:
@@ -32,6 +37,8 @@ jobs:
       - run: 'echo "No build required"'
 
   linux:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,6 +49,8 @@ jobs:
       - run: 'echo "No build required"'
 
   macos:
+    permissions:
+      contents: none
     runs-on: macos-latest
     strategy:
       matrix:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
