### PR TITLE
`conda-content-trust` is incompatible with `cryptography=41.0.0`

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,14 +8,15 @@ boto3  # also need the `minio` server, installed manually in CI
 chardet
 conda
 conda-build >=3.23.3
+conda-content-trust
+conda-forge::flake8-docstrings
 conda-forge::pytest-split
 conda-forge::pytest-xprocess
 conda-forge::xdoctest
-conda-forge::flake8-docstrings
 conda-package-handling >=1.3.0
 conda-verify
-conda-content-trust
 coverage
+cryptography <41.0.0
 flake8
 flask >=2.2
 git

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -16,7 +16,7 @@ conda-forge::xdoctest
 conda-package-handling >=1.3.0
 conda-verify
 coverage
-cryptography <41.0.0
+cryptography <41.0.0  # 41.0.0 breaks conda-content-trust 0.1.3
 flake8
 flask >=2.2
 git
@@ -31,7 +31,7 @@ pluggy >=1.0.0
 pre-commit
 pycosat >=0.6.3
 pyflakes
-pyopenssl >=16.2.0,<23.2.0
+pyopenssl >=16.2.0,<23.2.0  # 23.2.0 breaks conda-content-trust 0.1.3
 pytest
 pytest-cov
 pytest-mock

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -31,7 +31,7 @@ pluggy >=1.0.0
 pre-commit
 pycosat >=0.6.3
 pyflakes
-pyopenssl >=16.2.0
+pyopenssl >=16.2.0,<23.2.0
 pytest
 pytest-cov
 pytest-mock

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1491,11 +1491,11 @@ def test_update_all_updates_pip_pkg(clear_package_cache: None):
 
 def test_package_optional_pinning(clear_package_cache: None):
     with make_temp_env() as prefix:
-        run_command(Commands.CONFIG, prefix, "--add", "pinned_packages", "python=3.6.5")
+        run_command(Commands.CONFIG, prefix, "--add", "pinned_packages", "python=3.10")
         run_command(Commands.INSTALL, prefix, "openssl")
         assert not package_is_installed(prefix, "python")
         run_command(Commands.INSTALL, prefix, "flask")
-        assert package_is_installed(prefix, "python=3.6.5")
+        assert package_is_installed(prefix, "python=3.10")
 
 
 def test_update_deps_flag_absent(clear_package_cache: None):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1492,7 +1492,7 @@ def test_update_all_updates_pip_pkg(clear_package_cache: None):
 def test_package_optional_pinning(clear_package_cache: None):
     with make_temp_env() as prefix:
         run_command(Commands.CONFIG, prefix, "--add", "pinned_packages", "python=3.10")
-        run_command(Commands.INSTALL, prefix, "openssl")
+        run_command(Commands.INSTALL, prefix, "zlib")
         assert not package_is_installed(prefix, "python")
         run_command(Commands.INSTALL, prefix, "flask")
         assert package_is_installed(prefix, "python=3.10")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Constrain `cryptography` to `<41.0.0` so it'll work with `conda-content-trust`. Also tossed in a line sort for good measure.

Xref https://github.com/conda/conda-content-trust/issues/56

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
