### PR TITLE
Removed ref left behind from removing allow_other_channels docs.

### DIFF
--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -178,7 +178,6 @@ General configuration
 =====================
 
 * :ref:`config-channels`
-* :ref:`allow-other-channels`
 * :ref:`default-channels`
 * :ref:`auto-update-conda`
 * :ref:`always-yes`


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Connected to PR https://github.com/conda/conda/pull/11866. I accidentally left a page ref behind and didn't notice until now. This PR removes that.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
