### PR TITLE
Resolve prefix injection

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -336,11 +336,6 @@ class _Activator(object):
                 **env_vars,
             )
             deactivate_scripts = ()
-        # KO: I don't think this is true...
-        # elif self.environ.get('CONDA_PREFIX_%s' % (old_conda_shlvl - 1)) == prefix:
-        #     # in this case, user is attempting to activate the previous environment,
-        #     #  i.e. step back down
-        #     return self.build_deactivate()
         elif stack:
             export_vars, unset_vars = self.get_export_unset_vars(
                 path=self.pathsep_join(self._add_prefix_to_path(prefix)),

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -289,6 +289,7 @@ class _Activator(object):
         return self._build_activate_stack(env_name_or_prefix, True)
 
     def _build_activate_stack(self, env_name_or_prefix, stack):
+        # get environment prefix
         if re.search(r'\\|/', env_name_or_prefix):
             prefix = expand(env_name_or_prefix)
             if not isdir(join(prefix, 'conda-meta')):
@@ -299,78 +300,78 @@ class _Activator(object):
         else:
             prefix = locate_prefix_by_name(env_name_or_prefix)
 
-        # query environment
+        # get prior shlvl and prefix
         old_conda_shlvl = int(self.environ.get('CONDA_SHLVL', '').strip() or 0)
-        new_conda_shlvl = old_conda_shlvl + 1
         old_conda_prefix = self.environ.get('CONDA_PREFIX')
 
+        # if the prior active prefix is this prefix we are actually doing a reactivate
         if old_conda_prefix == prefix and old_conda_shlvl > 0:
             return self.build_reactivate()
 
         activate_scripts = self._get_activate_scripts(prefix)
+        conda_shlvl = old_conda_shlvl + 1
         conda_default_env = self._default_env(prefix)
         conda_prompt_modifier = self._prompt_modifier(prefix, conda_default_env)
-        conda_environment_env_vars = self._get_environment_env_vars(prefix)
-        unset_env_vars = [k for k, v in conda_environment_env_vars.items()
-                          if v == CONDA_ENV_VARS_UNSET_VAR]
-        [conda_environment_env_vars.pop(_) for _ in unset_env_vars]
+        env_vars = {
+            name: value
+            for name, value in self._get_environment_env_vars(prefix).items()
+            if value != CONDA_ENV_VARS_UNSET_VAR
+        }
 
-        clobbering_env_vars = [k for k in conda_environment_env_vars.keys()
-                               if k in os.environ.keys()]
-
-        for cvar in clobbering_env_vars:
-            save_var = "__CONDA_SHLVL_%s_%s" % (old_conda_shlvl, cvar)
-            conda_environment_env_vars[save_var] = os.environ.get(cvar)
-
-        if clobbering_env_vars:
+        # get clobbered environment variables
+        clobber_vars = set(env_vars.keys()).intersection(os.environ.keys())
+        if clobber_vars:
             print("WARNING: overwriting environment variables set in the machine", file=sys.stderr)
-            print("overwriting variable %s" % ' '.join(clobbering_env_vars), file=sys.stderr)
+            print(f"overwriting variable {clobber_vars}", file=sys.stderr)
+        for name in clobber_vars:
+            env_vars[f"__CONDA_SHLVL_{old_conda_shlvl}_{name}"] = os.environ.get(name)
 
-        unset_vars = []
         if old_conda_shlvl == 0:
             export_vars, unset_vars = self.get_export_unset_vars(
                 path=self.pathsep_join(self._add_prefix_to_path(prefix)),
                 conda_prefix=prefix,
-                conda_shlvl=new_conda_shlvl,
+                conda_shlvl=conda_shlvl,
                 conda_default_env=conda_default_env,
                 conda_prompt_modifier=conda_prompt_modifier,
-                **conda_environment_env_vars,
+                **env_vars,
+            )
+            deactivate_scripts = ()
+        # KO: I don't think this is true...
+        # elif self.environ.get('CONDA_PREFIX_%s' % (old_conda_shlvl - 1)) == prefix:
+        #     # in this case, user is attempting to activate the previous environment,
+        #     #  i.e. step back down
+        #     return self.build_deactivate()
+        elif stack:
+            export_vars, unset_vars = self.get_export_unset_vars(
+                path=self.pathsep_join(self._add_prefix_to_path(prefix)),
+                conda_prefix=prefix,
+                conda_shlvl=conda_shlvl,
+                conda_default_env=conda_default_env,
+                conda_prompt_modifier=conda_prompt_modifier,
+                **env_vars,
+                **{
+                    f"CONDA_PREFIX_{old_conda_shlvl}": old_conda_prefix,
+                    f"CONDA_STACKED_{conda_shlvl}": "true",
+                },
             )
             deactivate_scripts = ()
         else:
-            if self.environ.get('CONDA_PREFIX_%s' % (old_conda_shlvl - 1)) == prefix:
-                # in this case, user is attempting to activate the previous environment,
-                #  i.e. step back down
-                return self.build_deactivate()
-            if stack:
-                deactivate_scripts = ()
-                export_vars, unset_vars = self.get_export_unset_vars(
-                    path=self.pathsep_join(self._add_prefix_to_path(prefix)),
-                    conda_prefix=prefix,
-                    conda_shlvl=new_conda_shlvl,
-                    conda_default_env=conda_default_env,
-                    conda_prompt_modifier=conda_prompt_modifier,
-                    **conda_environment_env_vars,
-                )
-                export_vars['CONDA_PREFIX_%d' % old_conda_shlvl] = old_conda_prefix
-                export_vars['CONDA_STACKED_%d' % new_conda_shlvl] = 'true'
-            else:
-                deactivate_scripts = self._get_deactivate_scripts(old_conda_prefix)
-                export_vars, unset_vars = self.get_export_unset_vars(
-                    path=self.pathsep_join(self._replace_prefix_in_path(old_conda_prefix, prefix)),
-                    conda_prefix=prefix,
-                    conda_shlvl=new_conda_shlvl,
-                    conda_default_env=conda_default_env,
-                    conda_prompt_modifier=conda_prompt_modifier,
-                    **conda_environment_env_vars,
-                )
-                export_vars['CONDA_PREFIX_%d' % old_conda_shlvl] = old_conda_prefix
+            export_vars, unset_vars = self.get_export_unset_vars(
+                path=self.pathsep_join(self._replace_prefix_in_path(old_conda_prefix, prefix)),
+                conda_prefix=prefix,
+                conda_shlvl=conda_shlvl,
+                conda_default_env=conda_default_env,
+                conda_prompt_modifier=conda_prompt_modifier,
+                **env_vars,
+                **{
+                    f"CONDA_PREFIX_{old_conda_shlvl}": old_conda_prefix,
+                },
+            )
+            deactivate_scripts = self._get_deactivate_scripts(old_conda_prefix)
 
         set_vars = {}
         if context.changeps1:
             self._update_prompt(set_vars, conda_prompt_modifier)
-
-        self._build_activate_shell_custom(export_vars)
 
         return {
             'unset_vars': unset_vars,
@@ -522,21 +523,6 @@ class _Activator(object):
                                 clean_paths[sys.platform] if sys.platform in clean_paths else
                                 '/usr/bin')
         path_split = path.split(os.pathsep)
-        # We used to prepend sys.prefix\Library\bin to PATH on startup but not anymore.
-        # Instead, in conda 4.6 we add the full suite of entries. This is performed in
-        # condabin\conda.bat and condabin\ _conda_activate.bat. However, we
-        # need to ignore the stuff we add there, and only consider actual PATH entries.
-        prefix_dirs = tuple(self._get_path_dirs(sys.prefix))
-        start_index = 0
-        while (start_index < len(prefix_dirs) and
-               start_index < len(path_split) and
-               paths_equal(path_split[start_index], prefix_dirs[start_index])):
-            start_index += 1
-        path_split = path_split[start_index:]
-        library_bin_dir = self.path_conversion(
-                self.sep.join((sys.prefix, 'Library', 'bin')))
-        if paths_equal(path_split[0], library_bin_dir):
-            path_split = path_split[1:]
         return path_split
 
     def _get_path_dirs(self, prefix, extra_library_bin=False):
@@ -616,11 +602,6 @@ class _Activator(object):
             path_list[first_idx:first_idx] = list(self._get_path_dirs(new_prefix))
 
         return tuple(path_list)
-
-    def _build_activate_shell_custom(self, export_vars):
-        # A method that can be overridden by shell-specific implementations.
-        # The signature of this method may change in the future.
-        pass
 
     def _update_prompt(self, set_vars, conda_prompt_modifier):
         pass

--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -95,13 +95,13 @@ function Enter-CondaEnvironment {
     );
 
     begin {
-        $OldPath = Add-Sys-Prefix-To-Path;
+        # $OldPath = Add-Sys-Prefix-To-Path;
         If ($Stack) {
             $activateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate --stack $Name | Out-String);
         } Else {
             $activateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate $Name | Out-String);
         }
