### PR TITLE
Repodata state format per draft CEP

### DIFF
--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -99,7 +99,7 @@ def ensure_binary(value):
         return value
 
 
-def ensure_text_type(value):
+def ensure_text_type(value) -> str:
     try:
         return value.decode('utf-8')
     except AttributeError:  # pragma: no cover

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -13,22 +13,22 @@ from contextlib import closing
 from errno import EACCES, ENODEV, EPERM, EROFS
 from functools import partial
 from io import open as io_open
+from itertools import chain, islice
 from logging import getLogger
 from mmap import ACCESS_READ, mmap
 from os.path import dirname, exists, isdir, join, splitext
+from pathlib import Path
 from time import time
 
 from genericpath import getmtime, isfile
 
-from itertools import islice, chain
-
 from conda.common.iterators import groupby_to_dict as groupby
 from conda.gateways.repodata import (
-    CondaRepoInterface,
-    RepoInterface,
-    RepodataIsEmpty,
-    Response304ContentUnchanged,
     CacheJsonState,
+    CondaRepoInterface,
+    RepodataIsEmpty,
+    RepoInterface,
+    Response304ContentUnchanged,
 )
 
 from .. import CondaError
@@ -250,8 +250,8 @@ class SubdirData(metaclass=SubdirDataType):
         return CacheJsonState(self.cache_path_json, self.cache_path_state, self.repodata_fn).load()
 
     def _save_state(self, state: CacheJsonState):
-        assert state.cache_path_json == self.cache_path_json
-        assert state.cache_path_state == self.cache_path_state
+        assert Path(state.cache_path_json) == Path(self.cache_path_json)
+        assert Path(state.cache_path_state) == Path(self.cache_path_state)
         assert state.repodata_fn == self.repodata_fn
         return state.save()
 
@@ -642,7 +642,7 @@ def fetch_repodata_remote_request(url, etag, mod_stamp, repodata_fn=REPODATA_FN)
     subdir = SubdirData(Channel(url), repodata_fn=repodata_fn)
 
     try:
-        cache_state = CacheJsonState(None, None, repodata_fn)
+        cache_state = subdir._load_state()
         cache_state.etag = etag
         cache_state.mod = mod_stamp
         raw_repodata_str = subdir._repo.repodata(cache_state)

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import pathlib
 import pickle
 import re
 import warnings
@@ -29,6 +28,7 @@ from conda.gateways.repodata import (
     RepoInterface,
     RepodataIsEmpty,
     Response304ContentUnchanged,
+    CacheJsonState,
 )
 
 from .. import CondaError
@@ -67,10 +67,11 @@ class SubdirDataType(type):
         cache_key = channel.url(with_credentials=True), repodata_fn
         if cache_key in SubdirData._cache_:
             cache_entry = SubdirData._cache_[cache_key]
-            if cache_key[0].startswith("file://"):
-                file_path = url_to_path(channel.url() + "/" + repodata_fn)
-                if exists(file_path):
-                    if cache_entry._mtime > getmtime(file_path):
+            if cache_key[0] and cache_key[0].startswith("file://"):
+                channel_url = channel.url()
+                if channel_url:
+                    file_path = url_to_path(channel_url + "/" + repodata_fn)
+                    if exists(file_path) and cache_entry._mtime > getmtime(file_path):
                         return cache_entry
             else:
                 return cache_entry
@@ -78,58 +79,6 @@ class SubdirDataType(type):
         subdir_data_instance._mtime = now
         SubdirData._cache_[cache_key] = subdir_data_instance
         return subdir_data_instance
