### PR TITLE
Move `conda.core.solve._get_solver_class` to `CondaPluginManager.get_solver_backend`

### DIFF
--- a/conda/api.py
+++ b/conda/api.py
@@ -47,7 +47,7 @@ class Solver:
                 The set of package specs to remove from the prefix.
 
         """
-        solver_backend = context.plugin_manager.get_solver_backend()
+        solver_backend = context.plugin_manager.get_cached_solver_backend()
         self._internal = solver_backend(prefix, channels, subdirs, specs_to_add, specs_to_remove)
 
     def solve_final_state(self, update_modifier=NULL, deps_modifier=NULL, prune=NULL,

--- a/conda/api.py
+++ b/conda/api.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .base.constants import DepsModifier as _DepsModifier, UpdateModifier as _UpdateModifier
+from .base.context import context
 from .common.constants import NULL
 from .core.package_cache_data import PackageCacheData as _PackageCacheData
 from .core.prefix_data import PrefixData as _PrefixData
-from .core.solve import _get_solver_class
 from .core.subdir_data import SubdirData as _SubdirData
 from .models.channel import Channel
 
@@ -47,8 +47,8 @@ class Solver:
                 The set of package specs to remove from the prefix.
 
         """
-        SolverType = _get_solver_class()
-        self._internal = SolverType(prefix, channels, subdirs, specs_to_add, specs_to_remove)
+        solver_backend = context.plugin_manager.get_solver_backend()
+        self._internal = solver_backend(prefix, channels, subdirs, specs_to_add, specs_to_remove)
 
     def solve_final_state(self, update_modifier=NULL, deps_modifier=NULL, prune=NULL,
                           ignore_pinned=NULL, force_remove=NULL):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -842,12 +842,11 @@ class Context(Configuration):
         if self.libc_family_version[0]:
             builder.append("%s/%s" % self.libc_family_version)
         if self.solver != "classic":
-            from ..core.solve import _get_solver_class
-
             user_agent_str = "solver/%s" % self.solver
             try:
+                solver_backend = self.plugin_manager.get_solver_backend()
                 # Solver.user_agent has to be a static or class method
