### PR TITLE
Initial Apple M1 testing with cirrus-ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+macos_instance:
+  image: ghcr.io/cirruslabs/macos-ventura-base:latest
+
+env:
+  CIRRUS_CLONE_DEPTH: '0'
+
+task:
+  name: macos-m1
+  #only_if: $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'feature/.*' || $CIRRUS_BRANCH =~ 'pull/.*'
+  environment:
+    PYTHON: '3.10'
+    TEST_SPLITS: '3'
+    TEST_GROUP: '1'
+  test_script: |
+    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -O ~/miniconda.sh
+    bash ~/miniconda.sh -b -p $HOME/miniconda3
+    source $HOME/miniconda3/etc/profile.d/conda.sh
+    conda create --name conda-test-env "python=${PYTHON}" -y
+    conda activate conda-test-env
+    ./dev/macos/setup.sh
+    ./dev/macos/unit.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,11 @@ task:
     TEST_SPLITS: '3'
     TEST_GROUP: '1'
 
+  info_script: |
+    sysctl -n hw.ncpu
+    vm_stat
+    df -h
+
   miniconda_script: |
     wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -O ~/miniconda.sh
     bash ~/miniconda.sh -b -p $HOME/miniconda3

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,4 +37,4 @@ task:
   test_script: |
     source $HOME/miniconda3/etc/profile.d/conda.sh
     conda activate conda-test-env
-    pytest -m "cirrus" -v
+    python -m pytest -m "cirrus" -v

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,8 +8,6 @@ task:
   name: macos-m1
   skip: "changesIncludeOnly('docs/*')"
   only_if: $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'feature/.*$' || $CIRRUS_PR != ''
-  environment:
-    PYTHON: '3.10'
 
   info_script: |
     sysctl -n hw.ncpu

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,7 @@ env:
 
 task:
   name: macos-m1
+  skip: "changesIncludeOnly('docs/*')"
   only_if: $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'feature/.*$' || $CIRRUS_PR != ''
   environment:
     PYTHON: '3.10'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,8 +9,6 @@ task:
   only_if: $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'feature/.*$' || $CIRRUS_PR != ''
   environment:
     PYTHON: '3.10'
-    TEST_SPLITS: '3'
-    TEST_GROUP: '1'
 
   info_script: |
     sysctl -n hw.ncpu
@@ -21,6 +19,14 @@ task:
     wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -O ~/miniconda.sh
     bash ~/miniconda.sh -b -p $HOME/miniconda3
 
+  matrix:
+    - env:
+        PYTHON: '3.8'
+    - env:
+        PYTHON: '3.9'
+    - env:
+        PYTHON: '3.10'
+
   setup_script: |
     source $HOME/miniconda3/etc/profile.d/conda.sh
     conda create --name conda-test-env "python=${PYTHON}" -y
@@ -30,4 +36,4 @@ task:
   test_script: |
     source $HOME/miniconda3/etc/profile.d/conda.sh
     conda activate conda-test-env
-    ./dev/macos/unit.sh
+    pytest -m "cirrus" -v

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,11 +11,18 @@ task:
     PYTHON: '3.10'
     TEST_SPLITS: '3'
     TEST_GROUP: '1'
-  test_script: |
+
+  miniconda_script: |
     wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -O ~/miniconda.sh
     bash ~/miniconda.sh -b -p $HOME/miniconda3
+
+  setup_script: |
     source $HOME/miniconda3/etc/profile.d/conda.sh
     conda create --name conda-test-env "python=${PYTHON}" -y
     conda activate conda-test-env
     ./dev/macos/setup.sh
+
+  test_script: |
+    source $HOME/miniconda3/etc/profile.d/conda.sh
+    conda activate conda-test-env
     ./dev/macos/unit.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
 
 task:
   name: macos-m1
-  #only_if: $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'feature/.*' || $CIRRUS_BRANCH =~ 'pull/.*'
+  only_if: $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'feature/.*$' || $CIRRUS_PR != ''
   environment:
     PYTHON: '3.10'
     TEST_SPLITS: '3'

--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -14,6 +14,7 @@
 # CONDA_PREFIX too in some instances and that really needs fixing.
 
 import os
+import platform
 import sys
 from os.path import dirname, normpath, join, isfile
 from subprocess import check_output
@@ -36,7 +37,7 @@ def conda_ensure_sys_python_is_base_env_python():
     # C:\opt\conda\envs\py27
     # So lets just sys.exit on that.
 
