### PR TITLE
Modify plugin loading to only use canonical names

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -141,7 +141,7 @@ class CondaPluginManager(pluggy.PluginManager):
         specname = f"{self.project_name}_{name}"  # e.g. conda_solvers
         hook = getattr(self.hook, specname, None)
         if hook is None:
-            raise PluginError(f"Could not load `{specname}` plugins.")
+            raise PluginError(f"Could not find requested `{name}` plugins")
 
         plugins = sorted(
             (item for items in hook() for item in items),

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -50,8 +50,8 @@ class CondaPluginManager(pluggy.PluginManager):
     def get_canonical_name(self, plugin: object) -> str:
         # detect the fully qualified module name
         prefix = "<unknown_module>"
-        if module := getmodule(plugin):
-            prefix = module.__spec__.name if module.__spec__ else module.__name__
+        if (module := getmodule(plugin)) and module.__spec__:
+            prefix = module.__spec__.name
 
         # return the fully qualified name for modules
         if module is plugin:

--- a/news/12869-canonical-names
+++ b/news/12869-canonical-names
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Register plugins using their canonical/fully qualified name instead of the easily spoofable entry point name. (#12869)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/plugins/data/test-plugin/test_plugin-1.0.dist-info/entry_points.txt
+++ b/tests/plugins/data/test-plugin/test_plugin-1.0.dist-info/entry_points.txt
@@ -1,4 +1,4 @@
-[load_entrypoints]
+[test_plugin]
+blocked=test_plugin.blocked
 importerror=test_plugin.importerror
 success=test_plugin.success
-blocked=test_plugin.blocked

--- a/tests/plugins/data/test-plugin/test_plugin-1.0.dist-info/entry_points.txt
+++ b/tests/plugins/data/test-plugin/test_plugin-1.0.dist-info/entry_points.txt
@@ -1,2 +1,4 @@
-[conda]
-conda-test-plugin=test_plugin.plugin
+[load_entrypoints]
+importerror=test_plugin.importerror
+success=test_plugin.success
+blocked=test_plugin.blocked

--- a/tests/plugins/data/test-plugin/test_plugin/blocked.py
+++ b/tests/plugins/data/test-plugin/test_plugin/blocked.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+# see tests.plugins.test_manager.test_load_entrypoints_blocked
+# simulate a blocked plugin

--- a/tests/plugins/data/test-plugin/test_plugin/importerror.py
+++ b/tests/plugins/data/test-plugin/test_plugin/importerror.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+# see tests.plugins.test_manager.test_load_entrypoints_importerror
+# simulate an ImportError
+import package_that_does_not_exist

--- a/tests/plugins/data/test-plugin/test_plugin/success.py
+++ b/tests/plugins/data/test-plugin/test_plugin/success.py
@@ -1,11 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (C) 2022 Anaconda, Inc
-# SPDX-License-Identifier: BSD-3-Clause
-# this is where we simulate an ImportError
-# tested in test_manager.py::test_load_entrypoints_importerror
-import package_that_does_not_exist
-
+# see tests.plugins.test_manager.test_load_entrypoints_success
+# simulate a successful plugin
 from conda import plugins
 from conda.core.solve import Solver
 

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -31,13 +31,13 @@ class VerboseSolverPlugin:
 
 def test_load_no_plugins(plugin_manager):
     plugin_names = plugin_manager.load_plugins()
-    assert plugin_names == []
+    assert not plugin_names
 
 
 def test_load_two_plugins_one_impls(plugin_manager):
     this_module = sys.modules[__name__]
     plugin_names = plugin_manager.load_plugins(this_module)
-    assert plugin_names == [__name__]
+    assert plugin_names == 1
     assert plugin_manager.get_plugins() == {this_module}
     assert plugin_manager.hook.conda_solvers.get_hookimpls() == []
 
@@ -92,5 +92,6 @@ def test_load_entrypoints_importerror(plugin_manager, mocker, monkeypatch):
     assert plugin_manager.get_plugins() == set()
     assert mocked_warning.call_count == 1
     assert mocked_warning.call_args.args[0] == (
-        "Could not load conda plugin `conda-test-plugin`:\n\nNo module named 'package_that_does_not_exist'"
+        "Error while loading conda entry point: conda-test-plugin "
+        "(No module named 'package_that_does_not_exist')"
     )

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -109,7 +109,7 @@ def test_load_entrypoints_blocked(plugin_manager):
     assert plugin_manager.load_entrypoints("test_plugin", "blocked") == 0
 
     # pluggy > 1.0.0
-    if plugin_manager.get_plugins() is {None}:
+    if plugin_manager.get_plugins() == {None}:
         assert plugin_manager.list_name_plugin() == [("test_plugin.blocked", None)]
     # pluggy <= 1.0.0
     else:

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -86,11 +86,11 @@ def test_load_plugins_error(plugin_manager):
     plugin_manager.load_plugins(VerboseSolverPlugin)
     # then try again to trigger a PluginError via the `ValueError` that
     # pluggy.PluginManager.register throws on duplicate plugins
-    with pytest.raises(PluginError) as exc:
+    with pytest.raises(
+        PluginError, match="Error while loading first-party conda plugin"
+    ):
         plugin_manager.load_plugins(VerboseSolverPlugin)
     assert plugin_manager.get_plugins() == {VerboseSolverPlugin}
-    assert exc.value.return_code == 1
-    assert "Error while loading first-party conda plugin" in str(exc.value)
 
 
 def test_load_entrypoints_success(plugin_manager):

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -85,14 +85,14 @@ def test_load_plugins_error(plugin_manager, mocker):
 
 
 def test_load_entrypoints_success(plugin_manager):
-    assert plugin_manager.load_entrypoints("load_entrypoints", "success") == 1
+    assert plugin_manager.load_entrypoints("test_plugin", "success") == 1
     assert len(plugin_manager.get_plugins()) == 1
 
 
 def test_load_entrypoints_importerror(plugin_manager, mocker, monkeypatch):
     mocked_warning = mocker.patch("conda.plugins.manager.log.warning")
 
-    assert plugin_manager.load_entrypoints("load_entrypoints", "importerror") == 0
+    assert plugin_manager.load_entrypoints("test_plugin", "importerror") == 0
     assert len(plugin_manager.get_plugins()) == 0
 
     assert mocked_warning.call_count == 1
@@ -105,5 +105,6 @@ def test_load_entrypoints_importerror(plugin_manager, mocker, monkeypatch):
 def test_load_entrypoints_blocked(plugin_manager):
     plugin_manager.set_blocked("test_plugin.blocked")
 
-    assert plugin_manager.load_entrypoints("load_entrypoints", "blocked") == 0
+    assert plugin_manager.load_entrypoints("test_plugin", "blocked") == 0
+    print(plugin_manager.get_plugins())
     assert len(plugin_manager.get_plugins()) == 0

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -107,4 +107,5 @@ def test_load_entrypoints_blocked(plugin_manager):
 
     assert plugin_manager.load_entrypoints("test_plugin", "blocked") == 0
     print(plugin_manager.get_plugins())
+    print(plugin_manager.list_name_plugin())
     assert len(plugin_manager.get_plugins()) == 0

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -4,7 +4,9 @@ import logging
 import re
 import sys
 
+import pluggy
 import pytest
+from packaging.version import Version
 
 from conda import plugins
 from conda.core import solve
@@ -107,10 +109,8 @@ def test_load_entrypoints_blocked(plugin_manager):
     plugin_manager.set_blocked("test_plugin.blocked")
 
     assert plugin_manager.load_entrypoints("test_plugin", "blocked") == 0
-
-    # pluggy > 1.0.0
-    if plugin_manager.get_plugins() == {None}:
-        assert plugin_manager.list_name_plugin() == [("test_plugin.blocked", None)]
-    # pluggy <= 1.0.0
+    if Version(pluggy.__version__) > Version("1.0.0"):
+        assert plugin_manager.get_plugins() == {None}
     else:
-        assert plugin_manager.list_name_plugin() == []
+        assert plugin_manager.get_plugins() == set()
+    assert plugin_manager.list_name_plugin() == [("test_plugin.blocked", None)]

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -87,6 +87,7 @@ def test_load_plugins_error(plugin_manager, mocker):
 def test_load_entrypoints_success(plugin_manager):
     assert plugin_manager.load_entrypoints("test_plugin", "success") == 1
     assert len(plugin_manager.get_plugins()) == 1
+    assert plugin_manager.list_name_plugin()[0][0] == "test_plugin.success"
 
 
 def test_load_entrypoints_importerror(plugin_manager, mocker, monkeypatch):
@@ -106,6 +107,10 @@ def test_load_entrypoints_blocked(plugin_manager):
     plugin_manager.set_blocked("test_plugin.blocked")
 
     assert plugin_manager.load_entrypoints("test_plugin", "blocked") == 0
-    print(plugin_manager.get_plugins())
-    print(plugin_manager.list_name_plugin())
-    assert len(plugin_manager.get_plugins()) == 0
+
+    # pluggy > 1.0.0
+    if plugin_manager.get_plugins() is {None}:
+        assert plugin_manager.list_name_plugin() == [("test_plugin.blocked", None)]
+    # pluggy <= 1.0.0
+    else:
+        assert plugin_manager.list_name_plugin() == []

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -84,14 +84,26 @@ def test_load_plugins_error(plugin_manager, mocker):
     assert "load_plugins error" in str(exc.value)
 
 
+def test_load_entrypoints_success(plugin_manager):
+    assert plugin_manager.load_entrypoints("load_entrypoints", "success") == 1
+    assert len(plugin_manager.get_plugins()) == 1
+
+
 def test_load_entrypoints_importerror(plugin_manager, mocker, monkeypatch):
-    # the fake package under data/test-plugin is added to the PYTHONPATH
-    # via the pytest config
     mocked_warning = mocker.patch("conda.plugins.manager.log.warning")
-    plugin_manager.load_entrypoints("conda")
-    assert plugin_manager.get_plugins() == set()
+
+    assert plugin_manager.load_entrypoints("load_entrypoints", "importerror") == 0
+    assert len(plugin_manager.get_plugins()) == 0
+
     assert mocked_warning.call_count == 1
     assert mocked_warning.call_args.args[0] == (
-        "Error while loading conda entry point: conda-test-plugin "
+        "Error while loading conda entry point: importerror "
         "(No module named 'package_that_does_not_exist')"
     )
+
+
+def test_load_entrypoints_blocked(plugin_manager):
+    plugin_manager.set_blocked("test_plugin.blocked")
+
+    assert plugin_manager.load_entrypoints("load_entrypoints", "blocked") == 0
+    assert len(plugin_manager.get_plugins()) == 0

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -34,7 +34,7 @@ class VerboseSolverPlugin:
 
 def test_load_no_plugins(plugin_manager):
     plugin_names = plugin_manager.load_plugins()
-    assert not plugin_names
+    assert plugin_names == 0
 
 
 def test_load_two_plugins_one_impls(plugin_manager):

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -42,7 +42,7 @@ def test_load_two_plugins_one_impls(plugin_manager):
     assert plugin_manager.hook.conda_solvers.get_hookimpls() == []
 
     plugin_names = plugin_manager.load_plugins(VerboseSolverPlugin)
-    assert plugin_names == ["VerboseSolverPlugin"]
+    assert plugin_names == 1
     assert plugin_manager.get_plugins() == {this_module, VerboseSolverPlugin}
 
     hooks_impls = plugin_manager.hook.conda_solvers.get_hookimpls()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This changes how entry point plugins are registered. Instead of using the entry point name as the plugin name we use the canonical name (this is creates more consistency with how first-party plugins are loaded).

This is inspired by the spoofing concerns raised while implementing `--no-plugins` (https://github.com/conda/conda/pull/12824).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
