### PR TITLE
Improve error message about -p/-n flags

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1776,7 +1776,7 @@ def validate_prefix_name(prefix_name: str, ctx: Context, allow_base=True) -> str
                 f"""
                 Invalid environment name: {prefix_name!r}
                 Characters not allowed: {PREFIX_NAME_DISALLOWED_CHARS}
-                If you are specifying a path to an environment, the `-p` 
+                If you are specifying a path to an environment, the `-p`
                 flag should be used instead.
                 """
             )


### PR DESCRIPTION
Resolves #9762 

Improves error message to clarify that the user should use the `-p` flag instead of the `-n` flag when passing an environment path. 