-        $Env:PATH = $OldPath;
+        # $Env:PATH = $OldPath;
 
         Write-Verbose "[conda shell.powershell activate $Name]`n$activateCommand";
         Invoke-Expression -Command $activateCommand;
@@ -128,9 +128,9 @@ function Exit-CondaEnvironment {
     param();
 
     begin {
-        $OldPath = Add-Sys-Prefix-To-Path;
+        # $OldPath = Add-Sys-Prefix-To-Path;
         $deactivateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell deactivate | Out-String);
-        $Env:PATH = $OldPath;
+        # $Env:PATH = $OldPath;
 
         # If deactivate returns an empty string, we have nothing more to do,
         # so return early.
@@ -183,9 +183,9 @@ function Invoke-Conda() {
                 # There may be a command we don't know want to handle
                 # differently in the shell wrapper, pass it through
                 # verbatim.
-                $OldPath = Add-Sys-Prefix-To-Path;
+                # $OldPath = Add-Sys-Prefix-To-Path;
                 & $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA $Command @OtherArgs;
-                $Env:PATH = $OldPath;
+                # $Env:PATH = $OldPath;
             }
         }
     }

--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -45,35 +45,6 @@ function Get-CondaEnvironment {
 
 <#
     .SYNOPSIS
-        Adds the entries of sys.prefix to PATH and returns the old PATH.
-
-    .EXAMPLE
-        $OldPath = Add-Sys-Prefix-To-Path
-#>
-function Add-Sys-Prefix-To-Path() {
-    $OldPath = $Env:PATH;
-    if ($Env:_CE_CONDA -eq '' -And $Env:OS -eq 'Windows_NT') {
-        # Windows has a different layout for the python exe than other platforms.
-        $sysp = Split-Path $Env:CONDA_EXE -Parent;
-    } else {
-        $sysp = Split-Path $Env:CONDA_EXE -Parent;
-        $sysp = Split-Path $sysp -Parent;
-    }
-    if ($Env:OS -eq 'Windows_NT') {
-        $Env:PATH = $sysp + ';' +
-                    $sysp + '\Library\mingw-w64\bin;' +
-                    $sysp + '\Library\usr\bin;' +
-                    $sysp + '\Library\bin;' +
-                    $sysp + '\Scripts;' +
-                    $sysp + '\bin;' + $Env:PATH;
-    } else {
-        $Env:PATH = $sysp + '/bin:' + $Env:PATH;
-    }
-    return $OldPath;
-}
-
-<#
-    .SYNOPSIS
         Activates a conda environment, placing its commands and packages at
         the head of $Env:PATH.
 
@@ -95,13 +66,11 @@ function Enter-CondaEnvironment {
     );
 
     begin {
-        # $OldPath = Add-Sys-Prefix-To-Path;
         If ($Stack) {
             $activateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate --stack $Name | Out-String);
         } Else {
             $activateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate $Name | Out-String);
         }
