### PR TITLE
Add advisory for Miniconda pkg installers

### DIFF
--- a/docs/source/user-guide/install/macos.rst
+++ b/docs/source/user-guide/install/macos.rst
@@ -2,6 +2,9 @@
 Installing on macOS
 ===================
 
+.. caution::
+   If you use the .pkg installer for Miniconda, be aware that those installers may skip the which will cause the installation to fail. If the installer skips this page, click Change Install Location... on the Installation Type page and choose a location for your install, then click Continue.
+
 #. Download the installer:
 
    * `Miniconda installer for macOS <https://conda.io/miniconda.html>`_.

--- a/docs/source/user-guide/install/macos.rst
+++ b/docs/source/user-guide/install/macos.rst
@@ -3,7 +3,7 @@ Installing on macOS
 ===================
 
 .. caution::
-   If you use the .pkg installer for Miniconda, be aware that those installers may skip the Destination Select page which will cause the installation to fail. If the installer skips this page, click Change Install Location... on the Installation Type page and choose a location for your install, then click Continue.
+   If you use the .pkg installer for Miniconda, be aware that those installers may skip the Destination Select page which will cause the installation to fail. If the installer skips this page, click "Change Install Location..." on the Installation Type page and choose a location for your install, then click Continue.
 
 #. Download the installer:
 

--- a/docs/source/user-guide/install/macos.rst
+++ b/docs/source/user-guide/install/macos.rst
@@ -3,7 +3,7 @@ Installing on macOS
 ===================
 
 .. caution::
-   If you use the .pkg installer for Miniconda, be aware that those installers may skip the which will cause the installation to fail. If the installer skips this page, click Change Install Location... on the Installation Type page and choose a location for your install, then click Continue.
+   If you use the .pkg installer for Miniconda, be aware that those installers may skip the Destination Select page which will cause the installation to fail. If the installer skips this page, click Change Install Location... on the Installation Type page and choose a location for your install, then click Continue.
 
 #. Download the installer:
 


### PR DESCRIPTION
### Description

Miniconda pkg installers may skip the "Destination Select" page during the installation process, which can cause the installation to fail.

This PR contains an advisory with a workaround until the problem is fixed.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?