### PR TITLE
tests: use readline instead of regex capture to avoid deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Cache conda packages
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('conda.recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
+
+      - name: Cache minio
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: minio
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('conda.recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
+
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: conda-test-env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Cache conda packages
         uses: actions/cache@v3
         env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          # Increase this value to reset cache
           CACHE_NUMBER: 0
         with:
           path: ~/conda_pkgs_dir
@@ -202,7 +202,7 @@ jobs:
       - name: Cache minio
         uses: actions/cache@v3
         env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          # Increase this value to reset cache
           CACHE_NUMBER: 0
         with:
           path: minio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-py${{ env.PYTHON }}-${{
-            hashFiles('conda.recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
+            hashFiles('recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
 
       - name: Cache minio
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         with:
           path: ~/conda_pkgs_dir
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-py${{ env.PYTHON }}-${{
             hashFiles('conda.recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
 
       - name: Cache minio
@@ -207,7 +207,7 @@ jobs:
         with:
           path: minio
           key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            ${{ runner.os }}-minio-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda.recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
 
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           path: "C:\\conda_bin\\envs\\conda-test-env\\pkgs"
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-py${{ env.PYTHON }}-${{
-            hashFiles('conda.recipe/meta.yaml', 'dev/windows/setup.bat', 'tests/requirements.txt') }}
+            hashFiles('recipe/meta.yaml', 'dev/windows/setup.bat', 'tests/requirements.txt') }}
 
       - name: Set temp dirs correctly
         # https://github.com/actions/virtual-environments/issues/712

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           path: minio
           key:
             ${{ runner.os }}-minio-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('conda.recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
+            hashFiles('recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Cache conda packages
+        uses: actions/cache@v3
+        env:
+          # Increase this value to reset cache
+          CACHE_NUMBER: 0
+        with:
+          path: "C:\\conda_bin\\envs\\conda-test-env\\pkgs"
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-py${{ env.PYTHON }}-${{
+            hashFiles('conda.recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
+
       - name: Set temp dirs correctly
         # https://github.com/actions/virtual-environments/issues/712
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           path: "C:\\conda_bin\\envs\\conda-test-env\\pkgs"
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-py${{ env.PYTHON }}-${{
-            hashFiles('conda.recipe/meta.yaml', 'dev/macos/setup.sh', 'tests/requirements.txt') }}
+            hashFiles('conda.recipe/meta.yaml', 'dev/windows/setup.bat', 'tests/requirements.txt') }}
 
       - name: Set temp dirs correctly
         # https://github.com/actions/virtual-environments/issues/712

--- a/dev/macos/setup.sh
+++ b/dev/macos/setup.sh
@@ -2,9 +2,12 @@
 set -ex
 
 # Download the Minio server, needed for S3 tests
-curl -LO https://dl.minio.io/server/minio/release/darwin-amd64/minio
+if [[ ! -f minio ]]
+then
+    curl -LO https://dl.minio.io/server/minio/release/darwin-amd64/minio
+fi
 chmod +x minio
-sudo mv minio /usr/local/bin/minio
+sudo cp minio /usr/local/bin/minio
 
 # restoring the default for changeps1 to have parity with dev
 conda config --set changeps1 true

--- a/dev/windows/integration.bat
+++ b/dev/windows/integration.bat
@@ -4,7 +4,7 @@ cd \conda_src || goto :error
 CALL dev-init.bat || goto :error
 CALL conda info || goto :error
 CALL conda-build tests\test-recipes\activate_deactivate_package tests\test-recipes\pre_link_messages_package || goto :error
-CALL pytest -m "integration" --basetemp=C:\tmp -v --splits=%TEST_SPLITS% --group=%TEST_GROUP% || goto :error
+CALL pytest -m "integration" --basetemp=C:\tmp -v --splits=%TEST_SPLITS% --group=%TEST_GROUP% -k powershell || goto :error
 goto :EOF
 
 :error

--- a/dev/windows/integration.bat
+++ b/dev/windows/integration.bat
@@ -4,7 +4,7 @@ cd \conda_src || goto :error
 CALL dev-init.bat || goto :error
 CALL conda info || goto :error
 CALL conda-build tests\test-recipes\activate_deactivate_package tests\test-recipes\pre_link_messages_package || goto :error
-CALL pytest -m "integration" --basetemp=C:\tmp -v --splits=%TEST_SPLITS% --group=%TEST_GROUP% -k powershell || goto :error
+CALL pytest -m "integration" --basetemp=C:\tmp -v --splits=%TEST_SPLITS% --group=%TEST_GROUP% || goto :error
 goto :EOF
 
 :error

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1910,7 +1910,6 @@ class InteractiveShell:
         p = PopenSpawn(
             quote_for_shell(shell_found, *args),
             timeout=12,
-            maxread=5000,
             searchwindowsize=None,
             logfile=sys.stdout,
             cwd=os.getcwd(),
@@ -1986,8 +1985,9 @@ class InteractiveShell:
             self.sendline('echo get_var_start')
             self.sendline(self.print_env_var % env_var)
             self.sendline('echo get_var_end')
-            self.expect('get_var_start(.*)get_var_end')
-            value = self.p.match.groups()[0]
+            self.expect('get_var_start\n')
+            value = self.p.readline()
+            self.expect('get_var_end')
         if value is None:
             return default
         return ensure_text_type(value).strip()

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1975,11 +1975,11 @@ class InteractiveShell:
             self.sendline("@echo %%%s%%" % env_var)
             self.expect("@echo %%%s%%\r\n([^\r]*)\r" % env_var)
             value = self.p.match.groups()[0]
-        elif self.shell_name == 'powershell':
+        elif self.shell_name in ('powershell', 'pwsh'):
             self.sendline(self.print_env_var % env_var)
             # The \r\n\( is the newline after the env var and the start of the prompt.
             # If we knew the active env we could add that in as well as the closing )
-            self.expect(rf"\$Env:{env_var}\r\n([^\r]*)(\r\n).*")
+            self.expect(rf"\$Env:{env_var}\n([^\r]*)(\n).*")
             value = self.p.match.groups()[0]
         else:
             self.sendline('echo get_var_start')

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1911,8 +1911,8 @@ class InteractiveShell:
 
         p = PopenSpawn(
             quote_for_shell(shell_found, *args),
-            maxread=5000,
             timeout=12,
+            maxread=5000,
             searchwindowsize=None,
             logfile=sys.stdout,
             cwd=os.getcwd(),
@@ -1981,7 +1981,9 @@ class InteractiveShell:
         elif self.shell_name in ('powershell', 'pwsh'):
             self.sendline(self.print_env_var % env_var)
             self.expect(f"\\$Env:{env_var}\n")
-            value = self.p.readline()
+            value = "\\$Env"    # does windows echo twice?
+            while "\\$Env" in value:
+                value = self.p.readline()
         else:
             self.sendline('echo get_var_start')
             self.sendline(self.print_env_var % env_var)

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -108,6 +108,8 @@ PKG_B_ENV_VARS = '''
 }
 '''
 
+HDF5_VERSION = "1.12.1"
+
 @lru_cache(maxsize=None)
 def bash_unsupported_because():
     bash = which("bash")
@@ -1909,6 +1911,7 @@ class InteractiveShell:
 
         p = PopenSpawn(
             quote_for_shell(shell_found, *args),
+            maxread=5000,
             timeout=12,
             searchwindowsize=None,
             logfile=sys.stdout,
@@ -1977,10 +1980,8 @@ class InteractiveShell:
             value = self.p.match.groups()[0]
         elif self.shell_name in ('powershell', 'pwsh'):
             self.sendline(self.print_env_var % env_var)
-            # The \r\n\( is the newline after the env var and the start of the prompt.
-            # If we knew the active env we could add that in as well as the closing )
-            self.expect(rf"\$Env:{env_var}\n([^\r]*)(\n).*")
-            value = self.p.match.groups()[0]
+            self.expect(rf"\$Env:{env_var}\n")
+            value = self.p.readline()
         else:
             self.sendline('echo get_var_start')
             self.sendline(self.print_env_var % env_var)
@@ -2176,12 +2177,12 @@ class ShellWrapperIntegrationTests(TestCase):
         assert _CE_CONDA == _CE_CONDA2, "_CE_CONDA stacked changed by activation procedure\n:From\n{}\nto:\n{}".\
             format(_CE_CONDA, _CE_CONDA2)
 
-        shell.sendline('conda' + install + '-yq hdf5=1.10.2')
+        shell.sendline('conda' + install + f'-yq hdf5={HDF5_VERSION}')
         shell.expect('Executing transaction: ...working... done.*\n', timeout=60)
         shell.assert_env_var('?', '0', use_exact=True)
 
         shell.sendline('h5stat --version')
-        shell.expect(r'.*h5stat: Version 1.10.2.*')
+        shell.expect(fr'.*h5stat: Version {HDF5_VERSION}.*')
 
         # TODO: assert that reactivate worked correctly
 
@@ -2189,7 +2190,7 @@ class ShellWrapperIntegrationTests(TestCase):
         shell.expect(conda_is_a_function)
 
         shell.sendline(f"conda run {dev_arg} h5stat --version")
-        shell.expect(r".*h5stat: Version 1.10.2.*")
+        shell.expect(fr'.*h5stat: Version {HDF5_VERSION}.*')
 
         # regression test for #6840
         shell.sendline('conda' + install + '--blah')
@@ -2393,7 +2394,7 @@ class ShellWrapperIntegrationTests(TestCase):
             assert 'charizard' in PATH
 
             print('## [PowerShell integration] Installing.')
-            shell.sendline('conda install -yq hdf5=1.10.2')
+            shell.sendline(f'conda install -yq hdf5={HDF5_VERSION}')
             shell.expect('Executing transaction: ...working... done.*\n', timeout=100)
             shell.sendline('$LASTEXITCODE')
             shell.expect('0')
@@ -2401,12 +2402,12 @@ class ShellWrapperIntegrationTests(TestCase):
 
             print('## [PowerShell integration] Checking installed version.')
             shell.sendline('h5stat --version')
-            shell.expect(r'.*h5stat: Version 1.10.2.*')
+            shell.expect(fr'.*h5stat: Version {HDF5_VERSION}.*')
 
             # conda run integration test
             print("## [PowerShell integration] Checking conda run.")
             shell.sendline(f"conda run {dev_arg} h5stat --version")
-            shell.expect(r".*h5stat: Version 1.10.2.*")
+            shell.expect(fr'.*h5stat: Version {HDF5_VERSION}.*')
 
             print('## [PowerShell integration] Deactivating')
             shell.sendline('conda deactivate')
@@ -2499,18 +2500,18 @@ class ShellWrapperIntegrationTests(TestCase):
                 #       not require an old or incompatible version of any
                 #       library critical to the correct functioning of
                 #       Python (e.g. OpenSSL).
-                shell.sendline('conda install -yq hdf5=1.10.2')
+                shell.sendline(f'conda install -yq hdf5={HDF5_VERSION}')
                 shell.expect('Executing transaction: ...working... done.*\n', timeout=100)
                 shell.assert_env_var('errorlevel', '0', True)
                 # TODO: assert that reactivate worked correctly
 
                 shell.sendline('h5stat --version')
-                shell.expect(r'.*h5stat: Version 1.10.2.*')
+                shell.expect(fr'.*h5stat: Version {HDF5_VERSION}.*')
 
                 # conda run integration test
                 shell.sendline(f"conda run {dev_arg} h5stat --version")
 
-                shell.expect(r'.*h5stat: Version 1.10.2.*')
+                shell.expect(fr'.*h5stat: Version {HDF5_VERSION}.*')
 
                 shell.sendline('conda deactivate --dev')
                 shell.assert_env_var('CONDA_SHLVL', '1\r')

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1980,7 +1980,7 @@ class InteractiveShell:
             value = self.p.match.groups()[0]
         elif self.shell_name in ('powershell', 'pwsh'):
             self.sendline(self.print_env_var % env_var)
-            self.expect(rf"\$Env:{env_var}\n")
+            self.expect(f"\\$Env:{env_var}\n")
             value = self.p.readline()
         else:
             self.sendline('echo get_var_start')


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Test change. Does pexpect buffer size affect performance? (larger = slower)?

Appears to hang if the regex capture is larger than the buffer size, causing failures in osx-64 CI. readline() is better than increasing the buffer indefinitely.

Do we have to worry about multi-line env var's?

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
