### PR TITLE
Deprecate `conda.testing.integration.get_conda_list_tuple`

### DIFF
--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -447,6 +447,11 @@ def _package_is_installed(prefix, spec):
     return bool(len(prefix_recs))
 
 
+@deprecated(
+    "23.9",
+    "24.3",
+    addendum="Use `conda.core.prefix_data.PrefixData().get()` instead.",
+)
 def get_conda_list_tuple(prefix, package_name):
     stdout, stderr, _ = run_command(Commands.LIST, prefix)
     stdout_lines = stdout.split("\n")

--- a/news/12676-deprecate-get_conda_list_tuple
+++ b/news/12676-deprecate-get_conda_list_tuple
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.testing.integration.get_conda_list_tuple` as pending deprecation. Use `conda.core.prefix_data.PrefixData().get()` instead. (#12676)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -8,9 +8,9 @@ import pytest
 
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
 from conda.common.io import env_var
+from conda.core.prefix_data import PrefixData
 from conda.testing.integration import (
     Commands,
-    get_conda_list_tuple,
     make_temp_env,
     package_is_installed,
     run_command,
@@ -69,11 +69,10 @@ class PriorityIntegrationTests(TestCase):
                 )
 
                 # python sys.version should show conda-forge python
-                python_tuple = get_conda_list_tuple(prefix, "python")
-                assert python_tuple[3] == "conda-forge"
+                assert PrefixData(prefix).get("python").channel.name == "conda-forge"
+
                 # conda list should show pycosat coming from conda-forge
-                pycosat_tuple = get_conda_list_tuple(prefix, "pycosat")
-                assert pycosat_tuple[3] == "conda-forge"
+                assert PrefixData(prefix).get("pycosat").channel.name == "conda-forge"
 
     def test_channel_priority_update(self):
         """This case will fail now."""
@@ -108,5 +107,4 @@ class PriorityIntegrationTests(TestCase):
             assert "conda-forge" in superceded_split[1]
 
             # python sys.version should show conda-forge python
-            python_tuple = get_conda_list_tuple(prefix, "python")
-            assert python_tuple[3] == "conda-forge"
+            assert PrefixData(prefix).get("python").channel.name == "conda-forge"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Encourage using the conda API instead of parsing the CLI for tests.

Part of the effort to remove references to `conda.testing.integration.run_command` since its now marked as pending deprecation (see #12592).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
