### PR TITLE
Allow `conda init --dev` to output to either fd or tmp

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,10 +5,12 @@ tasks:
       mkdir -p .vscode
       echo '{"python.pythonPath": "/opt/conda/bin/python"}' > .vscode/settings.json
       git tag "$(git tag --sort=committerdate | tail -1).dev"
-      eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+      SCRIPT="$(sudo /opt/conda/bin/python -m conda init bash --dev --fd 3 3>&1 >&4)" 4>&1
+      eval "${SCRIPT}" >/dev/null
       sudo su root -c "/opt/conda/bin/conda install -yq conda-build"
     command: |
-      eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+      SCRIPT="$(sudo /opt/conda/bin/python -m conda init bash --dev --fd 3 3>&1 >&4)" 4>&1
+      eval "${SCRIPT}" >/dev/null
 
 vscode:
   extensions:

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -14,6 +14,7 @@ from argparse import (
 from logging import getLogger
 import os
 from os.path import abspath, expanduser, join
+from pathlib import Path
 from subprocess import Popen
 import sys
 from textwrap import dedent
@@ -698,7 +699,6 @@ def configure_parser_create(sub_parsers):
 def configure_parser_init(sub_parsers):
     help = "Initialize conda for shell interaction."
     descr = help
-
     epilog = dals(
         """
         Key parts of conda's functionality require that it interact directly with the shell
@@ -720,25 +720,6 @@ def configure_parser_init(sub_parsers):
         """
     )
 
-    # dev_example = dedent("""
-    #     # An example for creating an environment to develop on conda's own code. Clone the
-    #     # conda repo and install a dedicated miniconda within it. Remove all remnants of
-    #     # conda source files in the `site-packages` directory associated with
-    #     # `~/conda/devenv/bin/python`. Write a `conda.pth` file in that `site-packages`
-    #     # directory pointing to source code in `~/conda`, the current working directory.
-    #     # Write commands to stdout, suitable for bash `eval`, that sets up the current
-    #     # shell as a dev environment.
-    #
-    #         $ CONDA_PROJECT_ROOT="~/conda"
-    #         $ git clone git@github.com:conda/conda "$CONDA_PROJECT_ROOT"
-    #         $ cd "$CONDA_PROJECT_ROOT"
-    #         $ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-    #         $ bash Miniconda3-latest-Linux-x86_64.sh -bfp ./devenv
-    #         $ eval "$(./devenv/bin/python -m conda init --dev bash)"
-    #
-    #
-    # """)
-
     p = sub_parsers.add_parser(
         'init',
         description=descr,
@@ -749,8 +730,21 @@ def configure_parser_init(sub_parsers):
     p.add_argument(
         "--dev",
         action="store_true",
-        help=SUPPRESS,
+        help="Initialize in the current shell only.",
         default=NULL,
+    )
+    dev_piping_group = p.add_mutually_exclusive_group()
+    dev_piping_group.add_argument(
+        "--fd",
+        type=int,
+        help="When --dev is specified use --fd to pipe to a file descriptor besides stdout.",
+        default=None,
+    )
+    dev_piping_group.add_argument(
+        "--tmp",
+        type=Path,
+        help="When --dev is specified use --tmp to write to a temporary file instead of stdout.",
+        default=None,
     )
 
     p.add_argument(

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -25,7 +25,7 @@ def execute(args, parser):
     if args.dev:
         if len(selected_shells) != 1:
             raise ArgumentError("--dev can only handle one shell at a time right now")
-        return initialize_dev(selected_shells[0])
+        return initialize_dev(selected_shells[0], fd=args.fd, tmp=args.tmp)
 
     else:
         for_user = args.user

--- a/dev/linux/bashrc.sh
+++ b/dev/linux/bashrc.sh
@@ -3,7 +3,10 @@
 echo "Initializing conda in dev mode..."
 echo "Factory config is:"
 grep -e "conda location" -e "conda version" -e "python version" <(conda info -a) | sed 's/^\s*/  /'
-eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+
+# TODO: once #11865 is merged this can be updated
+SCRIPT="$(sudo conda init bash --dev)"
+eval "${SCRIPT}" >/dev/null
 if [[ $RUNNING_ON_DEVCONTAINER == 1 ]]; then
     conda init
 fi

--- a/dev/linux/bashrc.sh
+++ b/dev/linux/bashrc.sh
@@ -5,8 +5,7 @@ echo "Factory config is:"
 grep -e "conda location" -e "conda version" -e "python version" <(conda info -a) | sed 's/^\s*/  /'
 
 # TODO: once #11865 is merged this can be updated
-SCRIPT="$(sudo conda init bash --dev)"
-eval "${SCRIPT}" >/dev/null
+eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
 if [[ $RUNNING_ON_DEVCONTAINER == 1 ]]; then
     conda init
 fi

--- a/dev/linux/integration.sh
+++ b/dev/linux/integration.sh
@@ -6,12 +6,11 @@ TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
 # TODO: once #11865 is merged this can be updated
-SCRIPT="$(sudo /opt/conda/bin/conda init bash --dev)"
-eval "${SCRIPT}" >/dev/null
+eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
 conda info
 conda clean -ayq
 
-sudo /opt/conda/bin/conda install -yq conda-build
+sudo su root -c "/opt/conda/bin/conda install -yq conda-build"
 # TODO: make this a pytest fixture
 conda build tests/test-recipes/activate_deactivate_package tests/test-recipes/pre_link_messages_package
 

--- a/dev/linux/integration.sh
+++ b/dev/linux/integration.sh
@@ -5,9 +5,15 @@ set -o errtrace -o pipefail -o errexit
 TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
-sudo su root -c "/opt/conda/bin/conda install -yq conda-build"
-eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
-conda-build tests/test-recipes/activate_deactivate_package tests/test-recipes/pre_link_messages_package
+# TODO: once #11865 is merged this can be updated
+SCRIPT="$(sudo /opt/conda/bin/conda init bash --dev)"
+eval "${SCRIPT}" >/dev/null
 conda info
+conda clean -ayq
+
+sudo /opt/conda/bin/conda install -yq conda-build
+# TODO: make this a pytest fixture
+conda build tests/test-recipes/activate_deactivate_package tests/test-recipes/pre_link_messages_package
+
 pytest -m "integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
 python -m conda.common.io

--- a/dev/linux/unit.sh
+++ b/dev/linux/unit.sh
@@ -5,8 +5,10 @@ set -o errtrace -o pipefail -o errexit
 TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
-eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
+# TODO: once #11865 is merged this can be updated
+SCRIPT="$(sudo /opt/conda/bin/conda init bash --dev)"
+eval "${SCRIPT}" >/dev/null
 conda info
-# remove the pkg cache.  We can't hardlink from here anyway.  Having it around causes log problems.
-sudo rm -rf /opt/conda/pkgs/*-*-*
+conda clean -ayq
+
 pytest -m "not integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}

--- a/dev/linux/unit.sh
+++ b/dev/linux/unit.sh
@@ -6,8 +6,7 @@ TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
 # TODO: once #11865 is merged this can be updated
-SCRIPT="$(sudo /opt/conda/bin/conda init bash --dev)"
-eval "${SCRIPT}" >/dev/null
+eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
 conda info
 conda clean -ayq
 

--- a/dev/macos/integration.sh
+++ b/dev/macos/integration.sh
@@ -5,8 +5,15 @@ set -o errtrace -o pipefail -o errexit
 TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
-eval "$(sudo python -m conda init bash --dev)"
+# TODO: once #11865 is merged this can be updated
+SCRIPT="$(sudo /Users/runner/miniconda3/bin/conda init bash --dev)"
+eval "${SCRIPT}" >/dev/null
 conda info
+conda clean -ayq
+
+sudo /Users/runner/miniconda3/bin/conda install -yq conda-build
+# TODO: make this a pytest fixture
 conda-build tests/test-recipes/activate_deactivate_package
+
 pytest -m "integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
 python -m conda.common.io

--- a/dev/macos/integration.sh
+++ b/dev/macos/integration.sh
@@ -6,12 +6,11 @@ TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
 # TODO: once #11865 is merged this can be updated
-SCRIPT="$(sudo /Users/runner/miniconda3/bin/conda init bash --dev)"
-eval "${SCRIPT}" >/dev/null
+eval "$(sudo python -m conda init bash --dev)"
 conda info
 conda clean -ayq
 
-sudo /Users/runner/miniconda3/bin/conda install -yq conda-build
+sudo su root -c "python -m conda install -yq conda-build"
 # TODO: make this a pytest fixture
 conda-build tests/test-recipes/activate_deactivate_package
 

--- a/dev/macos/unit.sh
+++ b/dev/macos/unit.sh
@@ -5,6 +5,10 @@ set -o errtrace -o pipefail -o errexit
 TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
-eval "$(sudo python -m conda init bash --dev)"
+# TODO: once #11865 is merged this can be updated
+SCRIPT="$(sudo /Users/runner/miniconda3/bin/conda init bash --dev)"
+eval "${SCRIPT}" >/dev/null
 conda info
+conda clean -ayq
+
 pytest -m "not integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}

--- a/dev/macos/unit.sh
+++ b/dev/macos/unit.sh
@@ -6,8 +6,7 @@ TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
 # TODO: once #11865 is merged this can be updated
-SCRIPT="$(sudo /Users/runner/miniconda3/bin/conda init bash --dev)"
-eval "${SCRIPT}" >/dev/null
+eval "$(sudo python -m conda init bash --dev)"
 conda info
 conda clean -ayq
 

--- a/dev/start
+++ b/dev/start
@@ -26,6 +26,7 @@ cleanup() {
     unset _NAME
     unset _PYTHON
     unset _PYTHONEXE
+    unset _SCRIPT
     unset _SRC
     unset _UPDATE
     unset _UPDATED
@@ -258,7 +259,8 @@ echo "Initializing shell integration..."
 _AUTOBASE="${CONDA_AUTO_ACTIVATE_BASE:-undefined}"
 _EXPORTED="$(export -p | grep CONDA_AUTO_ACTIVATE_BASE)"
 export CONDA_AUTO_ACTIVATE_BASE=false
-eval "$(cd "${_SRC}" ; "${_ENVEXE}" init --dev bash)" > /dev/null
+_SCRIPT="$(cd "${_SRC}" ; "${_ENVEXE}" init bash --dev --fd 3 3>&1 >&4)" 4>&1
+eval "${_SCRIPT}" >/dev/null
 if [ "${_AUTOBASE}" = "undefined" ]; then
     unset CONDA_AUTO_ACTIVATE_BASE
 elif [ -n ${_EXPORTED+x} ]; then

--- a/dev/start.bat
+++ b/dev/start.bat
@@ -165,7 +165,7 @@
     @SET "_AUTOBASE=%CONDA_AUTO_ACTIVATE_BASE%"
 )
 @SET "CONDA_AUTO_ACTIVATE_BASE=false"
-@CALL :CONDA "%_ENVEXE%" init --dev cmd.exe > NUL
+@CALL :CONDA "%_ENVEXE%" init cmd.exe --dev --tmp dev-init.bat > NUL
 @CALL dev-init.bat > NUL
 @IF "%_AUTOBASE%"=="undefined" (
     @SET CONDA_AUTO_ACTIVATE_BASE=

--- a/dev/start.bat
+++ b/dev/start.bat
@@ -165,7 +165,7 @@
     @SET "_AUTOBASE=%CONDA_AUTO_ACTIVATE_BASE%"
 )
 @SET "CONDA_AUTO_ACTIVATE_BASE=false"
-@CALL :CONDA "%_ENVEXE%" init cmd.exe --dev --tmp dev-init.bat > NUL
+@CALL :CONDA "%_ENVEXE%" init --dev cmd.exe --tmp dev-init.bat > NUL
 @CALL dev-init.bat > NUL
 @IF "%_AUTOBASE%"=="undefined" (
     @SET CONDA_AUTO_ACTIVATE_BASE=

--- a/dev/windows/setup.bat
+++ b/dev/windows/setup.bat
@@ -19,7 +19,7 @@ CALL conda create -n conda-test-env -y python=%PYTHON% pywin32 --file=tests\requ
 CALL conda activate conda-test-env || goto :error
 CALL conda update openssl ca-certificates certifi || goto :error
 python -m conda init --install || goto :error
-python -m conda init cmd.exe --dev || goto :error
+python -m conda init cmd.exe --dev --tmp dev-init.bat || goto :error
 
 :: Download minio server needed for S3 tests and place it in our conda environment so is in PATH
 :: certutil somehow is able to download arbitrary files; don't aske me why: https://superuser.com/a/1545689

--- a/news/11865-adding-fd-tmp-options
+++ b/news/11865-adding-fd-tmp-options
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `--fd` and `--tmp` options (file descriptor and temporary file respectively) to `conda init --dev` so it'll be easier to control how/where to receive the generated script. (#11865)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Expose controlling where `conda init --dev` is output. There are three ways to output:
- stdout (default)
- a file descriptor (e.g., `--fd 3`), or
- a (temp) file (e.g., `--tmp $TMPDIR/conda-init-dev.$$.$RANDOM`)

This way, the shell interface can choose how to receive the initialization script (as opposed to being told how it must receive it).

Depends on #11862 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
