### PR TITLE
Enable one single test for linux-{aarch64, ppc64le}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,54 @@ jobs:
             test-report.xml
           retention-days: 1
 
+  linux-qemu:
+    # Run one single fast test per docker+qemu emulated linux platform to test that
+    # test execution is possible there (container+tools+dependencies work). Can be
+    # changed / extended to run specific tests in case there are platform related
+    # things to test. Running more tests is time consuming due to emulation
+    # (factor 2-10x slower).
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10']
+        platform: ['arm64', 'ppc64le']
+    env:
+      OS: linux-${{ matrix.platform }}
+      PYTHON: ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        # Equivalent to locally run:
+        #   `docker run --privileged --rm tonistiigi/binfmt --install all`
+
+      - name: Python linux-${{ matrix.platform }} ${{ matrix.python-version }} tests
+        run: >
+          docker run
+          --rm -v ${PWD}:/opt/conda-src
+          --platform linux/${{ matrix.platform }}
+          -e TEST_SPLITS
+          -e TEST_GROUP
+          ghcr.io/conda/conda-ci:main-linux-python${{ matrix.python-version }}
+          bash -c "source /opt/conda/etc/profile.d/conda.sh; \
+                   pytest -k test_DepsModifier_contract"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
+          # when locally dowloading and comparing results of different workflow runs.
+          name: test-results-${{ github.sha }}-linux-${{ matrix.platform }}-qemu-${{ matrix.python-version }}
+          path: |
+            .coverage
+            test-report.xml
+          retention-days: 1
+
   macos:
     runs-on: macos-latest
     strategy:
@@ -189,7 +237,7 @@ jobs:
           retention-days: 1
 
   analyze:
-    needs: [windows, linux, macos]
+    needs: [windows, linux, linux-qemu, macos]
     name: Analyze test results
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run one single fast test per docker+qemu emulated linux platform to test that test execution is possible there (container+tools+dependencies work). Can be changed / extended to run specific tests in case there are platform related things to test. Running more tests is time consuming due to emulation (factor 2-10x slower).

Superseds https://github.com/conda/conda/pull/11566

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
