### PR TITLE
Add `conda._vendor.toolz` fallback for `tlz`

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -11,7 +11,10 @@ import re
 import sys
 from textwrap import dedent
 
-from tlz.itertoolz import concatv, drop
+try:
+    from tlz.itertoolz import concatv, drop
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concatv, drop
 
 # Since we have to have configuration context here, anything imported by
 #   conda.base.context is fair game, but nothing more.

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -17,7 +17,10 @@ from contextlib import contextmanager
 from datetime import datetime
 import warnings
 
-from tlz.itertoolz import concat, concatv, unique
+try:
+    from tlz.itertoolz import concat, concatv, unique
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv, unique
 
 from .constants import (
     APP_NAME,

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -11,7 +11,10 @@ from os.path import isfile, join
 import sys
 from textwrap import wrap
 
-from tlz.itertoolz import concat, groupby
+try:
+    from tlz.itertoolz import concat, groupby
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, groupby
 
 from .. import CondaError
 from ..auxlib.entity import EntityEncoder

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -27,9 +27,14 @@ from os.path import basename, expandvars
 from stat import S_IFDIR, S_IFMT, S_IFREG
 import sys
 
-from tlz.itertoolz import concat, concatv, unique
-from tlz.dicttoolz import merge, merge_with
-from tlz.functoolz import excepts
+try:
+    from tlz.itertoolz import concat, concatv, unique
+    from tlz.dicttoolz import merge, merge_with
+    from tlz.functoolz import excepts
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv, unique
+    from conda._vendor.toolz.dicttoolz import merge, merge_with
+    from conda._vendor.toolz import excepts
 
 from .compat import isiterable, odict, primitive_types
 from .constants import NULL

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -11,7 +11,10 @@ import re
 import subprocess
 from urllib.parse import urlsplit
 
-from tlz.itertoolz import accumulate, concat
+try:
+    from tlz.itertoolz import accumulate, concat
+except ImportError:
+    from conda._vendor.toolz.itertoolz import accumulate, concat
 
 from .compat import on_win
 from .. import CondaError

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -18,7 +18,10 @@ import re
 import sys
 import warnings
 
-from tlz.itertoolz import concat, concatv, groupby
+try:
+    from tlz.itertoolz import concat, concatv, groupby
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
 
 from ... import CondaError
 from ..compat import odict, open

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -11,7 +11,10 @@ import platform
 import sys
 import warnings
 
-from tlz.itertoolz import concat, concatv
+try:
+    from tlz.itertoolz import concat, concatv
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv
 
 from .package_cache_data import PackageCacheData
 from .prefix_data import PrefixData

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -14,7 +14,10 @@ from traceback import format_exception_only
 from textwrap import indent
 import warnings
 
-from tlz.itertoolz import concat, concatv, interleave
+try:
+    from tlz.itertoolz import concat, concatv, interleave
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv, interleave
 
 from .package_cache_data import PackageCacheData
 from .path_actions import (CompileMultiPycAction, CreateNonadminAction, CreatePrefixRecordAction,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -13,7 +13,10 @@ from os.path import basename, dirname, getsize, join
 from sys import platform
 from tarfile import ReadError
 
-from tlz.itertoolz import concat, concatv, groupby
+try:
+    from tlz.itertoolz import concat, concatv, groupby
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
 
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -11,7 +11,10 @@ import re
 import sys
 from uuid import uuid4
 
-from tlz.itertoolz import concat
+try:
+    from tlz.itertoolz import concat
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat
 
 from .envs_manager import get_user_environments_txt_file, register_env, unregister_env
 from .portability import _PaddingError, update_prefix

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -10,7 +10,10 @@ from os.path import join
 import sys
 from textwrap import dedent
 
-from tlz.itertoolz import concat, concatv, groupby
+try:
+    from tlz.itertoolz import concat, concatv, groupby
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
 
 from .index import get_reduced_index, _supplement_index_with_system
 from .link import PrefixSetup, UnlinkLinkTransaction

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -21,7 +21,10 @@ import re
 from time import time
 import warnings
 
-from tlz.itertoolz import concat, take, groupby
+try:
+    from tlz.itertoolz import concat, groupby, take
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, groupby, take
 
 from .. import CondaError
 from ..auxlib.ish import dals

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -16,7 +16,10 @@ from textwrap import dedent
 from traceback import format_exception, format_exception_only
 import getpass
 
-from tlz.itertoolz import groupby
+try:
+    from tlz.itertoolz import groupby
+except ImportError:
+    from conda._vendor.toolz.itertoolz import groupby
 
 from .models.channel import Channel
 from .common.url import join_url, maybe_unquote

--- a/conda/history.py
+++ b/conda/history.py
@@ -16,7 +16,10 @@ from textwrap import dedent
 import time
 import warnings
 
-from tlz.itertoolz import groupby, take
+try:
+    from tlz.itertoolz import groupby, take
+except ImportError:
+    from conda._vendor.toolz.itertoolz import groupby, take
 
 from . import __version__ as CONDA_VERSION
 from .auxlib.ish import dals

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -7,7 +7,10 @@ from copy import copy
 from itertools import chain
 from logging import getLogger
 
-from tlz.itertoolz import concat, concatv, drop
+try:
+    from tlz.itertoolz import concat, concatv, drop
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv, drop
 
 from .._vendor.boltons.setutils import IndexedSet
 from ..base.constants import DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -12,7 +12,10 @@ from operator import attrgetter
 from os.path import basename
 import re
 
-from tlz.itertoolz import concat, concatv, groupby
+try:
+    from tlz.itertoolz import concat, concatv, groupby
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
 
 from .channel import Channel
 from .version import BuildNumberMatch, VersionSpec

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -7,7 +7,10 @@ import operator as op
 import re
 from itertools import zip_longest
 
-from tlz.functoolz import excepts
+try:
+    from tlz.functoolz import excepts
+except ImportError:
+    from conda._vendor.toolz.functoolz import excepts
 
 from ..exceptions import InvalidVersionSpec
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -16,7 +16,10 @@ from collections import defaultdict
 from logging import getLogger
 import sys
 
-from tlz.itertoolz import concatv
+try:
+    from tlz.itertoolz import concatv, groupby
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concatv, groupby
 
 from ._vendor.boltons.setutils import IndexedSet
 from .base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
@@ -370,7 +373,6 @@ def _plan_from_actions(actions, index):  # pragma: no cover
 
 def _inject_UNLINKLINKTRANSACTION(plan, index, prefix, axn, specs):  # pragma: no cover
     from os.path import isdir
-    from tlz.itertoolz import groupby
     from .models.dist import Dist
     from .instructions import LINK, PROGRESSIVEFETCHEXTRACT, UNLINK, UNLINKLINKTRANSACTION
     from .core.package_cache_data import ProgressiveFetchExtract

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -8,9 +8,12 @@ import copy
 from functools import lru_cache
 from logging import DEBUG, getLogger
 
-from .auxlib.decorators import memoizemethod
-from tlz.itertoolz import concat, groupby
+try:
+    from tlz.itertoolz import concat, groupby
+except ImportError:
+    from conda._vendor.toolz.itertoolz import concat, groupby
 
+from .auxlib.decorators import memoizemethod
 from ._vendor.frozendict import FrozenOrderedDict as frozendict
 from ._vendor.tqdm import tqdm
 from .base.constants import ChannelPriority, MAX_CHANNEL_PRIORITY, SatSolverChoice


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Yet another patch to fix the broken canary builds. Adding fallback imports to `conda._vendor.toolz` for all `tlz` imports.

This is necessary because of how `conda build` builds packages:
1. `conda build` generates the necessary build environment (which contains the new conda dependencies, e.g. `toolz`)
2. `conda build` generates a `build_env_setup.sh` script where at the very end, it runs something like:
    ```
    ...
    eval "$('path/to/python' -m conda shell.bash hook)"
    conda activate <ENV1>
    conda activate --stack <ENV2>
    ```
    this occurs in [conda_build.build._write_sh_activation_text](https://github.com/conda/conda-build/blob/11192e0054a3cf42a8d2ee976080a707b1b640e0/conda_build/build.py#L1824-L1827).
3. `conda build` changes directories to the working directory (in this case a shallow clone of our conda repo)
4. `conda build` runs the `build_env_setup.sh` from our working directory so when `path/to/python -m conda ...` is invoked the CWD (working directory) is added to Python's search path, and hence the conda source code is loaded even though all we are attempting to do is bootstrap the build environment.

The correct fix is to change the `path/to/python -m conda ...` command to `path/to/conda ...` but this is a chicken/egg problem, so we need to keep this PR's fix in place until conda-build is updated and released.

Xref: #11698 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
