### PR TITLE
Implement `repodata_patches` plugin hook

### DIFF
--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -756,9 +756,13 @@ class RepodataFetch:
         """
         parsed, state = self.fetch_latest()
         if isinstance(parsed, str):
-            return json.loads(parsed), state
-        else:
-            return parsed, state
+            parsed = json.loads(parsed)
+
+        # allow plugins to modify the repodata and state
+        for pre_solve in context.plugin_manager.get_hook_results("repodata_patches"):
+            parsed = pre_solve.action(parsed)
+
+        return parsed, state
 
     def fetch_latest_path(self) -> tuple[Path, RepodataState]:
         """

--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -3,6 +3,7 @@
 from .hookspec import hookimpl  # noqa: F401
 from .types import (  # noqa: F401
     CondaPreCommand,
+    CondaRepodataPatch,
     CondaSolver,
     CondaSubcommand,
     CondaVirtualPackage,

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -6,7 +6,13 @@ from collections.abc import Iterable
 
 import pluggy
 
-from .types import CondaPreCommand, CondaSolver, CondaSubcommand, CondaVirtualPackage
+from .types import (
+    CondaPreCommand,
+    CondaRepodataPatch,
+    CondaSolver,
+    CondaSubcommand,
+    CondaVirtualPackage,
+)
 
 spec_name = "conda"
 _hookspec = pluggy.HookspecMarker(spec_name)
@@ -122,4 +128,28 @@ class CondaSpecs:
                    action=example_pre_command,
                    run_for={"install", "create"},
                )
+        """
+
+    @_hookspec
+    def conda_repodata_patches(self) -> Iterable[CondaRepodataPatch]:
+        """
+        Register repodata patches in conda.
+
+        **Example:**
+
+        .. code-block:: python
+
+            from conda import plugins
+
+
+            def example_repodata_patch(repodata):
+                print("repodata patch action")
+
+
+            @plugins.hookimpl
+            def conda_repodata_patches():
+                yield CondaRepodataPatch(
+                    name="example-repodata-patch",
+                    action=example_repodata_patch,
+                )
         """

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -62,3 +62,15 @@ class CondaPreCommand(NamedTuple):
     name: str
     action: Callable
     run_for: set[str]
+
+
+class CondaRepodataPatch(NamedTuple):
+    """
+    A conda repodata patch.
+
+    :param name: Repodata patch name
+    :param action: Callable that will be run when the repodata is patched.
+    """
+
+    name: str
+    action: Callable[[dict], dict]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

After tinkering with the pre-solve (#12760) idea I realized that what I actually had in mind was a repodata patching hook.

The idea here is to allow for local manipulation of the `repodata.json` after fetching/caching but before usage.

POC plugin: https://github.com/kenodegard/conda-repodata

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
