### PR TITLE
Bring `get_plugin_manager` inline to `conda.base.context`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -155,14 +155,6 @@ def ssl_verify_validation(value):
     return True
 
 
-@functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache
-def get_plugin_manager():
-    pm = pluggy.PluginManager('conda')
-    pm.add_hookspecs(plugins)
-    pm.load_setuptools_entrypoints('conda')
-    return pm
-
-
 class Context(Configuration):
 
     add_pip_as_python_dependency = ParameterLoader(PrimitiveParameter(True))
@@ -398,13 +390,13 @@ class Context(Configuration):
         super(Context, self).__init__(search_path=search_path, app_name=APP_NAME,
                                       argparse_args=argparse_args)
 
-        # Add plugin support
-        self._plugin_manager = get_plugin_manager()
-
     @property
     @functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache
     def plugin_manager(self):
-        return self._plugin_manager
+        pm = pluggy.PluginManager("conda")
+        pm.add_hookspecs(plugins)
+        pm.load_setuptools_entrypoints("conda")
+        return pm
 
     def post_build_validation(self):
         errors = []


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Since the `get_plugin_manager` isn't called directly, let's just fold the entire implementation into the `context` object.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
