### PR TITLE
Add `win-arm64` as a recognized platform

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -80,6 +80,7 @@ KNOWN_SUBDIRS = PLATFORM_DIRECTORIES = (
     "osx-arm64",
     "win-32",
     "win-64",
+    "win-arm64",
     "zos-z",
 )
 

--- a/conda/models/enums.py
+++ b/conda/models/enums.py
@@ -17,7 +17,7 @@ from ..exceptions import CondaUpgradeError
 class Arch(Enum):
     x86 = 'x86'
     x86_64 = 'x86_64'
-    # arm64 is for macOS only
+    # arm64 is for macOS and Windows
     arm64 = 'arm64'
     armv6l = 'armv6l'
     armv7l = 'armv7l'

--- a/news/11778-add-win-arm64
+++ b/news/11778-add-win-arm64
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `win-arm64` as a known platform (subdir)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Add `win-64` to the list of known platforms (subdirs) as a first step to addressing conda/conda#11472. 

### Checklist - did you ...

- [x] Add a file to the `news` directory?
- [ ] Add / update necessary tests? - Declined; currently (public) systems for us to perform CI on.
- [ ] Add / update outdated documentation? - Declined; currently no actual packages for this platform, so we don't necessarily want to publicly broadcast its availability.