### PR TITLE
Change Debian Image from `buster-slim` to `stable-slim` on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # * https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
 
 # built-in arg set via `docker build --platform $TARGETPLATFORM ...` or TARGETPLATFORM=BUILDPLATFORM
-FROM --platform=$TARGETPLATFORM debian:buster-slim AS buildbase
+FROM --platform=$TARGETPLATFORM debian:stable AS buildbase
 
 # built-in arg set by `docker build --platform linux/$TARGETARCH ...`
 ARG TARGETARCH
@@ -41,7 +41,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
     rm ~/miniconda.sh && \
     /opt/conda/bin/conda clean --all --yes
 
-FROM --platform=$TARGETPLATFORM debian:buster-slim
+FROM --platform=$TARGETPLATFORM debian:stable
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # * https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
 
 # built-in arg set via `docker build --platform $TARGETPLATFORM ...` or TARGETPLATFORM=BUILDPLATFORM
-FROM --platform=$TARGETPLATFORM debian:stable AS buildbase
+FROM --platform=$TARGETPLATFORM debian:stable-slim AS buildbase
 
 # built-in arg set by `docker build --platform linux/$TARGETARCH ...`
 ARG TARGETARCH
@@ -41,7 +41,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
     rm ~/miniconda.sh && \
     /opt/conda/bin/conda clean --all --yes
 
-FROM --platform=$TARGETPLATFORM debian:stable
+FROM --platform=$TARGETPLATFORM debian:stable-slim
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH


### PR DESCRIPTION
Automated CI for Linux tests [appears to be broken](https://github.com/conda/conda/runs/7977706015?check_suite_focus=true) with the use of `debian:buster-slim` due to the [image being updated recently](https://hub.docker.com/_/debian/tags?page=1&name=buster-slim). Changing the Dockerfile to point to `debian:stable-slim` to avoid usage of release-specific codenames and thus provide more stability to these test runs.

Depends on: https://github.com/conda/conda/pull/11754