### PR TITLE
indirection to toolz through new conda.tlz module

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -11,7 +11,7 @@ import re
 import sys
 from textwrap import dedent
 
-from conda.tlz import concatv, drop
+from conda.tlz import concatv
 
 # Since we have to have configuration context here, anything imported by
 #   conda.base.context is fair game, but nothing more.
@@ -200,7 +200,7 @@ class _Activator(object):
             raise_invalid_command_error()
 
         command = arguments[0]
-        arguments = tuple(drop(1, arguments))
+        arguments = tuple(arguments[1:])
         help_flags = ('-h', '--help', '/?')
         non_help_args = tuple(arg for arg in arguments if arg not in help_flags)
         help_requested = len(arguments) != len(non_help_args)

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -11,10 +11,7 @@ import re
 import sys
 from textwrap import dedent
 
-try:
-    from tlz.itertoolz import concatv, drop
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concatv, drop
+from conda.tlz import concatv, drop
 
 # Since we have to have configuration context here, anything imported by
 #   conda.base.context is fair game, but nothing more.

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -17,10 +17,7 @@ from contextlib import contextmanager
 from datetime import datetime
 import warnings
 
-try:
-    from tlz.itertoolz import concat, concatv, unique
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, unique
+from conda.tlz import concat, concatv, unique
 
 from .constants import (
     APP_NAME,

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -11,10 +11,7 @@ from os.path import isfile, join
 import sys
 from textwrap import wrap
 
-try:
-    from tlz.itertoolz import concat, groupby
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby
+from conda.tlz import concat, groupby
 
 from .. import CondaError
 from ..auxlib.entity import EntityEncoder

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -27,14 +27,7 @@ from os.path import basename, expandvars
 from stat import S_IFDIR, S_IFMT, S_IFREG
 import sys
 
-try:
-    from tlz.itertoolz import concat, concatv, unique
-    from tlz.dicttoolz import merge, merge_with
-    from tlz.functoolz import excepts
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, unique
-    from conda._vendor.toolz.dicttoolz import merge, merge_with
-    from conda._vendor.toolz import excepts
+from conda.tlz import concat, concatv, unique, merge, merge_with, excepts
 
 from .compat import isiterable, odict, primitive_types
 from .constants import NULL

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -11,10 +11,7 @@ import re
 import subprocess
 from urllib.parse import urlsplit
 
-try:
-    from tlz.itertoolz import accumulate, concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import accumulate, concat
+from conda.tlz import accumulate, concat
 
 from .compat import on_win
 from .. import CondaError

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -18,10 +18,7 @@ import re
 import sys
 import warnings
 
-try:
-    from tlz.itertoolz import concat, concatv, groupby
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
+from conda.tlz import concat, concatv, groupby
 
 from ... import CondaError
 from ..compat import odict, open

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -11,10 +11,7 @@ import platform
 import sys
 import warnings
 
-try:
-    from tlz.itertoolz import concat, concatv
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv
+from conda.tlz import concat, concatv
 
 from .package_cache_data import PackageCacheData
 from .prefix_data import PrefixData

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -14,10 +14,7 @@ from traceback import format_exception_only
 from textwrap import indent
 import warnings
 
-try:
-    from tlz.itertoolz import concat, concatv, interleave
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, interleave
+from conda.tlz import concat, concatv, interleave
 
 from .package_cache_data import PackageCacheData
 from .path_actions import (CompileMultiPycAction, CreateNonadminAction, CreatePrefixRecordAction,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -13,10 +13,7 @@ from os.path import basename, dirname, getsize, join
 from sys import platform
 from tarfile import ReadError
 
-try:
-    from tlz.itertoolz import concat, concatv, groupby
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
+from conda.tlz import concat, concatv, groupby
 
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -11,10 +11,7 @@ import re
 import sys
 from uuid import uuid4
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.tlz import concat
 
 from .envs_manager import get_user_environments_txt_file, register_env, unregister_env
 from .portability import _PaddingError, update_prefix

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -10,10 +10,7 @@ from os.path import join
 import sys
 from textwrap import dedent
 
-try:
-    from tlz.itertoolz import concat, concatv, groupby
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
+from conda.tlz import concat, concatv, groupby
 
 from .index import get_reduced_index, _supplement_index_with_system
 from .link import PrefixSetup, UnlinkLinkTransaction

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -19,10 +19,7 @@ import re
 from time import time
 import warnings
 
-try:
-    from tlz.itertoolz import concat, groupby, take
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby, take
+from conda.tlz import concat, groupby, take
 
 from .. import CondaError
 from ..auxlib.ish import dals

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -16,10 +16,7 @@ from textwrap import dedent
 from traceback import format_exception, format_exception_only
 import getpass
 
-try:
-    from tlz.itertoolz import groupby
-except ImportError:
-    from conda._vendor.toolz.itertoolz import groupby
+from conda.tlz import groupby
 
 from .models.channel import Channel
 from .common.url import join_url, maybe_unquote

--- a/conda/history.py
+++ b/conda/history.py
@@ -16,10 +16,7 @@ from textwrap import dedent
 import time
 import warnings
 
-try:
-    from tlz.itertoolz import groupby, take
-except ImportError:
-    from conda._vendor.toolz.itertoolz import groupby, take
+from conda.tlz import groupby, take
 
 from . import __version__ as CONDA_VERSION
 from .auxlib.ish import dals

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -7,10 +7,7 @@ from copy import copy
 from itertools import chain
 from logging import getLogger
 
-try:
-    from tlz.itertoolz import concat, concatv, drop
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, drop
+from conda.tlz import concat, concatv, drop
 
 from .._vendor.boltons.setutils import IndexedSet
 from ..base.constants import DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -7,7 +7,7 @@ from copy import copy
 from itertools import chain
 from logging import getLogger
 
-from conda.tlz import concat, concatv, drop
+from conda.tlz import concat, concatv
 
 from .._vendor.boltons.setutils import IndexedSet
 from ..base.constants import DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL
@@ -439,7 +439,7 @@ def _read_channel_configuration(scheme, host, port, path):
     bump = None
     path_parts = path.strip("/").split("/")
     if path_parts and path_parts[0] == "conda":
-        bump, path = "conda", "/".join(drop(1, path_parts))
+        bump, path = "conda", "/".join(path_parts[1:])
     return (
         str(Url(hostname=host, port=port, path=bump)).rstrip("/"),
         path.strip("/") or None,

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -12,10 +12,7 @@ from operator import attrgetter
 from os.path import basename
 import re
 
-try:
-    from tlz.itertoolz import concat, concatv, groupby
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
+from conda.tlz import concat, concatv, groupby
 
 from .channel import Channel
 from .version import BuildNumberMatch, VersionSpec

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -7,10 +7,7 @@ import operator as op
 import re
 from itertools import zip_longest
 
-try:
-    from tlz.functoolz import excepts
-except ImportError:
-    from conda._vendor.toolz.functoolz import excepts
+from conda.tlz import excepts
 
 from ..exceptions import InvalidVersionSpec
 

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -16,10 +16,7 @@ from collections import defaultdict
 from logging import getLogger
 import sys
 
-try:
-    from tlz.itertoolz import concatv, groupby
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concatv, groupby
+from conda.tlz import concatv, groupby
 
 from ._vendor.boltons.setutils import IndexedSet
 from .base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -8,10 +8,7 @@ import copy
 from functools import lru_cache
 from logging import DEBUG, getLogger
 
-try:
-    from tlz.itertoolz import concat, groupby
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby
+from conda.tlz import concat, groupby
 
 from .auxlib.decorators import memoizemethod
 from ._vendor.frozendict import FrozenOrderedDict as frozendict

--- a/conda/tlz.py
+++ b/conda/tlz.py
@@ -2,7 +2,8 @@
 Indirection to tls / toolz library, just the imports we use.
 """
 
+
 try:
-    from toolz import merge, take, interleave, excepts, merge_with, concatv, concat, drop, accumulate, groupby, unique
+    from toolz import merge, take, interleave, excepts, merge_with, concatv, concat, accumulate, groupby, unique
 except ImportError:
-    from conda._vendor.toolz import merge, take, interleave, excepts, merge_with, concatv, concat, drop, accumulate, groupby, unique
+    from conda._vendor.toolz import merge, take, interleave, excepts, merge_with, concatv, concat, accumulate, groupby, unique

--- a/conda/tlz.py
+++ b/conda/tlz.py
@@ -1,0 +1,8 @@
+"""
+Indirection to tls / toolz library, just the imports we use.
+"""
+
+try:
+    from toolz import merge, take, interleave, excepts, merge_with, concatv, concat, drop, accumulate, groupby, unique
+except ImportError:
+    from conda._vendor.toolz import merge, take, interleave, excepts, merge_with, concatv, concat, drop, accumulate, groupby, unique

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -22,11 +22,7 @@ from conda.models.match_spec import MatchSpec
 from conda.models.prefix_graph import PrefixGraph
 from conda.history import History
 
-try:
-    from tlz.itertoolz import concatv, groupby
-except ImportError:  # pragma: no cover
-    from conda._vendor.toolz.itertoolz import concatv, groupby  # NOQA
-
+from conda.tlz import concatv, groupby
 
 VALID_KEYS = ('name', 'dependencies', 'prefix', 'channels', 'variables')
 

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 from unittest import TestCase, mock
 
 import pytest
-from tlz.itertoolz import concat
+from conda.tlz import concat
 
 from conda.auxlib.collection import AttrDict
 from conda.auxlib.ish import dals

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -14,7 +14,7 @@ from unittest import TestCase
 from uuid import uuid4
 
 import pytest
-from tlz.itertoolz import groupby
+from conda.tlz import groupby
 
 from conda.auxlib.collection import AttrDict
 from conda.base.context import context

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -21,7 +21,7 @@ from unittest import TestCase
 from uuid import uuid4
 
 import pytest
-from tlz.itertoolz import concatv
+from conda.tlz import concatv
 
 from conda import __version__ as conda_version
 from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -30,7 +30,7 @@ from uuid import uuid4
 
 import pytest
 import requests
-from tlz.itertoolz import groupby
+from conda.tlz import groupby
 
 from conda import (
     CondaError,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Redirect toolz through a module, with only the used toolz (found with regex + sets on conda/**/*.py), for a more pleasant single `try / except`. Provide a single place to redefine the most obvious toolz in terms of itertools, reducing our toolz dependency.