### PR TITLE
remove toolz.concatv

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from itertools import chain
 from errno import ENOENT
 import json
 import os
@@ -14,7 +15,7 @@ from textwrap import dedent
 try:
     from tlz.itertoolz import concatv, drop
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concatv, drop
+    from conda._vendor.toolz.itertoolz import drop
 
 # Since we have to have configuration context here, anything imported by
 #   conda.base.context is fair game, but nothing more.
@@ -54,7 +55,7 @@ class _Activator(object):
     path_conversion = None
     script_extension = None
     tempfile_extension = None  # None means write instructions to stdout rather than a temp file
-    command_join = None
+    command_join: str
 
     unset_var_tmpl = None
     export_var_tmpl = None
@@ -122,7 +123,7 @@ class _Activator(object):
         return script_export_vars or '', script_unset_vars or ''
 
     def _finalize(self, commands, ext):
-        commands = concatv(commands, ('',))  # add terminating newline
+        commands = chain(commands, ('',))  # add terminating newline
         if ext is None:
             return self.command_join.join(commands)
         elif ext:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 
 from errno import ENOENT
 from functools import lru_cache
+from itertools import chain
 from logging import getLogger
 import os
 from os.path import abspath, basename, expanduser, isdir, isfile, join, split as path_split
@@ -112,7 +113,7 @@ def mockable_context_envs_dirs(root_writable, root_prefix, _envs_dirs):
         )
     if on_win:
         fixed_dirs += join(user_data_dir(APP_NAME, APP_NAME), 'envs'),
-    return tuple(IndexedSet(expand(p) for p in concatv(_envs_dirs, fixed_dirs)))
+    return tuple(IndexedSet(expand(p) for p in chain(_envs_dirs, fixed_dirs)))
 
 
 def channel_alias_validation(value):
@@ -506,7 +507,7 @@ class Context(Configuration):
 
     @memoizedproperty
     def known_subdirs(self):
-        return frozenset(concatv(KNOWN_SUBDIRS, self.subdirs))
+        return frozenset(chain(KNOWN_SUBDIRS, self.subdirs))
 
     @property
     def bits(self):
