### PR TITLE
correct test recipe

### DIFF
--- a/tests/test-recipes/activate_deactivate_package/meta.yaml
+++ b/tests/test-recipes/activate_deactivate_package/meta.yaml
@@ -7,7 +7,7 @@ source:
 
 build:
   number: 0
-  noarch: True
+  noarch: generic
   script:
     - cp -r etc ${PREFIX}            #[not win]
     - (robocopy etc %PREFIX%\etc /E /v /fp) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0  #[win] https://superuser.com/a/346112


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Some versions of conda-build try to call .lower() on the boolean True as if it was a string. But the correct value is "generic".

IIRC this test recipe is duplicated in conda-build? Must we invoke conda-build as part of conda's tests or could we cache them?

Example https://github.com/conda/conda/actions/runs/3949958351/jobs/6761877312#step:7:90

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
