### PR TITLE
Remove `toolz.itertoolz.concatv`

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -30,8 +30,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Conda incorporates the following libraries into its distributed code:
 
+* appdirs, licensed as MIT
 * auxlib, licensed as ISC
 * boltons, licensed as BSD-3-Clause
-* pytoolz, licensed as BSD-3-Clause
+* py-cpuinfo, licensed as MIT
+* distro, licensed as Apache-2.0
+* frozendict, license as LGPL-3.0
+* toolz, licensed as BSD-3-Clause
 * tqdm, licensed as MIT
-* urllib3, licensed as MIT

--- a/Makefile
+++ b/Makefile
@@ -23,31 +23,6 @@ anaconda-submit-upload: clean-all
 	anaconda build submit . --queue conda-team/build_recipes --label stage
 
 
-# VERSION=0.0.41 make auxlib
-auxlib:
-	git clone https://github.com/kalefranz/auxlib.git --single-branch --branch $(VERSION) \
-	    && rm -rf conda/_vendor/auxlib \
-	    && mv auxlib/auxlib conda/_vendor/ \
-	    && rm -rf auxlib
-
-
-# VERSION=16.4.1 make boltons
-boltons:
-	git clone https://github.com/mahmoud/boltons.git --single-branch --branch $(VERSION) \
-	    && rm -rf conda/_vendor/boltons \
-	    && mv boltons/boltons conda/_vendor/ \
-	    && rm -rf boltons
-
-
-# VERSION=0.8.0 make toolz
-toolz:
-	git clone https://github.com/pytoolz/toolz.git --single-branch --branch $(VERSION) \
-	    && rm -rf conda/_vendor/toolz \
-	    && mv toolz/toolz conda/_vendor/ \
-	    && rm -rf toolz
-	rm -rf conda/_vendor/toolz/curried conda/_vendor/toolz/sandbox conda/_vendor/toolz/tests
-
-
 pytest-version:
 	pytest --version
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -19,9 +19,9 @@ from datetime import datetime
 import warnings
 
 try:
-    from tlz.itertoolz import concat, concatv, unique
+    from tlz.itertoolz import concat, unique
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, unique
+    from conda._vendor.toolz.itertoolz import concat, unique
 
 from .constants import (
     APP_NAME,
@@ -104,18 +104,18 @@ sys_rc_path = join(sys.prefix, '.condarc')
 
 def mockable_context_envs_dirs(root_writable, root_prefix, _envs_dirs):
     if root_writable:
-        fixed_dirs = (
+        fixed_dirs = [
             join(root_prefix, 'envs'),
             join('~', '.conda', 'envs'),
-        )
+        ]
     else:
-        fixed_dirs = (
+        fixed_dirs = [
             join('~', '.conda', 'envs'),
             join(root_prefix, 'envs'),
-        )
+        ]
     if on_win:
-        fixed_dirs += join(user_data_dir(APP_NAME, APP_NAME), 'envs'),
-    return tuple(IndexedSet(expand(p) for p in concatv(_envs_dirs, fixed_dirs)))
+        fixed_dirs.append(join(user_data_dir(APP_NAME, APP_NAME), "envs"))
+    return tuple(IndexedSet(expand(path) for path in (*_envs_dirs, *fixed_dirs)))
 
 
 def channel_alias_validation(value):
@@ -540,7 +540,7 @@ class Context(Configuration):
 
     @memoizedproperty
     def known_subdirs(self):
-        return frozenset(concatv(KNOWN_SUBDIRS, self.subdirs))
+        return frozenset((*KNOWN_SUBDIRS, *self.subdirs))
 
     @property
     def bits(self):
@@ -764,27 +764,28 @@ class Context(Configuration):
                 Channel.make_simple_channel(self.channel_alias, url) for url in urls)
              ) for name, urls in self._custom_multichannels.items()
         )
