### PR TITLE
add __init__.py for conda.gateways.repodata.jlap

### DIFF
--- a/conda/gateways/repodata/jlap/__init__.py
+++ b/conda/gateways/repodata/jlap/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Incremental repodata feature based on .jlap patch files.
+"""


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

conda.gateways.repodata.jlap wasn't packaged by setup.py, since it was using a search algorithm that looked for a missing `__init__.py`. Although init is no longer needed by Python since a long time ago, the packaging tool still wants it.

This will be detected in the usual way, instead of manually adding the module to setup.py's list of auto-detected ones.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