-        # $Env:PATH = $OldPath;
 
         Write-Verbose "[conda shell.powershell activate $Name]`n$activateCommand";
         Invoke-Expression -Command $activateCommand;
@@ -128,9 +97,7 @@ function Exit-CondaEnvironment {
     param();
 
     begin {
-        # $OldPath = Add-Sys-Prefix-To-Path;
         $deactivateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell deactivate | Out-String);
-        # $Env:PATH = $OldPath;
 
         # If deactivate returns an empty string, we have nothing more to do,
         # so return early.
@@ -183,9 +150,7 @@ function Invoke-Conda() {
                 # There may be a command we don't know want to handle
                 # differently in the shell wrapper, pass it through
                 # verbatim.
-                # $OldPath = Add-Sys-Prefix-To-Path;
                 & $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA $Command @OtherArgs;
-                # $Env:PATH = $OldPath;
             }
         }
     }

--- a/conda/shell/condabin/_conda_activate.bat
+++ b/conda/shell/condabin/_conda_activate.bat
@@ -10,17 +10,7 @@
 :FIXUP43
 
 @SETLOCAL EnableDelayedExpansion
-@IF DEFINED _CE_CONDA (
-  @REM when _CE_CONDA is defined, we're in develop mode.  CONDA_EXE is actually python.exe in the root of the dev env.
-  FOR %%A IN ("%CONDA_EXE%") DO @SET _sysp=%%~dpA
-) ELSE (
-  @REM This is the standard user case.  This script is run in root\condabin.
-  FOR %%A IN ("%~dp0.") DO @SET _sysp=%%~dpA
-  IF NOT EXIST "!_sysp!\Scripts\conda.exe" @SET "_sysp=!_sysp!..\"
-)
 @FOR %%A in ("%TMP%") do @SET TMP=%%~sA
