### PR TITLE
Fix error output bug in rename tests

### DIFF
--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -163,10 +163,12 @@ def test_rename_with_force(env_one, env_two):
     # Do a force rename
     run(f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_2} --force", disallow_stderr=False)
 
+    (_, _, exit_code), _ = list_envs()
 
     assert locate_prefix_by_name(TEST_ENV_NAME_2)
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_1)
+    assert exit_code is None
 
     # Clean up
     run(f"conda rename -n {TEST_ENV_NAME_2} {TEST_ENV_NAME_1}", disallow_stderr=False)
@@ -191,7 +193,8 @@ def test_rename_with_force_with_errors(env_one, env_two):
     # Make sure both environments still exist
     assert locate_prefix_by_name(TEST_ENV_NAME_2)
     assert locate_prefix_by_name(TEST_ENV_NAME_1)
-
+    (_, _, exit_code), _ = list_envs()
+    assert exit_code is None
 
 def test_rename_with_force_with_errors_prefix(env_prefix_one):
     """

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -29,7 +29,7 @@ def env_one():
     was (i.e. always make sure there is a TEST_ENV_NAME_1 present).
     """
     # Setup
-    run(f"conda create -n {TEST_ENV_NAME_1} -y")
+    run(f"conda create -n {TEST_ENV_NAME_1} -y", disallow_stderr=False)
 
     yield
 
@@ -41,7 +41,7 @@ def env_one():
 @pytest.fixture
 def env_two():
     # Setup
-    run(f"conda create -n {TEST_ENV_NAME_2} -y")
+    run(f"conda create -n {TEST_ENV_NAME_2} -y", disallow_stderr=False)
 
     yield
 
@@ -54,7 +54,7 @@ def env_prefix_one():
     """Used to get an environment created using -p flag"""
     # Setup
     tmpdir = tempfile.mkdtemp()
-    run(f"conda create -p {tmpdir} -y")
+    run(f"conda create -p {tmpdir} -y", disallow_stderr=False)
 
     yield tmpdir
 
@@ -70,24 +70,20 @@ def list_envs():
 
 
 def test_rename_by_name_success(env_one):
-    run(f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_RENAME}")
-
-    (out, err, exit_code), data = list_envs()
-    result = data.get("envs", [])
+    run(f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_RENAME}", disallow_stderr=False)
 
     assert locate_prefix_by_name(TEST_ENV_NAME_RENAME)
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_1)
-    assert err == ""
 
     # Clean up
-    run(f"conda rename -n {TEST_ENV_NAME_RENAME} {TEST_ENV_NAME_1}")
+    run(f"conda rename -n {TEST_ENV_NAME_RENAME} {TEST_ENV_NAME_1}", disallow_stderr=False)
 
 
 def test_rename_by_path_success(env_one):
     with tempfile.TemporaryDirectory() as temp_dir:
         new_name = str(pathlib.Path(temp_dir).joinpath("new-env"))
-        run(f"conda rename -n {TEST_ENV_NAME_1} {new_name}")
+        run(f"conda rename -n {TEST_ENV_NAME_1} {new_name}", disallow_stderr=False)
 
         (out, err, exit_code), data = list_envs()
         result = data.get("envs", [])
@@ -100,7 +96,7 @@ def test_rename_by_path_success(env_one):
 
         assert path_appears_in_env_list
         assert not original_name_in_envs
-        assert err == ""
+        assert exit_code is None
 
 
 def test_rename_by_name_name_already_exists_error(env_one):
@@ -165,18 +161,15 @@ def test_rename_with_force(env_one, env_two):
     Without this flag, it would return with an error message.
     """
     # Do a force rename
-    run(f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_2} --force")
+    run(f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_2} --force", disallow_stderr=False)
 
-    (out, err, exit_code), data = list_envs()
-    result = data.get("envs", [])
 
     assert locate_prefix_by_name(TEST_ENV_NAME_2)
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_1)
-    assert err == ""
 
     # Clean up
-    run(f"conda rename -n {TEST_ENV_NAME_2} {TEST_ENV_NAME_1}")
+    run(f"conda rename -n {TEST_ENV_NAME_2} {TEST_ENV_NAME_1}", disallow_stderr=False)
 
 
 def test_rename_with_force_with_errors(env_one, env_two):
@@ -189,18 +182,15 @@ def test_rename_with_force_with_errors(env_one, env_two):
     # Do a force rename
     with mock.patch("conda.cli.main_rename.install.clone") as clone_mock:
         clone_mock.side_effect = [CondaError(error_message)]
-        out, err, exit_code = run(
+        _, err, exit_code = run(
             f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_2} --force", disallow_stderr=False
         )
         assert error_message in err
-
-    (out, err, exit_code), data = list_envs()
-    result = data.get("envs", [])
+        assert exit_code == 1
 
     # Make sure both environments still exist
     assert locate_prefix_by_name(TEST_ENV_NAME_2)
     assert locate_prefix_by_name(TEST_ENV_NAME_1)
-    assert err == ""
 
 
 def test_rename_with_force_with_errors_prefix(env_prefix_one):
@@ -232,7 +222,8 @@ def test_rename_with_dry_run(env_one):
     Without this flag, it would actually execute all the actions.
     """
     (rename_out, rename_err, rename_exit_code) = run(
-        f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_RENAME} --dry-run"
+        f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_RENAME} --dry-run",
+        disallow_stderr=False,
     )
 
     (out, err, exit_code), data = list_envs()
@@ -241,12 +232,12 @@ def test_rename_with_dry_run(env_one):
     assert locate_prefix_by_name(TEST_ENV_NAME_1)
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_RENAME)
-    assert err == ""
+    assert exit_code is None
 
     rename_stdout = str(rename_out)
     assert "Dry run action: clone" in rename_stdout
     assert "Dry run action: rm_rf" in rename_stdout
-    assert rename_err == ""
+    assert exit_code is None
 
 
 def test_rename_with_force_and_dry_run(env_one, env_prefix_one):
@@ -256,7 +247,8 @@ def test_rename_with_force_and_dry_run(env_one, env_prefix_one):
     changes occur.
     """
     (rename_out, rename_err, rename_exit_code) = run(
-        f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_RENAME} --force --dry-run"
+        f"conda rename -n {TEST_ENV_NAME_1} {TEST_ENV_NAME_RENAME} --force --dry-run",
+        disallow_stderr=False,
     )
 
     (out, err, exit_code), data = list_envs()
@@ -265,7 +257,7 @@ def test_rename_with_force_and_dry_run(env_one, env_prefix_one):
     assert locate_prefix_by_name(TEST_ENV_NAME_1)
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_RENAME)
-    assert err == ""
+    assert exit_code is None
 
     rename_stdout = str(rename_out)
     assert (
@@ -274,4 +266,4 @@ def test_rename_with_force_and_dry_run(env_one, env_prefix_one):
     )
     assert "Dry run action: clone" in rename_stdout
     assert "Dry run action: rm_rf" in rename_stdout
-    assert rename_err == ""
+    assert rename_exit_code is None


### PR DESCRIPTION
Fixes https://github.com/conda/conda/issues/11905

All of the tests in `tests/cli/conda_main_rename.py` [fail on feature branches](https://github.com/conda/conda/actions/runs/3152698373/jobs/5128256911#step:3:536) due to the `notify_outdated_conda` warning.