### PR TITLE
Fix missing __unix virtual package in 22.11

### DIFF
--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -145,12 +145,12 @@ def _supplement_index_with_cache(index):
             index[pcrec] = pcrec
 
 
-def _make_virtual_package(name, version=None, build_string='0'):
+def _make_virtual_package(name, version=None, build_string=None):
     return PackageRecord(
             package_type=PackageType.VIRTUAL_SYSTEM,
             name=name,
             version=version or '0',
-            build_string=build_string,
+            build_string=build_string or '0',
             channel='@',
             subdir=context.subdir,
             md5="12345678901234567890123456789012",
@@ -184,9 +184,8 @@ def _supplement_index_with_system(index):
             )
         registered_names.append(package.name)
 
-        rec = _make_virtual_package(f"__{package.name}", package.version)
-
-        if package.version is not None:
+        if package.name is not None:
+            rec = _make_virtual_package(f"__{package.name}", package.version, package.build)
             index[rec] = rec
 
 

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -174,6 +174,8 @@ def _supplement_index_with_system(index):
     registered_names = []
     packages = context.plugin_manager.get_hook_results("virtual_packages")
     for package in packages:
+        if package.name is None:
+            continue
         if package.name in registered_names:
             raise PluginError(
                 "Conflicting virtual package entries found for the "
@@ -184,9 +186,8 @@ def _supplement_index_with_system(index):
             )
         registered_names.append(package.name)
 
-        if package.name is not None:
-            rec = _make_virtual_package(f"__{package.name}", package.version, package.build)
-            index[rec] = rec
+        rec = _make_virtual_package(f"__{package.name}", package.version, package.build)
+        index[rec] = rec
 
 
 def get_archspec_name():

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -96,6 +96,7 @@ class CondaSpecs:
                 yield plugins.CondaVirtualPackage(
                     name="my_custom_os",
                     version="1.2.3",
+                    build="x86_64",
                 )
 
         """

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -29,10 +29,12 @@ class CondaVirtualPackage(NamedTuple):
 
     :param name: Virtual package name (e.g., ``my_custom_os``).
     :param version: Virtual package version (e.g., ``1.2.3``).
+    :param version: Virtual package build string (e.g., ``x86_64``).
     """
 
     name: str
     version: str | None
+    build: str | None
 
 
 class CondaSolver(NamedTuple):

--- a/conda/plugins/virtual_packages/archspec.py
+++ b/conda/plugins/virtual_packages/archspec.py
@@ -7,4 +7,6 @@ from .. import hookimpl, CondaVirtualPackage
 def conda_virtual_packages():
     from ...core.index import get_archspec_name
 
-    yield CondaVirtualPackage("archspec", get_archspec_name())
+    archspec_name = get_archspec_name()
+    if archspec_name is not None:
+        yield CondaVirtualPackage("archspec", "1", archspec_name)

--- a/conda/plugins/virtual_packages/archspec.py
+++ b/conda/plugins/virtual_packages/archspec.py
@@ -8,5 +8,5 @@ def conda_virtual_packages():
     from ...core.index import get_archspec_name
 
     archspec_name = get_archspec_name()
-    if archspec_name is not None:
+    if archspec_name:
         yield CondaVirtualPackage("archspec", "1", archspec_name)

--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -84,4 +84,6 @@ def cached_cuda_version():
 
 @hookimpl
 def conda_virtual_packages():
-    yield CondaVirtualPackage("cuda", cached_cuda_version())
+    cuda_version = cached_cuda_version()
+    if cuda_version is not None:
+        yield CondaVirtualPackage("cuda", cuda_version, None)

--- a/conda/plugins/virtual_packages/linux.py
+++ b/conda/plugins/virtual_packages/linux.py
@@ -13,7 +13,7 @@ def conda_virtual_packages():
     if platform.system() != "Linux":
         return
 
