### PR TITLE
Use `**kwargs` instead of `OrderedDict` for `_Activator.get_export_unset_vars`

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -76,21 +76,20 @@ class _Activator(object):
         unset_vars = []
         export_vars = {}
 
-        def split_export_unset(func=None, **kwargs):
-            for name, value in kwargs.items():
-                if value is None:
-                    unset_vars.append(name.upper())
-                elif func and value:
-                    export_vars[name.upper()] = func(value)
-                else:
-                    export_vars[name.upper()] = value
-
         # split provided environment variables into exports vs unsets
-        split_export_unset(**kwargs)
+        for name, value in kwargs.items():
+            if value is None:
+                unset_vars.append(name.upper())
+            else:
+                export_vars[name.upper()] = value
 
         if export_metavars:
             # split meta variables into exports vs unsets
-            split_export_unset(func=self.path_conversion, **context.conda_exe_vars_dict)
+            for name, value in context.conda_exe_vars_dict.items():
+                if value is None:
+                    unset_vars.append(name.upper())
+                else:
+                    export_vars[name.upper()] = self.path_conversion(value) if value else value
         else:
             # unset all meta variables
             unset_vars.extend(context.conda_exe_vars_dict)

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -65,8 +65,7 @@ class _Activator(object):
         self._raw_arguments = arguments
         self.environ = os.environ.copy()
 
-    # Once Python2 dies odargs can become kwargs again since dicts are ordered since 3.6.
-    def get_export_unset_vars(self, odargs):
+    def get_export_unset_vars(self, **kwargs):
         """
         :param kwargs: environment variables to export. The `conda_exe_vars` meta
                        variables are also exported by default. If you do not want
@@ -78,7 +77,6 @@ class _Activator(object):
         :return: A OrderedDict of env vars to export ordered the same way as kwargs.
                  And a list of env vars to unset.
         """
-        kwargs = odargs
         conda_exe_vars_None = False if ('conda_exe_vars' not in kwargs or
                                         kwargs['conda_exe_vars'] is not None) else True
         conda_exe_unset_vars = []
@@ -107,7 +105,7 @@ class _Activator(object):
 
     # Used in tests only.
     def add_export_unset_vars(self, export_vars, unset_vars, **kwargs):
-        new_export_vars, new_unset_vars = self.get_export_unset_vars(odargs=OrderedDict(kwargs))
+        new_export_vars, new_unset_vars = self.get_export_unset_vars(**kwargs)
         if export_vars is not None:
             export_vars = OrderedDict(chain(export_vars.items(), new_export_vars.items()))
         if unset_vars is not None:
@@ -116,7 +114,7 @@ class _Activator(object):
 
     # Used in tests only.
     def get_scripts_export_unset_vars(self, **kwargs):
