### PR TITLE
lazy-load boto3 to save ~400ms startup time

### DIFF
--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -6,17 +6,26 @@ from logging import LoggerAdapter, getLogger
 from tempfile import SpooledTemporaryFile
 
 have_boto3 = have_boto = False
-try:
-    import boto3
 
-    have_boto3 = True
-except ImportError:
+
+def _load_boto3():
+    """
+    Import boto3 on demand only to save startup time.
+    """
+    global boto3, boto, have_boto3, have_boto
+
     try:
-        import boto
+        import boto3
 
-        have_boto = True
+        have_boto3 = True
     except ImportError:
-        pass
+        try:
+            import boto
+
+            have_boto = True
+        except ImportError:
+            pass
+
 
 from ....common.compat import ensure_binary
 from ....common.url import url_to_s3_info
@@ -36,6 +45,10 @@ class S3Adapter(BaseAdapter):
         resp = Response()
         resp.status_code = 200
         resp.url = request.url
+
+        if not have_boto3:
+            _load_boto3()
+
         if have_boto3:
             return self._send_boto3(boto3, resp, request)
         elif have_boto:

--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -5,24 +5,20 @@ import json
 from logging import LoggerAdapter, getLogger
 from tempfile import SpooledTemporaryFile
 
-have_boto3 = have_boto = False
+boto3 = boto = None
 
 
 def _load_boto3():
     """
     Import boto3 on demand only to save startup time.
     """
-    global boto3, boto, have_boto3, have_boto
+    global boto3, boto
 
     try:
         import boto3
-
-        have_boto3 = True
     except ImportError:
         try:
             import boto
-
-            have_boto = True
         except ImportError:
             pass
 
@@ -46,12 +42,12 @@ class S3Adapter(BaseAdapter):
         resp.status_code = 200
         resp.url = request.url
 
-        if not have_boto3:
+        if not (boto3 or boto):
             _load_boto3()
 
-        if have_boto3:
+        if boto3:
             return self._send_boto3(boto3, resp, request)
-        elif have_boto:
+        elif boto:
             return self._send_boto(boto, resp, request)
         else:
             stderrlog.info(

--- a/news/lazy-load-boto3
+++ b/news/lazy-load-boto3
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Import boto3 only when s3 channels are used, saving startup time.
+* Import boto3 only when s3 channels are used, saving startup time. (#12914)
 
 ### Bug fixes
 

--- a/news/lazy-load-boto3
+++ b/news/lazy-load-boto3
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Import boto3 only when s3 channels are used, saving startup time.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Address #12549 (partial).

On my machine using the scalene profiler:

```
. dev/start.sh -p 3.10
conda install scalene
echo "import conda.__main__" > con.py
python3 -m scalene con.py
```

`import boto3` takes about 350-450ms if boto3 is installed.

Instead, only import when s3 channels are actually used. If the user happens to have boto3 installed at all in their base environment, but doesn't use s3 channels, this should speed things up.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
