### PR TITLE
Deprecate `context.root_dir`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -636,7 +636,12 @@ class Context(Configuration):
             return 8 * struct.calcsize("P")
 
     @property
-    def root_dir(self):
+    @deprecated(
+        "24.3",
+        "24.9",
+        addendum="Please use `conda.base.context.context.root_prefix` instead.",
+    )
+    def root_dir(self) -> os.PathLike:
         # root_dir is an alias for root_prefix, we prefer the name "root_prefix"
         # because it is more consistent with other names
         return self.root_prefix

--- a/news/12701-deprecate-context-root_dir
+++ b/news/12701-deprecate-context-root_dir
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.base.context.context.root_dir` as pending deprecation. Use `conda.base.context.context.root_prefix` instead. (#12701)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -566,7 +566,7 @@ def env_is_created(env_name):
     from os.path import basename
 
     for prefix in list_all_known_prefixes():
-        name = ROOT_ENV_NAME if prefix == context.root_dir else basename(prefix)
+        name = ROOT_ENV_NAME if prefix == context.root_prefix else basename(prefix)
         if name == env_name:
             return True
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -201,7 +201,7 @@ class FileTests(unittest.TestCase):
 
     def test_trash_outside_prefix(self):
         tmp_dir = tempfile.mkdtemp()
-        rel = relpath(tmp_dir, context.root_dir)
+        rel = relpath(tmp_dir, context.root_prefix)
         self.assertTrue(rel.startswith(".."))
         move_path_to_trash(tmp_dir)
         self.assertFalse(exists(tmp_dir))


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We already prefer `context.root_prefix`, no need to keep this alias around.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
