### PR TITLE
Use workaround for use of `argparse.REMAINDER` for subcommands

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -405,6 +405,14 @@ def configure_parser_plugins(sub_parsers, plugin_subcommands) -> None:
         try:
             plugin_subcommand.configure_parser(parser)
         except NotImplementedError:
+            # we first need to work around an issue in argparse,
+            # in which when using argparse.REMAINDER will mess up
+            # the parsing if it's the first argument being parsed.
+            # https://github.com/python/cpython/issues/61252#issuecomment-1093606584
+            # found out that if we add an unused positional argument
+            # it should just work
+            breakpoint()
+            parser.add_argument("ignore")
             # we store all other arguments here, so we can pass them to the
             # plugin subcommands later
             parser.add_argument(

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -411,7 +411,6 @@ def configure_parser_plugins(sub_parsers, plugin_subcommands) -> None:
             # https://github.com/python/cpython/issues/61252#issuecomment-1093606584
             # found out that if we add an unused positional argument
             # it should just work
-            breakpoint()
             parser.add_argument("ignore")
             # we store all other arguments here, so we can pass them to the
             # plugin subcommands later


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Refs #12906

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- ~[ ] Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