-    if 'CONDA_PYTHON_EXE' in os.environ:
+    if platform.system().lower() == 'windows' and 'CONDA_PYTHON_EXE' in os.environ:
         if os.path.normpath(os.environ['CONDA_PYTHON_EXE']) != sys.executable:
             print("ERROR :: Running tests from a non-base Python interpreter. "
                   " Tests requires installing menuinst and that causes stderr "

--- a/dev/macos/setup.sh
+++ b/dev/macos/setup.sh
@@ -7,6 +7,7 @@ then
     curl -LO https://dl.minio.io/server/minio/release/darwin-amd64/minio
 fi
 chmod +x minio
+sudo mkdir -p /usr/local/bin
 sudo cp minio /usr/local/bin/minio
 
 # restoring the default for changeps1 to have parity with dev
@@ -15,4 +16,4 @@ conda config --set changeps1 true
 conda config --set use_only_tar_bz2 true
 # install all test requirements
 conda install --quiet --name conda-test-env --yes --file tests/requirements.txt
-conda update openssl ca-certificates certifi
+#conda update openssl ca-certificates certifi --yes

--- a/dev/macos/setup.sh
+++ b/dev/macos/setup.sh
@@ -16,4 +16,3 @@ conda config --set changeps1 true
 conda config --set use_only_tar_bz2 true
 # install all test requirements
 conda install --quiet --name conda-test-env --yes --file tests/requirements.txt
-#conda update openssl ca-certificates certifi --yes

--- a/news/12079-initial-apple-m1-testing
+++ b/news/12079-initial-apple-m1-testing
@@ -16,6 +16,6 @@
 
 ### Other
 
-* Enable initial Apple M1 (Apple Silicon) testing via Cirrus CI for Python 3.8, 3.9, 3.10. 
+* Enable initial Apple M1 (Apple Silicon) testing via Cirrus CI for Python 3.8, 3.9, 3.10.
   Only tests marked via `@pytest.mark.cirrus` run there until it is clear how much resources
   are availabe there.

--- a/news/12079-initial-apple-m1-testing
+++ b/news/12079-initial-apple-m1-testing
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Enable initial Apple M1 (Apple Silicon) testing via Cirrus CI for Python 3.8, 3.9, 3.10. 
+  Only tests marked via `@pytest.mark.cirrus` run there until it is clear how much resources
+  are availabe there.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ doctest_optionflags =
 markers =
     integration: integration tests that usually require an internet connect
     slow: slow running tests
+    cirrus: selected tests to run via Cirrus CI on Apple Silicon Machines (osx-arm64)
 
 
 [pycodestyle]

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -59,7 +59,6 @@ def solve(specs):
     return [Dist.from_string(fn) for fn in r.solve(specs)]
 
 
-@pytest.mark.cirrus
 class add_unlink_TestCase(unittest.TestCase):
     def generate_random_dist(self):
         return "foobar-%s-0" % random.randint(100, 200)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -59,6 +59,7 @@ def solve(specs):
     return [Dist.from_string(fn) for fn in r.solve(specs)]
 
 
+@pytest.mark.cirrus
 class add_unlink_TestCase(unittest.TestCase):
     def generate_random_dist(self):
         return "foobar-%s-0" % random.randint(100, 200)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -24,6 +24,7 @@ from conda.testing.helpers import TEST_DATA_DIR, add_subdir, add_subdir_to_iter,
 f_mkl = {"mkl"}
 
 
+@pytest.mark.cirrus
 class TestSolve(unittest.TestCase):
 
     def assert_have_mkl(self, precs, names):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Running tests natively on Apple M1 (osx-arm64, Apple Silicon).

Cirrus CI seems to be currently the only Apple M1 CI provider, which is free for OpenSource Projects ~~and requires enablement via https://github.com/marketplace/cirrus-ci for the org/repo~~(got enabled).

This currently runs one single marked Test Class with a Python version matrix (3.8, 3.9, 3.10). This can be extended over time by marking more test to run via cirrus in case there is any interest to run a test natively on osx-arm64.

~~Some results can be seen in my fork that got enabled for cirrus-ci, see e.g. https://github.com/dbast/conda/pull/1/checks?check_run_id=9385205816~~ Can now be seen as part of the CI runs in this PR.

TODO:
* ~~Cirrus CI enablement for the org/repo~~ Done
* ~~fixing the commented out "only_if:" statement~~ Done
* ~~investigate current failures, by fixing/changing setup.sh/unit.sh/integration.sh/tests.~~ switched to marked tests only
* ~~Extending the test task to test a matrix of TEST_GROUP/PYTHON/UNIT/INTEGRATION (can als be done with later PRs)~~ Python matrix is there.

The elegance of cirrus is that it can be also tested locally with full isolation, by running (initial run is slow due to the VM download, see also https://github.com/cirruslabs/tart):
* brew install cirruslabs/cli/cirrus
* cirrus run 

conda-forge also discussed the usage of cirrus-ci in https://conda-forge.org/docs/orga/minutes/2022-09-21.html

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
