### PR TITLE
Test that cache revalidate updates ttl

### DIFF
--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -29,10 +29,6 @@ from conda.gateways.repodata import (
 from conda.gateways.repodata.jlap import core, fetch, interface
 from conda.models.channel import Channel
 
-import logging
-
-log = logging.getLogger(__name__)
-
 
 def test_server_available(package_server: socket):
     port = package_server.getsockname()[1]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This test is meant to check a case that I was concerned about getting wrong.

1. Download repodata
2. Cache expires after 30 seconds
3. Will the cache "stay expired", checking "304 Not Modified" every time after the original expiration? Or will it add another 30 seconds and correctly check no more frequently than once every 30 seconds?

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
