### PR TITLE
Update & reenable binstar tests

### DIFF
--- a/conda_env/specs/binstar.py
+++ b/conda_env/specs/binstar.py
@@ -77,7 +77,7 @@ class BinstarSpec:
         return [data for data in self.package["files"] if data["type"] == ENVIRONMENT_TYPE]
 
     @cached_property
-    def _yaml(self) -> str:
+    def environment(self) -> Environment:
         versions = [
             {"normalized": normalized_version(d["version"]), "original": d["version"]}
             for d in self.file_data
@@ -89,11 +89,7 @@ class BinstarSpec:
         )
         if req is None:
             raise EnvironmentFileNotDownloaded(self.username, self.packagename)
-        return req.text
-
-    @property
-    def environment(self) -> Environment:
-        return from_yaml(self._yaml)
+        return from_yaml(req.text)
 
     @cached_property
     def package(self):

--- a/conda_env/specs/binstar.py
+++ b/conda_env/specs/binstar.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import importlib
+from functools import cached_property
 import re
 
 from conda.exceptions import EnvironmentFileNotDownloaded
 from conda.models.version import normalized_version
 
-from .. import env
+from ..env import from_yaml, Environment
 
 
 ENVIRONMENT_TYPE = 'env'
-# TODO: isolate binstar related code into conda_env.utils.binstar
 
 
 class BinstarSpec:
@@ -21,31 +20,19 @@ class BinstarSpec:
     spec.msg # => Error messages
     :raises: EnvironmentFileNotDownloaded
     """
-
-    _environment = None
-    _username = None
-    _packagename = None
-    _package = None
-    _file_data = None
-    _binstar = None
     msg = None
 
-    def __init__(self, name=None, **kwargs):
+    def __init__(self, name=None):
         self.name = name
-        self.quiet = False
 
-    def can_handle(self):
-        result = self._can_handle()
-        return result
-
-    def _can_handle(self):
+    def can_handle(self) -> bool:
         """
         Validates loader can process environment definition.
         :return: True or False
         """
         # TODO: log information about trying to find the package in binstar.org
         if self.valid_name():
-            if self.binstar is None:
+            if not self.binstar:
                 self.msg = ("Anaconda Client is required to interact with anaconda.org or an "
                             "Anaconda API. Please run `conda install anaconda-client -n base`.")
                 return False
@@ -53,7 +40,7 @@ class BinstarSpec:
             return self.package is not None and self.valid_package()
         return False
 
-    def valid_name(self):
+    def valid_name(self) -> bool:
         """
         Validates name
         :return: True or False
@@ -66,73 +53,60 @@ class BinstarSpec:
             self.msg = f"Invalid name {self.name!r}, try the format: user/package"
         return False
 
-    def valid_package(self):
+    def valid_package(self) -> bool:
         """
         Returns True if package has an environment file
         :return: True or False
         """
         return len(self.file_data) > 0
 
-    @property
-    def binstar(self):
-        if self._binstar is None:
-            try:
-                binstar_utils = importlib.import_module("binstar_client.utils")
-                self._binstar = binstar_utils.get_server_api()
-            except (AttributeError, ModuleNotFoundError):
-                pass
-        return self._binstar
+    @cached_property
+    def binstar(self) -> ModuleType:
+        try:
+            from binstar_client.utils import get_server_api
+
+            return get_server_api()
+        except ImportError:
+            pass
+
+    @cached_property
+    def file_data(self) -> list[dict[str, str]]:
+        return [data for data in self.package["files"] if data["type"] == ENVIRONMENT_TYPE]
+
+    @cached_property
+    def _yaml(self) -> str:
+        versions = [
+            {"normalized": normalized_version(d["version"]), "original": d["version"]}
+            for d in self.file_data
+        ]
+        latest_version = max(versions, key=lambda x: x["normalized"])["original"]
+        file_data = [data for data in self.package["files"] if data["version"] == latest_version]
+        req = self.binstar.download(
+            self.username, self.packagename, latest_version, file_data[0]["basename"]
+        )
+        if req is None:
+            raise EnvironmentFileNotDownloaded(self.username, self.packagename)
+        return req.text
 
     @property
