### PR TITLE
Adding new documentation article on writing tests

### DIFF
--- a/docs/source/dev-guide/index.rst
+++ b/docs/source/dev-guide/index.rst
@@ -7,6 +7,7 @@ Developer guide
 
    contributing
    development-environment
+   writing-tests
    releasing
    ../architecture
    deep-dive-install

--- a/docs/source/dev-guide/index.rst
+++ b/docs/source/dev-guide/index.rst
@@ -7,7 +7,7 @@ Developer guide
 
    contributing
    development-environment
-   writing-tests
+   writing-tests/index.rst
    releasing
    ../architecture
    deep-dive-install

--- a/docs/source/dev-guide/writing-tests.md
+++ b/docs/source/dev-guide/writing-tests.md
@@ -1,0 +1,148 @@
+# Writing Tests
+
+The following guide gives an overview of writing tests for the `conda` codebase.
+This article is mostly aimed at new contributors, especially those wishing
+to submit bug fixes. To give those new to writing tests in the conda codebase
+a proper introduction, this article will cover writing both integration
+and unit tests.
+
+```{admonition} Quick note about test style
+:class: tip
+
+Although our codebase includes class based `unittest` tests, our preferred
+format for all new tests are `pytest` style tests. These tests are written using
+functions and handle the setup and teardown of context for tests using fixtures.
+We recommend familiarizing yourself with `pytest` first before attempting to
+write tests for conda. Head over to their [Getting Started Guide][pytest-getting-started]
+to learn more.
+```
+
+## Integration tests
+
+Integration tests in `conda` test the application from a high level where each test can
+potentially cover large portions of the code.  These tests may also use the local
+file system and/or perform network calls. In the following sections, we cover
+several examples of exactly how these tests look, so you can use these for
+your own tests.
+
+### Running CLI level tests
+
+CLI level tests are the highest level integration tests you can write. This means that the code in
+the test is executed as if you were running it from the command line. For example,
+you may want to write a test to confirm that an environment is created after successfully
+running `conda create`. A test like this would look like the following:
+
+```python
+import os.path
+import json
+
+from conda.testing.helpers import run_inprocess_conda_command as run
+
+TEST_ENV_NAME_1 = "test-env-1"
+
+
+def test_creates_new_environment():
+    out, err, exit_code = run(f"conda create -n {TEST_ENV_NAME_1} -y")
+
+    assert "conda activate test" in out  # ensure activation message is present
+    assert err == ""  # no error messages
+    assert exit_code == 0  # successful exit code
+
+    # Perform a separate verification that everything works using the "conda env list" command
+    out, err, exit_code = run("conda env list --json")
+    json_out = json.loads(out)
+    env_names = {os.path.basename(path) for path in json_out.get("envs", tuple())}
+
+    assert TEST_ENV_NAME_1 in env_names
+    assert err == ""
+    assert exit_code == 0
+
+    out, err, exit_code = run(f"conda remove --all -n {TEST_ENV_NAME_1}")
+
+    assert err == ""
+    assert exit_code == 0
+```
+
+Let's break down exactly what is going on in the code snippet above:
+
+First, we import a function called `run_inprocess_conda_command` (aliased to `run` here) that allows
+us to run a command using the current running process. This ends up being much more efficient and quicker than
+running this test as a subprocess.
+
+In the test itself, we first use our `run` function to create a new environment. This function
+returns the standard out, standard error and the exit code of the command. This allows us to
+perform our inspections in order to determine whether the command successfully ran.
+
+The second part of the test again uses the `run` command to call `conda env list`. This time,
+we pass the `--json` flag, which allows capturing JSON that we can better parse and more easily
+inspect. This second part of the integration test not only ensures that our previous `conda create`
+command ran successfully, but also tests to make sure that `conda env list` runs correctly.
+
+Finally, we destroy the environment we just created and ensure the standard error and the exit
+code are what we expect them to be. It is important to remember removing anything you create
+as this will be present when other tests are run.
+
+### Tests with fixtures
+
+Sometimes in integration tests, you may want to re-use the same type of environment more than once.
+Copying and pasting this setup and teardown code into each individual test can make these tests more
+difficult read and harder to maintain.
+
+To overcome this, `conda` tests make extensive use of `pytest` fixtures. Below is an example of the
+previously shown test except that we now make the focus of the test the `conda env list` command and move
+the creation and removal of the environment into a fixture:
+
+```python
+# Writing a test for `conda env list`
+
+import os.path
+import json
+
+import pytest
+
+from conda.testing.helpers import run_inprocess_conda_command as run
+
+TEST_ENV_NAME_1 = "test-env-1"
+
+
+@pytest.fixture()
+def env_one():
+    out, err, exit_code = run(f"conda create -n {TEST_ENV_NAME_1} -y")
+
+    assert exit_code == 0
+
+    yield
+
+    out, err, exit_code = run(f"conda remove --all -n {TEST_ENV_NAME_1}")
+
+    assert exit_code == 0
+
+
+def test_env_list_finds_existing_environment(env_one):
+    # Because we're using fixtures we can immediately run the `conda env list` command
+    # and our test assertions
+    out, err, exit_code = run("conda env list --json")
+    json_out = json.loads(out)
+    env_names = {os.path.basename(path) for path in json_out.get("envs", tuple())}
+
+    assert TEST_ENV_NAME_1 in env_names
+    assert err == ""
+    assert exit_code == 0
+```
+
+In the fixture named `env_one`, we first create a new environment exactly the same as we
+did in our previous test. We make an assertion to ensure that it ran correctly, and
+yield to mark the end of the setup. In the teardown section after the yield statement,
+we run the `conda remove` command and also make an assertion to determine in ran correctly.
+
+This fixture will be run using the default scope in `pytest` which is `function`. This means
+that the setup and teardown will be run before and after each test. If you needed to share
+and environment or other pieces of data between tests, just remember to set the fixture
+scope appropriately. [Read here][pytest-scope]
+for more information on `pytest` fixture scopes.
+
+
+
+
+[pytest-getting-started]: https://docs.pytest.org/en/stable/getting-started.html
+[pytest-scope]: https://docs.pytest.org/en/stable/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session

