### PR TITLE
Add automatic workflow approval for first time contributors

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,17 @@
+name: Auto Approve
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+
+jobs:
+  auto-approve:
+    name: Automatic Workflow Approve
+    if: '!github.event.repository.fork'
+    runs-on: ubuntu-latest
+    steps:
+      - name: approve
+        uses: mheap/automatic-approve-action@v1
+        with:
+          token: ${{ secrets.PAT }}
+          workflows: "ci.yml,cla.yml"
+          dangerous_files: "integration.sh,setup.sh,unit.sh,integration.bat,setup.bat,unit.bat"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Enhance first time contributor experience by auto approving workflow runs (if no dangerous / ci-relevant files are touched).

Background: GitHub disabled automatic workflow runs for first time contributors in 2021, [see](https://github.blog/changelog/2021-04-22-github-actions-maintainers-must-approve-first-time-contributor-workflow-runs/) to protect agains strangers abusing PRs for crypto-mining. An auto-approval action (cron - not PR - triggered), can approve PRs, if no dangerous / ci-relevant files are touched, to lower the risk of crypto mining actions being added. (Though somebody could still hack the unit-tests to shell-out and do something crazy, but that is more complicated).

This is also an improvement for reviewers of first time contributions PRs, as the workflow approve is then superfluous and PRs to review will already have some ci feedback when having a first look.

If this works well, other repos could also benefit from it.

To be clarified:
* What secret to use (`secrets.PAT`), do we already have a repo/org secret that could be used here?
* Run-time and cadence of the action: I first found the action [here](https://github.com/qmk/qmk_firmware/blob/master/.github/workflows/auto_approve.yml), where it runs every 15 minutes and takes around 12-15 seconds for 242 open PRs, see [run-history](https://github.com/qmk/qmk_firmware/actions/workflows/auto_approve.yml)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
