### PR TITLE
Fixes a compatibility bug with darker and black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     rev: 1.5.1
     hooks:
       - id: darker
-        additional_dependencies: [black]
+        additional_dependencies: [black==22.10.0]
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
     hooks:


### PR DESCRIPTION
We recently ran into these errors while running pre-commit:

https://github.com/akaihola/darker/issues/412

This pull request version pins black when using darker to avoid this.