### PR TITLE
Provide a way to override condarc search path: `CONDA_NO_CONFIG_SEARCH_PATH`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -366,7 +366,7 @@ class Context(Configuration):
 
     def __init__(self, search_path=None, argparse_args=None):
         if search_path is None:
-            user_search_path = os.environ.get("CONDA_RC_SEARCH_PATH")
+            user_search_path = os.environ.get("CONDA_CONFIG_SEARCH_PATH")
             if user_search_path:
                 # defined and not empty -> split by : or ; and use
                 search_path = user_search_path.split(os.pathsep)

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -366,7 +366,10 @@ class Context(Configuration):
 
     def __init__(self, search_path=None, argparse_args=None):
         if search_path is None:
-            search_path = SEARCH_PATH
+            if os.environ.get("NO_CONDARC"):
+                search_path = ()
+            else:
+                search_path = SEARCH_PATH
 
         if argparse_args:
             # This block of code sets CONDA_PREFIX based on '-n' and '-p' flags, so that
@@ -1593,7 +1596,7 @@ def conda_in_private_env():
     return env_name == '_conda_' and basename(envs_dir) == 'envs'
 
 
-def reset_context(search_path=SEARCH_PATH, argparse_args=None):
+def reset_context(search_path=None, argparse_args=None):
     global context
     context.__init__(search_path, argparse_args)
     context.__dict__.pop('_Context__conda_build', None)
@@ -1604,7 +1607,7 @@ def reset_context(search_path=SEARCH_PATH, argparse_args=None):
 
 
 @contextmanager
-def fresh_context(env=None, search_path=SEARCH_PATH, argparse_args=None, **kwargs):
+def fresh_context(env=None, search_path=None, argparse_args=None, **kwargs):
     if env or kwargs:
         old_env = os.environ.copy()
         os.environ.update(env or {})

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -366,16 +366,10 @@ class Context(Configuration):
 
     def __init__(self, search_path=None, argparse_args=None):
         if search_path is None:
-            user_search_path = os.environ.get("CONDA_CONFIG_SEARCH_PATH")
-            if user_search_path:
-                # defined and not empty -> split by : or ; and use
-                search_path = user_search_path.split(os.pathsep)
-            elif user_search_path is None:
-                # not defined, we fall back to our hardcoded default
-                search_path = SEARCH_PATH
+            if os.environ.get("CONDA_NO_CONFIG_SEARCH_PATH"):
+                search_path = ("$CONDARC",)
             else:
-                # defined, but empty -> no search path!
-                search_path = ()
+                search_path = SEARCH_PATH
 
         if argparse_args:
             # This block of code sets CONDA_PREFIX based on '-n' and '-p' flags, so that

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -366,10 +366,16 @@ class Context(Configuration):
 
     def __init__(self, search_path=None, argparse_args=None):
         if search_path is None:
-            if os.environ.get("NO_CONDARC"):
-                search_path = ()
-            else:
+            user_search_path = os.environ.get("CONDA_RC_SEARCH_PATH")
+            if user_search_path:
+                # defined and not empty -> split by : or ; and use
+                search_path = user_search_path.split(os.pathsep)
+            elif user_search_path is None:
+                # not defined, we fall back to our hardcoded default
                 search_path = SEARCH_PATH
+            else:
+                # defined, but empty -> no search path!
+                search_path = ()
 
         if argparse_args:
             # This block of code sets CONDA_PREFIX based on '-n' and '-p' flags, so that

--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -152,11 +152,9 @@ to $HOME/.config should be used.
 ``CONDA_ROOT`` is the path for your base conda install.
 ``CONDA_PREFIX`` is the path to the current active environment.
 
-The default ``condarc`` search path can be overriden by setting a ``CONDA_CONFIG_SEARCH_PATH``
-environment variable to a colon (Unix) or semicolon (Windows) separated list of paths.
-Each path can be either a YAML config file or directories containing YAML files.
-Paths can contain environment variables (always with ``$VARIABLE`` or ``${VARIABLE}`` syntax),
-which will be expanded.
+The default ``SEARCH_PATH`` list can be ignored by setting the
+``CONDA_NO_CONFIG_SEARCH_PATH`` environment variable to a non-empty value. 
+In this mode, only the location specified by ``$CONDARC`` (if set) is searched.
 
 Conflict merging strategy
 -------------------------

