### PR TITLE
Correct the deprecation versions on `read_mod_and_etag()` function

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -672,7 +672,7 @@ class SubdirData(metaclass=SubdirDataType):
         return _internal_state
 
 
-@deprecated("23.9", "24.3", addendum="Cache headers are now stored in a separate file.")
+@deprecated("23.1", "23.9", addendum="Cache headers are now stored in a separate file.")
 def read_mod_and_etag(path):
     # this function should no longer be used by conda but is kept for API
     # stability. Was used to read inlined cache information from json; now


### PR DESCRIPTION
Sorry for the spam here! I updated the versions [previously on another pull request](https://github.com/conda/conda/pull/12656) but these numbers were incorrect. This should now properly comply with [CEP 9](https://github.com/conda-incubator/ceps/blob/main/cep-9.md).