### PR TITLE
handle BaseException in package_cache_data for expedient CTRL-C handling

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -763,12 +763,17 @@ class ProgressiveFetchExtract:
             for completed_future in as_completed(futures):
                 try:
                     prec_or_spec = completed_future.result()
-                except Exception:
+                except BaseException as e:
                     # Special handling for exceptions thrown inside future, not
                     # by futures handling code. Cancel any download that has not
                     # been started. In-progress futures will continue.
+                    # Could use executor.shutdown(cancel_futures=True) instead?
                     for future in futures:
                         future.cancel()
+
+                    # faster handling of KeyboardInterrupt e.g.
+                    if not isinstance(e, Exception):
+                        raise
 
                     # break, not raise. CondaMultiError() raised if exceptions.
                     break


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

If the user presses CTRL-C it will raise BaseException instead of Exception, in one of the threads. re-raise to make sure the main thread immediately sees the CTRL-C or other BaseException.