### PR TITLE
Require `toolz` & soften `cytoolz` dependency

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - pip
     - ruamel_yaml >=0.11.14,<0.17
     - setuptools >=31.0.1
+    - toolz >=0.8.1
   run:
     - python
     - conda-package-handling >=1.3.0

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -35,17 +35,18 @@ requirements:
   run:
     - python
     - conda-package-handling >=1.3.0
-    - cytoolz >=0.8.1
     - menuinst >=1.4.11,<2         # [win]
     - pycosat >=0.6.3
     - pyopenssl >=16.2.0
     - requests >=2.18.4,<3
     - ruamel_yaml >=0.11.14,<0.17
     - setuptools >=31.0.1
+    - toolz >=0.8.1
   run_constrained:
     - conda-build >=3
     - conda-env >=2.6
     - conda-content-trust >=0.1.1
+    - cytoolz >=0.8.1
 
 test:
   source_files:

--- a/news/11333-replace-toolz-dependency-with-cytoolz
+++ b/news/11333-replace-toolz-dependency-with-cytoolz
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Replace vendored toolz with cytoolz dependency. (#11589)
+* Replace vendored toolz with toolz dependency. (#11589) (#11700)
 
 ### Bug fixes
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - pip
     - ruamel_yaml >=0.11.14,<0.16
     - setuptools >=31.0.1
+    - toolz >=0.8.1
   run:
     - python
     - conda-package-handling

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - requests >=2.20.1,<3
     - ruamel_yaml >=0.11.14,<0.16
     - setuptools >=31.0.1
+    - toolz >=0.8.1
   run_constrained:
     - conda-build >=3
     - conda-env >=2.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,7 +12,6 @@ conda-forge::pytest-xprocess
 conda-forge::xdoctest
 conda-package-handling
 conda-verify
-cytoolz
 filelock
 flake8
 git
@@ -34,3 +33,4 @@ pytest-xdist
 requests
 responses
 ruamel_yaml
+toolz


### PR DESCRIPTION
### Description

As the codebase can benefit from `cytoolz` when present and still fallback to `toolz` when `cytoolz` is absent, would suggest softening the dependency here to just require `toolz`. This can be particularly helpful when supporting other Python implementations (like PyPy, etc.) since `toolz` is pure Python and should just work out-of-the-box. Thus this simplifies the process of bootstrapping a new Python implementation with Conda. Additionally if one or the other is faster for a Python implementation, this leaves it up to users to decide.

xref: https://github.com/conda/conda/issues/11698, https://github.com/conda/conda/pull/11589, https://github.com/conda/conda-build/pull/4556
supersedes: #11699

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
