### PR TITLE
Lock repodata cache by default

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -396,6 +396,7 @@ class Context(Configuration):
         PrimitiveParameter(0, element_type=int), aliases=("verbose", "verbosity")
     )
     experimental = ParameterLoader(SequenceParameter(PrimitiveParameter("", str)))
+    no_lock = ParameterLoader(PrimitiveParameter(False))
 
     ####################################################
     #               Solver Configuration               #
@@ -1096,6 +1097,7 @@ class Context(Configuration):
                 "repodata_threads",
                 "fetch_threads",
                 "experimental",
+                "no_lock",
             ),
             "Basic Conda Configuration": (  # TODO: Is there a better category name here?
                 "envs_dirs",
@@ -1752,6 +1754,11 @@ class Context(Configuration):
                 List of experimental features to enable.
                 """
             ),
+            no_lock=dals(
+                """
+                Disable index cache lock (defaults to enabled).
+                """
+            )
         )
 
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1758,7 +1758,7 @@ class Context(Configuration):
                 """
                 Disable index cache lock (defaults to enabled).
                 """
-            )
+            ),
         )
 
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -1845,7 +1845,12 @@ def add_parser_channels(p):
         action="append",
         choices=["jlap", "lock"],
         help="jlap: Download incremental package index data from repodata.jlap; implies 'lock'. "
-        "lock: use locking when reading, updating index (repodata.json) cache. ",
+        "lock: use locking when reading, updating index (repodata.json) cache. Now enabled.",
+    )
+    channel_customization_options.add_argument(
+        "--no-lock",
+        action="store_true",
+        help="Disable locking when reading, updating index (repodata.json) cache. ",
     )
     return channel_customization_options
 

--- a/conda/gateways/repodata/lock.py
+++ b/conda/gateways/repodata/lock.py
@@ -70,7 +70,7 @@ except ImportError:
 
 
 def lock(fd):
-    if "jlap" in context.experimental or "lock" in context.experimental:
-        # locking required for jlap
+    if not context.no_lock:
+        # locking required for jlap, now default for all
         return _lock_impl(fd)
     return _lock_noop(fd)

--- a/news/12920-lock-default
+++ b/news/12920-lock-default
@@ -1,0 +1,21 @@
+### Enhancements
+
+* Lock index cache metadata by default. Added `--no-lock` option in case of
+  problems, should not be necessary. Older `--experimental=lock` no longer has
+  an effect. (#12920)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/gateways/test_repodata_lock.py
+++ b/tests/gateways/test_repodata_lock.py
@@ -46,12 +46,14 @@ def test_lock_can_lock(tmp_path, use_lock: bool):
     # forked workers might share file handle and lock
     multiprocessing.set_start_method("spawn", force=True)
 
+    vars = {"CONDA_PLATFORM": "osx-64"}
+    if not use_lock:
+        vars["CONDA_NO_LOCK"] = "1" # sets option even if empty string
     with env_vars(
-        {"CONDA_PLATFORM": "osx-64", "CONDA_NO_LOCK": "" if use_lock else "false"},
+        vars,
         stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
-        if use_lock:
-            assert context.no_lock == True
+        assert context.no_lock == (not use_lock)
 
         cache = RepodataCache(tmp_path / "lockme", "repodata.json")
 

--- a/tests/gateways/test_repodata_lock.py
+++ b/tests/gateways/test_repodata_lock.py
@@ -8,10 +8,9 @@ import traceback
 
 import pytest
 
-from conda.base.context import conda_tests_ctxt_mgmt_def_pol
+from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
 from conda.common.io import env_vars
 from conda.gateways.repodata import RepodataCache, lock
-
 
 def locker(cache: RepodataCache, qout, qin):
     print(f"Attempt to lock {cache.cache_path_state}")
@@ -47,9 +46,12 @@ def test_lock_can_lock(tmp_path, use_lock: bool):
     multiprocessing.set_start_method("spawn", force=True)
 
     with env_vars(
-        {"CONDA_PLATFORM": "osx-64", "CONDA_EXPERIMENTAL": "lock" if use_lock else ""},
+        {"CONDA_PLATFORM": "osx-64", "CONDA_NO_LOCK": "" if use_lock else "false"},
         stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
+        if use_lock:
+            assert context.no_lock = True
+
         cache = RepodataCache(tmp_path / "lockme", "repodata.json")
 
         qout = multiprocessing.Queue()  # put here, get in subprocess

--- a/tests/gateways/test_repodata_lock.py
+++ b/tests/gateways/test_repodata_lock.py
@@ -12,6 +12,7 @@ from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
 from conda.common.io import env_vars
 from conda.gateways.repodata import RepodataCache, lock
 
+
 def locker(cache: RepodataCache, qout, qin):
     print(f"Attempt to lock {cache.cache_path_state}")
     qout.put("ready")
@@ -50,7 +51,7 @@ def test_lock_can_lock(tmp_path, use_lock: bool):
         stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
         if use_lock:
-            assert context.no_lock = True
+            assert context.no_lock == True
 
         cache = RepodataCache(tmp_path / "lockme", "repodata.json")
 

--- a/tests/gateways/test_repodata_lock.py
+++ b/tests/gateways/test_repodata_lock.py
@@ -48,7 +48,7 @@ def test_lock_can_lock(tmp_path, use_lock: bool):
 
     vars = {"CONDA_PLATFORM": "osx-64"}
     if not use_lock:
-        vars["CONDA_NO_LOCK"] = "1" # sets option even if empty string
+        vars["CONDA_NO_LOCK"] = "1"  # sets option even if empty string
     with env_vars(
         vars,
         stack_callback=conda_tests_ctxt_mgmt_def_pol,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

TODO figure out what to do with `--experimental=lock`.  The intention would be to keep all `--experimental=` options forever to not break configs as unknown ones create errors in the argument parser, but it might not be necessary to retain them in the command line help.

Fix #12920 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