-
-
-class CacheJsonState(dict):
-    """
-    Load/save `.state.json` that accompanies cached `repodata.json`
-    """
-
-    def __init__(self, cache_path_json, cache_path_state, repodata_fn):
-        self.cache_path_json = pathlib.Path(cache_path_json)
-        self.cache_path_state = pathlib.Path(cache_path_state)
-        self.repodata_fn = repodata_fn
-
-    def load(self) -> dict:
-        """
-        Cache headers and additional data needed to keep track of the cache are
-        stored separately, instead of the previous "added to repodata.json"
-        arrangement.
-        """
-        try:
-            state_path = self.cache_path_state
-            log.debug("Load %s cache from %s", self.repodata_fn, state_path)
-            with state_path.open("r") as s:
-                state = json.load(s)
-            # json and state files should match
-            json_stat = self.cache_path_json.stat()
-            if not (
-                state.get("mtime_ns") == json_stat.st_mtime_ns
-                and state.get("size") == json_stat.st_size
-            ):
-                # clear mod, etag, cache_control to encourage re-download
-                state.update({"etag": "", "mod": "", "cache_control": ""})
-            for alias in "_etag", "_mod", "_cache_control":
-                if alias[1:] in state:
-                    state[alias] = state.pop(alias[1:])
-            self.update(state)
-            return self
-        except (json.JSONDecodeError, OSError):
-            log.debug("Could not load state", exc_info=True)
-            self.clear()
-            return self
-
-    def save(self, state: dict):
-        """
-        Must be called after writing cache_path_json, as its mtime is included in .state.json
-        """
-        json_stat = self.cache_path_json.stat()
-        serialized = {}
-        serialized.update({"mtime_ns": json_stat.st_mtime_ns, "size": json_stat.st_size})
-        for alias in "_etag", "_mod", "_cache_control":
-            if alias in state:
-                serialized[alias[1:]] = state[alias]
-        return pathlib.Path(self.cache_path_state).write_text(json.dumps(serialized, indent=True))
 
 
 class SubdirData(metaclass=SubdirDataType):
@@ -181,7 +130,7 @@ class SubdirData(metaclass=SubdirDataType):
             self.load()
         param = package_ref_or_match_spec
         if isinstance(param, str):
-            param = MatchSpec(param)
+            param = MatchSpec(param)  # type: ignore
         if isinstance(param, MatchSpec):
             if param.get_exact_value("name"):
                 package_name = param.get_exact_value("name")
@@ -292,7 +241,7 @@ class SubdirData(metaclass=SubdirDataType):
             self.load()
         return iter(self._package_records)
 
-    def _load_state(self) -> dict:
+    def _load_state(self):
         """
         Cache headers and additional data needed to keep track of the cache are
         stored separately, instead of the previous "added to repodata.json"
@@ -300,10 +249,11 @@ class SubdirData(metaclass=SubdirDataType):
         """
         return CacheJsonState(self.cache_path_json, self.cache_path_state, self.repodata_fn).load()
 
-    def _save_state(self, state: dict):
-        return CacheJsonState(self.cache_path_json, self.cache_path_state, self.repodata_fn).save(
-            state
-        )
+    def _save_state(self, state: CacheJsonState):
+        assert state.cache_path_json == self.cache_path_json
+        assert state.cache_path_state == self.cache_path_state
+        assert state.repodata_fn == self.repodata_fn
+        return state.save()
 
     def _load(self):
         try:
@@ -326,7 +276,9 @@ class SubdirData(metaclass=SubdirDataType):
                     "_track_features_index": defaultdict(list),
                 }
             else:
-                mod_etag_headers = {}
+                mod_etag_headers = CacheJsonState(
+                    self.cache_path_json, self.cache_path_state, self.repodata_fn
+                )
         else:
             mod_etag_headers = self._load_state()
 
@@ -392,8 +344,6 @@ class SubdirData(metaclass=SubdirDataType):
                 cache_path_json = self.cache_path_json
                 with io_open(cache_path_json, "w") as fh:
                     fh.write(raw_repodata_str or "{}")
-                # quick thing to check for 'json matches stat', or store, check a message digest:
-                mod_etag_headers["mtime"] = pathlib.Path(cache_path_json).stat().st_mtime
                 self._save_state(mod_etag_headers)
             except OSError as e:
                 if e.errno in (EACCES, EPERM, EROFS):
@@ -411,11 +361,11 @@ class SubdirData(metaclass=SubdirDataType):
                 "Saving pickled state for %s at %s", self.url_w_repodata_fn, self.cache_path_pickle
             )
             with open(self.cache_path_pickle, "wb") as fh:
-                pickle.dump(self._internal_state, fh, -1)  # -1 means HIGHEST_PROTOCOL
+                pickle.dump(self._internal_state, fh, pickle.HIGHEST_PROTOCOL)
         except Exception:
             log.debug("Failed to dump pickled repodata.", exc_info=True)
 
