### PR TITLE
Don’t instantiate the solver backend for getting the user-agent.

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -846,7 +846,7 @@ class Context(Configuration):
             try:
                 solver_backend = self.plugin_manager.get_cached_solver_backend()
                 # Solver.user_agent has to be a static or class method
-                user_agent_str += f" {solver_backend().user_agent()}"
+                user_agent_str += f" {solver_backend.user_agent()}"
             except Exception as exc:
                 log.debug(
                     "User agent could not be fetched from solver class '%s'.",

--- a/tests/plugins/test_solvers.py
+++ b/tests/plugins/test_solvers.py
@@ -74,6 +74,10 @@ def test_solver_user_agent(plugin_manager, monkeypatch):
     plugin = VerboseSolverPlugin()
     plugin_manager.register(plugin)
     monkeypatch.setattr(context, "solver", "verbose-classic")
+    # context.user_agent is a memoizedproperty, which may have been cached from
+    # previous test runs. We're checking here and clear the cache if needed.
+    if "__user_agent" in context._cache_:
+        del context._cache_["__user_agent"]
     assert verbose_user_agent in context.user_agent
 
 

--- a/tests/plugins/test_solvers.py
+++ b/tests/plugins/test_solvers.py
@@ -70,14 +70,21 @@ def test_get_cached_solver_backend(plugin_manager, mocker):
     assert mocked.call_count == 1  # real caching!
 
 
-def test_solver_user_agent(plugin_manager, monkeypatch):
-    plugin = VerboseSolverPlugin()
-    plugin_manager.register(plugin)
+def clear_user_agent():
+    if "__user_agent" in context._cache_:
+        del context._cache_["__user_agent"]
+
+
+def test_solver_user_agent(monkeypatch, plugin_manager, request):
+    # setting the solver to the verbose classic version defined in this module
     monkeypatch.setattr(context, "solver", "verbose-classic")
     # context.user_agent is a memoizedproperty, which may have been cached from
     # previous test runs. We're checking here and clear the cache if needed.
-    if "__user_agent" in context._cache_:
-        del context._cache_["__user_agent"]
+    request.addfinalizer(clear_user_agent)
+    clear_user_agent()
+
+    plugin = VerboseSolverPlugin()
+    plugin_manager.register(plugin)
     assert verbose_user_agent in context.user_agent
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Updates the call of the user_agent staticmethod to be done on the class, not the instance, as incorrectly introduced in https://github.com/conda/conda/commit/ba7d9bc1b1516a48b2579ebb0d068986469280c3#diff-b088be378fc4d3c8240b5a24fd9d51409bb64226eb874be18a10eafadec79f78L850-R849.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fix #12103

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
