### PR TITLE
Adding `conda_env` to coverage reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,8 +12,6 @@ coverage:
 
 ignore:
   - conda/_vendor/.*
-  - conda/console.py
-  - conda/cli/activate.py
   - conda/cli/main_package.py
   - conda/exports.py
   - conda/gateways/connection/adapters/ftp.py

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,7 +11,6 @@ coverage:
         informational: true
 
 ignore:
-  - conda_env/.*
   - conda/_vendor/.*
   - conda/console.py
   - conda/cli/activate.py


### PR DESCRIPTION
Let's add `conda_env` to our coverage reports. This will be helpful for bug fix contributions later down the road.