### PR TITLE
Fixed outstanding spacing issue in conda init help text.

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -604,7 +604,8 @@ def configure_parser_init(sub_parsers):
     help = "Initialize conda for shell interaction."
     descr = help
 
-    epilog = dedent("""
+    epilog = dedent(
+        """
     Key parts of conda's functionality require that it interact directly with the shell
     within which conda is being invoked. The `conda activate` and `conda deactivate` commands
     specifically are shell-level commands. That is, they affect the state (e.g. environment
@@ -618,10 +619,11 @@ def configure_parser_init(sub_parsers):
     '--dry-run' flag.  To see the exact changes that are being or will be made to each location,
     use the '--verbose' flag.
 
-    IMPORTANT: After running `conda init`, most shells will need to be closed and restarted for 
+    IMPORTANT: After running `conda init`, most shells will need to be closed and restarted for
     changes to take effect.
 
-    """)
+    """
+    )
 
     # dev_example = dedent("""
     #     # An example for creating an environment to develop on conda's own code. Clone the

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -604,25 +604,25 @@ def configure_parser_init(sub_parsers):
     help = "Initialize conda for shell interaction."
     descr = help
 
-    epilog = dedent(
+    epilog = dals(
         """
-    Key parts of conda's functionality require that it interact directly with the shell
-    within which conda is being invoked. The `conda activate` and `conda deactivate` commands
-    specifically are shell-level commands. That is, they affect the state (e.g. environment
-    variables) of the shell context being interacted with. Other core commands, like
-    `conda create` and `conda install`, also necessarily interact with the shell environment.
-    They're therefore implemented in ways specific to each shell. Each shell must be configured
-    to make use of them.
+        Key parts of conda's functionality require that it interact directly with the shell
+        within which conda is being invoked. The `conda activate` and `conda deactivate` commands
+        specifically are shell-level commands. That is, they affect the state (e.g. environment
+        variables) of the shell context being interacted with. Other core commands, like
+        `conda create` and `conda install`, also necessarily interact with the shell environment.
+        They're therefore implemented in ways specific to each shell. Each shell must be configured
+        to make use of them.
 
-    This command makes changes to your system that are specific and customized for each shell.
-    To see the specific files and locations on your system that will be affected before, use the
-    '--dry-run' flag.  To see the exact changes that are being or will be made to each location,
-    use the '--verbose' flag.
+        This command makes changes to your system that are specific and customized for each shell.
+        To see the specific files and locations on your system that will be affected before, use
+        the '--dry-run' flag.  To see the exact changes that are being or will be made to each
+        location, use the '--verbose' flag.
 
-    IMPORTANT: After running `conda init`, most shells will need to be closed and restarted for
-    changes to take effect.
+        IMPORTANT: After running `conda init`, most shells will need to be closed and restarted for
+        changes to take effect.
 
-    """
+        """
     )
 
     # dev_example = dedent("""

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -618,8 +618,8 @@ def configure_parser_init(sub_parsers):
     '--dry-run' flag.  To see the exact changes that are being or will be made to each location,
     use the '--verbose' flag.
 
-    IMPORTANT: After running `conda init`, most shells will need to be closed and restarted for
-               changes to take effect.
+    IMPORTANT: After running `conda init`, most shells will need to be closed and restarted for 
+    changes to take effect.
 
     """)
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

Realized some spacing was not correct in the conda init changes from #8135 in PR #11574, which caused the note at the end to only be half bold and be on two lines. This should fix that.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->