-        all_multichannels = odict(
+        return odict(
             (name, channels)
-            for name, channels in concatv(
-                custom_multichannels.items(),
-                reserved_multichannels.items(),  # order maters, reserved overrides custom
+            for name, channels in (
+                *custom_multichannels.items(),
+                *reserved_multichannels.items(),  # order maters, reserved overrides custom
             )
         )
-        return all_multichannels
 
     @memoizedproperty
     def custom_channels(self):
         from ..models.channel import Channel
-        custom_channels = (Channel.make_simple_channel(self.channel_alias, url, name)
-                           for name, url in self._custom_channels.items())
-        channels_from_multichannels = concat(channel for channel
-                                             in self.custom_multichannels.values())
-        all_channels = odict((x.name, x) for x in (ch for ch in concatv(
-            channels_from_multichannels,
-            custom_channels,
-        )))
-        return all_channels
+
+        return odict(
+            (channel.name, channel)
+            for channel in (
+                *concat(channel for channel in self.custom_multichannels.values()),
+                *(
+                    Channel.make_simple_channel(self.channel_alias, url, name)
+                    for name, url in self._custom_channels.items()
+                ),
+            )
+        )
 
     @property
     def channels(self):
@@ -804,7 +805,7 @@ class Context(Configuration):
                     "--override-channels."
                 )
             else:
-                return tuple(IndexedSet(concatv(local_add, self._argparse_args['channel'])))
+                return tuple(IndexedSet((*local_add, *self._argparse_args["channel"])))
 
         # add 'defaults' channel when necessary if --channel is given via the command line
         if self._argparse_args and 'channel' in self._argparse_args:
@@ -817,10 +818,9 @@ class Context(Configuration):
             channel_in_config_files = any('channels' in context.raw_data[rc_file].keys()
                                           for rc_file in self.config_files)
             if argparse_channels and not channel_in_config_files:
-                return tuple(IndexedSet(concatv(local_add, argparse_channels,
-                                                (DEFAULTS_CHANNEL_NAME,))))
+                return tuple(IndexedSet((*local_add, *argparse_channels, DEFAULTS_CHANNEL_NAME)))
 
-        return tuple(IndexedSet(concatv(local_add, self._channels)))
+        return tuple(IndexedSet((*local_add, *self._channels)))
 
     @property
     def config_files(self):

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -26,10 +26,10 @@ from stat import S_IFDIR, S_IFMT, S_IFREG
 import sys
 
 try:
-    from tlz.itertoolz import concat, concatv, unique
+    from tlz.itertoolz import concat, unique
     from tlz.dicttoolz import merge, merge_with
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, unique
+    from conda._vendor.toolz.itertoolz import concat, unique
     from conda._vendor.toolz.dicttoolz import merge, merge_with
 
 from .compat import isiterable, odict, primitive_types
@@ -718,8 +718,9 @@ class MapLoadedParameter(LoadedParameter):
 
         # dump all matches in a dict
         # then overwrite with important matches
-        merged_values_important_overwritten = frozendict(merge(
-            concatv([merged_values], reversed(important_maps))))
+        merged_values_important_overwritten = frozendict(
+            merge((merged_values, *reversed(important_maps)))
+        )
 
         # create new parameter for the merged values
         return MapLoadedParameter(
@@ -777,23 +778,27 @@ class SequenceLoadedParameter(LoadedParameter):
 
         # also get lines that were marked as bottom, but reverse the match order so that lines
         # coming earlier will ultimately be last
-        bottom_lines = concat(get_marked_lines(m, ParameterFlag.bottom) for m, _ in
-                              reversed(relevant_matches_and_values))
+        bottom_lines = tuple(
+            concat(
+                get_marked_lines(m, ParameterFlag.bottom)
+                for m, _ in reversed(relevant_matches_and_values)
+            )
+        )
 
         # now, concat all lines, while reversing the matches
         #   reverse because elements closer to the end of search path take precedence
         all_lines = concat(v for _, v in reversed(relevant_matches_and_values))
 
         # stack top_lines + all_lines, then de-dupe
-        top_deduped = tuple(unique(concatv(top_lines, all_lines)))
+        top_deduped = tuple(unique((*top_lines, *all_lines)))
 
         # take the top-deduped lines, reverse them, and concat with reversed bottom_lines
         # this gives us the reverse of the order we want, but almost there
         # NOTE: for a line value marked both top and bottom, the bottom marker will win out
         #       for the top marker to win out, we'd need one additional de-dupe step
-        bottom_deduped = unique(concatv(reversed(tuple(bottom_lines)), reversed(top_deduped)))
+        bottom_deduped = tuple(unique((*reversed(bottom_lines), *reversed(top_deduped))))
         # just reverse, and we're good to go
-        merged_values = tuple(reversed(tuple(bottom_deduped)))
+        merged_values = tuple(reversed(bottom_deduped))
 
         return SequenceLoadedParameter(
             self._name,
@@ -861,8 +866,9 @@ class ObjectLoadedParameter(LoadedParameter):
 
         # dump all matches in a dict
         # then overwrite with important matches
-        merged_values_important_overwritten = frozendict(merge(
-            concatv([merged_values], reversed(important_maps))))
+        merged_values_important_overwritten = frozendict(
+            merge((merged_values, *reversed(important_maps)))
+        )
 
         # copy object and replace Parameter with LoadedParameter fields
         object_copy = copy.deepcopy(self._element_type)

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -780,8 +780,8 @@ class SequenceLoadedParameter(LoadedParameter):
         # coming earlier will ultimately be last
         bottom_lines = tuple(
             concat(
-                get_marked_lines(m, ParameterFlag.bottom)
-                for m, _ in reversed(relevant_matches_and_values)
+                get_marked_lines(match, ParameterFlag.bottom)
+                for match, _ in reversed(relevant_matches_and_values)
             )
         )
 

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -17,9 +17,9 @@ import sys
 import warnings
 
 try:
-    from tlz.itertoolz import concat, concatv
+    from tlz.itertoolz import concat
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv
+    from conda._vendor.toolz.itertoolz import concat
 
 from conda.common.iterators import groupby_to_dict as groupby
 
@@ -276,7 +276,7 @@ class PythonDistribution:
             missing_pyc_files = (ff for ff in (
                 _pyc_path(f, py_ver_mm) for f in files_set if _py_file_re.match(f)
             ) if ff not in files_set)
-            records = sorted(concatv(records, ((pf, None, None) for pf in missing_pyc_files)))
+            records = sorted((*records, *((pf, None, None) for pf in missing_pyc_files)))
             return records
 
         return []

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -10,9 +10,9 @@ import sys
 import warnings
 
 try:
-    from tlz.itertoolz import concat, concatv
+    from tlz.itertoolz import concat
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv
+    from conda._vendor.toolz.itertoolz import concat
 
 from .package_cache_data import PackageCacheData
 from .prefix_data import PrefixData
@@ -327,7 +327,7 @@ def get_reduced_index(prefix, channels, subdirs, specs, repodata_fn):
     # add feature records for the solver
     known_features = set()
     for rec in reduced_index.values():
-        known_features.update(concatv(rec.track_features, rec.features))
+        known_features.update((*rec.track_features, *rec.features))
     known_features.update(context.track_features)
     for ftr_str in known_features:
         rec = make_feature_record(ftr_str)

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -888,35 +888,11 @@ class UnlinkLinkTransaction:
         )
         create_nonadmin_actions = CreateNonadminAction.create_actions(*required_quad)
 
-        # if requested_spec:
-        #     application_entry_point_actions = CreateApplicationEntryPointAction.create_actions(
-        #         *required_quad
-        #     )
-        #     application_softlink_actions = CreateApplicationSoftlinkAction.create_actions(
-        #         *required_quad
-        #     )
-        # else:
-        #     application_entry_point_actions = ()
-        #     application_softlink_actions = ()
-        # leased_paths = tuple(axn.leased_path_entry for axn in (
-        #     *application_entry_point_actions,
-        #     *application_softlink_actions,
-        # ))
-
-        # if requested_spec:
-        #     register_private_env_actions = RegisterPrivateEnvAction.create_actions(
-        #         transaction_context, package_info, target_prefix, requested_spec, leased_paths
-        #     )
-        # else:
-        #     register_private_env_actions = ()
-
         # the ordering here is significant
         return (
             *create_directory_actions,
             *file_link_actions,
             *create_nonadmin_actions,
-            # *application_entry_point_actions,
-            # *register_private_env_actions,
         )
 
     @staticmethod

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -13,9 +13,9 @@ from textwrap import indent
 import warnings
 
 try:
-    from tlz.itertoolz import concat, concatv, interleave
+    from tlz.itertoolz import concat, interleave
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv, interleave
+    from conda._vendor.toolz.itertoolz import concat, interleave
 
 from .package_cache_data import PackageCacheData
 from .path_actions import (CompileMultiPycAction, CreateNonadminAction, CreatePrefixRecordAction,
@@ -100,12 +100,12 @@ def make_unlink_actions(transaction_context, target_prefix, prefix_record):
     #     transaction_context, package_cache_record, target_prefix
     # )
 
-    return tuple(concatv(
-        unlink_path_actions,
-        directory_remove_actions,
-        # unregister_private_package_actions,
-        remove_conda_meta_actions,
-    ))
+    return (
+        *unlink_path_actions,
+        *directory_remove_actions,
+        # *unregister_private_package_actions,
+        *remove_conda_meta_actions,
+    )
 
 
 def match_specs_to_dists(packages_info_to_link, specs):
@@ -401,10 +401,12 @@ class UnlinkLinkTransaction:
                 target_prefix)
             make_menu_action_groups.append(make_menu_ag)
 
-            all_link_path_actions = concatv(link_ag.actions,
-                                            compile_ag.actions,
-                                            entry_point_ag.actions,
-                                            make_menu_ag.actions)
+            all_link_path_actions = (
+                *link_ag.actions,
+                *compile_ag.actions,
+                *entry_point_ag.actions,
+                *make_menu_ag.actions,
+            )
             record_axns.extend(CreatePrefixRecordAction.create_actions(
                 transaction_context, pkg_info, target_prefix, lt, spec, all_link_path_actions))
 
@@ -749,12 +751,12 @@ class UnlinkLinkTransaction:
                             excs = UnlinkLinkTransaction._reverse_actions(axngroup)
                             rollback_excs.extend(excs)
 
-                raise CondaMultiError(tuple(concatv(
-                    ((e.errors[0], e.errors[2:])
-                     if isinstance(e, CondaMultiError)
-                     else (e,)),
-                    rollback_excs,
-                )))
+                raise CondaMultiError(
+                    (
+                        *((e.errors[0], e.errors[2:]) if isinstance(e, CondaMultiError) else (e,)),
+                        *rollback_excs,
+                    )
+                )
             else:
                 for axngroup in all_action_groups:
                     for action in axngroup.actions:
@@ -788,11 +790,13 @@ class UnlinkLinkTransaction:
             reverse_excs = ()
             if context.rollback_enabled:
                 reverse_excs = UnlinkLinkTransaction._reverse_actions(axngroup)
-            return CondaMultiError(tuple(concatv(
-                (e,),
-                (axngroup,),
-                reverse_excs,
-            )))
+            return CondaMultiError(
+                (
+                    e,
+                    axngroup,
+                    *reverse_excs,
+                )
+            )
 
     @staticmethod
     def _execute_post_link_actions(axngroup):
@@ -808,11 +812,13 @@ class UnlinkLinkTransaction:
                 reverse_excs = ()
                 if context.rollback_enabled:
                     reverse_excs = UnlinkLinkTransaction._reverse_actions(axngroup)
-                return CondaMultiError(tuple(concatv(
-                    (e,),
-                    (axngroup,),
-                    reverse_excs,
-                )))
+                return CondaMultiError(
+                    (
+                        e,
+                        axngroup,
+                        *reverse_excs,
+                    )
+                )
 
     @staticmethod
     def _reverse_actions(axngroup, reverse_from_idx=-1):
@@ -892,9 +898,9 @@ class UnlinkLinkTransaction:
         # else:
         #     application_entry_point_actions = ()
         #     application_softlink_actions = ()
-        # leased_paths = tuple(axn.leased_path_entry for axn in concatv(
-        #     application_entry_point_actions,
-        #     application_softlink_actions,
+        # leased_paths = tuple(axn.leased_path_entry for axn in (
+        #     *application_entry_point_actions,
+        #     *application_softlink_actions,
         # ))
 
         # if requested_spec:
@@ -905,13 +911,13 @@ class UnlinkLinkTransaction:
         #     register_private_env_actions = ()
 
         # the ordering here is significant
-        return tuple(concatv(
-            create_directory_actions,
-            file_link_actions,
-            create_nonadmin_actions,
-            # application_entry_point_actions,
-            # register_private_env_actions,
-        ))
+        return (
+            *create_directory_actions,
+            *file_link_actions,
+            *create_nonadmin_actions,
+            # *application_entry_point_actions,
+            # *register_private_env_actions,
+        )
 
     @staticmethod
     def _make_entry_point_actions(transaction_context, package_info, target_prefix,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -17,9 +17,9 @@ from tarfile import ReadError
 from functools import partial
 
 try:
-    from tlz.itertoolz import concat, concatv
+    from tlz.itertoolz import concat
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv
+    from conda._vendor.toolz.itertoolz import concat
 
 from conda.common.iterators import groupby_to_dict as groupby
 
@@ -217,7 +217,7 @@ class PackageCacheData(metaclass=PackageCacheType):
         if pkgs_dirs is None:
             pkgs_dirs = context.pkgs_dirs
         pc_groups = groupby(lambda pc: pc.is_writable, (cls(pd) for pd in pkgs_dirs))
-        return tuple(concatv(pc_groups.get(True, ()), pc_groups.get(False, ())))
+        return (*pc_groups.get(True, ()), *pc_groups.get(False, ()))
 
     @classmethod
     def get_all_extracted_entries(cls):
@@ -470,10 +470,10 @@ class PackageCacheData(metaclass=PackageCacheType):
         tar_bz2_extensions = groups[_CONDA_TARBALL_EXTENSION_V1] - conda_extensions
         others = groups[None] - conda_extensions - tar_bz2_extensions
         return sorted(
-            concatv(
-                (p + _CONDA_TARBALL_EXTENSION_V2 for p in conda_extensions),
-                (p + _CONDA_TARBALL_EXTENSION_V1 for p in tar_bz2_extensions),
-                others,
+            (
+                *(path + _CONDA_TARBALL_EXTENSION_V2 for path in conda_extensions),
+                *(path + _CONDA_TARBALL_EXTENSION_V1 for path in tar_bz2_extensions),
+                *others,
             )
         )
 

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -6,9 +6,9 @@ from itertools import chain
 from logging import getLogger
 
 try:
-    from tlz.itertoolz import concat, concatv
+    from tlz.itertoolz import concat
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv
+    from conda._vendor.toolz.itertoolz import concat
 
 from .._vendor.boltons.setutils import IndexedSet
 from ..base.constants import DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL
@@ -156,10 +156,13 @@ class Channel(metaclass=ChannelType):
                 cn = self.__canonical_name = self.name
                 return cn
 
-        if any(c.location == self.location for c in concatv(
-                (context.channel_alias,),
-                context.migrated_channel_aliases,
-        )):
+        if any(
+            alias.location == self.location
+            for alias in (
+                context.channel_alias,
+                *context.migrated_channel_aliases,
+            )
+        ):
             cn = self.__canonical_name = self.name
             return cn
 

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -11,9 +11,9 @@ from os.path import basename
 import re
 
 try:
-    from tlz.itertoolz import concat, concatv
+    from tlz.itertoolz import concat
 except ImportError:
-    from conda._vendor.toolz.itertoolz import concat, concatv
+    from conda._vendor.toolz.itertoolz import concat
 
 from conda.common.iterators import groupby_to_dict as groupby
 
@@ -479,7 +479,7 @@ class MatchSpec(metaclass=MatchSpecType):
             merged_specs.append(
                 reduce(lambda x, y: x._merge(y, union), group) if len(group) > 1 else group[0]
             )
-        return tuple(concatv(merged_specs, unmergeable))
+        return (*merged_specs, *unmergeable)
 
     @classmethod
     def union(cls, match_specs):

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -14,23 +14,17 @@ from collections import defaultdict
 from logging import getLogger
 import sys
 
-from conda.common.iterators import groupby_to_dict as groupby
-
-try:
-    from tlz.itertoolz import concatv
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concatv
-
 from ._vendor.boltons.setutils import IndexedSet
 from .base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
 from .base.context import context, stack_context_default
 from .common.io import dashlist, env_vars, time_recorder
+from .common.iterators import groupby_to_dict as groupby
 from .core.index import LAST_CHANNEL_URLS, _supplement_index_with_prefix
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.solve import diff_for_unlink_link_precs
 from .exceptions import CondaIndexError, PackagesNotFoundError
 from .history import History
-from .instructions import (FETCH, LINK, SYMLINK_CONDA, UNLINK)
+from .instructions import FETCH, LINK, SYMLINK_CONDA, UNLINK
 from .models.channel import Channel, prioritize_channels
 from .models.dist import Dist
 from .models.enums import LinkType
@@ -417,20 +411,20 @@ def _handle_menuinst(unlink_dists, link_dists):  # pragma: no cover
     # unlink
     menuinst_idx = next((q for q, d in enumerate(unlink_dists) if d.name == 'menuinst'), None)
     if menuinst_idx is not None:
-        unlink_dists = tuple(concatv(
-            unlink_dists[:menuinst_idx],
-            unlink_dists[menuinst_idx+1:],
-            unlink_dists[menuinst_idx:menuinst_idx+1],
-        ))
+        unlink_dists = (
+            *unlink_dists[:menuinst_idx],
+            *unlink_dists[menuinst_idx + 1 :],
+            *unlink_dists[menuinst_idx : menuinst_idx + 1],
+        )
 
     # link
     menuinst_idx = next((q for q, d in enumerate(link_dists) if d.name == 'menuinst'), None)
     if menuinst_idx is not None:
-        link_dists = tuple(concatv(
-            link_dists[menuinst_idx:menuinst_idx+1],
-            link_dists[:menuinst_idx],
-            link_dists[menuinst_idx+1:],
-        ))
+        link_dists = (
+            *link_dists[menuinst_idx : menuinst_idx + 1],
+            *link_dists[:menuinst_idx],
+            *link_dists[menuinst_idx + 1 :],
+        )
 
     return unlink_dists, link_dists
 

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -19,12 +19,6 @@ from conda.models.enums import PackageType
 from conda.models.match_spec import MatchSpec
 from conda.models.prefix_graph import PrefixGraph
 from conda.history import History
-
-try:
-    from tlz.itertoolz import concatv
-except ImportError:  # pragma: no cover
-    from conda._vendor.toolz.itertoolz import concatv  # NOQA
-
 from conda.common.iterators import groupby_to_dict as groupby
 
 
@@ -108,18 +102,24 @@ def from_environment(name, prefix, no_builds=False, ignore_channels=False, from_
 
     precs = tuple(PrefixGraph(pd.iter_records()).graph)
     grouped_precs = groupby(lambda x: x.package_type, precs)
-    conda_precs = sorted(concatv(
-        grouped_precs.get(None, ()),
-        grouped_precs.get(PackageType.NOARCH_GENERIC, ()),
-        grouped_precs.get(PackageType.NOARCH_PYTHON, ()),
-    ), key=lambda x: x.name)
+    conda_precs = sorted(
+        (
+            *grouped_precs.get(None, ()),
+            *grouped_precs.get(PackageType.NOARCH_GENERIC, ()),
+            *grouped_precs.get(PackageType.NOARCH_PYTHON, ()),
+        ),
+        key=lambda x: x.name,
+    )
 
-    pip_precs = sorted(concatv(
-        grouped_precs.get(PackageType.VIRTUAL_PYTHON_WHEEL, ()),
-        grouped_precs.get(PackageType.VIRTUAL_PYTHON_EGG_MANAGEABLE, ()),
-        grouped_precs.get(PackageType.VIRTUAL_PYTHON_EGG_UNMANAGEABLE, ()),
-        # grouped_precs.get(PackageType.SHADOW_PYTHON_EGG_LINK, ()),
-    ), key=lambda x: x.name)
+    pip_precs = sorted(
+        (
+            *grouped_precs.get(PackageType.VIRTUAL_PYTHON_WHEEL, ()),
+            *grouped_precs.get(PackageType.VIRTUAL_PYTHON_EGG_MANAGEABLE, ()),
+            *grouped_precs.get(PackageType.VIRTUAL_PYTHON_EGG_UNMANAGEABLE, ()),
+            # *grouped_precs.get(PackageType.SHADOW_PYTHON_EGG_LINK, ()),
+        ),
+        key=lambda x: x.name,
+    )
 
     if no_builds:
         dependencies = ['='.join((a.name, a.version)) for a in conda_precs]

--- a/news/12020-stop-using-toolz.itertoolz.concatv
+++ b/news/12020-stop-using-toolz.itertoolz.concatv
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Stop using `toolz.itertoolz.concatv`. (#12020)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_ven
 
 [flake8]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821
+ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -20,7 +20,6 @@ from unittest import TestCase
 from uuid import uuid4
 
 import pytest
-from tlz.itertoolz import concatv
 
 from conda import __version__ as conda_version
 from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT
@@ -1158,7 +1157,9 @@ class ShellWrapperUnitTests(TestCase):
         new_path_parts = activator._add_prefix_to_path(self.prefix)
         conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
 
-        e_activate_data = dals("""
+        e_activate_data = (
+            dals(
+                """
         PS1='%(ps1)s'
         %(conda_exe_unset)s
         export PATH='%(new_path)s'
@@ -1168,23 +1169,31 @@ class ShellWrapperUnitTests(TestCase):
         export CONDA_PROMPT_MODIFIER='(%(native_prefix)s) '
         %(conda_exe_export)s
         . "%(activate1)s"
-        """) % {
-            'native_prefix': self.prefix,
-            'new_path': activator.pathsep_join(new_path_parts),
-            'sys_executable': activator.path_conversion(sys.executable),
-            'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.sh')),
-            'ps1': '(%s) ' % self.prefix + os.environ.get('PS1', ''),
-            'conda_exe_unset': conda_exe_unset,
-            'conda_exe_export': conda_exe_export,
-        }
+        """
+            )
+            % {
+                "native_prefix": self.prefix,
+                "new_path": activator.pathsep_join(new_path_parts),
+                "sys_executable": activator.path_conversion(sys.executable),
+                "activate1": activator.path_conversion(
+                    join(self.prefix, "etc", "conda", "activate.d", "activate1.sh")
+                ),
+                "ps1": "(%s) " % self.prefix + os.environ.get("PS1", ""),
+                "conda_exe_unset": conda_exe_unset,
+                "conda_exe_export": conda_exe_export,
+            }
+        )
         import re
-        assert activate_data == re.sub(r'\n\n+', '\n', e_activate_data)
 
-        with env_vars({
-            'CONDA_PREFIX': self.prefix,
-            'CONDA_SHLVL': '1',
-            'PATH': os.pathsep.join(concatv(new_path_parts, (os.environ['PATH'],))),
-        }):
+        assert activate_data == re.sub(r"\n\n+", "\n", e_activate_data)
+
+        with env_vars(
+            {
+                "CONDA_PREFIX": self.prefix,
+                "CONDA_SHLVL": "1",
+                "PATH": os.pathsep.join((*new_path_parts, os.environ["PATH"])),
+            }
+        ):
             activator = PosixActivator()
             with captured() as c:
                 rc = main_sourced("shell.posix", *reactivate_args)
@@ -1193,21 +1202,30 @@ class ShellWrapperUnitTests(TestCase):
             reactivate_data = c.stdout
 
             new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
-            e_reactivate_data = dals("""
+            e_reactivate_data = (
+                dals(
+                    """
             . "%(deactivate1)s"
             PS1='%(ps1)s'
             export PATH='%(new_path)s'
             export CONDA_SHLVL='1'
             export CONDA_PROMPT_MODIFIER='(%(native_prefix)s) '
             . "%(activate1)s"
-            """) % {
-                'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.sh')),
-                'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.sh')),
-                'native_prefix': self.prefix,
-                'new_path': activator.pathsep_join(new_path_parts),
-                'ps1': '(%s) ' % self.prefix + os.environ.get('PS1', ''),
-            }
-            assert reactivate_data == re.sub(r'\n\n+', '\n', e_reactivate_data)
+            """
+                )
+                % {
+                    "activate1": activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "activate.d", "activate1.sh")
+                    ),
+                    "deactivate1": activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "deactivate.d", "deactivate1.sh")
+                    ),
+                    "native_prefix": self.prefix,
+                    "new_path": activator.pathsep_join(new_path_parts),
+                    "ps1": "(%s) " % self.prefix + os.environ.get("PS1", ""),
+                }
+            )
+            assert reactivate_data == re.sub(r"\n\n+", "\n", e_reactivate_data)
 
             with captured() as c:
                 rc = main_sourced("shell.posix", *deactivate_args)
