### PR TITLE
Deprecate `conda.testing.encode_for_env_var`

### DIFF
--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -35,6 +35,7 @@ from conda.common.compat import on_win
 from ..deprecations import deprecated
 
 
+@deprecated("23.9", "24.3")
 def encode_for_env_var(value) -> str:
     """Environment names and values need to be string."""
     if isinstance(value, str):
@@ -111,14 +112,10 @@ def conda_move_to_front_of_PATH():
             else:
                 new_p.append(pe)
 
-        new_path = os.pathsep.join(new_p)
-        new_path = encode_for_env_var(new_path)
-        os.environ["PATH"] = new_path
+        os.environ["PATH"] = os.pathsep.join(new_p)
         activator = activator_cls()
         p = activator._add_prefix_to_path(os.environ["CONDA_PREFIX"])
-        new_path = os.pathsep.join(p)
-        new_path = encode_for_env_var(new_path)
-        os.environ["PATH"] = new_path
+        os.environ["PATH"] = os.pathsep.join(p)
 
 
 @deprecated(

--- a/news/12677-deprecate-encode_for_env_var
+++ b/news/12677-deprecate-encode_for_env_var
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.testing.encode_for_env_var` as pending deprecation. (#12677)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The `str`/`bytes` check done here is unnecessary and likely a Python 2 remnant.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
