### PR TITLE
Add `pyproject.toml` support for `conda env create`

### DIFF
--- a/conda_env/specs/__init__.py
+++ b/conda_env/specs/__init__.py
@@ -14,9 +14,10 @@ from conda.gateways.connection.session import CONDA_SESSION_SCHEMES
 
 from .binstar import BinstarSpec
 from .requirements import RequirementsSpec
+from .toml_file import TomlSpec
 from .yaml_file import YamlFileSpec
 
-FileSpecTypes = Union[Type[YamlFileSpec], Type[RequirementsSpec]]
+FileSpecTypes = Union[Type[YamlFileSpec], Type[RequirementsSpec], Type[TomlSpec]]
 
 
 def get_spec_class_from_file(filename: str) -> FileSpecTypes:
@@ -26,7 +27,9 @@ def get_spec_class_from_file(filename: str) -> FileSpecTypes:
     :raises EnvironmentFileExtensionNotValid | EnvironmentFileNotFound:
     """
     # Check extensions
-    all_valid_exts = YamlFileSpec.extensions.union(RequirementsSpec.extensions)
+    all_valid_exts = YamlFileSpec.extensions.union(RequirementsSpec.extensions).union(
+        TomlSpec.extensions
+    )
     _, ext = os.path.splitext(filename)
 
     # First check if file exists and test the known valid extension for specs
@@ -40,6 +43,8 @@ def get_spec_class_from_file(filename: str) -> FileSpecTypes:
             return YamlFileSpec
         elif ext in RequirementsSpec.extensions:
             return RequirementsSpec
+        elif ext in TomlSpec.extensions:
+            return TomlSpec
     else:
         raise EnvironmentFileNotFound(filename=filename)
 

--- a/conda_env/specs/toml_file.py
+++ b/conda_env/specs/toml_file.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+import os
+
+from ..env import Environment
+
+
+class TomlSpec:
+    """Reads dependencies from a ``pyproject.toml`` file
+    and returns an :class:`Environment` object from it.
+
+    Note that this doesn't install the project described by the
+    ``pyproject.toml`` file itself, but only its dependencies.
+
+    Because the dependencies are expected to be conform to PEP 508,
+    rather than conda's syntax, they are all added as ``pip``
+    dependencies.
+
+    """
+
+    msg = None
+    extensions = {".toml"}
+
+    def __init__(self, filename=None, name=None, **kwargs):
+        self.filename = filename
+        self.name = name
+        self.msg = None
+
+    def _valid_file(self):
+        if os.path.exists(self.filename):
+            return True
+
+        self.msg = f"File {self.filename} does not exist"
+        return False
+
+    def _valid_name(self):
+        if self.name is None:
+            self.msg = "Environment with pyproject.toml file needs a name"
+            return False
+
+        return True
+
+    def can_handle(self):
+        return self._valid_file() and self._valid_name()
+
+    @property
+    def environment(self):
+        import tomli
+
+        with open(self.filename, "rb") as f:
+            dependencies = tomli.load(f)["project"]["dependencies"]
+        return Environment(name=self.name, dependencies=["pip", {"pip": dependencies}])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "tqdm >=4",
   "boltons >=23.0.0",
   "jsonpatch >=1.32",
+  "tomli >=2.0.0",
 ]
 dynamic = ["version"]
 

--- a/tests/conda_env/specs/test_toml_file.py
+++ b/tests/conda_env/specs/test_toml_file.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+import unittest
+
+from conda_env import env
+from conda_env.specs.toml_file import TomlSpec
+
+from .. import support_file
+
+
+class TestTomlSpec(unittest.TestCase):
+    def test_no_environment_file(self):
+        spec = TomlSpec(name=None, filename="not-a-file")
+        self.assertEqual(spec.can_handle(), False)
+
+    def test_no_name(self):
+        spec = TomlSpec(filename=support_file("pyproject.toml"))
+        self.assertEqual(spec.can_handle(), False)
+
+    def test_req_file_and_name(self):
+        spec = TomlSpec(filename=support_file("pyproject.toml"), name="env")
+        self.assertTrue(spec.can_handle())
+
+    def test_environment(self):
+        spec = TomlSpec(filename=support_file("pyproject.toml"), name="env")
+        self.assertIsInstance(spec.environment, env.Environment)
+        self.assertEqual(spec.environment.dependencies["conda"][0], "pip")
+        self.assertEqual(spec.environment.dependencies["pip"][0], "flask ==1.1.1")

--- a/tests/conda_env/support/pyproject.toml
+++ b/tests/conda_env/support/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+dependencies = [
+  "flask ==1.1.1",
+]


### PR DESCRIPTION
### Description

Fixes #10633

This is a fairly rough hack to see if this is an acceptable solution. It just reads the `project.dependencies` list in the supplied `pyproject.toml` and adds them as `pip` dependencies -- this is because I'm assuming that they will be using the PEP 508 syntax, rather than the conda one (for example, in conda's own `pyproject.toml`, `"menuinst >=1.4.11,<2 ; platform_system=='Windows'"` seems to be invalid for conda).

One thing in particular that I'm not sure whether it's confusing is that this only installs the `project.dependencies` list, and not the actual project itself. I think this is probably the minimally useful thing.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

I'll add a news file and some text in the `conda env create` docs if this feature is acceptable.