### PR TITLE
Add comment to explain .bashrc vs .bash_profile

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -452,6 +452,13 @@ def make_initialize_plan(conda_prefix, shells, for_user, for_system, anaconda_pr
     shells = set(shells)
     if shells & {'bash', 'zsh'}:
         if 'bash' in shells and for_user:
+            # On Linux, when opening the terminal, .bashrc is sourced (because it is an
+            # interactive shell).
+            # On macOS on the other hand, the .bash_profile gets sourced by default when executing
+            # it in Terminal.app. Some other programs do the same on macOS so that's why we're
+            # initializing conda in .bash_profile.
+            # On Windows, there are multiple ways to open bash depending on how it was installed.
+            # Git Bash, Cygwin, and MSYS2 all use .bash_profile by default.
             bashrc_path = expand(join('~', '.bash_profile' if (on_mac or on_win) else '.bashrc'))
             plan.append({
                 'function': init_sh_user.__name__,

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -451,7 +451,7 @@ def make_initialize_plan(conda_prefix, shells, for_user, for_system, anaconda_pr
     """
     Creates a plan for initializing conda in shells.
 
-    Bash: 
+    Bash:
     On Linux, when opening the terminal, .bashrc is sourced (because it is an interactive shell).
     On macOS on the other hand, the .bash_profile gets sourced by default when executing it in
     Terminal.app. Some other programs do the same on macOS so that's why we're initializing conda

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -448,17 +448,26 @@ def make_install_plan(conda_prefix):
 
 def make_initialize_plan(conda_prefix, shells, for_user, for_system, anaconda_prompt,
                          reverse=False):
+    """
+    Creates a plan for initializing conda in shells.
+
+    Bash: 
+    On Linux, when opening the terminal, .bashrc is sourced (because it is an interactive shell).
+    On macOS on the other hand, the .bash_profile gets sourced by default when executing it in
+    Terminal.app. Some other programs do the same on macOS so that's why we're initializing conda
+    in .bash_profile.
+    On Windows, there are multiple ways to open bash depending on how it was installed. Git Bash,
+    Cygwin, and MSYS2 all use .bash_profile by default.
+
+    PowerShell:
+    There's several places PowerShell can store its path, depending on if it's Windows PowerShell,
+    PowerShell Core on Windows, or PowerShell Core on macOS/Linux. The easiest way to resolve it
+    is to just ask different possible installations of PowerShell where their profiles are.
+    """
     plan = make_install_plan(conda_prefix)
     shells = set(shells)
     if shells & {'bash', 'zsh'}:
         if 'bash' in shells and for_user:
-            # On Linux, when opening the terminal, .bashrc is sourced (because it is an
-            # interactive shell).
-            # On macOS on the other hand, the .bash_profile gets sourced by default when executing
-            # it in Terminal.app. Some other programs do the same on macOS so that's why we're
-            # initializing conda in .bash_profile.
-            # On Windows, there are multiple ways to open bash depending on how it was installed.
-            # Git Bash, Cygwin, and MSYS2 all use .bash_profile by default.
             bashrc_path = expand(join('~', '.bash_profile' if (on_mac or on_win) else '.bashrc'))
             plan.append({
                 'function': init_sh_user.__name__,
@@ -563,11 +572,6 @@ def make_initialize_plan(conda_prefix, shells, for_user, for_system, anaconda_pr
         if for_system:
             profile = '$PROFILE.AllUsersAllHosts'
 
-        # There's several places PowerShell can store its path, depending
-        # on if it's Windows PowerShell, PowerShell Core on Windows, or
-        # PowerShell Core on macOS/Linux. The easiest way to resolve it is to
-        # just ask different possible installations of PowerShell where their
-        # profiles are.
         def find_powershell_paths(*exe_names):
             for exe_name in exe_names:
                 try:

--- a/news/11839-document-bashrc-bashprofile
+++ b/news/11839-document-bashrc-bashprofile
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Added a comment to the code that explains why .bashrc is modified on Linux and .bash_profile is modified on Windows/macOS when executing `conda init`.

--- a/news/11839-document-bashrc-bashprofile
+++ b/news/11839-document-bashrc-bashprofile
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Added a comment to the code that explains why .bashrc is modified on Linux and .bash_profile is modified on Windows/macOS when executing `conda init`.
+* Added a comment to the code that explains why .bashrc is modified on Linux and .bash_profile is modified on Windows/macOS when executing `conda init`. (#11849)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR adds a comment explaining why `.bashrc` gets modified on Linux and why `.bash_profile` gets modified on macOS + Windows instead when executing `conda init`.

Closes #11830 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
