### PR TITLE
Fix fish activation scripts

### DIFF
--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -69,10 +69,10 @@ function conda --inherit-variable CONDA_EXE
         set -e argv[1]
         switch $cmd
             case activate deactivate
-                eval ($CONDA_EXE shell.fish $cmd $argv)
+                $CONDA_EXE shell.fish $cmd $argv | source || return $status
             case install update upgrade remove uninstall
-                $CONDA_EXE $cmd $argv
-                and eval ($CONDA_EXE shell.fish reactivate)
+                $CONDA_EXE $cmd $argv || return $status
+                $CONDA_EXE shell.fish reactivate | source || return $status
             case '*'
                 $CONDA_EXE $cmd $argv
         end


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

From https://github.com/mamba-org/mamba/pull/2101:

In fish `(subproc)` will replace newlines with spaces. Thus, `eval (subproc)` will evaluate the output of `subproc` with newlines replaced with spaces. We need `| source` to keep the newlines.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
