### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/docs/source/dev-guide/development-environment.md
+++ b/docs/source/dev-guide/development-environment.md
@@ -175,6 +175,17 @@ normally). But once you open a PR to contribue your changes, pre-commit will
 be automatically run at which point any errors that occur will need to be
 addressed prior to proceeding.
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Conda with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
+
 ## Testing
 
 We use pytest to run our test suite. Please consult pytest's


### PR DESCRIPTION
### Description

[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Conda. It looks like this:

<img width="381" alt="image" src="https://user-images.githubusercontent.com/4949076/181377025-f73761ae-806c-44cd-879e-9bd8212b3929.png">

We think this will help users become more efficient with Conda CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!

### Checklist - did you ...
- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
