### PR TITLE
Deprecate private conda env

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from logging import getLogger
 from typing import Optional
 import os
-from os.path import abspath, basename, expanduser, isdir, isfile, join, split as path_split
+from os.path import abspath, expanduser, isdir, isfile, join, split as path_split
 import platform
 import sys
 import struct
@@ -475,7 +475,13 @@ class Context(Configuration):
 
     @property
     def conda_private(self):
-        return conda_in_private_env()
+        warnings.warn(
+            "`conda.base.context.context.conda_private` is pending deprecation and will be "
+            "removed in a future release. It's meaningless and any special meaning it may have "
+            "held is now void.",
+            PendingDeprecationWarning,
+        )
+        return False
 
     @property
     def platform(self):
@@ -629,8 +635,6 @@ class Context(Configuration):
     def root_prefix(self):
         if self._root_prefix:
             return abspath(expanduser(self._root_prefix))
-        elif conda_in_private_env():
-            return abspath(join(self.conda_prefix, '..', '..'))
         else:
             return self.conda_prefix
 
@@ -1610,12 +1614,6 @@ class Context(Configuration):
                 """
             ),
         )
-
-
-def conda_in_private_env():
-    # conda is located in its own private environment named '_conda_'
-    envs_dir, env_name = path_split(sys.prefix)
-    return env_name == '_conda_' and basename(envs_dir) == 'envs'
 
 
 def reset_context(search_path=SEARCH_PATH, argparse_args=None):

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -11,7 +11,7 @@ import sys
 
 from .common import print_envs_list, stdout_json
 from .. import CONDA_PACKAGE_ROOT, __version__ as conda_version
-from ..base.context import conda_in_private_env, context, env_name, sys_rc_path, user_rc_path
+from ..base.context import context, env_name, sys_rc_path, user_rc_path
 from ..common.compat import on_win
 from ..common.url import mask_anaconda_token
 from ..core.index import _supplement_index_with_system
@@ -155,7 +155,6 @@ def get_info_dict(system=False):
         conda_build_version=conda_build_version,
         root_prefix=context.root_prefix,
         conda_prefix=context.conda_prefix,
-        conda_private=conda_in_private_env(),
         av_data_dir=context.av_data_dir,
         av_metadata_url_base=context.signing_metadata_url_base,
         root_writable=context.root_writable,

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -81,7 +81,6 @@ platform = conda.base.context.context.platform
 root_dir = conda.base.context.context.root_prefix
 root_writable = conda.base.context.context.root_writable
 subdir = conda.base.context.context.subdir
-conda_private = conda.base.context.context.conda_private
 conda_build = conda.base.context.context.conda_build
 
 from .models.channel import get_conda_build_local_url  # NOQA


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

First introduced in conda 4.2 and updated in 4.3, conda introduced a private conda environment (`_conda` and `_conda_` respectively). This special env appears to have been a special local testing environment prior developers of conda used. This private env is undocumented, no longer in use, and adds an undesired complexity so we will deprecate it.

Xref: https://github.com/conda/conda-build/pull/4629

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
