### PR TITLE
Update solver plugin docstring/example

### DIFF
--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -29,9 +29,12 @@ class CondaSpecs:
         Example:
 
         .. code-block:: python
-
             from conda import plugins
             from conda.core import solve
+            import logging
+
+
+            log = logging.getLogger(__name__)
 
 
             class VerboseSolver(solve.Solver):
@@ -46,7 +49,6 @@ class CondaSpecs:
                     name="verbose-classic",
                     backend=VerboseSolver,
                 )
-
         """
 
     @_hookspec

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -29,9 +29,11 @@ class CondaSpecs:
         Example:
 
         .. code-block:: python
+
+            import logging
+
             from conda import plugins
             from conda.core import solve
-            import logging
 
 
             log = logging.getLogger(__name__)
@@ -49,6 +51,7 @@ class CondaSpecs:
                     name="verbose-classic",
                     backend=VerboseSolver,
                 )
+
         """
 
     @_hookspec


### PR DESCRIPTION
The current solver plugin API example is missing the `logging` import and a few other lines. One thing to troubleshoot is the how the `"My verbose solver!"` statement does not seem to print out in the terminal.