### PR TITLE
Provide a way to pin `minio` in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           path: minio.exe
           key:
-            ${{ runner.os }}-minio-${{ env.CACHE_NUMBER }}
+            ${{ runner.os }}-${{ env.MINIO_RELEASE && env.MINIO_RELEASE || 'minio' }}-${{ env.CACHE_NUMBER }}
 
       - name: Set temp dirs correctly
         # https://github.com/actions/virtual-environments/issues/712
@@ -323,7 +323,7 @@ jobs:
         with:
           path: minio
           key:
-            ${{ runner.os }}-minio-${{ env.CACHE_NUMBER }}
+            ${{ runner.os }}-${{ env.MINIO_RELEASE && env.MINIO_RELEASE || 'minio' }}}-${{ env.CACHE_NUMBER }}
 
       - uses: conda-incubator/setup-miniconda@v2
         name: Setup miniconda for defaults

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+    # see https://github.com/conda/conda/pull/12524
+    MINIO_RELEASE: 'archive/minio.RELEASE.2023-03-13T19-46-17Z'
+
 jobs:
   # detect whether any code changes are included in this PR
   changes:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/cache@v3
         env:
           # Increase this value to reset cache
-          CACHE_NUMBER: 3
+          CACHE_NUMBER: 4
         with:
           path: minio.exe
           key:
@@ -319,7 +319,7 @@ jobs:
         uses: actions/cache@v3
         env:
           # Increase this value to reset cache
-          CACHE_NUMBER: 3
+          CACHE_NUMBER: 4
         with:
           path: minio
           key:

--- a/dev/linux/setup.sh
+++ b/dev/linux/setup.sh
@@ -19,7 +19,7 @@ elif [ "${minioarch}" = "x86_64" ]; then
 elif [ "${minioarch}" = "ppc64el" ]; then
     minioarch=ppc64le
 fi
-wget --quiet https://dl.minio.io/server/minio/release/linux-${minioarch}/minio
+curl -sL -o minio https://dl.minio.io/server/minio/release/linux-${minioarch}/archive/minio.RELEASE.2023-03-13T19-46-17Z
 chmod +x minio
 sudo mv minio /usr/local/bin/minio
 

--- a/dev/linux/setup.sh
+++ b/dev/linux/setup.sh
@@ -19,7 +19,8 @@ elif [ "${minioarch}" = "x86_64" ]; then
 elif [ "${minioarch}" = "ppc64el" ]; then
     minioarch=ppc64le
 fi
-curl -sL -o minio https://dl.minio.io/server/minio/release/linux-${minioarch}/archive/minio.RELEASE.2023-03-13T19-46-17Z
+minio_release="${MINIO_RELEASE:-minio}" # use 'archive/XXXX' for older releases
+curl -sL -o minio "https://dl.minio.io/server/minio/release/linux-${minioarch}/${minio_release}"
 chmod +x minio
 sudo mv minio /usr/local/bin/minio
 

--- a/dev/macos/setup.sh
+++ b/dev/macos/setup.sh
@@ -4,7 +4,8 @@ set -ex
 # Download the Minio server, needed for S3 tests
 if [[ ! -f minio ]]
 then
-    curl -sL -o minio https://dl.min.io/server/minio/release/darwin-amd64/archive/minio.RELEASE.2023-03-13T19-46-17Z
+    minio_release="${MINIO_RELEASE:-minio}" # use 'archive/XXXX' for older releases
+    curl -sL -o minio "https://dl.min.io/server/minio/release/darwin-amd64/${minio_release}"
 fi
 chmod +x minio
 sudo cp minio /usr/local/bin/minio

--- a/dev/macos/setup.sh
+++ b/dev/macos/setup.sh
@@ -4,7 +4,7 @@ set -ex
 # Download the Minio server, needed for S3 tests
 if [[ ! -f minio ]]
 then
-    curl -LO https://dl.minio.io/server/minio/release/darwin-amd64/minio
+    curl -sL -o minio https://dl.min.io/server/minio/release/darwin-amd64/archive/minio.RELEASE.2023-03-13T19-46-17Z
 fi
 chmod +x minio
 sudo cp minio /usr/local/bin/minio

--- a/dev/windows/setup.bat
+++ b/dev/windows/setup.bat
@@ -21,7 +21,7 @@ python -m conda init --install || goto :error
 python -m conda init cmd.exe --dev || goto :error
 
 :: Download minio server needed for S3 tests and place it in our conda environment so is in PATH
