### PR TITLE
Formatting `rename` Command Examples to Have Proper Line Spacing

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1349,11 +1349,17 @@ def configure_parser_rename(sub_parsers) -> None:
 
     example = dals(
         """
+
         Examples:
+
             conda rename -n test123 test321
+
             conda rename --name test123 test321
+
             conda rename -p path/to/test123 test321
+
             conda rename --prefix path/to/test123 test321
+
         """
     )
 


### PR DESCRIPTION
Currently, the [`rename` command documentation page](https://docs.conda.io/projects/conda/en/latest/commands/rename.html) has no line spacing for the example commands and thus looks confusing:
![Screen Shot 2022-08-24 at 6 23 19 PM](https://user-images.githubusercontent.com/28930622/186742880-ee00cf44-c327-4407-a21c-ac2f6e4e9909.png)

This change will add the proper line spacing so that the examples show up properly.
