### PR TITLE
Alternative approach to fixing plugin subcommand line parsing

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -419,7 +419,6 @@ def configure_parser_plugins(sub_parsers, plugin_subcommands) -> None:
             description=plugin_subcommand.summary,
             help=plugin_subcommand.summary,
             formatter_class=RawDescriptionHelpFormatter,
-            add_help=False,
         )
         try:
             plugin_subcommand.configure_parser(parser)


### PR DESCRIPTION
This is an alternative approach I came up with while looking at @jezdez's proposed solution #12908.

It basically figures out when we can skip calling `parse_args`. Calling this method when the subcommand has not provided a `configure_parser` implementation will always cause the help pages to not work. The pull pull request bypasses that issue by simply not calling `parse_args` for subcommand plugins that have not defined this function.

They way we check for this is admittedly pretty ugly in the `parse_args` method. This could be improved 😅.

Resolves #12906