-    yield CondaVirtualPackage("unix", None)
+    yield CondaVirtualPackage("unix", None, None)
 
     # By convention, the kernel release string should be three or four
     # numeric components, separated by dots, followed by vendor-specific
@@ -23,11 +23,11 @@ def conda_virtual_packages():
     # development (`-rcN`) kernels, but that can be a TODO for later.
     dist_version = os.environ.get("CONDA_OVERRIDE_LINUX", platform.release())
     m = re.match(r"\d+\.\d+(\.\d+)?(\.\d+)?", dist_version)
-    yield CondaVirtualPackage("linux", m.group() if m else "0")
+    yield CondaVirtualPackage("linux", m.group() if m else "0", None)
 
     libc_family, libc_version = linux_get_libc_version()
     if not (libc_family and libc_version):
         # Default to glibc when using CONDA_SUBDIR var
         libc_family = "glibc"
     libc_version = os.getenv(f"CONDA_OVERRIDE_{libc_family.upper()}", libc_version)
-    yield CondaVirtualPackage(libc_family, libc_version)
+    yield CondaVirtualPackage(libc_family, libc_version, None)

--- a/conda/plugins/virtual_packages/osx.py
+++ b/conda/plugins/virtual_packages/osx.py
@@ -11,7 +11,7 @@ def conda_virtual_packages():
     if platform.system() != "Darwin":
         return
 
-    yield CondaVirtualPackage("unix", None)
+    yield CondaVirtualPackage("unix", None, None)
 
     dist_version = os.environ.get("CONDA_OVERRIDE_OSX", platform.mac_ver()[0])
-    yield CondaVirtualPackage("osx", dist_version)
+    yield CondaVirtualPackage("osx", dist_version, None)

--- a/conda/plugins/virtual_packages/windows.py
+++ b/conda/plugins/virtual_packages/windows.py
@@ -11,4 +11,4 @@ def conda_virtual_packages():
     if platform.system() != "Windows":
         return
 
-    yield CondaVirtualPackage("win", None)
+    yield CondaVirtualPackage("win", None, None)

--- a/news/12148-restore-default-virtual-packages
+++ b/news/12148-restore-default-virtual-packages
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Restore default virtual package specs as in 22.9.0 (#12148)
+  - re-add `__unix`/`__win` packages
+  - restore `__archspec` version/build string composition
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -65,7 +65,7 @@ def test_get_hook_results(plugin_manager):
     class SecondArchspec:
         @plugins.hookimpl
         def conda_virtual_packages():
-            yield plugins.CondaVirtualPackage("archspec", "")
+            yield plugins.CondaVirtualPackage("archspec", "", None)
 
     plugin_manager.register(SecondArchspec)
     with pytest.raises(

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -20,14 +20,17 @@ class VirtualPackagesPlugin:
         yield CondaVirtualPackage(
             name="abc",
             version="123",
+            build=None,
         )
         yield CondaVirtualPackage(
             name="def",
             version="456",
+            build=None,
         )
         yield CondaVirtualPackage(
             name="ghi",
             version="789",
+            build="xyz",
         )
 
 
@@ -52,6 +55,7 @@ def test_invoked(plugin):
     assert packages["__abc"].version == "123"
     assert packages["__def"].version == "456"
     assert packages["__ghi"].version == "789"
+    assert packages["__ghi"].build == "xyz"
 
 
 def test_duplicated(plugin_manager):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While publishing the latest `conda` release for conda-forge we encountered solver issues when the CI used `conda=22.11.0`. Particularly, the issues were seen when building Python 3.11 variants.
During those builds solving for the test environment failed since `responses` is a test requirement in the `conda-feedstock`. `responses` requires `pysocks` has only been recently (before a Python 3.11 variant of it would have been built) converted to a `noarch: python` package that depends on `__unix`/`__win` in https://github.com/conda-forge/pysocks-feedstock/pull/20 .

Turns out, `conda=22.11.0` does not create virtual packages for `__unix` and `__win`.

ref: https://github.com/conda-forge/admin-requests/pull/523
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
