### PR TITLE
Prototype for better organizing pre/post command hook function argment passing

### DIFF
--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -118,7 +118,7 @@ class CondaSpecs:
            from conda import plugins
 
 
-           def example_pre_command(command, arguments):
+           def example_pre_command(command, parsed_args=None, raw_args=None):
                print("pre-command action")
 
 
@@ -143,7 +143,7 @@ class CondaSpecs:
            from conda import plugins
 
 
-           def example_post_command(command, arguments):
+           def example_post_command(command, parsed_args=None, raw_args=None):
                print("post-command action")
 
 

--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -3,6 +3,7 @@
 """Entry point for all conda-env subcommands."""
 import os
 import sys
+from copy import deepcopy
 
 # pip_util.py import on_win from conda.exports
 # conda.exports resets the context
@@ -49,10 +50,11 @@ def do_call(arguments, parser):
     # Run the pre_command actions
     command = relative_mod.replace(".main_", "")
 
-    _run_command_hooks("pre", f"env_{command}", arguments)
+    plugin_arguments = deepcopy(arguments)
+    _run_command_hooks("pre", f"env_{command}", parsed_args=plugin_arguments)
     module = import_module(relative_mod, __name__.rsplit(".", 1)[0])
     exit_code = getattr(module, func_name)(arguments, parser)
-    _run_command_hooks("post", f"env_{command}", arguments)
+    _run_command_hooks("post", f"env_{command}", parsed_args=plugin_arguments)
 
     return exit_code
 

--- a/docs/source/dev-guide/plugins/post_commands.rst
+++ b/docs/source/dev-guide/plugins/post_commands.rst
@@ -1,14 +1,23 @@
-============
+=============
 Post-commands
-============
+=============
 
 Conda commands can be extended with the ``conda_post_commands`` plugin hook.
 By specifying the set of commands you would like to use in the ``run_for`` configuration
-option, you can execute code via the ``action`` option after these commands are run.
-The functions are provided ``command``, ``args`` and ``result`` as arguments which represent
-the name of the command currently running, the command line arguments, and the result of the
-running command, respectively. If the command fails for any reason, this plugin hook will not
-be run.
+option, you can execute code via the ``action`` option after these commands are run. ``action``
+should be a valid callable object.
+
+The ``action`` callable is provided the following arguments:
+
+- ``command``: name of the command currently being invoked
+- ``parsed_args``: an ``argparse.Namespace`` object; this will only be populated when the command
+   being run is a conda core command (e.g. ``install`` or ``create``)
+- ``raw_args``: a list of argument and option strings (e.g. ``['-p', '/tmp/path']``); this will
+  only be populated for plugin subcommands (i.e. subcommands that are not part of conda's
+  core).
+
+If the command fails for any reason, this plugin hook will not be run and the program will
+exit normally through conda's exception handler logic.
 
 If you would like to target ``conda env`` commands, prefix the command name with ``env_``.
 For example, ``conda env list`` would be passed to ``run_for`` as ``env_list``.

--- a/docs/source/dev-guide/plugins/pre_commands.rst
+++ b/docs/source/dev-guide/plugins/pre_commands.rst
@@ -4,9 +4,17 @@ Pre-commands
 
 Conda commands can be extended with the ``conda_pre_commands`` plugin hook.
 By specifying the set of commands you would like to use in the ``run_for`` configuration
-option, you can execute code via the ``action`` option before these commands are run.
-The functions are provided ``command`` and ``args`` arguments which represent the name
-of the command currently running and the command line arguments, respectively.
+option, you can execute code via the ``action`` option before these commands are run. ``action``
+should be a valid callable object.
+
+The ``action`` callable is provided the following arguments:
+
+- ``command``: name of the command currently being invoked
+- ``parsed_args``: an ``argparse.Namespace`` object; this will only be populated when the command
+   being run is a conda core command (e.g. ``install`` or ``create``)
+- ``raw_args``: a list of argument and option strings (e.g. ``['-p', '/tmp/path']``); this will
+  only be populated for plugin subcommands (i.e. subcommands that are not part of conda's
+  core).
 
 If you would like to target ``conda env`` commands, prefix the command name with ``env_``.
 For example, ``conda env list`` would be passed to ``run_for`` as ``env_list``.

--- a/tests/plugins/test_post_command.py
+++ b/tests/plugins/test_post_command.py
@@ -12,7 +12,7 @@ class PostCommandPlugin:
         self.args = None
 
     @staticmethod
-    def post_command_action(command, args) -> int:
+    def post_command_action(command, parsed_args=None, raw_args=None) -> int:
         pass
 
     @plugins.hookimpl

--- a/tests/plugins/test_pre_command.py
+++ b/tests/plugins/test_pre_command.py
@@ -11,7 +11,7 @@ class PreCommandPlugin:
         self.invoked = False
         self.args = None
 
-    def pre_command_action(self, command, args) -> int:
+    def pre_command_action(self, command, parsed_args=None, raw_args=None) -> int:
         pass
 
     @plugins.hookimpl


### PR DESCRIPTION
### Description

This pull request is an attempt to solve the inconsistency that currently exists when passing arguments to pre/post command hook action functions. As it currently stand, we pass in a single `arguments` argument that can either hold a parsed `argparse.Namespace` object or a list of raw strings from the command line (e.g. `['-p', '/tmp/path']`).

This pull request tried to acknowledge these differences by instead either passing in a `parsed_args` argument in the case of built-in conda commands or a `raw_args` argument for plugin subcommands. Plugin authors will be asked to write action functions which accept two keyword arguments (`parsed_args=None, raw_args=None`) to accommodate for this.

Instead of trying to solve the problem of somehow parsing plugin subcommand arguments, this approach acknowledges our short comings in not being able to reliably do that, and instead more clearly communicates to plugin authors when they can expect to receive a parsed arguments object and when not to.

### Checklist - did you ...
- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?