### PR TITLE
Clone if not a PR for `dorny/paths-filter` & add PAT token so `durations.yml` PRs run workflows

### DIFF
--- a/.github/workflows/durations.yml
+++ b/.github/workflows/durations.yml
@@ -1,11 +1,12 @@
 name: Update Durations
 
 on:
-  # Every Sunday at 00:00 UTC
+  # every Sunday at 00:00 UTC
   # https://crontab.guru/#0_0_*_*_0
   schedule:
     - cron: '0 0 * * 0'
 
+  # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/durations.yml
+++ b/.github/workflows/durations.yml
@@ -47,7 +47,9 @@ jobs:
       - name: create updated durations PR
         uses: peter-evans/create-pull-request@v5
         with:
-          branch: conda-bot-update-durations
+          push-to-fork: conda-bot/conda
+          token: ${{ secrets.DURATIONS_TOKEN }}
+          branch: update-durations
           delete-branch: true
           commit-message: Update test durations
           author: Conda Bot <18747875+conda-bot@users.noreply.github.com>

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,7 @@
 name: Tests
 
 on:
-  # NOTE: github.event context is push payload:
-  # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
+  # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#push
   push:
     branches:
       - main
@@ -13,8 +12,7 @@ on:
       - '[0-9].*.x'  # e.g., 4.14.x
       - '[0-9][0-9].*.x'  # e.g., 23.3.x
 
-  # NOTE: github.event context is pull_request payload:
-  # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+  # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
   pull_request:
 
   # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,14 +38,16 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      # necessary to detect changes
+      # https://github.com/dorny/paths-filter#supported-workflows
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v3
         # dorny/paths-filter needs git clone for push events
-        # https://github.com/marketplace/actions/paths-changes-filter#supported-workflows
-        if: github.event_name == 'push'
+        # https://github.com/dorny/paths-filter#supported-workflows
+        if: github.event_name != 'pull_request'
       - uses: dorny/paths-filter@v2.11.1
         id: filter
         with:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Two changes here:
- `workflow_dispatch` also needs the repo to be cloned for https://github.com/dorny/paths-filter to work
- use a PAT token + `push_to_fork` when creating the duration update PRs such that our workflows run on the generated PR (see https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536204092)

Xref https://github.com/conda/conda/pull/12778

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
