### PR TITLE
Modify `ExceptionHandler.write_out` to Properly Show Errors

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1136,10 +1136,7 @@ class ExceptionHandler(object):
         from .cli.main import init_loggers
 
         init_loggers(context)
-
-        content_str = "\n".join(content)
-        logger = getLogger("conda.stderr")
-        logger.info(content_str)
+        getLogger("conda.stderr").info("\n".join(content))
 
     @property
     def http_timeout(self):

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1336,7 +1336,6 @@ class ExceptionHandler(object):
             self._post_upload(do_upload)
 
     def _ask_upload(self):
-
         try:
             do_upload = timeout(
                 40,

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1133,14 +1133,13 @@ class ExceptionHandler(object):
 
     def write_out(self, *content):
         from .base.context import context
+        from .cli.main import init_loggers
+
+        init_loggers(context)
 
         content_str = "\n".join(content)
-        if True:
-            logger = getLogger("conda.%s" % ("stdout" if context.json else "stderr"))
-            logger.info(content_str)
-        else:
-            stream = sys.stdout if context.json else sys.stderr
-            stream.write(content_str)
+        logger = getLogger("conda.stderr")
+        logger.info(content_str)
 
     @property
     def http_timeout(self):
@@ -1340,13 +1339,18 @@ class ExceptionHandler(object):
             self._post_upload(do_upload)
 
     def _ask_upload(self):
-        self.write_out(
-            "If submitted, this report will be used by core maintainers to improve",
-            "future releases of conda.",
-            "Would you like conda to send this report to the core maintainers?",
-        )
+
         try:
-            do_upload = timeout(40, partial(input, "[y/N]: "))
+            do_upload = timeout(
+                40,
+                partial(
+                    input,
+                    "If submitted, this report will be used by core maintainers to improve\n"
+                    "future releases of conda.\n"
+                    "Would you like conda to send this report to the core maintainers? "
+                    "[y/N]: ",
+                ),
+            )
             return do_upload and boolify(do_upload)
         except Exception as e:
             log.debug("%r", e)

--- a/news/11746-modify-write-out
+++ b/news/11746-modify-write-out
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ensure that exceptions that are raised show up properly instead of resulting in a random [y/N] prompt (#11746)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Resolves https://github.com/conda/conda/issues/11689, first brought up in [this comment](https://github.com/conda/conda/pull/11435#pullrequestreview-1059455307).

This code change ensures that exceptions that are raised show up properly instead of resulting in a random and otherwise blank `[y/N]` prompt. We also tidied up the `ExceptionHandler._ask_upload` method where it asks whether or not the user would like to send an error report.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->