### PR TITLE
name hash algorithm in keys to better track draft CEP

### DIFF
--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -31,8 +31,8 @@ DIGEST_SIZE = 32  # 256 bits
 
 JLAP_KEY = "jlap"
 HEADERS = "headers"
-NOMINAL_HASH = "nominal_hash"
-ON_DISK_HASH = "actual_hash"
+NOMINAL_HASH = "blake2_256_nominal"
+ON_DISK_HASH = "blake2_256"
 LATEST = "latest"
 JLAP_UNAVAILABLE = "jlap_unavailable"
 ZSTD_UNAVAILABLE = "zstd_unavailable"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

At first I thought it would be more conservative to keep the hash key names the same, but the other PR addressing #12669 changed the whole filename. Change those key names to represent the hash algorithm used. [The draft CEP is here as a PR against the conda/ceps repository.](https://github.com/conda-incubator/ceps/pull/48)

The nominal hash and actual hash are used to track jlap changes. The nominal hash comes from the upstream file, hashed as formatted on the server. We look for those hashes in the `.jlap` changelog. The actual hash is our on-disk hash since we do not format the saved json exactly the same as the server; instead, we format it in a more compact way.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
