### PR TITLE
catch and ignore existence errors in `mkdir_p_sudo_safe`

### DIFF
--- a/conda/gateways/disk/__init__.py
+++ b/conda/gateways/disk/__init__.py
@@ -79,7 +79,11 @@ def mkdir_p_sudo_safe(path):
     if not isdir(base_dir):
         mkdir_p_sudo_safe(base_dir)
     log.trace('making directory %s', path)
-    os.mkdir(path)
+    try:
+        os.mkdir(path)
+    except OSError as e:
+        if not (e.errno == EEXIST and isdir(path)):
+            raise
     # # per the following issues, removing this code as of 4.6.0:
     # #   - https://github.com/conda/conda/issues/6569
     # #   - https://github.com/conda/conda/issues/6576

--- a/news/12490-mkdir-p-sudo-safe-race
+++ b/news/12490-mkdir-p-sudo-safe-race
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix race conditions in `mkdir_p_sudo_safe`. (#12490)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->


This function suffers from [race conditions](https://github.com/conda/conda-libmamba-solver/actions/runs/4420840267/jobs/7751017355#step:5:870) so we need to catch that exception:

```
_____________________________ test_clean_tarballs ______________________________
Traceback (most recent call last):
  File "/opt/conda-src/tests/cli/test_main_clean.py", line 109, in test_clean_tarballs
    with make_temp_env(pkg):
  File "/opt/conda/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/opt/conda-src/conda/testing/integration.py", line 326, in make_temp_env
    run_command(Commands.CREATE, prefix, *packages, **kwargs)
  File "/opt/conda-src/conda/testing/integration.py", line 287, in run_command
    result = do_call(args, p)
  File "/opt/conda-src/conda/cli/conda_argparse.py", line 122, in do_call
    return getattr(module, func_name)(args, parser)
  File "/opt/conda-src/conda/notices/core.py", line 121, in wrapper
    return func(*args, **kwargs)
  File "/opt/conda-src/conda/cli/main_create.py", line 41, in execute
    install(args, parser, 'create')
  File "/opt/conda-src/conda/cli/install.py", line 264, in install
    unlink_link_transaction = solver.solve_for_transaction(
  File "/opt/conda-src/conda/core/solve.py", line 134, in solve_for_transaction
    unlink_precs, link_precs = self.solve_for_diff(update_modifier, deps_modifier,
  File "/opt/conda-src/conda/core/solve.py", line 177, in solve_for_diff
    final_precs = self.solve_final_state(update_modifier, deps_modifier, prune, ignore_pinned,
  File "/opt/conda/lib/python3.10/site-packages/conda_libmamba_solver/solver.py", line 178, in solve_final_state
    index = LibMambaIndexHelper(
  File "/opt/conda/lib/python3.10/site-packages/conda_libmamba_solver/index.py", line 114, in __init__
    self._index = self._load_channels()
  File "/opt/conda/lib/python3.10/site-packages/conda_libmamba_solver/index.py", line 236, in _load_channels
    index = {info.noauth_url: info for info in executor.map(self._fetch_channel, urls)}
  File "/opt/conda/lib/python3.10/site-packages/conda_libmamba_solver/index.py", line 236, in <dictcomp>
    index = {info.noauth_url: info for info in executor.map(self._fetch_channel, urls)}
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 621, in result_iterator
    yield _result_or_cancel(fs.pop())
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 319, in _result_or_cancel
    return fut.result(timeout)
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/opt/conda/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/opt/conda/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/conda/lib/python3.10/site-packages/conda_libmamba_solver/index.py", line 212, in _fetch_channel
    subdir_data.load()
  File "/opt/conda-src/conda/core/subdir_data.py", line 264, in load
    _internal_state = self._load()
  File "/opt/conda-src/conda/core/subdir_data.py", line 314, in _load
    cache = self.repo_cache
  File "/opt/conda-src/conda/core/subdir_data.py", line 225, in repo_cache
    return RepodataCache(self.cache_path_base, self.repodata_fn)
  File "/opt/conda-src/conda/core/subdir_data.py", line 236, in cache_path_base
    self._cache_dir = create_cache_dir()
  File "/opt/conda-src/conda/core/subdir_data.py", line 709, in create_cache_dir
    mkdir_p_sudo_safe(cache_dir)
  File "/opt/conda-src/conda/gateways/disk/__init__.py", line 82, in mkdir_p_sudo_safe
    os.mkdir(path)
FileExistsError: [Errno 17] File exists: '/home/test_user/pytesttmp/bcac badcef/pkgs/cache'
```

I don't get why we are using rolling our own here though. `os.makedirs` provides the same functionality. The `sudo` parts are commented out, so maybe it's just a matter of doing the `chmod` parts and that's it.

Would it be ok to change that try/except logic to simply use `os.makedirs()`?

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
