### PR TITLE
Init conda after installing requirements in tests

### DIFF
--- a/dev/linux/unit.sh
+++ b/dev/linux/unit.sh
@@ -8,9 +8,9 @@ git config --global --add safe.directory /opt/conda-src
 TEST_SPLITS="${TEST_SPLITS:-1}"
 TEST_GROUP="${TEST_GROUP:-1}"
 
-eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
 # make sure all test requirements are installed
 sudo /opt/conda/bin/conda install --quiet -y -c defaults --file tests/requirements.txt
+eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
 conda info
 # remove the pkg cache.  We can't hardlink from here anyway.  Having it around causes log problems.
 sudo rm -rf /opt/conda/pkgs/*-*-*

--- a/news/12446-init-conda-after-installing-requirements
+++ b/news/12446-init-conda-after-installing-requirements
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Initialize conda after installing test requirements during CI (#12446)


### PR DESCRIPTION


<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

When setting up to run the unit tests initialize conda only after the requirements are installed since installing requirements may itself install conda undoing any initialization.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