--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -153,7 +153,7 @@ to $HOME/.config should be used.
 ``CONDA_PREFIX`` is the path to the current active environment.
 
 The default ``SEARCH_PATH`` list can be ignored by setting the
-``CONDA_NO_CONFIG_SEARCH_PATH`` environment variable to a non-empty value. 
+``CONDA_NO_CONFIG_SEARCH_PATH`` environment variable to a non-empty value.
 In this mode, only the location specified by ``$CONDARC`` (if set) is searched.
 
 Conflict merging strategy

--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -152,6 +152,9 @@ to $HOME/.config should be used.
 ``CONDA_ROOT`` is the path for your base conda install.
 ``CONDA_PREFIX`` is the path to the current active environment.
 
+The ``condarc`` search path can be overriden completely by setting a ``NO_CONDARC``
+environment variable to any non-empty value.
+
 Conflict merging strategy
 -------------------------
 When conflicts between configurations arise, the following strategies are employed:

--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -152,8 +152,11 @@ to $HOME/.config should be used.
 ``CONDA_ROOT`` is the path for your base conda install.
 ``CONDA_PREFIX`` is the path to the current active environment.
 
-The ``condarc`` search path can be overriden completely by setting a ``NO_CONDARC``
-environment variable to any non-empty value.
+The default ``condarc`` search path can be overriden by setting a ``CONDA_RC_SEARCH_PATH``
+environment variable to a colon (Unix) or semicolon (Windows) separated list of paths.
+Each path can be either a YAML config file or directories containing YAML files.
+Paths can contain environment variables (always with ``$VARIABLE`` or ``${VARIABLE}`` syntax),
+which will be expanded.
 
 Conflict merging strategy
 -------------------------

--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -152,7 +152,7 @@ to $HOME/.config should be used.
 ``CONDA_ROOT`` is the path for your base conda install.
 ``CONDA_PREFIX`` is the path to the current active environment.
 
-The default ``condarc`` search path can be overriden by setting a ``CONDA_RC_SEARCH_PATH``
+The default ``condarc`` search path can be overriden by setting a ``CONDA_CONFIG_SEARCH_PATH``
 environment variable to a colon (Unix) or semicolon (Windows) separated list of paths.
 Each path can be either a YAML config file or directories containing YAML files.
 Paths can contain environment variables (always with ``$VARIABLE`` or ``${VARIABLE}`` syntax),

