### PR TITLE
remove cgi import

### DIFF
--- a/news/13013-remove-cgi
+++ b/news/13013-remove-cgi
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove reference to deprecated cgi module by removing ftp STOR support
+  (#13013)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/13013-remove-cgi
+++ b/news/13013-remove-cgi
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Remove reference to deprecated cgi module by removing ftp STOR support
+* Remove import of deprecated cgi module by deprecating ftp STOR support
   (#13013)
 
 ### Docs


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix #13013

I can't imagine that conda ever needed to STOR files to ftp? It certainly doesn't show up in the tests.

What's the best way to deprecate this?

We could import cgi in the naughty functions, deprecate those and avoid the annoying import-time cgi warning.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
