### PR TITLE
Move coverage from setup.cfg to ease debugging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -218,7 +218,7 @@ jobs:
           -e TEST_GROUP
           ghcr.io/conda/conda-ci:main-linux-python${{ matrix.python-version }}
           bash -c "source /opt/conda/etc/profile.d/conda.sh; \
-                   pytest -k test_DepsModifier_contract"
+                   pytest --cov=conda -k test_DepsModifier_contract"
 
       - name: Upload test results
         if: always()

--- a/dev/linux/integration.sh
+++ b/dev/linux/integration.sh
@@ -14,5 +14,5 @@ conda info
 # put temporary files on same filesystem
 export TMP=$HOME/pytesttmp
 mkdir -p $TMP
-pytest --basetemp=$TMP -m "integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
+pytest --cov=conda --basetemp=$TMP -m "integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
 python -m conda.common.io

--- a/dev/linux/unit.sh
+++ b/dev/linux/unit.sh
@@ -14,4 +14,4 @@ sudo rm -rf /opt/conda/pkgs/*-*-*
 # put temporary files on same filesystem
 export TMP=$HOME/pytesttmp
 mkdir -p $TMP
-pytest --basetemp=$TMP -m "not integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
+pytest --cov=conda --basetemp=$TMP -m "not integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}

--- a/dev/macos/integration.sh
+++ b/dev/macos/integration.sh
@@ -8,5 +8,5 @@ TEST_GROUP="${TEST_GROUP:-1}"
 eval "$(sudo python -m conda init bash --dev)"
 conda info
 conda-build tests/test-recipes/activate_deactivate_package
-pytest -m "integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
-python -m conda.common.io
+pytest --cov=conda -m "integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
+python --cov=conda -m conda.common.io

--- a/dev/macos/integration.sh
+++ b/dev/macos/integration.sh
@@ -9,4 +9,4 @@ eval "$(sudo python -m conda init bash --dev)"
 conda info
 conda-build tests/test-recipes/activate_deactivate_package
 pytest --cov=conda -m "integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
-python --cov=conda -m conda.common.io
+python -m conda.common.io

--- a/dev/macos/unit.sh
+++ b/dev/macos/unit.sh
@@ -7,4 +7,4 @@ TEST_GROUP="${TEST_GROUP:-1}"
 
 eval "$(sudo python -m conda init bash --dev)"
 conda info
-pytest -m "not integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}
+pytest --cov=conda -m "not integration" -v --splits ${TEST_SPLITS} --group=${TEST_GROUP}

--- a/dev/windows/integration.bat
+++ b/dev/windows/integration.bat
@@ -4,7 +4,7 @@ cd \conda_src || goto :error
 CALL dev-init.bat || goto :error
 CALL conda info || goto :error
 CALL conda-build tests\test-recipes\activate_deactivate_package tests\test-recipes\pre_link_messages_package || goto :error
-CALL pytest -m "integration" --basetemp=C:\tmp -v --splits=%TEST_SPLITS% --group=%TEST_GROUP% || goto :error
+CALL pytest --cov=conda -m "integration" --basetemp=C:\tmp -v --splits=%TEST_SPLITS% --group=%TEST_GROUP% || goto :error
 goto :EOF
 
 :error

--- a/dev/windows/unit.bat
+++ b/dev/windows/unit.bat
@@ -3,7 +3,7 @@ pushd %TEMP% || goto :error
 cd \conda_src || goto :error
 CALL dev-init.bat || goto :error
 CALL conda info || goto :error
-CALL pytest -m "not integration" -v --splits=%TEST_SPLITS% --group=%TEST_GROUP% || goto :error
+CALL pytest --cov=conda -m "not integration" -v --splits=%TEST_SPLITS% --group=%TEST_GROUP% || goto :error
 goto :EOF
 
 :error

--- a/docs/source/dev-guide/development-environment.md
+++ b/docs/source/dev-guide/development-environment.md
@@ -193,10 +193,10 @@ $ source ./dev/start
 $ make unit
 
 # or alternately with pytest
-$ pytest -m "not integration" conda tests
+$ pytest --cov -m "not integration" conda tests
 
 # or you can use pytest to focus on one specific test
-$ pytest tests/test_create.py -k create_install_update_remove_smoketest
+$ pytest --cov tests/test_create.py -k create_install_update_remove_smoketest
 ```
 
 **cmd.exe (Windows)**
@@ -208,11 +208,14 @@ $ pytest tests/test_create.py -k create_install_update_remove_smoketest
 :: > docker compose run interactive
 
 :: run conda's unit tests with pytest
-> pytest -m "not integration" conda tests
+> pytest --cov -m "not integration" conda tests
 
 :: or you can use pytest to focus on one specific test
-> pytest tests\test_create.py -k create_install_update_remove_smoketest
+> pytest --cov tests\test_create.py -k create_install_update_remove_smoketest
 ```
+
+If you are not measuring code coverage, `pytest` can be run without the `--cov`
+option. The `docker compose` tests pass `--cov`.
 
 Note: Some integration tests require you build a package with conda-build beforehand.
 This is taking care of if you run `docker compose run integration-tests`, but you need

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ addopts =
     --xdoctest-style=google
     --cov-report xml
     --cov-report term-missing
-    --cov conda
     --cov-append
     --junitxml=test-report.xml
+    # --cov conda   # passed in test runner scripts instead (avoid debugger)
 doctest_optionflags =
     NORMALIZE_WHITESPACE
     IGNORE_EXCEPTION_DETAIL

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -63,6 +63,7 @@ LOG=${2}/${TESTDIR_LOG_FNAME_BIT}-${PYVER}${JOBS//=/-}.$(date +%Y-%m-%d.%H%M%S).
 
 CONDA_TEST_SAVE_TEMPS=1 \
   pytest \
+    --cov=conda \
     ${JOBS} \
     -vvv \
     --durations=0 \

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1824,7 +1824,18 @@ dependencies:
             assert yml_obj['channels'] == [channel_url.replace('cqgccfm1mfma', '<TOKEN>'), 'defaults']
 
             with pytest.raises(PackagesNotFoundError):
-                run_command(Commands.SEARCH, prefix, "boltons", "--json")
+                # this was supposed to be a package available in private but not
+                # public data-portal; boltons was added to defaults in 2023 Jan.
+                # --override-channels instead.
+                run_command(
+                    Commands.SEARCH,
+                    prefix,
+                    "boltons",
+                    "-c",
+                    channel_url,
+                    "--override-channels",
+                    "--json",
+                )
 
             stdout, stderr, _ = run_command(Commands.SEARCH, prefix, "anaconda-mosaic", "--json")
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I always run tests in the debugger, in vscode, but `--cov` prevents the debugger from working.

Instead, enable coverage in individual test runner scripts, for CI.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
