### PR TITLE
Fix More Crashes in MatchSpec and Version Parsing

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -403,7 +403,7 @@ def split_conda_url_easy_parts(known_subdirs, url):
     cleaned_url, token = split_anaconda_token(url)
     cleaned_url, platform = split_platform(known_subdirs, cleaned_url)
     _, ext = strip_pkg_extension(cleaned_url)
-    cleaned_url, package_filename = cleaned_url.rsplit('/', 1) if ext else (cleaned_url, None)
+    cleaned_url, package_filename = cleaned_url.rsplit('/', 1) if ext and '/' in cleaned_url else (cleaned_url, None)
 
     # TODO: split out namespace using regex
     url_parts = urlparse(cleaned_url)

--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -403,7 +403,9 @@ def split_conda_url_easy_parts(known_subdirs, url):
     cleaned_url, token = split_anaconda_token(url)
     cleaned_url, platform = split_platform(known_subdirs, cleaned_url)
     _, ext = strip_pkg_extension(cleaned_url)
-    cleaned_url, package_filename = cleaned_url.rsplit('/', 1) if ext and '/' in cleaned_url else (cleaned_url, None)
+    cleaned_url, package_filename = (
+        cleaned_url.rsplit("/", 1) if ext and "/" in cleaned_url else (cleaned_url, None)
+    )
 
     # TODO: split out namespace using regex
     url_parts = urlparse(cleaned_url)

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -704,9 +704,10 @@ def _parse_spec_str(spec_str):
         # missing versions like "==", "<=", and ">=" "correctly."
         #
         # All of these "missing version" cases result from match specs like "numpy==",
-        # "numpy<=" or "numpy>=" which existing code indicates should be treated as an error
-        # and an exception raised.
-        if version == '==':
+        # "numpy<=", "numpy>=", "numpy= " (with trailing space). Existing code indicates
+        # these should be treated as an error and an exception raised.
+        # IMPORTANT: "numpy=" (no trailing space) is treated as valid.
+        if version == "==" or version == "=":
             pass
         # Otherwise,
         # translate version '=1.2.3' to '1.2.3*'

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -562,10 +562,7 @@ class VersionSpec(BaseSpec, metaclass=SingleStrArgCachingType):
             rx = vspec_str.replace('.', r'\.').replace('+', r'\+').replace('*', r'.*')
             rx = r'^(?:%s)$' % rx
 
-            try:
-                self.regex = re.compile(rx)
-            except re.error as e:
-                raise InvalidVersionSpec(vspec_str, f"contains an invalid regular expression: {e}")
+            self.regex = re.compile(rx)
             matcher = self.regex_match
             is_exact = False
         elif vspec_str[-1] == '*':
@@ -651,12 +648,7 @@ class BuildNumberMatch(BaseSpec, metaclass=SingleStrArgCachingType):
             if vspec_str[0] != '^' or vspec_str[-1] != '$':
                 raise InvalidVersionSpec(vspec_str, "regex specs must start "
                                                     "with '^' and end with '$'")
-            try:
-                self.regex = re.compile(vspec_str)
-            except re.error as e:
-                raise InvalidVersionSpec(
-                    vspec_str, f"Contains an invalid regular expression. '{e}'"
-                )
+            self.regex = re.compile(vspec_str)
 
             matcher = self.regex_match
             is_exact = False

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -559,7 +559,11 @@ class VersionSpec(BaseSpec, metaclass=SingleStrArgCachingType):
         elif '*' in vspec_str.rstrip('*'):
             rx = vspec_str.replace('.', r'\.').replace('+', r'\+').replace('*', r'.*')
             rx = r'^(?:%s)$' % rx
-            self.regex = re.compile(rx)
+
+            try:
+                self.regex = re.compile(rx)
+            except re.error as e:
+                raise InvalidVersionSpec(vspec_str, f"contains an invalid regular expression: {e}")
             matcher = self.regex_match
             is_exact = False
         elif vspec_str[-1] == '*':
@@ -645,7 +649,13 @@ class BuildNumberMatch(BaseSpec, metaclass=SingleStrArgCachingType):
             if vspec_str[0] != '^' or vspec_str[-1] != '$':
                 raise InvalidVersionSpec(vspec_str, "regex specs must start "
                                                     "with '^' and end with '$'")