-@SET _sysp=!_sysp:~0,-1!
-@REM @SET PATH=!_sysp!;!_sysp!\Library\mingw-w64\bin;!_sysp!\Library\usr\bin;!_sysp!\Library\bin;!_sysp!\Scripts;!_sysp!\bin;%PATH%
 @REM It seems that it is not possible to have "CONDA_EXE=Something With Spaces"
 @REM and %* to contain: activate "Something With Spaces does not exist".
 @REM MSDOS associates the outer "'s and is unable to run very much at all.

--- a/conda/shell/condabin/_conda_activate.bat
+++ b/conda/shell/condabin/_conda_activate.bat
@@ -20,7 +20,7 @@
 )
 @FOR %%A in ("%TMP%") do @SET TMP=%%~sA
 @SET _sysp=!_sysp:~0,-1!
-@SET PATH=!_sysp!;!_sysp!\Library\mingw-w64\bin;!_sysp!\Library\usr\bin;!_sysp!\Library\bin;!_sysp!\Scripts;!_sysp!\bin;%PATH%
+@REM @SET PATH=!_sysp!;!_sysp!\Library\mingw-w64\bin;!_sysp!\Library\usr\bin;!_sysp!\Library\bin;!_sysp!\Scripts;!_sysp!\bin;%PATH%
 @REM It seems that it is not possible to have "CONDA_EXE=Something With Spaces"
 @REM and %* to contain: activate "Something With Spaces does not exist".
 @REM MSDOS associates the outer "'s and is unable to run very much at all.

--- a/conda/shell/condabin/conda.bat
+++ b/conda/shell/condabin/conda.bat
@@ -21,8 +21,9 @@
   FOR %%A IN ("%~dp0.") DO @SET _sysp=%%~dpA
   IF NOT EXIST "!_sysp!\Scripts\conda.exe" @SET "_sysp=!_sysp!..\"
 )
+@REM drop trailing slash
 @SET _sysp=!_sysp:~0,-1!
-@SET PATH=!_sysp!;!_sysp!\Library\mingw-w64\bin;!_sysp!\Library\usr\bin;!_sysp!\Library\bin;!_sysp!\Scripts;!_sysp!\bin;%PATH%
+@REM @SET PATH=!_sysp!;!_sysp!\Library\mingw-w64\bin;!_sysp!\Library\usr\bin;!_sysp!\Library\bin;!_sysp!\Scripts;!_sysp!\bin;%PATH%
 @SET CONDA_EXES="%CONDA_EXE%" %_CE_M% %_CE_CONDA%
 @CALL %CONDA_EXES% %*
 @ENDLOCAL

--- a/conda/shell/condabin/conda.bat
+++ b/conda/shell/condabin/conda.bat
@@ -12,21 +12,8 @@
 @IF [%1]==[activate]   "%~dp0_conda_activate" %*
 @IF [%1]==[deactivate] "%~dp0_conda_activate" %*
 
-@SETLOCAL EnableDelayedExpansion
-@IF DEFINED _CE_CONDA (
-  @REM when _CE_CONDA is defined, we're in develop mode.  CONDA_EXE is actually python.exe in the root of the dev env.
-  FOR %%A IN ("%CONDA_EXE%") DO @SET _sysp=%%~dpA
-) ELSE (
-  @REM This is the standard user case.  This script is run in root\condabin.
-  FOR %%A IN ("%~dp0.") DO @SET _sysp=%%~dpA
-  IF NOT EXIST "!_sysp!\Scripts\conda.exe" @SET "_sysp=!_sysp!..\"
-)
-@REM drop trailing slash
-@SET _sysp=!_sysp:~0,-1!
-@REM @SET PATH=!_sysp!;!_sysp!\Library\mingw-w64\bin;!_sysp!\Library\usr\bin;!_sysp!\Library\bin;!_sysp!\Scripts;!_sysp!\bin;%PATH%
 @SET CONDA_EXES="%CONDA_EXE%" %_CE_M% %_CE_CONDA%
 @CALL %CONDA_EXES% %*