-                user_agent_str += f" {_get_solver_class().user_agent()}"
+                user_agent_str += f" {solver_backend().user_agent()}"
             except Exception as exc:
                 log.debug(
                     "User agent could not be fetched from solver class '%s'.",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -844,7 +844,7 @@ class Context(Configuration):
         if self.solver != "classic":
             user_agent_str = "solver/%s" % self.solver
             try:
-                solver_backend = self.plugin_manager.get_solver_backend()
+                solver_backend = self.plugin_manager.get_cached_solver_backend()
                 # Solver.user_agent has to be a static or class method
                 user_agent_str += f" {solver_backend().user_agent()}"
             except Exception as exc:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -245,7 +245,7 @@ def install(args, parser, command='install'):
                 unlink_link_transaction = revert_actions(prefix, get_revision(args.revision),
                                                          index)
             else:
-                solver_backend = context.plugin_manager.get_solver_backend()
+                solver_backend = context.plugin_manager.get_cached_solver_backend()
                 solver = solver_backend(
                     prefix,
                     context.channels,

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -15,7 +15,6 @@ from ..common.constants import NULL
 from ..common.path import paths_equal, is_package_file
 from ..core.index import calculate_channel_urls, get_index
 from ..core.prefix_data import PrefixData
-from ..core.solve import _get_solver_class
 from ..exceptions import (CondaExitZero, CondaImportError, CondaOSError, CondaSystemExit,
                           CondaValueError, DirectoryNotACondaEnvironmentError,
                           DirectoryNotFoundError, DryRunExit, EnvironmentLocationNotFound,
@@ -246,9 +245,15 @@ def install(args, parser, command='install'):
                 unlink_link_transaction = revert_actions(prefix, get_revision(args.revision),
                                                          index)
             else:
-                SolverType = _get_solver_class()
-                solver = SolverType(prefix, context.channels, context.subdirs, specs_to_add=specs,
-                                    repodata_fn=repodata_fn, command=args.cmd)
+                solver_backend = context.plugin_manager.get_solver_backend()
+                solver = solver_backend(
+                    prefix,
+                    context.channels,
+                    context.subdirs,
+                    specs_to_add=specs,
+                    repodata_fn=repodata_fn,
+                    command=args.cmd,
+                )
                 update_modifier = context.update_modifier
                 if (isinstall or isremove) and args.update_modifier == NULL:
                     update_modifier = UpdateModifier.FREEZE_INSTALLED

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -83,7 +83,7 @@ def execute(args, parser):
             specs = specs_from_args(args.package_names)
         channel_urls = ()
         subdirs = ()
-        solver_backend = context.plugin_manager.get_solver_backend()
+        solver_backend = context.plugin_manager.get_cached_solver_backend()
         solver = solver_backend(prefix, channel_urls, subdirs, specs_to_remove=specs)
         txn = solver.solve_for_transaction()
         handle_txn(txn, prefix, args, False, True)

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -11,7 +11,6 @@ from ..base.context import context
 from ..core.envs_manager import unregister_env
 from ..core.link import PrefixSetup, UnlinkLinkTransaction
 from ..core.prefix_data import PrefixData
-from ..core.solve import _get_solver_class
 from ..exceptions import CondaEnvironmentError, CondaValueError, DirectoryNotACondaEnvironmentError
 from ..gateways.disk.delete import rm_rf, path_is_clean
 from ..models.match_spec import MatchSpec
@@ -84,7 +83,8 @@ def execute(args, parser):
             specs = specs_from_args(args.package_names)
         channel_urls = ()
         subdirs = ()
-        solver = _get_solver_class()(prefix, channel_urls, subdirs, specs_to_remove=specs)
+        solver_backend = context.plugin_manager.get_solver_backend()
+        solver = solver_backend(prefix, channel_urls, subdirs, specs_to_remove=specs)
         txn = solver.solve_for_transaction()
         handle_txn(txn, prefix, args, False, True)
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -49,14 +49,13 @@ def _get_solver_class(key=None):
 
     See ``context.solver`` for more details.
     """
-    from conda.plugins import solvers
-
     warnings.warn(
         "`conda.core.solve._get_solver_class` is pending deprecation and will be removed in a "
-        "future release.",
+        "future release. Please use `conda.base.context.plugin_manager.get_cached_solver_backend ",
+        "instead.",
         PendingDeprecationWarning,
     )
-    return solvers.get_solver((key or context.solver).lower())
+    return context.plugin_manager.get_cached_solver_backend(key or context.solver)
 
 
 class Solver:

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -29,7 +29,7 @@ from ..common.compat import odict
 from ..common.constants import NULL
 from ..common.io import Spinner, dashlist, time_recorder
 from ..common.path import get_major_minor_version, paths_equal
-from ..exceptions import (CondaValueError, PackagesNotFoundError, SpecsConfigurationConflictError,
+from ..exceptions import (PackagesNotFoundError, SpecsConfigurationConflictError,
                           UnsatisfiableError)
 from ..history import History
 from ..models.channel import Channel
@@ -48,21 +48,9 @@ def _get_solver_class(key=None):
 
     See ``context.solver`` for more details.
     """
-    solvers = context.plugin_manager.get_registered_plugins("solvers")
-    key = (key or context.solver).lower()
-
-    solvers_mapping = {}
-    for solver in solvers:
-        solvers_mapping[solver.name.lower()] = solver.backend
-
-    if key in solvers_mapping:
-        return solvers_mapping[key]
-    else:
-        raise CondaValueError(
-            f"You have chosen a non-default solver backend ({key}) "
-            f"but it was not recognized. Choose one of: "
-            f"{', '.join(solvers_mapping.keys())}"
-        )
+    from conda.plugins import solvers
+    # TODO add deprecation warning
+    return solvers.get_solver((key or context.solver).lower())
 
 
 class Solver:

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -6,6 +6,7 @@ from genericpath import exists
 from logging import DEBUG, getLogger
 from os.path import join
 import sys
+import warnings
 from textwrap import dedent
 
 try:
@@ -49,7 +50,12 @@ def _get_solver_class(key=None):
     See ``context.solver`` for more details.
     """
     from conda.plugins import solvers
-    # TODO add deprecation warning
+
+    warnings.warn(
+        "`conda.core.solve._get_solver_class` is pending deprecation and will be removed in a "
+        "future release.",
+        PendingDeprecationWarning,
+    )
     return solvers.get_solver((key or context.solver).lower())
 
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -51,7 +51,7 @@ def _get_solver_class(key=None):
     """
     warnings.warn(
         "`conda.core.solve._get_solver_class` is pending deprecation and will be removed in a "
-        "future release. Please use `conda.base.context.plugin_manager.get_cached_solver_backend ",
+        "future release. Please use `conda.base.context.plugin_manager.get_cached_solver_backend "
         "instead.",
         PendingDeprecationWarning,
     )

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -441,7 +441,6 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
     }, stack_callback=stack_context_default):
         from os.path import basename
         from ._vendor.boltons.setutils import IndexedSet
-        from .core.solve import _get_solver_class
         from .models.channel import Channel
         from .models.dist import Dist
         if channel_priority_map:
@@ -464,7 +463,8 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
         from .core.prefix_data import PrefixData
         PrefixData._cache_.clear()
 
-        solver = _get_solver_class()(prefix, channels, subdirs, specs_to_add=specs)
+        solver_backend = context.plugin_manager.get_solver_backend()
+        solver = solver_backend(prefix, channels, subdirs, specs_to_add=specs)
         if index:
             solver._index = {prec: prec for prec in index.values()}
         txn = solver.solve_for_transaction(prune=prune, ignore_pinned=not pinned)

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -463,7 +463,7 @@ def install_actions(prefix, index, specs, force=False, only_names=None, always_c
         from .core.prefix_data import PrefixData
         PrefixData._cache_.clear()
 
-        solver_backend = context.plugin_manager.get_solver_backend()
+        solver_backend = context.plugin_manager.get_cached_solver_backend()
         solver = solver_backend(prefix, channels, subdirs, specs_to_add=specs)
         if index:
             solver._index = {prec: prec for prec in index.values()}

--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -1,4 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from .hookspec import hookimpl  # noqa: F401
+from .hookspec import hookimpl
 from .types import CondaSolver, CondaSubcommand, CondaVirtualPackage  # noqa: F401
+
+#: Conda plugin hook implementation marker, please use ``conda.plugins.hookimpl``
+hookimpl = hookimpl

--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -1,7 +1,4 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from .hookspec import hookimpl
+from .hookspec import hookimpl  # noqa: F401
 from .types import CondaSolver, CondaSubcommand, CondaVirtualPackage  # noqa: F401
-
-#: Conda plugin hook implementation marker, please use ``conda.plugins.hookimpl``
-hookimpl = hookimpl

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -15,6 +15,10 @@ hookimpl = pluggy.HookimplMarker(spec_name)
 
 
 class CondaSpecs:
+    """
+    The conda plugin hookspecs, to be used by developers.
+    """
+
     @_hookspec
     def conda_solvers(self) -> Iterable[CondaSolver]:
         """

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -96,7 +96,7 @@ class CondaPluginManager(pluggy.PluginManager):
         See ``context.solver`` for more details.
 
         Please use the cached version of this method called
-        ``cached_solver_backend`` for high-throughput code paths
+        ``get_cached_solver_backend`` for high-throughput code paths
         which is set up as a instance-specific LRU cache.
         """
         # Some light data validation in case name isn't given.

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -36,7 +36,7 @@ class CondaPluginManager(pluggy.PluginManager):
         """
         Load the provided list of plugins and fail gracefully on error.
         The provided list plugins can either be classes or modules with
-        ``conda.plugins.hook_impl`
+        :attr:`~conda.plugins.hook_impl`.
         """
         plugin_names = []
         for plugin in plugins:
@@ -52,8 +52,11 @@ class CondaPluginManager(pluggy.PluginManager):
 
     def load_setuptools_entrypoints(self, *args, **kwargs) -> int:
         """
-        Overloading the parent method to add conda specific exception
-s        """
+        Overloading the parent method from pluggy to add conda specific exceptions.
+
+        See :meth:`pluggy.PluginManager.load_setuptools_entrypoints` for
+        more information.
+        """
         try:
             return super().load_setuptools_entrypoints(*args, **kwargs)
         except Exception as err:
@@ -101,7 +104,7 @@ s        """
         See ``context.solver`` for more details.
 
         Please use the cached version of this method called
-        ``get_cached_solver_backend`` for high-throughput code paths
+        :meth:`get_cached_solver_backend` for high-throughput code paths
         which is set up as a instance-specific LRU cache.
         """
         # Some light data validation in case name isn't given.

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -112,6 +112,10 @@ class CondaPluginManager(pluggy.PluginManager):
 
 @functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache
 def get_plugin_manager() -> CondaPluginManager:
+    """
+    Get a cached version of the :class:`~conda.plugins.manager.CondaPluginManager`
+    instance, with the built-in and the entrypoints provided plugins loaded.
+    """
     pm = CondaPluginManager()
     pm.add_hookspecs(CondaSpecs)
     pm.load_plugins(solvers, *virtual_packages.plugins)

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -24,6 +24,9 @@ class CondaPluginManager(pluggy.PluginManager):
         # Setting the default project name to the spec name for ease of use
         if project_name is None:
             project_name = spec_name
+        # Make the cache containers local to the instances so that the
+        # reference from cache to the instance gets garbage collected with the instance
+        self.get_solver_backend = functools.lru_cache()(self._get_solver_backend)
         super().__init__(project_name, *args, **kwargs)
 
     def load_plugins(self, *plugins) -> list[str]:
@@ -71,7 +74,7 @@ class CondaPluginManager(pluggy.PluginManager):
             )
         return plugins
 
-    def get_solver_backend(self, name: str = None) -> type[Solver]:
+    def _get_solver_backend(self, name: str = None) -> type[Solver]:
         """
         Load the correct solver backend.
 

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -19,6 +19,9 @@ class CondaPluginManager(pluggy.PluginManager):
     The conda plugin manager to implement behavior additional to
     pluggy's default plugin manager.
     """
+    #: Cached version of the :meth:`~conda.plugins.manager.CondaPluginManager.get_solver_backend`
+    #: method.
+    get_cached_solver_backend = None
 
     def __init__(self, project_name: str | None = None, *args, **kwargs) -> None:
         # Setting the default project name to the spec name for ease of use
@@ -31,7 +34,9 @@ class CondaPluginManager(pluggy.PluginManager):
 
     def load_plugins(self, *plugins) -> list[str]:
         """
-        Load the provided list of plugins and fail gracefully on failure.
+        Load the provided list of plugins and fail gracefully on error.
+        The provided list plugins can either be classes or modules with
+        ``conda.plugins.hook_impl`
         """
         plugin_names = []
         for plugin in plugins:
@@ -46,9 +51,9 @@ class CondaPluginManager(pluggy.PluginManager):
         return plugin_names
 
     def load_setuptools_entrypoints(self, *args, **kwargs) -> int:
-        """"
-        Overloading the parent method to add conda specific exception
         """
+        Overloading the parent method to add conda specific exception
+s        """
         try:
             return super().load_setuptools_entrypoints(*args, **kwargs)
         except Exception as err:

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -590,7 +590,7 @@ def get_solver(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(), h
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = context.plugin_manager.get_solver_backend()(
+            solver = context.plugin_manager.get_cached_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-1"),),
                 (context.subdir,),
@@ -619,7 +619,7 @@ def get_solver_2(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = context.plugin_manager.get_solver_backend()(
+            solver = context.plugin_manager.get_cached_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-2"),),
                 (context.subdir,),
@@ -648,7 +648,7 @@ def get_solver_4(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = context.plugin_manager.get_solver_backend()(
+            solver = context.plugin_manager.get_cached_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-4"),),
                 (context.subdir,),
@@ -677,7 +677,7 @@ def get_solver_5(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = context.plugin_manager.get_solver_backend()(
+            solver = context.plugin_manager.get_cached_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-5"),),
                 (context.subdir,),
@@ -710,7 +710,7 @@ def get_solver_aggregate_1(
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = context.plugin_manager.get_solver_backend()(
+            solver = context.plugin_manager.get_cached_solver_backend()(
                 tmpdir,
                 (
                     Channel(f"{EXPORTED_CHANNELS_DIR}/channel-2"),
@@ -746,7 +746,7 @@ def get_solver_aggregate_2(
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = context.plugin_manager.get_solver_backend()(
+            solver = context.plugin_manager.get_cached_solver_backend()(
                 tmpdir,
                 (
                     Channel(f"{EXPORTED_CHANNELS_DIR}/channel-4"),
@@ -780,7 +780,7 @@ def get_solver_must_unfreeze(
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = context.plugin_manager.get_solver_backend()(
+            solver = context.plugin_manager.get_cached_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-freeze"),),
                 (context.subdir,),
@@ -811,7 +811,7 @@ def get_solver_cuda(
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = context.plugin_manager.get_solver_backend()(
+            solver = context.plugin_manager.get_cached_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-1"),),
                 (context.subdir,),
@@ -835,4 +835,4 @@ def convert_to_dist_str(solution):
 
 @pytest.fixture()
 def solver_class():
-    return context.plugin_manager.get_solver_backend()
+    return context.plugin_manager.get_cached_solver_backend()

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -23,7 +23,6 @@ from ..base.context import context, reset_context, conda_tests_ctxt_mgmt_def_pol
 from ..common.compat import encode_arguments
 from ..common.io import argv, captured as common_io_captured, env_var
 from ..core.prefix_data import PrefixData
-from ..core.solve import _get_solver_class
 from ..core.subdir_data import SubdirData, make_feature_record
 from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.read import lexists
@@ -591,7 +590,7 @@ def get_solver(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(), h
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = _get_solver_class()(
+            solver = context.plugin_manager.get_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-1"),),
                 (context.subdir,),
@@ -620,7 +619,7 @@ def get_solver_2(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = _get_solver_class()(
+            solver = context.plugin_manager.get_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-2"),),
                 (context.subdir,),
@@ -649,7 +648,7 @@ def get_solver_4(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = _get_solver_class()(
+            solver = context.plugin_manager.get_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-4"),),
                 (context.subdir,),
@@ -678,7 +677,7 @@ def get_solver_5(tmpdir, specs_to_add=(), specs_to_remove=(), prefix_records=(),
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = _get_solver_class()(
+            solver = context.plugin_manager.get_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-5"),),
                 (context.subdir,),
@@ -711,7 +710,7 @@ def get_solver_aggregate_1(
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = _get_solver_class()(
+            solver = context.plugin_manager.get_solver_backend()(
                 tmpdir,
                 (
                     Channel(f"{EXPORTED_CHANNELS_DIR}/channel-2"),
@@ -747,7 +746,7 @@ def get_solver_aggregate_2(
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = _get_solver_class()(
+            solver = context.plugin_manager.get_solver_backend()(
                 tmpdir,
                 (
                     Channel(f"{EXPORTED_CHANNELS_DIR}/channel-4"),
@@ -781,7 +780,7 @@ def get_solver_must_unfreeze(
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = _get_solver_class()(
+            solver = context.plugin_manager.get_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-freeze"),),
                 (context.subdir,),
@@ -812,7 +811,7 @@ def get_solver_cuda(
             # We need CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=false here again (it's also in
             # get_index_r_*) to cover solver logics that need to load from disk instead of
             # hitting the SubdirData cache
-            solver = _get_solver_class()(
+            solver = context.plugin_manager.get_solver_backend()(
                 tmpdir,
                 (Channel(f"{EXPORTED_CHANNELS_DIR}/channel-1"),),
                 (context.subdir,),
@@ -836,4 +835,4 @@ def convert_to_dist_str(solution):
 
 @pytest.fixture()
 def solver_class():
-    return _get_solver_class()
+    return context.plugin_manager.get_solver_backend()

--- a/conda_env/installers/conda.py
+++ b/conda_env/installers/conda.py
@@ -26,7 +26,7 @@ def _solve(prefix, specs, args, env, *_, **kwargs):
     channels = IndexedSet(Channel(url) for url in _channel_priority_map)
     subdirs = IndexedSet(basename(url) for url in _channel_priority_map)
 
-    solver_backend = context.plugin_manager.get_solver_backend()
+    solver_backend = context.plugin_manager.get_cached_solver_backend()
     solver = solver_backend(prefix, channels, subdirs, specs_to_add=specs)
     return solver
 

--- a/conda_env/installers/conda.py
+++ b/conda_env/installers/conda.py
@@ -8,11 +8,11 @@ from conda._vendor.boltons.setutils import IndexedSet
 from conda.base.constants import UpdateModifier
 from conda.base.context import context
 from conda.common.constants import NULL
-from conda.core.solve import _get_solver_class
 from conda.exceptions import UnsatisfiableError
 from conda.models.channel import Channel, prioritize_channels
 
 from ..env import Environment
+
 
 def _solve(prefix, specs, args, env, *_, **kwargs):
     # TODO: support all various ways this happens
@@ -26,7 +26,8 @@ def _solve(prefix, specs, args, env, *_, **kwargs):
     channels = IndexedSet(Channel(url) for url in _channel_priority_map)
     subdirs = IndexedSet(basename(url) for url in _channel_priority_map)
 
-    solver = _get_solver_class()(prefix, channels, subdirs, specs_to_add=specs)
+    solver_backend = context.plugin_manager.get_solver_backend()
+    solver = solver_backend(prefix, channels, subdirs, specs_to_add=specs)
     return solver
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.ifconfig",
     "sphinx.ext.inheritance_diagram",
+    "sphinx.ext.intersphinx",
     "sphinxcontrib.plantuml",
     "conda_umls",
     "sphinx_sitemap",
@@ -234,3 +235,9 @@ plantuml_jarfile_path = os.path.abspath(
 plantuml = f"java -Djava.awt.headless=true -jar {plantuml_jarfile_path}"
 
 add_module_names = False
+
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'pluggy': ('https://pluggy.readthedocs.io/en/stable/', None),
+}

--- a/docs/source/dev-guide/plugins/index.rst
+++ b/docs/source/dev-guide/plugins/index.rst
@@ -106,6 +106,7 @@ API reference
 .. toctree::
    :maxdepth: 1
 
+   manager
    solvers
    subcommands
    virtual_packages

--- a/docs/source/dev-guide/plugins/index.rst
+++ b/docs/source/dev-guide/plugins/index.rst
@@ -101,6 +101,8 @@ the `"Choose an Open Source License"`_ site.
 API reference
 -------------
 
+.. autoattribute:: conda.plugins.hookimpl
+
 .. py:module:: conda.plugins
 
 .. toctree::

--- a/docs/source/dev-guide/plugins/index.rst
+++ b/docs/source/dev-guide/plugins/index.rst
@@ -101,9 +101,10 @@ the `"Choose an Open Source License"`_ site.
 API reference
 -------------
 
-.. autoattribute:: conda.plugins.hookimpl
+.. autoattribute:: conda.plugins::hookimpl
+   :no-value:
 
-.. py:module:: conda.plugins
+   Conda plugin hook implementation marker.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/dev-guide/plugins/manager.rst
+++ b/docs/source/dev-guide/plugins/manager.rst
@@ -1,0 +1,12 @@
+=======
+Manager
+=======
+
+The conda plugin manger extends pluggy's default plugin manager with a number
+of conda-specific features.
+
+.. autoclass:: conda.plugins.manager.CondaPluginManager
+   :members:
+   :undoc-members:
+
+.. autofunction:: conda.plugins.manager.get_plugin_manager

--- a/docs/source/dev-guide/plugins/solvers.rst
+++ b/docs/source/dev-guide/plugins/solvers.rst
@@ -7,7 +7,7 @@ The conda solvers can be extended with additional backends with the
 for configuration with the ``solver`` configuration and ``--solver``
 command line option.
 
-.. autoclass:: conda.models.plugins.CondaSolver
+.. autoclass:: conda.plugins.types.CondaSolver
    :members:
    :undoc-members:
 

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -6,6 +6,7 @@ from pprint import pprint
 import platform
 import sys
 import copy
+from unittest.mock import Mock
 
 import pytest
 
@@ -13,24 +14,16 @@ from conda.auxlib.ish import dals
 from conda.base.context import context, conda_tests_ctxt_mgmt_def_pol
 from conda.common.compat import on_linux
 from conda.common.io import env_var, env_vars
-from conda.core.solve import DepsModifier, _get_solver_class, UpdateModifier
+from conda.core.solve import DepsModifier, UpdateModifier
 from conda.exceptions import UnsatisfiableError, SpecsConfigurationConflictError
 from conda.models.channel import Channel
 from conda.models.records import PrefixRecord
 from conda.models.enums import PackageType
-from conda.plugins.virtual_packages import cuda
 from conda.resolve import MatchSpec
 from conda.testing.helpers import add_subdir_to_iter, get_solver, get_solver_2, get_solver_4, \
     get_solver_aggregate_1, get_solver_aggregate_2, get_solver_cuda, get_solver_must_unfreeze, \
     convert_to_dist_str, CHANNEL_DIR
 from conda._vendor.cpuinfo import get_cpu_info
-
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from unittest.mock import Mock, patch
-
-Solver = _get_solver_class()
 
 
 def test_solve_1(tmpdir):
@@ -2226,7 +2219,7 @@ def test_freeze_deps_1(tmpdir):
 def test_current_repodata_usage(tmpdir):
     # force this to False, because otherwise tests fail when run with old conda-build
     with env_var('CONDA_USE_ONLY_TAR_BZ2', False, stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        solver = _get_solver_class()(
+        solver = context.plugin_manager.get_solver_backend()(
             tmpdir.strpath, (Channel(CHANNEL_DIR),), ('win-64',),
             specs_to_add=[MatchSpec('zlib')], repodata_fn='current_repodata.json'
         )
@@ -2244,7 +2237,7 @@ def test_current_repodata_usage(tmpdir):
 
 
 def test_current_repodata_fallback(tmpdir):
-    solver = _get_solver_class()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir.strpath, (Channel(CHANNEL_DIR),), ('win-64',),
         specs_to_add=[MatchSpec('zlib=1.2.8')]
     )
@@ -2320,7 +2313,7 @@ def test_packages_in_solution_change_already_newest(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.1")]}
     post_packages = {"mypkg": [("mypkg", "0.1.1")]}
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[specs])
     constrained = solver.get_constrained_packages(pre_packages, post_packages, fake_index)
     assert len(constrained) == 0
@@ -2330,7 +2323,7 @@ def test_packages_in_solution_change_needs_update(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.0")]}
     post_packages = {"mypkg": [("mypkg", "0.1.1")]}
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[specs])
     constrained = solver.get_constrained_packages(pre_packages, post_packages, fake_index)
     assert len(constrained) == 0
@@ -2340,7 +2333,7 @@ def test_packages_in_solution_change_constrained(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.0")]}
     post_packages = {"mypkg": [("mypkg", "0.1.0")]}
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[specs])
     constrained = solver.get_constrained_packages(pre_packages, post_packages, fake_index)
     assert len(constrained) == 1
@@ -2360,7 +2353,7 @@ def test_determine_constricting_specs_conflicts(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert any(i for i in constricting if i[0] == "mypkgnot")
@@ -2380,7 +2373,7 @@ def test_determine_constricting_specs_conflicts_upperbound(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert any(i for i in constricting if i[0] == "mypkgnot")
@@ -2405,7 +2398,7 @@ def test_determine_constricting_specs_multi_conflicts(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert any(i for i in constricting if i[0] == "mypkgnot")
@@ -2426,7 +2419,7 @@ def test_determine_constricting_specs_no_conflicts_upperbound_compound_depends(t
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert constricting is None
@@ -2446,7 +2439,7 @@ def test_determine_constricting_specs_no_conflicts_version_star(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert constricting is None
@@ -2461,7 +2454,7 @@ def test_determine_constricting_specs_no_conflicts_free(tmpdir):
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert constricting is None
@@ -2481,7 +2474,7 @@ def test_determine_constricting_specs_no_conflicts_no_upperbound(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = _get_solver_class()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert constricting is None

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -2219,7 +2219,7 @@ def test_freeze_deps_1(tmpdir):
 def test_current_repodata_usage(tmpdir):
     # force this to False, because otherwise tests fail when run with old conda-build
     with env_var('CONDA_USE_ONLY_TAR_BZ2', False, stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        solver = context.plugin_manager.get_solver_backend()(
+        solver = context.plugin_manager.get_cached_solver_backend()(
             tmpdir.strpath, (Channel(CHANNEL_DIR),), ('win-64',),
             specs_to_add=[MatchSpec('zlib')], repodata_fn='current_repodata.json'
         )
@@ -2237,7 +2237,7 @@ def test_current_repodata_usage(tmpdir):
 
 
 def test_current_repodata_fallback(tmpdir):
-    solver = context.plugin_manager.get_solver_backend()(
+    solver = context.plugin_manager.get_cached_solver_backend()(
         tmpdir.strpath, (Channel(CHANNEL_DIR),), ('win-64',),
         specs_to_add=[MatchSpec('zlib=1.2.8')]
     )
@@ -2313,7 +2313,7 @@ def test_packages_in_solution_change_already_newest(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.1")]}
     post_packages = {"mypkg": [("mypkg", "0.1.1")]}
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[specs])
     constrained = solver.get_constrained_packages(pre_packages, post_packages, fake_index)
     assert len(constrained) == 0
@@ -2323,7 +2323,7 @@ def test_packages_in_solution_change_needs_update(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.0")]}
     post_packages = {"mypkg": [("mypkg", "0.1.1")]}
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[specs])
     constrained = solver.get_constrained_packages(pre_packages, post_packages, fake_index)
     assert len(constrained) == 0
@@ -2333,7 +2333,7 @@ def test_packages_in_solution_change_constrained(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.0")]}
     post_packages = {"mypkg": [("mypkg", "0.1.0")]}
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[specs])
     constrained = solver.get_constrained_packages(pre_packages, post_packages, fake_index)
     assert len(constrained) == 1
@@ -2353,7 +2353,7 @@ def test_determine_constricting_specs_conflicts(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert any(i for i in constricting if i[0] == "mypkgnot")
@@ -2373,7 +2373,7 @@ def test_determine_constricting_specs_conflicts_upperbound(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert any(i for i in constricting if i[0] == "mypkgnot")
@@ -2398,7 +2398,7 @@ def test_determine_constricting_specs_multi_conflicts(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert any(i for i in constricting if i[0] == "mypkgnot")
@@ -2419,7 +2419,7 @@ def test_determine_constricting_specs_no_conflicts_upperbound_compound_depends(t
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert constricting is None
@@ -2439,7 +2439,7 @@ def test_determine_constricting_specs_no_conflicts_version_star(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert constricting is None
@@ -2454,7 +2454,7 @@ def test_determine_constricting_specs_no_conflicts_free(tmpdir):
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert constricting is None
@@ -2474,7 +2474,7 @@ def test_determine_constricting_specs_no_conflicts_no_upperbound(tmpdir):
         )
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
+    solver = context.plugin_manager.get_cached_solver_backend()(tmpdir, (Channel(CHANNEL_DIR),), ('linux-64',),
                                  specs_to_add=[spec])
     constricting = solver.determine_constricting_specs(spec, solution_prec)
     assert constricting is None

--- a/tests/models/test_prefix_graph.py
+++ b/tests/models/test_prefix_graph.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
-
 from functools import lru_cache
 from pprint import pprint
 
@@ -15,11 +14,6 @@ from conda.models.records import PackageRecord
 from conda.testing.helpers import add_subdir_to_iter, get_solver_4, get_solver_5
 
 import pytest
-
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from unittest.mock import Mock, patch
 
 
 @lru_cache(maxsize=None)
@@ -700,11 +694,11 @@ def test_windows_sort_orders_2(tmpdir):
             conda.models.prefix_graph.on_win = old_on_win
 
 
-def test_sort_without_prep(tmpdir):
+def test_sort_without_prep(tmpdir, mocker):
     # Test the _toposort_prepare_graph method, here by not running it at all.
     # The method is invoked in every other test.  This is what happens when it's not invoked.
 
-    with patch.object(conda.models.prefix_graph.PrefixGraph, '_toposort_prepare_graph', return_value=None):
+    with mocker.patch.object(conda.models.prefix_graph.PrefixGraph, '_toposort_prepare_graph', return_value=None):
         records, specs = get_windows_conda_build_record_set(tmpdir)
         graph = PrefixGraph(records, specs)
 

--- a/tests/plugins/test_solvers.py
+++ b/tests/plugins/test_solvers.py
@@ -6,6 +6,7 @@ import re
 import pytest
 
 from conda.core import solve
+from conda.base.context import context
 from conda.exceptions import PluginError
 from conda import plugins
 
@@ -40,28 +41,23 @@ class VerboseSolverPlugin:
         )
 
 
-@pytest.fixture()
-def plugin(plugin_manager):
+def test_get_solver_backend(plugin_manager):
     plugin = SolverPlugin()
     plugin_manager.register(plugin)
-    return plugin
-
-
-def test_get_solver_class(plugin):
-    solver_class = solve._get_solver_class()
+    solver_class = plugin_manager.get_solver_backend()
     assert solver_class is solve.Solver
 
 
-def test_get_solver_class_multiple(plugin_manager):
+def test_get_solver_backend_multiple(plugin_manager):
     plugin = SolverPlugin()
     plugin_manager.register(plugin)
 
     plugin2 = VerboseSolverPlugin()
     plugin_manager.register(plugin2)
 
-    solver_class = solve._get_solver_class()
+    solver_class = plugin_manager.get_solver_backend()
     assert solver_class is solve.Solver
-    solver_class = solve._get_solver_class("verbose-classic")
+    solver_class = plugin_manager.get_solver_backend("verbose-classic")
     assert solver_class is VerboseSolver
 
 
@@ -72,7 +68,7 @@ def test_duplicated(plugin_manager):
     with pytest.raises(
         PluginError, match=re.escape("Conflicting `solvers` plugins found")
     ):
-        solve._get_solver_class()
+        plugin_manager.get_solver_backend()
 
 
 def test_get_no_solver(plugin_manager):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,6 +4,7 @@
 
 import json
 from unittest import TestCase
+from unittest.mock import patch
 
 import sys
 import os
@@ -31,12 +32,6 @@ from conda.exceptions import (
     conda_exception_handler,
     ExceptionHandler,
 )
-
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from unittest.mock import Mock, patch
-
 
 def _raise_helper(exception):
     raise exception

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -3,19 +3,15 @@
 
 
 import json
+import sys
+from unittest.mock import patch
 
 import pytest
-import sys
 
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol
 from conda.cli.python_api import Commands, run_command
 from conda.common.io import env_var
 from conda.testing.helpers import assert_equals, assert_in
-
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from unittest.mock import Mock, patch
 
 
 def test_info():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

As a follow up to @jaimergp's comment in https://github.com/conda/conda/pull/11993#pullrequestreview-1177196553 this deprecates `conda.core.solve._get_solver_class` in favor of a method of the `CondaPluginManager`.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
