### PR TITLE
Tweaks for dropping Python 3.7 support.

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -831,7 +831,7 @@ def configure_parser_install(sub_parsers):
 
     Install a specific version of 'python' into an environment, myenv::
 
-        conda install -p path/to/myenv python=3.10.9
+        conda install -p path/to/myenv python=3.10
 
     """)
     p = sub_parsers.add_parser(

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -831,7 +831,7 @@ def configure_parser_install(sub_parsers):
 
     Install a specific version of 'python' into an environment, myenv::
 
-        conda install -p path/to/myenv python=3.7.13
+        conda install -p path/to/myenv python=3.10.9
 
     """)
     p = sub_parsers.add_parser(

--- a/news/12436-drop-37-support
+++ b/news/12436-drop-37-support
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Drop Python 3.7 support. (#12436)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ import sys
 
 from setuptools import setup
 
-if not sys.version_info[:2] >= (3, 7):
+if not sys.version_info[:2] >= (3, 8):
     sys.exit(
-        f"conda is only meant for Python 3.7 and up. "
+        f"conda is only meant for Python 3.8 and up. "
         f"current version: {sys.version_info.major}.{sys.version_info.minor}"
     )
 
@@ -64,7 +64,6 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -85,6 +84,6 @@ setup(
         ],
     },
     install_requires=install_requires,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 if not sys.version_info[:2] >= (3, 8):
     sys.exit(
-        f"conda is only meant for Python 3.8 and up. "
+        f"conda requires Python 3.8 or newer. "
         f"current version: {sys.version_info.major}.{sys.version_info.minor}"
     )
 

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -1,7 +1,5 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-
-from unittest.mock import patch
 from conda.testing.integration import run_command, Commands
 
 import pytest
@@ -15,42 +13,47 @@ from conda.gateways.disk.delete import rm_rf
 def prefix(tmpdir):
     prefix = tmpdir.mkdir("cli_install_prefix")
     test_env = tmpdir.mkdir("cli_install_test_env")
-    run_command(Commands.CREATE, str(prefix), 'python=3.10')
+    run_command(Commands.CREATE, str(prefix), "python=3.9")
     yield str(prefix), str(test_env)
     rm_rf(prefix)
     rm_rf(test_env)
 
 
 @pytest.mark.integration
-def test_pre_link_message(prefix, pre_link_messages_package):
+def test_pre_link_message(mocker, prefix, pre_link_messages_package):
     prefix, _ = prefix
-    with patch("conda.cli.common.confirm_yn", return_value=True):
-        stdout, _, _ = run_command(
-            Commands.INSTALL, prefix, pre_link_messages_package, "--use-local"
-        )
-        assert "Lorem ipsum dolor sit amet" in stdout
+    mocker.patch("conda.cli.common.confirm_yn", return_value=True)
+    stdout, _, _ = run_command(Commands.INSTALL, prefix, pre_link_messages_package, "--use-local")
+    assert "Lorem ipsum dolor sit amet" in stdout
 
 
 @pytest.mark.integration
-def test_find_conflicts_called_once(prefix):
+def test_find_conflicts_called_once(mocker, prefix):
     prefix, test_env = prefix
-    bad_deps = {'python': {((MatchSpec("statistics"), MatchSpec("python[version='>=2.7,<2.8.0a0']")), 'python=3')}}
+    bad_deps = {
+        "python": {
+            (
+                (MatchSpec("statistics"), MatchSpec("python[version='>=2.7,<2.8.0a0']")),
+                "python=3",
+            )
+        }
+    }
+    mocked_find_conflicts = mocker.patch(
+        "conda.resolve.Resolve.find_conflicts",
+        side_effect=UnsatisfiableError(bad_deps, strict=True),
+    )
+    with pytest.raises(UnsatisfiableError):
+        # Statistics is a py27 only package allowing us a simple unsatisfiable case
+        run_command(Commands.INSTALL, prefix, "statistics")
+    assert mocked_find_conflicts.call_count == 1
 
-    with patch(
-            "conda.resolve.Resolve.find_conflicts",
-            side_effect=UnsatisfiableError(bad_deps, strict=True),
-        ) as mocked_find_conflicts:
-            with pytest.raises(UnsatisfiableError):
-                # Statistics is a py27 only package allowing us a simple unsatisfiable case
-                run_command(Commands.INSTALL, prefix, "statistics")
-            assert mocked_find_conflicts.call_count == 1
+    mocked_find_conflicts.reset_mock()
+    with pytest.raises(UnsatisfiableError):
+        run_command(Commands.INSTALL, prefix, "statistics", "--freeze-installed")
+    assert mocked_find_conflicts.call_count == 1
 
-            mocked_find_conflicts.reset_mock()
-            with pytest.raises(UnsatisfiableError):
-                run_command(Commands.INSTALL, prefix, "statistics", "--freeze-installed")
-            assert mocked_find_conflicts.call_count == 1
-
-            mocked_find_conflicts.reset_mock()
-            with pytest.raises(UnsatisfiableError):
-                run_command(Commands.CREATE, test_env, "statistics", "python=3.10")
-            assert mocked_find_conflicts.call_count == 1
+    mocked_find_conflicts.reset_mock()
+    with pytest.raises(UnsatisfiableError):
+        # statistics seems to be available on 3.10 though
+        run_command(Commands.CREATE, test_env, "statistics", "python=3.9")
+    assert mocked_find_conflicts.call_count == 1

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -15,7 +15,7 @@ from conda.gateways.disk.delete import rm_rf
 def prefix(tmpdir):
     prefix = tmpdir.mkdir("cli_install_prefix")
     test_env = tmpdir.mkdir("cli_install_test_env")
-    run_command(Commands.CREATE, str(prefix), 'python=3.7')
+    run_command(Commands.CREATE, str(prefix), 'python=3.10')
     yield str(prefix), str(test_env)
     rm_rf(prefix)
     rm_rf(test_env)
@@ -52,5 +52,5 @@ def test_find_conflicts_called_once(prefix):
 
             mocked_find_conflicts.reset_mock()
             with pytest.raises(UnsatisfiableError):
-                run_command(Commands.CREATE, test_env, "statistics", "python=3.7")
+                run_command(Commands.CREATE, test_env, "statistics", "python=3.10")
             assert mocked_find_conflicts.call_count == 1

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -467,14 +467,14 @@ class IntegrationTests(BaseTestCase):
         # For this test to work on Windows, you can either pass use_restricted_unicode=on_win
         # to make_temp_env(), or you can set PYTHONUTF8 to 1 (and use Python 3.7 or above).
         # We elect to test the more complex of the two options.
-        py_ver = "3.7"
+        py_ver = "3.10"
         with make_temp_env("python="+py_ver, "pip") as prefix:
             evs = {"PYTHONUTF8": "1"}
             # This test does not activate the env.
             if on_win:
                 evs['CONDA_DLL_SEARCH_MODIFICATION_ENABLE'] = '1'
             with env_vars(evs, stack_callback=conda_tests_ctxt_mgmt_def_pol):
-                check_call(PYTHON_BINARY + " -m pip install --no-binary flask flask==0.10.1",
+                check_call(PYTHON_BINARY + " -m pip install --no-binary flask flask==1.0.2",
                            cwd=prefix, shell=True)
                 PrefixData._cache_.clear()
                 stdout, stderr, _ = run_command(Commands.LIST, prefix)
@@ -491,15 +491,18 @@ class IntegrationTests(BaseTestCase):
     def test_list_with_pip_wheel(self):
         from conda.exports import rm_rf as _rm_rf
 
-        py_ver = "3.7"
+        py_ver = "3.10"
         with make_temp_env("python="+py_ver, "pip") as prefix:
             evs = {"PYTHONUTF8": "1"}
             # This test does not activate the env.
             if on_win:
                 evs['CONDA_DLL_SEARCH_MODIFICATION_ENABLE'] = '1'
             with env_vars(evs, stack_callback=conda_tests_ctxt_mgmt_def_pol):
-                check_call(PYTHON_BINARY + " -m pip install flask==0.10.1",
-                           cwd=prefix, shell=True)
+                check_call(
+                    PYTHON_BINARY + " -m pip install flask==1.0.2",
+                    cwd=prefix,
+                    shell=True,
+                )
                 PrefixData._cache_.clear()
                 stdout, stderr, _ = run_command(Commands.LIST, prefix)
                 stdout_lines = stdout.split('\n')
@@ -507,13 +510,13 @@ class IntegrationTests(BaseTestCase):
                            if line.lower().startswith("flask"))
 
                 # regression test for #3433
-                run_command(Commands.INSTALL, prefix, "python=3.5", no_capture=True)
-                assert package_is_installed(prefix, "python=3.5")
+                run_command(Commands.INSTALL, prefix, "python=3.9", no_capture=True)
+                assert package_is_installed(prefix, "python=3.9")
 
                 # regression test for #5847
                 #   when using rm_rf on a file
                 assert prefix in PrefixData._cache_
-                _rm_rf(join(prefix, get_python_site_packages_short_path("3.5")), "os.py")
+                _rm_rf(join(prefix, get_python_site_packages_short_path("3.9")), "os.py")
                 assert prefix not in PrefixData._cache_
 
         # regression test for #5980, related to #5847
@@ -638,11 +641,11 @@ dependencies:
             assert package_is_installed(prefix, 'bzip2')
 
     def test_tarball_install_and_bad_metadata(self):
-        with make_temp_env("python=3.7.2", "flask=1.0.2", "--json") as prefix:
-            assert package_is_installed(prefix, 'flask==1.0.2')
+        with make_temp_env("python=3.10.9", "flask=1.1.1", "--json") as prefix:
+            assert package_is_installed(prefix, 'flask==1.1.1')
             flask_data = [p for p in PrefixData(prefix).iter_records() if p['name'] == 'flask'][0]
             run_command(Commands.REMOVE, prefix, 'flask')
-            assert not package_is_installed(prefix, 'flask==1.0.2')
+            assert not package_is_installed(prefix, 'flask==1.1.1')
             assert package_is_installed(prefix, 'python')
 
             flask_fname = flask_data['fn']
@@ -672,7 +675,7 @@ dependencies:
             # regression test for #2626
             # install tarball with relative path, outside channel
             run_command(Commands.REMOVE, prefix, 'flask')
-            assert not package_is_installed(prefix, 'flask=1.0.2')
+            assert not package_is_installed(prefix, 'flask=1.1.1')
             tar_new_path = relpath(tar_new_path)
             run_command(Commands.INSTALL, prefix, tar_new_path)
             assert package_is_installed(prefix, 'flask=1')
@@ -714,11 +717,11 @@ dependencies:
             assert not package_is_installed(prefix, "python=2.7.12")
 
     def test_pinned_override_with_explicit_spec(self):
-        with make_temp_env("python=3.6") as prefix:
+        with make_temp_env("python=3.9") as prefix:
             run_command(Commands.CONFIG, prefix,
-                        "--add", "pinned_packages", "python=3.6.5")
-            run_command(Commands.INSTALL, prefix, "python=3.7", no_capture=True)
-            assert package_is_installed(prefix, "python=3.7")
+                        "--add", "pinned_packages", "python=3.9.16")
+            run_command(Commands.INSTALL, prefix, "python=3.10", no_capture=True)
+            assert package_is_installed(prefix, "python=3.10")
 
     def test_remove_all(self):
         with make_temp_env("python") as prefix:
@@ -767,18 +770,18 @@ dependencies:
     @pytest.mark.flaky(reruns=2)
     def test_dash_c_usage_replacing_python(self):
         # Regression test for #2606
-        with make_temp_env("-c", "conda-forge", "python=3.7", no_capture=True) as prefix:
+        with make_temp_env("-c", "conda-forge", "python=3.10", no_capture=True) as prefix:
             assert exists(join(prefix, PYTHON_BINARY))
-            assert package_is_installed(prefix, 'conda-forge::python=3.7')
+            assert package_is_installed(prefix, 'conda-forge::python=3.10')
             run_command(Commands.INSTALL, prefix, "decorator")
-            assert package_is_installed(prefix, 'conda-forge::python=3.7')
+            assert package_is_installed(prefix, 'conda-forge::python=3.10')
 
             with make_temp_env('--clone', prefix) as clone_prefix:
-                assert package_is_installed(clone_prefix, 'conda-forge::python=3.7')
+                assert package_is_installed(clone_prefix, 'conda-forge::python=3.10')
                 assert package_is_installed(clone_prefix, "decorator")
 
             # Regression test for #2645
-            fn = glob(join(prefix, 'conda-meta', 'python-3.7*.json'))[-1]
+            fn = glob(join(prefix, 'conda-meta', 'python-3.10*.json'))[-1]
             with open(fn) as f:
                 data = json.load(f)
             for field in ('url', 'channel', 'schannel'):