@@ -1257,7 +1275,9 @@ class ShellWrapperUnitTests(TestCase):
         new_path_parts = activator._add_prefix_to_path(self.prefix)
         conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
 
-        e_activate_data = dals("""
+        e_activate_data = (
+            dals(
+                """
         @SET "PATH=%(new_path)s"
         @SET "CONDA_PREFIX=%(converted_prefix)s"
         @SET "CONDA_SHLVL=1"
@@ -1265,21 +1285,28 @@ class ShellWrapperUnitTests(TestCase):
         @SET "CONDA_PROMPT_MODIFIER=(%(native_prefix)s) "
         %(conda_exe_export)s
         @CALL "%(activate1)s"
-        """) % {
-            'converted_prefix': activator.path_conversion(self.prefix),
-            'native_prefix': self.prefix,
-            'new_path': activator.pathsep_join(new_path_parts),
-            'sys_executable': activator.path_conversion(sys.executable),
-            'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.bat')),
-            'conda_exe_export': conda_exe_export,
-        }
+        """
+            )
+            % {
+                "converted_prefix": activator.path_conversion(self.prefix),
+                "native_prefix": self.prefix,
+                "new_path": activator.pathsep_join(new_path_parts),
+                "sys_executable": activator.path_conversion(sys.executable),
+                "activate1": activator.path_conversion(
+                    join(self.prefix, "etc", "conda", "activate.d", "activate1.bat")
+                ),
+                "conda_exe_export": conda_exe_export,
+            }
+        )
         assert activate_data == e_activate_data
 
