### PR TITLE
Remove potential `test_confirm_*` uncertainty with `always_yes` being set

### DIFF
--- a/tests/cli/test_common.py
+++ b/tests/cli/test_common.py
@@ -4,19 +4,19 @@ import os
 from io import StringIO
 
 import pytest
-from pytest import raises
+from pytest import MonkeyPatch, raises
 
-from conda.auxlib.collection import AttrDict
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
 from conda.cli.common import check_non_admin, confirm, confirm_yn, is_active_prefix
 from conda.common.compat import on_win
-from conda.common.io import captured, env_var
+from conda.common.io import captured, env_vars
 from conda.exceptions import CondaSystemExit, DryRunExit, OperationNotAllowed
 
 
 def test_check_non_admin_enabled_false():
-    with env_var(
-        "CONDA_NON_ADMIN_ENABLED", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol
+    with env_vars(
+        {"CONDA_NON_ADMIN_ENABLED": "false"},
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
         if on_win:
             from conda.common._os.windows import is_admin_on_windows
@@ -35,62 +35,80 @@ def test_check_non_admin_enabled_false():
 
 
 def test_check_non_admin_enabled_true():
-    with env_var(
-        "CONDA_NON_ADMIN_ENABLED", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol
+    with env_vars(
+        {"CONDA_NON_ADMIN_ENABLED": "true"},
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
         check_non_admin()
         assert True
 
 
-def test_confirm_yn_yes(monkeypatch):
+def test_confirm_yn_yes(monkeypatch: MonkeyPatch):
     monkeypatch.setattr("sys.stdin", StringIO("blah\ny\n"))
-    with env_var(
-        "CONDA_ALWAYS_YES", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        with env_var(
-            "CONDA_DRY_RUN", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol
-        ):
-            assert not context.always_yes
-            args = AttrDict(
-                {
-                    "dry_run": False,
-                }
-            )
-            with captured() as cap:
-                choice = confirm_yn(args)
-            assert choice is True
-            assert "Invalid choice" in cap.stdout
 
-
-def test_confirm_yn_no(monkeypatch):
-    monkeypatch.setattr("sys.stdin", StringIO("n\n"))
-    args = AttrDict(
+    with env_vars(
         {
-            "dry_run": False,
-        }
-    )
-    with pytest.raises(CondaSystemExit):
-        confirm_yn(args)
+            "CONDA_ALWAYS_YES": "false",
+            "CONDA_DRY_RUN": "false",
+        },
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
+    ), captured() as cap:
+        assert not context.always_yes
+        assert not context.dry_run
+
+        assert confirm_yn()
+
+    assert "Invalid choice" in cap.stdout
 
 
-def test_dry_run_exit():
-    with env_var("CONDA_DRY_RUN", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with pytest.raises(DryRunExit):
-            confirm_yn()
+def test_confirm_yn_no(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr("sys.stdin", StringIO("n\n"))
 
-        with pytest.raises(DryRunExit):
-            confirm()
+    with env_vars(
+        {
+            "CONDA_ALWAYS_YES": "false",
+            "CONDA_DRY_RUN": "false",
+        },
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
+    ), pytest.raises(CondaSystemExit):
+        assert not context.always_yes
+        assert not context.dry_run
+
+        confirm_yn()
 
 
-def test_always_yes():
-    with env_var(
-        "CONDA_ALWAYS_YES", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol
+def test_confirm_yn_dry_run_exit():
+    with env_vars(
+        {"CONDA_DRY_RUN": "true"},
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
+    ), pytest.raises(DryRunExit):
+        assert context.dry_run
+
+        confirm_yn()
+
+
+def test_confirm_dry_run_exit():
+    with env_vars(
+        {"CONDA_DRY_RUN": "true"},
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
+    ), pytest.raises(DryRunExit):
+        assert context.dry_run
+
+        confirm()
+
+
+def test_confirm_yn_always_yes():
+    with env_vars(
+        {
+            "CONDA_ALWAYS_YES": "true",
+            "CONDA_DRY_RUN": "false",
+        },
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
-        with env_var(
-            "CONDA_DRY_RUN", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol
-        ):
-            choice = confirm_yn()
-            assert choice is True
+        assert context.always_yes
+        assert not context.dry_run
+
+        assert confirm_yn()
 
 
 @pytest.mark.parametrize("prefix,active", [("", False), ("active_prefix", True)])


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

If `always_yes` gets set prior to running tests then tests will start to unexpectedly fail. This removes this uncertainty.

Seeks to resolve testing issue found in https://github.com/conda/conda/pull/12670

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