-@ENDLOCAL
 
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 

--- a/conda/shell/etc/profile.d/conda.csh
+++ b/conda/shell/etc/profile.d/conda.csh
@@ -1,5 +1,5 @@
-echo "Copyright (C) 2012 Anaconda, Inc" > /dev/null
-echo "SPDX-License-Identifier: BSD-3-Clause" > /dev/null
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
 
 if (! $?_CONDA_EXE) then
   set _CONDA_EXE="${PWD}/conda/shell/bin/conda"
@@ -26,13 +26,13 @@ if ("`alias conda`" == "") then
         set prompt=""
     endif
 else
-    set conda_tmp_path="$PATH"
-    setenv PATH "`dirname ${_CONDA_EXE}`:$PATH"
+    # set conda_tmp_path="$PATH"
+    # setenv PATH "`dirname ${_CONDA_EXE}`:$PATH"
     switch ( "${1}" )
         case "activate":
             set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh activate '${2}' ${argv[3-]})`"
             set conda_tmp_status=$status
-            setenv PATH "$conda_tmp_path"
+            # setenv PATH "$conda_tmp_path"
             if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
@@ -40,7 +40,7 @@ else
         case "deactivate":
             set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh deactivate '${2}' ${argv[3-]})`"
             set conda_tmp_status=$status
-            setenv PATH "$conda_tmp_path"
+            # setenv PATH "$conda_tmp_path"
             if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
@@ -49,14 +49,14 @@ else
             $_CONDA_EXE $argv[1-]
             set ask_conda="`(setenv prompt '${prompt}' ; '${_CONDA_EXE}' shell.csh reactivate)`"
             set conda_tmp_status=$status
-            setenv PATH "$conda_tmp_path"
+            # setenv PATH "$conda_tmp_path"
             if( $conda_tmp_status != 0 ) exit ${conda_tmp_status}
             eval "${ask_conda}"
             rehash
             breaksw
         default:
             $_CONDA_EXE $argv[1-]
-            setenv PATH "$conda_tmp_path"
+            # setenv PATH "$conda_tmp_path"
             breaksw
     endsw
 endif

--- a/conda/shell/etc/profile.d/conda.sh
+++ b/conda/shell/etc/profile.d/conda.sh
@@ -1,31 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
-__add_sys_prefix_to_path() {
-    # In dev-mode CONDA_EXE is python.exe and on Windows
-    # it is in a different relative location to condabin.
-    if [ -n "${_CE_CONDA}" ] && [ -n "${WINDIR+x}" ]; then
-        SYSP=$(\dirname "${CONDA_EXE}")
-    else
-        SYSP=$(\dirname "${CONDA_EXE}")
-        SYSP=$(\dirname "${SYSP}")
-    fi
-
-    if [ -n "${WINDIR+x}" ]; then
-        PATH="${SYSP}/bin:${PATH}"
-        PATH="${SYSP}/Scripts:${PATH}"
-        PATH="${SYSP}/Library/bin:${PATH}"
-        PATH="${SYSP}/Library/usr/bin:${PATH}"
-        PATH="${SYSP}/Library/mingw-w64/bin:${PATH}"
-        PATH="${SYSP}:${PATH}"
-    else
-        PATH="${SYSP}/bin:${PATH}"
-    fi
-    \export PATH
-}
-
 __conda_exe() (
-    __add_sys_prefix_to_path
     "$CONDA_EXE" $_CE_M $_CE_CONDA "$@"
 )
 

--- a/dev/windows/setup.bat
+++ b/dev/windows/setup.bat
@@ -18,6 +18,7 @@ CALL \conda_bin\scripts\activate.bat || goto :error
 CALL conda create -n conda-test-env -y python=%PYTHON% pywin32 --file=tests\requirements.txt || goto :error
 CALL conda activate conda-test-env || goto :error
 CALL conda update openssl ca-certificates certifi || goto :error
