### PR TITLE
Implement 2-phase parser with greedy subparsers

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -14,7 +14,6 @@ from argparse import (
     _HelpAction,
     _StoreAction,
 )
-from functools import lru_cache
 from importlib import import_module
 from logging import getLogger
 from os.path import abspath, expanduser, join
@@ -33,6 +32,7 @@ from ..base.constants import (
 from ..base.context import context
 from ..common.constants import NULL
 from ..deprecations import deprecated
+from .find_commands import find_commands, find_executable
 
 log = getLogger(__name__)
 
@@ -63,18 +63,13 @@ BUILTIN_COMMANDS = {
 }
 
 
-def generate_parser():
+def generate_pre_parser(**kwargs) -> ArgumentParser:
     p = ArgumentParser(
         description="conda is a tool for managing and deploying applications,"
         " environments and packages.",
+        **kwargs,
     )
-    p.add_argument(
-        "-V",
-        "--version",
-        action="version",
-        version="conda %s" % __version__,
-        help="Show the conda version number and exit.",
-    )
+
     p.add_argument(
         "--debug",
         action="store_true",
@@ -91,12 +86,27 @@ def generate_parser():
         default=NULL,
         help="Disable all plugins that are not built into conda.",
     )
+
+    return p
+
+
+def generate_parser(**kwargs) -> ArgumentParser:
+    p = generate_pre_parser(**kwargs)
+
+    p.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version="conda %s" % __version__,
+        help="Show the conda version number and exit.",
+    )
+
     sub_parsers = p.add_subparsers(
         metavar="COMMAND",
         title="commands",
         description="The following built-in and plugins subcommands are available.",
         dest="cmd",
-        required=True,
+        action=_GreedySubParsersAction,
     )
 
     configure_parser_clean(sub_parsers)
@@ -114,7 +124,7 @@ def generate_parser():
     configure_parser_run(sub_parsers)
     configure_parser_search(sub_parsers)
     configure_parser_update(sub_parsers, aliases=["upgrade"])
-    configure_parser_plugins(sub_parsers, p.plugin_subcommands)
+    configure_parser_plugins(sub_parsers)
 
     return p
 
