### PR TITLE
remove cache_dir memoization to improve unit tests reliability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -384,7 +384,7 @@ jobs:
   aggregate:
     # only aggregate test suite if there are code changes
     needs: [changes, windows, linux, linux-qemu, macos]
-    if: needs.changes.outputs.code == 'true' && always()
+    if: always() && needs.changes.outputs.code == 'true'
 
     runs-on: ubuntu-latest
     steps:
@@ -428,7 +428,7 @@ jobs:
     # - this is the main repo, and
     # - we are on the main, feature, or release branch
     if: >-
-      success()
+      always()
       && !github.event.repository.fork
       && (
         github.ref_name == 'main'

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -232,15 +232,17 @@ class SubdirData(metaclass=SubdirDataType):
 
     @property
     def cache_path_base(self):
-        if not hasattr(self, "_cache_dir") or self._cache_dir_key != context.pkgs_dirs:
-            # searches for writable directory; memoize per-instance.
-            self._cache_dir = create_cache_dir()
-            self._cache_dir_key = context.pkgs_dirs
-        # self.repodata_fn may change
         return join(
-            self._cache_dir,
+            create_cache_dir(),
             splitext(cache_fn_url(self.url_w_credentials, self.repodata_fn))[0],
         )
+
+        # Is this memoization causing bugs?
+        # if not hasattr(self, "_cache_dir") or self._cache_dir_key != context.pkgs_dirs:
+        #     # searches for writable directory; memoize per-instance.
+        #     self._cache_dir = create_cache_dir()
+        #     self._cache_dir_key = context.pkgs_dirs
+        # # self.repodata_fn may change
 
     @property
     def url_w_repodata_fn(self):

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -237,13 +237,6 @@ class SubdirData(metaclass=SubdirDataType):
             splitext(cache_fn_url(self.url_w_credentials, self.repodata_fn))[0],
         )
 
-        # Is this memoization causing bugs?
-        # if not hasattr(self, "_cache_dir") or self._cache_dir_key != context.pkgs_dirs:
-        #     # searches for writable directory; memoize per-instance.
-        #     self._cache_dir = create_cache_dir()
-        #     self._cache_dir_key = context.pkgs_dirs
-        # # self.repodata_fn may change
-
     @property
     def url_w_repodata_fn(self):
         return self.url_w_subdir + "/" + self.repodata_fn

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -232,9 +232,10 @@ class SubdirData(metaclass=SubdirDataType):
 
     @property
     def cache_path_base(self):
-        if not hasattr(self, "_cache_dir"):
+        if not hasattr(self, "_cache_dir") or self._cache_dir_key != context.pkgs_dirs:
             # searches for writable directory; memoize per-instance.
             self._cache_dir = create_cache_dir()
+            self._cache_dir_key = context.pkgs_dirs
         # self.repodata_fn may change
         return join(
             self._cache_dir,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix #12689 by recreating cache_dir any time we look it up, removing memoization.

I counted and this was only called 12 times when defaults and conda-forge are in the search.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
