### PR TITLE
Remove arguments/`sys.argv` from pre/post_command actions

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -117,9 +117,9 @@ def do_call(arguments: argparse.Namespace, parser: ArgumentParser):
     """
     # First, check if this is a plugin subcommand; if this attribute is present then it is
     if getattr(arguments, "plugin_subcommand", None):
-        _run_command_hooks("pre", arguments.plugin_subcommand.name, sys.argv[2:])
+        _run_command_hooks("pre", arguments.plugin_subcommand.name)
         result = arguments.plugin_subcommand.action(sys.argv[2:])
-        _run_command_hooks("post", arguments.plugin_subcommand.name, sys.argv[2:])
+        _run_command_hooks("post", arguments.plugin_subcommand.name)
 
         return result
 
@@ -130,25 +130,22 @@ def do_call(arguments: argparse.Namespace, parser: ArgumentParser):
     module = import_module(relative_mod, __name__.rsplit(".", 1)[0])
 
     command = relative_mod.replace(".main_", "")
-    _run_command_hooks("pre", command, arguments)
+    _run_command_hooks("pre", command)
     result = getattr(module, func_name)(arguments, parser)
-    _run_command_hooks("post", command, arguments)
+    _run_command_hooks("post", command)
 
     return result
 
 
-def _run_command_hooks(hook_type: CommandHookTypes, command: str, arguments) -> None:
+def _run_command_hooks(hook_type: CommandHookTypes, command: str) -> None:
     """
     Helper function used to gather applicable "pre" or "post" command hook functions
     and then run them.
-
-    The values in *args are passed directly through to the "pre" or "post" command
-    hook function.
     """
     actions = context.plugin_manager.yield_command_hook_actions(hook_type, command)
 
     for action in actions:
-        action(command, arguments)
+        action(command)
 
 
 def find_builtin_commands(parser):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -116,9 +116,9 @@ def do_call(arguments: argparse.Namespace, parser: ArgumentParser):
     """
     # First, check if this is a plugin subcommand; if this attribute is present then it is
     if getattr(arguments, "plugin_subcommand", None):
-        context.plugin_manager.apply_pre_commands(arguments.plugin_subcommand.name)
+        context.plugin_manager.invoke_pre_commands(arguments.plugin_subcommand.name)
         result = arguments.plugin_subcommand.action(sys.argv[2:])
-        context.plugin_manager.apply_post_commands(arguments.plugin_subcommand.name)
+        context.plugin_manager.invoke_post_commands(arguments.plugin_subcommand.name)
 
         return result
 
@@ -129,9 +129,9 @@ def do_call(arguments: argparse.Namespace, parser: ArgumentParser):
     module = import_module(relative_mod, __name__.rsplit(".", 1)[0])
 
     command = relative_mod.replace(".main_", "")
-    context.plugin_manager.apply_pre_commands(command)
+    context.plugin_manager.invoke_pre_commands(command)
     result = getattr(module, func_name)(arguments, parser)
-    context.plugin_manager.apply_post_commands(command)
+    context.plugin_manager.invoke_post_commands(command)
 
     return result
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -140,7 +140,6 @@ class CondaSpecs:
            @plugins.hookimpl
            def conda_pre_commands():
                yield CondaPreCommand(
-                   name="example-pre-command",
                    action=example_pre_command,
                    run_for={"install", "create"},
                )
@@ -165,7 +164,6 @@ class CondaSpecs:
            @plugins.hookimpl
            def conda_post_commands():
                yield CondaPostCommand(
-                   name="example-post-command",
                    action=example_post_command,
                    run_for={"install", "create"},
                )

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -140,6 +140,7 @@ class CondaSpecs:
            @plugins.hookimpl
            def conda_pre_commands():
                yield CondaPreCommand(
+                   name="example-pre-command",
                    action=example_pre_command,
                    run_for={"install", "create"},
                )
@@ -164,6 +165,7 @@ class CondaSpecs:
            @plugins.hookimpl
            def conda_post_commands():
                yield CondaPostCommand(
+                   name="example-post-command",
                    action=example_post_command,
                    run_for={"install", "create"},
                )

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -133,7 +133,7 @@ class CondaSpecs:
            from conda import plugins
 
 
-           def example_pre_command(command, arguments):
+           def example_pre_command(command):
                print("pre-command action")
 
 
@@ -158,7 +158,7 @@ class CondaSpecs:
            from conda import plugins
 
 
-           def example_post_command(command, arguments):
+           def example_post_command(command):
                print("post-command action")
 
 

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -21,7 +21,6 @@ from ..core.solve import Solver
 from ..exceptions import CondaValueError, PluginError
 from . import solvers, subcommands, virtual_packages
 from .hookspec import CondaSpecs, spec_name