-        export_vars, unset_vars = self.get_export_unset_vars(odargs=OrderedDict(kwargs))
+        export_vars, unset_vars = self.get_export_unset_vars(**kwargs)
         script_export_vars = script_unset_vars = None
         if export_vars:
             script_export_vars = self.command_join.join(
@@ -336,16 +334,14 @@ class _Activator(object):
 
         unset_vars = []
         if old_conda_shlvl == 0:
-            new_path = self.pathsep_join(self._add_prefix_to_path(prefix))
-            env_vars_to_export = OrderedDict((
-                    ('path', new_path),
-                    ('conda_prefix', prefix),
-                    ('conda_shlvl', new_conda_shlvl),
-                    ('conda_default_env', conda_default_env),
-                    ('conda_prompt_modifier', conda_prompt_modifier)))
-            for k, v in conda_environment_env_vars.items():
-                env_vars_to_export[k] = v
-            export_vars, unset_vars = self.get_export_unset_vars(odargs=env_vars_to_export)
+            export_vars, unset_vars = self.get_export_unset_vars(
+                path=self.pathsep_join(self._add_prefix_to_path(prefix)),
+                conda_prefix=prefix,
+                conda_shlvl=new_conda_shlvl,
+                conda_default_env=conda_default_env,
+                conda_prompt_modifier=conda_prompt_modifier,
+                **conda_environment_env_vars,
+            )
             deactivate_scripts = ()
         else:
             if self.environ.get('CONDA_PREFIX_%s' % (old_conda_shlvl - 1)) == prefix:
@@ -353,32 +349,27 @@ class _Activator(object):
                 #  i.e. step back down
                 return self.build_deactivate()
             if stack:
-                new_path = self.pathsep_join(self._add_prefix_to_path(prefix))
                 deactivate_scripts = ()
-                env_vars_to_export = OrderedDict((
-                    ('path', new_path),
-                    ('conda_prefix', prefix),
-                    ('conda_shlvl', new_conda_shlvl),
-                    ('conda_default_env', conda_default_env),
-                    ('conda_prompt_modifier', conda_prompt_modifier)))
-                for k, v in conda_environment_env_vars.items():
-                    env_vars_to_export[k] = v
-                export_vars, unset_vars = self.get_export_unset_vars(odargs=env_vars_to_export)
+                export_vars, unset_vars = self.get_export_unset_vars(
+                    path=self.pathsep_join(self._add_prefix_to_path(prefix)),
+                    conda_prefix=prefix,
+                    conda_shlvl=new_conda_shlvl,
+                    conda_default_env=conda_default_env,
+                    conda_prompt_modifier=conda_prompt_modifier,
+                    **conda_environment_env_vars,
+                )
                 export_vars['CONDA_PREFIX_%d' % old_conda_shlvl] = old_conda_prefix
                 export_vars['CONDA_STACKED_%d' % new_conda_shlvl] = 'true'
             else:
-                new_path = self.pathsep_join(
-                    self._replace_prefix_in_path(old_conda_prefix, prefix))
                 deactivate_scripts = self._get_deactivate_scripts(old_conda_prefix)
-                env_vars_to_export = OrderedDict((
-                    ('path', new_path),
-                    ('conda_prefix', prefix),
-                    ('conda_shlvl', new_conda_shlvl),
-                    ('conda_default_env', conda_default_env),
-                    ('conda_prompt_modifier', conda_prompt_modifier)))
-                for k, v in conda_environment_env_vars.items():
-                    env_vars_to_export[k] = v
-                export_vars, unset_vars = self.get_export_unset_vars(odargs=env_vars_to_export)
+                export_vars, unset_vars = self.get_export_unset_vars(
+                    path=self.pathsep_join(self._replace_prefix_in_path(old_conda_prefix, prefix)),
+                    conda_prefix=prefix,
+                    conda_shlvl=new_conda_shlvl,
+                    conda_default_env=conda_default_env,
+                    conda_prompt_modifier=conda_prompt_modifier,
+                    **conda_environment_env_vars,
+                )
                 export_vars['CONDA_PREFIX_%d' % old_conda_shlvl] = old_conda_prefix
 
         set_vars = {}
@@ -423,11 +414,12 @@ class _Activator(object):
             # top.  This would be *much* cleaner. I personally cannot abide that I have
             # deactivated conda and anything at all in my env still references it (apart from the
             # shell script, we need something I suppose!)
-            export_vars, unset_vars = self.get_export_unset_vars(odargs=OrderedDict((
-                ('conda_prefix', None),
-                ('conda_shlvl', new_conda_shlvl),
-                ('conda_default_env', None),
-                ('conda_prompt_modifier', None))))
+            export_vars, unset_vars = self.get_export_unset_vars(
+                conda_prefix=None,
+                conda_shlvl=new_conda_shlvl,
+                conda_default_env=None,
+                conda_prompt_modifier=None,
+            )
             conda_prompt_modifier = ''
             activate_scripts = ()
             export_path = {'PATH': new_path, }
@@ -450,14 +442,13 @@ class _Activator(object):
                     self._replace_prefix_in_path(old_conda_prefix, new_prefix)
                 )
 
