### PR TITLE
Cleaner caching for methods to be run only once per instance

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -267,8 +267,8 @@ class UnlinkLinkTransaction:
                 )
                 self.prefix_action_groups[stp.target_prefix] = PrefixActionGroup(*grps)
 
-    @time_recorder("unlink_link_prepare_and_verify")
     @lru_cache(maxsize=None)  # only run once
+    @time_recorder("unlink_link_prepare_and_verify")
     def verify(self):
         self.prepare()
 
@@ -1426,6 +1426,13 @@ class UnlinkLinkTransaction:
             fetch_precs,
         )
         return change_report
+
+    @classmethod
+    def cache_clear(cls) -> None:
+        cls._pfe.fget.cache_clear()  # type: ignore[attr-defined]
+        ProgressiveFetchExtract.cache_clear()
+        cls.prepare.cache_clear()
+        cls.verify.cache_clear()
 
 
 def run_script(

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -16,6 +16,7 @@ from os import scandir
 from os.path import basename, dirname, getsize, join
 from sys import platform
 from tarfile import ReadError
+from typing import Iterable
 
 from conda.common.iterators import groupby_to_dict as groupby
 
@@ -703,7 +704,7 @@ class ProgressiveFetchExtract:
         )
         return cache_action, extract_action
 
-    def __init__(self, link_prefs):
+    def __init__(self, link_prefs: Iterable[PackageRecord]):
         """
         Args:
             link_prefs (tuple[PackageRecord]):
@@ -712,7 +713,7 @@ class ProgressiveFetchExtract:
                 Here, "available" means the package tarball is both downloaded and extracted
                 to a package directory.
         """
-        self.link_precs = link_prefs
+        self.link_precs = tuple(link_prefs)
 
         log.debug(
             "instantiating ProgressiveFetchExtract with\n" "  %s\n",

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -724,8 +724,8 @@ class ProgressiveFetchExtract:
             {}
         )  # Map[pref, Tuple(CacheUrlAction, ExtractPackageAction)]
 
-    @time_recorder("fetch_extract_prepare")
     @lru_cache(maxsize=None)  # only run once
