### PR TITLE
rename `.state.json` to `.info.json` to track draft CEP

### DIFF
--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -20,14 +20,14 @@ from requests import HTTPError
 
 from conda.base.context import context
 from conda.gateways.connection import Response, Session
-from conda.gateways.repodata import RepodataState
+from conda.gateways.repodata import ETAG_KEY, LAST_MODIFIED_KEY, RepodataState
 
 from .core import JLAP
 
 log = logging.getLogger(__name__)
 
 
-DIGEST_SIZE = 32  # 160 bits a minimum 'for security' length?
+DIGEST_SIZE = 32  # 256 bits
 
 JLAP_KEY = "jlap"
 HEADERS = "headers"
@@ -36,6 +36,19 @@ ON_DISK_HASH = "actual_hash"
 LATEST = "latest"
 JLAP_UNAVAILABLE = "jlap_unavailable"
 ZSTD_UNAVAILABLE = "zstd_unavailable"
+
+# save these headers. at least etag, last-modified, cache-control plus a few
+# useful extras.
+STORE_HEADERS = {
+    "etag",
+    "last-modified",
+    "cache-control",
+    "content-range",
+    "content-length",
+    "date",
+    "content-type",
+    "content-encoding",
+}
 
 
 def hash():
@@ -77,7 +90,12 @@ def process_jlap_response(response: Response, pos=0, iv=b""):
     footer = json.loads(footer)
 
     new_state = {
-        "headers": {k.lower(): v for k, v in response.headers.items()},
+        # we need to save etag, last-modified, cache-control
+        "headers": {
+            k.lower(): v
+            for k, v in response.headers.items()
+            if k.lower() in STORE_HEADERS
+        },
         "iv": buffer[-3][-1],
         "pos": pos,
         "footer": footer,
@@ -115,15 +133,7 @@ def request_jlap(
     log.debug(
         "response headers: %s",
         pprint.pformat(
-            {
-                k: v
-                for k, v in response.headers.items()
-                if any(
-                    map(
-                        k.lower().__contains__, ("content", "last", "range", "encoding")
-                    )
-                )
-            }
+            {k: v for k, v in response.headers.items() if k.lower() in STORE_HEADERS}
         ),
     )
     log.debug("status: %d", response.status_code)
@@ -153,11 +163,6 @@ def find_patches(patches, have, want):
         if have == want:
             break
         if patch["to"] == want:
-            log.info(
-                "Collect %s \N{LEFTWARDS ARROW} %s",
-                format_hash(want),
-                format_hash(patch["from"]),
-            )
             apply.append(patch)
             want = patch["from"]
 
@@ -215,9 +220,21 @@ class HashWriter(io.RawIOBase):
 
 
 def download_and_hash(
-    hasher, url, json_path, session: Session, state: RepodataState | None, is_zst=False
+    hasher,
+    url,
+    json_path,
+    session: Session,
+    state: RepodataState | None,
+    is_zst=False,
+    dest_path: pathlib.Path | None = None,
 ):
-    """Download url if it doesn't exist, passing bytes through hasher.update()."""
+    """Download url if it doesn't exist, passing bytes through hasher.update().
+
+    json_path: Path of old cached data (ignore etag if not exists).
+    dest_path: Path to write new data.
+    """
+    if dest_path is None:
+        dest_path = json_path
     state = state or RepodataState()
     headers = build_headers(json_path, state)
     timeout = context.remote_connect_timeout_secs, context.remote_read_timeout_secs
@@ -230,10 +247,10 @@ def download_and_hash(
         if is_zst:
             decompressor = zstandard.ZstdDecompressor()
             writer = decompressor.stream_writer(
-                HashWriter(json_path.open("wb"), hasher), closefd=True  # type: ignore
+                HashWriter(dest_path.open("wb"), hasher), closefd=True  # type: ignore
             )
         else:
-            writer = HashWriter(json_path.open("wb"), hasher)
+            writer = HashWriter(dest_path.open("wb"), hasher)
         with writer as repodata:
             for block in response.iter_content(chunk_size=1 << 14):
                 repodata.write(block)
@@ -267,8 +284,8 @@ def request_url_jlap_state(
             # Don't deal with 304 Not Modified if hash unavailable e.g. if
             # cached without jlap
             if NOMINAL_HASH not in state:
-                state.pop("etag", None)
-                state.pop("mod", None)
+                state.pop(ETAG_KEY, None)
+                state.pop(LAST_MODIFIED_KEY, None)
 
             try:
                 if state.should_check_format("zst"):
@@ -320,12 +337,17 @@ def request_url_jlap_state(
 
         need_jlap = True
         try:
+            iv_hex = jlap_state.get("iv", "")
+            pos = jlap_state.get("pos", 0)
+            etag = headers.get(ETAG_KEY, None)
+            jlap_url = withext(url, ".jlap")
+            log.debug("Fetch %s from iv=%s, pos=%s", jlap_url, iv_hex, pos)
             # wrong to read state outside of function, and totally rebuild inside
             buffer, jlap_state = fetch_jlap(
-                withext(url, ".jlap"),
-                pos=jlap_state.get("pos", 0),
-                etag=headers.get("etag", None),
-                iv=bytes.fromhex(jlap_state.get("iv", "")),
+                jlap_url,
+                pos=pos,
+                etag=etag,
+                iv=bytes.fromhex(iv_hex),
                 session=session,
                 ignore_etag=False,
             )

--- a/news/12669-parametrize-cache-keys
+++ b/news/12669-parametrize-cache-keys
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Rename index cache metadata file `.state.json` to `.info.json` to track draft
+  CEP (#12669)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -21,10 +21,17 @@ from conda.core.subdir_data import SubdirData
 from conda.exceptions import CondaHTTPError
 from conda.gateways.connection.session import CondaSession
 from conda.gateways.repodata import (
+    CACHE_CONTROL_KEY,
+    CACHE_STATE_SUFFIX,
+    ETAG_KEY,
+    LAST_MODIFIED_KEY,
+    URL_KEY,
     CondaRepoInterface,
+    RepodataCache,
     RepodataOnDisk,
     RepodataState,
     Response304ContentUnchanged,
+    get_repo_interface,
 )
 from conda.gateways.repodata.jlap import core, fetch, interface
 from conda.models.channel import Channel
@@ -41,12 +48,15 @@ def test_jlap_fetch(package_server: socket, tmp_path: Path, mocker):
     host, port = package_server.getsockname()
     base = f"http://{host}:{port}/test"
 
+    cache = RepodataCache(base=tmp_path / "cache", repodata_fn="repodata.json")
+
     url = f"{base}/osx-64"
     repo = interface.JlapRepoInterface(
         url,
         repodata_fn="repodata.json",
+        cache=cache,
         cache_path_json=Path(tmp_path, "repodata.json"),
-        cache_path_state=Path(tmp_path, "repodata.state.json"),
+        cache_path_state=Path(tmp_path, f"repodata{CACHE_STATE_SUFFIX}"),
     )
 
     patched = mocker.patch(
@@ -97,7 +107,14 @@ def test_download_and_hash(
     destination = tmp_path / "repodata.json"
     url2 = base + "/osx-64/repodata.json"
     hasher2 = fetch.hash()
-    response = fetch.download_and_hash(hasher2, url2, destination, session, state)
+    response = fetch.download_and_hash(
+        hasher2,
+        url2,
+        destination,
+        session,
+        state,
+        dest_path=destination,
+    )
     print(response)
     print(state)
     t = destination.read_text()
@@ -142,7 +159,7 @@ def test_repodata_state(
     package_server: socket,
     use_jlap: bool,
 ):
-    """Test that .state.json file works correctly."""
+    """Test that cache metadata file works correctly."""
     host, port = package_server.getsockname()
     base = f"http://{host}:{port}/test"
     channel_url = f"{base}/osx-64"
@@ -185,7 +202,14 @@ def test_repodata_state(
 
         # not all required depending on server response, but our test server
         # will include them
-        for field in ("mod", "etag", "cache_control", "size", "mtime_ns"):
+        for field in (
+            LAST_MODIFIED_KEY,
+            ETAG_KEY,
+            CACHE_CONTROL_KEY,
+            URL_KEY,
+            "size",
+            "mtime_ns",
+        ):
             assert field in state
             assert f"_{field}" not in state
 
@@ -199,6 +223,9 @@ def test_jlap_flag(use_jlap):
     ):
         expected = "jlap" in use_jlap.split(",")
         assert ("jlap" in context.experimental) is expected
+
+        expected_cls = interface.JlapRepoInterface if expected else CondaRepoInterface
+        assert get_repo_interface() is expected_cls
 
 
 def test_jlap_sought(
@@ -333,6 +360,8 @@ def test_jlap_sought(
 
         # clear jlap_unavailable state flag, or it won't look (test this also)
         state = cache.load_state()
+        # avoid 304 to actually overwrite cached data
+        state.etag = ""
         assert fetch.JLAP_UNAVAILABLE not in state  # from previous portion of test
         state["refresh_ns"] = state["refresh_ns"] - int(1e9 * 60)
         cache.cache_path_state.write_text(json.dumps(dict(state)))
@@ -410,6 +439,12 @@ def test_jlap_errors(
         # gets the failure, falls back to non-jlap path, writes to disk
         with pytest.raises(RepodataOnDisk):
             sd._repo.repodata(state)  # type: ignore
+
+        # above call newly saves cache state, write a clean one again.
+        # clear any jlap failures
+        state.pop("has_jlap", None)
+        state.pop("jlap", None)
+        cache.cache_path_state.write_text(json.dumps(dict(state)))
 
         # force 304 not modified on the .jlap file (test server doesn't return 304
         # not modified on range requests)
@@ -523,7 +558,7 @@ def test_jlap_zst_not_404(mocker, package_server, tmp_path):
         url,
         repodata_fn="repodata.json",
         cache_path_json=Path(tmp_path, "repodata.json"),
-        cache_path_state=Path(tmp_path, "repodata.state.json"),
+        cache_path_state=Path(tmp_path, f"repodata{CACHE_STATE_SUFFIX}"),
     )
 
     def error(*args, **kwargs):
@@ -612,18 +647,6 @@ def make_test_jlap(original: bytes, changes=1):
     j = core.JLAP.from_lines(jlap_lines(), iv=core.DEFAULT_IV, verify=False)
 
     return j
-
-
-def test_jlap_get_place():
-    """(probably soon to be removed) helper function to get cache filenames."""
-    place = fetch.get_place(
-        "https://repo.anaconda.com/main/linux-64/current_repodata.json"
-    ).name
-    assert ".c" in place
-    place2 = fetch.get_place(
-        "https://repo.anaconda.com/main/linux-64/repodata.json"
-    ).name
-    assert ".c" not in place2
 
 
 def test_hashwriter():

--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -31,6 +31,10 @@ from conda.gateways.connection import (
     SSLError,
 )
 from conda.gateways.repodata import (
+    CACHE_CONTROL_KEY,
+    CACHE_STATE_SUFFIX,
+    ETAG_KEY,
+    LAST_MODIFIED_KEY,
     RepodataCache,
     RepodataIsEmpty,
     RepodataState,
@@ -52,7 +56,7 @@ def test_save(tmp_path):
 
     time.sleep(0.1)  # may be necessary on Windows for time.time_ns() to advance
 
-    # update last-checked-timestamp in .state.json
+    # update last-checked-timestamp in metadata file
     cache.refresh()
 
     # repodata.json's mtime should be equal
@@ -63,7 +67,7 @@ def test_save(tmp_path):
 
     assert state2 != state
 
-    # force reload repodata, .state.json from disk
+    # force reload repodata, metadata file from disk
     cache.load()
     state3 = dict(cache.state)
 
@@ -74,12 +78,12 @@ def test_stale(tmp_path):
     """RepodataCache should understand cache-control and modified time versus now."""
     TEST_DATA = "{}"
     cache = RepodataCache(tmp_path / "cacheme", "repodata.json")
-    MOD = "Thu, 26 Jan 2023 19:34:01 GMT"
-    cache.state.mod = MOD
-    CACHE_CONTROL = "public, max-age=30"
-    cache.state.cache_control = CACHE_CONTROL
-    ETAG = '"etag"'
-    cache.state.etag = ETAG
+    last_modified = "Thu, 26 Jan 2023 19:34:01 GMT"
+    cache.state.mod = last_modified
+    cache_control = "public, max-age=30"
+    cache.state.cache_control = cache_control
+    etag = '"unambiguous-etag"'
+    cache.state.etag = etag
     cache.save(TEST_DATA)
 
     cache.load()
@@ -109,15 +113,15 @@ def test_stale(tmp_path):
         context.local_repodata_ttl = original_ttl
 
     # since state's mtime_ns matches repodata.json stat(), these will be preserved
-    assert cache.state.mod == MOD
-    assert cache.state.cache_control == CACHE_CONTROL
-    assert cache.state.etag == ETAG
+    assert cache.state.mod == last_modified
+    assert cache.state.cache_control == cache_control
+    assert cache.state.etag == etag
 
     # XXX rewrite state without replacing repodata.json, assert still stale...
 
     # mismatched mtime empties cache headers
     state = dict(cache.state)
-    assert state["etag"]
+    assert state[ETAG_KEY]
     assert cache.state.etag
     state["mtime_ns"] = 0
     cache.cache_path_state.write_text(json.dumps(state))
@@ -125,23 +129,27 @@ def test_stale(tmp_path):
     assert not cache.state.mod
     assert not cache.state.etag
 
-    # check type problems
-    json_types = (None, True, False, 0, 0.5, math.nan, {}, "a string")
-    for type in json_types:
-        cache.state["cache_control"] = type
-        cache.stale()
-
     # if we don't match stat then load_state will clear the test "mod" value
     json_stat = cache.cache_path_json.stat()
 
-    # change wrongly-typed mod to empty string
-    cache.cache_path_state.write_text(
-        json.dumps(
-            {"mod": None, "mtime_ns": json_stat.st_mtime_ns, "size": json_stat.st_size}
+    # check type problems
+    json_types = (None, True, False, 0, 0.5, math.nan, {}, "a string")
+    for example in json_types:
+        cache.state["cache_control"] = example
+        cache.stale()
+
+        # change wrongly-typed mod to empty string
+        cache.cache_path_state.write_text(
+            json.dumps(
+                {
+                    "mod": example,
+                    "mtime_ns": json_stat.st_mtime_ns,
+                    "size": json_stat.st_size,
+                }
+            )
         )
-    )
-    state = cache.load_state()
-    assert state.mod == ""
+        state = cache.load_state()
+        assert state.mod == "" or isinstance(example, str)
 
     # preserve correct mod
     cache.cache_path_state.write_text(
@@ -162,7 +170,9 @@ def test_coverage_repodata_state(tmp_path):
 
     # assert invalid state is equal to no state
     state = RepodataState(
-        tmp_path / "garbage.json", tmp_path / "garbage.state.json", "repodata.json"
+        tmp_path / "garbage.json",
+        tmp_path / f"garbage{CACHE_STATE_SUFFIX}",
+        "repodata.json",
     )
     state.cache_path_state.write_text("not json")
     assert dict(state.load()) == {}
@@ -306,7 +316,7 @@ def test_cache_json(tmp_path: Path):
     cached json.
     """
     cache_json = tmp_path / "cached.json"
-    cache_state = tmp_path / "cached.state.json"
+    cache_state = tmp_path / f"cached{CACHE_STATE_SUFFIX}"
 
     cache_json.write_text("{}")
 
@@ -319,14 +329,14 @@ def test_cache_json(tmp_path: Path):
     state = RepodataState(cache_json, cache_state, "repodata.json")
     state.mod = mod  # this is the last-modified header not mtime_ns
     state.cache_control = "cache control"
-    state.etag = "etag"
+    state.etag = '"unambiguous-etag"'
     state.save()
 
     on_disk_format = json.loads(cache_state.read_text())
     print("disk format", on_disk_format)
-    assert on_disk_format["mod"] == mod
-    assert on_disk_format["cache_control"]
-    assert on_disk_format["etag"]
+    assert on_disk_format[LAST_MODIFIED_KEY] == mod
+    assert on_disk_format[CACHE_CONTROL_KEY]
+    assert on_disk_format[ETAG_KEY]
     assert isinstance(on_disk_format["size"], int)
     assert isinstance(on_disk_format["mtime_ns"], int)
 
@@ -335,11 +345,11 @@ def test_cache_json(tmp_path: Path):
     assert state2.cache_control
     assert state2.etag
 
-    assert state2["mod"] == state2.mod
-    assert state2["etag"] == state2.etag
-    assert state2["cache_control"] == state2.cache_control
+    assert state2[LAST_MODIFIED_KEY] == state2.mod
+    assert state2[ETAG_KEY] == state2.etag
+    assert state2[CACHE_CONTROL_KEY] == state2.cache_control
 
     cache_json.write_text("{ }")  # now invalid due to size
 
     state_invalid = RepodataState(cache_json, cache_state, "repodata.json").load()
-    assert state_invalid.get("mod") == ""
+    assert state_invalid.get(LAST_MODIFIED_KEY) == ""


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This is extracted from #12556 to simplify the other PR.

Move some strings into constants to make it easier to rename certain cache metadata keys / extension.

Some logging improvements.

Fixes #12669 

Fixes #12572

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