-            self.regex = re.compile(vspec_str)
+            try:
+                self.regex = re.compile(vspec_str)
+            except re.error as e:
+                raise InvalidVersionSpec(
+                    vspec_str, f"Contains an invalid regular expression. '{e}'"
+                )
+
             matcher = self.regex_match
             is_exact = False
         # if hasattr(spec, 'match'):

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -381,6 +381,8 @@ def treeify(spec_str):
             output.append(item)
     if stack:
         raise InvalidVersionSpec(spec_str, "unable to convert to expression tree: %s" % stack)
+    if not output:
+        raise InvalidVersionSpec(spec_str, "unable to determin version from spec")
     return output[0]
 
 

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -382,7 +382,7 @@ def treeify(spec_str):
     if stack:
         raise InvalidVersionSpec(spec_str, "unable to convert to expression tree: %s" % stack)
     if not output:
-        raise InvalidVersionSpec(spec_str, "unable to determin version from spec")
+        raise InvalidVersionSpec(spec_str, "unable to determine version from spec")
     return output[0]
 
 

--- a/news/12099-fix-fuzzing-crashes
+++ b/news/12099-fix-fuzzing-crashes
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix several more user facing MatchSpec crashes that were identified by fuzzing efforts. (#12099)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -590,6 +590,11 @@ class SpecStrParsingTests(TestCase):
             "_original_spec_str": "numpy",
             "name": "numpy",
         }
+        # For whatever reason "numpy=" is allowed as "numpy"
+        assert _parse_spec_str("numpy=") == {
+            "_original_spec_str": "numpy=",
+            "name": "numpy",
+        }
         assert _parse_spec_str("defaults::numpy") == {
             "_original_spec_str": "defaults::numpy",
             "channel": "defaults",

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -590,7 +590,7 @@ class SpecStrParsingTests(TestCase):
             "_original_spec_str": "numpy",
             "name": "numpy",
         }
-        # For whatever reason "numpy=" is allowed as "numpy"
+        # For whatever reason "numpy=" is allowed and will be interpreted as "numpy"
         assert _parse_spec_str("numpy=") == {
             "_original_spec_str": "numpy=",
             "name": "numpy",

--- a/tests/models/test_version.py
+++ b/tests/models/test_version.py
@@ -311,9 +311,16 @@ class TestVersionSpec(unittest.TestCase):
             VersionSpec("+1.2+")
         with pytest.raises(InvalidVersionSpec):
             VersionSpec("++")
-        # Fuzzer-identified crasher:
+        # Fuzzer-identified crashers:
         with pytest.raises(InvalidVersionSpec):
             VersionSpec("c +, 0/|0 *")
+
+        # Weird crashing versions intended to test unhandled edge cases
+        # in the "treeify" process
+        with pytest.raises(InvalidVersionSpec):
+            VersionSpec("a[version=)|(")
+        with pytest.raises(InvalidVersionSpec):
+            VersionSpec("a=)(=b")
 
         # Test for mishandling of '=='  and '=' without a version number
         with pytest.raises(InvalidVersionSpec):

--- a/tests/models/test_version.py
+++ b/tests/models/test_version.py
@@ -315,9 +315,11 @@ class TestVersionSpec(unittest.TestCase):
         with pytest.raises(InvalidVersionSpec):
             VersionSpec("c +, 0/|0 *")
 
-        # Test for mishandling of '==' without a version number
+        # Test for mishandling of '=='  and '=' without a version number
         with pytest.raises(InvalidVersionSpec):
             VersionSpec("==")
+        with pytest.raises(InvalidVersionSpec):
+            VersionSpec("=")
         # Additional tests based on the above
         with pytest.raises(InvalidVersionSpec):
             VersionSpec(">=")


### PR DESCRIPTION
### Description

Further fuzzing efforts have identified the following cases crashing cases.  More details once I chase them down.

"(-cuda*|*cnumpy==1.0uda|????*cu"
"numpy= " (the trailing space is important here)
"aults::n [channel=ana.conda,versiond=3]"
"a[=)(=b"

Found another while looking at this:
".*!=1.9,^)\$=0"

Interestingly, it only crashes when it is passed to VersionSpec via MatchSpec, not directly.

### Checklist

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?

