### PR TITLE
Substitute "repo.anaconda.com" for "www.anaconda.com" in http 000 msg

### DIFF
--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -319,7 +319,7 @@ of the remote server.
 An HTTP error occurred when trying to retrieve this URL.
 HTTP errors are often intermittent, and a simple retry will get you on your way.
 
-If your current network has https://www.anaconda.com blocked, please file
+If your current network has https://repo.anaconda.com blocked, please file
 a support request with your network engineering team.
 
 %s


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I know this is may seem like a nitpick.  But if a network administrator has blocked `repo.anaconda.com` but _not_ `www.anaconda.com`, these instructions may not actually be helpful. Consider the exchange:

USER: I was having trouble using conda, and the error message said that I should check to see if www.anaconda.com is blocked.

SYSADMIN:  nope, neither anaconda.com nor www.anaconda.com are on our block list. You should file a bug report with the conda folks, it's not our fault.

USER: hmm, OK, thanks.
