### PR TITLE
Include pinned file with clone

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -716,6 +716,11 @@ def configure_parser_create(sub_parsers):
         dest="dev",
         default=NULL,
     )
+    p.add_argument(
+        "--pinned",
+        action="store_true",
+        help="Copy pinned file when cloning the environment with `--clone`.",
+    )
     p.set_defaults(func='.main_create.execute')
 
 

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -54,7 +54,7 @@ def check_prefix(prefix, json=False):
         )
 
 
-def clone(src_arg, dst_prefix, json=False, quiet=False, index_args=None):
+def clone(src_arg, dst_prefix, json=False, quiet=False, index_args=None, pinned=False):
     if os.sep in src_arg:
         src_prefix = abspath(src_arg)
         if not isdir(src_prefix):
@@ -66,10 +66,9 @@ def clone(src_arg, dst_prefix, json=False, quiet=False, index_args=None):
         print("Source:      %s" % src_prefix)
         print("Destination: %s" % dst_prefix)
 
-    actions, untracked_files = clone_env(src_prefix, dst_prefix,
-                                         verbose=not json,
-                                         quiet=quiet,
-                                         index_args=index_args)
+    actions, untracked_files = clone_env(
+        src_prefix, dst_prefix, verbose=not json, quiet=quiet, index_args=index_args, pinned=pinned
+    )
 
     if json:
         common.stdout_json_success(
@@ -215,7 +214,14 @@ def install(args, parser, command='install'):
             raise TooManyArgumentsError(0, len(args.packages), list(args.packages),
                                         'did not expect any arguments for --clone')
 
-        clone(args.clone, prefix, json=context.json, quiet=context.quiet, index_args=index_args)
+        clone(
+            args.clone,
+            prefix,
+            json=context.json,
+            quiet=context.quiet,
+            index_args=index_args,
+            pinned=args.pinned,
+        )
         touch_nonadmin(prefix)
         print_activate(args.name or prefix)
         return

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -221,7 +221,7 @@ def touch_nonadmin(prefix):
             fo.write("")
 
 
-def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
+def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None, pinned=False):
     """
     clone existing prefix1 into new prefix2
     """
@@ -333,4 +333,20 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
     actions = explicit(
         urls, prefix2, verbose=not quiet, index=index, force_extract=False, index_args=index_args
     )
+
+    if pinned:
+        pinned_src = join(prefix1, "conda-meta", "pinned")
+        pinned_dst = join(prefix2, "conda-meta", "pinned")
+        fh = sys.stderr if context.json else sys.stdout
+
+        if exists(pinned_src):
+            if verbose:
+                print(f"Copying pinned file from {pinned_src} to {pinned_dst}", file=fh)
+            try:
+                shutil.copyfile(pinned_src, pinned_dst)
+            except OSError:
+                pass
+        elif verbose:
+            print("Source pinned file not found.", file=fh)
+
     return actions, untracked_files

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1144,6 +1144,27 @@ dependencies:
                     assert package_is_installed(clone_prefix, "flask=0.11.1=py_0")
                     assert isfile(join(clone_prefix, 'test.file'))  # untracked file
 
+    def test_clone_package_pinning(self):
+        with make_temp_env("python=3.9", "itsdangerous=1.1.0", no_capture=True) as prefix:
+            assert package_is_installed(prefix, "itsdangerous=1.1.0")
+            assert package_is_installed(prefix, "python=3.9")
+
+            with open(join(prefix, "conda-meta", "pinned"), "w") as fh:
+                fh.write("itsdangerous 1.1.0\n")
+
+            assert exists(join(prefix, "conda-meta", "pinned"))
+
+            with make_temp_env("--clone", prefix, "--pinned") as clone_prefix:
+                assert package_is_installed(clone_prefix, "itsdangerous=1.1.0")
+                assert exists(join(clone_prefix, "conda-meta", "pinned"))
+
+                run_command(Commands.UPDATE, clone_prefix, "--all", no_capture=True)
+                assert package_is_installed(clone_prefix, "itsdangerous=1.1.0")
+
+                run_command(Commands.UPDATE, clone_prefix, "--all", "--no-pin", no_capture=True)
+                assert not package_is_installed(clone_prefix, "itsdangerous=1.1.0")
+                breakpoint()
+
     def test_package_pinning(self):
         with make_temp_env("python=2.7", "itsdangerous=0.24", "pytz=2017.3", no_capture=True) as prefix:
             assert package_is_installed(prefix, "itsdangerous=0.24")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->
Issues addressed:

 - https://github.com/conda/conda/issues/1769
 - https://github.com/conda/conda/issues/9943

For long term reproducible environments, the `pinned` file is an important way of ensuring environment consistency independently of direct package dependencies. This PR is cautious by adding this as an optional `--pinned` flag to the clone operation, but arguably this should be on by default as the documentation mentions creating "an exact copy of an environment". This flag could be removed and the behavior enabled by default in a reworking of this PR if that is preferable.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

I can update the documentation to reflect the appropriate changes as needed, but figured it would be better to review the code changes first.