### PR TITLE
Create embedded links on docs pages

### DIFF
--- a/docs/source/user-guide/concepts/channels.rst
+++ b/docs/source/user-guide/concepts/channels.rst
@@ -18,11 +18,11 @@ from remote channels, which are URLs to directories
 containing conda packages.
 The ``conda`` command searches a set of channels. By default,
 packages are automatically downloaded and updated from
-the ``default`` channel https://repo.anaconda.com/pkgs/ which may require a
-paid license, as described in the `repository terms of service`_
-a commercial license. The ``conda-forge`` channel is free for all to use.
-You can modify what remote channels are automatically searched.
-You might want to do this to maintain a private or internal channel.
+the `default channel`_, which may require a
+paid license, as described in the `repository terms of service`_.
+The ``conda-forge`` channel is free for all to use.
+You can modify which remote channels are automatically searched;
+this feature is beneficial when maintaining a private or internal channel.
 For details, see how to :ref:`modify your channel lists <config-channels>`.
 
 We use conda-forge as an example channel.
@@ -107,3 +107,5 @@ per standard RSS practice.
           <title>linux-64:add:jupyterlab-1.0.4-py37_0.tar.bz2</title>
           <pubDate>26 Jul 2019 19:26:36 UTC</pubDate>
         </item>
+
+.. _`default channel`: https://repo.anaconda.com/pkgs/

--- a/docs/source/user-guide/tasks/manage-channels.rst
+++ b/docs/source/user-guide/tasks/manage-channels.rst
@@ -7,7 +7,7 @@ They serve as the base for hosting and managing packages.
 Conda packages are downloaded from remote channels, which are URLs to
 directories containing conda packages. The conda command searches a default
 set of channels and packages are automatically downloaded and updated
-from https://repo.anaconda.com/pkgs/. Read more about
+from the `default channel`_. Read more about
 :doc:`conda channels <../concepts/channels>` and the various terms of service
 for their use.
 
@@ -115,3 +115,5 @@ Details about it can be seen by typing ``conda config --describe channel_priorit
     True or False. True is now an alias to 'flexible'.
 
     channel_priority: flexible
+
+.. _`default channel`: https://repo.anaconda.com/pkgs/


### PR DESCRIPTION
Changing some raw hypertext URLs into embedded links + a few wording changes. See below for un-embedded links:

<img width="658" alt="Screen Shot 2023-02-23 at 10 19 27 PM" src="https://user-images.githubusercontent.com/28930622/221083962-f09d79b1-3d95-466c-8d85-0f8013d41e28.png">
<img width="666" alt="Screen Shot 2023-02-23 at 10 19 34 PM" src="https://user-images.githubusercontent.com/28930622/221083968-8ddc6f6b-2c30-46cb-9a09-655b725a7b5f.png">
