### PR TITLE
catch `ChunkedEncodingError` too

### DIFF
--- a/conda/gateways/connection/__init__.py
+++ b/conda/gateways/connection/__init__.py
@@ -7,7 +7,12 @@ try:
     from requests.adapters import BaseAdapter, HTTPAdapter
     from requests.auth import AuthBase, _basic_auth_str
     from requests.cookies import extract_cookies_to_jar
-    from requests.exceptions import ChunkedEncodingError, InvalidSchema, SSLError, ProxyError as RequestsProxyError
+    from requests.exceptions import (
+        ChunkedEncodingError,
+        InvalidSchema,
+        SSLError,
+        ProxyError as RequestsProxyError,
+    )
     from requests.hooks import dispatch_hook
     from requests.models import Response
     from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -20,8 +25,12 @@ except ImportError:  # pragma: no cover
     from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
     from pip._vendor.requests.auth import AuthBase, _basic_auth_str
     from pip._vendor.requests.cookies import extract_cookies_to_jar
-    from pip._vendor.requests.exceptions import (InvalidSchema, SSLError, ChunkedEncodingError,
-                                                 ProxyError as RequestsProxyError)
+    from pip._vendor.requests.exceptions import (
+        ChunkedEncodingError,
+        InvalidSchema,
+        SSLError,
+        ProxyError as RequestsProxyError,
+    )
     from pip._vendor.requests.hooks import dispatch_hook
     from pip._vendor.requests.models import Response
     from pip._vendor.requests.packages.urllib3.exceptions import InsecureRequestWarning

--- a/conda/gateways/connection/__init__.py
+++ b/conda/gateways/connection/__init__.py
@@ -3,11 +3,11 @@
 
 
 try:
-    from requests import ConnectionError, HTTPError, Session, ChunkedEncodingError
+    from requests import ConnectionError, HTTPError, Session
     from requests.adapters import BaseAdapter, HTTPAdapter
     from requests.auth import AuthBase, _basic_auth_str
     from requests.cookies import extract_cookies_to_jar
-    from requests.exceptions import InvalidSchema, SSLError, ProxyError as RequestsProxyError
+    from requests.exceptions import ChunkedEncodingError, InvalidSchema, SSLError, ProxyError as RequestsProxyError
     from requests.hooks import dispatch_hook
     from requests.models import Response
     from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -16,11 +16,11 @@ try:
     from requests.packages.urllib3.util.retry import Retry
 
 except ImportError:  # pragma: no cover
-    from pip._vendor.requests import ConnectionError, HTTPError, Session, ChunkedEncodingError
+    from pip._vendor.requests import ConnectionError, HTTPError, Session
     from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
     from pip._vendor.requests.auth import AuthBase, _basic_auth_str
     from pip._vendor.requests.cookies import extract_cookies_to_jar
-    from pip._vendor.requests.exceptions import (InvalidSchema, SSLError,
+    from pip._vendor.requests.exceptions import (InvalidSchema, SSLError, ChunkedEncodingError,
                                                  ProxyError as RequestsProxyError)
     from pip._vendor.requests.hooks import dispatch_hook
     from pip._vendor.requests.models import Response

--- a/conda/gateways/connection/__init__.py
+++ b/conda/gateways/connection/__init__.py
@@ -3,7 +3,7 @@
 
 
 try:
-    from requests import ConnectionError, HTTPError, Session
+    from requests import ConnectionError, HTTPError, Session, ChunkedEncodingError
     from requests.adapters import BaseAdapter, HTTPAdapter
     from requests.auth import AuthBase, _basic_auth_str
     from requests.cookies import extract_cookies_to_jar
@@ -16,7 +16,7 @@ try:
     from requests.packages.urllib3.util.retry import Retry
 
 except ImportError:  # pragma: no cover
-    from pip._vendor.requests import ConnectionError, HTTPError, Session
+    from pip._vendor.requests import ConnectionError, HTTPError, Session, ChunkedEncodingError
     from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
     from pip._vendor.requests.auth import AuthBase, _basic_auth_str
     from pip._vendor.requests.cookies import extract_cookies_to_jar
@@ -42,6 +42,7 @@ extract_cookies_to_jar = extract_cookies_to_jar
 get_auth_from_url = get_auth_from_url
 get_netrc_auth = get_netrc_auth
 ConnectionError = ConnectionError
+ChunkedEncodingError = ChunkedEncodingError
 HTTPError = HTTPError
 InvalidSchema = InvalidSchema
 SSLError = SSLError

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -32,6 +32,7 @@ from conda.exceptions import (
 )
 from conda.gateways.connection import (
     ConnectionError,
+    ChunkedEncodingError,
     HTTPError,
     InsecureRequestWarning,
     InvalidSchema,
@@ -195,7 +196,7 @@ Exception: {e}
 """
             )
 
-    except (ConnectionError, HTTPError) as e:
+    except (ConnectionError, HTTPError, ChunkedEncodingError) as e:
         status_code = getattr(e.response, "status_code", None)
         if status_code in (403, 404):
             if not url.endswith("/noarch"):
@@ -295,18 +296,14 @@ If your current network has https://www.anaconda.com blocked, please file
 a support request with your network engineering team.
 
 %s
-""" % maybe_unquote(
-                    repr(url)
-                )
+""" % maybe_unquote(repr(url))
 
             else:
                 help_message = """\
 An HTTP error occurred when trying to retrieve this URL.
 HTTP errors are often intermittent, and a simple retry will get you on your way.
 %s
-""" % maybe_unquote(
-                    repr(url)
-                )
+""" % maybe_unquote(repr(url))
 
         raise CondaHTTPError(
             help_message,

--- a/news/12487-ChunkedEncodingError
+++ b/news/12487-ChunkedEncodingError
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Catch `ChunkedEncodingError` exceptions to prevent network error tracebacks hitting the output. (#12196 via #12487)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #12196

This happens very rarely, but after enough CI runs you get one. I wonder if we should catch the [base `RequestException` class](https://requests.readthedocs.io/en/latest/_modules/requests/exceptions/) entirely instead of this reduced subset?

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
