### PR TITLE
Detect CUDA driver version in subprocess

### DIFF
--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import ctypes
 import functools
+import multiprocessing as mp
+import os
 import platform
 from contextlib import suppress
 
@@ -23,55 +25,33 @@ def cuda_version():
 
     Returns: version string (e.g., '9.2') or None if CUDA is not found.
     """
-    # platform-specific libcuda location
-    system = platform.system()
-    if system == "Darwin":
-        lib_filenames = [
-            "libcuda.dylib",  # check library path first
-            "/usr/local/cuda/lib/libcuda.dylib",
-        ]
-    elif system == "Linux":
-        lib_filenames = [
-            "libcuda.so",  # check library path first
-            "/usr/lib64/nvidia/libcuda.so",  # RHEL/Centos/Fedora
-            "/usr/lib/x86_64-linux-gnu/libcuda.so",  # Ubuntu
-        ]
-    elif system == "Windows":
-        lib_filenames = ["nvcuda.dll"]
-    else:
-        return None  # CUDA not available for other operating systems
-
-    # open library
-    if system == "Windows":
-        dll = ctypes.windll
-    else:
-        dll = ctypes.cdll
-    for lib_filename in lib_filenames:
-        with suppress(Exception):
-            libcuda = dll.LoadLibrary(lib_filename)
-            break
-    else:
-        return None
-
-    # Get CUDA version
+    # Do not inherit file descriptors and handles from the parent process.
+    # The `fork` start method should be considered unsafe as it can lead to
+    # crashes of the subprocess. The `spawn` start method is preferred.
+    ctx = mp.get_context("spawn")
+    queue = ctx.SimpleQueue()
     try:
-        cuInit = libcuda.cuInit
-        flags = ctypes.c_uint(0)
-        ret = cuInit(flags)
-        if ret != 0:
-            return None
+        # Spawn a subprocess to detect the CUDA version
+        detector = ctx.Process(
+            target=_cuda_driver_version_detector_target,
+            args=(queue,),
+            name="CUDA driver version detector",
+            daemon=True,
+        )
+        detector.start()
+        detector.join(timeout=60.0)
+    finally:
+        # Always cleanup the subprocess
+        try:
+            detector.kill()  # requires Python 3.7+
+        except AttributeError:
+            pass
 
-        cuDriverGetVersion = libcuda.cuDriverGetVersion
-        version_int = ctypes.c_int(0)
-        ret = cuDriverGetVersion(ctypes.byref(version_int))
-        if ret != 0:
-            return None
-
-        # Convert version integer to version string
-        value = version_int.value
-        return "%d.%d" % (value // 1000, (value % 1000) // 10)
-    except Exception:
+    if queue.empty():
         return None
+
+    result = queue.get()
+    return result
 
 
 @functools.lru_cache(maxsize=None)
@@ -87,3 +67,81 @@ def conda_virtual_packages():
     cuda_version = cached_cuda_version()
     if cuda_version is not None:
         yield CondaVirtualPackage("cuda", cuda_version, None)
+
+
+def _cuda_driver_version_detector_target(queue):
+    """
+    Attempt to detect the version of CUDA present in the operating system in a
+    subprocess.
+
+    On Windows and Linux, the CUDA library is installed by the NVIDIA
+    driver package, and is typically found in the standard library path,
+    rather than with the CUDA SDK (which is optional for running CUDA apps).
+
+    On macOS, the CUDA library is only installed with the CUDA SDK, and
+    might not be in the library path.
+
+    Returns: version string (e.g., '9.2') or None if CUDA is not found.
+             The result is put in the queue rather than a return value.
+    """
+    # Platform-specific libcuda location
+    system = platform.system()
+    if system == "Darwin":
+        lib_filenames = [
+            "libcuda.dylib",  # check library path first
+            "/usr/local/cuda/lib/libcuda.dylib",
+        ]
+    elif system == "Linux":
+        lib_filenames = [
+            "libcuda.so",  # check library path first
+            "/usr/lib64/nvidia/libcuda.so",  # RHEL/Centos/Fedora
+            "/usr/lib/x86_64-linux-gnu/libcuda.so",  # Ubuntu
+            "/usr/lib/wsl/lib/libcuda.so",  # WSL
+        ]
+    elif system == "Windows":
+        lib_filenames = ["nvcuda.dll"]
+    else:
+        queue.put(None)  # CUDA not available for other operating systems
+        return
+
+    # Open library
+    if system == "Windows":
+        dll = ctypes.windll
+    else:
+        dll = ctypes.cdll
+    for lib_filename in lib_filenames:
+        with suppress(Exception):
+            libcuda = dll.LoadLibrary(lib_filename)
+            break
+    else:
+        queue.put(None)
+        return
+
+    # Empty `CUDA_VISIBLE_DEVICES` can cause `cuInit()` returns `CUDA_ERROR_NO_DEVICE`
+    # Invalid `CUDA_VISIBLE_DEVICES` can cause `cuInit()` returns `CUDA_ERROR_INVALID_DEVICE`
+    # Unset this environment variable to avoid these errors
+    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+
+    # Get CUDA version
+    try:
+        cuInit = libcuda.cuInit
+        flags = ctypes.c_uint(0)
+        ret = cuInit(flags)
+        if ret != 0:
+            queue.put(None)
+            return
+
+        cuDriverGetVersion = libcuda.cuDriverGetVersion
+        version_int = ctypes.c_int(0)
+        ret = cuDriverGetVersion(ctypes.byref(version_int))
+        if ret != 0:
+            queue.put(None)
+            return
+
+        # Convert version integer to version string
+        value = version_int.value
+        queue.put("%d.%d" % (value // 1000, (value % 1000) // 10))
+        return
+    except Exception:
+        queue.put(None)
+        return

--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -3,7 +3,7 @@
 import ctypes
 import functools
 import itertools
-import multiprocessing as mp
+import multiprocessing
 import os
 import platform
 from contextlib import suppress
@@ -29,11 +29,11 @@ def cuda_version():
     # Do not inherit file descriptors and handles from the parent process.
     # The `fork` start method should be considered unsafe as it can lead to
     # crashes of the subprocess. The `spawn` start method is preferred.
-    ctx = mp.get_context("spawn")
-    queue = ctx.SimpleQueue()
+    context = multiprocessing.get_context("spawn")
+    queue = context.SimpleQueue()
     try:
         # Spawn a subprocess to detect the CUDA version
-        detector = ctx.Process(
+        detector = context.Process(
             target=_cuda_driver_version_detector_target,
             args=(queue,),
             name="CUDA driver version detector",

--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -43,10 +43,7 @@ def cuda_version():
         detector.join(timeout=60.0)
     finally:
         # Always cleanup the subprocess
-        try:
-            detector.kill()  # requires Python 3.7+
-        except AttributeError:
-            pass
+        detector.kill()  # requires Python 3.7+
 
     if queue.empty():
         return None
@@ -148,7 +145,7 @@ def _cuda_driver_version_detector_target(queue):
 
         # Convert version integer to version string
         value = version_int.value
-        queue.put("%d.%d" % (value // 1000, (value % 1000) // 10))
+        queue.put(f"{value // 1000}.{(value % 1000) // 10}")
         return
     except Exception:
         queue.put(None)

--- a/news/11667-cuda-detect-in-subprocess
+++ b/news/11667-cuda-detect-in-subprocess
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Detect CUDA driver version in subprocess. (#11667)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Followed by #11626, see https://github.com/conda/conda/pull/11626#issuecomment-1186553105.

The environment variable `CUDA_VISIBLE_DEVICES` can cause `libcuda.cuInit()` fails (returns non-zero). The CUDA driver detector detects the driver version in the current process. The user-defined environment variable will let it fail.

For example:

- An empty `CUDA_VISIBLE_DEVICES` will cause `libcuda.cuInit()` returns `CUDA_ERROR_NO_DEVICE` (100).

```console
$ CUDA_VISIBLE_DEVICES='' python3 -c 'from conda.plugins.virtual_packages import cuda; print(cuda.cuda_version())'
None
```

- An invalid `CUDA_VISIBLE_DEVICES` will cause `libcuda.cuInit()` returns `CUDA_ERROR_INVALID_DEVICE` (101).

```console
$ CUDA_VISIBLE_DEVICES='0,0' python3 -c 'from conda.plugins.virtual_packages import cuda; print(cuda.cuda_version())'
None
```

------

In this PR, we detect the CUDA driver version in a spawned subprocess, which unset the environment variable `CUDA_VISIBLE_DEVICES` before calling `libcuda.cuInit()`.

```console
$ CUDA_VISIBLE_DEVICES='' python3 -c 'from conda.plugins.virtual_packages import cuda; print(cuda.cuda_version())'
11.7

$ CUDA_VISIBLE_DEVICES='0,0' python3 -c 'from conda.plugins.virtual_packages import cuda; print(cuda.cuda_version())'
11.7
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] ~Add / update necessary tests?~
- [X] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
