### PR TITLE
9782 broken url in conda documentation

### DIFF
--- a/docs/source/user-guide/concepts/data-science.rst
+++ b/docs/source/user-guide/concepts/data-science.rst
@@ -23,4 +23,4 @@ Conda’s benefits include:
   without code changes.
 
 `Read more about how conda supports data scientists
-<https://kaust-vislab.github.io/introduction-to-conda-for-data-scientists>`_.
+<https://carpentries-incubator.github.io/introduction-to-conda-for-data-scientists/>`_.

--- a/news/9782-broken-url-in-conda-documentation
+++ b/news/9782-broken-url-in-conda-documentation
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Fixed bad URL to Introduction to conda for Data Scientists course in conda docs. (#9782)
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes [#9782](https://github.com/conda/conda/issues/9782). Discovered via the [Wayback Machine](https://web.archive.org/web/20191012063143/https://kaust-vislab.github.io/introduction-to-conda-for-data-scientists/) that the information that was in the old link on the Conda for Data Scientists page in the conda docs is now hosted at https://carpentries-incubator.github.io/introduction-to-conda-for-data-scientists/. I updated the link.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