+python -m conda init --install || goto :error
 python -m conda init cmd.exe --dev || goto :error
 
 :: Download minio server needed for S3 tests and place it in our conda environment so is in PATH

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2680,7 +2680,7 @@ def _run_command(*lines):
     else:
         script = "\n".join(
             (
-                f"source {Path(context.root_prefix, 'etc', 'profile.d', 'conda.sh')}",
+                f". {Path(context.root_prefix, 'etc', 'profile.d', 'conda.sh')}",
                 *lines,
             )
         )

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2691,6 +2691,7 @@ def create_stackable_envs():
 
     sys = _run_command(
         *("conda deactivate" for _ in range(5)),
+        "conda config --set auto_activate_base false",
         which,
     )
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2723,21 +2723,37 @@ def _run_command(*lines):
 @pytest.mark.parametrize(
     ("auto_stack", "stack", "run", "expected"),
     [
+        # no environments activated
         (0, "", "base", "base,sys"),
         (0, "", "has", "has,sys"),
         (0, "", "not", "sys"),
+        # one environment activated, no stacking
         (0, "base", "base", "base,sys"),
         (0, "base", "has", "has,sys"),
         (0, "base", "not", "sys"),
         (0, "has", "base", "base,sys"),
         (0, "has", "has", "has,sys"),
         (0, "has", "not", "sys"),
+        (0, "not", "base", "base,sys"),
+        (0, "not", "has", "has,sys"),
+        (0, "not", "not", "sys"),
+        # one environment activated, stacking allowed
         (5, "base", "base", "base,sys"),
         (5, "base", "has", "has,base,sys"),
         (5, "base", "not", "base,sys"),
+        (5, "has", "base", "base,has,sys"),
+        (5, "has", "has", "has,sys"),
+        (5, "has", "not", "has,sys"),
+        (5, "not", "base", "base,sys"),
+        (5, "not", "has", "has,sys"),
+        (5, "not", "not", "sys"),
+        # two environments activated, stacking allowed
         (5, "base,has", "base", "base,has,sys" if on_win else "base,has,base,sys"),
         (5, "base,has", "has", "has,base,sys"),
         (5, "base,has", "not", "has,base,sys"),
+        (5, "base,not", "base", "base,sys" if on_win else "base,base,sys"),
+        (5, "base,not", "has", "has,base,sys"),
+        (5, "base,not", "not", "base,sys"),
     ],
 )
 def test_stacking(create_stackable_envs, auto_stack, stack, run, expected):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Depends on #11649
Resolves #11174

When running `conda run`, users discovered that the wrong executable is invoked. This was especially noticeable on Windows. We first attempted to address this issue in #11257 but found that the source of the prefix injection occurred at the shell integration level so trying to do the path deduplication in the Python code would've been ripe for buggy behavior. 

<details> 
<summary>We narrowed it down to being the prefix injection that occurred in the following locations:</summary>

https://github.com/conda/conda/blob/8c835dd3b54b15ed68ef1a58ba8862a0e1ddcbae/conda/shell/etc/profile.d/conda.sh#L4-L30 

https://github.com/conda/conda/blob/8c835dd3b54b15ed68ef1a58ba8862a0e1ddcbae/conda/shell/etc/profile.d/conda.csh#L29-L30

https://github.com/conda/conda/blob/8c835dd3b54b15ed68ef1a58ba8862a0e1ddcbae/conda/shell/condabin/conda.bat#L25 

https://github.com/conda/conda/blob/8c835dd3b54b15ed68ef1a58ba8862a0e1ddcbae/conda/shell/condabin/_conda_activate.bat#L23 

https://github.com/conda/conda/blob/8c835dd3b54b15ed68ef1a58ba8862a0e1ddcbae/conda/shell/condabin/Conda.psm1#L46-L73

</details> 

After digging through `conda.activate` and the git history, it appears that the prefix injection code was first introduced in `conda 4.4` (April 2017), @kalefranz sums it up well in comments that have unfortunately not withstood the test of time:

https://github.com/conda/conda/blob/c6e8d6a0d1d654fae310d4a560396261e94bafa7/conda/activate.py#L219-L225

Subsequent changes indicate that this injection on Python startup was actually a Python 3.6 feedstock patch which appears to have been long since removed (https://github.com/AnacondaRecipes/python-feedstock/commit/ef17e171b307f436e7e383aa4698c7fbeefae1f8).

In `conda 4.6.9` (March 2019) the Python package patching was instead replaced (https://github.com/conda/conda/commit/ca77c9c715b49155eee4a763eaaeb3ff22f3c1a6) with the shell interface prefix injection that we see today.

Originally all of this prefix injection was unique to Windows but eventually in `conda 4.6.13` (April 2019) it was mirrored over to *nix systems (https://github.com/conda/conda/commit/8ec72dd83e97945b07a7425b3ce8e9ce661c713c) which is where we find ourselves now, still wondering WTF.
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
