### PR TITLE
Use `os.environ["GITHUB_ENV"]` instead of `${{ env.GITHUB_ENV }}`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -448,6 +448,7 @@ jobs:
         run: |
           from pathlib import Path
           from re import match
+          from os import environ
 
           if "${{ github.ref_name }}" == "main":
               # main branch commits are uploaded to the dev label
@@ -461,7 +462,7 @@ jobs:
               _, name = "${{ github.repository }}".split("/")
               label = f"rc-{name}-${{ github.ref_name }}"
 
-          Path("${{ env.GITHUB_ENV }}").write_text(f"ANACONDA_ORG_LABEL={label}")
+          Path(environ["GITHUB_ENV"]).write_text(f"ANACONDA_ORG_LABEL={label}")
 
       - name: Create and upload canary build
         uses: conda/actions/canary-release@v22.10.0


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

An attempt to fix canary build failure: https://github.com/conda/conda/actions/runs/5511204508/jobs/10046436606

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
