### PR TITLE
replace inspect.stack() with sys._getframe() to save ~170ms -> ~90ms

### DIFF
--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -3,6 +3,7 @@
 """Tools to aid in deprecating code."""
 from __future__ import annotations
 
+import sys
 import warnings
 from argparse import Action
 from functools import wraps
@@ -280,8 +281,8 @@ class DeprecationHandler:
         import inspect  # expensive
 
         try:
-            frame = inspect.stack()[2 + stack]
-            module = inspect.getmodule(frame[0])
+            frame = sys._getframe(2 + stack)
+            module = inspect.getmodule(frame)
             return (module, module.__name__)
         except (IndexError, AttributeError):
             raise DeprecatedError("unable to determine the calling module") from None

--- a/news/sys-getframe-inspect-stack
+++ b/news/sys-getframe-inspect-stack
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Faster deprecations module.
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/sys-getframe-inspect-stack
+++ b/news/sys-getframe-inspect-stack
@@ -8,7 +8,8 @@
 
 ### Deprecations
 
-* Faster deprecations module.
+* Reduce startup delay from deprecations module by using `sys._getframe()`
+  instead of `inspect.stack()`. (#12919)
 
 ### Docs
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

We only use a single frame, so use `sys._getframe` instead of `inspect.stack()`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
