### PR TITLE
Xonsh: allow --help and --version passthrough in conda.xsh

### DIFF
--- a/conda/shell/conda.xsh
+++ b/conda/shell/conda.xsh
@@ -23,7 +23,9 @@ def Env():
 def _parse_args(args=None):
     from argparse import ArgumentParser
     p = ArgumentParser(add_help=False)
-    p.add_argument('command')
+    p.add_argument('command', nargs='?')
+    p.add_argument('-h', '--help', dest='help', action='store_true', default=False)
+    p.add_argument('-v', '--version', dest='version', action='store_true', default=False)
     ns, _ = p.parse_known_args(args)
     if ns.command == 'activate':
         p.add_argument('env_name_or_prefix', default='base')

--- a/news/12344-passthrough-version-help-xonsh
+++ b/news/12344-passthrough-version-help-xonsh
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix arg_parse passthrough for ``--version`` and ``--help`` in conda.xsh
+* Fix arg_parse passthrough for ``--version`` and ``--help`` in conda.xsh. (#12344)
 
 ### Deprecations
 

--- a/news/12344-passthrough-version-help-xonsh
+++ b/news/12344-passthrough-version-help-xonsh
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix arg_parse passthrough for ``--version`` and ``--help`` in conda.xsh
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Fixes #12324 

xref xonsh/xonsh#5038

The argparser in `conda.xsh` was a bit too eager, so even though there's a function for passing through unparsed arguments, we were never reaching it.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
