### PR TITLE
Use updated ruamel.yaml API

### DIFF
--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -257,13 +257,9 @@ class Environment(object):
 
     def to_yaml(self, stream=None):
         d = self.to_dict()
-        out = yaml_safe_dump(d)
+        out = yaml_safe_dump(d, stream)
         if stream is None:
             return out
-        try:
-            stream.write(bytes(out, encoding="utf-8"))
-        except TypeError:
-            stream.write(out)
 
     def save(self):
         with open(self.filename, "wb") as fp:


### PR DESCRIPTION
### Description

With recent versions of ruamel yaml comments are no longer preserved unless one uses the current API instead of the old one.  This is a bit of a quick hack to make use of the new API.

Fixes #11513

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?