--- a/docs/source/dev-guide/writing-tests/index.rst
+++ b/docs/source/dev-guide/writing-tests/index.rst
@@ -3,7 +3,7 @@ Writing Tests
 ===============
 
 This section contains a series of guides and guidelines for writing tests
-in the conda repository.
+in the ``conda`` repository.
 
 .. raw:: html
 
@@ -66,12 +66,12 @@ considering storing these in ``conda.testing.base``.
 Adding new fixtures
 -------------------
 For fixtures that have a very limited scope or purpose, it is okay to define these
-alongside the tests themselves. But, if these fixtures could be used across multiple
-tests, they should be saved in a separate ``fixtures.py`` file. The ``conda.testing``
+alongside the tests themselves. However, if these fixtures could be used across multiple
+tests, then they should be saved in a separate ``fixtures.py`` file. The ``conda.testing``
 module already contains several of these files.
 
 If you want to add new fixtures within a new file, be sure to add a reference to this module in
-``tests/conftest.py::pytest_plugins``. This is a our preferred way of making
+``tests/conftest.py::pytest_plugins``. This is our preferred way of making
 fixtures available to our tests. Because of the way these are included in the
 environment, you should be mindful of naming schemes and choose ones that likely will not
 collide with each other. Consider using a prefix to achieve this.

