### PR TITLE
Do not show download bars in non interactive runs

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -543,8 +543,8 @@ class ProgressBar:
 
         return tqdm(*args, **kwargs)
 
-    @lru_cache(maxsize=1)
     @staticmethod
+    @lru_cache(maxsize=1)
     def interactive():
         """Return True if we're running in a terminal."""
         return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -760,7 +760,10 @@ class ProgressiveFetchExtract:
             return
 
         if not context.verbosity and not context.quiet and not context.json:
-            print("\nDownloading and Extracting Packages")
+            print(
+                "\nDownloading and Extracting Packages:", 
+                end="\n" if ProgressBar.interactive() else " ...working...",
+            )
         else:
             log.debug(
                 "prepared package cache actions:\n"
@@ -849,7 +852,10 @@ class ProgressiveFetchExtract:
             bar.close()
 
         if not context.verbosity and not context.quiet and not context.json:
-            print("\r")  # move to column 0
+            if ProgressBar.interactive():
+                print("\r")  # move to column 0
+            else:
+                print(" done")
 
         if exceptions:
             raise CondaMultiError(exceptions)
@@ -857,7 +863,7 @@ class ProgressiveFetchExtract:
         self._executed = True
 
     @staticmethod
-    def _progress_bar(prec_or_spec, position=None, leave=False):
+    def _progress_bar(prec_or_spec, position=None, leave=False) -> ProgressBar:
         desc = ""
         if prec_or_spec.name and prec_or_spec.version:
             desc = "{}-{}".format(prec_or_spec.name or "", prec_or_spec.version or "")
@@ -870,7 +876,7 @@ class ProgressiveFetchExtract:
 
         progress_bar = ProgressBar(
             desc,
-            not context.verbosity and not context.quiet,
+            not context.verbosity and not context.quiet and ProgressBar.interactive(),
             context.json,
             position=position,
             leave=leave,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -761,7 +761,7 @@ class ProgressiveFetchExtract:
 
         if not context.verbosity and not context.quiet and not context.json:
             print(
-                "\nDownloading and Extracting Packages:", 
+                "\nDownloading and Extracting Packages:",
                 end="\n" if ProgressBar.interactive() else " ...working...",
             )
         else:

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -30,7 +30,7 @@ from ..base.constants import (
 )
 from ..base.context import context
 from ..common.constants import NULL
-from ..common.io import ProgressBar, time_recorder
+from ..common.io import IS_INTERACTIVE, ProgressBar, time_recorder
 from ..common.path import expand, strip_pkg_extension, url_to_path
 from ..common.signals import signal_handler
 from ..common.url import path_to_url
@@ -762,7 +762,7 @@ class ProgressiveFetchExtract:
         if not context.verbosity and not context.quiet and not context.json:
             print(
                 "\nDownloading and Extracting Packages:",
-                end="\n" if ProgressBar.interactive() else " ...working...",
+                end="\n" if IS_INTERACTIVE else " ...working...",
             )
         else:
             log.debug(
@@ -852,7 +852,7 @@ class ProgressiveFetchExtract:
             bar.close()
 
         if not context.verbosity and not context.quiet and not context.json:
-            if ProgressBar.interactive():
+            if IS_INTERACTIVE:
                 print("\r")  # move to column 0
             else:
                 print(" done")
@@ -876,7 +876,7 @@ class ProgressiveFetchExtract:
 
         progress_bar = ProgressBar(
             desc,
-            not context.verbosity and not context.quiet and ProgressBar.interactive(),
+            not context.verbosity and not context.quiet and IS_INTERACTIVE,
             context.json,
             position=position,
             leave=leave,

--- a/news/12982-no-progress-bars-in-logs
+++ b/news/12982-no-progress-bars-in-logs
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Do not show progress bars in non interactive runs for cleaner logs. (#12982)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

As discussed in the Refinement session, async tqdm bars can make some [CI logs too long](https://github.com/conda/constructor/actions/runs/5799411468/job/15719353263#step:3:286) and makes reading these harder. In this PR I check whether `sys.stdout` is a TTY (like the `Spinner()` class does, and decide whether to create progress bars or not. Some extra care has been taking to adjust the output a bit so it doesn't look like it's hung.


Example output: [long-log.txt](https://github.com/conda/conda/files/12294913/long-log.txt)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

cc @dholth 