### PR TITLE
Fix `xonsh` Command Parser

### DIFF
--- a/conda/shell/conda.xsh
+++ b/conda/shell/conda.xsh
@@ -23,7 +23,7 @@ def Env():
 def _parse_args(args=None):
     from argparse import ArgumentParser
     p = ArgumentParser(add_help=False)
-    p.add_argument('command')
+    p.add_argument('command', nargs='?', default=None)
     ns, _ = p.parse_known_args(args)
     if ns.command == 'activate':
         p.add_argument('env_name_or_prefix', default='base')

--- a/news/12352-fix-xonsh-command-parser
+++ b/news/12352-fix-xonsh-command-parser
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Enable `xonsh` shell to recognize conda command args and flags that start with "-" (#12324)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
This is a bug fix for the following issue:
- https://github.com/conda/conda/issues/12324

See the comment in a related bug ticket here for the source of this fix: https://github.com/xonsh/xonsh/issues/5038#issuecomment-1426635346

**Before the fix:**

![Screen Shot 2023-02-13 at 3 50 01 PM](https://user-images.githubusercontent.com/28930622/218572761-9df759af-9e5e-437e-8170-1ce1981ded56.png)

**After the fix (`--help` menu shows up properly!):**

![Screen Shot 2023-02-13 at 3 49 31 PM](https://user-images.githubusercontent.com/28930622/218572786-2faa13a7-59e6-4eec-a89e-fe5b3edeb61b.png)


### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] ~~Add / update outdated documentation?~~

