### PR TITLE
remove useless output from conda.csh

### DIFF
--- a/conda/shell/etc/profile.d/conda.csh
+++ b/conda/shell/etc/profile.d/conda.csh
@@ -1,30 +1,11 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
-if (! $?_CONDA_EXE) then
-  set _CONDA_EXE="${PWD}/conda/shell/bin/conda"
-else
-  if ("$_CONDA_EXE" == "") then
-      set _CONDA_EXE="${PWD}/conda/shell/bin/conda"
-  endif
-endif
+set correct_conda_alias="source ${_CONDA_ROOT}/etc/profile.d/conda.csh"
 
-if ("`alias conda`" == "") then
-    if ($?_CONDA_EXE) then
-        # _CONDA_PFX is named so as not to cause confusion with CONDA_PREFIX
-        # If nested backticks were possible we wouldn't use any variables here.
-        set _CONDA_PFX=`dirname "${_CONDA_EXE}"`
-        set _CONDA_PFX=`dirname "${_CONDA_PFX}"`
-        alias conda source "${_CONDA_PFX}/etc/profile.d/conda.csh"
-        # And for good measure, get rid of it afterwards.
-        unset _CONDA_PFX
-    else
-        alias conda source "${PWD}/conda/shell/etc/profile.d/conda.csh"
-    endif
+if (!("`alias conda`" == "$correct_conda_alias")) then
     setenv CONDA_SHLVL 0
-    if (! $?prompt) then
-        set prompt=""
-    endif
+    alias conda $correct_conda_alias
 else
     switch ( "${1}" )
         case "activate":


### PR DESCRIPTION
I found that the CSH environment setup script prints a bunch of useless output every time I want to activate it.
```
usage: conda [-h] [-V] command ...

conda is a tool for managing and deploying applications, environments and packages.

Options:

positional arguments:
  command
    clean        Remove unused packages and caches.
    compare      Compare packages between conda environments.
    config       Modify configuration values in .condarc. This is modeled after the git config command. Writes to the user .condarc
                 file (/home/simonleary_umass_edu/.condarc) by default. Use the --show-sources flag to display all identified
                 configuration locations on your computer.
    create       Create a new conda environment from a list of specified packages.
    info         Display information about current conda install.
    init         Initialize conda for shell interaction.
    install      Installs a list of packages into a specified conda environment.
    list         List installed packages in a conda environment.
    package      Low-level conda package utility. (EXPERIMENTAL)
    remove       Remove a list of packages from a specified conda environment.
    rename       Renames an existing environment.
    run          Run an executable in a conda environment.
    search       Search for packages and display associated information.The input is a MatchSpec, a query language for conda packages.
                 See examples below.
    uninstall    Alias for conda remove.
    update       Updates conda packages to the latest compatible version.
    upgrade      Alias for conda update.
    notices      Retrieves latest channel notifications.

optional arguments:
  -h, --help     Show this help message and exit.
  -V, --version  Show the conda version number and exit.

conda commands available from other packages:
  content-trust
  env
  pack
```

I just pipe stdout to `/dev/null` and the output goes away. If I'm not mistaken, this `if` statement checks if the return code == 0, and piping stdout shouldn't change anything. Error messages shouldn't be hidden because stderr is unchanged.