-        with env_vars({
-            'CONDA_PREFIX': self.prefix,
-            'CONDA_SHLVL': '1',
-            'PATH': os.pathsep.join(concatv(new_path_parts, (os.environ['PATH'],))),
-        }):
+        with env_vars(
+            {
+                "CONDA_PREFIX": self.prefix,
+                "CONDA_SHLVL": "1",
+                "PATH": os.pathsep.join((*new_path_parts, os.environ["PATH"])),
+            }
+        ):
             activator = CmdExeActivator()
             with captured() as c:
                 assert main_sourced("shell.cmd.exe", "reactivate") == 0
@@ -1291,18 +1318,28 @@ class ShellWrapperUnitTests(TestCase):
             rm_rf(reactivate_result)
 
             new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
-            assert reactivate_data == dals("""
+            assert (
+                reactivate_data
+                == dals(
+                    """
             @CALL "%(deactivate1)s"
             @SET "PATH=%(new_path)s"
             @SET "CONDA_SHLVL=1"
             @SET "CONDA_PROMPT_MODIFIER=(%(native_prefix)s) "
             @CALL "%(activate1)s"
-            """) % {
-                'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.bat')),
-                'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.bat')),
-                'native_prefix': self.prefix,
-                'new_path': activator.pathsep_join(new_path_parts),
-            }
+            """
+                )
+                % {
+                    "activate1": activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "activate.d", "activate1.bat")
+                    ),
+                    "deactivate1": activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "deactivate.d", "deactivate1.bat")
+                    ),
+                    "native_prefix": self.prefix,
+                    "new_path": activator.pathsep_join(new_path_parts),
+                }
+            )
 
             with captured() as c:
                 assert main_sourced("shell.cmd.exe", "deactivate") == 0
