### PR TITLE
lock stdout while writing json progress bar

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -7,13 +7,7 @@ import os
 import signal
 import sys
 from collections import defaultdict
-from concurrent.futures import (
-    Executor,
-    Future,
-    ThreadPoolExecutor,
-    _base,
-    as_completed,
-)
+from concurrent.futures import Executor, Future, ThreadPoolExecutor, _base, as_completed
 from concurrent.futures.thread import _WorkItem
 from contextlib import contextmanager
 from enum import Enum
@@ -23,7 +17,7 @@ from io import BytesIO, StringIO
 from itertools import cycle
 from logging import CRITICAL, NOTSET, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
-from threading import Event, Lock, Thread
+from threading import Event, Lock, RLock, Thread
 from time import sleep, time
 
 from tqdm import tqdm
@@ -444,18 +438,6 @@ class Spinner:
                 else:
                     sys.stdout.write("done\n")
                 sys.stdout.flush()
-
-
-try:
-    from threading import RLock  # type: ignore
-except (ImportError, OSError):  # pragma: no cover
-    # according to tqdm, threading.RLock is not guaranteed
-    class RLock:
-        def __enter__(self):
-            pass
-
-        def __exit__(self, *exc):
-            pass
 
 
 class ProgressBar:

--- a/news/12231-lock-json-output
+++ b/news/12231-lock-json-output
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Lock sys.stdout to avoid corrupted --json multithreaded download progress.
+  (#12231)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

`sys.stdout` isn't threadsafe, leading to corrupted output. Lock while writing json progress bar substitute.

Fix #12225 
Fix #12231

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
