### PR TITLE
Move `get_plugin_manager` to `conda.plugins`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -5,14 +5,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import OrderedDict
 
-import functools
 from errno import ENOENT
 from functools import lru_cache
 from logging import getLogger
 import os
 from os.path import abspath, basename, expanduser, isdir, isfile, join, split as path_split
 import platform
-import pluggy
 import sys
 import struct
 from contextlib import contextmanager
@@ -63,8 +61,6 @@ from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..common.decorators import env_override
 
 from .. import CONDA_SOURCE_ROOT
-
-from .. import plugins
 
 try:
     os.getcwd()
@@ -153,14 +149,6 @@ def ssl_verify_validation(value):
                     "certificate bundle file, or a path to a directory containing "
                     "certificates of trusted CAs." % value)
     return True
-
-
-@functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache
-def get_plugin_manager():
-    pm = pluggy.PluginManager('conda')
-    pm.add_hookspecs(plugins)
-    pm.load_setuptools_entrypoints('conda')
-    return pm
 
 
 class Context(Configuration):
@@ -397,14 +385,6 @@ class Context(Configuration):
 
         super(Context, self).__init__(search_path=search_path, app_name=APP_NAME,
                                       argparse_args=argparse_args)
-
-        # Add plugin support
-        self._plugin_manager = get_plugin_manager()
-
-    @property
-    @functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache
-    def plugin_manager(self):
-        return self._plugin_manager
 
     def post_build_validation(self):
         errors = []

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -21,8 +21,8 @@ from textwrap import dedent
 import warnings
 
 from .. import __version__
+from .. import plugins
 from ..auxlib.ish import dals
-from ..base import context
 from ..base.constants import COMPATIBLE_SHELLS, CONDA_HOMEPAGE_URL, DepsModifier, \
     UpdateModifier, ExperimentalSolverChoice
 from ..common.constants import NULL
@@ -120,11 +120,10 @@ class ArgumentParser(ArgumentParserBase):
         if self.description:
             self.description += "\n\nOptions:\n"
 
-        pm = context.get_plugin_manager()
         self._subcommands = sorted(
             (
                 subcommand
-                for subcommands in pm.hook.conda_subcommands()
+                for subcommands in plugins.manager.hook.conda_subcommands()
                 for subcommand in subcommands
             ),
             key=lambda subcommand: subcommand.name,

--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -5,34 +5,12 @@ from __future__ import annotations
 
 import pluggy
 
-from typing import Callable, NamedTuple, Optional
-from collections.abc import Iterable
+from . import specs
+from .specs import CondaSubcommand  # noqa: F401
 
 
-_hookspec = pluggy.HookspecMarker("conda")
 register = pluggy.HookimplMarker("conda")
 
-
-class CondaSubcommand(NamedTuple):
-    """
-    Conda subcommand entry.
-
-    :param name: Subcommand name (e.g., ``conda my-subcommand-name``).
-    :param summary: Subcommand summary, will be shown in ``conda --help``.
-    :param action: Callable that will be run when the subcommand is invoked.
-    """
-    name: str
-    summary: str
-    action: Callable[
-        [list[str]],  # arguments
-        Optional[int],  # return code
-    ]
-
-
-@_hookspec
-def conda_subcommands() -> Iterable[CondaSubcommand]:
-    """
-    Register external subcommands in conda.
-
-    :return: An iterable of subcommand entries.
-    """
+manager = pluggy.PluginManager("conda")
+manager.add_hookspecs(specs)
+manager.load_setuptools_entrypoints("conda")

--- a/conda/plugins/specs.py
+++ b/conda/plugins/specs.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import pluggy
+
+from typing import Callable, NamedTuple, Optional
+from collections.abc import Iterable
+
+
+_hookspec = pluggy.HookspecMarker("conda")
+
+
+class CondaSubcommand(NamedTuple):
+    """
+    Conda subcommand entry.
+
+    :param name: Subcommand name (e.g., ``conda my-subcommand-name``).
+    :param summary: Subcommand summary, will be shown in ``conda --help``.
+    :param action: Callable that will be run when the subcommand is invoked.
+    """
+
+    name: str
+    summary: str
+    action: Callable[
+        [list[str]],  # arguments
+        Optional[int],  # return code
+    ]
+
+
+@_hookspec
+def conda_subcommands() -> Iterable[CondaSubcommand]:
+    """
+    Register external subcommands in conda.
+
+    :return: An iterable of subcommand entries.
+    """

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -12,10 +12,13 @@ from conda import plugins
 
 @pytest.fixture
 def plugin_manager(mocker):
-    pm = pluggy.PluginManager('conda')
-    pm.add_hookspecs(plugins)
-    mocker.patch('conda.base.context.get_plugin_manager', return_value=pm)
-    return pm
+    manager = pluggy.PluginManager("conda")
+    manager.add_hookspecs(plugins.specs)
+    mocker.patch(
+        "conda.plugins.manager",
+        manager,
+    )
+    return manager
 
 
 @pytest.fixture

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -6,10 +6,6 @@ from conda import plugins
 
 
 class SubcommandPlugin:
-    def __init__(self):
-        self.invoked = False
-        self.args = None
-
     def custom_command(self, args):
         pass
 
@@ -31,7 +27,10 @@ def plugin(mocker, plugin_manager):
     return plugin
 
 
-def test_invoked(plugin, cli_main):
+def test_invoked(plugin_manager, plugin, cli_main):
+    print(plugin_manager)
+    print(plugins.manager)
+
     cli_main('custom', 'some-arg', 'some-other-arg')
 
     plugin.custom_command.assert_called_with(['some-arg', 'some-other-arg'])


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

An alternative solution to #11785. Keeps all plugin/pluggy related content within the plugin submodule.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
