### PR TITLE
Add `flake8-docstrings` to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,5 @@ repos:
     hooks:
       # lint Python codes
       - id: flake8
+        args: [--docstring-convention=pep257]
+        additional_dependencies: [flake8-docstrings]

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -1268,10 +1268,12 @@ formatter_map = {
 
 
 def _build_activator_cls(shell):
-    """Construct the activator class dynamically from a base activator and any
-    number of formatters, appended using '+' to the name. For example,
-    `posix+json` (as in `conda shell.posix+json activate`) would use the
-    `PosixActivator` base class and add the `JSONFormatMixin`."""
+    """Dynamically construct the activator class.
+
+    Detect the base activator and any number of formatters (appended using '+' to the base name).
+    For example, `posix+json` (as in `conda shell.posix+json activate`) would use the
+    `PosixActivator` base class and add the `JSONFormatMixin`.
+    """
     shell_etc = shell.split("+")
     activator, formatters = shell_etc[0], shell_etc[1:]
     bases = [activator_map[activator]]

--- a/conda/api.py
+++ b/conda/api.py
@@ -43,9 +43,9 @@ class Solver:
                 A prioritized list of channels to use for the solution.
             subdirs (Sequence[str]):
                 A prioritized list of subdirs to use for the solution.
-            specs_to_add (Set[:class:`MatchSpec`]):
+            specs_to_add (set[:class:`MatchSpec`]):
                 The set of package specs to add to the prefix.
-            specs_to_remove (Set[:class:`MatchSpec`]):
+            specs_to_remove (set[:class:`MatchSpec`]):
                 The set of package specs to remove from the prefix.
 
         """
@@ -89,7 +89,7 @@ class Solver:
                 Forces removal of a package without removing packages that depend on it.
 
         Returns:
-            Tuple[PackageRef]:
+            tuple[PackageRef]:
                 In sorted dependency order from roots to leaves, the package references for
                 the solved state of the environment.
 
@@ -129,7 +129,7 @@ class Solver:
                 depending on the spec exactness.
 
         Returns:
-            Tuple[PackageRef], Tuple[PackageRef]:
+            tuple[PackageRef], tuple[PackageRef]:
                 A two-tuple of PackageRef sequences.  The first is the group of packages to
                 remove from the environment, in sorted dependency order from leaves to roots.
                 The second is the group of packages to add to the environment, in sorted
@@ -221,7 +221,7 @@ class SubdirData:
                 query object.  A :obj:`str` will be turned into a :obj:`MatchSpec` automatically.
 
         Returns:
-            Tuple[PackageRecord]
+            tuple[PackageRecord]
 
         """
         return tuple(self._internal.query(package_ref_or_match_spec))
@@ -244,7 +244,7 @@ class SubdirData:
                 If None, will fall back to context.subdirs.
 
         Returns:
-            Tuple[PackageRecord]
+            tuple[PackageRecord]
 
         """
         return tuple(
@@ -323,7 +323,7 @@ class PackageCacheData:
                 query object.  A :obj:`str` will be turned into a :obj:`MatchSpec` automatically.
 
         Returns:
-            Tuple[PackageCacheRecord]
+            tuple[PackageCacheRecord]
 
         """
         return tuple(self._internal.query(package_ref_or_match_spec))
@@ -343,7 +343,7 @@ class PackageCacheData:
                 If None, will fall back to context.pkgs_dirs.
 
         Returns:
-            Tuple[PackageCacheRecord]
+            tuple[PackageCacheRecord]
 
         """
         return tuple(_PackageCacheData.query_all(package_ref_or_match_spec, pkgs_dirs))
@@ -451,7 +451,7 @@ class PrefixData:
                 query object.  A :obj:`str` will be turned into a :obj:`MatchSpec` automatically.
 
         Returns:
-            Tuple[PrefixRecord]
+            tuple[PrefixRecord]
 
         """
         return tuple(self._internal.query(package_ref_or_match_spec))

--- a/conda/auxlib/type_coercion.py
+++ b/conda/auxlib/type_coercion.py
@@ -188,7 +188,7 @@ def typify(value, type_hint=None):
 
     Args:
         value (Any): Usually a string, not a sequence
-        type_hint (type or Tuple[type]):
+        type_hint (type or tuple[type]):
 
     Examples:
         >>> typify('32')

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -891,13 +891,7 @@ class Context(Configuration):
             if not self.override_channels_enabled:
                 from ..exceptions import OperationNotAllowed
 
-                raise OperationNotAllowed(
-                    dals(
-                        """
-                Overriding channels has been disabled.
-                """
-                    )
-                )
+                raise OperationNotAllowed("Overriding channels has been disabled.")
             elif not (
                 self._argparse_args
                 and "channel" in self._argparse_args
@@ -1080,9 +1074,7 @@ class Context(Configuration):
         stack=+1,
     )
     def cuda_version(self) -> Optional[str]:
-        """
-        Retrieves the current cuda version.
-        """
+        """Retrieves the current cuda version."""
         from conda.plugins.virtual_packages import cuda
 
         return cuda.cuda_version()

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import os
 import platform
 import struct
@@ -11,7 +13,6 @@ from itertools import chain
 from logging import getLogger
 from os.path import abspath, expanduser, isdir, isfile, join
 from os.path import split as path_split
-from typing import Optional
 
 try:
     from boltons.setutils import IndexedSet
@@ -576,19 +577,19 @@ class Context(Configuration):
         return _platform_map.get(sys.platform, "unknown")
 
     @property
-    def default_threads(self) -> Optional[int]:
+    def default_threads(self) -> int | None:
         return self._default_threads or None
 
     @property
-    def repodata_threads(self) -> Optional[int]:
+    def repodata_threads(self) -> int | None:
         return self._repodata_threads or self.default_threads
 
     @property
-    def fetch_threads(self) -> Optional[int]:
+    def fetch_threads(self) -> int | None:
         return self._fetch_threads or self.default_threads
 
     @property
-    def verify_threads(self) -> Optional[int]:
+    def verify_threads(self) -> int | None:
         if self._verify_threads:
             threads = self._verify_threads
         elif self.default_threads:
@@ -1073,7 +1074,7 @@ class Context(Configuration):
         addendum="Use `conda.plugins.virtual_packages.cuda.cuda_version` instead.",
         stack=+1,
     )
-    def cuda_version(self) -> Optional[str]:
+    def cuda_version(self) -> str | None:
         """Retrieves the current cuda version."""
         from conda.plugins.virtual_packages import cuda
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -768,7 +768,6 @@ class Context(Configuration):
         The vars can refer to each other if necessary since the dict is ordered.
         None means unset it.
         """
-
         if context.dev:
             return {
                 "CONDA_EXE": sys.executable,
@@ -1954,7 +1953,6 @@ def determine_target_prefix(ctx, args=None):
     Returns: the prefix
     Raises: CondaEnvironmentNotFoundError if the prefix is invalid
     """
-
     argparse_args = args or ctx._argparse_args
     try:
         prefix_name = argparse_args.name

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -750,15 +750,13 @@ class Context(Configuration):
 
     @property
     def av_data_dir(self):
-        """Directory where critical data for artifact verification (e.g.,
-        various public keys) can be found."""
+        """Where critical artifact verification data (e.g., various public keys) can be found."""
         # TODO (AV): Find ways to make this user configurable?
         return join(self.conda_prefix, "etc", "conda")
 
     @property
     def signing_metadata_url_base(self):
-        """Base URL where artifact verification signing metadata (*.root.json,
-        key_mgr.json) can be obtained."""
+        """Base URL for artifact verification signing metadata (*.root.json, key_mgr.json)."""
         if self._signing_metadata_url_base:
             return self._signing_metadata_url_base
         else:

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -354,17 +354,13 @@ class DeprecatedAction(_StoreAction):
 
 
 def configure_parser_clean(sub_parsers):
