### PR TITLE
Restore default argument for `SubdirData` method used by `conda-index`.

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -521,7 +521,7 @@ class SubdirData(metaclass=SubdirDataType):
         json_obj = json.loads(raw_repodata_str or "{}")
         return self._process_raw_repodata(json_obj, state=state)
 
-    def _process_raw_repodata(self, repodata, state: RepodataState | None):
+    def _process_raw_repodata(self, repodata, state: RepodataState | None = None):
         if not isinstance(state, RepodataState):
             state = RepodataState(
                 self.cache_path_json, self.cache_path_state, self.repodata_fn, dict=state

--- a/news/conda-index-fix
+++ b/news/conda-index-fix
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Restore default argument for `SubdirData` method used by `conda-index`.
+* Restore default argument for `SubdirData` method used by `conda-index`. (#12513)
 
 ### Deprecations
 

--- a/news/conda-index-fix
+++ b/news/conda-index-fix
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Restore default argument for `SubdirData` method used by `conda-index`.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

conda-index calls this method with one argument (the freshly generated index data). Restore default parameter.

This affects standalone conda-index; legacy conda-build index passes a string to a related method.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