@@ -126,18 +136,30 @@ def do_call(args: argparse.Namespace, parser: ArgumentParser):
     """
     # let's see if during the parsing phase it was discovered that the
     # called command was in fact a plugin subcommand
-    plugin_subcommand = getattr(args, "plugin_subcommand", None)
-
-    if plugin_subcommand:
+    if plugin := getattr(args, "_plugin", None):
         # pass on the rest of the plugin specific args or fall back to
         # the whole discovered arguments
         try:
-            plugin_args = tuple(args.plugin_args)
+            plugin_args = tuple(args._args)
         except AttributeError:
             plugin_args = args
-        context.plugin_manager.invoke_pre_commands(plugin_subcommand.name)
-        result = plugin_subcommand.action(plugin_args)
-        context.plugin_manager.invoke_post_commands(plugin_subcommand.name)
+        context.plugin_manager.invoke_pre_commands(plugin.name)
+        result = plugin.action(plugin_args)
+        context.plugin_manager.invoke_post_commands(plugin.name)
+    elif name := getattr(args, "_executable", None):
+        # run the subcommand from executables; legacy path
+        deprecated.topic(
+            "23.3",
+            "23.9",
+            topic="Loading conda subcommands via executables",
+            addendum="Use the plugin system instead.",
+        )
+        executable = find_executable(f"conda-{name}")
+        if not executable:
+            from ..exceptions import CommandNotFoundError
+
+            raise CommandNotFoundError(name)
+        _exec([executable, *args._args], os.environ)
     else:
         # let's call the subcommand the old-fashioned way via the assigned func..
         relative_mod, func_name = args.func.rsplit(".", 1)
@@ -158,149 +180,47 @@ def find_builtin_commands(parser):
 
 
 class ArgumentParser(ArgumentParserBase):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, add_help=True, **kwargs):
         kwargs.setdefault("formatter_class", RawDescriptionHelpFormatter)
-        if "add_help" not in kwargs:
-            add_custom_help = True
-            kwargs["add_help"] = False
-        else:
-            add_custom_help = False
-        # Handle option conflicts gracefully
-        kwargs.setdefault("conflict_handler", "resolve")
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, add_help=False, **kwargs)
 
-        if add_custom_help:
+        if add_help:
             add_parser_help(self)
-
-    # FUTURE: Python 3.8+, replace with functools.cached_property
-    @property
-    @lru_cache(maxsize=None)
-    def plugins_disabled(self) -> bool:
-        return "--no-plugins" in sys.argv or context.no_plugins
-
-    # FUTURE: Python 3.8+, replace with functools.cached_property
-    @property
-    @lru_cache(maxsize=None)
-    def plugin_subcommands(self):
-        # first, let's disable all external plugins if requested
-        if self.plugins_disabled:
-            context.plugin_manager.disable_external_plugins()
-        return {
-            subcommand.name: subcommand
-            for subcommand in context.plugin_manager.get_hook_results("subcommands")
-        }
-
-    def _get_action_from_name(self, name):
-        """Given a name, get the Action instance registered with this parser.
-        If only it were made available in the ArgumentError object. It is
-        passed as it's first arg...
-        """
-        container = self._actions
-        if name is None:
-            return None
-        for action in container:
-            if "/".join(action.option_strings) == name:
-                return action
-            elif action.metavar == name:
-                return action
-            elif action.dest == name:
-                return action
-
-    def error(self, message):
-        import re
-
-        from .find_commands import find_executable
-
-        exc = sys.exc_info()[1]
-        if exc:
-            # this is incredibly lame, but argparse stupidly does not expose
-            # reasonable hooks for customizing error handling
-            if hasattr(exc, "argument_name"):
-                argument = self._get_action_from_name(exc.argument_name)
-            else:
-                argument = None
-            if argument and argument.dest == "cmd":
-                m = re.match(r"invalid choice: u?'([-\w]*?)'", exc.message)
-                if m:
-                    cmd = m.group(1)
-                    if not cmd:
-                        self.print_help()
-                        sys.exit(0)
-                    else:
-                        # Run the subcommand from executables; legacy path
-                        deprecated.topic(
-                            "23.3",
-                            "23.9",
-                            topic="Loading conda subcommands via executables",
-                            addendum="Use the plugin system instead.",
-                        )
-                        executable = find_executable("conda-" + cmd)
-                        if not executable:
-                            from ..exceptions import CommandNotFoundError
-
-                            raise CommandNotFoundError(cmd)
-                        args = [find_executable("conda-" + cmd)]
-                        args.extend(sys.argv[2:])
-                        _exec(args, os.environ)
-
-        super().error(message)
-
-    def print_help(self):
-        super().print_help()
-
-        # using a set here to check for existence independent of order
-        if set(sys.argv[1:]).intersection({"", "help", "-h", "--help"}):
-            from .find_commands import find_commands
-
-            other_commands = find_commands()
-            if not self.plugins_disabled:
-                other_commands = set(other_commands).difference(self.plugin_subcommands)
-
-            if other_commands:
-                builder = [""]
-                builder.append("conda commands available from other packages (legacy):")
-                builder.extend("    %s" % cmd for cmd in sorted(other_commands))
-                print("\n".join(builder))
 
     def _check_value(self, action, value):
         # extend to properly handle when we accept multiple choices and the default is a list
         if action.choices is not None and isiterable(value):
             for element in value:
                 super()._check_value(action, element)
-        else:
+        elif value not in action.choices:
             super()._check_value(action, value)
 
-    def parse_args(self, args=None, namespace=None):
-        """
-        We override this method to check if we are running from a known plugin subcommand.
-        If we are, we do not want to handle argument parsing as this is delegated to the plugin
-        subcommand. We instead return a ``Namespace`` object with ``plugin_subcommand`` defined,
-        which is a ``conda.plugins.CondaSubcommand`` object.
-        """
-        # args default to the system args
-        if args is None:
-            args = sys.argv[1:]
 
-        namespace = super().parse_args(args=args, namespace=namespace)
+class _GreedySubParsersAction(argparse._SubParsersAction):
+    """A custom subparser action to conditionally act as a greedy consumer.
 