@@ -732,7 +733,7 @@ class Context(Configuration):
         )
         all_multichannels = odict(
             (name, channels)
-            for name, channels in concatv(
+            for name, channels in chain(
                 custom_multichannels.items(),
                 reserved_multichannels.items(),  # order maters, reserved overrides custom
             )
@@ -746,7 +747,7 @@ class Context(Configuration):
                            for name, url in self._custom_channels.items())
         channels_from_multichannels = concat(channel for channel
                                              in self.custom_multichannels.values())
-        all_channels = odict((x.name, x) for x in (ch for ch in concatv(
+        all_channels = odict((x.name, x) for x in (ch for ch in chain(
             channels_from_multichannels,
             custom_channels,
         )))
@@ -770,7 +771,7 @@ class Context(Configuration):
                     "--override-channels."
                 )
             else:
-                return tuple(IndexedSet(concatv(local_add, self._argparse_args['channel'])))
+                return tuple(IndexedSet(chain(local_add, self._argparse_args['channel'])))
 
         # add 'defaults' channel when necessary if --channel is given via the command line
         if self._argparse_args and 'channel' in self._argparse_args:
@@ -783,10 +784,10 @@ class Context(Configuration):
             channel_in_config_files = any('channels' in context.raw_data[rc_file].keys()
                                           for rc_file in self.config_files)
             if argparse_channels and not channel_in_config_files:
-                return tuple(IndexedSet(concatv(local_add, argparse_channels,
-                                                (DEFAULTS_CHANNEL_NAME,))))
+                return tuple(IndexedSet(chain(local_add, argparse_channels,
+                                                        (DEFAULTS_CHANNEL_NAME,))))
 
-        return tuple(IndexedSet(concatv(local_add, self._channels)))
+        return tuple(IndexedSet(chain(local_add, self._channels)))
 
     @property
     def config_files(self):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -19,9 +19,9 @@ from datetime import datetime
 import warnings
 
 try:
-    from tlz.itertoolz import concat, concatv, unique
+    from tlz.itertoolz import concat, unique
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, unique
+    from conda._vendor.toolz.itertoolz import concat, unique
 
 from .constants import (
     APP_NAME,
@@ -784,8 +784,9 @@ class Context(Configuration):
             channel_in_config_files = any('channels' in context.raw_data[rc_file].keys()
                                           for rc_file in self.config_files)
             if argparse_channels and not channel_in_config_files:
-                return tuple(IndexedSet(chain(local_add, argparse_channels,
-                                                        (DEFAULTS_CHANNEL_NAME,))))
+                return tuple(
+                    IndexedSet(chain(local_add, argparse_channels, (DEFAULTS_CHANNEL_NAME,)))
+                )
 
         return tuple(IndexedSet(chain(local_add, self._channels)))
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -19,9 +19,13 @@ from datetime import datetime
 import warnings
 
 try:
-    from tlz.itertoolz import concat, unique
+    from tlz.itertoolz import unique
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, unique
+    from conda._vendor.toolz.itertoolz import unique
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .constants import (
     APP_NAME,

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -12,9 +12,13 @@ import sys
 from textwrap import wrap
 
 try:
-    from tlz.itertoolz import concat, groupby
+    from tlz.itertoolz import groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby
+    from conda._vendor.toolz.itertoolz import groupby
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .. import CondaError
 from ..auxlib.entity import EntityEncoder

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -28,7 +28,7 @@ from stat import S_IFDIR, S_IFMT, S_IFREG
 import sys
 
 try:
-    from tlz.itertoolz import concat, concatv, unique
+    from tlz.itertoolz import concat, unique
     from tlz.dicttoolz import merge, merge_with
     from tlz.functoolz import excepts
 except ImportError:
@@ -702,7 +702,7 @@ class MapLoadedParameter(LoadedParameter):
         # dump all matches in a dict
         # then overwrite with important matches
         merged_values_important_overwritten = frozendict(merge(
-            concatv([merged_values], reversed(important_maps))))
+            chain([merged_values], reversed(important_maps))))
 
         # create new parameter for the merged values
         return MapLoadedParameter(
@@ -770,13 +770,13 @@ class SequenceLoadedParameter(LoadedParameter):
         all_lines = concat(v for _, v in reversed(relevant_matches_and_values))
 
         # stack top_lines + all_lines, then de-dupe
-        top_deduped = tuple(unique(concatv(top_lines, all_lines)))
+        top_deduped = tuple(unique(chain(top_lines, all_lines)))
 
         # take the top-deduped lines, reverse them, and concat with reversed bottom_lines
         # this gives us the reverse of the order we want, but almost there
         # NOTE: for a line value marked both top and bottom, the bottom marker will win out
         #       for the top marker to win out, we'd need one additional de-dupe step
-        bottom_deduped = unique(concatv(reversed(tuple(bottom_lines)), reversed(top_deduped)))
+        bottom_deduped = unique(chain(reversed(tuple(bottom_lines)), reversed(top_deduped)))
         # just reverse, and we're good to go
         merged_values = tuple(reversed(tuple(bottom_deduped)))
 
@@ -848,7 +848,7 @@ class ObjectLoadedParameter(LoadedParameter):
         # dump all matches in a dict
         # then overwrite with important matches
         merged_values_important_overwritten = frozendict(merge(
-            concatv([merged_values], reversed(important_maps))))
+            chain([merged_values], reversed(important_maps))))
 
         # copy object and replace Parameter with LoadedParameter fields
         object_copy = copy.deepcopy(self._element_type)

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -32,7 +32,7 @@ try:
     from tlz.dicttoolz import merge, merge_with
     from tlz.functoolz import excepts
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, unique
+    from conda._vendor.toolz.itertoolz import concat, unique
     from conda._vendor.toolz.dicttoolz import merge, merge_with
     from conda._vendor.toolz import excepts
 

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -28,13 +28,17 @@ from stat import S_IFDIR, S_IFMT, S_IFREG
 import sys
 
 try:
-    from tlz.itertoolz import concat, unique
+    from tlz.itertoolz import unique
     from tlz.dicttoolz import merge, merge_with
     from tlz.functoolz import excepts
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, unique
+    from conda._vendor.toolz.itertoolz import unique
     from conda._vendor.toolz.dicttoolz import merge, merge_with
     from conda._vendor.toolz import excepts
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .compat import isiterable, odict, primitive_types
 from .constants import NULL

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -12,9 +12,13 @@ import subprocess
 from urllib.parse import urlsplit
 
 try:
-    from tlz.itertoolz import accumulate, concat
+    from tlz.itertoolz import accumulate
 except ImportError:
-    from conda._vendor.toolz.itertoolz import accumulate, concat
+    from conda._vendor.toolz.itertoolz import accumulate
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .compat import on_win
 from .. import CondaError

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -20,9 +20,13 @@ import sys
 import warnings
 
 try:
-    from tlz.itertoolz import concat, groupby
+    from tlz.itertoolz import groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby
+    from conda._vendor.toolz.itertoolz import groupby
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from ... import CondaError
 from ..compat import odict, open

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -9,6 +9,7 @@ from csv import reader as csv_reader
 from email.parser import HeaderParser
 from errno import ENOENT
 from io import StringIO
+from itertools import chain
 from logging import getLogger
 from os import name as os_name, scandir, strerror
 from os.path import basename, dirname, isdir, isfile, join, lexists
@@ -19,9 +20,9 @@ import sys
 import warnings
 
 try:
-    from tlz.itertoolz import concat, concatv, groupby
+    from tlz.itertoolz import concat, groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
+    from conda._vendor.toolz.itertoolz import concat, groupby
 
 from ... import CondaError
 from ..compat import odict, open
@@ -276,7 +277,7 @@ class PythonDistribution(object):
             missing_pyc_files = (ff for ff in (
                 _pyc_path(f, py_ver_mm) for f in files_set if _py_file_re.match(f)
             ) if ff not in files_set)
-            records = sorted(concatv(records, ((pf, None, None) for pf in missing_pyc_files)))
+            records = sorted(chain(records, ((pf, None, None) for pf in missing_pyc_files)))
             return records
 
         return []

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -11,10 +11,9 @@ import platform
 import sys
 import warnings
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .package_cache_data import PackageCacheData
 from .prefix_data import PrefixData

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -12,9 +12,9 @@ import sys
 import warnings
 
 try:
-    from tlz.itertoolz import concat, concatv
+    from tlz.itertoolz import concat
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv
+    from conda._vendor.toolz.itertoolz import concat
 
 from .package_cache_data import PackageCacheData
 from .prefix_data import PrefixData
@@ -329,7 +329,7 @@ def get_reduced_index(prefix, channels, subdirs, specs, repodata_fn):
     # add feature records for the solver
     known_features = set()
     for rec in reduced_index.values():
-        known_features.update(concatv(rec.track_features, rec.features))
+        known_features.update(chain(rec.track_features, rec.features))
     known_features.update(context.track_features)
     for ftr_str in known_features:
         rec = make_feature_record(ftr_str)

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -15,9 +15,13 @@ from textwrap import indent
 import warnings
 
 try:
-    from tlz.itertoolz import concat, interleave
+    from tlz.itertoolz import interleave
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, interleave
+    from conda._vendor.toolz.itertoolz import interleave
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .package_cache_data import PackageCacheData
 from .path_actions import (CompileMultiPycAction, CreateNonadminAction, CreatePrefixRecordAction,

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -15,9 +15,9 @@ from textwrap import indent
 import warnings
 
 try:
-    from tlz.itertoolz import concat, concatv, interleave
+    from tlz.itertoolz import concat, interleave
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, interleave
+    from conda._vendor.toolz.itertoolz import concat, interleave
 
 from .package_cache_data import PackageCacheData
 from .path_actions import (CompileMultiPycAction, CreateNonadminAction, CreatePrefixRecordAction,
@@ -400,12 +400,14 @@ class UnlinkLinkTransaction(object):
                 target_prefix)
             make_menu_action_groups.append(make_menu_ag)
 
-            all_link_path_actions = chain(link_ag.actions,
-                                                    compile_ag.actions,
-                                                    entry_point_ag.actions,
-                                                    make_menu_ag.actions)
-            record_axns.extend(CreatePrefixRecordAction.create_actions(
-                transaction_context, pkg_info, target_prefix, lt, spec, all_link_path_actions))
+            all_link_path_actions = chain(
+                link_ag.actions, compile_ag.actions, entry_point_ag.actions, make_menu_ag.actions
+            )
+            record_axns.extend(
+                CreatePrefixRecordAction.create_actions(
+                    transaction_context, pkg_info, target_prefix, lt, spec, all_link_path_actions
+                )
+            )
 
         prefix_record_groups = [ActionGroup('record', None, record_axns, target_prefix)]
 

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import itertools
 from collections import defaultdict, namedtuple
+from itertools import chain
 from logging import getLogger
 import os
 from os.path import basename, dirname, isdir, join
@@ -99,7 +99,7 @@ def make_unlink_actions(transaction_context, target_prefix, prefix_record):
     #     transaction_context, package_cache_record, target_prefix
     # )
 
-    return tuple(concatv(
+    return tuple(chain(
         unlink_path_actions,
         directory_remove_actions,
         # unregister_private_package_actions,
@@ -248,7 +248,7 @@ class UnlinkLinkTransaction(object):
                 log.info(exceptions)
         try:
             self._verify_pre_link_message(
-                itertools.chain(
+                chain(
                     *(act.link_action_groups for act in self.prefix_action_groups.values())
                 )
             )
@@ -400,10 +400,10 @@ class UnlinkLinkTransaction(object):
                 target_prefix)
             make_menu_action_groups.append(make_menu_ag)
 
-            all_link_path_actions = concatv(link_ag.actions,
-                                            compile_ag.actions,
-                                            entry_point_ag.actions,
-                                            make_menu_ag.actions)
+            all_link_path_actions = chain(link_ag.actions,
+                                                    compile_ag.actions,
+                                                    entry_point_ag.actions,
+                                                    make_menu_ag.actions)
             record_axns.extend(CreatePrefixRecordAction.create_actions(
                 transaction_context, pkg_info, target_prefix, lt, spec, all_link_path_actions))
 
@@ -744,7 +744,7 @@ class UnlinkLinkTransaction(object):
                             excs = UnlinkLinkTransaction._reverse_actions(axngroup)
                             rollback_excs.extend(excs)
 
-                raise CondaMultiError(tuple(concatv(
+                raise CondaMultiError(tuple(chain(
                     ((e.errors[0], e.errors[2:])
                      if isinstance(e, CondaMultiError)
                      else (e,)),
@@ -783,7 +783,7 @@ class UnlinkLinkTransaction(object):
             reverse_excs = ()
             if context.rollback_enabled:
                 reverse_excs = UnlinkLinkTransaction._reverse_actions(axngroup)
-            return CondaMultiError(tuple(concatv(
+            return CondaMultiError(tuple(chain(
                 (e,),
                 (axngroup,),
                 reverse_excs,
@@ -803,7 +803,7 @@ class UnlinkLinkTransaction(object):
                 reverse_excs = ()
                 if context.rollback_enabled:
                     reverse_excs = UnlinkLinkTransaction._reverse_actions(axngroup)
-                return CondaMultiError(tuple(concatv(
+                return CondaMultiError(tuple(chain(
                     (e,),
                     (axngroup,),
                     reverse_excs,
@@ -900,7 +900,7 @@ class UnlinkLinkTransaction(object):
         #     register_private_env_actions = ()
 
         # the ordering here is significant
-        return tuple(concatv(
+        return tuple(chain(
             create_directory_actions,
             file_link_actions,
             create_nonadmin_actions,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import codecs
 from collections import defaultdict
 from errno import EACCES, ENOENT, EPERM, EROFS
+from itertools import chain
 from json import JSONDecodeError
 from logging import getLogger
 from os import scandir
@@ -194,7 +195,7 @@ class PackageCacheData(metaclass=PackageCacheType):
             lambda pc: pc.is_writable,
             (cls(pd) for pd in pkgs_dirs)
         )
-        return tuple(concatv(pc_groups.get(True, ()), pc_groups.get(False, ())))
+        return tuple(chain(pc_groups.get(True, ()), pc_groups.get(False, ())))
 
     @classmethod
     def get_all_extracted_entries(cls):
@@ -423,7 +424,7 @@ class PackageCacheData(metaclass=PackageCacheType):
         conda_extensions = groups[_CONDA_TARBALL_EXTENSION_V2]
         tar_bz2_extensions = groups[_CONDA_TARBALL_EXTENSION_V1] - conda_extensions
         others = groups[None] - conda_extensions - tar_bz2_extensions
-        return sorted(concatv(
+        return sorted(chain(
             (p + _CONDA_TARBALL_EXTENSION_V2 for p in conda_extensions),
             (p + _CONDA_TARBALL_EXTENSION_V1 for p in tar_bz2_extensions),
             others,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -15,9 +15,13 @@ from sys import platform
 from tarfile import ReadError
 
 try:
-    from tlz.itertoolz import concat, groupby
+    from tlz.itertoolz import groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby
+    from conda._vendor.toolz.itertoolz import groupby
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -15,9 +15,9 @@ from sys import platform
 from tarfile import ReadError
 
 try:
-    from tlz.itertoolz import concat, concatv, groupby
+    from tlz.itertoolz import concat, groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
+    from conda._vendor.toolz.itertoolz import concat, groupby
 
 from .path_actions import CacheUrlAction, ExtractPackageAction
 from .. import CondaError, CondaMultiError, conda_signal_handler

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -11,10 +11,9 @@ import re
 import sys
 from uuid import uuid4
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .envs_manager import get_user_environments_txt_file, register_env, unregister_env
 from .portability import _PaddingError, update_prefix

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -12,9 +12,13 @@ import sys
 from textwrap import dedent
 
 try:
-    from tlz.itertoolz import concat, groupby
+    from tlz.itertoolz import groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby
+    from conda._vendor.toolz.itertoolz import groupby
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .index import get_reduced_index, _supplement_index_with_system
 from .link import PrefixSetup, UnlinkLinkTransaction

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -20,9 +20,13 @@ from time import time
 import warnings
 
 try:
-    from tlz.itertoolz import concat, groupby, take
+    from tlz.itertoolz import groupby, take
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby, take
+    from conda._vendor.toolz.itertoolz import groupby, take
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .. import CondaError
 from ..auxlib.ish import dals

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -8,9 +8,9 @@ from itertools import chain
 from logging import getLogger
 
 try:
-    from tlz.itertoolz import concat, concatv, drop
+    from tlz.itertoolz import concat, drop
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, drop
+    from conda._vendor.toolz.itertoolz import concat, drop
 
 from .._vendor.boltons.setutils import IndexedSet
 from ..base.constants import DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL
@@ -158,7 +158,7 @@ class Channel(metaclass=ChannelType):
                 cn = self.__canonical_name = self.name
                 return cn
 
-        if any(c.location == self.location for c in concatv(
+        if any(c.location == self.location for c in chain(
                 (context.channel_alias,),
                 context.migrated_channel_aliases,
         )):

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -7,10 +7,9 @@ from copy import copy
 from itertools import chain
 from logging import getLogger
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .._vendor.boltons.setutils import IndexedSet
 from ..base.constants import DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -7,15 +7,16 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 
 from collections.abc import Mapping
 from functools import reduce
+from itertools import chain
 from logging import getLogger
 from operator import attrgetter
 from os.path import basename
 import re
 
 try:
-    from tlz.itertoolz import concat, concatv, groupby
+    from tlz.itertoolz import concat, groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, groupby
+    from conda._vendor.toolz.itertoolz import concat, groupby
 
 from .channel import Channel
 from .version import BuildNumberMatch, VersionSpec
@@ -479,7 +480,7 @@ class MatchSpec(metaclass=MatchSpecType):
             merged_specs.append(
                 reduce(lambda x, y: x._merge(y, union), group) if len(group) > 1 else group[0]
             )
-        return tuple(concatv(merged_specs, unmergeable))
+        return tuple(chain(merged_specs, unmergeable))
 
     @classmethod
     def union(cls, match_specs):

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -14,9 +14,13 @@ from os.path import basename
 import re
 
 try:
-    from tlz.itertoolz import concat, groupby
+    from tlz.itertoolz import groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby
+    from conda._vendor.toolz.itertoolz import groupby
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .channel import Channel
 from .version import BuildNumberMatch, VersionSpec

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -12,14 +12,15 @@ NOTE:
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from itertools import chain
 from collections import defaultdict
 from logging import getLogger
 import sys
 
 try:
-    from tlz.itertoolz import concatv, groupby
+    from tlz.itertoolz import groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concatv, groupby
+    from conda._vendor.toolz.itertoolz import groupby
 
 from ._vendor.boltons.setutils import IndexedSet
 from .base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
@@ -417,7 +418,7 @@ def _handle_menuinst(unlink_dists, link_dists):  # pragma: no cover
     # unlink
     menuinst_idx = next((q for q, d in enumerate(unlink_dists) if d.name == 'menuinst'), None)
     if menuinst_idx is not None:
-        unlink_dists = tuple(concatv(
+        unlink_dists = tuple(chain(
             unlink_dists[:menuinst_idx],
             unlink_dists[menuinst_idx+1:],
             unlink_dists[menuinst_idx:menuinst_idx+1],
@@ -426,7 +427,7 @@ def _handle_menuinst(unlink_dists, link_dists):  # pragma: no cover
     # link
     menuinst_idx = next((q for q, d in enumerate(link_dists) if d.name == 'menuinst'), None)
     if menuinst_idx is not None:
-        link_dists = tuple(concatv(
+        link_dists = tuple(chain(
             link_dists[menuinst_idx:menuinst_idx+1],
             link_dists[:menuinst_idx],
             link_dists[menuinst_idx+1:],

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -9,9 +9,13 @@ from functools import lru_cache
 from logging import DEBUG, getLogger
 
 try:
-    from tlz.itertoolz import concat, groupby
+    from tlz.itertoolz import groupby
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, groupby
+    from conda._vendor.toolz.itertoolz import groupby
+
+import itertools
+
+concat = itertools.chain.from_iterable
 
 from .auxlib.decorators import memoizemethod
 from ._vendor.frozendict import FrozenOrderedDict as frozendict

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -23,9 +23,9 @@ from conda.models.prefix_graph import PrefixGraph
 from conda.history import History
 
 try:
-    from tlz.itertoolz import concatv, groupby
+    from tlz.itertoolz import concatv, groupby, unique
 except ImportError:  # pragma: no cover
-    from conda._vendor.toolz.itertoolz import concatv, groupby  # NOQA
+    from conda._vendor.toolz.itertoolz import concatv, groupby, unique  # NOQA
 
 
 VALID_KEYS = ('name', 'dependencies', 'prefix', 'channels', 'variables')
@@ -198,31 +198,6 @@ class Dependencies(OrderedDict):
     def add(self, package_name):
         self.raw.append(package_name)
         self.parse()
-
-
-def unique(seq, key=None):
-    """ Return only unique elements of a sequence
-    >>> tuple(unique((1, 2, 3)))
-    (1, 2, 3)
-    >>> tuple(unique((1, 2, 1, 3)))
-    (1, 2, 3)
-    Uniqueness can be defined by key keyword
-    >>> tuple(unique(['cat', 'mouse', 'dog', 'hen'], key=len))
-    ('cat', 'mouse')
-    """
-    seen = set()
-    seen_add = seen.add
-    if key is None:
-        for item in seq:
-            if item not in seen:
-                seen_add(item)
-                yield item
-    else:  # calculate key
-        for item in seq:
-            val = key(item)
-            if val not in seen:
-                seen_add(val)
-                yield item
 
 
 class Environment(object):

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -23,9 +23,9 @@ from conda.models.prefix_graph import PrefixGraph
 from conda.history import History
 
 try:
-    from tlz.itertoolz import concatv, groupby, unique
+    from tlz.itertoolz import groupby, unique
 except ImportError:  # pragma: no cover
-    from conda._vendor.toolz.itertoolz import concatv, groupby, unique  # NOQA
+    from conda._vendor.toolz.itertoolz import groupby, unique  # NOQA
 
 
 VALID_KEYS = ('name', 'dependencies', 'prefix', 'channels', 'variables')
@@ -108,13 +108,13 @@ def from_environment(name, prefix, no_builds=False, ignore_channels=False, from_
 
     precs = tuple(PrefixGraph(pd.iter_records()).graph)
     grouped_precs = groupby(lambda x: x.package_type, precs)
-    conda_precs = sorted(concatv(
+    conda_precs = sorted(chain(
         grouped_precs.get(None, ()),
         grouped_precs.get(PackageType.NOARCH_GENERIC, ()),
         grouped_precs.get(PackageType.NOARCH_PYTHON, ()),
     ), key=lambda x: x.name)
 
-    pip_precs = sorted(concatv(
+    pip_precs = sorted(chain(
         grouped_precs.get(PackageType.VIRTUAL_PYTHON_WHEEL, ()),
         grouped_precs.get(PackageType.VIRTUAL_PYTHON_EGG_MANAGEABLE, ()),
         grouped_precs.get(PackageType.VIRTUAL_PYTHON_EGG_UNMANAGEABLE, ()),


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

`itertools.chain()` is used since conda's arguments to `concatv` are never generators

Replace verbatim copy of toolz.unique with import.

See also https://github.com/conda/conda/issues/11698