-    def _read_local_repodata(self, state):
+    def _read_local_repodata(self, state: CacheJsonState):
         # first try reading pickled data
         _pickled_state = self._read_pickled(state)
         if _pickled_state:
@@ -459,7 +409,7 @@ class SubdirData(metaclass=SubdirDataType):
         yield "_pickle_version", pickled_state.get("_pickle_version"), REPODATA_PICKLE_VERSION
         yield "fn", pickled_state.get("fn"), self.repodata_fn
 
-    def _read_pickled(self, state):
+    def _read_pickled(self, state: CacheJsonState):
 
         if not isfile(self.cache_path_pickle) or not isfile(self.cache_path_json):
             # Don't trust pickled data if there is no accompanying json data
@@ -476,7 +426,7 @@ class SubdirData(metaclass=SubdirDataType):
             return None
 
         def checks():
-            return self._pickle_valid_checks(_pickled_state, state.get("_mod"), state.get("_etag"))
+            return self._pickle_valid_checks(_pickled_state, state.mod, state.etag)
 
         def _check_pickled_valid():
             for _, left, right in checks():
@@ -493,16 +443,16 @@ class SubdirData(metaclass=SubdirDataType):
 
         return _pickled_state
 
-    def _process_raw_repodata_str(self, raw_repodata_str, state: dict | None = None):
+    def _process_raw_repodata_str(self, raw_repodata_str, state: CacheJsonState | None = None):
         """
         state contains information that was previously in-band in raw_repodata_str.
         """
         json_obj = json.loads(raw_repodata_str or "{}")
         return self._process_raw_repodata(json_obj, state=state)
 
-    def _process_raw_repodata(self, repodata, state=None):
+    def _process_raw_repodata(self, repodata, state: CacheJsonState | None):
         if state is None:
-            state = {}
+            state = CacheJsonState(self.cache_path_json, self.cache_path_state, self.repodata_fn)
         subdir = repodata.get("info", {}).get("subdir") or self.channel.subdir
         assert subdir == self.channel.subdir
         add_pip = context.add_pip_as_python_dependency
@@ -600,30 +550,11 @@ class SubdirData(metaclass=SubdirDataType):
 
                 _package_records.append(package_record)
                 _names_index[package_record.name].append(package_record)
-                for ftr_name in package_record.track_features:
+                for ftr_name in package_record.track_features:  # type: ignore
                     _track_features_index[ftr_name].append(package_record)
 
         self._internal_state = _internal_state
         return _internal_state
-
-
-def read_mod_and_etag(path):
-    with open(path, "rb") as f:
-        try:
-            with closing(mmap(f.fileno(), 0, access=ACCESS_READ)) as m:
-                match_objects = islice(re.finditer(REPODATA_HEADER_RE, m), 3)
-                result = dict(map(ensure_unicode, mo.groups()) for mo in match_objects)
-                return result
-        except (BufferError, ValueError):  # pragma: no cover
-            # BufferError: cannot close exported pointers exist
-            #   https://github.com/conda/conda/issues/4592
-            # ValueError: cannot mmap an empty file
-            return {}
-        except OSError as e:  # pragma: no cover
-            # OSError: [Errno 19] No such device
-            if e.errno == ENODEV:
-                return {}
-            raise
 
 
 def get_cache_control_max_age(cache_control_value):
@@ -666,7 +597,40 @@ def cache_fn_url(url, repodata_fn=REPODATA_FN):
     return f"{md5.hexdigest()[:8]}.json"
 
 
