### PR TITLE
Deprecate `conda.plugins.subcommands.doctor.cli.get_prefix`

### DIFF
--- a/conda/plugins/subcommands/doctor/cli.py
+++ b/conda/plugins/subcommands/doctor/cli.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import argparse
 
-from ....base.context import context, locate_prefix_by_name
-from ....cli.common import validate_prefix
+from ....base.context import context
 from ....cli.conda_argparse import add_parser_prefix
-from ....exceptions import CondaEnvException
+from ....deprecations import deprecated
 from ... import CondaSubcommand, hookimpl
 
 
@@ -28,25 +27,12 @@ def get_parsed_args(argv: list[str]) -> argparse.Namespace:
     return args
 
 
+@deprecated(
+    "24.3", "24.9", addendum="Use `conda.base.context.context.target_prefix` instead."
+)
 def get_prefix(args: argparse.Namespace) -> str:
-    """
-    Determine the correct prefix to use provided the CLI arguments and the context object.
-
-    When not specified via CLI options, the default is the currently active prefix
-    """
-    if args.name:
-        return locate_prefix_by_name(args.name)
-
-    if args.prefix:
-        return validate_prefix(args.prefix)
-
-    if context.active_prefix:
-        return context.active_prefix
-
-    raise CondaEnvException(
-        "No environment specified. Activate an environment or specify the "
-        "environment via `--name` or `--prefix`."
-    )
+    context.__init__(argparse_args=args)
+    return context.target_prefix
 
 
 def execute(argv: list[str]) -> None:
@@ -54,8 +40,8 @@ def execute(argv: list[str]) -> None:
     from .health_checks import display_health_checks
 
     args = get_parsed_args(argv)
-    prefix = get_prefix(args)
-    display_health_checks(prefix, verbose=args.verbose)
+    context.__init__(argparse_args=args)
+    display_health_checks(context.target_prefix, verbose=args.verbose)
 
 
 @hookimpl

--- a/news/12725-deprecate-get_prefix
+++ b/news/12725-deprecate-get_prefix
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.plugins.subcommands.doctor.cli.get_prefix` as pending deprecation. Use `conda.base.context.context.target_prefix` instead. (#12725)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/plugins/subcommands/doctor/test_cli.py
+++ b/tests/plugins/subcommands/doctor/test_cli.py
@@ -57,36 +57,3 @@ def test_conda_doctor_with_test_environment():
         assert MISSING_FILES_SUCCESS_MESSAGE in out
         assert not err  # no error message
         assert not code  # successful exit code
-
-
-def test_get_prefix_name():
-    assert get_prefix(Namespace(name="base", prefix=None)) == context.root_prefix
-
-
-def test_get_prefix_bad_name():
-    with pytest.raises(EnvironmentNameNotFound):
-        get_prefix(Namespace(name="invalid", prefix=None))
-
-
-def test_get_prefix_prefix():
-    with make_temp_env() as prefix:
-        assert get_prefix(Namespace(name=None, prefix=prefix)) == prefix
-
-
-def test_get_prefix_bad_prefix(tmp_path: Path):
-    with pytest.raises(DirectoryNotACondaEnvironmentError):
-        assert get_prefix(Namespace(name=None, prefix=tmp_path))
-
-
-def test_get_prefix_active():
-    with make_temp_env() as prefix, env_vars(
-        {"CONDA_PREFIX": prefix},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        assert get_prefix(Namespace(name=None, prefix=None)) == prefix
-
-
-def test_get_prefix_not_active(monkeypatch: MonkeyPatch):
-    monkeypatch.delenv("CONDA_PREFIX")
-    with pytest.raises(CondaEnvException):
-        get_prefix(Namespace(name=None, prefix=None))


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda.plugins.subcommands.doctor.cli.get_prefix` duplicates existing functionality that is solved by doing one of the following:

```python
from conda.base.context import context, determine_target_prefix
args = <argparse parsing>

# option 1
prefix = determine_target_prefix(context, args)

# option 2
context.__init__(argparse_args=args)
prefix = context.target_prefix
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
