### PR TITLE
Deprecate unused `conda.another_to_unicode`

### DIFF
--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from os.path import abspath, dirname
 import sys
+import warnings
 
 from json import JSONEncoder
 
@@ -40,6 +41,11 @@ CONDA_PACKAGE_ROOT = abspath(dirname(__file__))
 CONDA_SOURCE_ROOT = dirname(CONDA_PACKAGE_ROOT)
 
 def another_to_unicode(val):
+    warnings.warn(
+        "`conda.another_to_unicode` is pending deprecation and will be removed in a "
+        "future release.",
+        PendingDeprecationWarning,
+    )
     # ignore flake8 on this because it finds this as an error on py3 even though it is guarded
     if isinstance(val, basestring) and not isinstance(val, unicode):  # NOQA
         return unicode(val, encoding='utf-8')  # NOQA

--- a/news/11678-pendingdeprecation-another_to_unicode
+++ b/news/11678-pendingdeprecation-another_to_unicode
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.another_to_unicode` as pending deprecation. (#11678)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This is unused across all conda org repos. [Search GitHub](https://cs.github.com/?scopeName=All+repos&scope=&q=another_to_unicode) and only found references to forks defining this function.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