--- a/news/11838-no-condarc
+++ b/news/11838-no-condarc
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Setting `NO_CONDARC` will allow `conda` to run without loading any file-based configuration (#11838)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/11838-no-condarc
+++ b/news/11838-no-condarc
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* The `CONDA_CONFIG_SEARCH_PATH` environment variable will allow users to override the default `condarc` search path. If set to an empty string, it will disable file-based configuration (#11838)
+* The `CONDA_NO_CONFIG_SEARCH_PATH` environment variable will allow users to override the default `condarc` search path. If set to a non-empty string, it will only search for the location specified by `$CONDARC`, if any. (#11838)
 
 ### Bug fixes
 

--- a/news/11838-no-condarc
+++ b/news/11838-no-condarc
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Setting `NO_CONDARC` will allow `conda` to run without loading any file-based configuration (#11838)
+* The `CONDA_RC_SEARCH_PATH` environment variable will allow users to override the default `condarc` search path. If set to an empty string, it will disable file-based configuration loading. (#11838)
 
 ### Bug fixes
 

--- a/news/11838-no-condarc
+++ b/news/11838-no-condarc
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* The `CONDA_RC_SEARCH_PATH` environment variable will allow users to override the default `condarc` search path. If set to an empty string, it will disable file-based configuration loading. (#11838)
+* The `CONDA_CONFIG_SEARCH_PATH` environment variable will allow users to override the default `condarc` search path. If set to an empty string, it will disable file-based configuration (#11838)
 
 ### Bug fixes
 

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -564,13 +564,13 @@ def test_condarc_search_path_override(tmpdir):
         reset_context()
         assert "uniquely_named_channel" in context.channels
 
-        # $CONDA_RC_SEARCH_PATH overrides the default search path, but
+        # $CONDA_CONFIG_SEARCH_PATH overrides the default search path,
         # but we can still include CONDARC in that path :)
-        with env_var("CONDA_RC_SEARCH_PATH", "$CONDARC"):
+        with env_var("CONDA_CONFIG_SEARCH_PATH", "$CONDARC"):
             reset_context()
             assert "uniquely_named_channel" in context.channels
 
         # If we set it to the empty string, then no file will be loaded
-        with env_var("CONDA_RC_SEARCH_PATH", ""):
+        with env_var("CONDA_CONFIG_SEARCH_PATH", ""):
             reset_context()
             assert "uniquely_named_channel" not in context.channels

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -547,3 +547,24 @@ def test_validate_prefix_name(prefix, allow_base, mock_return_values, expected):
         else:
             actual = validate_prefix_name(prefix, ctx, allow_base=allow_base)
             assert actual == str(expected)
+
+
+def test_condarc_search_path_override(tmpdir):
+    custom_condarc = os.path.join(tmpdir, "condarc")
+    with open(custom_condarc, "w") as f:
+        f.write(
+            dals(
+                """
+                channels: ["uniquely_named_channel"]
+                """
+            )
+        )
+    # $CONDARC allows us to add one more file or directory to the search path
+    with env_var("CONDARC", custom_condarc):
+        reset_context()
+        assert "uniquely_named_channel" in context.channels
+
+        # NO_CONDARC overrides all config loading from any file, CONDARC incl.
+        with env_var("NO_CONDARC", "1"):
+            reset_context()
+            assert "uniquely_named_channel" not in context.channels

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -564,7 +564,13 @@ def test_condarc_search_path_override(tmpdir):
         reset_context()
         assert "uniquely_named_channel" in context.channels
 
-        # NO_CONDARC overrides all config loading from any file, CONDARC incl.
-        with env_var("NO_CONDARC", "1"):
+        # $CONDA_RC_SEARCH_PATH overrides the default search path, but
+        # but we can still include CONDARC in that path :)
+        with env_var("CONDA_RC_SEARCH_PATH", "$CONDARC"):
+            reset_context()
+            assert "uniquely_named_channel" in context.channels
+
+        # If we set it to the empty string, then no file will be loaded
+        with env_var("CONDA_RC_SEARCH_PATH", ""):
             reset_context()
             assert "uniquely_named_channel" not in context.channels

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -565,12 +565,12 @@ def test_condarc_search_path_override(tmpdir):
         assert "uniquely_named_channel" in context.channels
 
         # $CONDA_CONFIG_SEARCH_PATH overrides the default search path,
-        # but we can still include CONDARC in that path :)
-        with env_var("CONDA_CONFIG_SEARCH_PATH", "$CONDARC"):
+        # only respecting the location of $CONDARC, if set
+        with env_var("CONDA_NO_CONFIG_SEARCH_PATH"):
             reset_context()
             assert "uniquely_named_channel" in context.channels
 
-        # If we set it to the empty string, then no file will be loaded
-        with env_var("CONDA_CONFIG_SEARCH_PATH", ""):
-            reset_context()
-            assert "uniquely_named_channel" not in context.channels
+    # Without $CONDARC, no config file is loaded
+    with env_var("CONDA_NO_CONFIG_SEARCH_PATH", ""):
+        reset_context()
+        assert "uniquely_named_channel" not in context.channels


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Some uses of `conda` require working in absolute isolation from user configurations. One example is conda-standalone as used in `constructor`.

Some issues originating from this problem can be found here: https://github.com/conda/constructor/issues/568. 

The solution is simple: in the presence of a non-empty `NO_CONDARC` environment variable, the default search path is overridden and thus no configuration is loaded from disk, at all. 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

Closes https://github.com/conda/constructor/issues/542

Questions: 

* An alternative solution to this problem would be exposing `CONDA_SEARCH_PATH` as a configurable list. Maybe not linked directly in the context object (bootstrapping issue). Instead of using `NO_CONDARC`, the user could set `CONDA_SEARCH_PATH=""`, achieving the same effect. This would be more flexible but also confusing and unneeded?