### PR TITLE
jlap: disable warning when not context.ssl_verify

### DIFF
--- a/conda/gateways/repodata/jlap/interface.py
+++ b/conda/gateways/repodata/jlap/interface.py
@@ -7,6 +7,8 @@ import logging
 import os
 from pathlib import Path
 
+from conda.base.context import context
+from conda.gateways.connection.download import disable_ssl_verify_warning
 from conda.gateways.connection.session import CondaSession
 
 from .. import (
@@ -70,6 +72,9 @@ class JlapRepoInterface(RepoInterface):
         When repodata is not updated, it doesn't matter whether this function or
         the caller reads from a file.
         """
+        if not context.ssl_verify:
+            disable_ssl_verify_warning()
+
         session = CondaSession()
 
         repodata_url = f"{self._url}/{self._repodata_fn}"

--- a/news/12731-jlap-respect-ssl-verify
+++ b/news/12731-jlap-respect-ssl-verify
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Hide InsecureRequestWarning for jlap when CONDA_SSL_VERIFY=false, matching
+  non-jlap behavior. (#12731)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,11 @@ from conda.base.context import context, reset_context
 from conda.testing import conda_cli, path_factory, tmp_env
 
 from . import http_test_server
-from .fixtures_jlap import package_repository_base, package_server  # NOQA
+from .fixtures_jlap import (  # NOQA
+    package_repository_base,
+    package_server,
+    package_server_ssl,
+)
 
 pytest_plugins = (
     # Add testing fixtures and internal pytest plugins here

--- a/tests/fixtures_jlap.py
+++ b/tests/fixtures_jlap.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import flask
 import pytest
-from werkzeug.serving import WSGIRequestHandler, make_server
+from werkzeug.serving import WSGIRequestHandler, generate_adhoc_ssl_context, make_server
 
 app = flask.Flask(__name__)
 
@@ -58,10 +58,16 @@ class NoLoggingWSGIRequestHandler(WSGIRequestHandler):
         pass
 
 
-def make_server_with_socket(socket: socket.socket, base_: Path = base):
+def make_server_with_socket(socket: socket.socket, base_: Path = base, ssl=False):
     global server, base
     base = base_
     assert isinstance(socket.fileno(), int)
+    ssl_context = None
+
+    if ssl:
+        # openssl may fail when mixing defaults + conda-forge
+        ssl_context = generate_adhoc_ssl_context()
+
     server = make_server(
         "127.0.0.1",
         port=0,
@@ -69,6 +75,7 @@ def make_server_with_socket(socket: socket.socket, base_: Path = base):
         fd=socket.fileno(),
         threaded=True,
         request_handler=NoLoggingWSGIRequestHandler,
+        ssl_context=ssl_context,
     )
     server.serve_forever()
 
@@ -94,11 +101,11 @@ def prepare_socket() -> socket.socket:
     return s
 
 
-def _package_server(cleanup=True, base: Path | None = None):
+def _package_server(cleanup=True, base: Path | None = None, ssl=False):
     socket = prepare_socket()
     context = multiprocessing.get_context("spawn")
     process = context.Process(
-        target=make_server_with_socket, args=(socket, base), daemon=True
+        target=make_server_with_socket, args=(socket, base, ssl), daemon=True
     )
     process.start()
     yield socket
@@ -122,6 +129,11 @@ def package_repository_base(tmp_path_factory):
 @pytest.fixture(scope="session")
 def package_server(package_repository_base):
     yield from _package_server(base=package_repository_base)
+
+
+@pytest.fixture(scope="session")
+def package_server_ssl(package_repository_base):
+    yield from _package_server(base=package_repository_base, ssl=True)
 
 
 if __name__ == "__main__":

--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -83,46 +83,6 @@ def test_jlap_fetch(package_server: socket, tmp_path: Path, mocker):
     assert patched.call_count == 4
 
 
-def test_jlap_fetch(package_server: socket, tmp_path: Path, mocker):
-    """Check that JlapRepoInterface doesn't raise exceptions."""
-    host, port = package_server.getsockname()
-    base = f"http://{host}:{port}/test"
-
-    cache = RepodataCache(base=tmp_path / "cache", repodata_fn="repodata.json")
-
-    url = f"{base}/osx-64"
-    repo = interface.JlapRepoInterface(
-        url,
-        repodata_fn="repodata.json",
-        cache=cache,
-        cache_path_json=Path(tmp_path, "repodata.json"),
-        cache_path_state=Path(tmp_path, f"repodata{CACHE_STATE_SUFFIX}"),
-    )
-
-    patched = mocker.patch(
-        "conda.gateways.repodata.jlap.fetch.download_and_hash",
-        wraps=fetch.download_and_hash,
-    )
-
-    state = {}
-    with pytest.raises(RepodataOnDisk):
-        repo.repodata(state)
-
-    # however it may make two requests - one to look for .json.zst, the second
-    # to look for .json
-    assert patched.call_count == 2
-
-    # second will try to fetch (non-existent) .jlap, then fall back to .json
-    with pytest.raises(RepodataOnDisk):
-        repo.repodata(state)  # a 304?
-
-    with pytest.raises(RepodataOnDisk):
-        repo.repodata(state)
-
-    # we may be able to do better than this by setting "zst unavailable" sooner
-    assert patched.call_count == 4
-
-
 @pytest.mark.parametrize("verify_ssl", [True, False])
 def test_jlap_fetch_ssl(
     package_server_ssl: socket, tmp_path: Path, mocker, verify_ssl: bool

--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -18,7 +18,7 @@ import zstandard
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
 from conda.common.io import env_vars
 from conda.core.subdir_data import SubdirData
-from conda.exceptions import CondaHTTPError
+from conda.exceptions import CondaHTTPError, CondaSSLError
 from conda.gateways.connection.session import CondaSession
 from conda.gateways.repodata import (
     CACHE_CONTROL_KEY,
@@ -81,6 +81,84 @@ def test_jlap_fetch(package_server: socket, tmp_path: Path, mocker):
 
     # we may be able to do better than this by setting "zst unavailable" sooner
     assert patched.call_count == 4
+
+
+def test_jlap_fetch(package_server: socket, tmp_path: Path, mocker):
+    """Check that JlapRepoInterface doesn't raise exceptions."""
+    host, port = package_server.getsockname()
+    base = f"http://{host}:{port}/test"
+
+    cache = RepodataCache(base=tmp_path / "cache", repodata_fn="repodata.json")
+
+    url = f"{base}/osx-64"
+    repo = interface.JlapRepoInterface(
+        url,
+        repodata_fn="repodata.json",
+        cache=cache,
+        cache_path_json=Path(tmp_path, "repodata.json"),
+        cache_path_state=Path(tmp_path, f"repodata{CACHE_STATE_SUFFIX}"),
+    )
+
+    patched = mocker.patch(
+        "conda.gateways.repodata.jlap.fetch.download_and_hash",
+        wraps=fetch.download_and_hash,
+    )
+
+    state = {}
+    with pytest.raises(RepodataOnDisk):
+        repo.repodata(state)
+
+    # however it may make two requests - one to look for .json.zst, the second
+    # to look for .json
+    assert patched.call_count == 2
+
+    # second will try to fetch (non-existent) .jlap, then fall back to .json
+    with pytest.raises(RepodataOnDisk):
+        repo.repodata(state)  # a 304?
+
+    with pytest.raises(RepodataOnDisk):
+        repo.repodata(state)
+
+    # we may be able to do better than this by setting "zst unavailable" sooner
+    assert patched.call_count == 4
+
+
+@pytest.mark.parametrize("verify_ssl", [True, False])
+def test_jlap_fetch_ssl(
+    package_server_ssl: socket, tmp_path: Path, mocker, verify_ssl: bool
+):
+    """Check that JlapRepoInterface doesn't raise exceptions."""
+    host, port = package_server_ssl.getsockname()
+    base = f"https://{host}:{port}/test"
+
+    cache = RepodataCache(base=tmp_path / "cache", repodata_fn="repodata.json")
+
+    url = f"{base}/osx-64"
+    repo = interface.JlapRepoInterface(
+        url,
+        repodata_fn="repodata.json",
+        cache=cache,
+        cache_path_json=Path(tmp_path, f"repodata_{verify_ssl}.json"),
+        cache_path_state=Path(tmp_path, f"repodata_{verify_ssl}{CACHE_STATE_SUFFIX}"),
+    )
+
+    expected_exception = CondaSSLError if verify_ssl else RepodataOnDisk
+
+    state = {}
+    with env_vars(
+        {"CONDA_SSL_VERIFY": str(verify_ssl).lower()},
+        stack_callback=conda_tests_ctxt_mgmt_def_pol,
+    ), pytest.raises(expected_exception), pytest.warns() as record:
+        repo.repodata(state)
+
+    # If we didn't disable warnings, we will see two 'InsecureRequestWarning'
+    assert len(record) == 0, f"Unexpected warning {record[0]._category_name}"
+
+    # clear session cache to avoid leftover wrong-ssl-verify Session()
+    try:
+        del CondaSession._thread_local.session
+    except AttributeError:
+        pass
 
 
 def test_download_and_hash(

--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -104,6 +104,12 @@ def test_jlap_fetch_ssl(
 
     expected_exception = CondaSSLError if verify_ssl else RepodataOnDisk
 
+    # clear session cache to avoid leftover wrong-ssl-verify Session()
+    try:
+        del CondaSession._thread_local.session
+    except AttributeError:
+        pass
+
     state = {}
     with env_vars(
         {"CONDA_SSL_VERIFY": str(verify_ssl).lower()},


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix  #12731 

adhoc ssl context in test is a bit slow to create and showed an ssl error when I had mixed defaults+conda-forge in my development environment.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
