### PR TITLE
Fix distutils imports for upcoming deprecation in Python 3.12.

### DIFF
--- a/news/12762-distutils-deprecation
+++ b/news/12762-distutils-deprecation
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Stop using distutils directly in favor of the vendored version in
+  setuptools 60 and later. (#11136)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "pyopenssl >=16.2.0",
   "requests >=2.18.4,<3",
   "ruamel.yaml >=0.11.14,<0.18",
-  "setuptools >=31.0.1",
+  "setuptools >=60.0.0",
   "toolz >=0.8.1",
   "tqdm >=4",
 ]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - python
     - requests >=2.18.4,<3
     - ruamel.yaml >=0.11.14,<0.18
-    - setuptools >=31.0.1
+    - setuptools >=60.0.0
     - toolz >=0.8.1
     - tqdm >=4
   run_constrained:

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -3,8 +3,8 @@
 import ntpath
 import os
 import sys
-from distutils.sysconfig import get_python_lib
 from os.path import abspath, dirname, isfile, join, realpath
+from sysconfig import get_path
 
 import pytest
 
@@ -56,7 +56,7 @@ def test_get_python_info(verbose):
     python_exe, python_version, site_packages_dir = _get_python_info(sys.prefix)
     assert realpath(python_exe) == realpath(sys.executable)
     assert python_version == "%s.%s.%s" % sys.version_info[:3]
-    assert site_packages_dir == get_python_lib()
+    assert site_packages_dir == get_path("platlib")
 
 
 def test_make_install_plan(verbose, mocker):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -41,7 +41,7 @@ pytest-xdist
 requests >=2.18.4,<3
 responses
 ruamel.yaml >=0.11.14,<0.18
-setuptools >=31.0.1
+setuptools >=60.0.0
 setuptools_scm  # needed for devenv version detection
 toolz >=0.8.1
 tqdm >=4


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This removes imports from distutils that can be replaced with setuptools imports, following the guidance in the [migration guide](https://peps.python.org/pep-0632/#migration-advice).

Also bumps up to [setuptools 60.0.0](https://setuptools.pypa.io/en/latest/history.html#v60-0-0) since that's when "Setuptools once again makes its local copy of distutils the default. To override, set SETUPTOOLS_USE_DISTUTILS=stdlib".

Fix #11136.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
