### PR TITLE
use 2 unit test splits for osx, to reduce concurrency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -283,35 +283,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - default-channel: 'conda-forge'
-            python-version: '3.9'
-            test-type: 'unit'
-            test-group: '1'
-          - default-channel: 'conda-forge'
-            python-version: '3.9'
-            test-type: 'unit'
-            test-group: '2'
-          - default-channel: 'conda-forge'
-            python-version: '3.9'
-            test-type: 'unit'
+        default-channel: ['defaults', 'conda-forge']
+        python-version: ['3.9']
+        test-type: ['unit', 'integration']
+        test-group: ['1', '2', '3']
+        # fewer test splits for quicker unit tests, keep 3 splits for integration
+        test-splits: [2, 3]
+        exclude:
+          - test-type: unit
             test-group: '3'
-          - default-channel: 'defaults'
-            python-version: '3.9'
-            test-type: 'integration'
-            test-group: '1'
-          - default-channel: 'defaults'
-            python-version: '3.9'
-            test-type: 'integration'
-            test-group: '2'
-          - default-channel: 'defaults'
-            python-version: '3.9'
-            test-type: 'integration'
-            test-group: '3'
+          - test-type: unit
+            test-splits: 3
+          - test-type: integration
+            test-splits: 2
+          # odd choice kept for parity with previous commit
+          - test-type: integration
+            default-channel: 'conda-forge'
+          - test-type: unit
+            default-channel: 'defaults'
     env:
       OS: macOS
       PYTHON: ${{ matrix.python-version }}
-      TEST_SPLITS: 3
+      TEST_SPLITS: ${{ matrix.test-splits }}
       TEST_GROUP: ${{ matrix.test-group }}
     steps:
       - uses: actions/checkout@v3

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -127,7 +127,7 @@ class TestSolve(unittest.TestCase):
 
 def test_generate_eq_1():
     # avoid cache from other tests which may have different result
-    r._reduced_index_cache = {}
+    _index, r = get_index_r_1()
 
     reduced_index = r.get_reduced_index((MatchSpec('anaconda'), ))
     r2 = Resolve(reduced_index, True)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Two unit-tests splits for OSX. Will save us ~6 minutes of setup time since we avoid running the third split. Since the integration tests are much slower, a bigger unit tests run won't hold anything up.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
