### PR TITLE
restore CondaMultiError from package downloads

### DIFF
--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
+import datetime
 import json
 from os.path import abspath, basename, dirname, join
 
@@ -9,22 +10,22 @@ import pytest
 from conda import CondaError, CondaMultiError
 from conda.base.constants import PACKAGE_CACHE_MAGIC_FILE
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol
+from conda.common.compat import on_win
 from conda.common.io import env_vars
 from conda.core import package_cache_data
+from conda.core.index import get_index
 from conda.core.package_cache_data import (
     PackageCacheData,
-    ProgressiveFetchExtract,
-    PackageRecord,
     PackageCacheRecord,
+    PackageRecord,
+    ProgressiveFetchExtract,
 )
 from conda.core.path_actions import CacheUrlAction
-from conda.exports import url_path, MatchSpec
+from conda.exports import MatchSpec, url_path
 from conda.gateways.disk.create import copy
 from conda.gateways.disk.permissions import make_read_only
 from conda.gateways.disk.read import isfile, listdir, yield_lines
 from conda.testing.integration import make_temp_package_cache
-from conda.common.compat import on_win
-import datetime
 
 CHANNEL_DIR = abspath(join(dirname(__file__), "..", "data", "conda_format_repo"))
 CONDA_PKG_REPO = url_path(CHANNEL_DIR)
@@ -88,7 +89,9 @@ def test_ProgressiveFetchExtract_prefers_conda_v2_format():
             if rec.name == "zlib" and rec.version == "1.2.11":
                 break
         cache_action, extract_action = ProgressiveFetchExtract.make_actions_for_record(rec)
+    assert cache_action
     assert cache_action.target_package_basename.endswith(".conda")
+    assert extract_action
     assert extract_action.source_full_path.endswith(".conda")
 
 

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -73,6 +73,25 @@ zlib_conda_prec = PackageRecord.from_objects(
 )
 
 
+def test_ProgressiveFetchExtract_prefers_conda_v2_format():
+    # force this to False, because otherwise tests fail when run with old conda-build
+    # zlib is available in local "linux-64" subdir
+    with env_vars(
+        {"CONDA_USE_ONLY_TAR_BZ2": False, "CONDA_SUBDIR": "linux-64"},
+        False,
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
+    ):
+        index = get_index([CONDA_PKG_REPO], prepend=False)
+        rec = next(iter(index))
+        for rec in index:
+            # zlib is the one package in the test index that has a .conda file record
+            if rec.name == "zlib" and rec.version == "1.2.11":
+                break
+        cache_action, extract_action = ProgressiveFetchExtract.make_actions_for_record(rec)
+    assert cache_action.target_package_basename.endswith(".conda")
+    assert extract_action.source_full_path.endswith(".conda")
+
+
 @pytest.mark.skipif(
     on_win and datetime.datetime.now() < datetime.datetime(2020, 1, 30), reason="time bomb"
 )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Jaime noticed we were raising a http error here instead of collecting them all into `CondaMultiError`. Fix and test.

Do we do a good job of formatting CondaMultiError for the end user?