@@ -1342,7 +1379,9 @@ class ShellWrapperUnitTests(TestCase):
         new_path_parts = activator._add_prefix_to_path(self.prefix)
         conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
 
-        e_activate_data = dals("""
+        e_activate_data = (
+            dals(
+                """
         set prompt='%(prompt)s';
         setenv PATH "%(new_path)s";
         setenv CONDA_PREFIX "%(native_prefix)s";
@@ -1351,22 +1390,29 @@ class ShellWrapperUnitTests(TestCase):
         setenv CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
         %(conda_exe_export)s;
         source "%(activate1)s";
-        """) % {
-            'converted_prefix': activator.path_conversion(self.prefix),
-            'native_prefix': self.prefix,
-            'new_path': activator.pathsep_join(new_path_parts),
-            'sys_executable': activator.path_conversion(sys.executable),
-            'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.csh')),
-            'prompt': '(%s) ' % self.prefix + os.environ.get('prompt', ''),
-            'conda_exe_export': conda_exe_export,
-        }
+        """
+            )
+            % {
+                "converted_prefix": activator.path_conversion(self.prefix),
+                "native_prefix": self.prefix,
+                "new_path": activator.pathsep_join(new_path_parts),
+                "sys_executable": activator.path_conversion(sys.executable),
+                "activate1": activator.path_conversion(
+                    join(self.prefix, "etc", "conda", "activate.d", "activate1.csh")
+                ),
+                "prompt": "(%s) " % self.prefix + os.environ.get("prompt", ""),
+                "conda_exe_export": conda_exe_export,
+            }
+        )
         assert activate_data == e_activate_data
 
