### PR TITLE
Mark `conda.cli.python_api` for deprecation

### DIFF
--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -6,10 +6,13 @@ from ..base.constants import SEARCH_PATH
 from ..base.context import context
 from ..common.compat import encode_arguments
 from ..common.io import CaptureTarget, argv, captured
+from ..deprecations import deprecated
 from ..exceptions import conda_exception_handler
 from ..gateways.logging import initialize_std_loggers
 from .conda_argparse import do_call
 from .main import generate_parser
+
+deprecated.module("24.3", "24.9", addendum="Use `conda.testing.conda_cli` instead.")
 
 log = getLogger(__name__)
 

--- a/news/12796-deprecate-python_api
+++ b/news/12796-deprecate-python_api
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.cli.python_api` as pending deprecation. Use `conda.testing.conda_cli` fixture instead. (#12796)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

For testing purposes we now have the `conda_cli` fixture that we prefer to use. Otherwise this interface is for downstream projects that wish to programmatically interact with conda and offers an "API" when there isn't a clean and easy to use one in place.

Is this something we can afford to deprecate?

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