@@ -789,7 +792,7 @@ dependencies:
             PrefixData._cache_ = {}
 
             with make_temp_env('-c', 'conda-forge', '--clone', prefix) as clone_prefix:
-                assert package_is_installed(clone_prefix, 'python=3.7')
+                assert package_is_installed(clone_prefix, 'python=3.10')
                 assert package_is_installed(clone_prefix, 'decorator')
 
     def test_install_prune_flag(self):
@@ -1057,7 +1060,7 @@ dependencies:
             else:
                 # We force the use of 'the other' Python on Windows so that Windows
                 # runtime / DLL incompatibilities will be readily apparent.
-                py_ver = "3.7"
+                py_ver = "3.10"
                 packages.append(f"python={py_ver}")
             with make_temp_env(*packages, use_restricted_unicode=False) as prefix:
                 if use_sys_python:
@@ -1418,9 +1421,9 @@ dependencies:
             assert "not-a-real-package" in error
 
     def test_conda_pip_interop_dependency_satisfied_by_pip(self):
-        with make_temp_env("python=3.7", "pip", use_restricted_unicode=False) as prefix:
-            pip_ioo, pip_ioe, _ = run_command(Commands.CONFIG, prefix, "--set", "pip_interop_enabled", "true")
-            pip_o, pip_e, _ = run_command(Commands.RUN, prefix, "--dev", "python", "-m", "pip", "install", "itsdangerous")
+        with make_temp_env("python=3.10", "pip", use_restricted_unicode=False) as prefix:
+            run_command(Commands.CONFIG, prefix, "--set", "pip_interop_enabled", "true")
+            run_command(Commands.RUN, prefix, "--dev", "python", "-m", "pip", "install", "itsdangerous")
 
             PrefixData._cache_.clear()
             output, error, _ = run_command(Commands.LIST, prefix)
