### PR TITLE
`conda run` replaces python process when possible

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1213,6 +1213,12 @@ def configure_parser_run(sub_parsers):
              "the user's current working directory if no directory is specified.",
         default=os.getcwd()
     )
+    p.add_argument(
+        "--no-capture-output",
+        "--live-stream",
+        action=DeprecatedAction,
+        help="DEPRECATED. I/O is no longer captured.",
+    )
 
     p.add_argument(
         'executable_call',

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1213,13 +1213,6 @@ def configure_parser_run(sub_parsers):
              "the user's current working directory if no directory is specified.",
         default=os.getcwd()
     )
-    p.add_argument(
-        "--no-capture-output",
-        "--live-stream",
-        action="store_true",
-        help="Don't capture stdout/stderr (standard out/standard error).",
-        default=False,
-    )
 
     p.add_argument(
         'executable_call',

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -12,8 +12,8 @@ from .common import validate_prefix
 
 def execute(args, parser):
 
-    # create run script    
-    call_args = wrap_exec_call(
+    # create run script
+    _, call_args = wrap_exec_call(
         context.root_prefix,
         validate_prefix(context.target_prefix or os.getenv("CONDA_PREFIX") or context.root_prefix),
         args.dev,

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -2,55 +2,31 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-from logging import getLogger
 import os
-import sys
 
 from ..base.context import context
-from ..utils import wrap_subprocess_call
-from ..gateways.disk.delete import rm_rf
+from ..utils import wrap_exec_call
 from ..common.compat import encode_environment
-from ..gateways.subprocess import subprocess_call
 from .common import validate_prefix
 
 
 def execute(args, parser):
-    # create run script
-    script, command = wrap_subprocess_call(
+
+    # create run script    
+    call_args = wrap_exec_call(
         context.root_prefix,
         validate_prefix(context.target_prefix or os.getenv("CONDA_PREFIX") or context.root_prefix),
         args.dev,
         args.debug_wrapper_scripts,
         args.executable_call,
-        use_system_tmp_path=True,
     )
 
-    # run script
-    response = subprocess_call(
-        command,
-        env=encode_environment(os.environ.copy()),
-        path=args.cwd,
-        raise_on_error=False,
-        capture_output=not args.no_capture_output,
+    if args.cwd:
+        os.chdir(args.cwd)
+
+    # run script, replacing conda python process
+    os.execvpe(
+        file=call_args[0],
+        args=call_args,
+        env=encode_environment(os.environ),
     )
-
-    # display stdout/stderr if it was captured
-    if not args.no_capture_output:
-        if response.stdout:
-            print(response.stdout, file=sys.stdout)
-        if response.stderr:
-            print(response.stderr, file=sys.stderr)
-
-    # log error
-    if response.rc != 0:
-        log = getLogger(__name__)
-        log.error(f"`conda run {' '.join(args.executable_call)}` failed. (See above for error)")
-
-    # remove script
-    if "CONDA_TEST_SAVE_TEMPS" not in os.environ:
-        rm_rf(script)
-    else:
-        log = getLogger(__name__)
-        log.warning(f"CONDA_TEST_SAVE_TEMPS :: retaining main_run script {script}")
-
-    return response

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -27,6 +27,7 @@ from ..core.subdir_data import SubdirData, make_feature_record
 from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.read import lexists
 from ..gateways.logging import initialize_logging
+from ..gateways.subprocess import subprocess_call
 from ..history import History
 from ..models.channel import Channel
 from ..models.records import PackageRecord
@@ -145,6 +146,24 @@ def run_inprocess_conda_command(command, disallow_stderr: bool = True):
     print(c.stderr, file=sys.stderr)
     print(c.stdout)
     return c.stdout, c.stderr, exit_code
+
+
+def run_subprocess_conda_command(command, disallow_stderr: bool = True):
+
+    reset_context(())
+
+    if command.startswith("conda "):
+        command = "python -m " + command
+
+    with captured(disallow_stderr) as c:
+        initialize_logging()
+        try:
+            response = subprocess_call(command=command, raise_on_error=False, capture_output=False)
+        except SystemExit:
+            pass
+    print(c.stderr, file=sys.stderr)
+    print(c.stdout)
+    return c.stdout, c.stderr, response.rc
 
 
 def add_subdir(dist_string):

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -361,11 +361,12 @@ def massage_arguments(arguments, errors='assert'):
 
 
 def _wrap_bat(
-        root_prefix,
-        prefix,
-        dev_mode,
-        debug_wrapper_scripts,
-        arguments,
+    root_prefix,
+    prefix,
+    dev_mode,
+    debug_wrapper_scripts,
+    arguments,
+    newline="\n",
 ):
     """wrap :param arguments: in a .bat file"""
     with StringIO() as bat:
@@ -376,42 +377,42 @@ def _wrap_bat(
             conda_bat = environ.get("CONDA_BAT",
                                     abspath(join(root_prefix, 'condabin', 'conda.bat')))
         silencer = "" if debug_wrapper_scripts else "@"
-        bat.write(f"{silencer}ECHO OFF\n")
-        bat.write(f"{silencer}SET PYTHONIOENCODING=utf-8\n")
-        bat.write(f"{silencer}SET PYTHONUTF8=1\n")
+        bat.write(f"{silencer}ECHO OFF{newline}")
+        bat.write(f"{silencer}SET PYTHONIOENCODING=utf-8{newline}")
+        bat.write(f"{silencer}SET PYTHONUTF8=1{newline}")
         bat.write(
             f'{silencer}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'  # noqa
         )
-        bat.write(f"{silencer}chcp 65001 > NUL\n")
+        bat.write(f"{silencer}chcp 65001 > NUL{newline}")
         if dev_mode:
             from . import CONDA_SOURCE_ROOT
 
-            bat.write(f"{silencer}SET CONDA_DEV=1\n")
+            bat.write(f"{silencer}SET CONDA_DEV=1{newline}")
             # In dev mode, conda is really:
             # 'python -m conda'
             # *with* PYTHONPATH set.
-            bat.write(f"{silencer}SET PYTHONPATH={CONDA_SOURCE_ROOT}\n")
-            bat.write(f"{silencer}SET CONDA_EXE={sys.executable}\n")
-            bat.write(f"{silencer}SET _CE_M=-m\n")
-            bat.write(f"{silencer}SET _CE_CONDA=conda\n")
+            bat.write(f"{silencer}SET PYTHONPATH={CONDA_SOURCE_ROOT}{newline}")
+            bat.write(f"{silencer}SET CONDA_EXE={sys.executable}{newline}")
+            bat.write(f"{silencer}SET _CE_M=-m{newline}")
+            bat.write(f"{silencer}SET _CE_CONDA=conda{newline}")
         if debug_wrapper_scripts:
-            bat.write("echo *** environment before *** 1>&2\n")
-            bat.write("SET 1>&2\n")
+            bat.write(f"echo *** environment before *** 1>&2{newline}")
+            bat.write(f"SET 1>&2{newline}")
         # Not sure there is any point in backing this up, nothing will get called with it reset
         # after all!
         # fh.write("@FOR /F \"tokens=100\" %%F IN ('chcp') DO @SET CONDA_OLD_CHCP=%%F\n")
         # fh.write('@chcp 65001>NUL\n')
-        bat.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"\n')
-        bat.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
+        bat.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"{newline}')
+        bat.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%{newline}")
         if debug_wrapper_scripts:
-            bat.write("echo *** environment after *** 1>&2\n")
-            bat.write("SET 1>&2\n")
-        if len(arguments) == 1 and "\n" in arguments[0]:  # multiline
+            bat.write(f"echo *** environment after *** 1>&2{newline}")
+            bat.write(f"SET 1>&2{newline}")
+        if len(arguments) == 1 and newline in arguments[0]:  # multiline
             # No point silencing the first line. If that's what's wanted then
             # it needs doing for each line and the caller may as well do that.
-            bat.write(f"{arguments[0]}\n")
+            bat.write(f"{arguments[0]}{newline}")
         else:
-            assert not any("\n" in arg for arg in arguments), (
+            assert not any(newline in arg for arg in arguments), (
                 "Support for scripts where arguments contain newlines not implemented.\n"
                 ".. requires writing the script to an external file and knowing how to "
                 "transform the command-line (e.g. `python -c args` => `python file`) "
@@ -419,9 +420,9 @@ def _wrap_bat(
                 ".. https://stackoverflow.com/a/15032476 (adds unacceptable escaping"
                 "requirements)"
             )
-            bat.write(f"{silencer}{quote_for_shell(*arguments)}\n")
-        bat.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
-        bat.write(f"{silencer}chcp %_CONDA_OLD_CHCP%>NUL\n")
+            bat.write(f"{silencer}{quote_for_shell(*arguments)}{newline}")
+        bat.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%{newline}")
+        bat.write(f"{silencer}chcp %_CONDA_OLD_CHCP%>NUL")
         return bat.getvalue()
 
 
@@ -431,13 +432,14 @@ def _wrap_sh(
     dev_mode,
     debug_wrapper_scripts,
     arguments,
+    newline="\n",
 ):
     """wrap :param arguments: in a .sh script"""
     with StringIO() as sh:
         if dev_mode:
             from . import CONDA_SOURCE_ROOT
 
-            sh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + "\n")
+            sh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + newline)
             conda_exe = [abspath(join(root_prefix, 'bin', 'python')), '-m', 'conda']
             dev_arg = '--dev'
             dev_args = [dev_arg]
@@ -447,18 +449,18 @@ def _wrap_sh(
             dev_args = []
         hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
         if debug_wrapper_scripts:
-            sh.write(">&2 echo '*** environment before ***'\n" ">&2 env\n")
-            sh.write(f'>&2 echo "$({hook_quoted})"\n')
-        sh.write(f'eval "$({hook_quoted})"\n')
-        sh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
+            sh.write(f">&2 echo '*** environment before ***'{newline}>&2 env{newline}")
+            sh.write(f'>&2 echo "$({hook_quoted})"{newline}')
+        sh.write(f'eval "$({hook_quoted})"{newline}')
+        sh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}{newline}")
         if debug_wrapper_scripts:
-            sh.write(">&2 echo '*** environment after ***'\n" ">&2 env\n")
-        if len(arguments) == 1 and "\n" in arguments[0]:  # multiline
+            sh.write(f">&2 echo '*** environment after ***'{newline}>&2 env{newline}")
+        if len(arguments) == 1 and newline in arguments[0]:  # multiline
             # The ' '.join() is pointless since mutliline is only True when there's 1 arg
             # still, if that were to change this would prevent breakage.
-            sh.write("{}\n".format(" ".join(arguments)))
+            sh.write("{}".format(" ".join(arguments)))
         else:
-            sh.write(f"{quote_for_shell(*arguments)}\n")
+            sh.write(f"{quote_for_shell(*arguments)}")
         return sh.getvalue()
 
 
@@ -513,9 +515,25 @@ def wrap_subprocess_call(
         mode="w", prefix=tmp_prefix, suffix=shell["shell_suffix"], delete=False
     ) as fh:
         if shell["shell_suffix"] == ".sh":
-            fh.write(_wrap_sh(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments))
+            fh.write(
+                _wrap_sh(
+                    root_prefix,
+                    prefix,
+                    dev_mode,
+                    debug_wrapper_scripts,
+                    arguments,
+                )
+            )
         elif shell["shell_suffix"] == ".bat":
-            fh.write(_wrap_bat(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments))
+            fh.write(
+                _wrap_bat(
+                    root_prefix,
+                    prefix,
+                    dev_mode,
+                    debug_wrapper_scripts,
+                    arguments,
+                )
+            )
         else:
             raise ValueError(f"cannot wrap commands in '{shell['shell_suffix']}' script")
         script_caller = fh.name
@@ -545,21 +563,30 @@ def wrap_exec_call(
     if shell["exec"]:
         arguments.insert(0, shell["exec"])
     if shell["shell_suffix"] == ".sh":
-        script = _wrap_sh(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments)
+        script = _wrap_sh(
+            root_prefix,
+            prefix,
+            dev_mode,
+            debug_wrapper_scripts,
+            arguments,
+            newline=shell.get("line_join") or "\n",
+        )
     elif shell["shell_suffix"] == ".bat":
-        script = _wrap_bat(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments)
+        script = _wrap_bat(
+            root_prefix,
+            prefix,
+            dev_mode,
+            debug_wrapper_scripts,
+            arguments,
+            newline=shell.get("line_join") or "\n",
+        )
     else:
         raise ValueError(f"cannot wrap commands in '{shell['shell_suffix']}' script")
-    if shell.get("line_join"):
-        # join lines with shell['line_join'], dropping empty lines
-        command = shell["line_join"].join(line for line in script.splitlines() if line)
-    else:
-        command = script
     command_args = [
         shell["which"],
         *(shell["debug_args"] if debug_wrapper_scripts else []),
         *shell["shell_args"],
-        command,
+        script,
     ]
     return script, command_args
 

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -3,6 +3,7 @@
 
 from contextlib import contextmanager
 from functools import lru_cache, wraps
+from io import StringIO
 import logging
 from os.path import abspath, join, isfile, basename, dirname
 from os import environ
@@ -92,8 +93,10 @@ def human_bytes(n):
 #    either an executable on PATH, or a full path to an executable for a shell
 unix_shell_base = dict(
                        binpath="/bin/",  # mind the trailing slash.
+                       debug_args=['-x'],
                        echo="echo",
                        env_script_suffix=".sh",
+                       exec='exec ',
                        nul='2>/dev/null',
                        path_from=path_identity,
                        path_to=path_identity,
@@ -159,6 +162,8 @@ if on_win:
             printpath="@echo %PATH%",
             exe="cmd.exe",
             shell_args=["/d", "/c"],
+            debug_args=[],
+            exec='',
             path_from=path_identity,
             path_to=path_identity,
             slash_convert=("/", "\\"),
@@ -207,6 +212,7 @@ else:
         "fish": dict(
             unix_shell_base, exe="fish",
             pathsep=" ",
+            debug_args=["--debug='complete,*history*'"],
         ),
     }
 
@@ -460,6 +466,127 @@ def wrap_subprocess_call(
             command_args = [shell_path, script_caller]
 
     return script_caller, command_args
+
+
+def wrap_exec_call(
+        root_prefix,
+        prefix,
+        dev_mode,
+        debug_wrapper_scripts,
+        arguments,
+):
+    arguments = massage_arguments(arguments)
+    multiline = False
+    if len(arguments) == 1 and '\n' in arguments[0]:
+        multiline = True
+    shell = {}
+    # use first matching shell
+    for shopts in shells.values():
+        if which(shopts.get('exe','')):
+            shell = shopts.copy()
+            shell['which'] = which(shell['exe'])
+            break
+    if not shell:
+        Exception("No compatible shell found!")
+    if on_win:
+        if shell['exe']=='cmd.exe':
+            shell['which'] = get_comspec()  # fail early with KeyError if undefined
+        if dev_mode:
+            from conda import CONDA_PACKAGE_ROOT
+            conda_bat = join(CONDA_PACKAGE_ROOT, 'shell', 'condabin', 'conda.bat')
+        else:
+            conda_bat = environ.get("CONDA_BAT",
+                                    abspath(join(root_prefix, 'condabin', 'conda.bat')))
+        with StringIO() as fh:
+            silencer = "" if debug_wrapper_scripts else "@"
+            fh.write(f"{silencer}ECHO OFF\n")
+            fh.write(f"{silencer}SET PYTHONIOENCODING=utf-8\n")
+            fh.write(f"{silencer}SET PYTHONUTF8=1\n")
+            fh.write(
+                f'{silencer}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'  # noqa
+            )
+            fh.write(f"{silencer}chcp 65001 > NUL\n")
+            if dev_mode:
+                from . import CONDA_SOURCE_ROOT
+
+                fh.write(f"{silencer}SET CONDA_DEV=1\n")
+                # In dev mode, conda is really:
+                # 'python -m conda'
+                # *with* PYTHONPATH set.
+                fh.write(f"{silencer}SET PYTHONPATH={CONDA_SOURCE_ROOT}\n")
+                fh.write(f"{silencer}SET CONDA_EXE={sys.executable}\n")
+                fh.write(f"{silencer}SET _CE_M=-m\n")
+                fh.write(f"{silencer}SET _CE_CONDA=conda\n")
+            if debug_wrapper_scripts:
+                fh.write('echo *** environment before *** 1>&2\n')
+                fh.write('SET 1>&2\n')
+            # Not sure there is any point in backing this up, nothing will get called with it reset
+            # after all!
+            # fh.write("@FOR /F \"tokens=100\" %%F IN ('chcp') DO @SET CONDA_OLD_CHCP=%%F\n")
+            # fh.write('@chcp 65001>NUL\n')
+            fh.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"\n')
+            fh.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
+            if debug_wrapper_scripts:
+                fh.write('echo *** environment after *** 1>&2\n')
+                fh.write('SET 1>&2\n')
+            if multiline:
+                # No point silencing the first line. If that's what's wanted then
+                # it needs doing for each line and the caller may as well do that.
+                fh.write(f"{arguments[0]}\n")
+            else:
+                assert not any("\n" in arg for arg in arguments), (
+                    "Support for scripts where arguments contain newlines not implemented.\n"
+                    ".. requires writing the script to an external file and knowing how to "
+                    "transform the command-line (e.g. `python -c args` => `python file`) "
+                    "in a tool dependent way, or attempting something like:\n"
+                    ".. https://stackoverflow.com/a/15032476 (adds unacceptable escaping"
+                    "requirements)"
+                )
+                fh.write(f"{silencer}{shell['exec']}{quote_for_shell(*arguments)}\n")
+            fh.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
+            fh.write(f"{silencer}chcp %_CONDA_OLD_CHCP%>NUL\n")
+            commands = fh.getvalue()
+            
+    else:
+
+        # During tests, we sometimes like to have a temp env with e.g. an old python in it
+        # and have it run tests against the very latest development sources. For that to
+        # work we need extra smarts here, we want it to be instead:
+        if dev_mode:
+            conda_exe = [abspath(join(root_prefix, 'bin', 'python')), '-m', 'conda']
+            dev_arg = '--dev'
+            dev_args = [dev_arg]
+        else:
+            conda_exe = [environ.get("CONDA_EXE", abspath(join(root_prefix, 'bin', 'conda')))]
+            dev_arg = ''
+            dev_args = []
+        with StringIO() as fh:
+            if dev_mode:
+                from . import CONDA_SOURCE_ROOT
+
+                fh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + "\n")
+            hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
+            if debug_wrapper_scripts:
+                fh.write(">&2 echo '*** environment before ***'\n" ">&2 env\n")
+                fh.write(f'>&2 echo "$({hook_quoted})"\n')
+            fh.write(f'eval "$({hook_quoted})"\n')
+            fh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
+            if debug_wrapper_scripts:
+                fh.write(">&2 echo '*** environment after ***'\n" ">&2 env\n")
+            if multiline:
+                # The ' '.join() is pointless since mutliline is only True when there's 1 arg
+                # still, if that were to change this would prevent breakage.
+                fh.write(f"{shell['exec']}{' '.join(arguments)}\n")
+            else:
+                fh.write(f"{shell['exec']}{quote_for_shell(*arguments)}\n")
+            commands = fh.getvalue()
+
+    return (
+        [shell['which']]
+        + (shell['debug_args'] if debug_wrapper_scripts else [])
+        + shell['shell_args']
+        + [commands]
+    )
 
 
 def get_comspec():

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -92,35 +92,37 @@ def human_bytes(n):
 # defaults for unix shells.  Note: missing "exe" entry, which should be set to
 #    either an executable on PATH, or a full path to an executable for a shell
 unix_shell_base = dict(
-                       binpath="/bin/",  # mind the trailing slash.
-                       debug_args=['-x'],
-                       echo="echo",
-                       env_script_suffix=".sh",
-                       exec='exec ',
-                       nul='2>/dev/null',
-                       path_from=path_identity,
-                       path_to=path_identity,
-                       pathsep=":",
-                       printdefaultenv='echo $CONDA_DEFAULT_ENV',
-                       printpath="echo $PATH",
-                       printps1='echo $CONDA_PROMPT_MODIFIER',
-                       promptvar='PS1',
-                       sep="/",
-                       set_var='export ',
-                       shell_args=["-l", "-c"],
-                       shell_suffix="",
-                       slash_convert=("\\", "/"),
-                       source_setup="source",
-                       test_echo_extra="",
-                       var_format="${}",
+    binpath="/bin/",  # mind the trailing slash.
+    debug_args=["-x"],
+    echo="echo",
+    env_script_suffix=".sh",
+    exec="exec",
+    line_join=" && ",
+    nul="2>/dev/null",
+    path_from=path_identity,
+    path_to=path_identity,
+    pathsep=":",
+    printdefaultenv="echo $CONDA_DEFAULT_ENV",
+    printpath="echo $PATH",
+    printps1="echo $CONDA_PROMPT_MODIFIER",
+    promptvar="PS1",
+    sep="/",
+    set_var="export ",
+    script_args=[],
+    shell_args=["-l", "-c"],
+    shell_suffix=".sh",
+    slash_convert=("\\", "/"),
+    source_setup="source",
+    test_echo_extra="",
+    var_format="${}",
 )
 
 msys2_shell_base = dict(
-                        unix_shell_base,
-                        path_from=unix_path_to_win,
-                        path_to=win_path_to_unix,
-                        binpath="/bin/",  # mind the trailing slash.
-                        printpath="python -c \"import os; print(';'.join(os.environ['PATH'].split(';')[1:]))\" | cygpath --path -f -",  # NOQA
+    unix_shell_base,
+    path_from=unix_path_to_win,
+    path_to=win_path_to_unix,
+    binpath="/bin/",  # mind the trailing slash.
+    printpath="python -c \"import os; print(';'.join(os.environ['PATH'].split(';')[1:]))\" | cygpath --path -f -",  # NOQA
 )
 
 if on_win:
@@ -135,6 +137,9 @@ if on_win:
         #    set_var='export ',
         #    shell_suffix=".ps",
         #    env_script_suffix=".ps",
+        #    debug_args=[],
+        #    script_args=[],
+        #    shell_args=[],
         #    printps1='echo $PS1',
         #    printdefaultenv='echo $CONDA_DEFAULT_ENV',
         #    printpath="echo %PATH%",
@@ -161,6 +166,7 @@ if on_win:
                             'echo()',
             printpath="@echo %PATH%",
             exe="cmd.exe",
+            script_args=["/d", "/c"],
             shell_args=["/d", "/c"],
             debug_args=[],
             exec='',
@@ -213,6 +219,11 @@ else:
             unix_shell_base, exe="fish",
             pathsep=" ",
             debug_args=["--debug='complete,*history*'"],
+        ),
+        "sh": dict(  # fallback to sh if no bash (#8611)
+            unix_shell_base,
+            exe="sh",
+            shell_args=["-c"],  # -l not supported in POSIX sh
         ),
     }
 
@@ -349,90 +360,84 @@ def massage_arguments(arguments, errors='assert'):
     return arguments
 
 
-def wrap_subprocess_call(
+def _wrap_bat(
         root_prefix,
         prefix,
         dev_mode,
         debug_wrapper_scripts,
         arguments,
-        use_system_tmp_path=False):
-    arguments = massage_arguments(arguments)
-    if not use_system_tmp_path:
-        tmp_prefix = abspath(join(prefix, '.tmp'))
-    else:
-        tmp_prefix = None
-    script_caller = None
-    multiline = False
-    if len(arguments) == 1 and '\n' in arguments[0]:
-        multiline = True
-    if on_win:
-        comspec = get_comspec()  # fail early with KeyError if undefined
+):
+    """wrap :param arguments: in a .bat file"""
+    with StringIO() as bat:
         if dev_mode:
             from conda import CONDA_PACKAGE_ROOT
             conda_bat = join(CONDA_PACKAGE_ROOT, 'shell', 'condabin', 'conda.bat')
         else:
             conda_bat = environ.get("CONDA_BAT",
                                     abspath(join(root_prefix, 'condabin', 'conda.bat')))
-        with Utf8NamedTemporaryFile(mode='w', prefix=tmp_prefix,
-                                    suffix='.bat', delete=False) as fh:
-            silencer = "" if debug_wrapper_scripts else "@"
-            fh.write(f"{silencer}ECHO OFF\n")
-            fh.write(f"{silencer}SET PYTHONIOENCODING=utf-8\n")
-            fh.write(f"{silencer}SET PYTHONUTF8=1\n")
-            fh.write(
-                f'{silencer}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'  # noqa
-            )
-            fh.write(f"{silencer}chcp 65001 > NUL\n")
-            if dev_mode:
-                from . import CONDA_SOURCE_ROOT
-
-                fh.write(f"{silencer}SET CONDA_DEV=1\n")
-                # In dev mode, conda is really:
-                # 'python -m conda'
-                # *with* PYTHONPATH set.
-                fh.write(f"{silencer}SET PYTHONPATH={CONDA_SOURCE_ROOT}\n")
-                fh.write(f"{silencer}SET CONDA_EXE={sys.executable}\n")
-                fh.write(f"{silencer}SET _CE_M=-m\n")
-                fh.write(f"{silencer}SET _CE_CONDA=conda\n")
-            if debug_wrapper_scripts:
-                fh.write('echo *** environment before *** 1>&2\n')
-                fh.write('SET 1>&2\n')
-            # Not sure there is any point in backing this up, nothing will get called with it reset
-            # after all!
-            # fh.write("@FOR /F \"tokens=100\" %%F IN ('chcp') DO @SET CONDA_OLD_CHCP=%%F\n")
-            # fh.write('@chcp 65001>NUL\n')
-            fh.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"\n')
-            fh.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
-            if debug_wrapper_scripts:
-                fh.write('echo *** environment after *** 1>&2\n')
-                fh.write('SET 1>&2\n')
-            if multiline:
-                # No point silencing the first line. If that's what's wanted then
-                # it needs doing for each line and the caller may as well do that.
-                fh.write(f"{arguments[0]}\n")
-            else:
-                assert not any("\n" in arg for arg in arguments), (
-                    "Support for scripts where arguments contain newlines not implemented.\n"
-                    ".. requires writing the script to an external file and knowing how to "
-                    "transform the command-line (e.g. `python -c args` => `python file`) "
-                    "in a tool dependent way, or attempting something like:\n"
-                    ".. https://stackoverflow.com/a/15032476 (adds unacceptable escaping"
-                    "requirements)"
-                )
-                fh.write(f"{silencer}{quote_for_shell(*arguments)}\n")
-            fh.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
-            fh.write(f"{silencer}chcp %_CONDA_OLD_CHCP%>NUL\n")
-            script_caller = fh.name
-        command_args = [comspec, '/d', '/c', script_caller]
-    else:
-        shell_path = which('bash') or which('sh')
-        if shell_path is None:
-            raise Exception("No compatible shell found!")
-
-        # During tests, we sometimes like to have a temp env with e.g. an old python in it
-        # and have it run tests against the very latest development sources. For that to
-        # work we need extra smarts here, we want it to be instead:
+        silencer = "" if debug_wrapper_scripts else "@"
+        bat.write(f"{silencer}ECHO OFF\n")
+        bat.write(f"{silencer}SET PYTHONIOENCODING=utf-8\n")
+        bat.write(f"{silencer}SET PYTHONUTF8=1\n")
+        bat.write(
+            f'{silencer}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'  # noqa
+        )
+        bat.write(f"{silencer}chcp 65001 > NUL\n")
         if dev_mode:
+            from . import CONDA_SOURCE_ROOT
+
+            bat.write(f"{silencer}SET CONDA_DEV=1\n")
+            # In dev mode, conda is really:
+            # 'python -m conda'
+            # *with* PYTHONPATH set.
+            bat.write(f"{silencer}SET PYTHONPATH={CONDA_SOURCE_ROOT}\n")
+            bat.write(f"{silencer}SET CONDA_EXE={sys.executable}\n")
+            bat.write(f"{silencer}SET _CE_M=-m\n")
+            bat.write(f"{silencer}SET _CE_CONDA=conda\n")
+        if debug_wrapper_scripts:
+            bat.write("echo *** environment before *** 1>&2\n")
+            bat.write("SET 1>&2\n")
+        # Not sure there is any point in backing this up, nothing will get called with it reset
+        # after all!
+        # fh.write("@FOR /F \"tokens=100\" %%F IN ('chcp') DO @SET CONDA_OLD_CHCP=%%F\n")
+        # fh.write('@chcp 65001>NUL\n')
+        bat.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"\n')
+        bat.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
+        if debug_wrapper_scripts:
+            bat.write("echo *** environment after *** 1>&2\n")
+            bat.write("SET 1>&2\n")
+        if len(arguments) == 1 and "\n" in arguments[0]:  # multiline
+            # No point silencing the first line. If that's what's wanted then
+            # it needs doing for each line and the caller may as well do that.
+            bat.write(f"{arguments[0]}\n")
+        else:
+            assert not any("\n" in arg for arg in arguments), (
+                "Support for scripts where arguments contain newlines not implemented.\n"
+                ".. requires writing the script to an external file and knowing how to "
+                "transform the command-line (e.g. `python -c args` => `python file`) "
+                "in a tool dependent way, or attempting something like:\n"
+                ".. https://stackoverflow.com/a/15032476 (adds unacceptable escaping"
+                "requirements)"
+            )
+            bat.write(f"{silencer}{quote_for_shell(*arguments)}\n")
+        bat.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
+        bat.write(f"{silencer}chcp %_CONDA_OLD_CHCP%>NUL\n")
+        return bat.getvalue()
+
+
+def _wrap_sh(
+    root_prefix,
+    prefix,
+    dev_mode,
+    debug_wrapper_scripts,
+    arguments,
+):
+    """wrap :param arguments: in a .sh script"""
+    with StringIO() as sh:
+        if dev_mode:
+            from . import CONDA_SOURCE_ROOT
+
+            sh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + "\n")
             conda_exe = [abspath(join(root_prefix, 'bin', 'python')), '-m', 'conda']
             dev_arg = '--dev'
             dev_args = [dev_arg]
@@ -440,31 +445,86 @@ def wrap_subprocess_call(
             conda_exe = [environ.get("CONDA_EXE", abspath(join(root_prefix, 'bin', 'conda')))]
             dev_arg = ''
             dev_args = []
-        with Utf8NamedTemporaryFile(mode='w', prefix=tmp_prefix, delete=False) as fh:
-            if dev_mode:
-                from . import CONDA_SOURCE_ROOT
-
-                fh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + "\n")
-            hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
-            if debug_wrapper_scripts:
-                fh.write(">&2 echo '*** environment before ***'\n" ">&2 env\n")
-                fh.write(f'>&2 echo "$({hook_quoted})"\n')
-            fh.write(f'eval "$({hook_quoted})"\n')
-            fh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
-            if debug_wrapper_scripts:
-                fh.write(">&2 echo '*** environment after ***'\n" ">&2 env\n")
-            if multiline:
-                # The ' '.join() is pointless since mutliline is only True when there's 1 arg
-                # still, if that were to change this would prevent breakage.
-                fh.write("{}\n".format(" ".join(arguments)))
-            else:
-                fh.write(f"{quote_for_shell(*arguments)}\n")
-            script_caller = fh.name
+        hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
         if debug_wrapper_scripts:
-            command_args = [shell_path, "-x", script_caller]
+            sh.write(">&2 echo '*** environment before ***'\n" ">&2 env\n")
+            sh.write(f'>&2 echo "$({hook_quoted})"\n')
+        sh.write(f'eval "$({hook_quoted})"\n')
+        sh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
+        if debug_wrapper_scripts:
+            sh.write(">&2 echo '*** environment after ***'\n" ">&2 env\n")
+        if len(arguments) == 1 and "\n" in arguments[0]:  # multiline
+            # The ' '.join() is pointless since mutliline is only True when there's 1 arg
+            # still, if that were to change this would prevent breakage.
+            sh.write("{}\n".format(" ".join(arguments)))
         else:
-            command_args = [shell_path, script_caller]
+            sh.write(f"{quote_for_shell(*arguments)}\n")
+        return sh.getvalue()
 
+
+def _get_shell(shell_name=None, condition=lambda x: True):
+    """
+    get a compatible shell's configuration dict
+
+    :param shell_name: (optional str) name of a shell
+            if None, iterate through global "shells" and return first match
+    :param condition: (optional callable[[dict],bool]) matching condition
+            should return True when passed a shell configuration dict
+            if that shell is acceptable, False to continue searching
+    """
+    shell = {}
+    # use first matching shell if shell_name is None
+    for s in [shell_name] if shell_name else shells.keys():
+        scfg = shells.get(s, {})
+        if which(scfg.get("exe", "")) and condition(scfg):
+            shell = scfg.copy()
+            if shell["exe"] == "cmd.exe":
+                shell["which"] = get_comspec()
+            else:
+                shell["which"] = which(shell["exe"])
+            break
+    if not shell:
+        raise RuntimeError("No compatible shell found!")
+    return shell
+
+
+def wrap_subprocess_call(
+    root_prefix,
+    prefix,
+    dev_mode,
+    debug_wrapper_scripts,
+    arguments,
+    use_system_tmp_path=False,
+):
+    """
+    :return: (script_caller, command_args)
+        - script_caller: filename of the temporary script
+        - command_args: full list of args, including script_caller,
+                        to pass to the subprocess
+    """
+    arguments = massage_arguments(arguments)
+    if not use_system_tmp_path:
+        tmp_prefix = abspath(join(prefix, ".tmp"))
+    else:
+        tmp_prefix = None
+    script_caller = None
+    shell = _get_shell(condition=lambda s: s["shell_suffix"] in [".bat", ".sh"])
+    with Utf8NamedTemporaryFile(
+        mode="w", prefix=tmp_prefix, suffix=shell["shell_suffix"], delete=False
+    ) as fh:
+        if shell["shell_suffix"] == ".sh":
+            fh.write(_wrap_sh(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments))
+        elif shell["shell_suffix"] == ".bat":
+            fh.write(_wrap_bat(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments))
+        else:
+            raise ValueError(f"cannot wrap commands in '{shell['shell_suffix']}' script")
+        script_caller = fh.name
+    command_args = [
+        shell["which"],
+        *(shell["debug_args"] if debug_wrapper_scripts else []),
+        *shell["script_args"],
+        script_caller,
+    ]
     return script_caller, command_args
 
 
@@ -475,118 +535,33 @@ def wrap_exec_call(
         debug_wrapper_scripts,
         arguments,
 ):
+    """
+    :return: (script, command_args)
+        - script: contents of the wrapper script
+        - command_args: full list of args, including contents of script, to exec
+    """
     arguments = massage_arguments(arguments)
-    multiline = False
-    if len(arguments) == 1 and '\n' in arguments[0]:
-        multiline = True
-    shell = {}
-    # use first matching shell
-    for shopts in shells.values():
-        if which(shopts.get('exe','')):
-            shell = shopts.copy()
-            shell['which'] = which(shell['exe'])
-            break
-    if not shell:
-        Exception("No compatible shell found!")
-    if on_win:
-        if shell['exe']=='cmd.exe':
-            shell['which'] = get_comspec()  # fail early with KeyError if undefined
-        if dev_mode:
-            from conda import CONDA_PACKAGE_ROOT
-            conda_bat = join(CONDA_PACKAGE_ROOT, 'shell', 'condabin', 'conda.bat')
-        else:
-            conda_bat = environ.get("CONDA_BAT",
-                                    abspath(join(root_prefix, 'condabin', 'conda.bat')))
-        with StringIO() as fh:
-            silencer = "" if debug_wrapper_scripts else "@"
-            fh.write(f"{silencer}ECHO OFF\n")
-            fh.write(f"{silencer}SET PYTHONIOENCODING=utf-8\n")
-            fh.write(f"{silencer}SET PYTHONUTF8=1\n")
-            fh.write(
-                f'{silencer}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'  # noqa
-            )
-            fh.write(f"{silencer}chcp 65001 > NUL\n")
-            if dev_mode:
-                from . import CONDA_SOURCE_ROOT
-
-                fh.write(f"{silencer}SET CONDA_DEV=1\n")
-                # In dev mode, conda is really:
-                # 'python -m conda'
-                # *with* PYTHONPATH set.
-                fh.write(f"{silencer}SET PYTHONPATH={CONDA_SOURCE_ROOT}\n")
-                fh.write(f"{silencer}SET CONDA_EXE={sys.executable}\n")
-                fh.write(f"{silencer}SET _CE_M=-m\n")
-                fh.write(f"{silencer}SET _CE_CONDA=conda\n")
-            if debug_wrapper_scripts:
-                fh.write('echo *** environment before *** 1>&2\n')
-                fh.write('SET 1>&2\n')
-            # Not sure there is any point in backing this up, nothing will get called with it reset
-            # after all!
-            # fh.write("@FOR /F \"tokens=100\" %%F IN ('chcp') DO @SET CONDA_OLD_CHCP=%%F\n")
-            # fh.write('@chcp 65001>NUL\n')
-            fh.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"\n')
-            fh.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
-            if debug_wrapper_scripts:
-                fh.write('echo *** environment after *** 1>&2\n')
-                fh.write('SET 1>&2\n')
-            if multiline:
-                # No point silencing the first line. If that's what's wanted then
-                # it needs doing for each line and the caller may as well do that.
-                fh.write(f"{arguments[0]}\n")
-            else:
-                assert not any("\n" in arg for arg in arguments), (
-                    "Support for scripts where arguments contain newlines not implemented.\n"
-                    ".. requires writing the script to an external file and knowing how to "
-                    "transform the command-line (e.g. `python -c args` => `python file`) "
-                    "in a tool dependent way, or attempting something like:\n"
-                    ".. https://stackoverflow.com/a/15032476 (adds unacceptable escaping"
-                    "requirements)"
-                )
-                fh.write(f"{silencer}{shell['exec']}{quote_for_shell(*arguments)}\n")
-            fh.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
-            fh.write(f"{silencer}chcp %_CONDA_OLD_CHCP%>NUL\n")
-            commands = fh.getvalue()
-            
+    shell = _get_shell(condition=lambda s: s["shell_suffix"] in [".bat", ".sh"])
+    if shell["exec"]:
+        arguments.insert(0, shell["exec"])
+    if shell["shell_suffix"] == ".sh":
+        script = _wrap_sh(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments)
+    elif shell["shell_suffix"] == ".bat":
+        script = _wrap_bat(root_prefix, prefix, dev_mode, debug_wrapper_scripts, arguments)
     else:
-
-        # During tests, we sometimes like to have a temp env with e.g. an old python in it
-        # and have it run tests against the very latest development sources. For that to
-        # work we need extra smarts here, we want it to be instead:
-        if dev_mode:
-            conda_exe = [abspath(join(root_prefix, 'bin', 'python')), '-m', 'conda']
-            dev_arg = '--dev'
-            dev_args = [dev_arg]
-        else:
-            conda_exe = [environ.get("CONDA_EXE", abspath(join(root_prefix, 'bin', 'conda')))]
-            dev_arg = ''
-            dev_args = []
-        with StringIO() as fh:
-            if dev_mode:
-                from . import CONDA_SOURCE_ROOT
-
-                fh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + "\n")
-            hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
-            if debug_wrapper_scripts:
-                fh.write(">&2 echo '*** environment before ***'\n" ">&2 env\n")
-                fh.write(f'>&2 echo "$({hook_quoted})"\n')
-            fh.write(f'eval "$({hook_quoted})"\n')
-            fh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
-            if debug_wrapper_scripts:
-                fh.write(">&2 echo '*** environment after ***'\n" ">&2 env\n")
-            if multiline:
-                # The ' '.join() is pointless since mutliline is only True when there's 1 arg
-                # still, if that were to change this would prevent breakage.
-                fh.write(f"{shell['exec']}{' '.join(arguments)}\n")
-            else:
-                fh.write(f"{shell['exec']}{quote_for_shell(*arguments)}\n")
-            commands = fh.getvalue()
-
-    return (
-        [shell['which']]
-        + (shell['debug_args'] if debug_wrapper_scripts else [])
-        + shell['shell_args']
-        + [commands]
-    )
+        raise ValueError(f"cannot wrap commands in '{shell['shell_suffix']}' script")
+    if shell.get("line_join"):
+        # join lines with shell['line_join'], dropping empty lines
+        command = shell["line_join"].join(line for line in script.splitlines() if line)
+    else:
+        command = script
+    command_args = [
+        shell["which"],
+        *(shell["debug_args"] if debug_wrapper_scripts else []),
+        *shell["shell_args"],
+        command,
+    ]
+    return script, command_args
 
 
 def get_comspec():

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -169,6 +169,7 @@ if on_win:
             script_args=["/d", "/c"],
             shell_args=["/d", "/c"],
             debug_args=[],
+            line_join="&&",
             exec='',
             path_from=path_identity,
             path_to=path_identity,
@@ -367,6 +368,7 @@ def _wrap_bat(
     debug_wrapper_scripts,
     arguments,
     newline="\n",
+    shell=False,
 ):
     """wrap :param arguments: in a .bat file"""
     with StringIO() as bat:
@@ -381,7 +383,9 @@ def _wrap_bat(
         bat.write(f"{silencer}SET PYTHONIOENCODING=utf-8{newline}")
         bat.write(f"{silencer}SET PYTHONUTF8=1{newline}")
         bat.write(
-            f'{silencer}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'  # noqa
+            f'{silencer}FOR /F "tokens=2 delims=:." {"%" if shell else "%%"}A in (\'chcp\') do '
+            + f'{silencer}for {"%" if shell else "%%"}B in ({"%" if shell else "%%"}A) do '
+            + f'{silencer}set "_CONDA_OLD_CHCP={"%" if shell else "%%"}B"{newline}'
         )
         bat.write(f"{silencer}chcp 65001 > NUL{newline}")
         if dev_mode:
@@ -398,12 +402,8 @@ def _wrap_bat(
         if debug_wrapper_scripts:
             bat.write(f"echo *** environment before *** 1>&2{newline}")
             bat.write(f"SET 1>&2{newline}")
-        # Not sure there is any point in backing this up, nothing will get called with it reset
-        # after all!
-        # fh.write("@FOR /F \"tokens=100\" %%F IN ('chcp') DO @SET CONDA_OLD_CHCP=%%F\n")
-        # fh.write('@chcp 65001>NUL\n')
         bat.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"{newline}')
-        bat.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%{newline}")
+        bat.write(f"( {silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL% ){newline}")
         if debug_wrapper_scripts:
             bat.write(f"echo *** environment after *** 1>&2{newline}")
             bat.write(f"SET 1>&2{newline}")
@@ -420,8 +420,8 @@ def _wrap_bat(
                 ".. https://stackoverflow.com/a/15032476 (adds unacceptable escaping"
                 "requirements)"
             )
-            bat.write(f"{silencer}{quote_for_shell(*arguments)}{newline}")
-        bat.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%{newline}")
+            bat.write(f"{quote_for_shell(*arguments)}{newline}")
+        bat.write(f"( {silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL% ){newline}")
         bat.write(f"{silencer}chcp %_CONDA_OLD_CHCP%>NUL")
         return bat.getvalue()
 
@@ -579,6 +579,7 @@ def wrap_exec_call(
             debug_wrapper_scripts,
             arguments,
             newline=shell.get("line_join") or "\n",
+            shell=True,
         )
     else:
         raise ValueError(f"cannot wrap commands in '{shell['shell_suffix']}' script")

--- a/news/10351-conda-run-TERM-signaling
+++ b/news/10351-conda-run-TERM-signaling
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Commands started by `conda run` will receive TERM and other signals as expected.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@
 
 import json
 import unittest
-import uuid
 import os
 import re
 import stat
@@ -15,7 +14,11 @@ from conda.base.constants import on_win
 from conda.base.context import context
 from conda.common.io import captured
 from conda.gateways.disk.delete import rm_rf
-from conda.testing.helpers import capture_json_with_argv, run_inprocess_conda_command
+from conda.testing.helpers import (
+    capture_json_with_argv,
+    run_inprocess_conda_command,
+    run_subprocess_conda_command,
+)
 from conda.testing.integration import Commands, run_command, make_temp_env, make_temp_prefix
 
 
@@ -251,7 +254,7 @@ def test_search_envs():
 def test_run_returns_int():
     prefix = make_temp_prefix(name="test")
     with make_temp_env(prefix=prefix):
-        stdout, stderr, result = run_inprocess_conda_command(f"conda run -p {prefix} echo hi")
+        stdout, stderr, result = run_subprocess_conda_command(f"conda run -p {prefix} echo hi")
 
         assert isinstance(result, int)
 
@@ -259,7 +262,7 @@ def test_run_returns_int():
 def test_run_returns_zero_errorlevel():
     prefix = make_temp_prefix(name="test")
     with make_temp_env(prefix=prefix):
-        stdout, stderr, result = run_inprocess_conda_command(f"conda run -p {prefix} exit 0")
+        stdout, stderr, result = run_subprocess_conda_command(f"conda run -p {prefix} exit 0")
 
         assert result == 0
 
@@ -267,26 +270,9 @@ def test_run_returns_zero_errorlevel():
 def test_run_returns_nonzero_errorlevel():
     prefix = make_temp_prefix(name="test")
     with make_temp_env(prefix=prefix) as prefix:
-        stdout, stderr, result = run_inprocess_conda_command(f'conda run -p "{prefix}" exit 5')
+        stdout, stderr, result = run_subprocess_conda_command(f'conda run -p "{prefix}" exit 5')
 
         assert result == 5
-
-
-def test_run_uncaptured(capfd):
-    prefix = make_temp_prefix(name="test")
-    with make_temp_env(prefix=prefix):
-        random_text = uuid.uuid4().hex
-        stdout, stderr, result = run_inprocess_conda_command(
-            f"conda run -p {prefix} --no-capture-output echo {random_text}"
-        )
-
-        assert result == 0
-        # Output is not captured
-        assert stdout == ""
-
-        # Check that the expected output is somewhere between the conda logs
-        captured = capfd.readouterr()
-        assert random_text in captured.out
 
 
 @pytest.mark.skipif(on_win, reason="cannot make readonly env on win")
@@ -313,7 +299,7 @@ def test_run_readonly_env(request):
 
         assert raise_ok
 
-        stdout, stderr, result = run_inprocess_conda_command(f"conda run -p {prefix} exit 0")
+        stdout, stderr, result = run_subprocess_conda_command(f"conda run -p {prefix} exit 0")
 
         # Reset permissions in case all goes according to plan
         reset_permissions()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The main use case of `conda run` - interacting with an environment in one quick command, without activating it. `conda run` currently works by wrapping commands in a .sh/.bat script and running that script in a subprocess. This complicates a seemingly simple use-case, and was the source of the `--no-capture-output` flag that has caused so many users confusion (#11316). This arrangement also causes strange behavior with respect to signaling, and whether e.g. TERM signals and interrupts are passed through to the command as intuitively expected (#10351, #11420).

On UNIX systems in particular, the model of using exec to replace the foreground process, rather than spawning a child subprocess, seems like a better fit for `conda run`. On Windows the issue is complicated by a lack of any equivalent to UNIX's exec, but I still believe that improvements are possible.

This draft PR is intended to spur discussion about alternative ways that `conda run` could work. It refactors the wrapper script code, to allow generating the text of a wrapper script without writing it to disc. This output can then be used to construct an exec (or spawn, on Windows) call that (effectively) replaces the `conda` python process, if possible. The `--no-capture-output` flag can then be removed entirely, as conda is not anywhere between the command's I/O and the user.

This draft PR:

- Fixes #10351
- Fixes #11420
- Relates to several issues under #11316

I'm not sure at all if this is the right solution, but I hope that this contribution helps to spur discussion about even simpler, lighter-weight ways to interact with `conda` environments.

I look forward to hearing your thoughts!

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