-    descr = dedent(
+    descr = "Remove unused packages and caches."
+    example = dals(
         """
-    Remove unused packages and caches.
-    """
-    )
-    example = dedent(
-        """
-    Examples::
+        Examples::
 
-        conda clean --tarballs
-    """
+            conda clean --tarballs
+        """
     )
     p = sub_parsers.add_parser(
         "clean",

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -118,9 +118,7 @@ def get_revision(arg, json=False):
 
 
 def install(args, parser, command="install"):
-    """
-    conda install, conda update, and conda create
-    """
+    """Logic for `conda install`, `conda update`, and `conda create`."""
     context.validate_configuration()
     check_non_admin()
     # this is sort of a hack.  current_repodata.json may not have any .tar.bz2 files,

--- a/conda/cli/main_notices.py
+++ b/conda/cli/main_notices.py
@@ -7,9 +7,7 @@ from ..notices import core as notices
 
 
 def execute(args: Namespace, _: ArgumentParser):
-    """
-    Command that retrieves channel notifications, caches them and displays them.
-    """
+    """Command that retrieves channel notifications, caches them and displays them."""
     try:
         channel_notice_set = notices.retrieve_notices()
     except OSError as exc:

--- a/conda/cli/main_package.py
+++ b/conda/cli/main_package.py
@@ -18,9 +18,7 @@ from ..misc import untracked
 
 
 def remove(prefix, files):
-    """
-    Remove files for a given prefix.
-    """
+    """Remove files for a given prefix."""
     dst_dirs = set()
     for f in files:
         dst = join(prefix, f)
@@ -128,10 +126,7 @@ def _add_info_dir(t, tmp_dir, files, has_prefix, info):
 
 
 def create_conda_pkg(prefix, files, info, tar_path, update_info=None):
-    """
-    create a conda package with `files` (in `prefix` and `info` metadata)
-    at `tar_path`, and return a list of warning strings
-    """
+    """Create a conda package and return a list of warnings."""
     files = sorted(files)
     warnings = []
     has_prefix = []
@@ -193,9 +188,10 @@ def make_tarbz2(prefix, name="unknown", version="0.0", build_number=0, files=Non
 
 
 def which_package(path):
-    """
-    given the path (of a (presumably) conda installed file) iterate over
-    the conda packages the file came from.  Usually the iteration yields
+    """Return the package containing the path.
+
+    Provided the path of a (presumably) conda installed file, iterate over
+    the conda packages the file came from. Usually the iteration yields
     only one package.
     """
     path = abspath(path)
@@ -211,9 +207,10 @@ def which_package(path):
 
 
 def which_prefix(path):
-    """
-    given the path (to a (presumably) conda installed file) return the
-    environment prefix in which the file in located
+    """Return the prefix for the provided path.
+
+    Provided the path of a (presumably) conda installed file, return the
+    environment prefix in which the file in located.
     """
     prefix = abspath(path)
     while True:

--- a/conda/cli/main_rename.py
+++ b/conda/cli/main_rename.py
@@ -46,9 +46,7 @@ def validate_destination(dest: str, force: bool = False) -> str:
 
 
 def execute(args, _):
-    """
-    Executes the command for renaming an existing environment
-    """
+    """Executes the command for renaming an existing environment."""
     source = validate_src(args.name, args.prefix)
     destination = validate_destination(args.destination, force=args.force)
 

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -23,9 +23,7 @@ class _ClauseList:
         self.extend = self._clause_list.extend
 
     def get_clause_count(self):
-        """
-        Return number of stored clauses.
-        """
+        """Return number of stored clauses."""
         return len(self._clause_list)
 
     def save_state(self):
@@ -48,9 +46,7 @@ class _ClauseList:
         return self._clause_list
 
     def as_array(self):
-        """
-        Return clauses as a flat int array, each clause being terminated by 0.
-        """
+        """Return clauses as a flat int array, each clause being terminated by 0."""
         clause_array = array("i")
         for c in self._clause_list:
             clause_array.extend(c)
@@ -115,16 +111,12 @@ class _ClauseArray:
                 clause.append(v)
 
     def as_array(self):
-        """
-        Return clauses as a flat int array, each clause being terminated by 0.
-        """
+        """Return clauses as a flat int array, each clause being terminated by 0."""
         return self._clause_array
 
 
 class _SatSolver:
-    """
-    Simple wrapper to call a SAT solver given a _ClauseList/_ClauseArray instance.
-    """
+    """Simple wrapper to call a SAT solver given a _ClauseList/_ClauseArray instance."""
 
     def __init__(self, **run_kwargs):
         self._run_kwargs = run_kwargs or {}

--- a/conda/common/_os/linux.py
+++ b/conda/common/_os/linux.py
@@ -12,9 +12,7 @@ log = getLogger(__name__)
 
 @lru_cache(maxsize=None)
 def linux_get_libc_version():
-    """
-    If on linux, returns (libc_family, version), otherwise (None, None).
-    """
+    """If on linux, returns (libc_family, version), otherwise (None, None)."""
     if not sys.platform.startswith("linux"):
         return None, None
 

--- a/conda/common/_os/linux.py
+++ b/conda/common/_os/linux.py
@@ -15,7 +15,6 @@ def linux_get_libc_version():
     """
     If on linux, returns (libc_family, version), otherwise (None, None).
     """
-
     if not sys.platform.startswith("linux"):
         return None, None
 

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -414,9 +414,7 @@ class YamlRawParameter(RawParameter):
 
 
 class DefaultValueRawParameter(RawParameter):
-    """
-    Wraps a default value as a RawParameter, for usage in ParameterLoader.
-    """
+    """Wraps a default value as a RawParameter, for usage in ParameterLoader."""
 
     def __init__(self, source, key, raw_value):
         super().__init__(source, key, raw_value)
@@ -704,9 +702,7 @@ class PrimitiveLoadedParameter(LoadedParameter):
 
 
 class MapLoadedParameter(LoadedParameter):
-    """
-    LoadedParameter type that holds a map (i.e. dict) of LoadedParameters.
-    """
+    """LoadedParameter type that holds a map (i.e. dict) of LoadedParameters."""
 
     _type = frozendict
 
@@ -781,9 +777,7 @@ class MapLoadedParameter(LoadedParameter):
 
 
 class SequenceLoadedParameter(LoadedParameter):
-    """
-    LoadedParameter type that holds a sequence (i.e. list) of LoadedParameters.
-    """
+    """LoadedParameter type that holds a sequence (i.e. list) of LoadedParameters."""
 
     _type = tuple
 
@@ -880,9 +874,7 @@ class SequenceLoadedParameter(LoadedParameter):
 
 
 class ObjectLoadedParameter(LoadedParameter):
-    """
-    LoadedParameter type that holds a mapping (i.e. object) of LoadedParameters.
-    """
+    """LoadedParameter type that holds a mapping (i.e. object) of LoadedParameters."""
 
     _type = object
 
@@ -956,11 +948,7 @@ class ObjectLoadedParameter(LoadedParameter):
 
 
 class ConfigurationObject:
-    """
-    Dummy class to mark whether a Python object has config parameters within.
-    """
-
-    pass
+    """Dummy class to mark whether a Python object has config parameters within."""
 
 
 class Parameter(metaclass=ABCMeta):
@@ -986,9 +974,7 @@ class Parameter(metaclass=ABCMeta):
 
     @property
     def default(self):
-        """
-        Returns a DefaultValueRawParameter that wraps the actual default value.
-        """
+        """Returns a DefaultValueRawParameter that wraps the actual default value."""
         wrapped_default = DefaultValueRawParameter("default", "default", self._default)
         return self.load("default", wrapped_default)
 
@@ -1073,9 +1059,7 @@ class PrimitiveParameter(Parameter):
 
 
 class MapParameter(Parameter):
-    """
-    Parameter type for a Configuration class that holds a map (i.e. dict) of Parameters.
-    """
+    """Parameter type for a Configuration class that holds a map (i.e. dict) of Parameters."""
 
     _type = frozendict
 
@@ -1128,9 +1112,7 @@ class MapParameter(Parameter):
 
 
 class SequenceParameter(Parameter):
-    """
-    Parameter type for a Configuration class that holds a sequence (i.e. list) of Parameters.
-    """
+    """Parameter type for a Configuration class that holds a sequence (i.e. list) of Parameters."""
 
     _type = tuple
 
@@ -1186,9 +1168,7 @@ class SequenceParameter(Parameter):
 
 
 class ObjectParameter(Parameter):
-    """
-    Parameter type for a Configuration class that holds an object with Parameter fields.
-    """
+    """Parameter type for a Configuration class that holds an object with Parameter fields."""
 
     _type = object
 

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -673,7 +673,7 @@ class PrimitiveLoadedParameter(LoadedParameter):
     ):
         """
         Args:
-            element_type (type or Tuple[type]): Type-validation of parameter's value.
+            element_type (type or tuple[type]): Type-validation of parameter's value.
             value (primitive value): primitive python value.
         """
         self._type = element_type
@@ -1040,7 +1040,7 @@ class PrimitiveParameter(Parameter):
         """
         Args:
             default (primitive value): default value if the Parameter is not found.
-            element_type (type or Tuple[type]): Type-validation of parameter's value. If None,
+            element_type (type or tuple[type]): Type-validation of parameter's value. If None,
                 type(default) is used.
         """
         self._type = type(default) if element_type is None else element_type

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -163,7 +163,7 @@ def env_unmodified(callback=None):
 
 @contextmanager
 def captured(stdout=CaptureTarget.STRING, stderr=CaptureTarget.STRING):
-    """Capture outputs of sys.stdout and sys.stderr.
+    r"""Capture outputs of sys.stdout and sys.stderr.
 
     If stdout is STRING, capture sys.stdout as a string,
     if stdout is None, do not capture sys.stdout, leaving it untouched,
@@ -171,6 +171,14 @@ def captured(stdout=CaptureTarget.STRING, stderr=CaptureTarget.STRING):
 
     Behave correspondingly for stderr with the exception that if stderr is STDOUT,
     redirect sys.stderr to stdout target and set stderr attribute of yielded object to None.
+
+    .. code-block:: pycon
+        >>> from conda.common.io import captured
+        >>> with captured() as c:
+        ...     print("hello world!")
+        ...
+        >>> c.stdout
+        'hello world!\n'
 
     Args:
         stdout: capture target for sys.stdout, one of STRING, None, or file-like object
@@ -181,22 +189,9 @@ def captured(stdout=CaptureTarget.STRING, stderr=CaptureTarget.STRING):
             corresponding file-like function argument.
     """
 
-    # NOTE: This function is not thread-safe.  Using within multi-threading may cause spurious
-    # behavior of not returning sys.stdout and sys.stderr back to their 'proper' state
-    # """
-    # Context manager to capture the printed output of the code in the with block
-    #
-    # Bind the context manager to a variable using `as` and the result will be
-    # in the stdout property.
-    #
-    # >>> from conda.common.io import captured
-    # >>> with captured() as c:
-    # ...     print('hello world!')
-    # ...
-    # >>> c.stdout
-    # 'hello world!\n'
-    # """
     def write_wrapper(self, to_write):
+        # NOTE: This function is not thread-safe.  Using within multi-threading may cause spurious
+        # behavior of not returning sys.stdout and sys.stderr back to their 'proper' state
         # This may have to deal with a *lot* of text.
         if hasattr(self, "mode") and "b" in self.mode:
             wanted = bytes

--- a/conda/common/iterators.py
+++ b/conda/common/iterators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import collections
 import itertools
-from typing import Generator
+from typing import Any, Generator, Sequence
 
 
 def groupby_to_dict(keyfunc, sequence):

--- a/conda/common/iterators.py
+++ b/conda/common/iterators.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""
-Replacements for parts of the toolz library.
-"""
+"""Replacements for parts of the toolz library."""
 from __future__ import annotations
 
 import collections

--- a/conda/common/iterators.py
+++ b/conda/common/iterators.py
@@ -11,9 +11,9 @@ from typing import Generator
 
 
 def groupby_to_dict(keyfunc, sequence):
-    """
-    toolz-style groupby, returns a dictionary of { key: [group] } instead of
-    iterators.
+    """A `toolz`-style groupby implementation.
+
+    Returns a dictionary of { key: [group] } instead of iterators.
     """
     result = collections.defaultdict(list)
     for key, group in itertools.groupby(sequence, keyfunc):
@@ -22,8 +22,9 @@ def groupby_to_dict(keyfunc, sequence):
 
 
 def unique(sequence: Sequence[Any]) -> Generator[Any, None, None]:
-    """
-    toolz inspired unique, returns a generator of unique elements in the sequence
+    """A `toolz` inspired `unique` implementation.
+
+    Returns a generator of unique elements in the sequence
     """
     seen: set[Any] = set()
     yield from (

--- a/conda/common/logic.py
+++ b/conda/common/logic.py
@@ -151,8 +151,7 @@ class Clauses:
         return self._eval(self._clauses.Xor, (f, g), (), polarity, name)
 
     def ITE(self, c, t, f, polarity=None, name=None):
-        """
-        if c then t else f
+        """If c Then t Else f.
 
         In this function, if any of c, t, or f are True and False the resulting
         expression is resolved.

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -65,9 +65,7 @@ class MetadataWarning(Warning):
 # Dist classes
 # -----------------------------------------------------------------------------
 class PythonDistribution:
-    """
-    Base object describing a python distribution based on path to anchor file.
-    """
+    """Base object describing a python distribution based on path to anchor file."""
 
     MANIFEST_FILES = ()  # Only one is used, but many names available
     REQUIRES_FILES = ()  # Only one is used, but many names available
@@ -143,9 +141,7 @@ class PythonDistribution:
 
     @staticmethod
     def _parse_requires_file_data(data, global_section="__global__"):
-        """
-        https://setuptools.readthedocs.io/en/latest/formats.html#requires-txt
-        """
+        # https://setuptools.readthedocs.io/en/latest/formats.html#requires-txt
         requires = {}
         lines = [line.strip() for line in data.split("\n") if line]
 
@@ -187,9 +183,7 @@ class PythonDistribution:
 
     @staticmethod
     def _parse_entries_file_data(data):
-        """
-        https://setuptools.readthedocs.io/en/latest/formats.html#entry-points-txt-entry-point-plugin-metadata
-        """
+        # https://setuptools.readthedocs.io/en/latest/formats.html#entry-points-txt-entry-point-plugin-metadata
         # FIXME: Use pkg_resources which provides API for this?
         entries_data = {}
         config = ConfigParser()
@@ -205,9 +199,7 @@ class PythonDistribution:
         return entries_data
 
     def _load_requires_provides_file(self):
-        """
-        https://setuptools.readthedocs.io/en/latest/formats.html#requires-txt
-        """
+        # https://setuptools.readthedocs.io/en/latest/formats.html#requires-txt
         # FIXME: Use pkg_resources which provides API for this?
         requires, extras = None, None
         for fname in self.REQUIRES_FILES:
@@ -604,9 +596,7 @@ class PythonDistributionMetadata:
 
     @classmethod
     def _read_metadata(cls, fpath):
-        """
-        Read the original format which is stored as RFC-822 headers.
-        """
+        """Read the original format which is stored as RFC-822 headers."""
         data = {}
         if fpath and isfile(fpath):
             parser = HeaderParser()
@@ -938,9 +928,7 @@ def get_site_packages_anchor_files(site_packages_path, site_packages_dir):
 
 
 def get_dist_file_from_egg_link(egg_link_file, prefix_path):
-    """
-    Return the egg info file path following an egg link.
-    """
+    """Return the egg info file path following an egg link."""
     egg_info_full_path = None
 
     egg_link_path = join(prefix_path, win_path_ok(egg_link_file))
@@ -1103,9 +1091,7 @@ def _is_literal(o):
 
 
 class Evaluator:
-    """
-    This class is used to evaluate marker expressions.
-    """
+    """This class is used to evaluate marker expressions."""
 
     operations = {
         "==": lambda x, y: x == y,

--- a/conda/common/pkg_formats/python.py
+++ b/conda/common/pkg_formats/python.py
@@ -797,7 +797,6 @@ class PythonDistributionMetadata:
         -----
         - [1] https://packaging.python.org/specifications/version-specifiers/
         """
-
         return self._get_multiple_data(["obsoletes_dist", "obsoletes"])
 
     def get_classifiers(self):

--- a/conda/common/serialize.py
+++ b/conda/common/serialize.py
@@ -53,7 +53,7 @@ def yaml_safe_load(string):
 
 
 def yaml_round_trip_dump(object, stream=None):
-    """dump object to string or stream"""
+    """Dump object to string or stream."""
     ostream = stream or StringIO()
     _yaml_round_trip().dump(object, ostream)
     if not stream:
@@ -61,7 +61,7 @@ def yaml_round_trip_dump(object, stream=None):
 
 
 def yaml_safe_dump(object, stream=None):
-    """dump object to string or stream"""
+    """Dump object to string or stream."""
     ostream = stream or StringIO()
     _yaml_safe().dump(object, ostream)
     if not stream:

--- a/conda/common/toposort.py
+++ b/conda/common/toposort.py
@@ -13,7 +13,6 @@ def _toposort(data):
     dependences, each subsequent set consists of items that depend upon
     items in the preceding sets.
     """
-
     # Special case empty input.
     if len(data) == 0:
         return
@@ -67,7 +66,6 @@ def _safe_toposort(data):
     dependencies, each subsequent set consists of items that depend upon
     items in the preceding sets.
     """
-
     # Special case empty input.
     if len(data) == 0:
         return

--- a/conda/common/toposort.py
+++ b/conda/common/toposort.py
@@ -11,7 +11,8 @@ def _toposort(data):
     and whose values are a set of dependent items. Output is a list of
     sets in topological order. The first set consists of items with no
     dependences, each subsequent set consists of items that depend upon
-    items in the preceding sets."""
+    items in the preceding sets.
+    """
 
     # Special case empty input.
     if len(data) == 0:
@@ -64,7 +65,8 @@ def _safe_toposort(data):
     and whose values are a set of dependent items. Output is a list of
     sets in topological order. The first set consists of items with no
     dependencies, each subsequent set consists of items that depend upon
-    items in the preceding sets."""
+    items in the preceding sets.
+    """
 
     # Special case empty input.
     if len(data) == 0:

--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -489,9 +489,11 @@ def maybe_unquote(url):
 
 
 def remove_auth(url: str) -> str:
-    """
-    >>> remove_auth('https://user:password@anaconda.com')
-    'https://anaconda.com'
+    """Remove embedded authentication from URL.
+
+    .. code-block:: pycon
+        >>> remove_auth("https://user:password@anaconda.com")
+        'https://anaconda.com'
     """
     url = urlparse(url)
     url_no_auth = url.replace(username="", password="")

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -815,9 +815,7 @@ def run_plan_elevated(plan):
     subprocess reads the content of the file, modifies the content of the file with updated
     execution status, and then closes the file.  This process then reads the content of that file
     for the individual operation execution results, and then deletes the file.
-
     """
-
     if any(step["result"] == Result.NEEDS_SUDO for step in plan):
         if on_win:
             from ..common._os.windows import run_as_admin

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1459,10 +1459,16 @@ class UnlinkLinkTransaction:
         return change_report
 
 
-def run_script(prefix, prec, action="post-link", env_prefix=None, activate=False):
+def run_script(
+    prefix: str,
+    prec,
+    action: str = "post-link",
+    env_prefix: str = None,
+    activate: bool = False,
+) -> bool:
     """
-    call the post-link (or pre-unlink) script, and return True on success,
-    False on failure
+    Call the post-link (or pre-unlink) script, returning True on success,
+    False on failure.
     """
     path = join(
         prefix,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -704,7 +704,7 @@ class ProgressiveFetchExtract:
     def __init__(self, link_prefs):
         """
         Args:
-            link_prefs (Tuple[PackageRecord]):
+            link_prefs (tuple[PackageRecord]):
                 A sequence of :class:`PackageRecord`s to ensure available in a known
                 package cache, typically for a follow-on :class:`UnlinkLinkTransaction`.
                 Here, "available" means the package tarball is both downloaded and extracted

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -68,9 +68,7 @@ EXTRACT_THREADS = min(os.cpu_count() or 1, 3) if THREADSAFE_EXTRACT else 1
 
 
 class PackageCacheType(type):
-    """
-    This metaclass does basic caching of PackageCache instance objects.
-    """
+    """This metaclass does basic caching of PackageCache instance objects."""
 
     def __call__(cls, pkgs_dir):
         if isinstance(pkgs_dir, PackageCacheData):
@@ -886,9 +884,7 @@ class ProgressiveFetchExtract:
 
 
 def do_cache_action(prec, cache_action, progress_bar, download_total=1.0):
-    """
-    This function gets called from `ProgressiveFetchExtract.execute`
-    """
+    """This function gets called from `ProgressiveFetchExtract.execute`."""
     # pass None if already cached (simplifies code)
     if not cache_action:
         return prec
@@ -908,9 +904,7 @@ def do_cache_action(prec, cache_action, progress_bar, download_total=1.0):
 
 
 def do_extract_action(prec, extract_action, progress_bar):
-    """
-    This function gets called after do_cache_action completes.
-    """
+    """This function gets called after do_cache_action completes."""
     # pass None if already extracted (simplifies code)
     if not extract_action:
         return prec

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -768,7 +768,8 @@ class CompileMultiPycAction(MultiPathAction):
 class AggregateCompileMultiPycAction(CompileMultiPycAction):
     """Bunch up all of our compile actions, so that they all get carried out at once.
     This avoids clobbering and is faster when we have several individual packages requiring
-    compilation"""
+    compilation.
+    """
 
     def __init__(self, *individuals, **kw):
         transaction_context = individuals[0].transaction_context

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -90,9 +90,9 @@ class Solver:
                 A prioritized list of channels to use for the solution.
             subdirs (Sequence[str]):
                 A prioritized list of subdirs to use for the solution.
-            specs_to_add (Set[:class:`MatchSpec`]):
+            specs_to_add (set[:class:`MatchSpec`]):
                 The set of package specs to add to the prefix.
-            specs_to_remove (Set[:class:`MatchSpec`]):
+            specs_to_remove (set[:class:`MatchSpec`]):
                 The set of package specs to remove from the prefix.
 
         """
@@ -204,7 +204,7 @@ class Solver:
                 See :meth:`solve_final_state`.
 
         Returns:
-            Tuple[PackageRef], Tuple[PackageRef]:
+            tuple[PackageRef], tuple[PackageRef]:
                 A two-tuple of PackageRef sequences.  The first is the group of packages to
                 remove from the environment, in sorted dependency order from leaves to roots.
                 The second is the group of packages to add to the environment, in sorted
@@ -275,7 +275,7 @@ class Solver:
                 whether to call find_conflicts (slow) in ssc.r.solve
 
         Returns:
-            Tuple[PackageRef]:
+            tuple[PackageRef]:
                 In sorted dependency order from roots to leaves, the package references for
                 the solved state of the environment.
 
@@ -1569,8 +1569,8 @@ def diff_for_unlink_link_precs(
 # def get_install_transaction(prefix, index, spec_strs, force=False, only_names=None,
 #                             always_copy=False, pinned=True, update_deps=True,
 #                             prune=False, channel_priority_map=None, is_update=False):
-#     # type: (str, Dict[Dist, Record], List[str], bool, Option[List[str]], bool, bool, bool,
-#     #        bool, bool, bool, Dict[str, Sequence[str, int]]) -> List[Dict[weird]]
+#     # type: (str, dict[Dist, Record], list[str], bool, list[str] | None, bool, bool, bool,
+#     #        bool, bool, bool, dict[str, Sequence[str, int]]) -> list[dict[weird]]
 #
 #     # split out specs into potentially multiple preferred envs if:
 #     #  1. the user default env (root_prefix) is the prefix being considered here

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -556,11 +556,11 @@ class SubdirData(metaclass=SubdirDataType):
         return _pickled_state
 
     def _process_raw_repodata_str(
-        self, raw_repodata_str, state: RepodataState | None = None
+        self,
+        raw_repodata_str,
+        state: RepodataState | None = None,
     ):
-        """
-        state contains information that was previously in-band in raw_repodata_str.
-        """
+        """State contains information that was previously in-band in raw_repodata_str."""
         json_obj = json.loads(raw_repodata_str or "{}")
         return self._process_raw_repodata(json_obj, state=state)
 

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -103,9 +103,7 @@ class SubdirDataType(type):
 
 
 class PackageRecordList(UserList):
-    """
-    Lazily convert dicts to PackageRecord.
-    """
+    """Lazily convert dicts to PackageRecord."""
 
     def __getitem__(self, i):
         if isinstance(i, slice):
@@ -221,9 +219,7 @@ class SubdirData(metaclass=SubdirDataType):
 
     @property
     def _repo(self) -> RepoInterface:
-        """
-        Changes as we mutate self.repodata_fn.
-        """
+        """Changes as we mutate self.repodata_fn."""
         return self.RepoInterface(
             self.url_w_credentials,
             self.repodata_fn,
@@ -263,9 +259,7 @@ class SubdirData(metaclass=SubdirDataType):
 
     @property
     def cache_path_state(self):
-        """
-        Out-of-band etag and other state needed by the RepoInterface.
-        """
+        """Out-of-band etag and other state needed by the RepoInterface."""
         return Path(
             self.cache_path_base
             + ("1" if context.use_only_tar_bz2 else "")
@@ -499,9 +493,7 @@ class SubdirData(metaclass=SubdirDataType):
             return _internal_state
 
     def _pickle_valid_checks(self, pickled_state, mod, etag):
-        """
-        Throw away the pickle if these don't all match.
-        """
+        """Throw away the pickle if these don't all match."""
         yield "_url", pickled_state.get("_url"), self.url_w_credentials
         yield "_schannel", pickled_state.get("_schannel"), self.channel.canonical_name
         yield "_add_pip", pickled_state.get(

--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from functools import wraps
 from types import ModuleType
+from typing import Any, Callable
 
 from packaging.version import Version, parse
 

--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -157,7 +157,7 @@ class DeprecationHandler:
         addendum: str | None = None,
         stack: int = 0,
     ) -> None:
-        """Deprecation function for module constant (global).
+        """Deprecation function for module constant/global.
 
         :param deprecate_in: Version in which code will be marked as deprecated.
         :param remove_in: Version in which code is expected to be removed.

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -366,9 +366,7 @@ if on_win:  # pragma: no cover
 
 
 def linked_data(prefix, ignore_channels=False):
-    """
-    Return a dictionary of the linked packages in prefix.
-    """
+    """Return a dictionary of the linked packages in prefix."""
     from .core.prefix_data import PrefixData
     from .models.dist import Dist
 
@@ -380,9 +378,7 @@ def linked_data(prefix, ignore_channels=False):
 
 
 def linked(prefix, ignore_channels=False):
-    """
-    Return the Dists of linked packages in prefix.
-    """
+    """Return the Dists of linked packages in prefix."""
     from .models.enums import PackageType
 
     conda_package_types = PackageType.conda_package_types()

--- a/conda/gateways/connection/adapters/ftp.py
+++ b/conda/gateways/connection/adapters/ftp.py
@@ -179,7 +179,8 @@ class FTPAdapter(BaseAdapter):
         """Given a PreparedRequest object, reverse the process of adding HTTP
         Basic auth to obtain the username and password. Allows the FTP adapter
         to piggyback on the basic auth notation without changing the control
-        flow."""
+        flow.
+        """
         auth_header = request.headers.get("Authorization")
 
         if auth_header:
@@ -207,7 +208,8 @@ class FTPAdapter(BaseAdapter):
     def get_host_and_path_from_url(self, request):
         """Given a PreparedRequest object, split the URL in such a manner as to
         determine the host and the path. This is a separate method to wrap some
-        of urlparse's craziness."""
+        of urlparse's craziness.
+        """
         url = request.url
         parsed = urlparse(url)
         path = parsed.path
@@ -225,7 +227,8 @@ class FTPAdapter(BaseAdapter):
 def data_callback_factory(variable):
     """Returns a callback suitable for use by the FTP library. This callback
     will repeatedly save data into the variable provided to this function. This
-    variable should be a file-like structure."""
+    variable should be a file-like structure.
+    """
 
     def callback(data):
         variable.write(data)
@@ -245,7 +248,8 @@ def build_binary_response(request, data, code):
 
 def build_response(request, data, code, encoding):
     """Builds a response object from the data returned by ftplib, using the
-    specified encoding."""
+    specified encoding.
+    """
     response = Response()
 
     response.encoding = encoding
@@ -266,7 +270,8 @@ def build_response(request, data, code, encoding):
 
 def parse_multipart_files(request):
     """Given a prepared request, return a file-like object containing the
-    original data. This is pretty hacky."""
+    original data. This is pretty hacky.
+    """
     # Start by grabbing the pdict.
     _, pdict = cgi.parse_header(request.headers["Content-Type"])
 

--- a/conda/gateways/connection/adapters/ftp.py
+++ b/conda/gateways/connection/adapters/ftp.py
@@ -289,8 +289,8 @@ def parse_multipart_files(request):
 
 
 def get_status_code_from_code_response(code):
-    """
-    The idea is to handle complicated code response (even multi lines).
+    r"""Handle complicated code response, even multi-lines.
+
     We get the status code in two ways:
     - extracting the code from the last valid line in the response
     - getting it from the 3 first digits in the code

--- a/conda/gateways/connection/adapters/ftp.py
+++ b/conda/gateways/connection/adapters/ftp.py
@@ -135,7 +135,6 @@ class FTPAdapter(BaseAdapter):
 
     def stor(self, path, request):
         """Executes the FTP STOR command on the given path."""
-
         # First, get the file handle. We assume (bravely)
         # that there is only one file to be sent to a given URL. We also
         # assume that the filename is sent as part of the URL, not as part of

--- a/conda/gateways/connection/download.py
+++ b/conda/gateways/connection/download.py
@@ -264,9 +264,7 @@ def download_text(url):
 
 
 class TmpDownload:
-    """
-    Context manager to handle downloads to a tempfile
-    """
+    """Context manager to handle downloads to a tempfile."""
 
     def __init__(self, url, verbose=True):
         self.url = url

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -283,7 +283,8 @@ def backoff_rmdir(dirpath, max_tries=MAX_TRIES):
 def path_is_clean(path):
     """Sometimes we can't completely remove a path because files are considered in use
     by python (hardlinking confusion).  For our tests, it is sufficient that either the
-    folder doesn't exist, or nothing but temporary file copies are left."""
+    folder doesn't exist, or nothing but temporary file copies are left.
+    """
     clean = not exists(path)
     if not clean:
         for root, dirs, fns in walk(path):

--- a/conda/gateways/disk/link.py
+++ b/conda/gateways/disk/link.py
@@ -218,11 +218,12 @@ else:  # pragma: no cover
         return "\\\\?\\" + path
 
     def local_format(string):
-        """
-        format the string using variables in the caller's local namespace.
-        >>> a = 3
-        >>> local_format("{a:5}")
-        '    3'
+        """Format the string using variables in the caller's local namespace.
+
+        .. code-block:: pycon
+            >>> a = 3
+            >>> local_format("{a:5}")
+            '    3'
         """
         context = inspect.currentframe().f_back.f_locals
         return string.format_map(context)

--- a/conda/gateways/disk/link.py
+++ b/conda/gateways/disk/link.py
@@ -229,9 +229,7 @@ else:  # pragma: no cover
         return string.format_map(context)
 
     def is_symlink(path):
-        """
-        Assuming path is a reparse point, determine if it's a symlink.
-        """
+        """Assuming path is a reparse point, determine if it's a symlink."""
         path = _patch_path(path)
         try:
             return _is_symlink(next(find_files(path)))

--- a/conda/gateways/disk/link.py
+++ b/conda/gateways/disk/link.py
@@ -340,9 +340,9 @@ else:  # pragma: no cover
             return cast(data, POINTER(arr_typ)).contents.value
 
     def readlink(link):
-        """
+        """Return a string representing the path to which the symbolic link points.
+
         readlink(link) -> target
-        Return a string representing the path to which the symbolic link points.
         """
         handle = CreateFile(
             link,

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -13,6 +13,7 @@ from itertools import chain
 from logging import getLogger
 from os.path import isdir, isfile, join  # noqa
 from pathlib import Path
+from typing import Literal
 
 from ...auxlib.collection import first
 from ...auxlib.compat import shlex_split_unicode

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -228,14 +228,13 @@ def read_paths_json(extracted_package_directory):
 
 
 def read_has_prefix(path):
-    """
-    reads `has_prefix` file and return dict mapping filepaths to tuples(placeholder, FileMode)
+    """Reads `has_prefix` file and return dict mapping filepaths to tuples(placeholder, FileMode).
 
-    A line in `has_prefix` contains one of
+    A line in `has_prefix` contains one of:
       * filepath
       * placeholder mode filepath
 
-    mode values are one of
+    Mode values are one of:
       * text
       * binary
     """

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import os
 import re
 import tempfile
@@ -9,7 +11,6 @@ from logging import getLogger
 from os.path import basename, dirname, exists, isdir, join, split
 from shutil import move
 from subprocess import PIPE, Popen
-from typing import Optional
 
 from ...base.constants import DRY_RUN_PREFIX
 from ...base.context import context
@@ -102,9 +103,7 @@ def rename(source_path, destination_path, force=False):
 
 
 @contextmanager
-def rename_context(
-    source: str, destination: Optional[str] = None, dry_run: bool = False
-):
+def rename_context(source: str, destination: str | None = None, dry_run: bool = False):
     """
     Used for removing a directory when there are dependent actions (i.e. you need to ensure
     other actions succeed before removing it).

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -109,37 +109,10 @@ class StdStreamHandler(StreamHandler):
         output to the stream.
         """
         try:
-            unicode
-            _unicode = True
-        except NameError:
-            _unicode = False
-
-        try:
             msg = self.format(record)
             stream = self.stream
             fs = "%s"
-            if not _unicode:  # if no unicode support...
-                stream.write(fs % msg)
-            else:
-                try:
-                    if isinstance(msg, unicode) and getattr(
-                        stream, "encoding", None
-                    ):  # NOQA
-                        ufs = "%s"
-                        try:
-                            stream.write(ufs % msg)
-                        except UnicodeEncodeError:
-                            # Printing to terminals sometimes fails. For example,
-                            # with an encoding of 'cp1251', the above write will
-                            # work if written to a stream opened or wrapped by
-                            # the codecs module, but fail when writing to a
-                            # terminal even when the codepage is set to cp1251.
-                            # An extra encoding step seems to be needed.
-                            stream.write((ufs % msg).encode(stream.encoding))
-                    else:
-                        stream.write(fs % msg)
-                except UnicodeError:
-                    stream.write(fs % msg.encode("UTF-8"))
+            stream.write(fs % msg)
             terminator = getattr(record, "terminator", self.terminator)
             stream.write(terminator)
             self.flush()

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -47,7 +47,6 @@ class TokenURLFilter(Filter):
         At the same time we replace tokens in the arguments which was
         not happening until now.
         """
-
         record.msg = self.TOKEN_REPLACE(record.msg)
         if record.args:
             new_args = tuple(
@@ -109,7 +108,6 @@ class StdStreamHandler(StreamHandler):
         has an 'encoding' attribute, it is used to determine how to do the
         output to the stream.
         """
-
         try:
             unicode
             _unicode = True

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -85,9 +85,7 @@ class Response304ContentUnchanged(Exception):
 
 
 class CondaRepoInterface(RepoInterface):
-    """
-    Provides an interface for retrieving repodata data from channels
-    """
+    """Provides an interface for retrieving repodata data from channels."""
 
     #: Channel URL
     _url: str
@@ -159,9 +157,7 @@ def _add_http_value_to_dict(resp, http_key, d, dict_key):
 
 @contextmanager
 def conda_http_errors(url, repodata_fn):
-    """
-    Use in a with: statement to translate requests exceptions to conda ones.
-    """
+    """Use in a with: statement to translate requests exceptions to conda ones."""
     try:
         yield
     except RequestsProxyError:
@@ -326,9 +322,7 @@ HTTP errors are often intermittent, and a simple retry will get you on your way.
 
 
 class RepodataState(UserDict):
-    """
-    Load/save `.state.json` that accompanies cached `repodata.json`
-    """
+    """Load/save `.state.json` that accompanies cached `repodata.json`."""
 
     _aliased = {"_mod", "_etag", "_cache_control", "_url"}
     _strings = {"mod", "etag", "cache_control", "url"}
@@ -374,9 +368,7 @@ class RepodataState(UserDict):
 
     @deprecated("23.3", "23.9", addendum="use RepodataCache")
     def save(self):
-        """
-        Must be called after writing cache_path_json, as its mtime is included in .state.json
-        """
+        """Must be called after writing cache_path_json, since mtime is included in .state.json."""
         serialized = dict(self)
         json_stat = self.cache_path_json.stat()
         serialized.update(
@@ -388,9 +380,7 @@ class RepodataState(UserDict):
 
     @property
     def mod(self) -> str:
-        """
-        Last-Modified header or ""
-        """
+        """Last-Modified header or ""."""
         return self.get("mod") or ""
 
     @mod.setter
@@ -399,9 +389,7 @@ class RepodataState(UserDict):
 
     @property
     def etag(self) -> str:
-        """
-        Etag header or ""
-        """
+        """Etag header or ""."""
         return self.get("etag") or ""
 
     @etag.setter
@@ -410,9 +398,7 @@ class RepodataState(UserDict):
 
     @property
     def cache_control(self) -> str:
-        """
-        Cache-Control header or ""
-        """
+        """Cache-Control header or ""."""
         return self.get("cache_control") or ""
 
     @cache_control.setter
@@ -461,16 +447,12 @@ class RepodataState(UserDict):
         }
 
     def clear_has_format(self, format: str):
-        """
-        Remove 'has_{format}' instead of setting to False
-        """
+        """Remove 'has_{format}' instead of setting to False."""
         key = f"has_{format}"
         self.pop(key, None)
 
     def should_check_format(self, format: str) -> bool:
-        """
-        Return True if named format should be attempted.
-        """
+        """Return True if named format should be attempted."""
         has, when = self.has_format(format)
         return (
             has is True
@@ -526,9 +508,7 @@ class RepodataCache:
 
     @property
     def cache_path_state(self):
-        """
-        Out-of-band etag and other state needed by the RepoInterface.
-        """
+        """Out-of-band etag and other state needed by the RepoInterface."""
         return pathlib.Path(
             self.cache_dir,
             self.name + ("1" if context.use_only_tar_bz2 else "") + ".state.json",
@@ -593,9 +573,7 @@ class RepodataCache:
         return self.state
 
     def save(self, data: str):
-        """
-        Write data to <repodata>.json cache path, synchronize state.
-        """
+        """Write data to <repodata>.json cache path, synchronize state."""
         temp_path = self.cache_dir / f"{self.name}.{os.urandom(4).hex()}.tmp"
 
         try:
@@ -635,9 +613,7 @@ class RepodataCache:
             state_file.write(json.dumps(dict(self.state), indent=2))
 
     def refresh(self, refresh_ns=0):
-        """
-        Update access time in .state.json to indicate a HTTP 304 Not Modified response.
-        """
+        """Update access time in .state.json to indicate a HTTP 304 Not Modified response."""
         with self.cache_path_state.open("a+") as state_file, lock(state_file):
             # "a+" avoids trunctating file before we have the lock and creates
             state_file.seek(0)

--- a/conda/gateways/repodata/jlap/__init__.py
+++ b/conda/gateways/repodata/jlap/__init__.py
@@ -1,5 +1,3 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""
-Incremental repodata feature based on .jlap patch files.
-"""
+"""Incremental repodata feature based on .jlap patch files."""

--- a/conda/gateways/repodata/jlap/core.py
+++ b/conda/gateways/repodata/jlap/core.py
@@ -20,16 +20,14 @@ DEFAULT_IV = b"\0" * DIGEST_SIZE
 
 
 def keyed_hash(data: bytes, key: bytes):
-    """
-    Keyed hash.
-    """
+    """Keyed hash."""
     return blake2b(data, key=key, digest_size=DIGEST_SIZE)
 
 
 def line_and_pos(lines: Iterable[bytes], pos=0) -> Iterator[tuple[int, bytes]]:
-    """
-    lines: iterator over input split by '\n', with '\n' removed.
-    pos: initial position
+    r"""
+    :param lines: iterator over input split by '\n', with '\n' removed.
+    :param pos: initial position
     """
     for line in lines:
         yield pos, line
@@ -39,7 +37,7 @@ def line_and_pos(lines: Iterable[bytes], pos=0) -> Iterator[tuple[int, bytes]]:
 class JLAP(UserList):
     @classmethod
     def from_lines(cls, lines: Iterable[bytes], iv: bytes, pos=0, verify=True):
-        """
+        r"""
         :param lines: iterator over input split by b'\n', with b'\n' removed
         :param pos: initial position
         :param iv: initialization vector (first line of .jlap stream, hex

--- a/conda/gateways/repodata/jlap/core.py
+++ b/conda/gateways/repodata/jlap/core.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""
-Small jlap reader.
-"""
+"""Small jlap reader."""
 
 from __future__ import annotations
 
@@ -116,29 +114,21 @@ class JLAP(UserList):
         return self
 
     def write(self, path: Path):
-        """
-        Write buffer to path.
-        """
+        """Write buffer to path."""
         with Path(path).open("w", encoding="utf-8", newline="\n") as p:
             return p.write("\n".join(b[1] for b in self))
 
     @property
     def body(self):
-        """
-        All lines except the first, and last two.
-        """
+        """All lines except the first, and last two."""
         return self[1:-2]
 
     @property
     def penultimate(self):
-        """
-        Next-to-last line. Should contain the footer.
-        """
+        """Next-to-last line. Should contain the footer."""
         return self[-2]
 
     @property
     def last(self):
-        """
-        Last line. Should contain the trailing checksum.
-        """
+        """Last line. Should contain the trailing checksum."""
         return self[-1]

--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -39,9 +39,7 @@ ZSTD_UNAVAILABLE = "zstd_unavailable"
 
 
 def hash():
-    """
-    Ordinary hash.
-    """
+    """Ordinary hash."""
     return blake2b(digest_size=DIGEST_SIZE)
 
 
@@ -98,9 +96,7 @@ def fetch_jlap(url, pos=0, etag=None, iv=b"", ignore_etag=True, session=None):
 def request_jlap(
     url, pos=0, etag=None, ignore_etag=True, session: Session | None = None
 ):
-    """
-    Return the part of the remote .jlap file we are interested in.
-    """
+    """Return the part of the remote .jlap file we are interested in."""
     headers = {}
     if pos:
         headers["range"] = f"bytes={pos}-"
@@ -147,9 +143,7 @@ def request_jlap(
 
 
 def format_hash(hash):
-    """
-    Abbreviate hash for formatting.
-    """
+    """Abbreviate hash for formatting."""
     return hash[:16] + "\N{HORIZONTAL ELLIPSIS}"
 
 
@@ -197,9 +191,7 @@ def timeme(message):
 
 
 def build_headers(json_path: pathlib.Path, state: RepodataState):
-    """
-    Caching headers for a path and state.
-    """
+    """Caching headers for a path and state."""
     headers = {}
     # simplify if we require state to be empty when json_path is missing.
     if json_path.exists():
@@ -225,9 +217,7 @@ class HashWriter(io.RawIOBase):
 def download_and_hash(
     hasher, url, json_path, session: Session, state: RepodataState | None, is_zst=False
 ):
-    """
-    Download url if it doesn't exist, passing bytes through hasher.update()
-    """
+    """Download url if it doesn't exist, passing bytes through hasher.update()."""
     state = state or RepodataState()
     headers = build_headers(json_path, state)
     timeout = context.remote_connect_timeout_secs, context.remote_read_timeout_secs

--- a/conda/gateways/repodata/lock.py
+++ b/conda/gateways/repodata/lock.py
@@ -19,9 +19,7 @@ LOCK_SLEEP = 1
 
 @contextmanager
 def _lock_noop(fd):
-    """
-    When locking is not available.
-    """
+    """When locking is not available."""
     yield
 
 

--- a/conda/history.py
+++ b/conda/history.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import codecs
 import logging
 import os
@@ -97,10 +99,8 @@ class History:
     def file_is_empty(self):
         return os.stat(self.path).st_size == 0
 
-    def update(self):
-        """
-        update the history file (creating a new one if necessary)
-        """
+    def update(self) -> None:
+        """Update the history file (creating a new one if necessary)."""
         try:
             try:
                 last = set(self.get_state())
@@ -116,10 +116,10 @@ class History:
             else:
                 raise
 
-    def parse(self):
-        """
-        parse the history file and return a list of
-        tuples(datetime strings, set of distributions/diffs, comments)
+    def parse(self) -> list[tuple[str, set[str], list[str]]]:
+        """Parse the history file.
+
+        Return a list of tuples(datetime strings, set of distributions/diffs, comments).
         """
         res = []
         if not isfile(self.path):
@@ -207,9 +207,9 @@ class History:
         return item
 
     def get_user_requests(self):
-        """
-        return a list of user requested items.  Each item is a dict with the
-        following keys:
+        """Return a list of user requested items.
+
+        Each item is a dict with the following keys:
         'date': the date and time running the command
         'cmd': a list of argv of the actual command which was run
         'action': install/remove/update
@@ -304,9 +304,7 @@ class History:
         return {name: spec for name, spec in spec_map.items() if name in prefix_recs}
 
     def construct_states(self):
-        """
-        return a list of tuples(datetime strings, set of distributions)
-        """
+        """Return a list of tuples(datetime strings, set of distributions)."""
         res = []
         cur = set()
         for dt, cont, unused_com in self.parse():
@@ -324,12 +322,12 @@ class History:
         return res
 
     def get_state(self, rev=-1):
-        """
-        return the state, i.e. the set of distributions, for a given revision,
-        defaults to latest (which is the same as the current state when
-        the log file is up-to-date)
+        """Return the state, i.e. the set of distributions, for a given revision.
 
-        Returns a list of dist_strs
+        Defaults to latest (which is the same as the current state when
+        the log file is up-to-date).
+
+        Returns a list of dist_strs.
         """
         states = self.construct_states()
         if not states:

--- a/conda/lock.py
+++ b/conda/lock.py
@@ -62,7 +62,6 @@ class FileLock:
     """
 
     def __init__(self, path_to_lock, retries=10):
-        """ """
         self.path_to_lock = abspath(path_to_lock)
         self.retries = retries
         self.lock_file_path = f"{self.path_to_lock}.pid{{0}}.{LOCK_EXTENSION}"

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -227,9 +227,7 @@ def touch_nonadmin(prefix):
 
 
 def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
-    """
-    clone existing prefix1 into new prefix2
-    """
+    """Clone existing prefix1 into new prefix2."""
     untracked_files = untracked(prefix1)
 
     # Discard conda, conda-env and any package that depends on them

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -152,9 +152,7 @@ def rel_path(prefix, path, windows_forward_slashes=True):
 
 
 def walk_prefix(prefix, ignore_predefined_files=True, windows_forward_slashes=True):
-    """
-    Return the set of all files in a given prefix directory.
-    """
+    """Return the set of all files in a given prefix directory."""
     res = set()
     prefix = abspath(prefix)
     ignore = {
@@ -198,9 +196,7 @@ def walk_prefix(prefix, ignore_predefined_files=True, windows_forward_slashes=Tr
 
 
 def untracked(prefix, exclude_self_build=False):
-    """
-    Return (the set) of all untracked files for a given prefix.
-    """
+    """Return (the set) of all untracked files for a given prefix."""
     conda_files = conda_installed_files(prefix, exclude_self_build)
     return {
         path
@@ -216,9 +212,7 @@ def untracked(prefix, exclude_self_build=False):
 
 
 def touch_nonadmin(prefix):
-    """
-    Creates $PREFIX/.nonadmin if sys.prefix/.nonadmin exists (on Windows)
-    """
+    """Creates $PREFIX/.nonadmin if sys.prefix/.nonadmin exists (on Windows)."""
     if on_win and exists(join(context.root_prefix, ".nonadmin")):
         if not isdir(prefix):
             os.makedirs(prefix)

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -67,9 +67,10 @@ class MatchSpecType(type):
 
 
 class MatchSpec(metaclass=MatchSpecType):
-    """
-    :class:`MatchSpec` is, fundamentally, a query language for conda packages.  Any of the fields
-    that comprise a :class:`PackageRecord` can be used to compose a :class:`MatchSpec`.
+    """The query language for conda packages.
+
+    Any of the fields that comprise a :class:`PackageRecord` can be used to compose a
+    :class:`MatchSpec`.
 
     :class:`MatchSpec` can be composed with keyword arguments, where keys are any of the
     attributes of :class:`PackageRecord`.  Values for keyword arguments are the exact values the
@@ -123,7 +124,6 @@ class MatchSpec(metaclass=MatchSpecType):
 
 
     Examples:
-
         >>> str(MatchSpec(name='foo', build='py2*', channel='conda-forge'))
         'conda-forge::foo[build=py2*]'
         >>> str(MatchSpec('foo 1.0 py27_0'))
@@ -145,7 +145,6 @@ class MatchSpec(metaclass=MatchSpecType):
       - build
     must be given as exact values.  In the future, the namespace field will be added to this list.
     Alternatively, an exact spec is given by '*[md5=12345678901234567890123456789012]'.
-
     """
 
     FIELD_NAMES = (

--- a/conda/models/prefix_graph.py
+++ b/conda/models/prefix_graph.py
@@ -34,8 +34,8 @@ class PrefixGraph:
     def __init__(self, records, specs=()):
         records = tuple(records)
         specs = set(specs)
-        self.graph = graph = {}  # Dict[PrefixRecord, Set[PrefixRecord]]
-        self.spec_matches = spec_matches = {}  # Dict[PrefixRecord, Set[MatchSpec]]
+        self.graph = graph = {}  # dict[PrefixRecord, set[PrefixRecord]]
+        self.spec_matches = spec_matches = {}  # dict[PrefixRecord, set[MatchSpec]]
         for node in records:
             parent_match_specs = tuple(MatchSpec(d) for d in node.depends)
             parent_nodes = {
@@ -56,7 +56,7 @@ class PrefixGraph:
             spec (MatchSpec):
 
         Returns:
-            Tuple[PrefixRecord]: The removed nodes.
+            tuple[PrefixRecord]: The removed nodes.
 
         """
         node_matches = {node for node in self.graph if spec.match(node)}
@@ -82,7 +82,7 @@ class PrefixGraph:
         A specialized method used to determine only dependencies of requested specs.
 
         Returns:
-            Tuple[PrefixRecord]: The removed nodes.
+            tuple[PrefixRecord]: The removed nodes.
 
         """
         graph = self.graph
@@ -111,7 +111,7 @@ class PrefixGraph:
         """Prune back all packages until all child nodes are anchored by a spec.
 
         Returns:
-            Tuple[PrefixRecord]: The pruned nodes.
+            tuple[PrefixRecord]: The pruned nodes.
 
         """
         graph = self.graph

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -12,12 +12,8 @@ from ..exceptions import InvalidVersionSpec
 log = getLogger(__name__)
 
 
-def normalized_version(version):
-    """
-    normalized_version() is needed by conda-env
-    It is currently being pulled from resolve instead, but
-    eventually it ought to come from here
-    """
+def normalized_version(version: str) -> VersionOrder:
+    """Parse a version string and return VersionOrder object."""
     return VersionOrder(version)
 
 
@@ -45,8 +41,8 @@ class SingleStrArgCachingType(type):
 
 
 class VersionOrder(metaclass=SingleStrArgCachingType):
-    """
-    This class implements an order relation between version strings.
+    """Implement an order relation between version strings.
+
     Version strings can contain the usual alphanumeric characters
     (A-Za-z0-9), separated into components by dots and underscores. Empty
     segments (i.e. two consecutive dots, a leading/trailing underscore)
@@ -56,7 +52,6 @@ class VersionOrder(metaclass=SingleStrArgCachingType):
     scheme itself). Version comparison is case-insensitive.
 
     Conda supports six types of version strings:
-
     * Release versions contain only integers, e.g. '1.0', '2.3.5'.
     * Pre-release versions use additional letters such as 'a' or 'rc',
       for example '1.0a1', '1.2.beta3', '2.3.5rc3'.
@@ -76,14 +71,12 @@ class VersionOrder(metaclass=SingleStrArgCachingType):
     To obtain a predictable version ordering, it is crucial to keep the
     version number scheme of a given package consistent over time.
     Specifically,
-
     * version strings should always have the same number of components
       (except for an optional tag suffix or local version string),
     * letters/strings indicating non-release versions should always
       occur at the same position.
 
     Before comparison, version strings are parsed as follows:
-
     * They are first split into epoch, version number, and local version
       number at '!' and '+' respectively. If there is no '!', the epoch is
       set to 0. If there is no '+', the local version is empty.
@@ -97,13 +90,11 @@ class VersionOrder(metaclass=SingleStrArgCachingType):
     * The same is repeated for the local version part.
 
     Examples:
-
         1.2g.beta15.rc  =>  [[0], [1], [2, 'g'], [0, 'beta', 15], [0, 'rc']]
         1!2.15.1_ALPHA  =>  [[1], [2], [15], [1, '_alpha']]
 
     The resulting lists are compared lexicographically, where the following
     rules are applied to each pair of corresponding subcomponents:
-
     * integers are compared numerically
     * strings are compared lexicographically, case-insensitive
     * strings are smaller than integers, except
@@ -113,7 +104,6 @@ class VersionOrder(metaclass=SingleStrArgCachingType):
       treated as integer 0 to ensure '1.1' == '1.1.0'.
 
     The resulting order is:
-
            0.4
          < 0.4.0
          < 0.4.1.rc

--- a/conda/notices/cache.py
+++ b/conda/notices/cache.py
@@ -52,9 +52,7 @@ def is_notice_response_cache_expired(
     now = datetime.now(timezone.utc)
 
     def is_channel_notice_expired(expired_at: Optional[datetime]) -> bool:
-        """
-        If there is no "expired_at" field present assume it is expired
-        """
+        """If there is no "expired_at" field present assume it is expired."""
         if expired_at is None:
             return True
         return expired_at < now
@@ -88,9 +86,7 @@ def get_notices_cache_file() -> Path:
 def get_notice_response_from_cache(
     url: str, name: str, cache_dir: Path
 ) -> Optional[ChannelNoticeResponse]:
-    """
-    Retrieves a notice response object from cache if it exists.
-    """
+    """Retrieves a notice response object from cache if it exists."""
     cache_key = ChannelNoticeResponse.get_cache_key(url, cache_dir)
 
     if os.path.isfile(cache_key):
@@ -105,9 +101,7 @@ def get_notice_response_from_cache(
 def write_notice_response_to_cache(
     channel_notice_response: ChannelNoticeResponse, cache_dir: Path
 ) -> None:
-    """
-    Writes our notice data to our local cache location
-    """
+    """Writes our notice data to our local cache location."""
     cache_key = ChannelNoticeResponse.get_cache_key(
         channel_notice_response.url, cache_dir
     )
@@ -119,9 +113,7 @@ def write_notice_response_to_cache(
 def mark_channel_notices_as_viewed(
     cache_file: Path, channel_notices: Sequence[ChannelNotice]
 ) -> None:
-    """
-    Insert channel notice into our database marking it as read.
-    """
+    """Insert channel notice into our database marking it as read."""
     notice_ids = {chn.id for chn in channel_notices}
 
     with open(cache_file) as fp:
@@ -138,9 +130,7 @@ def mark_channel_notices_as_viewed(
 def get_viewed_channel_notice_ids(
     cache_file: Path, channel_notices: Sequence[ChannelNotice]
 ) -> Set[str]:
-    """
-    Return the ids of the channel notices which have already been seen.
-    """
+    """Return the ids of the channel notices which have already been seen."""
     notice_ids = {chn.id for chn in channel_notices}
 
     with open(cache_file) as fp:

--- a/conda/notices/cache.py
+++ b/conda/notices/cache.py
@@ -6,13 +6,15 @@ Handles all caching logic including:
   - Saving to cache
   - Determining whether not certain items have expired and need to be refreshed
 """
+from __future__ import annotations
+
 import json
 import logging
 import os
 from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path
-from typing import Optional, Sequence, Set
+from typing import Sequence
 
 from .._vendor.appdirs import user_cache_dir
 from ..base.constants import APP_NAME, NOTICES_CACHE_FN, NOTICES_CACHE_SUBDIR
@@ -51,7 +53,7 @@ def is_notice_response_cache_expired(
     """
     now = datetime.now(timezone.utc)
 
-    def is_channel_notice_expired(expired_at: Optional[datetime]) -> bool:
+    def is_channel_notice_expired(expired_at: datetime | None) -> bool:
         """If there is no "expired_at" field present assume it is expired."""
         if expired_at is None:
             return True
@@ -85,7 +87,7 @@ def get_notices_cache_file() -> Path:
 
 def get_notice_response_from_cache(
     url: str, name: str, cache_dir: Path
-) -> Optional[ChannelNoticeResponse]:
+) -> ChannelNoticeResponse | None:
     """Retrieves a notice response object from cache if it exists."""
     cache_key = ChannelNoticeResponse.get_cache_key(url, cache_dir)
 
@@ -129,7 +131,7 @@ def mark_channel_notices_as_viewed(
 
 def get_viewed_channel_notice_ids(
     cache_file: Path, channel_notices: Sequence[ChannelNotice]
-) -> Set[str]:
+) -> set[str]:
     """Return the ids of the channel notices which have already been seen."""
     notice_ids = {chn.id for chn in channel_notices}
 

--- a/conda/notices/core.py
+++ b/conda/notices/core.py
@@ -68,9 +68,7 @@ def retrieve_notices(
 
 
 def display_notices(channel_notice_set: ChannelNoticeResultSet) -> None:
-    """
-    Prints the channel notices to std out
-    """
+    """Prints the channel notices to std out."""
     views.print_notices(channel_notice_set.channel_notices)
 
     # Updates cache database, marking displayed notices as "viewed"
@@ -163,9 +161,7 @@ def filter_notices(
     limit: int | None = None,
     exclude: set[str] | None = None,
 ) -> Sequence[ChannelNotice]:
-    """
-    Perform filtering actions for the provided sequence of ChannelNotice objects.
-    """
+    """Perform filtering actions for the provided sequence of ChannelNotice objects."""
     if exclude:
         channel_notices = tuple(
             channel_notice

--- a/conda/notices/fetch.py
+++ b/conda/notices/fetch.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional, Sequence, Tuple
+from typing import Sequence
 
 import requests
 
@@ -15,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_notice_responses(
-    url_and_names: Sequence[Tuple[str, str]],
+    url_and_names: Sequence[tuple[str, str]],
     silent: bool = False,
     max_workers: int = 10,
 ) -> Sequence[ChannelNoticeResponse]:
@@ -47,7 +49,7 @@ def get_notice_responses(
 
 
 @cached_response
-def get_channel_notice_response(url: str, name: str) -> Optional[ChannelNoticeResponse]:
+def get_channel_notice_response(url: str, name: str) -> ChannelNoticeResponse | None:
     """
     Return a channel response object. We use this to wrap the response with
     additional channel information to use. If the response was invalid we suppress/log

--- a/conda/notices/types.py
+++ b/conda/notices/types.py
@@ -9,9 +9,7 @@ from ..base.constants import NoticeLevel
 
 
 class ChannelNotice(NamedTuple):
-    """
-    Represents an individual channel notice
-    """
+    """Represents an individual channel notice."""
 
     id: Optional[str]
     channel_name: Optional[str]
@@ -78,9 +76,7 @@ class ChannelNoticeResponse(NamedTuple):
 
     @staticmethod
     def _parse_iso_timestamp(iso_timestamp: Optional[str]) -> Optional[datetime]:
-        """
-        We try to parse this as a valid ISO timestamp and fail over to a default value of none.
-        """
+        """Parse ISO timestamp and fail over to a default value of none."""
         if iso_timestamp is None:
             return None
         try:
@@ -90,9 +86,7 @@ class ChannelNoticeResponse(NamedTuple):
 
     @classmethod
     def get_cache_key(cls, url: str, cache_dir: Path) -> Path:
-        """
-        Returns the place where this channel response will be stored as cache by hashing the url.
-        """
+        """Returns where this channel response will be cached by hashing the URL."""
         bytes_filename = url.encode()
         sha256_hash = hashlib.sha256(bytes_filename)
         cache_filename = f"{sha256_hash.hexdigest()}.json"

--- a/conda/notices/types.py
+++ b/conda/notices/types.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import hashlib
 from datetime import datetime
 from pathlib import Path
-from typing import NamedTuple, Optional, Sequence
+from typing import NamedTuple, Sequence
 
 from ..base.constants import NoticeLevel
 
@@ -11,13 +13,13 @@ from ..base.constants import NoticeLevel
 class ChannelNotice(NamedTuple):
     """Represents an individual channel notice."""
 
-    id: Optional[str]
-    channel_name: Optional[str]
-    message: Optional[str]
+    id: str | None
+    channel_name: str | None
+    message: str | None
     level: NoticeLevel
-    created_at: Optional[datetime]
-    expired_at: Optional[datetime]
-    interval: Optional[int]
+    created_at: datetime | None
+    expired_at: datetime | None
+    interval: int | None
 
 
 class ChannelNoticeResultSet(NamedTuple):
@@ -39,7 +41,7 @@ class ChannelNoticeResultSet(NamedTuple):
 class ChannelNoticeResponse(NamedTuple):
     url: str
     name: str
-    json_data: Optional[dict]
+    json_data: dict | None
 
     @property
     def notices(self) -> Sequence[ChannelNotice]:
@@ -63,7 +65,7 @@ class ChannelNoticeResponse(NamedTuple):
         return ()
 
     @staticmethod
-    def _parse_notice_level(level: Optional[str]) -> NoticeLevel:
+    def _parse_notice_level(level: str | None) -> NoticeLevel:
         """
         We use this to validate notice levels and provide reasonable defaults
         if any are invalid.
@@ -75,7 +77,7 @@ class ChannelNoticeResponse(NamedTuple):
             return NoticeLevel(NoticeLevel.INFO)
 
     @staticmethod
-    def _parse_iso_timestamp(iso_timestamp: Optional[str]) -> Optional[datetime]:
+    def _parse_iso_timestamp(iso_timestamp: str | None) -> datetime | None:
         """Parse ISO timestamp and fail over to a default value of none."""
         if iso_timestamp is None:
             return None

--- a/conda/notices/views.py
+++ b/conda/notices/views.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""
-Handles all display/view logic
-"""
+"""Handles all display/view logic."""
 from typing import Sequence
 
 from .types import ChannelNotice
@@ -31,9 +29,7 @@ def print_notices(channel_notices: Sequence[ChannelNotice]):
 
 
 def print_notice_message(notice: ChannelNotice, indent: str = "  ") -> None:
-    """
-    Prints a single channel notice
-    """
+    """Prints a single channel notice."""
     timestamp = f"{notice.created_at:%c}" if notice.created_at else ""
 
     level = f"[{notice.level}] -- {timestamp}"
@@ -44,9 +40,7 @@ def print_notice_message(notice: ChannelNotice, indent: str = "  ") -> None:
 def print_more_notices_message(
     total_notices: int, displayed_notices: int, viewed_notices: int
 ) -> None:
-    """
-    Conditionally shows a message informing users how many more message there are.
-    """
+    """Conditionally shows a message informing users how many more message there are."""
     notices_not_shown = total_notices - viewed_notices - displayed_notices
 
     if notices_not_shown > 0:

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -574,9 +574,7 @@ def get_blank_actions(prefix):  # pragma: no cover
 
 @time_recorder("execute_plan")
 def execute_plan(old_plan, index=None, verbose=False):  # pragma: no cover
-    """
-    Deprecated: This should `conda.instructions.execute_instructions` instead
-    """
+    """Deprecated: This should `conda.instructions.execute_instructions` instead."""
     plan = _update_old_plan(old_plan)
     execute_instructions(plan, index, verbose)
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -23,10 +23,7 @@ class CondaSpecs:
         """
         Register solvers in conda.
 
-        :return: An iterable of solvers entries.
-
         Example:
-
         .. code-block:: python
 
             import logging
@@ -51,6 +48,7 @@ class CondaSpecs:
                     backend=VerboseSolver,
                 )
 
+        :return: An iterable of solvers entries.
         """
 
     @_hookspec
@@ -58,10 +56,7 @@ class CondaSpecs:
         """
         Register external subcommands in conda.
 
-        :return: An iterable of subcommand entries.
-
         Example:
-
         .. code-block:: python
 
             from conda import plugins
@@ -79,6 +74,7 @@ class CondaSpecs:
                     action=example_command,
                 )
 
+        :return: An iterable of subcommand entries.
         """
 
     @_hookspec
@@ -86,10 +82,7 @@ class CondaSpecs:
         """
         Register virtual packages in Conda.
 
-        :return: An iterable of virtual package entries.
-
         Example:
-
         .. code-block:: python
 
             from conda import plugins
@@ -103,4 +96,5 @@ class CondaSpecs:
                     build="x86_64",
                 )
 
+        :return: An iterable of virtual package entries.
         """

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -14,9 +14,7 @@ hookimpl = pluggy.HookimplMarker(spec_name)
 
 
 class CondaSpecs:
-    """
-    The conda plugin hookspecs, to be used by developers.
-    """
+    """The conda plugin hookspecs, to be used by developers."""
 
     @_hookspec
     def conda_solvers(self) -> Iterable[CondaSolver]:

--- a/conda/plugins/solvers.py
+++ b/conda/plugins/solvers.py
@@ -6,9 +6,7 @@ from . import CondaSolver, hookimpl
 
 @hookimpl(tryfirst=True)  # make sure the classic solver can't be overwritten
 def conda_solvers():
-    """
-    The classic solver as shipped by default in conda.
-    """
+    """The classic solver as shipped by default in conda."""
     from ..core.solve import Solver
 
     yield CondaSolver(

--- a/conda/plugins/subcommands/doctor/__init__.py
+++ b/conda/plugins/subcommands/doctor/__init__.py
@@ -1,6 +1,4 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""
-Provide 'conda doctor' environment check feature.
-"""
+"""Provide 'conda doctor' environment check feature."""
 # This file is here for packaging, not for importing submodules.

--- a/conda/plugins/subcommands/doctor/cli.py
+++ b/conda/plugins/subcommands/doctor/cli.py
@@ -50,9 +50,7 @@ def get_prefix(args: argparse.Namespace) -> str:
 
 
 def execute(argv: list[str]) -> None:
-    """
-    Run conda doctor subcommand.
-    """
+    """Run conda doctor subcommand."""
     from .health_checks import display_health_checks
 
     args = get_parsed_args(argv)

--- a/conda/plugins/subcommands/doctor/health_checks.py
+++ b/conda/plugins/subcommands/doctor/health_checks.py
@@ -12,18 +12,14 @@ MISSING_FILES_SUCCESS_MESSAGE = f"{OK_MARK} There are no packages with missing f
 
 
 def display_report_heading(prefix: str) -> None:
-    """
-    Displays our report heading
-    """
+    """Displays our report heading."""
     print("-" * 20)
     print(REPORT_TITLE)
     print(f"Environment Name: {Path(prefix).name}\n")
 
 
 def find_packages_with_missing_files(prefix: str | Path) -> dict[str, list[str]]:
-    """
-    Finds packages listed in conda-meta which have missing files
-    """
+    """Finds packages listed in conda-meta which have missing files."""
     packages_with_missing_files = {}
     prefix = Path(prefix)
     for file in (prefix / "conda-meta").glob("*.json"):
@@ -35,9 +31,7 @@ def find_packages_with_missing_files(prefix: str | Path) -> dict[str, list[str]]
 
 
 def display_health_checks(prefix: str, verbose: bool) -> None:
-    """
-    Prints health report
-    """
+    """Prints health report."""
     display_report_heading(prefix)
     missing_files = find_packages_with_missing_files(prefix)
     if missing_files:

--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -54,9 +54,7 @@ def cuda_version():
 
 @functools.lru_cache(maxsize=None)
 def cached_cuda_version():
-    """
-    A cached version of the cuda detection system.
-    """
+    """A cached version of the cuda detection system."""
     return cuda_version()
 
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -633,7 +633,7 @@ class Resolve:
 
     @memoizemethod
     def _broader(self, ms, specs_by_name):
-        """prevent introduction of matchspecs that broaden our selection of choices"""
+        """Prevent introduction of matchspecs that broaden our selection of choices."""
         if not specs_by_name:
             return False
         return ms.strictness < specs_by_name[0].strictness

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -93,7 +93,8 @@ def exactness_and_number_of_deps(resolve_obj, ms):
     """Sorting key to emphasize packages that have more strict
     requirements. More strict means the reduced index can be reduced
     more, so we want to consider these more constrained deps earlier in
-    reducing the index."""
+    reducing the index.
+    """
     if ms.strictness == 3:
         prec = resolve_obj.find_matches(ms)
         value = 3

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import copy
 import itertools
 from collections import defaultdict, deque

--- a/conda/shell/conda.xsh
+++ b/conda/shell/conda.xsh
@@ -106,9 +106,7 @@ aliases['conda'] = _conda_main
 
 
 def _list_dirs(path):
-    """
-    Generator that lists the directories in a given path.
-    """
+    """Generator that lists the directories in a given path."""
     import os
     for entry in os.scandir(path):
         if not entry.name.startswith('.') and entry.is_dir():
@@ -116,9 +114,7 @@ def _list_dirs(path):
 
 
 def _get_envs_unfiltered():
-    """
-    Grab a list of all conda env dirs from conda, allowing all warnings.
-    """
+    """Grab a list of all conda env dirs from conda, allowing all warnings."""
     import os
     import importlib
 
@@ -152,9 +148,7 @@ def _get_envs_unfiltered():
 
 
 def _get_envs():
-    """
-    Grab a list of all conda env dirs from conda, ignoring all warnings
-    """
+    """Grab a list of all conda env dirs from conda, ignoring all warnings."""
     import warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -162,9 +156,7 @@ def _get_envs():
 
 
 def _conda_completer(prefix, line, start, end, ctx):
-    """
-    Completion for conda
-    """
+    """Completion for conda."""
     args = line.split(' ')
     possible = set()
     if len(args) == 0 or args[0] not in ['xonda', 'conda']:

--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -65,9 +65,7 @@ def disable_channel_notices():
 
 @pytest.fixture(scope="function")
 def reset_conda_context():
-    """
-    Resets the context object after each test function is run.
-    """
+    """Resets the context object after each test function is run."""
     yield
 
     reset_context()

--- a/conda/testing/gateways/fixtures.py
+++ b/conda/testing/gateways/fixtures.py
@@ -42,7 +42,7 @@ def minio_s3_server(xprocess, tmp_path):
             return f"http://localhost:{self.port}/{self.name}"
 
         def populate_bucket(self, endpoint, bucket_name, channel_dir):
-            "prepare the s3 connection for our minio instance"
+            """Prepare the s3 connection for our minio instance"""
 
             # Make the minio bucket public first
             # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-example-bucket-policies.html#set-a-bucket-policy

--- a/conda/testing/gateways/fixtures.py
+++ b/conda/testing/gateways/fixtures.py
@@ -43,7 +43,6 @@ def minio_s3_server(xprocess, tmp_path):
 
         def populate_bucket(self, endpoint, bucket_name, channel_dir):
             """Prepare the s3 connection for our minio instance"""
-
             # Make the minio bucket public first
             # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-example-bucket-policies.html#set-a-bucket-policy
             session = boto3.session.Session()

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""
-Helpers for the tests
-"""
+"""Helpers for the tests."""
 
 import json
 import os

--- a/conda/testing/notices/helpers.py
+++ b/conda/testing/notices/helpers.py
@@ -22,9 +22,9 @@ DEFAULT_NOTICE_MESG = "Here is an example message that will be displayed to user
 
 def get_test_notices(
     messages: Sequence[str],
-    level: Optional[str] = "info",
-    created_at: Optional[datetime.datetime] = None,
-    expired_at: Optional[datetime.datetime] = None,
+    level: str | None = "info",
+    created_at: datetime.datetime | None = None,
+    expired_at: datetime.datetime | None = None,
 ) -> dict:
     created_at = created_at or datetime.datetime.now(datetime.timezone.utc)
     expired_at = expired_at or created_at + datetime.timedelta(days=7)
@@ -98,7 +98,7 @@ class DummyArgs:
 def notices_decorator_assert_message_in_stdout(
     captured,
     messages: Sequence[str],
-    dummy_mesg: Optional[str] = None,
+    dummy_mesg: str | None = None,
     not_in: bool = False,
 ):
     """

--- a/conda/testing/notices/helpers.py
+++ b/conda/testing/notices/helpers.py
@@ -86,9 +86,7 @@ def offset_cache_file_mtime(mtime_offset) -> None:
 
 
 class DummyArgs:
-    """
-    Dummy object that sets all kwargs as object properties
-    """
+    """Dummy object that sets all kwargs as object properties."""
 
     def __init__(self, **kwargs):
         self.no_ansi_colors = True

--- a/conda/testing/solver_helpers.py
+++ b/conda/testing/solver_helpers.py
@@ -184,7 +184,7 @@ class SolverTests:
     """Tests for :py:class:`conda.core.solve.Solver` implementations."""
 
     @property
-    def solver_class(self) -> Type[Solver]:
+    def solver_class(self) -> type[Solver]:
         """Class under test."""
         raise NotImplementedError
 

--- a/conda/testing/solver_helpers.py
+++ b/conda/testing/solver_helpers.py
@@ -223,7 +223,8 @@ class SolverTests:
 
     def assert_unsatisfiable(self, exc_info, entries):
         """Helper to assert that a :py:class:`conda.exceptions.UnsatisfiableError`
-        instance as a the specified set of unsatisfiable specifications."""
+        instance as a the specified set of unsatisfiable specifications.
+        """
         assert issubclass(exc_info.type, UnsatisfiableError)
         if exc_info.type is UnsatisfiableError:
             assert (

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -10,6 +10,7 @@ from functools import lru_cache, wraps
 from os import PathLike, environ
 from os.path import abspath, basename, dirname, isfile, join
 from pathlib import Path
+from typing import Literal
 
 from . import CondaError
 from .auxlib.compat import Utf8NamedTemporaryFile, shlex_split_unicode

--- a/docs/source/_ext/conda_umls.py
+++ b/docs/source/_ext/conda_umls.py
@@ -48,9 +48,7 @@ replacements = (
 
 
 def post_process(files, output_path):
-    """
-    Replace all items from the replacements list above in the given files.
-    """
+    """Replace all items from the replacements list above in the given files."""
     for file in files:
         with fileinput.input(
             files=[os.path.join(output_path, file)], inplace=True

--- a/news/12620-add-flake8-docstrings
+++ b/news/12620-add-flake8-docstrings
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Add flake8-docstrings to pre-commit. (#12620)
+
+### Other
+
+* Enable flake8 checks that are now handled by black. (#12620)

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_ven
 
 [flake8]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D200,D202,D205,D400,D401
+ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D200,D205,D400,D401
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,13 +37,22 @@ pythonpath =
 
 [pycodestyle]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503
+ignore = E722,E731,W503
 exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 
 [flake8]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D205,D400,D401
+# E203 whitespace before ':'
+# E402 module level import not at top of file
+# E722 do not use bare 'except'
+# E731 do not assign a lambda expression, use a def
+# W503 line break before binary operator
+# D1** Missing docstring
+# D205 1 blank line required between summary line and description
+# D400 First line should end with a period
+# D401 First line should be in imperative mood
+ignore = E203,E402,E722,E731,W503,D1,D205,D400,D401
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,13 +35,9 @@ pythonpath =
     tests/plugins/data/test-plugin
 
 
-[pycodestyle]
-max-line-length = 99
-ignore = E722,E731,W503
-exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
-
-
 [flake8]
+# see black+flake8 config
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 max-line-length = 99
 # E203 whitespace before ':'
 # E402 module level import not at top of file
@@ -52,7 +48,7 @@ max-line-length = 99
 # D205 1 blank line required between summary line and description
 # D400 First line should end with a period
 # D401 First line should be in imperative mood
-ignore = E203,E402,E722,E731,W503,D1,D205,D400,D401
+extend-ignore = E203,E402,E722,E731,W503,D1,D205,D400,D401
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_ven
 
 [flake8]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203
+ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D200,D202,D205,D209,D400,D401,D403
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_ven
 
 [flake8]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D200,D202,D205,D209,D400,D401,D403
+ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D200,D202,D205,D209,D400,D401
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_ven
 
 [flake8]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D200,D205,D400,D401
+ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D205,D400,D401
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ exclude = build/*,.tox/*,devenv*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_ven
 
 [flake8]
 max-line-length = 99
-ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D200,D202,D205,D209,D400,D401
+ignore = E126,E133,E226,E241,E242,E302,E704,E731,E722,W503,E402,W504,F821,E203,D100,D101,D102,D103,D104,D105,D107,D200,D202,D205,D400,D401
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -139,8 +139,8 @@ class ContextCustomRcTests(TestCase):
     def test_signing_metadata_url_base_empty_default_channels(self):
         string = dals(
             """
-        default_channels: []
-        """
+            default_channels: []
+            """
         )
         reset_context()
         rd = {
@@ -155,8 +155,8 @@ class ContextCustomRcTests(TestCase):
     def test_client_ssl_cert(self):
         string = dals(
             """
-        client_ssl_cert_key: /some/key/path
-        """
+            client_ssl_cert_key: /some/key/path
+            """
         )
         reset_context()
         rd = {
@@ -421,21 +421,17 @@ class ContextCustomRcTests(TestCase):
             assert context.execute_threads == 3
 
     def test_channels_defaults(self):
-        """
-        Test when no channels provided in cli
-        """
+        """Test when no channels provided in cli."""
         reset_context(())
         assert context.channels == ("defaults",)
 
     def test_channels_defaults_condarc(self):
-        """
-        Test when no channels provided in cli, but some in condarc
-        """
+        """Test when no channels provided in cli, but some in condarc."""
         reset_context(())
         string = dals(
             """
-        channels: ['defaults', 'conda-forge']
-        """
+            channels: ['defaults', 'conda-forge']
+            """
         )
         rd = {
             "testdata": YamlRawParameter.make_raw_parameters(
@@ -461,8 +457,8 @@ class ContextCustomRcTests(TestCase):
         reset_context((), argparse_args=AttrDict(channel=["conda-forge"]))
         string = dals(
             """
-        channels: ['defaults', 'conda-forge']
-        """
+            channels: ['defaults', 'conda-forge']
+            """
         )
         rd = {
             "testdata": YamlRawParameter.make_raw_parameters(
@@ -482,8 +478,8 @@ class ContextCustomRcTests(TestCase):
         reset_context((), argparse_args=AttrDict(channel=["other"]))
         string = dals(
             """
-        channels: ['conda-forge']
-        """
+            channels: ['conda-forge']
+            """
         )
         rd = {
             "testdata": YamlRawParameter.make_raw_parameters(
@@ -505,8 +501,8 @@ class ContextCustomRcTests(TestCase):
         reset_context((), argparse_args=AttrDict(channel=["conda-forge"]))
         string = dals(
             """
-        channels: ['conda-forge']
-        """
+            channels: ['conda-forge']
+            """
         )
         rd = {
             "testdata": YamlRawParameter.make_raw_parameters(
@@ -517,9 +513,7 @@ class ContextCustomRcTests(TestCase):
         assert context.channels == ("conda-forge",)
 
     def test_expandvars(self):
-        """
-        Environment variables should be expanded in settings that have expandvars=True.
-        """
+        """Environment variables should be expanded in settings that have expandvars=True."""
 
         def _get_expandvars_context(attr, config_expr, env_value):
             with mock.patch.dict(os.environ, {"TEST_VAR": env_value}):
@@ -579,9 +573,7 @@ class ContextCustomRcTests(TestCase):
         assert any("foo" in d for d in pkgs_dirs)
 
     def test_channel_settings(self):
-        """
-        Makes sure that "channel_settings" appears as we expect it to on the context object
-        """
+        """Ensure "channel_settings" appears as we expect it to on the context object."""
         assert context.channel_settings == (
             {"channel": "darwin", "param_one": "value_one", "param_two": "value_two"},
             {

--- a/tests/cli/test_main_notices.py
+++ b/tests/cli/test_main_notices.py
@@ -215,9 +215,7 @@ def test_cache_names_appear_as_expected(
     notices_cache_dir,
     notices_mock_http_session_get,
 ):
-    """
-    This is a test to make sure the cache filenames appear as we expect them to.
-    """
+    """This is a test to make sure the cache filenames appear as we expect them to."""
     with mock.patch(
         "conda.notices.core.get_channel_name_and_urls"
     ) as get_channel_name_and_urls:
@@ -300,9 +298,7 @@ def test_notices_appear_once_when_running_decorated_commands(
 
 
 def test_notices_work_with_s3_channel(notices_cache_dir, notices_mock_http_session_get):
-    """
-    As a user, I want notices to be correctly retrieved from channels with s3 URLs.
-    """
+    """As a user, I want notices to be correctly retrieved from channels with s3 URLs."""
     s3_channel = "s3://conda-org"
     messages = ("Test One", "Test Two")
     messages_json = get_test_notices(messages)

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -147,9 +147,7 @@ def test_cannot_rename_base_env_by_path(env_one):
 
 
 def test_cannot_rename_active_env_by_name(env_one):
-    """
-    Makes sure that we cannot rename our active environment.
-    """
+    """Makes sure that we cannot rename our active environment."""
     _, data = list_envs()
     result = data.get("envs", [])
 

--- a/tests/common/test_configuration.py
+++ b/tests/common/test_configuration.py
@@ -656,8 +656,8 @@ class ConfigurationTests(TestCase):
         # regression test for conda/conda#3467
         string = dals(
             """
-        proxy_servers: bad values
-        """
+            proxy_servers: bad values
+            """
         )
         data = {
             "s1": YamlRawParameter.make_raw_parameters(

--- a/tests/common/test_url.py
+++ b/tests/common/test_url.py
@@ -111,9 +111,7 @@ URLPARSE_TEST_DATA = [
 
 @pytest.mark.parametrize("test_url_str,exp_url_obj", URLPARSE_TEST_DATA)
 def test_urlparse(test_url_str, exp_url_obj):
-    """
-    Tests a variety of different use cases for `conda.common.url.urlparse`
-    """
+    """Tests a variety of different use cases for `conda.common.url.urlparse`."""
     answer = urlparse(test_url_str)
 
     for attr in exp_url_obj.__annotations__.keys():
@@ -147,9 +145,7 @@ URL_OBJ_UNPARSE_DATA = [
 
 @pytest.mark.parametrize("test_url_obj, expected_url", URL_OBJ_UNPARSE_DATA)
 def test_url_obj_unparse(test_url_obj, expected_url):
-    """
-    Tests the variety of object instantiations for the `conda.common.url.Url`
-    """
+    """Tests the variety of object instantiations for the `conda.common.url.Url`."""
     url_obj = Url(*test_url_obj)
 
     assert str(url_obj) == expected_url

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -340,9 +340,7 @@ class IntegrationTests(unittest.TestCase):
         )
 
     def test_conda_env_create_empty_file(self):
-        """
-        Test `conda env create --file=file_name.yml` where file_name.yml is empty
-        """
+        """Test `conda env create --file=file_name.yml` where file_name.yml is empty."""
         tmp_file = tempfile.NamedTemporaryFile(suffix=".yml", delete=False)
 
         with self.assertRaises(SpecNotFound):
@@ -353,9 +351,7 @@ class IntegrationTests(unittest.TestCase):
 
     @pytest.mark.integration
     def test_conda_env_create_http(self):
-        """
-        Test `conda env create --file=https://some-website.com/environment.yml`
-        """
+        """Test `conda env create --file=https://some-website.com/environment.yml`."""
         run_env_command(
             Commands.ENV_CREATE,
             None,
@@ -599,9 +595,7 @@ class NewIntegrationTests(unittest.TestCase):
         run_env_command(Commands.ENV_REMOVE, TEST_ENV_NAME_2)
 
     def test_env_export(self):
-        """
-        Test conda env export
-        """
+        """Test conda env export."""
 
         run_conda_command(Commands.CREATE, TEST_ENV_NAME_2, "flask")
         assert env_is_created(TEST_ENV_NAME_2)
@@ -636,9 +630,7 @@ class NewIntegrationTests(unittest.TestCase):
         assert not env_is_created(TEST_ENV_NAME_2)
 
     def test_env_export_with_variables(self):
-        """
-        Test conda env export
-        """
+        """Test conda env export."""
 
         run_conda_command(Commands.CREATE, TEST_ENV_NAME_2, "flask")
         assert env_is_created(TEST_ENV_NAME_2)
@@ -681,9 +673,7 @@ class NewIntegrationTests(unittest.TestCase):
         assert not env_is_created(TEST_ENV_NAME_2)
 
     def test_env_export_json(self):
-        """
-        Test conda env export
-        """
+        """Test conda env export."""
 
         run_conda_command(Commands.CREATE, TEST_ENV_NAME_2, "flask")
         assert env_is_created(TEST_ENV_NAME_2)
@@ -719,9 +709,7 @@ class NewIntegrationTests(unittest.TestCase):
         assert not env_is_created(TEST_ENV_NAME_2)
 
     def test_list(self):
-        """
-        Test conda list -e and conda create from txt
-        """
+        """Test conda list -e and conda create from txt."""
 
         run_conda_command(Commands.CREATE, TEST_ENV_NAME_2)
         self.assertTrue(env_is_created(TEST_ENV_NAME_2))
@@ -743,9 +731,7 @@ class NewIntegrationTests(unittest.TestCase):
         self.assertEqual(snowflake, snowflake2)
 
     def test_export_multi_channel(self):
-        """
-        Test conda env export
-        """
+        """Test conda env export."""
         from conda.core.prefix_data import PrefixData
 
         PrefixData._cache_.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,9 +43,7 @@ def clear_cache():
 
 @pytest.fixture(scope="session")
 def support_file_server():
-    """
-    Open a local web server to test remote support files.
-    """
+    """Open a local web server to test remote support files."""
     base = Path(__file__).parents[0] / "conda_env" / "support"
     http = http_test_server.run_test_server(str(base))
     yield http

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -546,7 +546,5 @@ def test_cover_extract_bad_package(tmp_path):
 
 
 def test_conda_build_alias():
-    """
-    conda-build wants to use an old import.
-    """
+    """conda-build wants to use an old import."""
     assert conda.core.package_cache.ProgressiveFetchExtract

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -416,9 +416,7 @@ def test_state_is_not_json(tmp_path, platform=OVERRIDE_PLATFORM):
 
 
 def test_subdir_data_dict_state(platform=OVERRIDE_PLATFORM):
-    """
-    SubdirData can accept a dict instead of a RepodataState, for compatibility.
-    """
+    """SubdirData can accept a dict instead of a RepodataState, for compatibility."""
     local_channel = Channel(join(CHANNEL_DIR, platform))
     sd = SubdirData(channel=local_channel)
     sd._read_pickled({})  # type: ignore

--- a/tests/fixtures_jlap.py
+++ b/tests/fixtures_jlap.py
@@ -37,9 +37,7 @@ def shutdown():
 
 @app.route("/latency/<float:delay>")
 def latency(delay):
-    """
-    Set delay before each file response.
-    """
+    """Set delay before each file response."""
     global LATENCY
     LATENCY = delay
     return "OK"
@@ -76,9 +74,7 @@ def make_server_with_socket(socket: socket.socket, base_: Path = base):
 
 
 def run_on_random_port():
-    """
-    Run in a new process to minimize interference with test.
-    """
+    """Run in a new process to minimize interference with test."""
     return next(_package_server())
 
 

--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -37,9 +37,7 @@ def test_server_available(package_server: socket):
 
 
 def test_jlap_fetch(package_server: socket, tmp_path: Path, mocker):
-    """
-    Check that JlapRepoInterface doesn't raise exceptions.
-    """
+    """Check that JlapRepoInterface doesn't raise exceptions."""
     host, port = package_server.getsockname()
     base = f"http://{host}:{port}/test"
 
@@ -144,9 +142,7 @@ def test_repodata_state(
     package_server: socket,
     use_jlap: bool,
 ):
-    """
-    Test that .state.json file works correctly.
-    """
+    """Test that .state.json file works correctly."""
     host, port = package_server.getsockname()
     base = f"http://{host}:{port}/test"
     channel_url = f"{base}/osx-64"
@@ -196,10 +192,7 @@ def test_repodata_state(
 
 @pytest.mark.parametrize("use_jlap", ["jlap", "jlapopotamus", "jlap,another", ""])
 def test_jlap_flag(use_jlap):
-    """
-    Test that CONDA_EXPERIMENTAL is a comma-delimited list.
-    """
-
+    """Test that CONDA_EXPERIMENTAL is a comma-delimited list."""
     with env_vars(
         {"CONDA_EXPERIMENTAL": use_jlap},
         stack_callback=conda_tests_ctxt_mgmt_def_pol,
@@ -213,9 +206,7 @@ def test_jlap_sought(
     tmp_path: Path,
     package_repository_base: Path,
 ):
-    """
-    Test that we try to fetch the .jlap file.
-    """
+    """Test that we try to fetch the .jlap file."""
     host, port = package_server.getsockname()
     base = f"http://{host}:{port}/test"
     channel_url = f"{base}/osx-64"
@@ -355,9 +346,7 @@ def test_jlap_sought(
 def test_jlap_errors(
     package_server: socket, tmp_path: Path, package_repository_base: Path, mocker
 ):
-    """
-    Test that we handle 304 Not Modified responses, other errors.
-    """
+    """Test that we handle 304 Not Modified responses, other errors."""
     host, port = package_server.getsockname()
     base = f"http://{host}:{port}/test"
     channel_url = f"{base}/osx-64"
@@ -552,9 +541,7 @@ def test_jlap_zst_not_404(mocker, package_server, tmp_path):
 
 
 def test_jlap_core(tmp_path: Path):
-    """
-    Code paths not excercised by other tests.
-    """
+    """Code paths not excercised by other tests."""
     with pytest.raises(ValueError):
         # incorrect trailing hash
         core.JLAP.from_lines(
@@ -591,9 +578,7 @@ def test_jlap_core(tmp_path: Path):
 
 
 def make_test_jlap(original: bytes, changes=1):
-    """
-    :original: as bytes, to avoid any newline confusion.
-    """
+    """:original: as bytes, to avoid any newline confusion."""
 
     def jlap_lines():
         yield core.DEFAULT_IV.hex().encode("utf-8")
@@ -630,9 +615,7 @@ def make_test_jlap(original: bytes, changes=1):
 
 
 def test_jlap_get_place():
-    """
-    (probably soon to be removed) helper function to get cache filenames.
-    """
+    """(probably soon to be removed) helper function to get cache filenames."""
     place = fetch.get_place(
         "https://repo.anaconda.com/main/linux-64/current_repodata.json"
     ).name
@@ -644,9 +627,7 @@ def test_jlap_get_place():
 
 
 def test_hashwriter():
-    """
-    Test that HashWriter closes its backing file in a context manager.
-    """
+    """Test that HashWriter closes its backing file in a context manager."""
     closed = False
 
     class backing:

--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -39,9 +39,7 @@ from conda.gateways.repodata import (
 
 
 def test_save(tmp_path):
-    """
-    Check regular cache save, load operations.
-    """
+    """Check regular cache save, load operations."""
     TEST_DATA = "{}"
     cache = RepodataCache(tmp_path / "lockme", "repodata.json")
     cache.save(TEST_DATA)
@@ -73,9 +71,7 @@ def test_save(tmp_path):
 
 
 def test_stale(tmp_path):
-    """
-    RepodataCache should understand cache-control and modified time versus now.
-    """
+    """RepodataCache should understand cache-control and modified time versus now."""
     TEST_DATA = "{}"
     cache = RepodataCache(tmp_path / "cacheme", "repodata.json")
     MOD = "Thu, 26 Jan 2023 19:34:01 GMT"

--- a/tests/notices/test_fetch.py
+++ b/tests/notices/test_fetch.py
@@ -12,9 +12,7 @@ from conda.testing.notices.helpers import add_resp_to_mock
 def test_get_channel_notice_response_timeout_error(
     notices_cache_dir, notices_mock_http_session_get
 ):
-    """
-    Tests the timeout error case for the get_channel_notice_response function
-    """
+    """Tests the timeout error case for the get_channel_notice_response function."""
     with patch("conda.notices.fetch.logger") as mock_logger:
         notices_mock_http_session_get.side_effect = requests.exceptions.Timeout
 
@@ -28,9 +26,7 @@ def test_get_channel_notice_response_timeout_error(
 def test_get_channel_notice_response_malformed_json(
     notices_cache_dir, notices_mock_http_session_get
 ):
-    """
-    Tests malformed json error case for the get_channel_notice_response function
-    """
+    """Tests malformed json error case for the get_channel_notice_response function."""
     messages = ("hello", "hello 2")
     with patch("conda.notices.fetch.logger") as mock_logger:
         add_resp_to_mock(notices_mock_http_session_get, 200, messages, raise_exc=True)
@@ -48,9 +44,7 @@ def test_get_channel_notice_response_malformed_json(
 
 
 def test_notice_response_cache_expired():
-    """
-    Channel notice is expired if expired_at is None
-    """
+    """Channel notice is expired if expired_at is None."""
 
     class ExpiredAtNone:
         expired_at = None

--- a/tests/notices/test_types.py
+++ b/tests/notices/test_types.py
@@ -5,9 +5,7 @@ from conda.testing.notices.helpers import get_test_notices
 
 
 def test_channel_notice_response():
-    """
-    Tests a normal invocation of the ChannelNoticeResponse class
-    """
+    """Tests a normal invocation of the ChannelNoticeResponse class."""
     messages = tuple(f"Test {idx}" for idx in range(1, 4, 1))
     expected_num_notices = len(messages)
     json_data = get_test_notices(messages)
@@ -22,7 +20,7 @@ def test_channel_notice_response():
 def test_channel_notice_response_date_parse_error():
     """
     Test a creation of the ChannelNoticeResponse object where we pass in bad values for
-     "created_at" and "level" and make sure the appropriate defaults are there.
+    "created_at" and "level" and make sure the appropriate defaults are there.
     """
     messages = tuple(f"Test {idx}" for idx in range(1, 4, 1))
     json_data = get_test_notices(messages)

--- a/tests/plugins/data/test-plugin/test_plugin/plugin.py
+++ b/tests/plugins/data/test-plugin/test_plugin/plugin.py
@@ -12,9 +12,7 @@ from conda.core.solve import Solver
 
 @plugins.hookimpl
 def conda_solvers():
-    """
-    The conda plugin hook implementation to load the solver into conda.
-    """
+    """The conda plugin hook implementation to load the solver into conda."""
     yield plugins.CondaSolver(
         name="test",
         backend=Solver,

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -38,18 +38,14 @@ def plugin(mocker, plugin_manager):
 
 
 def test_invoked(plugin, cli_main):
-    """
-    Ensure we are able to invoke our command after creating it
-    """
+    """Ensure we are able to invoke our command after creating it."""
     cli_main("custom", "some-arg", "some-other-arg")
 
     plugin.custom_command.assert_called_with(["some-arg", "some-other-arg"])
 
 
 def test_help(plugin, cli_main, capsys):
-    """
-    Ensures the command appears on the help page
-    """
+    """Ensures the command appears on the help page."""
     cli_main("--help")
 
     stdout, stderr = capsys.readouterr()
@@ -58,9 +54,7 @@ def test_help(plugin, cli_main, capsys):
 
 
 def test_duplicated(plugin_manager, cli_main, capsys):
-    """
-    Ensures we get an error when attempting to register commands with the same `name` property
-    """
+    """Ensures we get an error when attempting to register commands with the same `name` property."""
     plugin_manager.register(SubcommandPlugin())
     plugin_manager.register(SubcommandPlugin())
 

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -125,9 +125,7 @@ def test_subdir_override():
 
 
 def test_glibc_override():
-    """
-    Conda should not produce a libc virtual package when CONDA_OVERRIDE_GLIBC=""
-    """
+    """Conda should not produce a libc virtual package when CONDA_OVERRIDE_GLIBC=""."""
     for version in "", "1.0":
         with env_vars(
             {"CONDA_SUBDIR": "linux-64", "CONDA_OVERRIDE_GLIBC": version},

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -11,6 +11,7 @@ conda-build >=3.23.3
 conda-forge::pytest-split
 conda-forge::pytest-xprocess
 conda-forge::xdoctest
+conda-forge::flake8-docstrings
 conda-package-handling >=1.3.0
 conda-verify
 coverage

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -155,8 +155,6 @@ def test_topic_remove(deprecated_v3):
 
 
 def test_version_fallback():
-    """
-    Test that conda can run even if deprecations can't parse the version.
-    """
+    """Test that conda can run even if deprecations can't parse the version."""
     version = DeprecationHandler(None)._version  # type: ignore
     assert version.major == version.minor == version.micro == 0

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -90,9 +90,7 @@ class TestExecutePlan(unittest.TestCase):
 
 
 def test_prefix_cmd():
-    """
-    Unused, but run it anyway.
-    """
+    """Unused, but run it anyway."""
     state = {}
     instructions.PREFIX_CMD(state, "prefix")
     assert state["prefix"] == "prefix"

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -8,9 +8,7 @@ from conda.lock import DirectoryLock, FileLock, LockError
 
 
 def test_filelock_passes(tmpdir):
-    """
-    Normal test on file lock
-    """
+    """Normal test on file lock."""
     package_name = "conda_file1"
     tmpfile = join(tmpdir.strpath, package_name)
     with FileLock(tmpfile) as lock:
@@ -44,9 +42,7 @@ def test_filelock_locks(tmpdir):
 
 
 def test_folder_locks(tmpdir):
-    """
-    Test on Directory lock
-    """
+    """Test on Directory lock."""
     package_name = "dir_1"
     tmpfile = join(tmpdir.strpath, package_name)
     with DirectoryLock(tmpfile) as lock1:

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -76,9 +76,7 @@ class PriorityIntegrationTests(TestCase):
                 assert pycosat_tuple[3] == "conda-forge"
 
     def test_channel_priority_update(self):
-        """
-        This case will fail now
-        """
+        """This case will fail now."""
         with make_temp_env("python=3.8", "pycosat") as prefix:
             assert package_is_installed(prefix, "python")
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,10 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from conda.core.solve import Solver
 from conda.testing.solver_helpers import SolverTests
 
 
 class TestClassicSolver(SolverTests):
     @property
-    def solver_class(self):
+    def solver_class(self) -> type[Solver]:
         return Solver

--- a/tests/test_toposort.py
+++ b/tests/test_toposort.py
@@ -90,9 +90,7 @@ class TopoSortTests(unittest.TestCase):
 
 
 def test_degenerate():
-    """
-    Edge cases.
-    """
+    """Edge cases."""
     assert toposort({}) == []
     assert toposort({}, safe=False) == []
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -209,9 +209,7 @@ def test_quote_for_shell(args, expected):
 
 
 def test_ensure_dir(tmpdir):
-    """
-    Ensures that this decorator creates a directory
-    """
+    """Ensures that this decorator creates a directory."""
     new_dir = "test_dir"
 
     @utils.ensure_dir_exists
@@ -224,9 +222,7 @@ def test_ensure_dir(tmpdir):
 
 
 def test_ensure_dir_errors():
-    """
-    Test to ensure correct error handling
-    """
+    """Test to ensure correct error handling."""
     new_dir = "test_dir"
     exc_message = "Test!"
 
@@ -245,9 +241,7 @@ def test_ensure_dir_errors():
 
 
 def test_safe_open(tmpdir):
-    """
-    Ensures this context manager open and closes files appropriately
-    """
+    """Ensures this context manager open and closes files appropriately."""
     new_file = Path(tmpdir).joinpath("test.file")
     content = "test"
 
@@ -262,9 +256,7 @@ def test_safe_open(tmpdir):
 
 
 def test_safe_open_errors():
-    """
-    Test to ensure correct error handling
-    """
+    """Test to ensure correct error handling."""
     exc_message = "Test!"
 
     with patch("conda.utils.open") as mock_open:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Part of the larger effort to review all docstrings. This adds `flake8-docstrings` to pre-commit and otherwise does the easy cleanup.

For now all of the docstring linting rules are ignored (D100-107) so these can be tackled in individual PRs.

Xref #12613

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