-        # if the current run is not handled by argparse subparser with
-        # the conventional name of "cmd", we simply return the already parsed
-        # argparse namespace and hope the 3rd party library handles the rest
-        current_cmd = getattr(namespace, "cmd", None)
-        if current_cmd is None:
-            return namespace
+    This is a workaround since argparse.REMAINDER does not work as expected,
+    see https://github.com/python/cpython/issues/61252.
+    """
 
-        # alternatively if the current run is not handled by a plugin-based
-        # subcommand we move on, as well
-        plugin_subcommand = self.plugin_subcommands.get(current_cmd, None)
-        if plugin_subcommand is None:
-            return namespace
+    def __call__(self, parser, namespace, values, option_string=None):
+        super().__call__(parser, namespace, values, option_string)
 
-        # finally, we add the parsed plugin subcommand if available to the
-        # current namespace, so we can later refer to it
-        else:
-            namespace.plugin_subcommand = plugin_subcommand
-            return namespace
+        parser = self._name_parser_map[values[0]]
+
+        # if the parser has a greedy=True attribute we want to consume all arguments
+        # i.e. all unknown args should be passed to the subcommand as is
+        if getattr(parser, "greedy", False):
+            try:
+                extra = getattr(namespace, argparse._UNRECOGNIZED_ARGS_ATTR)
+                delattr(namespace, argparse._UNRECOGNIZED_ARGS_ATTR)
+            except AttributeError:
+                extra = []
+            namespace._args = extra
+
+    def _get_subactions(self):
+        """Sort actions for subcommands to appear alphabetically in help blurb."""
+        return sorted(self._choices_actions, key=lambda action: action.dest)
 
 
 def _exec(executable_args, env_vars):
@@ -374,44 +294,80 @@ class ExtendConstAction(Action):
 # #############################################################################################
 
 
-def configure_parser_plugins(sub_parsers, plugin_subcommands) -> None:
+def configure_parser_plugins(sub_parsers) -> None:
     """
     For each of the provided plugin-based subcommands, we'll create
     a new subparser for an improved help printout and calling the
     :meth:`~conda.plugins.types.CondaSubcommand.configure_parser`
     with the newly created subcommand specific argument parser.
     """
-    for plugin_subcommand in plugin_subcommands.values():
+    plugins = context.plugin_manager.get_subcommands()
+    for name, plugin in plugins.items():
         # if the name of the plugin-based subcommand overlaps a built-in
         # subcommand, we print an error
-        if plugin_subcommand.name.lower() in BUILTIN_COMMANDS:
-            error_message = dals(
-                f"""
-                The plugin '{plugin_subcommand.name}' is trying to override the built-in command
-                with the same name, which is not allowed.
+        if name in BUILTIN_COMMANDS:
+            log.error(
+                dals(
+                    f"""
+                    The plugin '{name}' is trying to override the built-in command
+                    with the same name, which is not allowed.
 
-                Please uninstall the plugin to stop seeing this error message.
-                """
+                    Please uninstall the plugin to stop seeing this error message.
+                    """
+                )
             )
-            log.error(error_message)
             continue
 
         parser = sub_parsers.add_parser(
-            plugin_subcommand.name,
-            description=plugin_subcommand.summary,
-            help=plugin_subcommand.summary,
-            formatter_class=RawDescriptionHelpFormatter,
+            name,
+            description=plugin.summary,
+            help=plugin.summary,
+            add_help=False,
         )
-        try:
-            plugin_subcommand.configure_parser(parser)
-        except NotImplementedError:
-            # we store all other arguments here, so we can pass them to the
-            # plugin subcommands later
-            parser.add_argument(
-                "plugin_args",
-                nargs=argparse.REMAINDER,  # everything remaining, after the subcommand name
-                help=argparse.SUPPRESS,  # to hide it from the help output
+
+        # case 1: plugin extends the parser
+        if plugin.configure_parser:
+            plugin.configure_parser(parser)
+
+            try:
+                add_parser_help(parser)
+            except argparse.ArgumentError:
+                pass
+
+        # case 2: plugin has their own parser, see _GreedySubParsersAction
+        else:
+            parser.greedy = True
+
+        parser.set_defaults(_plugin=plugin)
+
+    legacy = ["env"] if context.no_plugins else set(find_commands()).difference(plugins)
+    for name in legacy:
+        # if the name of the plugin-based subcommand overlaps a built-in
+        # subcommand, we print an error
+        if name in BUILTIN_COMMANDS:
+            log.error(
+                dals(
+                    f"""
+                    The (legacy) plugin '{name}' is trying to override the built-in command
+                    with the same name, which is not allowed.
+
+                    Please uninstall the plugin to stop seeing this error message.
+                    """
+                )
             )
+            continue
+
+        parser = sub_parsers.add_parser(
+            name,
+            description=f"(legacy) Invoke `conda-{name}`.",
+            help=f"(legacy) Invoke `conda-{name}`.",
+            add_help=False,
+        )
+
+        # case 3: legacy plugins are always greedy
+        parser.greedy = True
+
+        parser.set_defaults(_executable=name)
 
 
 def configure_parser_clean(sub_parsers):

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -33,26 +33,32 @@ def generate_parser(*args, **kwargs):
 def main_subshell(*args, post_parse_hook=None, **kwargs):
     """Entrypoint for the "subshell" invocation of CLI interface. E.g. `conda create`."""
     # defer import here so it doesn't hit the 'conda shell.*' subcommands paths
-    from .conda_argparse import generate_parser
+    from ..base.context import context
+    from .conda_argparse import do_call, generate_parser, generate_pre_parser
 
     args = args or ["--help"]
 
-    p = generate_parser()
-    args = p.parse_args(args)
+    pre_parser = generate_pre_parser(add_help=False)
+    pre, unknown = pre_parser.parse_known_args(args)
 
-    from ..base.context import context
+    context.__init__(argparse_args=pre)
+    if context.no_plugins:
+        context.plugin_manager.disable_external_plugins()
+
+    # reinitialize in case any of the entrypoints modified the context
+    context.__init__(argparse_args=pre)
+
+    parser = generate_parser(add_help=True)
+    args = parser.parse_args(unknown, namespace=pre)
 
     context.__init__(argparse_args=args)
-
     init_loggers(context)
 
     # used with main_pip.py
     if post_parse_hook:
-        post_parse_hook(args, p)
+        post_parse_hook(args, parser)
 
-    from .conda_argparse import do_call
-
-    exit_code = do_call(args, p)
+    exit_code = do_call(args, parser)
     if isinstance(exit_code, int):
         return exit_code
     elif hasattr(exit_code, "rc"):

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -22,6 +22,7 @@ from ..core.solve import Solver
 from ..exceptions import CondaValueError, PluginError
 from . import solvers, subcommands, virtual_packages
 from .hookspec import CondaSpecs, spec_name
+from .types import CondaSubcommand
 
 log = logging.getLogger(__name__)
 
@@ -228,6 +229,12 @@ class CondaPluginManager(pluggy.PluginManager):
         for name, plugin in self.list_name_plugin():
             if not name.startswith("conda.plugins.") and not self.is_blocked(name):
                 self.set_blocked(name)
+
+    def get_subcommands(self) -> dict[str, CondaSubcommand]:
+        return {
+            subcommand.name.lower(): subcommand
+            for subcommand in self.get_hook_results("subcommands")
+        }
 
 
 @functools.lru_cache(maxsize=None)  # FUTURE: Python 3.9+, replace w/ functools.cache

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -15,10 +15,6 @@ from typing import Callable, NamedTuple
 from ..core.solve import Solver
 
 
-def _not_implemented_configure_parser(parser: ArgumentParser) -> None:
-    raise NotImplementedError
-
-
 @dataclass
 class CondaSubcommand:
     """
@@ -39,9 +35,7 @@ class CondaSubcommand:
         [Namespace | tuple[str]],  # arguments
         int | None,  # return code
     ]
-    configure_parser: Callable[[ArgumentParser], None] = field(
-        default=_not_implemented_configure_parser
-    )
+    configure_parser: Callable[[ArgumentParser], None] | None = field(default=None)
 
 
 class CondaVirtualPackage(NamedTuple):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Splits CLI parser into a 2-phase parser. Phase 1 only parses `conda`'s options (e.g., `conda --json`, `conda --no-plugins`, etc.) allowing us to disable plugins before generating the complete parser for phase 2. A benefit of the 2-phase parser is any option parsed in phase 1 can appear anywhere on the CLI, so the following are identical:

```
conda --json doctor
conda doctor --json
```

Note that `conda doctor` has not explicitly defined `--json` as one of its arguments:

https://github.com/conda/conda/blob/b89a1470aed2383047cef05ff1e738bf0337eeec/conda/plugins/subcommands/doctor/cli.py#L22-L30

In addition to the 2-phase parser we also implement a custom `argparse._SubParserAction` that will greedily consume all unmatched arguments, this is the change that resolves the `argparse.REMAINDER` issue.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
