### PR TITLE
Remove `test_main_rename.py` customizations in favor of existing functions/fixtures

### DIFF
--- a/news/12517-update-test_main_rename
+++ b/news/12517-update-test_main_rename
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Update `tests/cli/test_main_rename.py` to use latest fixtures. (#12517)

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -15,20 +15,20 @@ from conda.core.envs_manager import list_all_known_prefixes
 from conda.exceptions import CondaError, EnvironmentNameNotFound
 from conda.testing.helpers import set_active_prefix
 
-TEST_ENV_NAME_1 = "env-1"
 TEST_ENV_NAME_2 = "env-2"
 TEST_ENV_NAME_RENAME = "renamed-env"
 
 
 @pytest.fixture
-def env_one():
+def env_one() -> Iterable[str]:
     # Setup
-    conda_cli("create", "-n", TEST_ENV_NAME_1, "-y")
+    name = uuid.uuid4().hex
+    conda_cli("create", "-n", name, "-y")
 
-    yield
+    yield name
 
     # Teardown
-    conda_cli("remove", "--all", "-y", "-n", TEST_ENV_NAME_1)
+    conda_cli("remove", "--all", "-y", "-n", name)
     conda_cli("remove", "--all", "-y", "-n", TEST_ENV_NAME_RENAME)
 
 
@@ -56,54 +56,51 @@ def env_prefix_one():
     conda_cli("remove", "--all", "-y", "-p", tmpdir)
 
 
-def test_rename_by_name_success(env_one):
-    conda_cli("rename", "-n", TEST_ENV_NAME_1, TEST_ENV_NAME_RENAME)
+def test_rename_by_name_success(env_one: str):
+    conda_cli("rename", "-n", env_one, TEST_ENV_NAME_RENAME)
 
     assert locate_prefix_by_name(TEST_ENV_NAME_RENAME)
     with pytest.raises(EnvironmentNameNotFound):
-        locate_prefix_by_name(TEST_ENV_NAME_1)
+        locate_prefix_by_name(env_one)
 
 
-def test_rename_by_path_success(env_one):
+def test_rename_by_path_success(env_one: str):
     with tempfile.TemporaryDirectory() as temp_dir:
         new_name = str(pathlib.Path(temp_dir).joinpath("new-env"))
-        conda_cli("rename", "-n", TEST_ENV_NAME_1, new_name)
+        conda_cli("rename", "-n", env_one, new_name)
 
         result = list_all_known_prefixes()
 
         path_appears_in_env_list = any(new_name == path for path in result)
-        original_name_in_envs = any(path.endswith(TEST_ENV_NAME_1) for path in result)
+        original_name_in_envs = any(path.endswith(env_one) for path in result)
 
         assert path_appears_in_env_list
         assert not original_name_in_envs
 
 
-def test_rename_by_name_name_already_exists_error(env_one):
+def test_rename_by_name_name_already_exists_error(env_one: str):
     """Test to ensure that we do not rename if the name already exists"""
-    out, err, exit_code = conda_cli("rename", "-n", TEST_ENV_NAME_1, TEST_ENV_NAME_1)
-    assert (
-        f"The environment '{TEST_ENV_NAME_1}' already exists. Override with --force"
-        in err
-    )
+    out, err, exit_code = conda_cli("rename", "-n", env_one, env_one)
+    assert f"The environment '{env_one}' already exists. Override with --force" in err
 
 
-def test_rename_by_path_path_already_exists_error(env_one):
+def test_rename_by_path_path_already_exists_error(env_one: str):
     """Test to ensure that we do not rename if the path already exists"""
     with tempfile.TemporaryDirectory() as tempdir:
-        out, err, exit_code = conda_cli("rename", "-n", TEST_ENV_NAME_1, tempdir)
+        out, err, exit_code = conda_cli("rename", "-n", env_one, tempdir)
         assert (
             f"The environment '{os.path.basename(os.path.normpath(tempdir))}' already exists. Override with --force"
             in err
         )
 
 
-def test_cannot_rename_base_env_by_name(env_one):
+def test_cannot_rename_base_env_by_name():
     """Test to ensure that we cannot rename the base env invoked by name"""
     out, err, exit_code = conda_cli("rename", "-n", "base", TEST_ENV_NAME_RENAME)
     assert "The 'base' environment cannot be renamed" in err
 
 
-def test_cannot_rename_base_env_by_path(env_one):
+def test_cannot_rename_base_env_by_path():
     """Test to ensure that we cannot rename the base env invoked by path"""
     out, err, exit_code = conda_cli(
         "rename", "-p", context.root_prefix, TEST_ENV_NAME_RENAME
@@ -111,37 +108,35 @@ def test_cannot_rename_base_env_by_path(env_one):
     assert "The 'base' environment cannot be renamed" in err
 
 
-def test_cannot_rename_active_env_by_name(env_one):
+def test_cannot_rename_active_env_by_name(env_one: str):
     """Makes sure that we cannot rename our active environment."""
     result = list_all_known_prefixes()
 
-    prefix_list = [res for res in result if res.endswith(TEST_ENV_NAME_1)]
+    prefix_list = [res for res in result if res.endswith(env_one)]
 
     assert len(prefix_list) > 0
 
     prefix = prefix_list[0]
 
     with set_active_prefix(prefix):
-        out, err, exit_code = conda_cli(
-            "rename", "-n", TEST_ENV_NAME_1, TEST_ENV_NAME_RENAME
-        )
+        out, err, exit_code = conda_cli("rename", "-n", env_one, TEST_ENV_NAME_RENAME)
         assert "Cannot rename the active environment" in err
 
 
-def test_rename_with_force(env_one, env_two):
+def test_rename_with_force(env_one: str, env_two):
     """
     Runs a test where we specify the --force flag to remove an existing directory.
     Without this flag, it would return with an error message.
     """
     # Do a force rename
-    conda_cli("rename", "-n", TEST_ENV_NAME_1, TEST_ENV_NAME_2, "--force")
+    conda_cli("rename", "-n", env_one, TEST_ENV_NAME_2, "--force")
 
     assert locate_prefix_by_name(TEST_ENV_NAME_2)
     with pytest.raises(EnvironmentNameNotFound):
-        locate_prefix_by_name(TEST_ENV_NAME_1)
+        locate_prefix_by_name(env_one)
 
 
-def test_rename_with_force_with_errors(env_one, env_two):
+def test_rename_with_force_with_errors(env_one: str, env_two):
     """
     Runs a test where we specify the --force flag to remove an existing directory.
     Additionally, in this test, we mock an exception to recreate a failure condition.
@@ -152,14 +147,14 @@ def test_rename_with_force_with_errors(env_one, env_two):
     with mock.patch("conda.cli.main_rename.install.clone") as clone_mock:
         clone_mock.side_effect = [CondaError(error_message)]
         _, err, exit_code = conda_cli(
-            "rename", "-n", TEST_ENV_NAME_1, TEST_ENV_NAME_2, "--force"
+            "rename", "-n", env_one, TEST_ENV_NAME_2, "--force"
         )
         assert error_message in err
         assert exit_code == 1
 
     # Make sure both environments still exist
     assert locate_prefix_by_name(TEST_ENV_NAME_2)
-    assert locate_prefix_by_name(TEST_ENV_NAME_1)
+    assert locate_prefix_by_name(env_one)
 
 
 def test_rename_with_force_with_errors_prefix(env_prefix_one):
@@ -184,16 +179,16 @@ def test_rename_with_force_with_errors_prefix(env_prefix_one):
         assert os.path.isdir(env_prefix_one)
 
 
-def test_rename_with_dry_run(env_one):
+def test_rename_with_dry_run(env_one: str):
     """
     Runs a test where we specify the --dry-run flag to remove an existing directory.
     Without this flag, it would actually execute all the actions.
     """
     (rename_out, rename_err, rename_exit_code) = conda_cli(
-        "rename", "-n", TEST_ENV_NAME_1, TEST_ENV_NAME_RENAME, "--dry-run"
+        "rename", "-n", env_one, TEST_ENV_NAME_RENAME, "--dry-run"
     )
 
-    assert locate_prefix_by_name(TEST_ENV_NAME_1)
+    assert locate_prefix_by_name(env_one)
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_RENAME)
 
@@ -202,17 +197,17 @@ def test_rename_with_dry_run(env_one):
     assert "Dry run action: rm_rf" in rename_stdout
 
 
-def test_rename_with_force_and_dry_run(env_one, env_prefix_one):
+def test_rename_with_force_and_dry_run(env_one: str, env_prefix_one):
     """
     Runs a test where we specify the --force and --dry-run flags to forcefully rename
     an existing directory. We need to ensure that --dry-run is effective and that no
     changes occur.
     """
     (rename_out, rename_err, rename_exit_code) = conda_cli(
-        "rename", "-n", TEST_ENV_NAME_1, TEST_ENV_NAME_RENAME, "--force", "--dry-run"
+        "rename", "-n", env_one, TEST_ENV_NAME_RENAME, "--force", "--dry-run"
     )
 
-    assert locate_prefix_by_name(TEST_ENV_NAME_1)
+    assert locate_prefix_by_name(env_one)
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_RENAME)
 

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -95,7 +95,7 @@ def test_cannot_rename_base_env_by_name(env_rename: str):
 def test_cannot_rename_base_env_by_path(env_rename: str):
     """Test to ensure that we cannot rename the base env invoked by path"""
     with pytest.raises(TypeError, match="The 'base' environment cannot be renamed"):
-        conda_cli("rename", "-p", context.root_prefix, env_rename)
+        conda_cli("rename", "--prefix", context.root_prefix, env_rename)
 
 
 def test_cannot_rename_active_env_by_name(env_one: str, env_rename: str):
@@ -156,7 +156,7 @@ def test_rename_with_force_with_errors_prefix(mocker: MockerFixture, tmp_path: P
     )
     with tmp_env() as prefix:
         with pytest.raises(CondaError, match=error_message):
-            conda_cli("rename", "-p", prefix, tmp_path, "--force")
+            conda_cli("rename", "--prefix", prefix, tmp_path, "--force")
 
         # Make sure both directories still exist
         assert tmp_path.is_dir()

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -24,31 +24,31 @@ def env_rename() -> Iterable[str]:
     yield name
 
     # Teardown
-    conda_cli("remove", "--all", "-y", "--name", name)
+    conda_cli("remove", "--all", "--yes", "--name", name)
 
 
 @pytest.fixture
 def env_one() -> Iterable[str]:
     # Setup
     name = uuid.uuid4().hex
-    conda_cli("create", "--name", name, "-y")
+    conda_cli("create", "--name", name, "--yes")
 
     yield name
 
     # Teardown
-    conda_cli("remove", "--all", "-y", "--name", name)
+    conda_cli("remove", "--all", "--yes", "--name", name)
 
 
 @pytest.fixture
 def env_two() -> Iterable[str]:
     # Setup
     name = uuid.uuid4().hex
-    conda_cli("create", "--name", name, "-y")
+    conda_cli("create", "--name", name, "--yes")
 
     yield name
 
     # Teardown
-    conda_cli("remove", "--all", "-y", "--name", name)
+    conda_cli("remove", "--all", "--yes", "--name", name)
 
 
 def test_rename_by_name_success(env_one: str, env_rename: str):

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -20,13 +20,8 @@ TEST_ENV_NAME_2 = "env-2"
 TEST_ENV_NAME_RENAME = "renamed-env"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def env_one():
-    """
-    This fixture has been given a module scope to help decrease execution time.
-    When using the fixture, please rename the original environment back to what it
-    was (i.e. always make sure there is a TEST_ENV_NAME_1 present).
-    """
     # Setup
     conda_cli("create", "-n", TEST_ENV_NAME_1, "-y")
 
@@ -68,9 +63,6 @@ def test_rename_by_name_success(env_one):
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_1)
 
-    # Clean up
-    conda_cli("rename", "-n", TEST_ENV_NAME_RENAME, TEST_ENV_NAME_1)
-
 
 def test_rename_by_path_success(env_one):
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -78,9 +70,6 @@ def test_rename_by_path_success(env_one):
         conda_cli("rename", "-n", TEST_ENV_NAME_1, new_name)
 
         result = list_all_known_prefixes()
-
-        # Clean up
-        conda_cli("rename", "-p", new_name, TEST_ENV_NAME_1)
 
         path_appears_in_env_list = any(new_name == path for path in result)
         original_name_in_envs = any(path.endswith(TEST_ENV_NAME_1) for path in result)
@@ -150,9 +139,6 @@ def test_rename_with_force(env_one, env_two):
     assert locate_prefix_by_name(TEST_ENV_NAME_2)
     with pytest.raises(EnvironmentNameNotFound):
         locate_prefix_by_name(TEST_ENV_NAME_1)
-
-    # Clean up
-    conda_cli("rename", "-n", TEST_ENV_NAME_2, TEST_ENV_NAME_1)
 
 
 def test_rename_with_force_with_errors(env_one, env_two):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

A number of changes occurred here:
- Converts all constants into randomized values returned by fixtures
- Converted `unittest.mock` to `mocker` fixtures
- Eliminated subprocess `list_envs` implementation in favor of calling `conda.core.envs_manager.list_all_known_prefixes`
- Added type hinting
- Converted all fixtures to function scoped to eliminate potentially fragile extra cleanup phase for select tests
- uses the new `conda_cli`, `tmp_env`, and `path_factory` fixtures

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