-            env_vars_to_export = OrderedDict((
-                ('conda_prefix', new_prefix),
-                ('conda_shlvl', new_conda_shlvl),
-                ('conda_default_env', conda_default_env),
-                ('conda_prompt_modifier', conda_prompt_modifier)))
-            for k, v in new_conda_environment_env_vars.items():
-                env_vars_to_export[k] = v
-            export_vars, unset_vars2 = self.get_export_unset_vars(odargs=env_vars_to_export)
+            export_vars, unset_vars2 = self.get_export_unset_vars(
+                conda_prefix=new_prefix,
+                conda_shlvl=new_conda_shlvl,
+                conda_default_env=conda_default_env,
+                conda_prompt_modifier=conda_prompt_modifier,
+                **new_conda_environment_env_vars,
+            )
             unset_vars += unset_vars2
             export_path = {'PATH': new_path, }
             activate_scripts = self._get_activate_scripts(new_prefix)
@@ -1115,7 +1106,7 @@ class JSONFormatMixin(_Activator):
             }
 
     def get_scripts_export_unset_vars(self, **kwargs):
-        export_vars, unset_vars = self.get_export_unset_vars(odargs=OrderedDict(kwargs))
+        export_vars, unset_vars = self.get_export_unset_vars(**kwargs)
         script_export_vars = script_unset_vars = None
         if export_vars:
             script_export_vars = dict(export_vars.items())

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -63,12 +63,10 @@ class _Activator(object):
         self._raw_arguments = arguments
         self.environ = os.environ.copy()
 
