### PR TITLE
Ignore comment style D200

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ max-line-length = 99
 # D205 1 blank line required between summary line and description
 # D400 First line should end with a period
 # D401 First line should be in imperative mood
-extend-ignore = E203,E402,E722,E731,W503,D1,D205,D400,D401
+extend-ignore = E203,E402,E722,E731,W503,D1,D200,D205,D400,D401
 exclude = .asv*,build/*,.tox/*,dev*/*,env/*,test_data/*,tests/*,ve/*,utils/*,*/_vendor/*,conda/compat.py,conda/common/compat.py,conda_env/compat.py
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This linter rule enforces a docstring style

`"""Single line comments"""`

instead of the (was) very common in our codebase

```
"""
Single line comments
"""
```

Ignore this rule to ease development.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