+def read_mod_and_etag(path):
+    # this function should no longer be used by conda but is kept for API
+    # stability. Was used to read inlined cache information from json; now
+    # stored in *.state.json
+    warnings.warn(
+        "`conda.core.subdir_data.read_mod_and_etag` is pending deprecation "
+        "and will be removed in the future.",
+        PendingDeprecationWarning,
+    )
+    with open(path, "rb") as f:
+        try:
+            with closing(mmap(f.fileno(), 0, access=ACCESS_READ)) as m:
+                match_objects = islice(re.finditer(REPODATA_HEADER_RE, m), 3)
+                result = dict(
+                    map(ensure_unicode, mo.groups()) for mo in match_objects  # type: ignore
+                )
+                return result
+        except (BufferError, ValueError):  # pragma: no cover
+            # BufferError: cannot close exported pointers exist
+            #   https://github.com/conda/conda/issues/4592
+            # ValueError: cannot mmap an empty file
+            return {}
+        except OSError as e:  # pragma: no cover
+            # OSError: [Errno 19] No such device
+            if e.errno == ENODEV:
+                return {}
+            raise
+
+
 def fetch_repodata_remote_request(url, etag, mod_stamp, repodata_fn=REPODATA_FN):
+    """
+    :param etag: cached etag header
+    :param mod_stamp: cached last-modified header
+    """
     # this function should no longer be used by conda but is kept for API stability
     warnings.warn(
         "The `conda.core.subdir_data.fetch_repodata_remote_request` function "
@@ -678,7 +642,10 @@ def fetch_repodata_remote_request(url, etag, mod_stamp, repodata_fn=REPODATA_FN)
     subdir = SubdirData(Channel(url), repodata_fn=repodata_fn)
 
     try:
-        raw_repodata_str = subdir._repo.repodata({"_etag": etag, "_mtime": mod_stamp})
+        cache_state = CacheJsonState(None, None, repodata_fn)
+        cache_state.etag = etag
+        cache_state.mod = mod_stamp
+        raw_repodata_str = subdir._repo.repodata(cache_state)
     except RepodataIsEmpty:
         if repodata_fn != REPODATA_FN:
             raise  # is UnavailableInvalidChannel subclass

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -311,8 +311,7 @@ class CacheJsonState(dict):
         try:
             state_path = self.cache_path_state
             log.debug("Load %s cache from %s", self.repodata_fn, state_path)
-            with state_path.open("r") as s:
-                state = json.load(s)
+            state = json.loads(state_path.read_text())
             # json and state files should match
             json_stat = self.cache_path_json.stat()
             if not (

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -85,9 +85,9 @@ class CondaRepoInterface(RepoInterface):
         etag = state.etag
         last_modified = state.mod
         if etag:
-            headers["If-None-Match"] = etag
+            headers["If-None-Match"] = str(etag)
         if last_modified:
-            headers["If-Modified-Since"] = last_modified
+            headers["If-Modified-Since"] = str(last_modified)
         filename = self._repodata_fn
 
         url = join_url(self._url, filename)

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -317,18 +317,18 @@ def test_cache_json(tmp_path):
     """
     cache_json = tmp_path / "cached.json"
     cache_state = tmp_path / "cached.state.json"
-    cache_json.write_text("{}")
 
-    CacheJsonState(cache_json, cache_state, "repodata.json").save({})
+    CacheJsonState(cache_json, cache_state, "repodata.json").save()
 
     state = CacheJsonState(cache_json, cache_state, "repodata.json").load()
 
     mod = "last modified time"
+
+    state = CacheJsonState(cache_json, cache_state, "repodata.json")
     state["_mod"] = mod
     state["_cache_control"] = "cache control"
     state["_etag"] = "etag"
-
-    CacheJsonState(cache_json, cache_state, "repodata.json").save(state)
+    state.save()
 
     on_disk_format = json.loads(cache_state.read_text())
     print("disk format", on_disk_format)
@@ -342,6 +342,10 @@ def test_cache_json(tmp_path):
     assert state2["_mod"] == mod
     assert state2["_cache_control"]
     assert state2["_etag"]
+
+    assert state2["_mod"] == state2.mod
+    assert state2["_etag"] == state2.etag
+    assert state2["_cache_control"] == state2.cache_control
 
     cache_json.write_text("{ }")  # now invalid due to size
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Standardized field names, plus mtime checks to ignore `X.state.json` if `X.json` was changed.

Although the CEP is not finished, we want to merge the mtime checks to make sure an outdated `state.json` is ignored. `*.state.json` stores fields previously in-lined into cached `repodata.json`, files named with hexadecimal `<prefix>.json` in places like `~/miniconda3/pkgs/cache/`

https://github.com/conda-incubator/ceps/pull/46

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
