### PR TITLE
Replace tlz concat with itertools

### DIFF
--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -9,10 +9,7 @@ from os.path import isfile, join
 import sys
 from textwrap import wrap
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from conda.common.iterators import groupby_to_dict as groupby
 

--- a/conda/common/iterators.py
+++ b/conda/common/iterators.py
@@ -8,6 +8,7 @@ Replacements for parts of the toolz library.
 import itertools
 import collections
 
+
 def groupby_to_dict(keyfunc, sequence):
     """
     toolz-style groupby, returns a dictionary of { key: [group] } instead of
@@ -17,3 +18,7 @@ def groupby_to_dict(keyfunc, sequence):
     for key, group in itertools.groupby(sequence, keyfunc):
         result[key].extend(group)
     return dict(result)
+
+
+def concat(seqs):
+    return itertools.chain.from_iterable(seqs)

--- a/conda/common/iterators.py
+++ b/conda/common/iterators.py
@@ -14,7 +14,7 @@ def groupby_to_dict(keyfunc, sequence):
     toolz-style groupby, returns a dictionary of { key: [group] } instead of
     iterators.
     """
-    result = collections.defaultdict(lambda: [])
+    result = collections.defaultdict(list)
     for key, group in itertools.groupby(sequence, keyfunc):
         result[key].extend(group)
     return dict(result)

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -16,10 +16,7 @@ import re
 import sys
 import warnings
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from conda.common.iterators import groupby_to_dict as groupby
 

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -7,10 +7,7 @@ import platform
 import sys
 import warnings
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from .package_cache_data import PackageCacheData
 from .prefix_data import PrefixData

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -16,10 +16,7 @@ from sys import platform
 from tarfile import ReadError
 from functools import partial
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from conda.common.iterators import groupby_to_dict as groupby
 

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -9,10 +9,7 @@ import re
 import sys
 from uuid import uuid4
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from .envs_manager import get_user_environments_txt_file, register_env, unregister_env
 from .portability import _PaddingError, update_prefix

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -9,10 +9,7 @@ import sys
 import warnings
 from textwrap import dedent
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from conda.common.iterators import groupby_to_dict as groupby
 

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -5,10 +5,7 @@ from copy import copy
 from itertools import chain
 from logging import getLogger
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from .._vendor.boltons.setutils import IndexedSet
 from ..base.constants import DEFAULTS_CHANNEL_NAME, MAX_CHANNEL_PRIORITY, UNKNOWN_CHANNEL

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -11,10 +11,7 @@ from os.path import basename
 import warnings
 import re
 
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from conda.common.iterators import groupby_to_dict as groupby
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -7,11 +7,7 @@ from functools import lru_cache
 from logging import DEBUG, getLogger
 
 from conda.common.iterators import groupby_to_dict as groupby
-
-try:
-    from tlz.itertoolz import concat
-except ImportError:
-    from conda._vendor.toolz.itertoolz import concat
+from conda.common.iterators import concat
 
 from .auxlib.decorators import memoizemethod
 from ._vendor.frozendict import FrozenOrderedDict as frozendict

--- a/news/12164-concat-itertools
+++ b/news/12164-concat-itertools
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Use itertools.chain.from_iterable instead of equivalent tlz.concat


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

toolz concat forwards to itertools; we can forward ourselves instead.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
