### PR TITLE
require requests >=2.20.1, drop monkeypatch

### DIFF
--- a/conda/gateways/connection/__init__.py
+++ b/conda/gateways/connection/__init__.py
@@ -4,18 +4,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from functools import partial
 
-def should_bypass_proxies_patched(should_bypass_proxies_func, url, no_proxy=None):
-    # Monkey patch requests, per https://github.com/requests/requests/pull/4723
-    if url.startswith("file://"):
-        return True
-    try:
-        return should_bypass_proxies_func(url, no_proxy)
-    except TypeError:
-        # For versions of requests we shouldn't have to deal with.
-        # https://github.com/conda/conda/issues/7503
-        # https://github.com/conda/conda/issues/7506
-        return should_bypass_proxies_func(url)
-
 
 try:
     from requests import ConnectionError, HTTPError, Session
@@ -30,11 +18,6 @@ try:
     from requests.utils import get_auth_from_url, get_netrc_auth
     from requests.packages.urllib3.util.retry import Retry
 
-    # monkeypatch requests
-    from requests.utils import should_bypass_proxies
-    import requests.utils
-    requests.utils.should_bypass_proxies = partial(should_bypass_proxies_patched,
-                                                   should_bypass_proxies)
 except ImportError:  # pragma: no cover
     from pip._vendor.requests import ConnectionError, HTTPError, Session
     from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
@@ -48,12 +31,6 @@ except ImportError:  # pragma: no cover
     from pip._vendor.requests.structures import CaseInsensitiveDict
     from pip._vendor.requests.utils import get_auth_from_url, get_netrc_auth
     from pip._vendor.requests.packages.urllib3.util.retry import Retry
-
-    # monkeypatch requests
-    from pip._vendor.requests.utils import should_bypass_proxies
-    import pip._vendor.requests.utils
-    pip._vendor.requests.utils.should_bypass_proxies = partial(should_bypass_proxies_patched,
-                                                               should_bypass_proxies)
 
 
 dispatch_hook = dispatch_hook

--- a/conda/gateways/connection/__init__.py
+++ b/conda/gateways/connection/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
-from functools import partial
 
 
 try:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - menuinst >=1.4.11,<2         # [win]
     - pycosat >=0.6.3
     - pyopenssl >=16.2.0
-    - requests >=2.18.4,<3
+    - requests >=2.20.1,<3
     - ruamel_yaml >=0.11.14,<0.16
     - setuptools >=31.0.1
   run_constrained:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ source.
 """
 install_requires = [
     "pycosat >=0.6.3",
-    "requests >=2.12.4",
+    "requests >=2.20.1",
     "ruamel_yaml_conda >=0.11.14",
     "menuinst ; platform_system=='Windows'",
 ]


### PR DESCRIPTION
Updates requests to the first version after the one that includes the monkeypatch.

https://github.com/psf/requests/blob/main/HISTORY.md#2200-2018-10-18

### Tasks

- [X] open PR for defaults: https://github.com/AnacondaRecipes/conda-feedstock/pull/7
- [X] open PR for conda-forge: https://github.com/conda-forge/conda-feedstock/pull/169