### PR TITLE
Prevent [name=...] from overwriting name specified outside of brackets

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -8,6 +8,7 @@ from functools import reduce
 from logging import getLogger
 from operator import attrgetter
 from os.path import basename
+import warnings
 import re
 
 try:
@@ -742,6 +743,17 @@ def _parse_spec_str(spec_str):
         components['build'] = build
 
     # anything in brackets will now strictly override key as set in other area of spec str
+    # EXCEPT FOR: name
+    # If we let name in brackets override a name outside of brackets it is possible to write
+    # MatchSpecs that appear to install one package but actually install a completely different one
+    # e.g. tensorflow[name=* version=* md5=<hash of pytorch package> ] will APPEAR to install
+    # tensorflow but actually install pytorch.
+    if "name" in components and "name" in brackets:
+        warnings.warn(
+            f"'name' specified both inside ({brackets['name']}) and outside ({components['name']})"
+            " of brackets. the value outside of brackets ({components['name']}) will be used."
+        )
+        del brackets["name"]
     components.update(brackets)
     components['_original_spec_str'] = original_spec_str
     _PARSE_CACHE[original_spec_str] = components

--- a/news/12062-fix-name-overwrite
+++ b/news/12062-fix-name-overwrite
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fixed a confusing case where [name=...] could overwrite the name specified outside of brackets. (#12062)
+* Prefer the outer name when a MatchSpec specifies a package's name twice package-name[name=package-name] (#12062)
 
 ### Deprecations
 

--- a/news/12062-fix-name-overwrite
+++ b/news/12062-fix-name-overwrite
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fixed a confusing case where [name=...] could overwrite the name specified outside of brackets. (#12062)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -655,6 +655,30 @@ class SpecStrParsingTests(TestCase):
             "build": "3",
         }
 
+        # Ensure 'name' within brackets can't override the name specified outside of brackets
+        assert _parse_spec_str(
+            "tensorflow[name=* version=* md5=253b922ecdb5a30884875948b8904983]"
+        ) == {
+            "_original_spec_str": "tensorflow[name=* version=* md5=253b922ecdb5a30884875948b8904983]",
+            "name": "tensorflow",
+            "version": "*",
+            "md5": "253b922ecdb5a30884875948b8904983",
+        }
+        assert _parse_spec_str("tensorflow[name=pytorch]") == {
+            "_original_spec_str": "tensorflow[name=pytorch]",
+            "name": "tensorflow",
+        }
+
+        assert _parse_spec_str(
+            "defaults::numpy=1.8=py27_0 [name=\"pytorch\" channel='anaconda',version=\">=1.8,<2|1.9\", build='3']"
+        ) == {
+            "_original_spec_str": "defaults::numpy=1.8=py27_0 [name=\"pytorch\" channel='anaconda',version=\">=1.8,<2|1.9\", build='3']",
+            "channel": "anaconda",
+            "name": "numpy",
+            "version": ">=1.8,<2|1.9",
+            "build": "3",
+        }
+
     def test_star_name(self):
         assert _parse_spec_str("* 2.7.4") == {
             "_original_spec_str": "* 2.7.4",


### PR DESCRIPTION
### Description

Letting [name=...] overwrite the name specified outside of brackets in MatchSpecs allows for confusing cases where it seems one package will be installed but, in reality, another one is installed.

It's worth noting that this is a minor change to MatchSpec behavior.  We have no indication that this behavior is relied upon anywhere but its worth keeping in mind.  We should be confident that we aren't negatively impacting anyone before merging this PR.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
