### PR TITLE
use python 3.9 for test_conda_pip_interop_conda_editable_package

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1603,8 +1603,9 @@ dependencies:
 
 
     def test_conda_pip_interop_conda_editable_package(self):
-        with env_var('CONDA_RESTORE_FREE_CHANNEL', True, stack_callback=conda_tests_ctxt_mgmt_def_pol):
-            with make_temp_env("python=2.7", "pip=10", "git", use_restricted_unicode=on_win) as prefix:
+        with env_vars({"CONDA_REPORT_ERRORS": "false"},
+            stack_callback=conda_tests_ctxt_mgmt_def_pol):
+            with make_temp_env("python=3.9", "pip", "git", use_restricted_unicode=on_win) as prefix:
                 workdir = prefix
 
                 run_command(Commands.CONFIG, prefix, "--set", "pip_interop_enabled", "true")
@@ -1635,7 +1636,7 @@ dependencies:
                         "pysocks !=1.5.7,<2.0,>=1.5.6"
                     ],
                     "depends": [
-                        "python 2.7.*"
+                        "python 3.9.*"
                     ],
                     "fn": "urllib3-1.19.1-dev_0",
                     "name": "urllib3",
@@ -1650,6 +1651,7 @@ dependencies:
                                                 use_exception_handler=True)
                 assert not stderr
                 json_obj = json_loads(stdout)
+
                 assert "UNLINK" not in json_obj["actions"]
                 link_dists = json_obj["actions"]["LINK"]
                 assert len(link_dists) == 1


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Was seeing `ValueError: Unregistered SAT variable name: conda-forge/noarch::urllib3-1.26.11-pyhd8ed1ab_0` in this test. Update Python to make it easier to test on modern systems.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