-    def get_export_unset_vars(self, *, conda_exe_vars=True, **kwargs):
+    def get_export_unset_vars(self, export_metavars=True, **kwargs):
         """
-        :param kwargs: environment variables to export. The `conda_exe_vars` meta
-                       variables are also exported by default. If you do not want
-                       this to happen then pass:
-                           conda_exe_vars=None
+        :param export_metavars: whether to export `conda_exe_vars` meta variables.
+        :param kwargs: environment variables to export.
                        .. if you pass and set any other variable to None, then it
                        emits it to the dict with a value of None.
 
@@ -90,12 +88,12 @@ class _Activator(object):
         # split provided environment variables into exports vs unsets
         split_export_unset(**kwargs)
 
-        if conda_exe_vars is None:
-            # unset all meta variables
-            unset_vars.extend(context.conda_exe_vars_dict)
-        else:
+        if export_metavars:
             # split meta variables into exports vs unsets
             split_export_unset(func=self.path_conversion, **context.conda_exe_vars_dict)
+        else:
+            # unset all meta variables
+            unset_vars.extend(context.conda_exe_vars_dict)
 
         return export_vars, unset_vars
 
@@ -403,7 +401,7 @@ class _Activator(object):
         set_vars = {}
         if old_conda_shlvl == 1:
             new_path = self.pathsep_join(self._remove_prefix_from_path(old_conda_prefix))
-            # You might think that you can remove the CONDA_EXE vars by passing conda_exe_vars=None
+            # You might think that you can remove the CONDA_EXE vars with export_metavars=False
             # here so that "deactivate means deactivate" but you cannot since the conda shell
             # scripts still refer to them and they only set them once at the top. We could change
             # that though, the conda() shell function could set them instead of doing it at the

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -78,13 +78,12 @@ class _Activator(object):
         unset_vars = []
         export_vars = {}
 
-        def split_export_unset(**kwargs):
+        def split_export_unset(func=None, **kwargs):
             for name, value in kwargs.items():
                 if value is None:
                     unset_vars.append(name.upper())
-                elif value and isinstance(value, str):
-                    # ensure paths use the correct delimiter
-                    export_vars[name.upper()] = self.path_conversion(value)
+                elif func and value:
+                    export_vars[name.upper()] = func(value)
                 else:
                     export_vars[name.upper()] = value
 
@@ -96,7 +95,7 @@ class _Activator(object):
             unset_vars.extend(context.conda_exe_vars_dict)
         else:
             # split meta variables into exports vs unsets
-            split_export_unset(**context.conda_exe_vars_dict)
+            split_export_unset(func=self.path_conversion, **context.conda_exe_vars_dict)
 
         return export_vars, unset_vars
 

--- a/news/11649-refactor-get_export_unset_vars
+++ b/news/11649-refactor-get_export_unset_vars
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Refactor `conda.activate._Activator.get_export_unset_vars` to use `**kwargs` instead of `OrderedDict`. (#11649)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -930,32 +930,28 @@ class ActivatorUnitTests(TestCase):
                     original_path = tuple(activator._get_starting_path_list())
                     builder = activator.build_deactivate()
 
-                    unset_vars = [
-                        'CONDA_PREFIX',
-                        'CONDA_DEFAULT_ENV',
-                        'CONDA_PROMPT_MODIFIER',
-                        'PKG_A_ENV',
-                        'PKG_B_ENV',
-                        'ENV_ONE',
-                        'ENV_TWO',
-                        'ENV_THREE'
-                    ]
-
                     new_path = activator.pathsep_join(activator.path_conversion(original_path))
-                    assert builder['set_vars'] == {
-                        'PS1': os.environ.get('PS1', ''),
-                    }
-                    export_vars = OrderedDict((
-                        ('CONDA_SHLVL', 0),
-                    ))
-                    export_path = {'PATH': new_path,}
-                    export_vars, unset_vars = activator.add_export_unset_vars(export_vars, unset_vars,
-                                                                              conda_exe_vars=True)
-                    assert builder['export_vars'] == export_vars
-                    assert builder['unset_vars'] == unset_vars
-                    assert builder['export_path'] == export_path
-                    assert builder['activate_scripts'] == ()
-                    assert builder['deactivate_scripts'] == (activator.path_conversion(deactivate_d_1),)
+                    export_vars, unset_vars = activator.add_export_unset_vars(
+                        {"CONDA_SHLVL": 0},
+                        [
+                            "CONDA_PREFIX",
+                            "CONDA_DEFAULT_ENV",
+                            "CONDA_PROMPT_MODIFIER",
+                            "PKG_A_ENV",
+                            "PKG_B_ENV",
+                            "ENV_ONE",
+                            "ENV_TWO",
+                            "ENV_THREE",
+                        ],
+                    )
+                    assert builder["set_vars"] == {"PS1": os.environ.get("PS1", "")}
+                    assert builder["export_vars"] == export_vars
+                    assert builder["unset_vars"] == unset_vars
+                    assert builder["export_path"] == {"PATH": new_path}
+                    assert builder["activate_scripts"] == ()
+                    assert builder["deactivate_scripts"] == (
+                        activator.path_conversion(deactivate_d_1),
+                    )
 
     def test_get_env_vars_big_whitespace(self):
         with tempdir() as td:
@@ -1216,7 +1212,7 @@ class ShellWrapperUnitTests(TestCase):
             deactivate_data = c.stdout
 
             new_path = activator.pathsep_join(activator._remove_prefix_from_path(self.prefix))
-            conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars(conda_exe_vars=True)
+            conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
 
             e_deactivate_data = dals("""
             export PATH='%(new_path)s'
@@ -1397,9 +1393,8 @@ class ShellWrapperUnitTests(TestCase):
             deactivate_data = c.stdout
 
             new_path = activator.pathsep_join(activator._remove_prefix_from_path(self.prefix))
-            conda_exe_vars = ';\n'.join([activator.export_var_tmpl % (k, v) for k, v in context.conda_exe_vars_dict.items()])
 
-            conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars(conda_exe_vars=True)
+            conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
 
             e_deactivate_data = dals("""
             setenv PATH "%(new_path)s";


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Since conda has [dropped Python 3.6 support](https://github.com/conda/conda/releases/tag/4.13.0), we can finally switch to using `**kwargs` instead of using `OrderedDict`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