-from .types import CommandHookTypes
 
 log = logging.getLogger(__name__)
 
@@ -132,7 +131,7 @@ class CondaPluginManager(pluggy.PluginManager):
             )
         return plugins
 
-    def get_solver_backend(self, name: str = None) -> type[Solver]:
+    def get_solver_backend(self, name: str | None = None) -> type[Solver]:
         """
         Get the solver backend with the given name (or fall back to the
         name provided in the context).
@@ -167,19 +166,25 @@ class CondaPluginManager(pluggy.PluginManager):
 
         return backend
 
-    def yield_command_hook_actions(self, hook_type: CommandHookTypes, command: str):
+    def apply_pre_commands(self, command: str) -> None:
         """
-        Yields either the ``CondaPreCommand.action`` or ``CondaPostCommand.action`` functions
-        registered by the ``conda_pre_commands`` or ``conda_post_commands`` hook.
+        Invokes ``CondaPreCommand.action`` functions registered with ``conda_pre_commands``.
 
-        :param hook_type: the type of command hook to retrieve
         :param command: name of the command that is currently being invoked
         """
-        command_hooks = self.get_hook_results(f"{hook_type}_commands")
+        for hook in self.get_hook_results("pre_commands"):
+            if command in hook.run_for:
+                hook.action(command)
 
-        for command_hook in command_hooks:
-            if command in command_hook.run_for:
-                yield command_hook.action
+    def apply_post_commands(self, command: str) -> None:
+        """
+        Invokes ``CondaPostCommand.action`` functions registered with ``conda_post_commands``.
+
+        :param command: name of the command that is currently being invoked
+        """
+        for hook in self.get_hook_results("post_commands"):
+            if command in hook.run_for:
+                hook.action(command)
 
 
 @functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -166,7 +166,7 @@ class CondaPluginManager(pluggy.PluginManager):
 
         return backend
 
-    def apply_pre_commands(self, command: str) -> None:
+    def invoke_pre_commands(self, command: str) -> None:
         """
         Invokes ``CondaPreCommand.action`` functions registered with ``conda_pre_commands``.
 
@@ -176,7 +176,7 @@ class CondaPluginManager(pluggy.PluginManager):
             if command in hook.run_for:
                 hook.action(command)
 
-    def apply_post_commands(self, command: str) -> None:
+    def invoke_post_commands(self, command: str) -> None:
         """
         Invokes ``CondaPostCommand.action`` functions registered with ``conda_post_commands``.
 

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -72,10 +72,12 @@ class CondaPreCommand(NamedTuple):
     For details on how this is used, see
     :meth:`~conda.plugins.hookspec.CondaSpecs.conda_pre_commands`.
 
+    :param name: Pre-command name (e.g., ``custom_plugin_pre_commands``).
     :param action: Callable which contains the code to be run.
     :param run_for: Represents the command(s) this will be run on (e.g. ``install`` or ``create``).
     """
 
+    name: str
     action: Callable[[str], None]
     run_for: set[str]
 
@@ -87,9 +89,11 @@ class CondaPostCommand(NamedTuple):
     For details on how this is used, see
     :meth:`~conda.plugins.hookspec.CondaSpecs.conda_post_commands`.
 
+    :param name: Post-command name (e.g., ``custom_plugin_post_commands``).
     :param action: Callable which contains the code to be run.
     :param run_for: Represents the command(s) this will be run on (e.g. ``install`` or ``create``).
     """
 
+    name: str
     action: Callable[[str], None]
     run_for: set[str]

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -78,7 +78,7 @@ class CondaPreCommand(NamedTuple):
     """
 
     name: str
-    action: Callable
+    action: Callable[[str], None]
     run_for: set[str]
 
 
@@ -95,5 +95,5 @@ class CondaPostCommand(NamedTuple):
     """
 
     name: str
-    action: Callable
+    action: Callable[[str], None]
     run_for: set[str]

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -8,12 +8,9 @@ Each type corresponds to the plugin hook for which it is used.
 """
 from __future__ import annotations
 
-from typing import Callable, Literal, NamedTuple
+from typing import Callable, NamedTuple
 
 from ..core.solve import Solver
-
-CommandHookTypes = Literal["pre", "post"]
-"""The two different types of `conda_*_commands` hooks that are available"""
 
 
 class CondaSubcommand(NamedTuple):

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -72,12 +72,10 @@ class CondaPreCommand(NamedTuple):
     For details on how this is used, see
     :meth:`~conda.plugins.hookspec.CondaSpecs.conda_pre_commands`.
 
