### PR TITLE
docs: fix simple typo, enventually -> eventually

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
-# this module contains miscellaneous stuff which enventually could be moved
+# this module contains miscellaneous stuff which eventually could be moved
 # into other places
 
 from __future__ import absolute_import, division, print_function, unicode_literals


### PR DESCRIPTION
There is a small typo in conda/misc.py.

Should read `eventually` rather than `enventually`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md