### PR TITLE
ISSUE_SORTING.md change to HOW_WE_USE_GITHUB.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To see how this process works for this project, read "[The Issue Sorting Process
 [anaconda-issues]: https://github.com/ContinuumIO/anaconda-issues/issues
 [anaconda-support]: https://anaconda.cloud/support-center
 [anaconda-bug-report]: https://anaconda.org/contact/report
-[sorting]: https://github.com/conda/infra/blob/main/ISSUE_SORTING.md
+[sorting]: https://github.com/conda/infrastructure/blob/main/HOW_WE_USE_GITHUB.md
 [development-environment]: https://docs.conda.io/projects/conda/en/latest/dev-guide/development-environment.html
 
 ## Conda capitalization standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To see how this process works for this project, read "[The Issue Sorting Process
 [anaconda-issues]: https://github.com/ContinuumIO/anaconda-issues/issues
 [anaconda-support]: https://anaconda.cloud/support-center
 [anaconda-bug-report]: https://anaconda.org/contact/report
-[sorting]: https://github.com/conda/infrastructure/blob/main/HOW_WE_USE_GITHUB.md
+[sorting]: https://github.com/conda/infra/blob/main/HOW_WE_USE_GITHUB.md
 [development-environment]: https://docs.conda.io/projects/conda/en/latest/dev-guide/development-environment.html
 
 ## Conda capitalization standards


### PR DESCRIPTION
### Description
The ISSUE_SORTING.md file was renamed to HOW_WE_USE_GITHUB.md, this was causing the error #12367 

### Change made: 
The file name ISSUE_SORTING.md is change to HOW_WE_USE_GITHUB.md
```
[sorting]: https://github.com/conda/infrastructure/blob/main/ISSUE_SORTING.md to
[sorting]: https://github.com/conda/infrastructure/blob/main/HOW_WE_USE_GITHUB.md
```
in CONTRIBUTING.md

### Issue solve
This will solve #12367


