### PR TITLE
Update Docstring in Hookspec Module

### DIFF
--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -17,7 +17,7 @@ hookimpl = pluggy.HookimplMarker(spec_name)
 class CondaSpecs:
 
     @_hookspec
-    def conda_subcommands() -> Iterable[CondaSubcommand]:
+    def conda_subcommands(self) -> Iterable[CondaSubcommand]:
         """
         Register external subcommands in conda.
 
@@ -45,7 +45,7 @@ class CondaSpecs:
         """
 
     @_hookspec
-    def conda_virtual_packages() -> Iterable[CondaVirtualPackage]:
+    def conda_virtual_packages(self) -> Iterable[CondaVirtualPackage]:
         """
         Register virtual packages in Conda.
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -36,7 +36,7 @@ class CondaSpecs:
 
 
             @plugins.hookimpl
-            def conda_subcommands(self):
+            def conda_subcommands():
                 yield CondaSubcommand(
                     name="example",
                     summary="example command",
@@ -60,7 +60,7 @@ class CondaSpecs:
 
 
             @plugins.hookimpl
-            def conda_virtual_packages(self):
+            def conda_virtual_packages():
                 yield CondaVirtualPackage(
                     name="my_custom_os",
                     version="1.2.3",


### PR DESCRIPTION
When `self` is declared in a plugin function decorated with `@plugins.hookimpl`, the following error is output:

```
    hookimpl definition: conda_subcommands(self)
    Argument(s) {'self'} are declared in the hookimpl but can not be found in the hookspec
```

Editing the docstrings in `hookspec` module in order to avoid a plugin developer from encountering this error.