### PR TITLE
Fail with a readable error message if PackageCacheRecords are missing

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -99,10 +99,10 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
     specs_with_missing_pcrecs = [str(spec) for spec, pcrec in specs_pcrecs if pcrec is None]
     if specs_with_missing_pcrecs:
         if len(specs_with_missing_pcrecs) == len(specs_pcrecs):
-            raise AssertionError("No PackageCacheRecords found")
+            raise AssertionError("No package cache records found")
         else:
-            raise AssertionError("Missing PackageCacheRecords for: %s"
-                                 % ', '.join(specs_with_missing_pcrecs))
+            missing_precs_list = ", ".join(specs_with_missing_pcrecs)
+            raise AssertionError(f"Missing package cache records for: {missing_precs_list}")
 
     precs_to_remove = []
     prefix_data = PrefixData(prefix)

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -94,7 +94,15 @@ def explicit(specs, prefix, verbose=False, force_extract=True, index_args=None, 
     # need to add package name to fetch_specs so that history parsing keeps track of them correctly
     specs_pcrecs = tuple([spec, next(PackageCacheData.query_all(spec), None)]
                          for spec in fetch_specs)
-    assert not any(spec_pcrec[1] is None for spec_pcrec in specs_pcrecs)
+
+    # Assert that every spec has a PackageCacheRecord
+    specs_with_missing_pcrecs = [str(spec) for spec, pcrec in specs_pcrecs if pcrec is None]
+    if specs_with_missing_pcrecs:
+        if len(specs_with_missing_pcrecs) == len(specs_pcrecs):
+            raise AssertionError("No PackageCacheRecords found")
+        else:
+            raise AssertionError("Missing PackageCacheRecords for: %s"
+                                 % ', '.join(specs_with_missing_pcrecs))
 
     precs_to_remove = []
     prefix_data = PrefixData(prefix)

--- a/news/11591-readable-error-message-if-packagecacherecords-missing
+++ b/news/11591-readable-error-message-if-packagecacherecords-missing
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Added an informative message if explicit install fails due to requested
+  packages not being in the cache.

--- a/news/11591-readable-error-message-if-packagecacherecords-missing
+++ b/news/11591-readable-error-message-if-packagecacherecords-missing
@@ -1,4 +1,4 @@
 ### Enhancements
 
 * Added an informative message if explicit install fails due to requested
-  packages not being in the cache.
+  packages not being in the cache. (#11591)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -26,16 +26,20 @@ def test_Utf8NamedTemporaryFile():
         raise exc
 
 
-def test_cache_fn_url(self):
+def test_cache_fn_url():
     url = "http://repo.continuum.io/pkgs/pro/osx-64/"
+
     # implicit repodata.json
-    self.assertEqual(cache_fn_url(url), "7618c8b6.json")
+    assert cache_fn_url(url) == "7618c8b6.json"
+    
     # explicit repodata.json
-    self.assertEqual(cache_fn_url(url, "repodata.json"), "7618c8b6.json")
+    assert cache_fn_url(url, "repodata.json") == "7618c8b6.json"
+    
     # explicit current_repodata.json
-    self.assertEqual(cache_fn_url(url, "current_repodata.json"), "8be5dc16.json")
+    assert cache_fn_url(url, "current_repodata.json") == "8be5dc16.json"
+    
     url = "http://repo.anaconda.com/pkgs/pro/osx-64/"
-    self.assertEqual(cache_fn_url(url), "e42afea8.json")
+    assert cache_fn_url(url) == "e42afea8.json"
 
 
 def test_url_pat_1():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,59 +1,62 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-
 import codecs
 import sys
-import unittest
 from unittest.mock import patch
-
 import pytest
 
 from conda.core.subdir_data import cache_fn_url
 from conda.misc import url_pat, explicit, walk_prefix
 from conda.utils import Utf8NamedTemporaryFile
 
-class TestMisc(unittest.TestCase):
 
-    def test_Utf8NamedTemporaryFile(self):
-        test_string = 'ōγђ家固한áêñßôç'
-        try:
-            with Utf8NamedTemporaryFile(delete=False) as tf:
-                tf.write(test_string.encode('utf-8') if hasattr(test_string, 'encode') else test_string)
-                fname = tf.name
-            with codecs.open(fname, mode='rb', encoding='utf-8') as fh:
-                value = fh.read()
-            assert value == test_string
-        except Exception as e:
-            raise e
+def test_Utf8NamedTemporaryFile():
+    test_string = "ōγђ家固한áêñßôç"
+    try:
+        with Utf8NamedTemporaryFile(delete=False) as tf:
+            tf.write(
+                test_string.encode("utf-8") if hasattr(test_string, "encode") else test_string
+            )
+            fname = tf.name
+        with codecs.open(fname, mode="rb", encoding="utf-8") as fh:
+            value = fh.read()
+        assert value == test_string
+    except Exception as exc:
+        raise exc
 
-    def test_cache_fn_url(self):
-        url = "http://repo.continuum.io/pkgs/pro/osx-64/"
-        # implicit repodata.json
-        self.assertEqual(cache_fn_url(url), '7618c8b6.json')
-        # explicit repodata.json
-        self.assertEqual(cache_fn_url(url, 'repodata.json'), '7618c8b6.json')
-        # explicit current_repodata.json
-        self.assertEqual(cache_fn_url(url, "current_repodata.json"), '8be5dc16.json')
-        url = "http://repo.anaconda.com/pkgs/pro/osx-64/"
-        self.assertEqual(cache_fn_url(url), 'e42afea8.json')
 
-    def test_url_pat_1(self):
-        m = url_pat.match('http://www.cont.io/pkgs/linux-64/foo.tar.bz2'
-                          '#d6918b03927360aa1e57c0188dcb781b')
-        self.assertEqual(m.group('url_p'), 'http://www.cont.io/pkgs/linux-64')
-        self.assertEqual(m.group('fn'), 'foo.tar.bz2')
-        self.assertEqual(m.group('md5'), 'd6918b03927360aa1e57c0188dcb781b')
+def test_cache_fn_url(self):
+    url = "http://repo.continuum.io/pkgs/pro/osx-64/"
+    # implicit repodata.json
+    self.assertEqual(cache_fn_url(url), "7618c8b6.json")
+    # explicit repodata.json
+    self.assertEqual(cache_fn_url(url, "repodata.json"), "7618c8b6.json")
+    # explicit current_repodata.json
+    self.assertEqual(cache_fn_url(url, "current_repodata.json"), "8be5dc16.json")
+    url = "http://repo.anaconda.com/pkgs/pro/osx-64/"
+    self.assertEqual(cache_fn_url(url), "e42afea8.json")
 
-    def test_url_pat_2(self):
-        m = url_pat.match('http://www.cont.io/pkgs/linux-64/foo.tar.bz2')
-        self.assertEqual(m.group('url_p'), 'http://www.cont.io/pkgs/linux-64')
-        self.assertEqual(m.group('fn'), 'foo.tar.bz2')
-        self.assertEqual(m.group('md5'), None)
 
-    def test_url_pat_3(self):
-        m = url_pat.match('http://www.cont.io/pkgs/linux-64/foo.tar.bz2#1234')
-        self.assertEqual(m, None)
+def test_url_pat_1():
+    match = url_pat.match(
+        "http://test/pkgs/linux-64/foo.tar.bz2" "#d6918b03927360aa1e57c0188dcb781b"
+    )
+    assert match.group("url_p") == "http://test/pkgs/linux-64"
+    assert match.group("fn") == "foo.tar.bz2"
+    assert match.group("md5") == "d6918b03927360aa1e57c0188dcb781b"
+
+
+def test_url_pat_2():
+    match = url_pat.match("http://test/pkgs/linux-64/foo.tar.bz2")
+    assert match.group("url_p") == "http://test/pkgs/linux-64"
+    assert match.group("fn") == "foo.tar.bz2"
+    assert match.group("md5") == None
+
+
+def test_url_pat_3():
+    match = url_pat.match("http://test/pkgs/linux-64/foo.tar.bz2#1234")
+    assert match is None
 
 
 # Patching ProgressiveFetchExtract prevents trying to download a package from the url.
@@ -104,15 +107,10 @@ def test_walk_prefix(tmpdir):  # tmpdir is a py.test utility
     # a file
     mock_directory = {
         "LICENSE.txt": None,
-        "envs": {"ignore1": None,
-                 "ignore2": None},
+        "envs": {"ignore1": None, "ignore2": None},
         "python.app": None,
-        "bin": {"activate": None,
-                "conda": None,
-                "deactivate": None,
-                "testfile": None},
-        "testdir1": {"testfile": None,
-                     "testdir2": {"testfile": None}},
+        "bin": {"activate": None, "conda": None, "deactivate": None, "testfile": None},
+        "testdir1": {"testfile": None, "testdir2": {"testfile": None}},
         "testfile1": None,
     }
 
@@ -121,13 +119,8 @@ def test_walk_prefix(tmpdir):  # tmpdir is a py.test utility
     # walk_prefix has windows_forward_slahes on by default, so we don't need
     # any special-casing there
 
-    answer = {"testfile1", "bin/testfile", "testdir1/testfile",
-              "testdir1/testdir2/testfile"}
+    answer = {"testfile1", "bin/testfile", "testdir1/testfile", "testdir1/testdir2/testfile"}
     if sys.platform != "darwin":
         answer.add("python.app")
 
     assert walk_prefix(tmpdir.strpath) == answer
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -31,13 +31,13 @@ def test_cache_fn_url():
 
     # implicit repodata.json
     assert cache_fn_url(url) == "7618c8b6.json"
-    
+
     # explicit repodata.json
     assert cache_fn_url(url, "repodata.json") == "7618c8b6.json"
-    
+
     # explicit current_repodata.json
     assert cache_fn_url(url, "current_repodata.json") == "8be5dc16.json"
-    
+
     url = "http://repo.anaconda.com/pkgs/pro/osx-64/"
     assert cache_fn_url(url) == "e42afea8.json"
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -58,28 +58,36 @@ class TestMisc(unittest.TestCase):
 
 # Patching ProgressiveFetchExtract prevents trying to download a package from the url.
 # Note that we cannot monkeypatch context.dry_run, because explicit() would exit early with that.
-@patch('conda.misc.ProgressiveFetchExtract')
+@patch("conda.misc.ProgressiveFetchExtract")
 def test_explicit_no_cache(ProgressiveFetchExtract):
     """Test that explicit() raises and notifies if none of the specs were found in the cache."""
-    with pytest.raises(AssertionError, match='No PackageCacheRecords found'):
+    with pytest.raises(AssertionError, match="No package cache records found"):
         explicit(
-            ['http://www.cont.io/pkgs/linux-64/foo-1.0.0-py_0.tar.bz2',
-             'http://www.cont.io/pkgs/linux-64/bar-1.0.0-py_0.tar.bz2',
-             ], '')
+            [
+                "http://test/pkgs/linux-64/foo-1.0.0-py_0.tar.bz2",
+                "http://test/pkgs/linux-64/bar-1.0.0-py_0.tar.bz2",
+            ],
+            "",
+        )
 
 
 # Patching ProgressiveFetchExtract prevents trying to download a package from the url.
 # Note that we cannot monkeypatch context.dry_run, because explicit() would exit early with that.
-@patch('conda.misc.ProgressiveFetchExtract')
+@patch("conda.misc.ProgressiveFetchExtract")
 def test_explicit_missing_cache_entries(ProgressiveFetchExtract):
     """Test that explicit() raises and notifies if some of the specs were not found in the cache."""
     from conda.core.package_cache_data import PackageCacheData
-    with pytest.raises(AssertionError,
-                       match="Missing PackageCacheRecords for: pkgs/linux-64::foo==1.0.0=py_0"):
+
+    with pytest.raises(
+        AssertionError, match="Missing package cache records for: pkgs/linux-64::foo==1.0.0=py_0"
+    ):
         explicit(
-            ['http://www.cont.io/pkgs/linux-64/foo-1.0.0-py_0.tar.bz2',  # does not exist
-             PackageCacheData.get_all_extracted_entries()[0].url,        # exists
-            ], '')
+            [
+                "http://test/pkgs/linux-64/foo-1.0.0-py_0.tar.bz2",  # does not exist
+                PackageCacheData.get_all_extracted_entries()[0].url,  # exists
+            ],
+            "",
+        )
 
 
 def make_mock_directory(tmpdir, mock_directory):


### PR DESCRIPTION
### Description

I recently got tripped up by a broken channel that triggered the assertion.

However, the error is not quite helpful to the user. Even from the code context it's hard to understand what the issue is.

This PR replaces the `assert` statement by  an `AssertionError` with a proper message. I've chosen `AssertionError` to raise the same exception type. Let me know if you would like to raise a different exception here.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes? - *Not a significant change*
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests? - *I believe setting up a test for this is hard. If you have a good idea how to test this, I'm happy to include it.*
- [x] Add / update outdated documentation? - *Does not apply*
