### PR TITLE
download and extract packages in a thread pool

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -198,7 +198,8 @@ class ProgressFileWrapper(object):
 
 
 def extract_tarball(tarball_full_path, destination_directory=None, progress_update_callback=None):
-    import conda_package_handling.api
+    # requires version >= 0.4.0 (unreleased as of 2022-09-08)
+    import conda_package_streaming.extract
 
     if destination_directory is None:
         if tarball_full_path[-8:] == CONDA_PACKAGE_EXTENSION_V1:
@@ -215,16 +216,19 @@ def extract_tarball(tarball_full_path, destination_directory=None, progress_upda
         log.debug("package folder %s was not empty, but we're writing there.",
                   destination_directory)
 
-    conda_package_handling.api.extract(tarball_full_path, dest_dir=destination_directory)
+    conda_package_streaming.extract.extract(tarball_full_path, dest_dir=destination_directory)
 
-    if sys.platform.startswith('linux') and os.getuid() == 0:
-        # When extracting as root, tarfile will by restore ownership
-        # of extracted files.  However, we want root to be the owner
-        # (our implementation of --no-same-owner).
-        for root, dirs, files in os.walk(destination_directory):
-            for fn in files:
-                p = join(root, fn)
-                os.lchown(p, 0, 0)
+    if False:
+        # Handled by conda_package_streaming already, with old "no libarchive" conda-package-handling code
+        # XXX better there, or here in this conda-specific location?
+        if sys.platform.startswith('linux') and os.getuid() == 0:
+            # When extracting as root, tarfile will by restore ownership
+            # of extracted files.  However, we want root to be the owner
+            # (our implementation of --no-same-owner).
+            for root, dirs, files in os.walk(destination_directory):
+                for fn in files:
+                    p = join(root, fn)
+                    os.lchown(p, 0, 0)
 
 
 def make_menu(prefix, file_path, remove=False):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Conda download and extract is aggressively single-threaded. Make it parallel. For #11608

See also https://github.com/dholth/conda-benchmarks/blob/main/benchmarks/conda_install.py#L42

Requires `pip install git+https://github.com/conda-incubator/conda-package-streaming#egg=conda-package-streaming` (released version does not include extract API); older libarchive-based extractor appears to be not threadsafe? (it uses `os.chdir()` for example)

The tests are difficult, it is very easy to accidentally time "packages already cached" as conda likes to look in a number of cache directories.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
