### PR TITLE
Update deprecation version to reflect when function was deprecated

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -672,7 +672,7 @@ class SubdirData(metaclass=SubdirDataType):
         return _internal_state
 
 
-@deprecated("23.1", "23.5", addendum="Cache headers are now stored in a separate file.")
+@deprecated("23.9", "24.3", addendum="Cache headers are now stored in a separate file.")
 def read_mod_and_etag(path):
     # this function should no longer be used by conda but is kept for API
     # stability. Was used to read inlined cache information from json; now


### PR DESCRIPTION
The [PR where the `read_mod_and_etag()` function was originally marked for deprecation](https://github.com/conda/conda/pull/12090) had [this comment](https://github.com/conda/conda/pull/12090/files#r1119254480) which pointed to a later deprecation date (which matches with the deprecation schedule we are following overall per [CEP 9](https://github.com/conda-incubator/ceps/blob/main/cep-9.md) policy).