-    :param name: Pre-command name (e.g., ``custom_plugin_pre_commands``).
     :param action: Callable which contains the code to be run.
     :param run_for: Represents the command(s) this will be run on (e.g. ``install`` or ``create``).
     """
 
-    name: str
     action: Callable[[str], None]
     run_for: set[str]
 
@@ -89,11 +87,9 @@ class CondaPostCommand(NamedTuple):
     For details on how this is used, see
     :meth:`~conda.plugins.hookspec.CondaSpecs.conda_post_commands`.
 
-    :param name: Post-command name (e.g., ``custom_plugin_post_commands``).
     :param action: Callable which contains the code to be run.
     :param run_for: Represents the command(s) this will be run on (e.g. ``install`` or ``create``).
     """
 
-    name: str
     action: Callable[[str], None]
     run_for: set[str]

--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -49,10 +49,10 @@ def do_call(arguments, parser):
     # Run the pre_command actions
     command = relative_mod.replace(".main_", "")
 
-    _run_command_hooks("pre", f"env_{command}", arguments)
+    _run_command_hooks("pre", f"env_{command}")
     module = import_module(relative_mod, __name__.rsplit(".", 1)[0])
     exit_code = getattr(module, func_name)(arguments, parser)
-    _run_command_hooks("post", f"env_{command}", arguments)
+    _run_command_hooks("post", f"env_{command}")
 
     return exit_code
 

--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -10,7 +10,7 @@ import sys
 # when importing pip (and pip_util)
 import conda.exports  # noqa
 from conda.base.context import context
-from conda.cli.conda_argparse import ArgumentParser, _run_command_hooks
+from conda.cli.conda_argparse import ArgumentParser
 from conda.cli.main import init_loggers
 from conda.exceptions import conda_exception_handler
 from conda.gateways.logging import initialize_logging
@@ -49,10 +49,10 @@ def do_call(arguments, parser):
     # Run the pre_command actions
     command = relative_mod.replace(".main_", "")
 
-    _run_command_hooks("pre", f"env_{command}")
+    context.plugin_manager.apply_pre_commands(f"env_{command}")
     module = import_module(relative_mod, __name__.rsplit(".", 1)[0])
     exit_code = getattr(module, func_name)(arguments, parser)
-    _run_command_hooks("post", f"env_{command}")
+    context.plugin_manager.apply_post_commands(f"env_{command}")
 
     return exit_code
 

--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -49,10 +49,10 @@ def do_call(arguments, parser):
     # Run the pre_command actions
     command = relative_mod.replace(".main_", "")
 
-    context.plugin_manager.apply_pre_commands(f"env_{command}")
+    context.plugin_manager.invoke_pre_commands(f"env_{command}")
     module = import_module(relative_mod, __name__.rsplit(".", 1)[0])
     exit_code = getattr(module, func_name)(arguments, parser)
-    context.plugin_manager.apply_post_commands(f"env_{command}")
+    context.plugin_manager.invoke_post_commands(f"env_{command}")
 
     return exit_code
 

--- a/docs/source/dev-guide/plugins/post_commands.rst
+++ b/docs/source/dev-guide/plugins/post_commands.rst
@@ -5,9 +5,8 @@ Post-commands
 Conda commands can be extended with the ``conda_post_commands`` plugin hook.
 By specifying the set of commands you would like to use in the ``run_for`` configuration
 option, you can execute code via the ``action`` option after these commands are run.
-The functions are provided ``command``, ``args`` and ``result`` as arguments which represent
-the name of the command currently running, the command line arguments, and the result of the
-running command, respectively. If the command fails for any reason, this plugin hook will not
+The functions are provided a ``command`` argument representing the name
+of the command currently running. If the command fails for any reason, this plugin hook will not
 be run.
 
 If you would like to target ``conda env`` commands, prefix the command name with ``env_``.

--- a/docs/source/dev-guide/plugins/pre_commands.rst
+++ b/docs/source/dev-guide/plugins/pre_commands.rst
@@ -5,8 +5,8 @@ Pre-commands
 Conda commands can be extended with the ``conda_pre_commands`` plugin hook.
 By specifying the set of commands you would like to use in the ``run_for`` configuration
 option, you can execute code via the ``action`` option before these commands are run.
-The functions are provided ``command`` and ``args`` arguments which represent the name
-of the command currently running and the command line arguments, respectively.
+The functions are provided a ``command`` argument representing the name
+of the command currently running.
 
 If you would like to target ``conda env`` commands, prefix the command name with ``env_``.
 For example, ``conda env list`` would be passed to ``run_for`` as ``env_list``.

