### PR TITLE
Channel Notices doesn't handle i/o errors

### DIFF
--- a/conda/cli/main_notices.py
+++ b/conda/cli/main_notices.py
@@ -3,6 +3,7 @@
 
 from argparse import Namespace, ArgumentParser
 
+from ..exceptions import CondaError
 from ..notices import core as notices
 
 
@@ -10,6 +11,9 @@ def execute(args: Namespace, _: ArgumentParser):
     """
     Command that retrieves channel notifications, caches them and displays them.
     """
-    channel_notice_set = notices.retrieve_notices()
+    try:
+        channel_notice_set = notices.retrieve_notices()
+    except OSError as exc:
+        raise CondaError(f"Unable to retrieve notices: {exc}")
 
     notices.display_notices(channel_notice_set)

--- a/conda/notices/cache.py
+++ b/conda/notices/cache.py
@@ -17,7 +17,7 @@ from typing import Optional, Sequence, Set
 
 from .._vendor.appdirs import user_cache_dir
 from ..base.constants import APP_NAME, NOTICES_CACHE_SUBDIR, NOTICES_CACHE_FN
-from ..utils import ensure_dir_exists, safe_open
+from ..utils import ensure_dir_exists
 
 from .types import ChannelNoticeResponse, ChannelNotice
 
@@ -78,7 +78,7 @@ def get_notices_cache_file() -> Path:
     cache_file = cache_dir.joinpath(NOTICES_CACHE_FN)
 
     if not cache_file.is_file():
-        with safe_open(cache_file, "w") as fp:
+        with open(cache_file, "w") as fp:
             fp.write("")
 
     return cache_file
@@ -93,7 +93,7 @@ def get_notice_response_from_cache(
     cache_key = ChannelNoticeResponse.get_cache_key(url, cache_dir)
 
     if os.path.isfile(cache_key):
-        with safe_open(cache_key, "r") as fp:
+        with open(cache_key) as fp:
             data = json.load(fp)
         chn_ntc_resp = ChannelNoticeResponse(url, name, data)
 
@@ -109,7 +109,7 @@ def write_notice_response_to_cache(
     """
     cache_key = ChannelNoticeResponse.get_cache_key(channel_notice_response.url, cache_dir)
 
-    with safe_open(cache_key, "w") as fp:
+    with open(cache_key, "w") as fp:
         json.dump(channel_notice_response.json_data, fp)
 
 
@@ -121,14 +121,14 @@ def mark_channel_notices_as_viewed(
     """
     notice_ids = {chn.id for chn in channel_notices}
 
-    with safe_open(cache_file, "r") as fp:
+    with open(cache_file) as fp:
         contents: str = fp.read()
 
     contents_unique = set(filter(None, set(contents.splitlines())))
     contents_new = contents_unique.union(notice_ids)
 
     # Save new version of cache file
-    with safe_open(cache_file, "w") as fp:
+    with open(cache_file, "w") as fp:
         fp.write("\n".join(contents_new))
 
 
@@ -140,7 +140,7 @@ def get_viewed_channel_notice_ids(
     """
     notice_ids = {chn.id for chn in channel_notices}
 
-    with safe_open(cache_file, "r") as fp:
+    with open(cache_file) as fp:
         contents: str = fp.read()
 
     contents_unique = set(filter(None, set(contents.splitlines())))

--- a/conda/notices/core.py
+++ b/conda/notices/core.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from functools import wraps
+import logging
 import time
+from functools import wraps
 from typing import Sequence
 
 from ..base.context import context, Context
@@ -18,6 +19,8 @@ from .types import ChannelNotice, ChannelNoticeResponse, ChannelNoticeResultSet
 # Used below in type hints
 ChannelName = str
 ChannelUrl = str
+
+logger = logging.getLogger(__name__)
 
 
 def retrieve_notices(
@@ -44,11 +47,7 @@ def retrieve_notices(
 
     # We always want to modify the mtime attribute of the file if we are trying to retrieve notices
     # This is used later in "is_channel_notices_cache_expired"
-    try:
-        cache_file.touch()
-    except OSError:
-        # It's okay if we fail to update this file
-        pass
+    cache_file.touch()
 
     viewed_notices = None
     viewed_channel_notices = 0
@@ -98,19 +97,28 @@ def notices(func):
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if is_channel_notices_enabled(context) and is_channel_notices_cache_expired():
-            channel_notice_set = retrieve_notices(
-                limit=context.number_channel_notices,
-                always_show_viewed=False,
-                silent=True,
-            )
-            return_value = func(*args, **kwargs)
-            display_notices(channel_notice_set)
+        if is_channel_notices_enabled(context):
+            channel_notice_set = None
 
-            return return_value
+            try:
+                if is_channel_notices_cache_expired():
+                    channel_notice_set = retrieve_notices(
+                        limit=context.number_channel_notices,
+                        always_show_viewed=False,
+                        silent=True,
+                    )
+            except OSError as exc:
+                # If we encounter any OSError related error, we simply abandon
+                # fetching notices
+                logger.error(f"Unable to open cache file: {str(exc)}")
 
-        else:
-            return func(*args, **kwargs)
+            if channel_notice_set is not None:
+                return_value = func(*args, **kwargs)
+                display_notices(channel_notice_set)
+
+                return return_value
+
+        return func(*args, **kwargs)
 
     return wrapper
 

--- a/conda/notices/core.py
+++ b/conda/notices/core.py
@@ -44,7 +44,11 @@ def retrieve_notices(
 
     # We always want to modify the mtime attribute of the file if we are trying to retrieve notices
     # This is used later in "is_channel_notices_cache_expired"
-    cache_file.touch()
+    try:
+        cache_file.touch()
+    except OSError:
+        # It's okay if we fail to update this file
+        pass
 
     viewed_notices = None
     viewed_channel_notices = 0

--- a/tests/cli/test_main_notices.py
+++ b/tests/cli/test_main_notices.py
@@ -312,11 +312,15 @@ def test_notices_does_not_interrupt_command_on_failure(
         "conda.notices.core.logger.error"
     ) as mock_logger:
         mock_open.side_effect = [PermissionError(error_message)]
-        run(f"conda create -n {env_name} -y -c local --override-channels")
+        _, _, exit_code = run(f"conda create -n {env_name} -y -c local --override-channels")
+
+        assert exit_code is None
 
         assert mock_logger.call_args == mock.call(f"Unable to open cache file: {error_message}")
 
-    run(f"conda env remove -n {env_name}")
+    _, _, exit_code = run(f"conda env remove -n {env_name}")
+
+    assert exit_code is None
 
 
 def test_notices_cannot_read_cache_files(notices_cache_dir, notices_mock_http_session_get):


### PR DESCRIPTION
Fix for this issue:

- https://github.com/conda/conda/issues/12310