-        with env_vars({
-            'CONDA_PREFIX': self.prefix,
-            'CONDA_SHLVL': '1',
-            'PATH': os.pathsep.join(concatv(new_path_parts, (os.environ['PATH'],))),
-        }):
+        with env_vars(
+            {
+                "CONDA_PREFIX": self.prefix,
+                "CONDA_SHLVL": "1",
+                "PATH": os.pathsep.join((*new_path_parts, os.environ["PATH"])),
+            }
+        ):
             activator = CshActivator()
             with captured() as c:
                 rc = main_sourced("shell.csh", *reactivate_args)
@@ -1375,20 +1421,29 @@ class ShellWrapperUnitTests(TestCase):
             reactivate_data = c.stdout
 
             new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
-            e_reactivate_data = dals("""
+            e_reactivate_data = (
+                dals(
+                    """
             source "%(deactivate1)s";
             set prompt='%(prompt)s';
             setenv PATH "%(new_path)s";
             setenv CONDA_SHLVL "1";
             setenv CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
             source "%(activate1)s";
-            """) % {
-                'prompt': '(%s) ' % self.prefix + os.environ.get('prompt', ''),
-                'new_path': activator.pathsep_join(new_path_parts),
-                'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.csh')),
-                'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.csh')),
-                'native_prefix': self.prefix,
-            }
+            """
+                )
+                % {
+                    "prompt": "(%s) " % self.prefix + os.environ.get("prompt", ""),
+                    "new_path": activator.pathsep_join(new_path_parts),
+                    "activate1": activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "activate.d", "activate1.csh")
+                    ),
+                    "deactivate1": activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "deactivate.d", "deactivate1.csh")
+                    ),
+                    "native_prefix": self.prefix,
+                }
+            )
             assert reactivate_data == e_reactivate_data
             with captured() as c:
                 rc = main_sourced("shell.csh", *deactivate_args)
