### PR TITLE
Make split line f-string

### DIFF
--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -363,7 +363,7 @@ def request_url_jlap_state(
             apply = find_patches(patches, have, want)
             log.info(
                 f"Apply {len(apply)} patches "
-                "{format_hash(have)} \N{RIGHTWARDS ARROW} {format_hash(want)}"
+                f"{format_hash(have)} \N{RIGHTWARDS ARROW} {format_hash(want)}"
             )
 
             if apply:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Line split to satisfy linter missed f-prefix

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
