### PR TITLE
Suggestions for the original pull request: 12003

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -239,8 +239,8 @@ class SubdirData(metaclass=SubdirDataType):
             log.debug("Could not load state", exc_info=True)
             return {}
 
-    def _save_state(self, state: dict) -> None:
-        pathlib.Path(self.cache_path_state).write_text(json.dumps(state, indent=True))
+    def _save_state(self, state: dict):
+        return pathlib.Path(self.cache_path_state).write_text(json.dumps(state, indent=True))
 
     def _load(self):
         try:

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -271,7 +271,7 @@ def test_metadata_cache_works(platform="linux-64"):
 
     with env_vars(
         {"CONDA_PLATFORM": platform}, stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ), patch.object(CondaRepoInterface, "repodata", return_value={}) as fetcher:
+    ), patch.object(CondaRepoInterface, "fetch_repodata", return_value={}) as fetcher:
         sd_a = SubdirData(channel)
         precs_a = tuple(sd_a.query("zlib"))
         assert fetcher.call_count == 1
@@ -288,7 +288,7 @@ def test_metadata_cache_clearing(platform="linux-64"):
 
     with env_vars(
         {"CONDA_PLATFORM": platform}, stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ), patch.object(CondaRepoInterface, "repodata", return_value={}) as fetcher:
+    ), patch.object(CondaRepoInterface, "fetch_repodata", return_value={}) as fetcher:
         sd_a = SubdirData(channel)
         precs_a = tuple(sd_a.query("zlib"))
         assert fetcher.call_count == 1


### PR DESCRIPTION
Here are my suggestions for improvement:

- I think we should divorce the SubdirData and CondaRepoInterface objects from each other. This coupling doesn't seem worth it. If you decide to keep this coupling, please make the property public instead of protected, so we know it's okay to use this property from outside the `SubdirData` object.
- In `conda/gateways/repodata/__init__.py` I chose to remove the `**kwargs` from the `__init__` method of the `CondaRepoInterface` object because they were not being used at.
- Added some more type hinting where necessary.