--- a/docs/source/dev-guide/writing-tests/index.rst
+++ b/docs/source/dev-guide/writing-tests/index.rst
@@ -1,0 +1,77 @@
+===============
+Writing Tests
+===============
+
+This section contains a series of guides and guidelines for writing tests
+in the conda repository.
+
+.. raw:: html
+
+   <hr>
+
+Guides
+======
+
+:doc:`integration-tests`
+This guide gives an overview of how to write integration tests using full
+command invocation. It also covers creating fixtures to use with these types
+of tests.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   integration-tests
+
+.. raw:: html
+
+   <hr>
+
+General Guidelines
+==================
+
+* `Preferred test style (pytest)`_
+* `Organizing tests`_
+* `The "conda.testing" module`_
+* `Adding new fixtures`_
+
+.. note::
+   It should be noted that existing tests may deviate
+   from these guidelines, and that is okay. These guidelines are here to inform how we
+   would like all new tests to look and function.
+
+Preferred test style (pytest)
+-----------------------------
+Although our codebase includes class based unittest tests, our preferred
+format for all new tests are pytest style tests. These tests are written using
+functions and handle the setup and teardown of context for tests using fixtures.
+We recommend familiarizing yourself with pytest first before attempting to
+write tests for conda. Head over to their `Getting Started Guide <https://docs.pytest.org/en/stable/getting-started.html>`_
+to learn more.
+
+Organizing tests
+----------------
+Tests should be organized in a way that mirrors the main ``conda`` module.
+For example, if you were writing a test for a function in
+``conda/base/context.py``, you would place this test in ``tests/base/test_context.py``.
+
+The "conda.testing" module
+----------------------------
+This is a module that contains anything that could possibly help with
+writing tests, including fixtures, functions and classes. Feel free to
+make additions to this module as you see fit, but be mindful of organization.
+For example, if your testing utilities are primarily only for the ``base`` module
+considering storing these in ``conda.testing.base``.
+
+Adding new fixtures
+-------------------
+For fixtures that have a very limited scope or purpose, it is okay to define these
+alongside the tests themselves. But, if these fixtures could be used across multiple
+tests, they should be saved in a separate ``fixtures.py`` file. The ``conda.testing``
+module already contains several of these files.
+
+If you want to add new fixtures within a new file, be sure to add a reference to this module in
+``tests/conftest.py::pytest_plugins``. This is a our preferred way of making
+fixtures available to our tests. Because of the way these are included in the
+environment, you should be mindful of naming schemes and choose ones that likely will not
+collide with each other. Consider using a prefix to achieve this.

--- a/docs/source/dev-guide/writing-tests/index.rst
+++ b/docs/source/dev-guide/writing-tests/index.rst
@@ -131,7 +131,7 @@ invoking the ``reset_context`` command like in the following example:
 
 
    def test_updating_context_manually():
-       # Load some custom variables in to context here like above...
+       # Load some custom variables into context here like above...
 
        reset_context()
 

--- a/docs/source/dev-guide/writing-tests/index.rst
+++ b/docs/source/dev-guide/writing-tests/index.rst
@@ -42,7 +42,7 @@ General Guidelines
 
 Preferred test style (pytest)
 -----------------------------
-Although our codebase includes class based unittest tests, our preferred
+Although our codebase includes class-based unittest tests, our preferred
 format for all new tests are pytest style tests. These tests are written using
 functions and handle the setup and teardown of context for tests using fixtures.
 We recommend familiarizing yourself with pytest first before attempting to

--- a/docs/source/dev-guide/writing-tests/index.rst
+++ b/docs/source/dev-guide/writing-tests/index.rst
@@ -87,7 +87,7 @@ Where this causes problems is during tests where you may want to run ``conda`` c
 hundreds of times within the same process. Therefore, it is important to always reset this object
 to a fresh state when writing tests.
 
-This can be accomplished by using the ``reset_context`` function which also lives in the
+This can be accomplished by using the ``reset_context`` function, which also lives in the
 ``conda.base.context`` module. The following example shows how you would modify the context
 object and then reset it using the ``reset_conda_context`` ``pytest`` fixture:
 

--- a/docs/source/dev-guide/writing-tests/index.rst
+++ b/docs/source/dev-guide/writing-tests/index.rst
@@ -42,11 +42,11 @@ General Guidelines
 
 Preferred test style (pytest)
 -----------------------------
-Although our codebase includes class-based unittest tests, our preferred
-format for all new tests are pytest style tests. These tests are written using
+Although our codebase includes class-based ``unittest`` tests, our preferred
+format for all new tests are ``pytest`` style tests. These tests are written using
 functions and handle the setup and teardown of context for tests using fixtures.
-We recommend familiarizing yourself with pytest first before attempting to
-write tests for conda. Head over to their `Getting Started Guide <https://docs.pytest.org/en/stable/getting-started.html>`_
+We recommend familiarizing yourself with ``pytest`` first before attempting to
+write tests for ``conda``. Head over to their `Getting Started Guide <https://docs.pytest.org/en/stable/getting-started.html>`_
 to learn more.
 
 Organizing tests

