### PR TITLE
Add .jlap, .json.zst extensions to paths to make them downloadable

### DIFF
--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -31,6 +31,10 @@ PATH_MATCH_REGEX = (
     r"|//"              # windows UNC path
 )
 
+# any other extension will be mangled by CondaSession.get() as it tries to find
+# channel names from URLs, through strip_pkg_extension()
+KNOWN_EXTENSIONS = (".conda", ".tar.bz2", ".json", ".jlap", ".json.zst")
+
 
 def is_path(value):
     if '://' in value:
@@ -338,7 +342,7 @@ def which(executable):
     return find_executable(executable)
 
 
-def strip_pkg_extension(path):
+def strip_pkg_extension(path: str):
     """
     Examples:
         >>> strip_pkg_extension("/path/_license-1.1-py27_1.tar.bz2")
@@ -350,14 +354,10 @@ def strip_pkg_extension(path):
     """
     # NOTE: not using CONDA_TARBALL_EXTENSION_V1 or CONDA_TARBALL_EXTENSION_V2 to comply with
     #       import rules and to avoid a global lookup.
-    if path[-6:] == ".conda":
-        return path[:-6], ".conda"
-    elif path[-8:] == ".tar.bz2":
-        return path[:-8], ".tar.bz2"
-    elif path[-5:] == ".json":
-        return path[:-5], ".json"
-    else:
-        return path, None
+    for extension in KNOWN_EXTENSIONS:
+        if path.endswith(extension):
+            return path[: -len(extension)], extension
+    return path, None
 
 
 def is_package_file(path):

--- a/news/12261-add-downloadable-extensions
+++ b/news/12261-add-downloadable-extensions
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Add additional extensions to conda.common.path for future use. (#12261)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Due to the way conda's network stack works today, we can only download certain extensions, otherwise these are stripped or taken to be part of a channel name. We anticipate needing to download `.json.zst` and `.jlap` in the near future; add these. Is otherwise harmless (may prevent users from including these extensions in `/some/channelname.json.zst/osx-64/` for example).

Also, reformat a test with black and pymodernize.

Fix #12261 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
