### PR TITLE
Root user implies `conda init --system`

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -462,7 +462,9 @@ def make_initialize_plan(conda_prefix, shells, for_user, for_system, anaconda_pr
                 },
             })
 
-        if for_system:
+        from ..common._os import is_admin 
+
+        if for_system or is_admin():
             plan.append({
                 'function': init_sh_system.__name__,
                 'kwargs': {
@@ -470,7 +472,7 @@ def make_initialize_plan(conda_prefix, shells, for_user, for_system, anaconda_pr
                     'conda_prefix': conda_prefix,
                     'reverse': reverse,
                 },
-            })
+            })     
 
     if 'fish' in shells:
         if for_user:


### PR DESCRIPTION
### Description

This PR is an attempt to fix the `conda init` ran as root, to initialize conda environment for all the users!

Resolves #9083 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