-    def file_data(self):
-        if self._file_data is None:
-            self._file_data = [data
-                               for data in self.package['files']
-                               if data['type'] == ENVIRONMENT_TYPE]
-        return self._file_data
+    def environment(self) -> Environment:
+        return from_yaml(self._yaml)
 
-    @property
-    def environment(self):
-        """
-        :raises: EnvironmentFileNotDownloaded
-        """
-        if self._environment is None:
-            versions = [{'normalized': normalized_version(d['version']), 'original': d['version']}
-                        for d in self.file_data]
-            latest_version = max(versions, key=lambda x: x['normalized'])['original']
-            file_data = [data
-                         for data in self.package['files']
-                         if data['version'] == latest_version]
-            req = self.binstar.download(self.username, self.packagename, latest_version,
-                                        file_data[0]['basename'])
-            if req is None:
-                raise EnvironmentFileNotDownloaded(self.username, self.packagename)
-            self._environment = req.text
-        return env.from_yaml(self._environment)
-
-    @property
+    @cached_property
     def package(self):
-        if self._package is None:
-            try:
-                self._package = self.binstar.package(self.username, self.packagename)
-            except IndexError:
-                self.msg = "{} was not found on anaconda.org.\n"\
-                           "You may need to be logged in. Try running:\n"\
-                           "    anaconda login".format(self.name)
-        return self._package
+        try:
+            return self.binstar.package(self.username, self.packagename)
+        except (IndexError, AttributeError):
+            self.msg = (
+                "{} was not found on anaconda.org.\n"
+                "You may need to be logged in. Try running:\n"
+                "    anaconda login".format(self.name)
+            )
 
-    @property
-    def username(self):
-        if self._username is None:
-            self._username = self.parse()[0]
-        return self._username
+    @cached_property
+    def username(self) -> str:
+        return self.name.split("/", 1)[0]
 
-    @property
-    def packagename(self):
-        if self._packagename is None:
-            self._packagename = self.parse()[1]
-        return self._packagename
-
-    def parse(self):
-        """Parse environment definition handle"""
-        return self.name.split('/', 1)
+    @cached_property
+    def packagename(self) -> str:
+        return self.name.split("/", 1)[1]

--- a/conda_env/specs/binstar.py
+++ b/conda_env/specs/binstar.py
@@ -1,7 +1,10 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from functools import cached_property
 import re
+from types import ModuleType
 
 from conda.exceptions import EnvironmentFileNotDownloaded
 from conda.models.version import normalized_version

