### PR TITLE
Move `conda.models.plugins` to `conda.plugins.types`

### DIFF
--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from .hookspec import hookimpl  # noqa: F401
+from .types import CondaVirtualPackage, CondaSubcommand  # noqa: F401

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 
 import pluggy
 
-from ..models.plugins import CondaSubcommand, CondaVirtualPackage
+from .types import CondaSubcommand, CondaVirtualPackage
 
 spec_name = "conda"
 _hookspec = pluggy.HookspecMarker(spec_name)
@@ -28,7 +28,7 @@ class CondaSpecs:
         .. code-block:: python
 
             from conda import plugins
-            from conda.models.plugins import CondaSubcommand
+            from conda.plugins.types import CondaSubcommand
 
 
             def example_command(args):
@@ -56,7 +56,7 @@ class CondaSpecs:
         .. code-block:: python
 
             from conda import plugins
-            from conda.models.plugins import CondaVirtualPackage
+            from conda.plugins.types import CondaVirtualPackage
 
 
             @plugins.hookimpl

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -56,6 +56,7 @@ class CondaSpecs:
 
             from conda import plugins
 
+
             @plugins.hookimpl
             def conda_virtual_packages():
                 yield plugins.CondaVirtualPackage(

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -28,7 +28,6 @@ class CondaSpecs:
         .. code-block:: python
 
             from conda import plugins
-            from conda.plugins.types import CondaSubcommand
 
 
             def example_command(args):
@@ -37,7 +36,7 @@ class CondaSpecs:
 
             @plugins.hookimpl
             def conda_subcommands():
-                yield CondaSubcommand(
+                yield plugins.CondaSubcommand(
                     name="example",
                     summary="example command",
                     action=example_command,
@@ -56,12 +55,10 @@ class CondaSpecs:
         .. code-block:: python
 
             from conda import plugins
-            from conda.plugins.types import CondaVirtualPackage
-
 
             @plugins.hookimpl
             def conda_virtual_packages():
-                yield CondaVirtualPackage(
+                yield plugins.CondaVirtualPackage(
                     name="my_custom_os",
                     version="1.2.3",
                 )

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -13,6 +13,7 @@ class CondaSubcommand(NamedTuple):
     :param summary: Subcommand summary, will be shown in ``conda --help``.
     :param action: Callable that will be run when the subcommand is invoked.
     """
+
     name: str
     summary: str
     action: Callable[
@@ -28,5 +29,6 @@ class CondaVirtualPackage(NamedTuple):
     :param name: Virtual package name (e.g., ``my_custom_os``).
     :param version: Virtual package version (e.g., ``1.2.3``).
     """
+
     name: str
     version: str | None

--- a/conda/plugins/virtual_packages/archspec.py
+++ b/conda/plugins/virtual_packages/archspec.py
@@ -1,12 +1,10 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-
-from conda import plugins
-from conda.models.plugins import CondaVirtualPackage
+from .. import hookimpl, CondaVirtualPackage
 
 
-@plugins.hookimpl
+@hookimpl
 def conda_virtual_packages():
-    from conda.core.index import get_archspec_name
+    from ...core.index import get_archspec_name
 
     yield CondaVirtualPackage("archspec", get_archspec_name())

--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -1,14 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-
 import ctypes
 import functools
 import platform
 from contextlib import suppress
 
-from conda import plugins
-from conda.common.decorators import env_override
-from conda.models.plugins import CondaVirtualPackage
+from ...common.decorators import env_override
+from .. import hookimpl, CondaVirtualPackage
 
 
 @env_override("CONDA_OVERRIDE_CUDA", convert_empty_to_none=True)
@@ -84,6 +82,6 @@ def cached_cuda_version():
     return cuda_version()
 
 
-@plugins.hookimpl
+@hookimpl
 def conda_virtual_packages():
     yield CondaVirtualPackage("cuda", cached_cuda_version())

--- a/conda/plugins/virtual_packages/linux.py
+++ b/conda/plugins/virtual_packages/linux.py
@@ -1,16 +1,14 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-
 import os
 import platform
 import re
 
-from conda import plugins
-from conda.common._os.linux import linux_get_libc_version
-from conda.models.plugins import CondaVirtualPackage
+from ...common._os.linux import linux_get_libc_version
+from .. import hookimpl, CondaVirtualPackage
 
 
-@plugins.hookimpl
+@hookimpl
 def conda_virtual_packages():
     if platform.system() != "Linux":
         return

--- a/conda/plugins/virtual_packages/osx.py
+++ b/conda/plugins/virtual_packages/osx.py
@@ -1,14 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-
 import os
 import platform
 
-from conda import plugins
-from conda.models.plugins import CondaVirtualPackage
+from .. import hookimpl, CondaVirtualPackage
 
 
-@plugins.hookimpl
+@hookimpl
 def conda_virtual_packages():
     if platform.system() != "Darwin":
         return

--- a/conda/plugins/virtual_packages/windows.py
+++ b/conda/plugins/virtual_packages/windows.py
@@ -3,11 +3,10 @@
 
 import platform
 
-from conda import plugins
-from conda.models.plugins import CondaVirtualPackage
+from .. import hookimpl, CondaVirtualPackage
 
 
-@plugins.hookimpl
+@hookimpl
 def conda_virtual_packages():
     if platform.system() != "Windows":
         return

--- a/docs/source/dev-guide/plugins/subcommands.rst
+++ b/docs/source/dev-guide/plugins/subcommands.rst
@@ -6,7 +6,7 @@ The conda CLI can be extended with the ``conda_subcommands`` plugin hook.
 Registered subcommands will be available under the ``conda <subcommand>``
 command.
 
-.. autoclass:: conda.models.plugins.CondaSubcommand
+.. autoclass:: conda.plugins.types.CondaSubcommand
    :members:
    :undoc-members:
 

--- a/docs/source/dev-guide/plugins/virtual_packages.rst
+++ b/docs/source/dev-guide/plugins/virtual_packages.rst
@@ -7,7 +7,7 @@ the plugin system. This mechanism lets users write plugins that provide
 version identification for proprieties only known at runtime (e.g., OS
 information).
 
-.. autoclass:: conda.models.plugins.CondaVirtualPackage
+.. autoclass:: conda.plugins.types.CondaVirtualPackage
    :members:
    :undoc-members:
 

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from conda import plugins
-from conda.models.plugins import CondaSubcommand
+from conda.plugins.types import CondaSubcommand
 
 
 class SubcommandPlugin:

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -8,7 +8,7 @@ import conda.core.index
 from conda.common.io import env_var
 from conda.exceptions import PluginError
 from conda.base.context import context
-from conda.models.plugins import CondaVirtualPackage
+from conda.plugins.types import CondaVirtualPackage
 from conda.testing.solver_helpers import package_dict
 from conda import plugins
 from conda.plugins.virtual_packages import cuda


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

POC of internal discussion.

Moving `conda.models.plugins` to `conda.plugins.types` for stricter domain organization and to avoid adding more confusion to `conda.models`.

My intention with the import rules of `conda/plugins/__init__.py` is to expose everything necessary to make a plugin. The plugin implementations (e.g., `conda.plugins.virtual_pacakges`) should never be sideloaded by importing `conda.plugins`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
