### PR TITLE
remove --cov-report term-missing from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ addopts =
     --xdoctest-modules
     --xdoctest-style=google
     --cov-report xml
-    --cov-report term-missing
     --cov-append
     --junitxml=test-report.xml
     # --cov conda   # passed in test runner scripts instead (avoid debugger)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

`--cov-report term-missing` is the per-file missing coverage information at the end of our test runs.

We already interact with coverage through much more useful reports like the codecov website or through `coverage html`, or by downloading the coverage data and doing other reporting outside the github actions log. So this report is just something annoying to scroll past when looking for a test failure. Remove it.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
