### PR TITLE
Updating docs to remove references to the mythical version 5 🦄

### DIFF
--- a/docs/source/user-guide/tasks/manage-channels.rst
+++ b/docs/source/user-guide/tasks/manage-channels.rst
@@ -95,9 +95,8 @@ Strict channel priority
 
 As of version 4.6.0, Conda has a strict channel priority feature.
 Strict channel priority can dramatically speed up conda operations and
-also reduce package incompatibility problems. We recommend it as a default.
-However, it may break old environment files, so we plan to delay making it
-conda's out-of-the-box default until the next major version bump, conda 5.0.
+also reduce package incompatibility problems. We recommend setting channel
+priority to "strict" when possible.
 
 Details about it can be seen by typing ``conda config --describe channel_priority``.
 


### PR DESCRIPTION
This pull request removes a reference to conda version 5. As we all know by now, version 5 dead ☠️ and will never happen. Let's clean up our docs to remove any references to it.

I did some basic grepping in the docs directory and this was the only reference I was able to find 🤷‍♂️.