--- a/news/12712-pre-command-plugin-hook
+++ b/news/12712-pre-command-plugin-hook
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add a new "pre_commands" hook allowing plugins to run code before a `conda` subcommand. (#12712)
+* Add a new "pre_commands" hook allowing plugins to run code before a `conda` subcommand. (#12712, #12864)
 
 ### Docs
 

--- a/news/12758-post-command-plugin-hook
+++ b/news/12758-post-command-plugin-hook
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add a new "post_commands" hook allowing plugins to run code before a `conda` subcommand. (#12758)
+* Add a new "post_commands" hook allowing plugins to run code before a `conda` subcommand. (#12758, #12864)
 
 ### Docs
 

--- a/tests/plugins/test_post_command.py
+++ b/tests/plugins/test_post_command.py
@@ -7,7 +7,7 @@ from conda.plugins.types import CondaPostCommand
 
 
 class PostCommandPlugin:
-    def post_command_action(self, command) -> int:
+    def post_command_action(self, command: str) -> int:
         pass
 
     @plugins.hookimpl

--- a/tests/plugins/test_post_command.py
+++ b/tests/plugins/test_post_command.py
@@ -7,12 +7,7 @@ from conda.plugins.types import CondaPostCommand
 
 
 class PostCommandPlugin:
-    def __init__(self):
-        self.invoked = False
-        self.args = None
-
-    @staticmethod
-    def post_command_action(command, args) -> int:
+    def post_command_action(self, command) -> int:
         pass
 
     @plugins.hookimpl
@@ -26,11 +21,7 @@ class PostCommandPlugin:
 
 @pytest.fixture()
 def post_command_plugin(mocker, plugin_manager):
-    mocker.patch.object(
-        PostCommandPlugin,
-        "post_command_action",
-        wraps=PostCommandPlugin.post_command_action,
-    )
+    mocker.patch.object(PostCommandPlugin, "post_command_action")
 
     post_command_plugin = PostCommandPlugin()
     plugin_manager.register(post_command_plugin)

--- a/tests/plugins/test_post_command.py
+++ b/tests/plugins/test_post_command.py
@@ -13,6 +13,7 @@ class PostCommandPlugin:
     @plugins.hookimpl
     def conda_post_commands(self):
         yield CondaPostCommand(
+            name="custom-post-command",
             action=self.post_command_action,
             run_for={"install", "create", "info"},
         )

--- a/tests/plugins/test_post_command.py
+++ b/tests/plugins/test_post_command.py
@@ -13,7 +13,6 @@ class PostCommandPlugin:
     @plugins.hookimpl
     def conda_post_commands(self):
         yield CondaPostCommand(
-            name="custom-post-command",
             action=self.post_command_action,
             run_for={"install", "create", "info"},
         )

--- a/tests/plugins/test_pre_command.py
+++ b/tests/plugins/test_pre_command.py
@@ -7,11 +7,7 @@ from conda.plugins.types import CondaPreCommand
 
 
 class PreCommandPlugin:
-    def __init__(self):
-        self.invoked = False
-        self.args = None
-
-    def pre_command_action(self, command, args) -> int:
+    def pre_command_action(self, command) -> int:
         pass
 
     @plugins.hookimpl
@@ -57,7 +53,7 @@ def test_pre_command_action_raises_exception(pre_command_plugin, conda_cli):
     that it bubbles up to the top and isn't caught anywhere. This will ensure that it
     goes through our normal exception catching/reporting mechanism.
     """
-    exc_message = "Boom!"
+    exc_message = "💥"
     pre_command_plugin.pre_command_action.side_effect = [Exception(exc_message)]
 
     with pytest.raises(Exception, match=exc_message):

--- a/tests/plugins/test_pre_command.py
+++ b/tests/plugins/test_pre_command.py
@@ -13,6 +13,7 @@ class PreCommandPlugin:
     @plugins.hookimpl
     def conda_pre_commands(self):
         yield CondaPreCommand(
+            name="custom-pre-command",
             action=self.pre_command_action,
             run_for={"install", "create", "info"},
         )

--- a/tests/plugins/test_pre_command.py
+++ b/tests/plugins/test_pre_command.py
@@ -13,7 +13,6 @@ class PreCommandPlugin:
     @plugins.hookimpl
     def conda_pre_commands(self):
         yield CondaPreCommand(
-            name="custom-pre-command",
             action=self.pre_command_action,
             run_for={"install", "create", "info"},
         )

--- a/tests/plugins/test_pre_command.py
+++ b/tests/plugins/test_pre_command.py
@@ -7,7 +7,7 @@ from conda.plugins.types import CondaPreCommand
 
 
 class PreCommandPlugin:
-    def pre_command_action(self, command) -> int:
+    def pre_command_action(self, command: str) -> int:
         pass
 
     @plugins.hookimpl


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Since we haven't solved the [inconsistency](https://github.com/conda/conda/pull/12814) of builtin subcommands passing a parsed `Namespace` and plugin subcommands passing an iterable of strings (i.e., `sys.argv`) this removes passing in the args into the pre/post command until we can properly identify a safe path forward.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
