### PR TITLE
Install missing curl for Linux images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -8,16 +8,20 @@ on:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
   pull_request:
     paths:
-      - 'Dockerfile'
       - '.github/workflows/images.yml'
+      - 'Dockerfile'
+      - 'dev/linux/install_miniconda.sh'
+      - 'dev/linux/setup.sh'
       - 'tests/requirements.txt'
 
   # NOTE: github.event context is push payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
   push:
     paths:
-      - 'Dockerfile'
       - '.github/workflows/images.yml'
+      - 'Dockerfile'
+      - 'dev/linux/install_miniconda.sh'
+      - 'dev/linux/setup.sh'
       - 'tests/requirements.txt'
 
   # NOTE: github.event context is workflow_dispatch payload:

--- a/dev/linux/setup.sh
+++ b/dev/linux/setup.sh
@@ -4,7 +4,7 @@ set -o errtrace -o pipefail -o errexit
 
 apt-get update --fix-missing
 apt-get install -y --no-install-recommends \
-    tini wget build-essential bzip2 ca-certificates \
+    tini wget curl build-essential bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 git mercurial subversion \
     sudo htop less nano man grep
 apt-get clean


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Linux images are newly failing because curl is missing. Not sure why since curl is still listed as a supported software: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
