### PR TITLE
Make `conda info --verbose` work

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -373,6 +373,7 @@ def configure_parser_info(sub_parsers):
         "--all",
         "-v",
         "--verbose",
+        dest="verbosity",
         action="store_true",
         help="Show all information.",
     )

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -312,12 +312,12 @@ def execute(args, parser):
 
     options = 'envs', 'system'
 
-    if args.all or context.json:
+    if args.verbosity or context.json:
         for option in options:
             setattr(args, option, True)
     info_dict = get_info_dict(args.system)
 
-    if (args.all or all(not getattr(args, opt) for opt in options)) and not context.json:
+    if (args.verbosity or all(not getattr(args, opt) for opt in options)) and not context.json:
         stdout_logger = getLogger("conda.stdoutlog")
         stdout_logger.info(get_main_info_str(info_dict))
         stdout_logger.info("\n")


### PR DESCRIPTION
Resolves #12420 

Turn default `-v` flag off, and aliase `--all` with `-v`/`--verbose` for `conda info`

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