--- a/docs/source/dev-guide/writing-tests/index.rst
+++ b/docs/source/dev-guide/writing-tests/index.rst
@@ -58,7 +58,7 @@ For example, if you were writing a test for a function in
 The "conda.testing" module
 ----------------------------
 This is a module that contains anything that could possibly help with
-writing tests, including fixtures, functions and classes. Feel free to
+writing tests, including fixtures, functions, and classes. Feel free to
 make additions to this module as you see fit, but be mindful of organization.
 For example, if your testing utilities are primarily only for the ``base`` module
 considering storing these in ``conda.testing.base``.

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -1,31 +1,12 @@
-# Writing Tests
+# Integration Tests
 
-The following guide gives an overview of writing tests for the `conda` codebase.
-This article is mostly aimed at new contributors, especially those wishing
-to submit bug fixes. To give those new to writing tests in the conda codebase
-a proper introduction, this article will cover writing both integration
-and unit tests.
-
-```{admonition} Quick note about test style
-:class: tip
-
-Although our codebase includes class based `unittest` tests, our preferred
-format for all new tests are `pytest` style tests. These tests are written using
-functions and handle the setup and teardown of context for tests using fixtures.
-We recommend familiarizing yourself with `pytest` first before attempting to
-write tests for conda. Head over to their [Getting Started Guide][pytest-getting-started]
-to learn more.
-```
-
-## Integration tests
-
-Integration tests in `conda` test the application from a high level where each test can
+Integration tests in conda test the application from a high level where each test can
 potentially cover large portions of the code.  These tests may also use the local
 file system and/or perform network calls. In the following sections, we cover
-several examples of exactly how these tests look, so you can use these for
-your own tests.
+several examples of exactly how these tests look. When writing your own integration tests,
+these should serve as a good starting point.
 
-### Running CLI level tests
+## Running CLI level tests
 
 CLI level tests are the highest level integration tests you can write. This means that the code in
 the test is executed as if you were running it from the command line. For example,
@@ -54,8 +35,6 @@ def test_creates_new_environment():
     env_names = {os.path.basename(path) for path in json_out.get("envs", tuple())}
 
     assert TEST_ENV_NAME_1 in env_names
-    assert err == ""
-    assert exit_code == 0
 
     out, err, exit_code = run(f"conda remove --all -n {TEST_ENV_NAME_1}")
 
@@ -75,14 +54,14 @@ perform our inspections in order to determine whether the command successfully r
 
 The second part of the test again uses the `run` command to call `conda env list`. This time,
 we pass the `--json` flag, which allows capturing JSON that we can better parse and more easily
-inspect. This second part of the integration test not only ensures that our previous `conda create`
-command ran successfully, but also tests to make sure that `conda env list` runs correctly.
+inspect. We then assert whether the environment we just created is actually in the list of all
+environments currently available.
 
 Finally, we destroy the environment we just created and ensure the standard error and the exit
 code are what we expect them to be. It is important to remember removing anything you create
 as this will be present when other tests are run.
 
-### Tests with fixtures
+## Tests with fixtures
 
 Sometimes in integration tests, you may want to re-use the same type of environment more than once.
 Copying and pasting this setup and teardown code into each individual test can make these tests more
