### PR TITLE
Remove legacy `dotupdate` logger references

### DIFF
--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -312,7 +312,7 @@ def make_temp_env(*packages, **kwargs):
             rm_rf(prefix)
     if not isdir(prefix):
         make_temp_prefix(name, use_restricted_unicode, prefix)
-    with disable_logger("fetch"), disable_logger("dotupdate"):
+    with disable_logger("fetch"):
         try:
             # try to clear any config that's been set by other tests
             # CAUTION :: This does not partake in the context stack management code

--- a/tests/conda_env/test_create.py
+++ b/tests/conda_env/test_create.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import unittest
-from logging import Handler, getLogger
 from os.path import exists, join
 from unittest import TestCase
 from uuid import uuid4
@@ -23,23 +22,6 @@ from .utils import Commands, make_temp_envs_dir, run_command
 
 PYTHON_BINARY = "python.exe" if on_win else "bin/python"
 from tests.test_utils import is_prefix_activated_PATHwise
-
-
-def disable_dotlog():
-    class NullHandler(Handler):
-        def emit(self, record):
-            pass
-
-    dotlogger = getLogger("dotupdate")
-    saved_handlers = dotlogger.handlers
-    dotlogger.handlers = []
-    dotlogger.addHandler(NullHandler())
-    return saved_handlers
-
-
-def reenable_dotlog(handlers):
-    dotlogger = getLogger("dotupdate")
-    dotlogger.handlers = handlers
 
 
 def package_is_installed(prefix, spec, pip=None):
@@ -77,12 +59,6 @@ def get_env_vars(prefix):
 
 @pytest.mark.integration
 class IntegrationTests(TestCase):
-    def setUp(self):
-        self.saved_dotlog_handlers = disable_dotlog()
-
-    def tearDown(self):
-        reenable_dotlog(self.saved_dotlog_handlers)
-
     def test_create_update(self):
         with make_temp_envs_dir() as envs_dir:
             with env_var(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Remove `dotupdate` logger references. From the CHANGELOG these were last mentioned in `conda 3.18.0` from 2015.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