-powershell.exe -Command "If (-Not (Test-Path 'minio.exe')) { Invoke-WebRequest -Uri 'https://dl.minio.io/server/minio/release/windows-amd64/minio.exe' -OutFile 'minio.exe' | Out-Null }" || goto :error
+powershell.exe -Command "If (-Not (Test-Path 'minio.exe')) { Invoke-WebRequest -Uri 'https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2023-03-13T19-46-17Z' -OutFile 'minio.exe' | Out-Null }" || goto :error
 copy minio.exe %CONDA_PREFIX%\minio.exe || goto :error
 
 goto :EOF

--- a/dev/windows/setup.bat
+++ b/dev/windows/setup.bat
@@ -21,7 +21,9 @@ python -m conda init --install || goto :error
 python -m conda init cmd.exe --dev || goto :error
 
 :: Download minio server needed for S3 tests and place it in our conda environment so is in PATH
-powershell.exe -Command "If (-Not (Test-Path 'minio.exe')) { Invoke-WebRequest -Uri 'https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2023-03-13T19-46-17Z' -OutFile 'minio.exe' | Out-Null }" || goto :error
+:: You can pin to an older release by setting MINIO_RELEASE to 'archive/XXXX'
+if "%MINIO_RELEASE%x" == "x" set "MINIO_RELEASE=minio"
+powershell.exe -Command "If (-Not (Test-Path 'minio.exe')) { Invoke-WebRequest -Uri 'https://dl.min.io/server/minio/release/windows-amd64/!MINIO_RELEASE!' -OutFile 'minio.exe' | Out-Null }" || goto :error
 copy minio.exe %CONDA_PREFIX%\minio.exe || goto :error
 
 goto :EOF

--- a/dev/windows/setup.bat
+++ b/dev/windows/setup.bat
@@ -22,7 +22,7 @@ python -m conda init cmd.exe --dev || goto :error
 
 :: Download minio server needed for S3 tests and place it in our conda environment so is in PATH
 :: You can pin to an older release by setting MINIO_RELEASE to 'archive/XXXX'
-if "%MINIO_RELEASE%x" == "x" set "MINIO_RELEASE=minio"
+if "%MINIO_RELEASE%x" == "x" set "MINIO_RELEASE=minio.exe"
 powershell.exe -Command "If (-Not (Test-Path 'minio.exe')) { Invoke-WebRequest -Uri 'https://dl.min.io/server/minio/release/windows-amd64/!MINIO_RELEASE!' -OutFile 'minio.exe' | Out-Null }" || goto :error
 copy minio.exe %CONDA_PREFIX%\minio.exe || goto :error
 

--- a/dev/windows/setup.bat
+++ b/dev/windows/setup.bat
@@ -22,8 +22,9 @@ python -m conda init cmd.exe --dev || goto :error
 
 :: Download minio server needed for S3 tests and place it in our conda environment so is in PATH
 :: You can pin to an older release by setting MINIO_RELEASE to 'archive/XXXX'
+
 if "%MINIO_RELEASE%x" == "x" set "MINIO_RELEASE=minio.exe"
-powershell.exe -Command "If (-Not (Test-Path 'minio.exe')) { Invoke-WebRequest -Uri 'https://dl.min.io/server/minio/release/windows-amd64/!MINIO_RELEASE!' -OutFile 'minio.exe' | Out-Null }" || goto :error
+powershell.exe -Command "If (-Not (Test-Path 'minio.exe')) { Invoke-WebRequest -Uri 'https://dl.min.io/server/minio/release/windows-amd64/%MINIO_RELEASE%' -OutFile 'minio.exe' | Out-Null }" || goto :error
 copy minio.exe %CONDA_PREFIX%\minio.exe || goto :error
 
 goto :EOF

--- a/news/12524-minio-pin
+++ b/news/12524-minio-pin
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Expose a `MINIO_RELEASE` environment variable to provide a way to pin `minio` versions in CI setup scripts. (#12525)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Needed by https://github.com/conda/conda-libmamba-solver/pull/159, which fixes a few tests in `conda-libmamba-solver`. This PR exposes a `MINIO_RELEASE` environment variable, which defaults to `minio` if not set. By specifying `archive/minio.RELEASE.<timestamp>` you can install a different version than latest.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
