### PR TITLE
Replace `toolz.itertoolz.interleave` with `zip`

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -279,8 +279,8 @@ class UnlinkLinkTransaction:
         assert not context.dry_run
         try:
             # innermost dict.values() is an iterable of PrefixActionGroup namedtuple
-            # zip() is an iterable of sets of each PrefixActionGroup namedtuple key
-            self._execute(tuple(chain(*zip(*self.prefix_action_groups.values()))))
+            # zip() is an iterable of each PrefixActionGroup namedtuple key
+            self._execute(tuple(chain(*chain(*zip(*self.prefix_action_groups.values())))))
         finally:
             rm_rf(self.transaction_context['temp_dir'])
 

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -13,11 +13,6 @@ from traceback import format_exception_only
 from textwrap import indent
 import warnings
 
-try:
-    from tlz.itertoolz import interleave
-except ImportError:
-    from conda._vendor.toolz.itertoolz import interleave
-
 from .package_cache_data import PackageCacheData
 from .path_actions import (CompileMultiPycAction, CreateNonadminAction, CreatePrefixRecordAction,
                            CreatePythonEntryPointAction, LinkPathAction, MakeMenuAction,
@@ -283,9 +278,9 @@ class UnlinkLinkTransaction:
 
         assert not context.dry_run
         try:
-            self._execute(
-                tuple(chain.from_iterable(interleave(self.prefix_action_groups.values())))
-            )
+            # innermost dict.values() is an iterable of PrefixActionGroup namedtuple
+            # zip() is an iterable of sets of each PrefixActionGroup namedtuple key
+            self._execute(tuple(chain(*zip(*self.prefix_action_groups.values()))))
         finally:
             rm_rf(self.transaction_context['temp_dir'])
 

--- a/tests/common/test_iterators.py
+++ b/tests/common/test_iterators.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from itertools import chain
+
+from conda.core.link import PrefixActionGroup
+
+
+def test_interleave():
+    try:
+        from tlz.itertoolz import interleave
+    except ImportError:
+        from conda._vendor.toolz.itertoolz import interleave
+
+    prefix_action_groups = {
+        "remove_menu_action_groups": PrefixActionGroup([1, 2], [], [], [], [], [], [], [], []),
+        "unlink_action_groups": PrefixActionGroup([], [3, 4], [], [], [], [], [], [], []),
+        "unregister_action_groups": PrefixActionGroup([], [], [5, 6], [], [], [], [], [], []),
+        "link_action_groups": PrefixActionGroup([], [], [], [7, 8], [], [], [], [], []),
+        "register_action_groups": PrefixActionGroup([], [], [], [], [9, 10], [], [], [], []),
+        "compile_action_groups": PrefixActionGroup([], [], [], [], [], [11, 12], [], [], []),
+        "make_menu_action_groups": PrefixActionGroup([], [], [], [], [], [], [13, 14], [], []),
+        "entry_point_action_groups": PrefixActionGroup([], [], [], [], [], [], [], [15, 16], []),
+        "prefix_record_groups": PrefixActionGroup([], [], [], [], [], [], [], [], [17, 18]),
+        "all": PrefixActionGroup(["a"], ["b"], ["c"], ["d"], ["e"], ["f"], ["g"], ["h"], ["i"]),
+    }
+
+    # old style
+    old_tuple = tuple(chain.from_iterable(interleave(prefix_action_groups.values())))
+
+    # new style
+    new_tuple = tuple(chain(*chain(*zip(*prefix_action_groups.values()))))
+
+    assert old_tuple == new_tuple


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

No need to depend on `toolz`'s `interleave` when `zip` does the job.

Xref https://github.com/conda/conda/issues/11718

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
