### PR TITLE
Improve error handling while loading plugins

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -114,7 +114,7 @@ class ArgumentParser(ArgumentParserBase):
         if self.description:
             self.description += "\n\nOptions:\n"
 
-        self._subcommands = context.plugin_manager.get_registered_plugins("subcommands")
+        self._subcommands = context.plugin_manager.get_hook_results("subcommands")
 
         if self._subcommands:
             self.epilog = 'conda commands available from other packages:' + ''.join(
@@ -1812,7 +1812,7 @@ def add_parser_solver(p):
     See ``context.solver`` for more info.
     """
     solver_choices = [
-        solver.name for solver in context.plugin_manager.get_registered_plugins("solvers")
+        solver.name for solver in context.plugin_manager.get_hook_results("solvers")
     ]
     group = p.add_mutually_exclusive_group()
     group.add_argument(

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -172,7 +172,7 @@ def _supplement_index_with_system(index):
     conflict.
     """
     registered_names = []
-    packages = context.plugin_manager.get_registered_plugins("virtual_packages")
+    packages = context.plugin_manager.get_hook_results("virtual_packages")
     for package in packages:
         if package.name in registered_names:
             raise PluginError(

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -48,7 +48,7 @@ def _get_solver_class(key=None):
 
     See ``context.solver`` for more details.
     """
-    solvers = context.plugin_manager.get_registered_plugins("solvers")
+    solvers = context.plugin_manager.get_hook_results("solvers")
     key = (key or context.solver).lower()
 
     solvers_mapping = {}

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -33,19 +33,33 @@ class CondaPluginManager(pluggy.PluginManager):
             try:
                 plugin_name = self.register(plugin)
             except ValueError as err:
-                raise PluginError(f"Error while registering conda plugins: {err}")
+                raise PluginError(
+                    f"Error while loading conda plugins from {plugins}: {err}"
+                )
             else:
                 plugin_names.append(plugin_name)
         return plugin_names
 
-    def get_registered_plugins(self, plugin_name: str) -> list:
+    def load_setuptools_entrypoints(self, *args, **kwargs) -> int:
+        """"
+        Overloading the parent method to add conda specific exception
         """
-        Return all registered plugins for the given name.
+        try:
+            return super().load_setuptools_entrypoints(*args, **kwargs)
+        except Exception as err:
+            raise PluginError(
+                f"Error while loading conda plugins from entrypoints: {err}"
+            )
+
+    def get_hook_results(self, name: str) -> list:
         """
-        hook_name = f"{self.project_name}_{plugin_name}"  # e.g. conda_solvers
-        hook = getattr(self.hook, hook_name, None)
+        Return results of the plugin hooks with the given name and
+        raise an error if there is an conflict.
+        """
+        specname = f"{self.project_name}_{name}"  # e.g. conda_solvers
+        hook = getattr(self.hook, specname, None)
         if hook is None:
-            raise PluginError(f"Could not load `{hook_name}` plugins.")
+            raise PluginError(f"Could not load `{specname}` plugins.")
 
         plugins = sorted(
             (item for items in hook() for item in items),
@@ -58,11 +72,11 @@ class CondaPluginManager(pluggy.PluginManager):
             raise PluginError(
                 dals(
                     f"""
-                    Conflicting `{plugin_name}` plugins found:
+                    Conflicting `{name}` plugins found:
 
                     {', '.join([str(conflict) for conflict in conflicts])}
 
-                    Multiple conda plugins are registered via the `{hook_name}` hook.
+                    Multiple conda plugins are registered via the `{specname}` hook.
                     Please make sure that you don't have any incompatible plugins installed.
                     """
                 )
@@ -72,8 +86,8 @@ class CondaPluginManager(pluggy.PluginManager):
 
 @functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache
 def get_plugin_manager() -> CondaPluginManager:
-    pm = CondaPluginManager()
-    pm.add_hookspecs(CondaSpecs)
-    pm.load_plugins(solvers, *virtual_packages.plugins)
-    pm.load_setuptools_entrypoints(spec_name)
-    return pm
+    plugin_manager = CondaPluginManager()
+    plugin_manager.add_hookspecs(CondaSpecs)
+    plugin_manager.load_plugins(solvers, *virtual_packages.plugins)
+    plugin_manager.load_setuptools_entrypoints(spec_name)
+    return plugin_manager

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+import logging
+import re
+import sys
+
+import pytest
+
+from conda.core import solve
+from conda.exceptions import PluginError
+from conda import plugins
+from conda.plugins import virtual_packages
+
+
+log = logging.getLogger(__name__)
+
+
+class VerboseSolver(solve.Solver):
+    def solve_final_state(self, *args, **kwargs):
+        log.info("My verbose solver!")
+        return super().solve_final_state(*args, **kwargs)
+
+
+class VerboseSolverPlugin:
+    @plugins.hookimpl
+    def conda_solvers(self):
+        yield plugins.CondaSolver(
+            name="verbose-classic",
+            backend=VerboseSolver,
+        )
+
+
+def test_load_no_plugins(plugin_manager):
+    plugin_names = plugin_manager.load_plugins()
+    assert plugin_names == []
+
+
+def test_load_two_plugins_one_impls(plugin_manager):
+    this_module = sys.modules[__name__]
+    plugin_names = plugin_manager.load_plugins(this_module)
+    assert plugin_names == [__name__]
+    assert plugin_manager.get_plugins() == {this_module}
+    assert plugin_manager.hook.conda_solvers.get_hookimpls() == []
+
+    plugin_names = plugin_manager.load_plugins(VerboseSolverPlugin)
+    assert plugin_names == ["VerboseSolverPlugin"]
+    assert plugin_manager.get_plugins() == {this_module, VerboseSolverPlugin}
+
+    hooks_impls = plugin_manager.hook.conda_solvers.get_hookimpls()
+    assert len(hooks_impls) == 1
+    assert hooks_impls[0].plugin == VerboseSolverPlugin
+
+
+def test_get_hook_results(plugin_manager):
+    name = "virtual_packages"
+    assert plugin_manager.get_hook_results(name) == []
+
+    # loading the archspec plugin module and make sure it was loaded correctly
+    plugin_manager.load_plugins(virtual_packages.archspec)
+    hook_result = plugin_manager.get_hook_results(name)
+    assert len(hook_result) == 1
+    assert hook_result[0].name == "archspec"
+
+    # let's double-check the validation of conflicting plugins works
+    class SecondArchspec:
+        @plugins.hookimpl
+        def conda_virtual_packages():
+            yield plugins.CondaVirtualPackage("archspec", "")
+
+    plugin_manager.register(SecondArchspec)
+    with pytest.raises(
+        PluginError, match=re.escape("Conflicting `virtual_packages` plugins found")
+    ):
+        plugin_manager.get_hook_results(name)
+
+
+def test_load_plugins_error(plugin_manager, mocker):
+    with mocker.patch.object(
+        plugin_manager, "register", side_effect=ValueError("load_plugins error")
+    ):
+        with pytest.raises(PluginError) as exc:
+            plugin_manager.load_plugins(VerboseSolverPlugin)
+        assert plugin_manager.get_plugins() == set()
+        assert exc.value.return_code == 1
+        assert "load_plugins error" in str(exc.value)
+
+
+def test_load_setuptools_entrypoints_error(plugin_manager, mocker):
+    with mocker.patch(
+        "pluggy._manager.importlib_metadata.distributions",
+        side_effect=ValueError("load_setuptools_entrypoints error"),
+    ):
+        with pytest.raises(PluginError) as exc:
+            plugin_manager.load_setuptools_entrypoints("conda")
+        assert plugin_manager.get_plugins() == set()
+        assert exc.value.return_code == 1
+        assert "load_setuptools_entrypoints error" in str(exc.value)

--- a/tests/plugins/test_solvers.py
+++ b/tests/plugins/test_solvers.py
@@ -76,12 +76,12 @@ def test_duplicated(plugin_manager):
 
 
 def test_get_no_solver(plugin_manager):
-    assert plugin_manager.get_registered_plugins("solvers") == []
+    assert plugin_manager.get_hook_results("solvers") == []
 
 
 def test_get_one_solver(plugin_manager):
     plugin_manager.register(SolverPlugin())
-    solvers = plugin_manager.get_registered_plugins("solvers")
+    solvers = plugin_manager.get_hook_results("solvers")
     assert solvers == [classic_solver]
 
 
@@ -96,7 +96,7 @@ def test_get_two_solvers(plugin_manager):
     plugin2 = VerboseSolverPlugin()
     plugin_manager.register(plugin2)
 
-    solvers = plugin_manager.get_registered_plugins("solvers")
+    solvers = plugin_manager.get_hook_results("solvers")
     assert solvers == [classic_solver, verbose_classic_solver]
 
 
@@ -107,4 +107,4 @@ def test_get_conflicting_solvers(plugin_manager):
     with pytest.raises(
         PluginError, match=re.escape("Conflicting `solvers` plugins found")
     ):
-        plugin_manager.get_registered_plugins("solvers")
+        plugin_manager.get_hook_results("solvers")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

- This refactors `get_registered_plugins` to improve error handling, renames the method to `get_hook_results` which is more correct.
- Adds error handling to `load_setuptools_entrypoints`.
- Adds tests for CondaPluginManager.

Fix #12096.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- ~[ ] Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
