### PR TITLE
add usedforsecurity=False for hashlib.md5 for FIPS compliance

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -905,8 +905,11 @@ def cache_fn_url(url, repodata_fn=REPODATA_FN):
     #    are looking for the cache under keys without this.
     if repodata_fn != REPODATA_FN:
         url += repodata_fn
-    md5 = hashlib.md5(ensure_binary(url)).hexdigest()
-    return '%s.json' % (md5[:8],)
+    try:
+        md5 = hashlib.md5(ensure_binary(url))
+    except ValueError:
+        md5 = hashlib.md5(ensure_binary(url), usedforsecurity=False)
+    return '%s.json' % (md5.hexdigest()[:8],)
 
 
 def add_http_value_to_dict(resp, http_key, d, dict_key):

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -905,6 +905,9 @@ def cache_fn_url(url, repodata_fn=REPODATA_FN):
     #    are looking for the cache under keys without this.
     if repodata_fn != REPODATA_FN:
         url += repodata_fn
+
+    # TODO: remove try-except when conda only supports Python 3.9+, as
+    # `usedforsecurity=False` was added in 3.9.
     try:
         md5 = hashlib.md5(ensure_binary(url))
     except ValueError:

--- a/news/11658-add-fips-md5-support
+++ b/news/11658-add-fips-md5-support
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix MD5 hash generation for FIPS-enabled systems (#11658)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This pull request is a fix for a problem highlighted in #7335.

Conda fails to install packages on FIPS-enabled systems because use of the MD5 algorithm is disallowed for security purposes. Since conda is not using it for such a purpose, this pull request makes use of the `usedforsecurity=False` flag in `hashlib.md5` (available since Python 3.9 in CPython, and earlier on RHEL/CentOS systems).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
