### PR TITLE
Document channel::package syntax for environment.yml files

### DIFF
--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -850,6 +850,8 @@ EXAMPLE: A more complex environment file:
        - Flask-Testing
 
 .. note::
+   **Using wildcards**
+
    Note the use of the wildcard * when defining the patch version
    number. Defining the version number by fixing the major and minor
    version numbers while allowing the patch version number to vary
@@ -857,7 +859,8 @@ EXAMPLE: A more complex environment file:
    to get any bug fixes whilst still maintaining consistency of
    software environment.
 
-.. note::
+   **Specifying channels outside of "channels"**
+
    You may occasionally want to specify which channel conda will
    use to install a specific package. To accomplish this, use the
    `channel::package` syntax in `dependencies:`, as demonstrated

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -842,7 +842,7 @@ EXAMPLE: A more complex environment file:
    dependencies:
      - python=3.9
      - bokeh=2.4.2
-     - numpy=1.21.*
+     - conda-forge::numpy=1.21.*
      - nodejs=16.13.*
      - flask
      - pip
@@ -856,6 +856,15 @@ EXAMPLE: A more complex environment file:
    allows us to use our environment file to update our environment
    to get any bug fixes whilst still maintaining consistency of
    software environment.
+
+.. note::
+   You may occasionally want to specify which channel conda will 
+   use to install a specific package. To accomplish this, use the
+   `channel::package` syntax in `dependencies:`, as demonstrated
+   above with `conda-forge::numpy` (version numbers optional). The
+   specified channel does not need to be present in the `channels:`
+   list, which is useful if you want some—but not *all*—packages
+   installed from a community channel such as `conda-forge`.
 
 You can exclude the default channels by adding ``nodefaults``
 to the channels list.

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -858,7 +858,7 @@ EXAMPLE: A more complex environment file:
    software environment.
 
 .. note::
-   You may occasionally want to specify which channel conda will 
+   You may occasionally want to specify which channel conda will
    use to install a specific package. To accomplish this, use the
    `channel::package` syntax in `dependencies:`, as demonstrated
    above with `conda-forge::numpy` (version numbers optional). The

--- a/news/11890-env-yml-channel-pkg-docs
+++ b/news/11890-env-yml-channel-pkg-docs
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Documented optional `channel::package` syntax for specifying dependencies in `environment.yml` files. (#11890)
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Adds documentation requested in #11890.

Documented `channel::package` syntax for dependency specification in a `note:` in the **Sharing an Environment** section of `docs/source/user-guide/tasks/manage-environments.rst`. Also added `news` file, but it may not be needed for a change of this magnitude.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
