### PR TITLE
Removing Python 3.7 from matrix.  Also, making exclude matrix on linu…

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: ${{ github.ref == 'refs/heads/main' }}
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10']
         channel: [defaults]
         include:
           - python: '3.10'  # same as miniforge

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,7 +177,7 @@ jobs:
           - default-channel: 'conda-forge'
             python-version: '3.8'
           - default-channel: 'conda-forge'
-            python-version: '3.10'
+            python-version: '3.9'
     env:
       OS: Linux
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,16 +60,14 @@ jobs:
       fail-fast: false
       matrix:
         default-channel: ['defaults', 'conda-forge']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         conda-subdir: ['win-64']
         test-type: ['unit', 'integration']
         test-group: ['1', '2', '3']
         exclude:
           # exclude all but one Python version for conda-forge
           - default-channel: 'conda-forge'
-            python-version: '3.7'
-          - default-channel: 'conda-forge'
-            python-version: '3.9'
+            python-version: '3.8'
           - default-channel: 'conda-forge'
             python-version: '3.10'
     env:
@@ -171,17 +169,15 @@ jobs:
       fail-fast: false
       matrix:
         default-channel: ['defaults', 'conda-forge']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         test-type: ['unit', 'integration']
         test-group: ['1', '2', '3']
         exclude:
           # exclude all but one Python version for conda-forge
           - default-channel: 'conda-forge'
-            python-version: '3.7'
-          - default-channel: 'conda-forge'
             python-version: '3.8'
           - default-channel: 'conda-forge'
-            python-version: '3.9'
+            python-version: '3.10'
     env:
       OS: Linux
       PYTHON: ${{ matrix.python-version }}


### PR DESCRIPTION
### Description

Addresses issue #12436 to drop Python 3.7 Support.

Also, syncs what is used in tests matrix in windows and linux section (which may have been on purpose).