@@ -131,7 +110,7 @@ def test_env_list_finds_existing_environment(env_one):
 ```
 
 In the fixture named `env_one`, we first create a new environment exactly the same as we
-did in our previous test. We make an assertion to ensure that it ran correctly, and
+did in our previous test. We make an assertion to ensure that it ran correctly and
 yield to mark the end of the setup. In the teardown section after the yield statement,
 we run the `conda remove` command and also make an assertion to determine in ran correctly.
 
@@ -141,8 +120,4 @@ and environment or other pieces of data between tests, just remember to set the 
 scope appropriately. [Read here][pytest-scope]
 for more information on `pytest` fixture scopes.
 
-
-
-
-[pytest-getting-started]: https://docs.pytest.org/en/stable/getting-started.html
 [pytest-scope]: https://docs.pytest.org/en/stable/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-Integration tests in conda test the application from a high level where each test can
+Integration tests in `conda` test the application from a high level where each test can
 potentially cover large portions of the code. These tests may also use the local
 file system and/or perform network calls. In the following sections, we cover
 several examples of exactly how these tests look. When writing your own integration tests,
@@ -111,7 +111,7 @@ def test_env_list_finds_existing_environment(env_one):
 
 In the fixture named `env_one`, we first create a new environment in exactly the same way as we
 did in our previous test. We make an assertion to ensure that it ran correctly and
-yield to mark the end of the setup. In the teardown section after the yield statement,
+yield to mark the end of the setup. In the teardown section after the `yield` statement,
 we run the `conda remove` command and also make an assertion to determine it ran correctly.
 
 This fixture will be run using the default scope in `pytest`, which is `function`. This means

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -1,7 +1,7 @@
 # Integration Tests
 
 Integration tests in conda test the application from a high level where each test can
-potentially cover large portions of the code.  These tests may also use the local
+potentially cover large portions of the code. These tests may also use the local
 file system and/or perform network calls. In the following sections, we cover
 several examples of exactly how these tests look. When writing your own integration tests,
 these should serve as a good starting point.
@@ -49,7 +49,7 @@ us to run a command using the current running process. This ends up being much m
 running this test as a subprocess.
 
 In the test itself, we first use our `run` function to create a new environment. This function
-returns the standard out, standard error and the exit code of the command. This allows us to
+returns the standard out, standard error, and the exit code of the command. This allows us to
 perform our inspections in order to determine whether the command successfully ran.
 
 The second part of the test again uses the `run` command to call `conda env list`. This time,
@@ -58,17 +58,17 @@ inspect. We then assert whether the environment we just created is actually in t
 environments currently available.
 
 Finally, we destroy the environment we just created and ensure the standard error and the exit
-code are what we expect them to be. It is important to remember removing anything you create
-as this will be present when other tests are run.
+code are what we expect them to be. It is important to remember to remove anything you create,
+as it will be present when other tests are run.
 
 ## Tests with fixtures
 
 Sometimes in integration tests, you may want to re-use the same type of environment more than once.
 Copying and pasting this setup and teardown code into each individual test can make these tests more
-difficult read and harder to maintain.
+difficult to read and harder to maintain.
 
 To overcome this, `conda` tests make extensive use of `pytest` fixtures. Below is an example of the
-previously shown test except that we now make the focus of the test the `conda env list` command and move
+previously-shown test, except that we now make the focus of the test the `conda env list` command and move
 the creation and removal of the environment into a fixture:
 
 ```python
@@ -98,7 +98,7 @@ def env_one():
 
 
 def test_env_list_finds_existing_environment(env_one):
-    # Because we're using fixtures we can immediately run the `conda env list` command
+    # Because we're using fixtures, we can immediately run the `conda env list` command
     # and our test assertions
     out, err, exit_code = run("conda env list --json")
     json_out = json.loads(out)
@@ -109,14 +109,14 @@ def test_env_list_finds_existing_environment(env_one):
     assert exit_code == 0
 ```
 
-In the fixture named `env_one`, we first create a new environment exactly the same as we
+In the fixture named `env_one`, we first create a new environment in exactly the same way as we
 did in our previous test. We make an assertion to ensure that it ran correctly and
 yield to mark the end of the setup. In the teardown section after the yield statement,
-we run the `conda remove` command and also make an assertion to determine in ran correctly.
+we run the `conda remove` command and also make an assertion to determine it ran correctly.
 
-This fixture will be run using the default scope in `pytest` which is `function`. This means
-that the setup and teardown will be run before and after each test. If you needed to share
-and environment or other pieces of data between tests, just remember to set the fixture
+This fixture will be run using the default scope in `pytest`, which is `function`. This means
+that the setup and teardown will be run before and after each test. If you need to share
+an environment or other pieces of data between tests, just remember to set the fixture
 scope appropriately. [Read here][pytest-scope]
 for more information on `pytest` fixture scopes.
 


### PR DESCRIPTION
This pull request implements issue #11593 by adding a new documentation article on how to write tests. I've organized the pull request to have two pages: one is an index page that has a list of guides and general guidelines and the other is a guide on how to write integration tests in conda. The guides section will initially only have a single guide, but it will be able to accommodate more guides in the future.