+    @time_recorder("fetch_extract_prepare")
     def prepare(self) -> None:
         self.paired_actions.update(
             (prec, self.make_actions_for_record(prec)) for prec in self.link_precs
@@ -874,6 +874,11 @@ class ProgressiveFetchExtract:
 
     def __eq__(self, other):
         return hash(self) == hash(other)
+
+    @classmethod
+    def cache_clear(cls) -> None:
+        cls.prepare.cache_clear()
+        cls.execute.cache_clear()
 
 
 def do_cache_action(prec, cache_action, progress_bar, download_total=1.0):

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -71,7 +71,7 @@ def assert_not_pkg(name, contents):
 
 
 # conda clean --force-pkgs-dirs
-def test_clean_force_pkgs_dirs(clear_cache):
+def test_clean_force_pkgs_dirs():
     pkg = "bzip2"
 
     with make_temp_package_cache() as pkgs_dir:
@@ -92,7 +92,7 @@ def test_clean_force_pkgs_dirs(clear_cache):
 
 
 # conda clean --packages
-def test_clean_and_packages(clear_cache):
+def test_clean_and_packages():
     pkg = "bzip2"
 
     with make_temp_package_cache() as pkgs_dir:
@@ -126,7 +126,7 @@ def test_clean_and_packages(clear_cache):
 
 
 # conda clean --tarballs
-def test_clean_tarballs(clear_cache):
+def test_clean_tarballs():
     pkg = "bzip2"
 
     with make_temp_package_cache() as pkgs_dir:
@@ -151,7 +151,7 @@ def test_clean_tarballs(clear_cache):
 
 
 # conda clean --index-cache
-def test_clean_index_cache(clear_cache):
+def test_clean_index_cache():
     pkg = "bzip2"
 
     with make_temp_package_cache():
@@ -175,7 +175,7 @@ def test_clean_index_cache(clear_cache):
 
 
 # conda clean --tempfiles
-def test_clean_tempfiles(clear_cache):
+def test_clean_tempfiles():
     """Tempfiles are either suffixed with .c~ or .trash.
 
     .c~ is used to indicate that conda is actively using that file. If the conda process is
@@ -215,7 +215,7 @@ def test_clean_tempfiles(clear_cache):
 
 
 # conda clean --logfiles
-def test_clean_logfiles(clear_cache):
+def test_clean_logfiles():
     """Logfiles are found in pkgs_dir/.logs.
 
     Since these log files were uniquely created during the experimental
@@ -253,7 +253,7 @@ def test_clean_logfiles(clear_cache):
 
 # conda clean --all [--verbose]
 @pytest.mark.parametrize("verbose", [True, False])
-def test_clean_all(clear_cache, verbose: bool):
+def test_clean_all(verbose: bool):
     pkg = "bzip2"
     args = ("--yes", "--json")
     if verbose:
@@ -307,7 +307,7 @@ def test_clean_all(clear_cache, verbose: bool):
 
 # conda clean --all --verbose
 @pytest.mark.parametrize("as_json", [True, False])
-def test_clean_all_mock_lstat(clear_cache, mocker: MockerFixture, as_json: bool):
+def test_clean_all_mock_lstat(mocker: MockerFixture, as_json: bool):
     pkg = "bzip2"
     args = ("--yes", "--verbose")
     if as_json:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,11 @@ def test_recipes_channel(monkeypatch: MonkeyPatch) -> None:
 
 @pytest.fixture
 def clear_cache():
+    from conda.core.link import UnlinkLinkTransaction
     from conda.core.subdir_data import SubdirData
 
     SubdirData.clear_cached_local_channel_data(exclude_file=False)
+    UnlinkLinkTransaction.cache_clear()
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,13 +33,15 @@ def test_recipes_channel(monkeypatch: MonkeyPatch) -> None:
     assert context.bld_path == TEST_RECIPES_CHANNEL
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def clear_cache():
     from conda.core.link import UnlinkLinkTransaction
+    from conda.core.package_cache_data import PackageCacheData
     from conda.core.subdir_data import SubdirData
 
     SubdirData.clear_cached_local_channel_data(exclude_file=False)
     UnlinkLinkTransaction.cache_clear()
+    PackageCacheData.clear()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -108,16 +108,11 @@ stderr_log_level(TEST_LOG_LEVEL, "requests")
 pytestmark = pytest.mark.integration
 
 
-@pytest.fixture
-def clear_package_cache() -> None:
-    PackageCacheData.clear()
-
-
 @pytest.mark.skipif(
     context.subdir not in ("linux-64", "osx-64", "win-32", "win-64", "linux-32"),
     reason="Skip unsupported platforms",
 )
-def test_install_python2_and_search(clear_package_cache: None):
+def test_install_python2_and_search():
     with Utf8NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as env_txt:
         log.warning(f"Creating empty temporary environment txt file {env_txt}")
         environment_txt = env_txt.name
@@ -169,7 +164,7 @@ def test_install_python2_and_search(clear_package_cache: None):
     os.unlink(environment_txt)
 
 
-def test_run_preserves_arguments(clear_package_cache: None):
+def test_run_preserves_arguments():
     with make_temp_env("python=3") as prefix:
         echo_args_py = os.path.join(prefix, "echo-args.py")
         with open(echo_args_py, "w") as echo_args:
@@ -185,7 +180,7 @@ def test_run_preserves_arguments(clear_package_cache: None):
                 assert args[i] == line.replace("\r", "")
 
 
-def test_create_install_update_remove_smoketest(clear_package_cache: None):
+def test_create_install_update_remove_smoketest():
     with make_temp_env("python=3.9") as prefix:
         assert exists(join(prefix, PYTHON_BINARY))
         assert package_is_installed(prefix, "python=3")
@@ -217,7 +212,7 @@ def test_create_install_update_remove_smoketest(clear_package_cache: None):
         assert package_is_installed(prefix, "python=3")
 
 
-def test_install_broken_post_install_keeps_existing_folders(clear_package_cache: None):
+def test_install_broken_post_install_keeps_existing_folders():
     # regression test for https://github.com/conda/conda/issues/8258
     with make_temp_env("python=3.5") as prefix:
         assert exists(join(prefix, BIN_DIRECTORY))
@@ -234,7 +229,7 @@ def test_install_broken_post_install_keeps_existing_folders(clear_package_cache:
         assert exists(join(prefix, BIN_DIRECTORY))
 
 
-def test_safety_checks(clear_package_cache: None):
+def test_safety_checks():
     # This test uses https://anaconda.org/conda-test/spiffy-test-app/0.5/download/noarch/spiffy-test-app-0.5-pyh6afbcc8_0.tar.bz2
     # which is a modification of https://anaconda.org/conda-test/spiffy-test-app/1.0/download/noarch/spiffy-test-app-1.0-pyh6afabb7_0.tar.bz2
     # as documented in info/README within that package.
@@ -293,7 +288,7 @@ def test_safety_checks(clear_package_cache: None):
         assert package_is_installed(prefix, "spiffy-test-app=0.5")
 
 
-def test_json_create_install_update_remove(clear_package_cache: None):
+def test_json_create_install_update_remove():
     # regression test for #5384
 
     def assert_json_parsable(content):
@@ -392,7 +387,7 @@ def test_json_create_install_update_remove(clear_package_cache: None):
         rmtree(prefix, ignore_errors=True)
 
 
-def test_not_writable_env_raises_EnvironmentNotWritableError(clear_package_cache: None):
+def test_not_writable_env_raises_EnvironmentNotWritableError():
     with make_temp_env() as prefix:
         make_read_only(join(prefix, PREFIX_MAGIC_FILE))
         stdout, stderr, _ = run_command(
@@ -402,7 +397,7 @@ def test_not_writable_env_raises_EnvironmentNotWritableError(clear_package_cache
         assert prefix in stderr
 
 
-def test_conda_update_package_not_installed(clear_package_cache: None):
+def test_conda_update_package_not_installed():
     with make_temp_env() as prefix:
         with pytest.raises(PackageNotInstalledError):
             run_command(Commands.UPDATE, prefix, "sqlite", "openssl")
@@ -412,7 +407,7 @@ def test_conda_update_package_not_installed(clear_package_cache: None):
         assert conda_error.value.message.startswith("Invalid spec for 'conda update'")
 
 
-def test_noarch_python_package_with_entry_points(clear_package_cache: None):
+def test_noarch_python_package_with_entry_points():
     # this channel has an ancient flask that is incompatible with jinja2>=3.1.0
     with make_temp_env("-c", "conda-test", "flask", "jinja2<3.1") as prefix:
         py_ver = get_python_version_for_prefix(prefix)
@@ -435,7 +430,7 @@ def test_noarch_python_package_with_entry_points(clear_package_cache: None):
         assert not isfile(exe_path)
 
 
-def test_noarch_python_package_without_entry_points(clear_package_cache: None):
+def test_noarch_python_package_without_entry_points():
     # regression test for #4546
     with make_temp_env("-c", "conda-test", "itsdangerous") as prefix:
         py_ver = get_python_version_for_prefix(prefix)
@@ -451,7 +446,7 @@ def test_noarch_python_package_without_entry_points(clear_package_cache: None):
         assert not isfile(join(prefix, pyc_file))
 
 
-def test_noarch_python_package_reinstall_on_pyver_change(clear_package_cache: None):
+def test_noarch_python_package_reinstall_on_pyver_change():
     with make_temp_env(
         "-c",
         "conda-test",
@@ -480,12 +475,12 @@ def test_noarch_python_package_reinstall_on_pyver_change(clear_package_cache: No
         assert isfile(join(prefix, pyc_file_py2))
 
 
-def test_noarch_generic_package(clear_package_cache: None):
+def test_noarch_generic_package():
     with make_temp_env("-c", "conda-test", "font-ttf-inconsolata") as prefix:
         assert isfile(join(prefix, "fonts", "Inconsolata-Regular.ttf"))
 
 
-def test_override_channels(clear_package_cache: None):
+def test_override_channels():
     with pytest.raises(OperationNotAllowed):
         with env_var(
             "CONDA_OVERRIDE_CHANNELS_ENABLED",
@@ -513,7 +508,7 @@ def test_override_channels(clear_package_cache: None):
     assert json.loads(stdout)["flask"][0]["noarch"] == "python"
 
 
-def test_create_empty_env(clear_package_cache: None):
+def test_create_empty_env():
     with make_temp_env() as prefix:
         assert exists(join(prefix, "conda-meta/history"))
 
@@ -537,7 +532,7 @@ def test_create_empty_env(clear_package_cache: None):
 
 
 @pytest.mark.skipif(reason="conda-forge doesn't have a full set of packages")
-def test_strict_channel_priority(clear_package_cache: None):
+def test_strict_channel_priority():
     with make_temp_env() as prefix:
         stdout, stderr, rc = run_command(
             Commands.CREATE,
@@ -572,7 +567,7 @@ def test_strict_channel_priority(clear_package_cache: None):
         ]
 
 
-def test_strict_resolve_get_reduced_index(clear_package_cache: None):
+def test_strict_resolve_get_reduced_index():
     channels = (Channel("defaults"),)
     specs = (MatchSpec("anaconda"),)
     index = get_reduced_index(None, channels, context.subdirs, specs, "repodata.json")
@@ -595,7 +590,7 @@ def test_strict_resolve_get_reduced_index(clear_package_cache: None):
         assert {} == channel_name_groups
 
 
-def test_list_with_pip_no_binary(clear_package_cache: None):
+def test_list_with_pip_no_binary():
     from conda.exports import rm_rf as _rm_rf
 
     # For this test to work on Windows, you can either pass use_restricted_unicode=on_win
@@ -629,7 +624,7 @@ def test_list_with_pip_no_binary(clear_package_cache: None):
             assert prefix not in PrefixData._cache_
 
 
-def test_list_with_pip_wheel(clear_package_cache: None):
+def test_list_with_pip_wheel():
     from conda.exports import rm_rf as _rm_rf
 
     py_ver = "3.10"
@@ -677,7 +672,7 @@ def test_list_with_pip_wheel(clear_package_cache: None):
         assert prefix not in PrefixData._cache_
 
 
-def test_compare_success(clear_package_cache: None):
+def test_compare_success():
     with make_temp_env("python=3.6", "flask=1.0.2", "bzip2=1.0.8") as prefix:
         env_file = join(prefix, "env.yml")
         touch(env_file)
@@ -699,7 +694,7 @@ def test_compare_success(clear_package_cache: None):
         rmtree(prefix, ignore_errors=True)
 
 
-def test_compare_fail(clear_package_cache: None):
+def test_compare_fail():
     with make_temp_env("python=3.6", "flask=1.0.2", "bzip2=1.0.8") as prefix:
         env_file = join(prefix, "env.yml")
         touch(env_file)
@@ -725,9 +720,7 @@ def test_compare_fail(clear_package_cache: None):
         rmtree(prefix, ignore_errors=True)
 
 
-def test_install_tarball_from_local_channel(
-    clear_package_cache: None, tmp_path: Path, monkeypatch: MonkeyPatch
-):
+def test_install_tarball_from_local_channel(tmp_path: Path, monkeypatch: MonkeyPatch):
     # Regression test for #2812
     # install from local channel
     """
@@ -780,7 +773,7 @@ def test_install_tarball_from_local_channel(
             assert package_is_installed(prefix2, "flask")
 
 
-def test_tarball_install(clear_package_cache: None):
+def test_tarball_install():
     with make_temp_env("bzip2") as prefix:
         # We have a problem. If bzip2 is extracted already but the tarball is missing then this fails.
         bzip2_data = [
@@ -824,7 +817,7 @@ def test_tarball_install(clear_package_cache: None):
         assert package_is_installed(prefix, "bzip2")
 
 
-def test_tarball_install_and_bad_metadata(clear_package_cache: None):
+def test_tarball_install_and_bad_metadata():
     with make_temp_env("python=3.10.9", "flask=1.1.1", "--json") as prefix:
         assert package_is_installed(prefix, "flask==1.1.1")
         flask_data = [
@@ -889,7 +882,7 @@ def test_tarball_install_and_bad_metadata(clear_package_cache: None):
 
 
 @pytest.mark.skipif(on_win, reason="windows python doesn't depend on readline")
-def test_update_with_pinned_packages(clear_package_cache: None):
+def test_update_with_pinned_packages():
     # regression test for #6914
     with make_temp_env(
         "-c", "https://repo.anaconda.com/pkgs/free", "python=2.7.12"
@@ -905,7 +898,7 @@ def test_update_with_pinned_packages(clear_package_cache: None):
         assert not package_is_installed(prefix, "python=2.7.12")
 
 
-def test_pinned_override_with_explicit_spec(clear_package_cache: None):
+def test_pinned_override_with_explicit_spec():
     with make_temp_env("python=3.9") as prefix:
         run_command(
             Commands.CONFIG, prefix, "--add", "pinned_packages", "python=3.9.16"
@@ -914,7 +907,7 @@ def test_pinned_override_with_explicit_spec(clear_package_cache: None):
         assert package_is_installed(prefix, "python=3.10")
 
 
-def test_remove_all(clear_package_cache: None):
+def test_remove_all():
     with make_temp_env("python") as prefix:
         assert exists(join(prefix, PYTHON_BINARY))
         assert package_is_installed(prefix, "python")
@@ -935,7 +928,7 @@ def test_remove_all(clear_package_cache: None):
     on_win, reason="windows usually doesn't support symlinks out-of-the box"
 )
 @patch("conda.core.link.hardlink_supported", side_effect=lambda x, y: False)
-def test_allow_softlinks(hardlink_supported_mock, clear_package_cache: None):
+def test_allow_softlinks(hardlink_supported_mock):
     hardlink_supported_mock._result_cache.clear()
     with env_var(
         "CONDA_ALLOW_SOFTLINKS",
@@ -957,7 +950,7 @@ def test_allow_softlinks(hardlink_supported_mock, clear_package_cache: None):
 
 
 @pytest.mark.skipif(on_win, reason="nomkl not present on windows")
-def test_remove_features(clear_package_cache: None):
+def test_remove_features():
     with make_temp_env("python=2", "numpy=1.13", "nomkl") as prefix:
         assert exists(join(prefix, PYTHON_BINARY))
         assert package_is_installed(prefix, "numpy")
@@ -978,7 +971,7 @@ def test_remove_features(clear_package_cache: None):
     on_win and context.bits == 32, reason="no 32-bit windows python on conda-forge"
 )
 @pytest.mark.flaky(reruns=2)
-def test_dash_c_usage_replacing_python(clear_package_cache: None):
+def test_dash_c_usage_replacing_python():
     # Regression test for #2606
     with make_temp_env("-c", "conda-forge", "python=3.10", no_capture=True) as prefix:
         assert exists(join(prefix, PYTHON_BINARY))
@@ -1006,7 +999,7 @@ def test_dash_c_usage_replacing_python(clear_package_cache: None):
             assert package_is_installed(clone_prefix, "decorator")
 
 
-def test_install_prune_flag(clear_package_cache: None):
+def test_install_prune_flag():
     with make_temp_env("python=3", "flask") as prefix:
         assert package_is_installed(prefix, "flask")
         assert package_is_installed(prefix, "python=3")
@@ -1018,7 +1011,7 @@ def test_install_prune_flag(clear_package_cache: None):
 
 
 @pytest.mark.skipif(on_win, reason="readline is only a python dependency on unix")
-def test_remove_force_remove_flag(clear_package_cache: None):
+def test_remove_force_remove_flag():
     with make_temp_env("python") as prefix:
         assert package_is_installed(prefix, "readline")
         assert package_is_installed(prefix, "python")
@@ -1028,7 +1021,7 @@ def test_remove_force_remove_flag(clear_package_cache: None):
         assert package_is_installed(prefix, "python")
 
 
-def test_install_force_reinstall_flag(clear_package_cache: None):
+def test_install_force_reinstall_flag():
     with make_temp_env("python") as prefix:
         stdout, stderr, _ = run_command(
             Commands.INSTALL,
@@ -1047,7 +1040,7 @@ def test_install_force_reinstall_flag(clear_package_cache: None):
         assert unlink_actions[0]["name"] == "python"
 
 
-def test_create_no_deps_flag(clear_package_cache: None):
+def test_create_no_deps_flag():
     with make_temp_env("python=2", "flask", "--no-deps") as prefix:
         assert package_is_installed(prefix, "flask")
         assert package_is_installed(prefix, "python=2")
@@ -1055,7 +1048,7 @@ def test_create_no_deps_flag(clear_package_cache: None):
         assert not package_is_installed(prefix, "itsdangerous")
 
 
-def test_create_only_deps_flag(clear_package_cache: None):
+def test_create_only_deps_flag():
     with make_temp_env("python", "flask", "--only-deps", no_capture=True) as prefix:
         assert not package_is_installed(prefix, "flask")
         assert package_is_installed(prefix, "python")
@@ -1080,7 +1073,7 @@ def test_create_only_deps_flag(clear_package_cache: None):
         assert not package_is_installed(prefix, "flask")
 
 
-def test_install_update_deps_flag(clear_package_cache: None):
+def test_install_update_deps_flag():
     with make_temp_env("flask=2.0.1", "jinja2=3.0.1") as prefix:
         python = join(prefix, PYTHON_BINARY)
         result_before = subprocess_call_with_clean_env([python, "--version"])
@@ -1093,7 +1086,7 @@ def test_install_update_deps_flag(clear_package_cache: None):
         assert package_is_installed(prefix, "jinja2>3.0.1")
 
 
-def test_install_only_deps_flag(clear_package_cache: None):
+def test_install_only_deps_flag():
     with make_temp_env("flask=2.0.2", "jinja2=3.0.2") as prefix:
         python = join(prefix, PYTHON_BINARY)
         result_before = subprocess_call_with_clean_env([python, "--version"])
@@ -1109,7 +1102,7 @@ def test_install_only_deps_flag(clear_package_cache: None):
         assert not package_is_installed(prefix, "flask")
 
 
-def test_install_update_deps_only_deps_flags(clear_package_cache: None):
+def test_install_update_deps_only_deps_flags():
     with make_temp_env("flask=2.0.1", "jinja2=3.0.1") as prefix:
         python = join(prefix, PYTHON_BINARY)
         result_before = subprocess_call_with_clean_env([python, "--version"])
@@ -1130,7 +1123,7 @@ def test_install_update_deps_only_deps_flags(clear_package_cache: None):
 
 
 @pytest.mark.xfail(on_win, reason="nomkl not present on windows", strict=True)
-def test_install_features(clear_package_cache: None):
+def test_install_features():
     with make_temp_env("python=2", "numpy=1.13", "nomkl", no_capture=True) as prefix:
         assert package_is_installed(prefix, "numpy")
         assert package_is_installed(prefix, "nomkl")
@@ -1150,7 +1143,7 @@ def test_install_features(clear_package_cache: None):
         # assert not package_is_installed(prefix, "mkl")  # pruned as an indirect dep
 
 
-def test_clone_offline_simple(clear_package_cache: None):
+def test_clone_offline_simple():
     with make_temp_env("bzip2") as prefix:
         assert package_is_installed(prefix, "bzip2")
 
@@ -1159,7 +1152,7 @@ def test_clone_offline_simple(clear_package_cache: None):
             assert package_is_installed(clone_prefix, "bzip2")
 
 
-def test_conda_config_describe(clear_package_cache: None):
+def test_conda_config_describe():
     with make_temp_env() as prefix:
         stdout, stderr, _ = run_command(Commands.CONFIG, prefix, "--describe")
         assert not stderr
@@ -1237,7 +1230,7 @@ def test_conda_config_describe(clear_package_cache: None):
             assert json_obj["cmd_line"] == {"json": True}
 
 
-def test_conda_config_validate(clear_package_cache: None):
+def test_conda_config_validate():
     with make_temp_env() as prefix:
         run_command(Commands.CONFIG, prefix, "--set", "ssl_verify", "no")
         stdout, stderr, _ = run_command(Commands.CONFIG, prefix, "--validate")
@@ -1271,7 +1264,7 @@ def test_conda_config_validate(clear_package_cache: None):
     context.subdir not in ("linux-64", "osx-64", "win-32", "win-64", "linux-32"),
     reason="Skip unsupported platforms",
 )
-def test_rpy_search(clear_package_cache: None):
+def test_rpy_search():
     with make_temp_env("python=3.5", "--override-channels", "-c", "defaults") as prefix:
         payload, _, _ = run_command(
             Commands.CONFIG, prefix, "--get", "channels", "--json"
@@ -1317,7 +1310,7 @@ def test_rpy_search(clear_package_cache: None):
 
 
 @pytest.mark.parametrize("use_sys_python", [True, False])
-def test_compile_pyc(use_sys_python: bool, clear_package_cache: None):
+def test_compile_pyc(use_sys_python: bool):
     evs = {}
     with env_vars(evs, stack_callback=conda_tests_ctxt_mgmt_def_pol):
         packages = []
@@ -1361,7 +1354,7 @@ def test_compile_pyc(use_sys_python: bool, clear_package_cache: None):
             ), f"Failed to generate expected .pyc file {test_pyc_path}"
 
 
-def test_conda_run_1(clear_package_cache: None):
+def test_conda_run_1():
     with make_temp_env(use_restricted_unicode=False, name=str(uuid4())[:7]) as prefix:
         output, error, rc = run_command(Commands.RUN, prefix, "echo", "hello")
         assert output == f"hello{os.linesep}\n"
@@ -1373,20 +1366,20 @@ def test_conda_run_1(clear_package_cache: None):
         assert rc == 5
 
 
-def test_conda_run_nonexistant_prefix(clear_package_cache: None):
+def test_conda_run_nonexistant_prefix():
     with make_temp_env(use_restricted_unicode=False, name=str(uuid4())[:7]) as prefix:
         prefix = join(prefix, "clearly_a_prefix_that_does_not_exist")
         with pytest.raises(EnvironmentLocationNotFound):
             output, error, rc = run_command(Commands.RUN, prefix, "echo", "hello")
 
 
-def test_conda_run_prefix_not_a_conda_env(clear_package_cache: None):
+def test_conda_run_prefix_not_a_conda_env():
     with tempdir() as prefix:
         with pytest.raises(DirectoryNotACondaEnvironmentError):
             output, error, rc = run_command(Commands.RUN, prefix, "echo", "hello")
 
 
-def test_clone_offline_multichannel_with_untracked(clear_package_cache: None):
+def test_clone_offline_multichannel_with_untracked():
     with env_vars(
         {
             "CONDA_DLL_SEARCH_MODIFICATION_ENABLE": "1",
@@ -1428,7 +1421,7 @@ def test_clone_offline_multichannel_with_untracked(clear_package_cache: None):
                 assert isfile(join(clone_prefix, "test.file"))  # untracked file
 
 
-def test_package_pinning(clear_package_cache: None):
+def test_package_pinning():
     with make_temp_env(
         "python=2.7", "itsdangerous=0.24", "pytz=2017.3", no_capture=True
     ) as prefix:
@@ -1451,7 +1444,7 @@ def test_package_pinning(clear_package_cache: None):
         assert not package_is_installed(prefix, "itsdangerous=0.24")
 
 
-def test_update_all_updates_pip_pkg(clear_package_cache: None):
+def test_update_all_updates_pip_pkg():
     with make_temp_env("python=3.6", "pip", "pytz=2018", no_capture=True) as prefix:
         pip_ioo, pip_ioe, _ = run_command(
             Commands.CONFIG, prefix, "--set", "pip_interop_enabled", "true"
@@ -1489,7 +1482,7 @@ def test_update_all_updates_pip_pkg(clear_package_cache: None):
         assert package_is_installed(prefix, "pytz>2018")
 
 
-def test_package_optional_pinning(clear_package_cache: None):
+def test_package_optional_pinning():
     with make_temp_env() as prefix:
         run_command(Commands.CONFIG, prefix, "--add", "pinned_packages", "python=3.10")
         run_command(Commands.INSTALL, prefix, "zlib")
@@ -1498,7 +1491,7 @@ def test_package_optional_pinning(clear_package_cache: None):
         assert package_is_installed(prefix, "python=3.10")
 
 
-def test_update_deps_flag_absent(clear_package_cache: None):
+def test_update_deps_flag_absent():
     with make_temp_env("python=2", "itsdangerous=0.24") as prefix:
         assert package_is_installed(prefix, "python=2")
         assert package_is_installed(prefix, "itsdangerous=0.24")
@@ -1510,7 +1503,7 @@ def test_update_deps_flag_absent(clear_package_cache: None):
         assert package_is_installed(prefix, "flask")
 
 
-def test_update_deps_flag_present(clear_package_cache: None):
+def test_update_deps_flag_present():
     with make_temp_env("python=2", "itsdangerous=0.24") as prefix:
         assert package_is_installed(prefix, "python=2")
         assert package_is_installed(prefix, "itsdangerous=0.24")
@@ -1525,7 +1518,7 @@ def test_update_deps_flag_present(clear_package_cache: None):
 
 @pytest.mark.skipif(True, reason="Add this test back someday.")
 # @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
-def test_shortcut_in_underscore_env_shows_message(clear_package_cache: None):
+def test_shortcut_in_underscore_env_shows_message():
     prefix = make_temp_prefix("_" + str(uuid4())[:7])
     with make_temp_env(prefix=prefix):
         stdout, stderr, _ = run_command(Commands.INSTALL, prefix, "console_shortcut")
@@ -1536,7 +1529,7 @@ def test_shortcut_in_underscore_env_shows_message(clear_package_cache: None):
 
 
 @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
-def test_shortcut_not_attempted_with_no_shortcuts_arg(clear_package_cache: None):
+def test_shortcut_not_attempted_with_no_shortcuts_arg():
     prefix = make_temp_prefix("_" + str(uuid4())[:7])
     shortcut_dir = get_shortcut_dir()
     shortcut_file = join(shortcut_dir, f"Anaconda Prompt ({basename(prefix)}).lnk")
@@ -1552,7 +1545,7 @@ def test_shortcut_not_attempted_with_no_shortcuts_arg(clear_package_cache: None)
 
 
 @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
-def test_shortcut_creation_installs_shortcut(clear_package_cache: None):
+def test_shortcut_creation_installs_shortcut():
     shortcut_dir = get_shortcut_dir()
     shortcut_dir = join(
         shortcut_dir,
@@ -1581,7 +1574,7 @@ def test_shortcut_creation_installs_shortcut(clear_package_cache: None):
 
 
 @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
-def test_shortcut_absent_does_not_barf_on_uninstall(clear_package_cache: None):
+def test_shortcut_absent_does_not_barf_on_uninstall():
     shortcut_dir = get_shortcut_dir()
     shortcut_dir = join(
         shortcut_dir,
@@ -1609,7 +1602,7 @@ def test_shortcut_absent_does_not_barf_on_uninstall(clear_package_cache: None):
 
 
 @pytest.mark.skipif(not on_win, reason="shortcuts only relevant on Windows")
-def test_shortcut_absent_when_condarc_set(clear_package_cache: None):
+def test_shortcut_absent_when_condarc_set():
     shortcut_dir = get_shortcut_dir()
     shortcut_dir = join(
         shortcut_dir,
@@ -1643,7 +1636,7 @@ def test_shortcut_absent_when_condarc_set(clear_package_cache: None):
             os.remove(shortcut_file)
 
 
-def test_create_default_packages(clear_package_cache: None):
+def test_create_default_packages():
     # Regression test for #3453
     try:
         prefix = make_temp_prefix(str(uuid4())[:7])
@@ -1670,7 +1663,7 @@ def test_create_default_packages(clear_package_cache: None):
         rmtree(prefix, ignore_errors=True)
 
 
-def test_create_default_packages_no_default_packages(clear_package_cache: None):
+def test_create_default_packages_no_default_packages():
     try:
         prefix = make_temp_prefix(str(uuid4())[:7])
 
@@ -1696,7 +1689,7 @@ def test_create_default_packages_no_default_packages(clear_package_cache: None):
         rmtree(prefix, ignore_errors=True)
 
 
-def test_create_dry_run(clear_package_cache: None):
+def test_create_dry_run():
     # Regression test for #3453
     prefix = "/some/place"
     with pytest.raises(DryRunExit):
@@ -1719,7 +1712,7 @@ def test_create_dry_run(clear_package_cache: None):
     assert join("another", "place") in output
 
 
-def test_create_dry_run_json(clear_package_cache: None):
+def test_create_dry_run_json():
     prefix = "/some/place"
     with pytest.raises(DryRunExit):
         run_command(Commands.CREATE, prefix, "flask", "--dry-run", "--json")
@@ -1737,14 +1730,14 @@ def test_create_dry_run_json(clear_package_cache: None):
     assert "flask" in names
 
 
-def test_create_dry_run_yes_safety(clear_package_cache: None):
+def test_create_dry_run_yes_safety():
     with make_temp_env() as prefix:
         with pytest.raises(CondaValueError):
             run_command(Commands.CREATE, prefix, "--dry-run", "--yes")
         assert exists(prefix)
 
 
-def test_packages_not_found(clear_package_cache: None):
+def test_packages_not_found():
     with make_temp_env() as prefix:
         with pytest.raises(PackagesNotFoundError) as exc:
             run_command(Commands.INSTALL, prefix, "not-a-real-package")
@@ -1759,7 +1752,7 @@ def test_packages_not_found(clear_package_cache: None):
         assert "not-a-real-package" in error
 
 
-def test_conda_pip_interop_dependency_satisfied_by_pip(clear_package_cache: None):
+def test_conda_pip_interop_dependency_satisfied_by_pip():
     with make_temp_env("python=3.10", "pip", use_restricted_unicode=False) as prefix:
         run_command(Commands.CONFIG, prefix, "--set", "pip_interop_enabled", "true")
         run_command(
@@ -1812,7 +1805,7 @@ def test_conda_pip_interop_dependency_satisfied_by_pip(clear_package_cache: None
 @pytest.mark.skipif(
     context.subdir == "win-32", reason="metadata is wrong; give python2.7"
 )
-def test_conda_pip_interop_pip_clobbers_conda(clear_package_cache: None):
+def test_conda_pip_interop_pip_clobbers_conda():
     # 1. conda install old six
     # 2. pip install -U six
     # 3. conda list shows new six and deletes old conda record
@@ -2017,7 +2010,7 @@ def test_conda_pip_interop_pip_clobbers_conda(clear_package_cache: None):
     context.subdir not in ("linux-64", "osx-64", "win-32", "win-64", "linux-32"),
     reason="Skip unsupported platforms",
 )
-def test_conda_pip_interop_conda_editable_package(clear_package_cache: None):
+def test_conda_pip_interop_conda_editable_package():
     with env_vars(
         {
             "CONDA_REPORT_ERRORS": "false",
@@ -2151,7 +2144,7 @@ def test_conda_pip_interop_conda_editable_package(clear_package_cache: None):
             assert unlink_dists[0]["channel"] == "pypi"
 
 
-def test_conda_pip_interop_compatible_release_operator(clear_package_cache: None):
+def test_conda_pip_interop_compatible_release_operator():
     # Regression test for #7776
     # important to start the env with six 1.9.  That version forces an upgrade later in the test
     with make_temp_env(
@@ -2218,7 +2211,7 @@ def test_conda_pip_interop_compatible_release_operator(clear_package_cache: None
             )
 
 
-def test_install_freezes_env_by_default(clear_package_cache: None):
+def test_install_freezes_env_by_default():
     """We pass --no-update-deps/--freeze-installed by default, effectively.  This helps speed things
     up by not considering changes to existing stuff unless the solve ends up unsatisfiable.
     """
@@ -2248,7 +2241,7 @@ def test_install_freezes_env_by_default(clear_package_cache: None):
 
 
 @pytest.mark.skipif(on_win, reason="gawk is a windows only package")
-def test_search_gawk_not_win_filter(clear_package_cache: None):
+def test_search_gawk_not_win_filter():
     with make_temp_env() as prefix:
         stdout, stderr, _ = run_command(
             Commands.SEARCH,
@@ -2270,7 +2263,7 @@ def test_search_gawk_not_win_filter(clear_package_cache: None):
 
 
 @pytest.mark.skipif(not on_win, reason="gawk is a windows only package")
-def test_search_gawk_on_win(clear_package_cache: None):
+def test_search_gawk_on_win():
     with make_temp_env() as prefix:
         stdout, _, _ = run_command(
             Commands.SEARCH, prefix, "*gawk", "--json", use_exception_handler=True
@@ -2283,7 +2276,7 @@ def test_search_gawk_on_win(clear_package_cache: None):
 
 
 @pytest.mark.skipif(not on_win, reason="gawk is a windows only package")
-def test_search_gawk_on_win_filter(clear_package_cache: None):
+def test_search_gawk_on_win_filter():
     with make_temp_env() as prefix:
         stdout, _, _ = run_command(
             Commands.SEARCH,
@@ -2300,7 +2293,7 @@ def test_search_gawk_on_win_filter(clear_package_cache: None):
         assert not len(json_obj.keys()) == 0
 
 
-def test_bad_anaconda_token_infinite_loop(clear_package_cache: None):
+def test_bad_anaconda_token_infinite_loop():
     # This test is being changed around 2017-10-17, when the behavior of anaconda.org
     # was changed.  Previously, an expired token would return with a 401 response.
     # Now, a 200 response is always given, with any public packages available on the channel.
@@ -2350,7 +2343,6 @@ def test_bad_anaconda_token_infinite_loop(clear_package_cache: None):
     reason="binstar token found in global configuration",
 )
 def test_anaconda_token_with_private_package(
-    clear_package_cache: None,
     conda_cli: CondaCLIFixture,
     capsys: CaptureFixture,
 ):
@@ -2376,7 +2368,7 @@ def test_anaconda_token_with_private_package(
     assert package in json_loads(stdout)
 
 
-def test_use_index_cache(clear_package_cache: None):
+def test_use_index_cache():
     from conda.core.subdir_data import SubdirData
     from conda.gateways.connection.session import CondaSession
 
@@ -2426,7 +2418,7 @@ def test_use_index_cache(clear_package_cache: None):
             )
 
 
-def test_offline_with_empty_index_cache(clear_package_cache: None):
+def test_offline_with_empty_index_cache():
     from conda.core.subdir_data import SubdirData
 
     SubdirData.clear_cached_local_channel_data(exclude_file=False)
@@ -2501,7 +2493,7 @@ def test_offline_with_empty_index_cache(clear_package_cache: None):
         SubdirData.clear_cached_local_channel_data(exclude_file=False)
 
 
-def test_create_from_extracted(clear_package_cache: None):
+def test_create_from_extracted():
     with make_temp_package_cache() as pkgs_dir:
         assert context.pkgs_dirs == (pkgs_dir,)
 
@@ -2532,7 +2524,7 @@ def test_create_from_extracted(clear_package_cache: None):
             assert not pkgs_dir_has_tarball("openssl-")
 
 
-def test_install_mkdir(clear_package_cache: None):
+def test_install_mkdir():
     try:
         prefix = make_temp_prefix()
         with open(os.path.join(prefix, "tempfile.txt"), "w") as f:
@@ -2566,7 +2558,7 @@ def test_install_mkdir(clear_package_cache: None):
 
 
 @pytest.mark.skipif(on_win, reason="python doesn't have dependencies on windows")
-def test_disallowed_packages(clear_package_cache: None):
+def test_disallowed_packages():
     with make_temp_env() as prefix:
         with env_var(
             "CONDA_DISALLOWED_PACKAGES",
@@ -2580,7 +2572,7 @@ def test_disallowed_packages(clear_package_cache: None):
         assert exc_val.dump_map()["package_ref"]["name"] == "sqlite"
 
 
-def test_dont_remove_conda_1(clear_package_cache: None):
+def test_dont_remove_conda_1():
     pkgs_dirs = context.pkgs_dirs
     prefix = make_temp_prefix()
     with env_vars(
@@ -2609,7 +2601,7 @@ def test_dont_remove_conda_1(clear_package_cache: None):
             assert package_is_installed(prefix, "conda-build")
 
 
-def test_dont_remove_conda_2(clear_package_cache: None):
+def test_dont_remove_conda_2():
     # regression test for #6904
     pkgs_dirs = context.pkgs_dirs
     prefix = make_temp_prefix()
@@ -2637,7 +2629,7 @@ def test_dont_remove_conda_2(clear_package_cache: None):
             assert package_is_installed(prefix, "pycosat")
 
 
-def test_force_remove(clear_package_cache: None):
+def test_force_remove():
     with make_temp_env() as prefix:
         stdout, stderr, _ = run_command(Commands.INSTALL, prefix, "libarchive")
         assert package_is_installed(prefix, "libarchive")
@@ -2656,7 +2648,7 @@ def test_force_remove(clear_package_cache: None):
     run_command(Commands.REMOVE, prefix, "--all")
 
 
-def test_download_only_flag(clear_package_cache: None):
+def test_download_only_flag():
     from conda.core.link import UnlinkLinkTransaction
 
     with patch.object(UnlinkLinkTransaction, "execute") as mock_method:
@@ -2666,7 +2658,7 @@ def test_download_only_flag(clear_package_cache: None):
             assert mock_method.call_count == 1
 
 
-def test_transactional_rollback_simple(clear_package_cache: None):
+def test_transactional_rollback_simple():
     from conda.core.path_actions import CreatePrefixRecordAction
 
     with patch.object(CreatePrefixRecordAction, "execute") as mock_method:
@@ -2677,7 +2669,7 @@ def test_transactional_rollback_simple(clear_package_cache: None):
             assert not package_is_installed(prefix, "openssl")
 
 
-def test_transactional_rollback_upgrade_downgrade(clear_package_cache: None):
+def test_transactional_rollback_upgrade_downgrade():
     with make_temp_env("python=3.8", no_capture=True) as prefix:
         assert exists(join(prefix, PYTHON_BINARY))
         assert package_is_installed(prefix, "python=3")
@@ -2694,7 +2686,7 @@ def test_transactional_rollback_upgrade_downgrade(clear_package_cache: None):
             assert package_is_installed(prefix, "flask=2.1.3")
 
 
-def test_directory_not_a_conda_environment(clear_package_cache: None):
+def test_directory_not_a_conda_environment():
     prefix = make_temp_prefix(str(uuid4())[:7])
     with open(join(prefix, "tempfile.txt"), "w") as f:
         f.write("weeee")
@@ -2705,7 +2697,7 @@ def test_directory_not_a_conda_environment(clear_package_cache: None):
         rm_rf(prefix)
 
 
-def test_multiline_run_command(clear_package_cache: None):
+def test_multiline_run_command():
     with make_temp_env() as prefix:
         env_which_etc, errs_etc, _ = run_command(
             Commands.RUN,
@@ -2725,7 +2717,7 @@ def test_multiline_run_command(clear_package_cache: None):
 
 
 @pytest.mark.skip("Test is flaky")
-def test_conda_downgrade(clear_package_cache: None):
+def test_conda_downgrade():
     # Create an environment with the current conda under test, but include an earlier
     # version of conda and other packages in that environment.
     # Make sure we can flip back and forth.
@@ -2805,7 +2797,7 @@ def test_conda_downgrade(clear_package_cache: None):
 
 
 @pytest.mark.skipif(on_win, reason="openssl only has a postlink script on unix")
-def test_run_script_called(clear_package_cache: None):
+def test_run_script_called():
     import conda.core.link
 
     with patch.object(conda.core.link, "subprocess_call") as rs:
@@ -2821,7 +2813,7 @@ def test_run_script_called(clear_package_cache: None):
 
 
 @pytest.mark.xfail(on_mac, reason="known broken; see #11127")
-def test_post_link_run_in_env(clear_package_cache: None):
+def test_post_link_run_in_env():
     test_pkg = "_conda_test_env_activated_when_post_link_executed"
     # a non-unicode name must be provided here as activate.d scripts
     # are not executed on windows, see https://github.com/conda/conda/issues/8241
@@ -2829,12 +2821,12 @@ def test_post_link_run_in_env(clear_package_cache: None):
         assert package_is_installed(prefix, test_pkg)
 
 
-def test_conda_info_python(clear_package_cache: None):
+def test_conda_info_python():
     output, _, _ = run_command(Commands.INFO, None, "python=3.5")
     assert "python 3.5.4" in output
 
 
-def test_toolz_cytoolz_package_cache_regression(clear_package_cache: None):
+def test_toolz_cytoolz_package_cache_regression():
     with make_temp_env("python=3.5", use_restricted_unicode=on_win) as prefix:
         pkgs_dir = join(prefix, "pkgs")
         with env_var(
@@ -2849,7 +2841,7 @@ def test_toolz_cytoolz_package_cache_regression(clear_package_cache: None):
             assert package_is_installed(prefix, "toolz")
 
 
-def test_remove_spellcheck(clear_package_cache: None):
+def test_remove_spellcheck():
     with make_temp_env("numpy=1.12") as prefix:
         assert exists(join(prefix, PYTHON_BINARY))
         assert package_is_installed(prefix, "numpy")
@@ -2870,7 +2862,7 @@ def test_remove_spellcheck(clear_package_cache: None):
         assert package_is_installed(prefix, "numpy")
 
 
-def test_conda_list_json(clear_package_cache: None):
+def test_conda_list_json():
     def pkg_info(s):
         # function from nb_conda/envmanager.py
         if isinstance(s, str):
@@ -2894,7 +2886,7 @@ def test_conda_list_json(clear_package_cache: None):
 @pytest.mark.skipif(
     context.subdir == "win-32", reason="dependencies not available for win-32"
 )
-def test_legacy_repodata(clear_package_cache: None):
+def test_legacy_repodata():
     channel = join(dirname(abspath(__file__)), "data", "legacy_repodata")
     subdir = context.subdir
     if subdir not in ("win-64", "linux-64", "osx-64"):
@@ -2911,7 +2903,7 @@ def test_legacy_repodata(clear_package_cache: None):
 @pytest.mark.skipif(
     context.subdir == "win-32", reason="dependencies not available for win-32"
 )
-def test_cross_channel_incompatibility(clear_package_cache: None):
+def test_cross_channel_incompatibility():
     # regression test for https://github.com/conda/conda/issues/8772
     # conda-forge puts a run_constrains on libboost, which they don't have on conda-forge.
     #   This is a way of forcing libboost to be removed.  It's a way that they achieve
@@ -2937,7 +2929,7 @@ def test_cross_channel_incompatibility(clear_package_cache: None):
     context.subdir != "linux-64",
     reason="lazy; package constraint here only valid on linux-64",
 )
-def test_neutering_of_historic_specs(clear_package_cache: None):
+def test_neutering_of_historic_specs():
     with make_temp_env("psutil=5.6.3=py37h7b6447c_0") as prefix:
         stdout, stderr, _ = run_command(Commands.INSTALL, prefix, "python=3.6")
         with open(os.path.join(prefix, "conda-meta", "history")) as f:
@@ -2952,19 +2944,19 @@ def test_neutering_of_historic_specs(clear_package_cache: None):
 @pytest.mark.skipif(
     not context.subdir.startswith("linux"), reason="__glibc only available on linux"
 )
-def test_install_bound_virtual_package(clear_package_cache: None):
+def test_install_bound_virtual_package():
     with make_temp_env("__glibc>0"):
         pass
 
 
 @pytest.mark.integration
-def test_remove_empty_env(clear_package_cache: None):
+def test_remove_empty_env():
     with make_temp_env() as prefix:
         run_command(Commands.CREATE, prefix)
         run_command(Commands.REMOVE, prefix, "--all")
 
 
-def test_remove_ignore_nonenv(clear_package_cache: None):
+def test_remove_ignore_nonenv():
     with tempdir() as test_root:
         prefix = join(test_root, "not-an-env")
         filename = join(prefix, "file.dat")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Both `conda.core.link.UnlinkLinkTransactions` and `conda.core.package_cache_data.ProgressiveFetchExtract` implemented a manual caching logic with boolean flags. Replace this with `lru_cache`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
