### PR TITLE
Remove Python version pinning for correct test results

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -891,7 +891,14 @@ dependencies:
             result_before = subprocess_call_with_clean_env([python, "--version"])
             assert package_is_installed(prefix, "flask=2.0.1")
             assert package_is_installed(prefix, "jinja2=3.0.1")
-            run_command(Commands.INSTALL, prefix, "flask", "python=3.10", "--update-deps", "--only-deps")
+            run_command(
+                Commands.INSTALL,
+                prefix,
+                "flask",
+                "python",
+                "--update-deps",
+                "--only-deps",
+            )
             result_after = subprocess_call_with_clean_env([python, "--version"])
             assert result_before == result_after
             assert package_is_installed(prefix, "flask=2.0.1")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Since Python 3.11 is now available on defaults the `test_create.py::test_install_update_deps_only_deps_flags` test started failing. Easy correction by removing version pinning.

Found via #12509 in https://github.com/conda/conda/actions/runs/4475317036/jobs/7864628287?pr=12509#step:3:288

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