--- a/news/12495-reenable-binstar-tests
+++ b/news/12495-reenable-binstar-tests
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Fix and re-enable binstar tests. Replace custom property caching with `functools.cached_property`. (#12495)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [tool:pytest]
 minversion = 3.0
 testpaths = conda tests
+norecursedirs = .* build/ conda/_vendor/* dist/ docs/ tests/data/*
 addopts =
     --ignore setup.py
     --ignore conda/__main__.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ addopts =
     --ignore setup.py
     --ignore conda/__main__.py
     --ignore conda/_vendor
+    --ignore tests/conda_env/installers/test_pip.py
+    --ignore tests/conda_env/specs/test_base.py
+    --ignore tests/conda_env/specs/test_requirements.py
+    --ignore tests/conda_env/specs/test_yaml_file.py
     --ignore tests/conda_env/support
     --ignore tests/conda_env/utils/test_uploader.py
     --ignore test_data

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,10 @@
 [tool:pytest]
 minversion = 3.0
 testpaths = conda tests
-norecursedirs = .* *.egg* build dist env ve conda/_vendor/* conda_env/* test_data/*
 addopts =
     --ignore setup.py
     --ignore conda/__main__.py
     --ignore conda/_vendor
-    --ignore tests/conda_env/specs/test_binstar.py
     --ignore tests/conda_env/support
     --ignore tests/conda_env/utils/test_uploader.py
     --ignore test_data

--- a/tests/conda_env/specs/test_binstar.py
+++ b/tests/conda_env/specs/test_binstar.py
@@ -1,88 +1,114 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from pytest_mock import MockerFixture
 
-import types
-import unittest
-from unittest.mock import patch, MagicMock
-from binstar_client import errors
-
+from binstar_client.errors import NotFound
 from conda_env.specs.binstar import BinstarSpec
 from conda_env.env import Environment
 
 
-class TestBinstarSpec(unittest.TestCase):
-    def test_has_can_handle_method(self):
-        spec = BinstarSpec()
-        self.assertTrue(hasattr(spec, 'can_handle'))
-        self.assertIsInstance(spec.can_handle, types.MethodType)
-
-    def test_name_not_present(self):
-        spec = BinstarSpec(filename='filename')
-        self.assertEqual(spec.can_handle(), False)
-        self.assertEqual(spec.msg, "Can't process without a name")
-
-    def test_invalid_name(self):
-        spec = BinstarSpec(name='invalid-name')
-        self.assertEqual(spec.can_handle(), False)
-        self.assertEqual(spec.msg, "Invalid name 'invalid-name', try the format: user/package")
-
-    def test_package_not_exist(self):
-        with patch('conda_env.specs.binstar.get_binstar') as get_binstar_mock:
-            package = MagicMock(side_effect=errors.NotFound('msg'))
-            binstar = MagicMock(package=package)
-            get_binstar_mock.return_value = binstar
-            spec = BinstarSpec(name='darth/no-exist')
-            self.assertEqual(spec.package, None)
-            self.assertEqual(spec.can_handle(), False)
-
-    def test_package_without_environment_file(self):
-        with patch('conda_env.specs.binstar.get_binstar') as get_binstar_mock:
-            package = MagicMock(return_value={'files': []})
-            binstar = MagicMock(package=package)
-            get_binstar_mock.return_value = binstar
-            spec = BinstarSpec('darth/no-env-file')
-
-            self.assertEqual(spec.can_handle(), False)
-
-    def test_download_environment(self):
-        fake_package = {
-            'files': [{'type': 'env', 'version': '1', 'basename': 'environment.yml'}]
-        }
-        fake_req = MagicMock(text="name: env")
-        with patch('conda_env.specs.binstar.get_binstar') as get_binstar_mock:
-            package = MagicMock(return_value=fake_package)
-            downloader = MagicMock(return_value=fake_req)
-            binstar = MagicMock(package=package, download=downloader)
-            get_binstar_mock.return_value = binstar
-
-            spec = BinstarSpec(name='darth/env-file')
-            self.assertIsInstance(spec.environment, Environment)
-
-    def test_environment_version_sorting(self):
-        fake_package = {
-            'files': [
-                {'type': 'env', 'version': '0.1.1', 'basename': 'environment.yml'},
-                {'type': 'env', 'version': '0.1a.2', 'basename': 'environment.yml'},
-                {'type': 'env', 'version': '0.2.0', 'basename': 'environment.yml'},
-            ]
-        }
-        fake_req = MagicMock(text="name: env")
-        with patch('conda_env.specs.binstar.get_binstar') as get_binstar_mock:
-            package = MagicMock(return_value=fake_package)
-            downloader = MagicMock(return_value=fake_req)
-            binstar = MagicMock(package=package, download=downloader)
-            get_binstar_mock.return_value = binstar
-
-            spec = BinstarSpec(name='darth/env-file')
-            spec.environment
-            downloader.assert_called_with('darth', 'env-file', '0.2.0', 'environment.yml')
-
-    def test_binstar_not_installed(self):
-        spec = BinstarSpec(name='user/package')
-        spec.binstar = None
-        self.assertFalse(spec.can_handle())
-        self.assertEqual(spec.msg, 'Please install binstar')
+def test_name_not_present():
+    """No name provided."""
+    spec = BinstarSpec()
+    assert not spec.package
+    assert not spec.can_handle()
+    assert spec.msg == "Can't process without a name"
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_invalid_name():
+    """Invalid name provided."""
+    spec = BinstarSpec("invalid-name")
+    assert not spec.package
+    assert not spec.can_handle()
+    assert spec.msg == "Invalid name 'invalid-name', try the format: user/package"
+
+
+def test_package_not_exist(mocker: MockerFixture):
+    """Package doesn't exist."""
+    mocker.patch(
+        "conda_env.specs.binstar.BinstarSpec.binstar",
+        new_callable=mocker.PropertyMock,
+        return_value=mocker.MagicMock(package=mocker.MagicMock(side_effect=NotFound("msg"))),
+    )
+
+    spec = BinstarSpec("darth/no-exist")
+    assert not spec.package
+    assert not spec.can_handle()
+
+
+def test_package_without_environment_file(mocker: MockerFixture):
+    """Package exists but no environment file is present."""
+    mocker.patch(
+        "conda_env.specs.binstar.BinstarSpec.binstar",
+        new_callable=mocker.PropertyMock,
+        return_value=mocker.MagicMock(package=mocker.MagicMock(return_value={"files": []})),
+    )
+
+    spec = BinstarSpec("darth/no-env-file")
+    assert spec.package
+    assert not spec.can_handle()
+
+
+def test_download_environment(mocker: MockerFixture):
+    """Package exists with an environment file."""
+    mocker.patch(
+        "conda_env.specs.binstar.BinstarSpec.binstar",
+        new_callable=mocker.PropertyMock,
+        return_value=mocker.MagicMock(
+            package=mocker.MagicMock(
+                return_value={
+                    "files": [{"type": "env", "version": "1", "basename": "environment.yml"}],
+                },
+            ),
+            download=mocker.MagicMock(return_value=mocker.MagicMock(text="name: env")),
+        ),
+    )
+
+    spec = BinstarSpec("darth/env-file")
+    assert spec.package
+    assert spec.can_handle()
+    assert isinstance(spec.environment, Environment)
+
+
+def test_environment_version_sorting(mocker: MockerFixture):
+    """Package exists with multiple environment files, get latest version."""
+    downloader = mocker.MagicMock(return_value=mocker.MagicMock(text="name: env"))
+    mocker.patch(
+        "conda_env.specs.binstar.BinstarSpec.binstar",
+        new_callable=mocker.PropertyMock,
+        return_value=mocker.MagicMock(
+            package=mocker.MagicMock(
+                return_value={
+                    "files": [
+                        {"type": "env", "version": "0.1.1", "basename": "environment.yml"},
+                        {"type": "env", "version": "0.1a.2", "basename": "environment.yml"},
+                        {"type": "env", "version": "0.2.0", "basename": "environment.yml"},
+                    ],
+                },
+            ),
+            download=downloader,
+        ),
+    )
+
+    spec = BinstarSpec("darth/env-file")
+    assert spec.package
+    assert spec.can_handle()
+    assert isinstance(spec.environment, Environment)
+    downloader.assert_called_with("darth", "env-file", "0.2.0", "environment.yml")
+
+
+def test_binstar_not_installed(mocker: MockerFixture):
+    """Mock anaconda-client not installed."""
+    mocker.patch(
+        "conda_env.specs.binstar.BinstarSpec.binstar",
+        new_callable=mocker.PropertyMock,
+        return_value=None,
+    )
+
+    spec = BinstarSpec("user/package")
+    assert not spec.package
+    assert not spec.can_handle()
+    assert spec.msg == (
+        "Anaconda Client is required to interact with anaconda.org or an Anaconda API. "
+        "Please run `conda install anaconda-client -n base`."
+    )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The `tests/conda_env/specs/test_binstar.py` tests were unittest style and broken. This converts them into pytest tests and fixes them. Also updated `conda_env.specs.binstar.BinstarSpec` to use `functools.cached_property` instead of custom implementation.

Xref #11321

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
