### PR TITLE
remove unused _track_features_index optimization

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -238,7 +238,7 @@ class SubdirData(metaclass=SubdirDataType):
         self._internal_state = _internal_state
         self._package_records = _internal_state["_package_records"]
         self._names_index = _internal_state["_names_index"]
-        self._track_features_index = _internal_state["_track_features_index"]  # Unused since 22.3
+        self._track_features_index = _internal_state["_track_features_index"]  # Unused since early 2023
         self._loaded = True
         return self
 
@@ -292,7 +292,7 @@ class SubdirData(metaclass=SubdirDataType):
                 return {
                     "_package_records": (),
                     "_names_index": defaultdict(list),
-                    "_track_features_index": defaultdict(list),  # Unused since 22.3
+                    "_track_features_index": defaultdict(list),  # Unused since early 2023
                 }
             else:
                 mod_etag_headers = {}

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -151,14 +151,6 @@ class SubdirData(metaclass=SubdirDataType):
                 for prec in self._iter_records_by_name(package_name):
                     if param.match(prec):
                         yield prec
-            elif param.get_exact_value("track_features"):
-                track_features = param.get_exact_value("track") or ()
-                candidates = chain.from_iterable(
-                    self._track_features_index[feature_name] for feature_name in track_features
-                )
-                for prec in candidates:
-                    if param.match(prec):
-                        yield prec
             else:
                 for prec in self.iter_records():
                     if param.match(prec):
@@ -246,7 +238,7 @@ class SubdirData(metaclass=SubdirDataType):
         self._internal_state = _internal_state
         self._package_records = _internal_state["_package_records"]
         self._names_index = _internal_state["_names_index"]
-        self._track_features_index = _internal_state["_track_features_index"]
+        self._track_features_index = _internal_state["_track_features_index"]  # Unused since 22.3
         self._loaded = True
         return self
 
@@ -300,7 +292,7 @@ class SubdirData(metaclass=SubdirDataType):
                 return {
                     "_package_records": (),
                     "_names_index": defaultdict(list),
-                    "_track_features_index": defaultdict(list),
+                    "_track_features_index": defaultdict(list),  # Unused since 22.3
                 }
             else:
                 mod_etag_headers = {}
@@ -577,8 +569,6 @@ class SubdirData(metaclass=SubdirDataType):
                 _package_records.append(info)
                 record_index = len(_package_records) - 1
                 _names_index[info["name"]].append(record_index)
-                for ftr_name in info.get("track_features", []):
-                    _track_features_index[ftr_name].append(record_index)
 
         self._internal_state = _internal_state
         return _internal_state

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -160,7 +160,7 @@ class SubdirData(metaclass=SubdirDataType):
                         yield prec
         else:
             assert isinstance(param, PackageRecord)
-            for prec in self._names_index[param.name]:
+            for prec in self._iter_records_by_name(param.name):
                 if prec == param:
                     yield prec
 

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -124,10 +124,13 @@ class SubdirData(metaclass=SubdirDataType):
                     dashlist(ignored_urls),
                 )
             channel_urls = IndexedSet(grouped_urls.get(True, ()))
+
         check_allowlist(channel_urls)
-        subdir_query = lambda url: tuple(
-            SubdirData(Channel(url), repodata_fn=repodata_fn).query(package_ref_or_match_spec)
-        )
+
+        def subdir_query(url):
+            return tuple(
+                SubdirData(Channel(url), repodata_fn=repodata_fn).query(package_ref_or_match_spec)
+            )
 
         # TODO test timing with ProcessPoolExecutor
         Executor = (
@@ -238,7 +241,8 @@ class SubdirData(metaclass=SubdirDataType):
         self._internal_state = _internal_state
         self._package_records = _internal_state["_package_records"]
         self._names_index = _internal_state["_names_index"]
-        self._track_features_index = _internal_state["_track_features_index"]  # Unused since early 2023
+        # Unused since early 2023:
+        self._track_features_index = _internal_state["_track_features_index"]
         self._loaded = True
         return self
 

--- a/news/remove-track-features-index
+++ b/news/remove-track-features-index
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove unused optimization for searching packages based on
+  `*[track_features=<feature name>]`.
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -25,6 +25,7 @@ from conda.core.subdir_data import (
     read_mod_and_etag,
     CondaRepoInterface,
 )
+from conda.testing.helpers import CHANNEL_DIR
 from conda.models.channel import Channel
 
 log = getLogger(__name__)
@@ -305,6 +306,17 @@ def test_metadata_cache_clearing(platform=OVERRIDE_PLATFORM):
         precs_b = tuple(sd_b.query("zlib"))
         assert fetcher.call_count == 2
         assert precs_b == precs_a
+
+
+def test_search_by_packagerecord(platform=OVERRIDE_PLATFORM):
+    local_channel = Channel(join(CHANNEL_DIR, platform))
+    sd = SubdirData(channel=local_channel)
+
+    # test slow "check against all packages" query
+    assert len(tuple(sd.query("*[version=1.2.11]"))) >= 1
+
+    # test search by PackageRecord
+    assert any(sd.query(next(sd.query("zlib"))))  # type: ignore
 
 
 # @pytest.mark.integration


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

AFAICT this has been broken for years, and no one has missed it.

Retain empty properties of SubdirData "just in case" (for API reasons)

Ironically, this should fix searching for `track_features` (since we no longer compare against the missing `track` key), it just goes through the compare-matchspec-against-all-packagerecord path like any other MatchSpec that doesn't specify an exact `name` 

Fix #12319 

Fixes unreleased search-by-packagerecord bug.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
