### PR TITLE
`conda.testing.run` was renamed to `conda.testing.conda_cli`

### DIFF
--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -123,7 +123,7 @@ def assert_in(a, b, output=""):
     )
 
 
-@deprecated("23.9", "24.3", addendum="Use `conda.testing.run` instead.")
+@deprecated("23.9", "24.3", addendum="Use `conda.testing.conda_cli` instead.")
 def run_inprocess_conda_command(command, disallow_stderr: bool = True):
     # anything that uses this function is an integration test
     reset_context(())

--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -211,7 +211,7 @@ def temp_chdir(target_dir):
         os.chdir(curdir)
 
 
-@deprecated("23.9", "24.3", addendum="Use `conda.testing.run` instead.")
+@deprecated("23.9", "24.3", addendum="Use `conda.testing.conda_cli` instead.")
 def run_command(command, prefix, *arguments, **kwargs):
     assert isinstance(arguments, tuple), "run_command() arguments must be tuples"
     arguments = massage_arguments(arguments)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The deprecation message is wrong. The new `conda.testing.run` fixture was renamed to `conda.testing.conda_cli`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
