### PR TITLE
Modify `ArgumentParser` to print to `stderr` instead of `stdout`

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -161,8 +161,15 @@ class ArgumentParser(ArgumentParserBase):
 
         super(ArgumentParser, self).error(message)
 
-    def print_help(self):
-        super(ArgumentParser, self).print_help()
+    def print_usage(self, file=None):
+        if file is None:
+            file = sys.stderr
+        super().print_usage(file)
+
+    def print_help(self, file=None):
+        if file is None:
+            file = sys.stderr
+        super().print_help(file)
 
         if sys.argv[1:] in ([], [''], ['help'], ['-h'], ['--help']):
             from .find_commands import find_commands
@@ -170,8 +177,8 @@ class ArgumentParser(ArgumentParserBase):
             if other_commands:
                 builder = ['']
                 builder.append("conda commands available from other packages:")
-                builder.extend('  %s' % cmd for cmd in sorted(other_commands))
-                print('\n'.join(builder))
+                builder.extend("  %s" % cmd for cmd in sorted(other_commands))
+                self._print_message("\n".join(builder), file)
 
 
 def _exec(executable_args, env_vars):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Working towards supporting `argparse` for `activate`/`deactivate` commands. Since those commands are based on evaluating the output printed to `stdout` we need to ensure instead that all `argparse` outputs are dumped to `stderr`.

Resolves #11748 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