@@ -1439,26 +1494,32 @@ class ShellWrapperUnitTests(TestCase):
         %(sourcer)s "%(activate1)s"
         """)
         e_activate_info = {
-            'converted_prefix': activator.path_conversion(self.prefix),
-            'native_prefix': self.prefix,
-            'new_path': activator.pathsep_join(new_path_parts),
-            'sys_executable': activator.path_conversion(sys.executable),
-            'conda_exe_export': conda_exe_export,
+            "converted_prefix": activator.path_conversion(self.prefix),
+            "native_prefix": self.prefix,
+            "new_path": activator.pathsep_join(new_path_parts),
+            "sys_executable": activator.path_conversion(sys.executable),
+            "conda_exe_export": conda_exe_export,
         }
         if on_win:
-            e_activate_info['sourcer'] = 'source-cmd --suppress-skip-message'
-            e_activate_info['activate1'] = activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.bat'))
+            e_activate_info["sourcer"] = "source-cmd --suppress-skip-message"
+            e_activate_info["activate1"] = activator.path_conversion(
+                join(self.prefix, "etc", "conda", "activate.d", "activate1.bat")
+            )
         else:
-            e_activate_info['sourcer'] = 'source-bash --suppress-skip-message'
-            e_activate_info['activate1'] = activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.sh'))
+            e_activate_info["sourcer"] = "source-bash --suppress-skip-message"
+            e_activate_info["activate1"] = activator.path_conversion(
+                join(self.prefix, "etc", "conda", "activate.d", "activate1.sh")
+            )
         e_activate_data = e_activate_template % e_activate_info
         assert activate_data == e_activate_data
 
-        with env_vars({
-            'CONDA_PREFIX': self.prefix,
-            'CONDA_SHLVL': '1',
-            'PATH': os.pathsep.join(concatv(new_path_parts, (os.environ['PATH'],))),
-        }):
+        with env_vars(
+            {
+                "CONDA_PREFIX": self.prefix,
+                "CONDA_SHLVL": "1",
+                "PATH": os.pathsep.join((*new_path_parts, os.environ["PATH"])),
+            }
+        ):
             activator = XonshActivator()
             with captured() as c:
                 rc = main_sourced("shell.xonsh", *reactivate_args)
@@ -1467,13 +1528,15 @@ class ShellWrapperUnitTests(TestCase):
             reactivate_data = c.stdout
 
             new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
-            e_reactivate_template = dals("""
+            e_reactivate_template = dals(
+                """
             %(sourcer)s "%(deactivate1)s"
             $PATH = '%(new_path)s'
             $CONDA_SHLVL = '1'
             $CONDA_PROMPT_MODIFIER = '(%(native_prefix)s) '
             %(sourcer)s "%(activate1)s"
-            """)
+            """
+            )
             e_reactivate_info = {
                 'new_path': activator.pathsep_join(new_path_parts),
                 'native_prefix': self.prefix,
@@ -1531,7 +1594,9 @@ class ShellWrapperUnitTests(TestCase):
 
         new_path_parts = activator._add_prefix_to_path(self.prefix)
         conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
-        e_activate_data = dals("""
+        e_activate_data = (
+            dals(
+                """
         set -gx PATH "%(new_path)s";
         set -gx CONDA_PREFIX "%(native_prefix)s";
         set -gx CONDA_SHLVL "1";
@@ -1539,21 +1604,28 @@ class ShellWrapperUnitTests(TestCase):
         set -gx CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
         %(conda_exe_export)s;
         source "%(activate1)s";
-        """) % {
-            'converted_prefix': activator.path_conversion(self.prefix),
-            'native_prefix': self.prefix,
-            'new_path': activator.pathsep_join(new_path_parts),
-            'sys_executable': activator.path_conversion(sys.executable),
-            'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.fish')),
-            'conda_exe_export': conda_exe_export,
-        }
+        """
+            )
+            % {
+                "converted_prefix": activator.path_conversion(self.prefix),
+                "native_prefix": self.prefix,
+                "new_path": activator.pathsep_join(new_path_parts),
+                "sys_executable": activator.path_conversion(sys.executable),
+                "activate1": activator.path_conversion(
+                    join(self.prefix, "etc", "conda", "activate.d", "activate1.fish")
+                ),
+                "conda_exe_export": conda_exe_export,
+            }
+        )
         assert activate_data == e_activate_data
 
-        with env_vars({
-            'CONDA_PREFIX': self.prefix,
-            'CONDA_SHLVL': '1',
-            'PATH': os.pathsep.join(concatv(new_path_parts, (os.environ['PATH'],))),
-        }):
+        with env_vars(
+            {
+                "CONDA_PREFIX": self.prefix,
+                "CONDA_SHLVL": "1",
+                "PATH": os.pathsep.join((*new_path_parts, os.environ["PATH"])),
+            }
+        ):
             activator = FishActivator()
             with captured() as c:
                 rc = main_sourced("shell.fish", *reactivate_args)
@@ -1562,18 +1634,27 @@ class ShellWrapperUnitTests(TestCase):
             reactivate_data = c.stdout
 
             new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
-            e_reactivate_data = dals("""
+            e_reactivate_data = (
+                dals(
+                    """
             source "%(deactivate1)s";
             set -gx PATH "%(new_path)s";
             set -gx CONDA_SHLVL "1";
             set -gx CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
             source "%(activate1)s";
-            """) % {
-                'new_path': activator.pathsep_join(new_path_parts),
-                'activate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.fish')),
-                'deactivate1': activator.path_conversion(join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.fish')),
-                'native_prefix': self.prefix,
-            }
+            """
+                )
+                % {
+                    "new_path": activator.pathsep_join(new_path_parts),
+                    "activate1": activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "activate.d", "activate1.fish")
+                    ),
+                    "deactivate1": activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "deactivate.d", "deactivate1.fish")
+                    ),
+                    "native_prefix": self.prefix,
+                }
+            )
             assert reactivate_data == e_reactivate_data
 
             with captured() as c:
@@ -1611,7 +1692,9 @@ class ShellWrapperUnitTests(TestCase):
 
         new_path_parts = activator._add_prefix_to_path(self.prefix)
         conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
-        e_activate_data = dals("""
+        e_activate_data = (
+            dals(
+                """
         $Env:PATH = "%(new_path)s"
         $Env:CONDA_PREFIX = "%(prefix)s"
         $Env:CONDA_SHLVL = "1"
@@ -1619,20 +1702,25 @@ class ShellWrapperUnitTests(TestCase):
         $Env:CONDA_PROMPT_MODIFIER = "(%(prefix)s) "
         %(conda_exe_export)s
         . "%(activate1)s"
-        """) % {
-            'prefix': self.prefix,
-            'new_path': activator.pathsep_join(new_path_parts),
-            'sys_executable': sys.executable,
-            'activate1': join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.ps1'),
-            'conda_exe_export': conda_exe_export,
-        }
+        """
+            )
+            % {
+                "prefix": self.prefix,
+                "new_path": activator.pathsep_join(new_path_parts),
+                "sys_executable": sys.executable,
+                "activate1": join(self.prefix, "etc", "conda", "activate.d", "activate1.ps1"),
+                "conda_exe_export": conda_exe_export,
+            }
+        )
         assert activate_data == e_activate_data
 
-        with env_vars({
-            'CONDA_PREFIX': self.prefix,
-            'CONDA_SHLVL': '1',
-            'PATH': os.pathsep.join(concatv(new_path_parts, (os.environ['PATH'],))),
-        }):
+        with env_vars(
+            {
+                "CONDA_PREFIX": self.prefix,
+                "CONDA_SHLVL": "1",
+                "PATH": os.pathsep.join((*new_path_parts, os.environ["PATH"])),
+            }
+        ):
             activator = PowerShellActivator()
             with captured() as c:
                 rc = main_sourced("shell.powershell", *reactivate_args)
@@ -1641,18 +1729,26 @@ class ShellWrapperUnitTests(TestCase):
             reactivate_data = c.stdout
 
             new_path_parts = activator._replace_prefix_in_path(self.prefix, self.prefix)
-            assert reactivate_data == dals("""
+            assert (
+                reactivate_data
+                == dals(
+                    """
             . "%(deactivate1)s"
             $Env:PATH = "%(new_path)s"
             $Env:CONDA_SHLVL = "1"
             $Env:CONDA_PROMPT_MODIFIER = "(%(prefix)s) "
             . "%(activate1)s"
-            """) % {
-                'activate1': join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.ps1'),
-                'deactivate1': join(self.prefix, 'etc', 'conda', 'deactivate.d', 'deactivate1.ps1'),
-                'prefix': self.prefix,
-                'new_path': activator.pathsep_join(new_path_parts),
-            }
+            """
+                )
+                % {
+                    "activate1": join(self.prefix, "etc", "conda", "activate.d", "activate1.ps1"),
+                    "deactivate1": join(
+                        self.prefix, "etc", "conda", "deactivate.d", "deactivate1.ps1"
+                    ),
+                    "prefix": self.prefix,
+                    "new_path": activator.pathsep_join(new_path_parts),
+                }
+            )
 
             with captured() as c:
                 rc = main_sourced("shell.powershell", *deactivate_args)
@@ -1718,19 +1814,23 @@ class ShellWrapperUnitTests(TestCase):
             },
             "scripts": {
                 "activate": [
-                    activator.path_conversion(join(self.prefix, 'etc', 'conda', 'activate.d', 'activate1.sh')),
+                    activator.path_conversion(
+                        join(self.prefix, "etc", "conda", "activate.d", "activate1.sh")
+                    ),
                 ],
                 "deactivate": [],
-            }
+            },
         }
         assert json.loads(activate_data) == e_activate_data
 
-        with env_vars({
-            'CONDA_PREFIX': self.prefix,
-            'CONDA_SHLVL': '1',
-            'PATH': os.pathsep.join(concatv(new_path_parts, (os.environ['PATH'],))),
-        }):
-            activator = _build_activator_cls('posix+json')()
+        with env_vars(
+            {
+                "CONDA_PREFIX": self.prefix,
+                "CONDA_SHLVL": "1",
+                "PATH": os.pathsep.join((*new_path_parts, os.environ["PATH"])),
+            }
+        ):
+            activator = _build_activator_cls("posix+json")()
             with captured() as c:
                 rc = main_sourced("shell.posix+json", *reactivate_args)
             assert not c.stderr
@@ -1923,19 +2023,28 @@ class InteractiveShell:
         )
 
         # set state for context
-        joiner = os.pathsep.join if self.shell_name == 'fish' else self.activator.pathsep_join
-        PATH = joiner(self.activator.path_conversion(concatv(
-            self.activator._get_starting_path_list(),
-            (dirname(which(self.shell_name)),),
-        )))
+        joiner = os.pathsep.join if self.shell_name == "fish" else self.activator.pathsep_join
+        PATH = joiner(
+            self.activator.path_conversion(
+                (
+                    *self.activator._get_starting_path_list(),
+                    dirname(which(self.shell_name)),
+                )
+            )
+        )
         self.original_path = PATH
         env = {
             "CONDA_AUTO_ACTIVATE_BASE": "false",
             "PYTHONPATH": self.activator.path_conversion(CONDA_SOURCE_ROOT),
             "PATH": PATH,
         }
-        for ev in ('CONDA_TEST_SAVE_TEMPS', 'CONDA_TEST_TMPDIR', 'CONDA_TEST_USER_ENVIRONMENTS_TXT_FILE'):
-            if ev in os.environ: env[ev] = os.environ[ev]
+        for ev in (
+            "CONDA_TEST_SAVE_TEMPS",
+            "CONDA_TEST_TMPDIR",
+            "CONDA_TEST_USER_ENVIRONMENTS_TXT_FILE",
+        ):
+            if ev in os.environ:
+                env[ev] = os.environ[ev]
 
         for name, val in env.items():
             p.sendline(self.activator.export_var_tmpl % (name, val))


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Opting to use argument unpacking instead of `toolz.itertoolz.concatv`. All of the uses of `concatv` were immediately expanded into static types, so the generator `concatv` returned was unnecessary.

Alternative to #11769 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
