### PR TITLE
Implement `PluginManager.load_default`

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -8,10 +8,16 @@ from . import virtual_packages
 from .hookspec import CondaSpecs, spec_name
 
 
+class PluginManager(pluggy.PluginManager):
+    def load_default(self):
+        for plugin in virtual_packages.plugins:
+            self.register(plugin)
+
+
 @functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache
 def get_plugin_manager() -> pluggy.PluginManager:
-    pm = pluggy.PluginManager(spec_name)
+    pm = PluginManager(spec_name)
     pm.add_hookspecs(CondaSpecs)
-    virtual_packages.register(pm)
+    pm.load_default()
     pm.load_setuptools_entrypoints(spec_name)
     return pm

--- a/conda/plugins/virtual_packages/__init__.py
+++ b/conda/plugins/virtual_packages/__init__.py
@@ -2,17 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import pluggy
-
 from . import archspec, cuda, linux, osx, windows
 
 
-def register(pm: pluggy.PluginManager) -> None:
-    """
-    Please add a nice doc string too explaining why this function exists!
-    """
-    pm.register(archspec)
-    pm.register(cuda)
-    pm.register(linux)
-    pm.register(osx)
-    pm.register(windows)
+plugins = [archspec, cuda, linux, osx, windows]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

POC of internal discussion.

Subclasses `pluggy.PluginManager` with a set of default plugins to be loaded in `get_plugin_manager`.

Xref: https://github.com/conda/conda/pull/12060

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