@@ -2059,19 +2062,19 @@ dependencies:
             assert isdir(prefix)
             assert isfile(os.path.join(prefix, 'tempfile.txt'))
             with pytest.raises(DirectoryNotACondaEnvironmentError):
-                run_command(Commands.INSTALL, prefix, "python=3.7.2", "--mkdir")
+                run_command(Commands.INSTALL, prefix, "python", "--mkdir")
 
             run_command(Commands.CREATE, prefix)
-            run_command(Commands.INSTALL, prefix, "python=3.7.2", "--mkdir")
-            assert package_is_installed(prefix, "python=3.7.2")
+            run_command(Commands.INSTALL, prefix, "python", "--mkdir")
+            assert package_is_installed(prefix, "python")
 
             rm_rf(prefix, clean_empty_parents=True)
             assert path_is_clean(prefix)
 
             # this part also a regression test for #4849
-            run_command(Commands.INSTALL, prefix, "python-dateutil=2.6.1", "python=3.5.6", "--mkdir", no_capture=True)
-            assert package_is_installed(prefix, "python=3.5.6")
-            assert package_is_installed(prefix, "python-dateutil=2.6.1")
+            run_command(Commands.INSTALL, prefix, "python-dateutil", "python", "--mkdir", no_capture=True)
+            assert package_is_installed(prefix, "python")
+            assert package_is_installed(prefix, "python-dateutil")
 
         finally:
             rm_rf(prefix, clean_empty_parents=True)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Follow up to #12436.

- adds news
- updates metadata
- updates tests to not use Python 3.7 anymore 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- ~[ ] Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
