### PR TITLE
Warn about misconfiguration when signature verification is enabled

### DIFF
--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -41,7 +41,7 @@ class _SignatureVerification:
 
         # signing url must be defined
         if not context.signing_metadata_url_base:
-            log.info(
+            log.warn(
                 "metadata signature verification requested, "
                 "but no metadata URL base has not been specified."
             )

--- a/news/12639-warn-missing-sig-url-base
+++ b/news/12639-warn-missing-sig-url-base
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Warn about misconfiguration when signature verification is enabled (#12639)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Generate a warning, rather than an info-level message, if the user has enabled metadata signature verification (via `extra_safety_checks`) but has _not_ configured a [required] value for `signing_metadata_url_base`. This avoids the situation where signature verification seems to mysteriously not happen if the user is not running `conda` using in a mode where INFO and lower priority log messages are displayed.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
