### PR TITLE
modify test to account for boltons in defaults

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1824,7 +1824,18 @@ dependencies:
             assert yml_obj['channels'] == [channel_url.replace('cqgccfm1mfma', '<TOKEN>'), 'defaults']
 
             with pytest.raises(PackagesNotFoundError):
-                run_command(Commands.SEARCH, prefix, "boltons", "--json")
+                # this was supposed to be a package available in private but not
+                # public data-portal; boltons was added to defaults in 2023 Jan.
+                # --override-channels instead.
+                run_command(
+                    Commands.SEARCH,
+                    prefix,
+                    "boltons",
+                    "-c",
+                    channel_url,
+                    "--override-channels",
+                    "--json",
+                )
 
             stdout, stderr, _ = run_command(Commands.SEARCH, prefix, "anaconda-mosaic", "--json")
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

A test requires boltons to be absent from defaults but it was added on 23 Jan 2023. Use `--override-channels` to look in the specified channel only, instead. Presumably boltons is in the private version of this test channel, but I'm not a member.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
