### PR TITLE
Fix for broken Windows test runners on CI

### DIFF
--- a/conda/testing/notices/helpers.py
+++ b/conda/testing/notices/helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 
 import datetime
 import uuid
@@ -9,6 +10,11 @@ from itertools import chain
 from pathlib import Path
 from typing import Optional, Sequence
 from unittest import mock
+
+from conda.base.context import Context
+from conda.notices.core import get_channel_name_and_urls
+from conda.notices.types import ChannelNoticeResponse
+from conda.models.channel import get_channel_objs
 
 DEFAULT_NOTICE_MESG = "Here is an example message that will be displayed to users"
 
@@ -106,3 +112,13 @@ class MockResponse:
         if self.raise_exc:
             raise ValueError("Error")
         return self.json_data
+
+
+def get_notice_cache_filenames(ctx: Context) -> tuple[str]:
+    """Returns the filenames of the cache files that will be searched for"""
+    channel_urls_and_names = get_channel_name_and_urls(get_channel_objs(ctx))
+
+    return tuple(
+        ChannelNoticeResponse.get_cache_key(url, name, Path("")).name
+        for url, name in channel_urls_and_names
+    )

--- a/tests/cli/test_main_notices.py
+++ b/tests/cli/test_main_notices.py
@@ -5,13 +5,14 @@ import datetime
 
 import pytest
 
-from conda.base.constants import on_win
+from conda.base.context import context
 from conda.cli import main_notices as notices
 from conda.cli import conda_argparse
 from conda.testing.notices.helpers import (
     add_resp_to_mock,
     create_notice_cache_files,
     get_test_notices,
+    get_notice_cache_filenames,
 )
 
 
@@ -61,10 +62,7 @@ def test_main_notices_reads_from_cache(
     """
     args, parser = conda_notices_args_n_parser
     messages = ("Test One", "Test Two")
-    cache_files = ("defaults-pkgs-r-notices.json", "defaults-pkgs-main-notices.json")
-
-    if on_win:
-        cache_files += ("defaults-pkgs-msys2-notices.json",)
+    cache_files = get_notice_cache_filenames(context)
 
     messages_json_seq = tuple(get_test_notices(messages) for _ in cache_files)
     create_notice_cache_files(notices_cache_dir, cache_files, messages_json_seq)
@@ -95,10 +93,7 @@ def test_main_notices_reads_from_expired_cache(
     messages = ("Test One", "Test Two")
     messages_different = ("With different value one", "With different value two")
     created_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=14)
-    cache_files = ("defaults-pkgs-r-notices.json", "defaults-pkgs-main-notices.json")
-
-    if on_win:
-        cache_files += ("defaults-pkgs-msys2-notices.json",)
+    cache_files = get_notice_cache_filenames(context)
 
     # Cache first version of notices, with a cache date we know is expired
     messages_json_seq = tuple(


### PR DESCRIPTION
This pull request is a bug fix for a previously merged pull request: #11462 .

We are still having trouble with the following test:

- `tests/cli/test_main_notices.py::test_main_notices_read_from_cache`

My hunch right now is that this failure is related to the hard coded cache file names that were present in the tests. The change I'm proposing is to fetch these file names dynamically with a new function:
- `conda.testing.notices.helpers.get_notice_cache_filenames`

This should hopefully solve this problem as now the tests will be looking to the global `context` object to see exactly which cache files it should create.