### PR TITLE
Lazy conda content trust

### DIFF
--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -509,8 +509,8 @@ class SubdirData(metaclass=SubdirDataType):
             for fn, info in group:
                 _package_records.info[fn] = info
 
-                # Must modify info past this point for signature verification to
-                # work.
+                # Must not modify info past this point for signature
+                # verification to work.
                 additional_info = {}
 
                 if copy_legacy_md5:

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -104,6 +104,8 @@ class PackageRecordList(UserList):
 
     def __getitem__(self, i):
         if isinstance(i, slice):
+            # does conda slice?
+            raise NotImplemented()
             sliced = self.__class__(self.data[i])
             sliced.signatures = self.signatures
             sliced.info = self.info
@@ -115,7 +117,7 @@ class PackageRecordList(UserList):
                 # updates to the info dictionary performed below do not
                 # invalidate the signatures provided in metadata.json.
                 fn = record["fn"]
-                info = self.info[fn]
+                info = self.info.pop(fn)
                 # TODO add an if enabled: before the function call.
                 signature_verification(info, fn, self.signatures)
                 record = PackageRecord(**{**info, **record})

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -105,7 +105,7 @@ class PackageRecordList(UserList):
     def __getitem__(self, i):
         if isinstance(i, slice):
             # does conda slice?
-            raise NotImplemented()
+            raise NotImplementedError()
             sliced = self.__class__(self.data[i])
             sliced.signatures = self.signatures
             sliced.info = self.info

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -229,13 +229,16 @@ class _SignatureVerification:
                 f"Invalid JSON returned from {signing_data_url}/{filename}"
             )
 
-    def __call__(self, info, fn, signatures):
+    def __call__(self, info, fn, signatures, deepcopy=True):
         if not self.enabled or fn not in signatures:
             return
 
         # create a signable envelope (a dict with the info and signatures)
-        envelope = wrap_as_signable(info)
-        envelope["signatures"] = signatures[fn]
+        # envelope = wrap_as_signable(info)
+        envelope = {
+            "signatures": signatures[fn],
+            "signed": info,
+        }  # like wrap_as_signable without now-unnecessary deepcopy()
 
         try:
             verify_delegation("pkg_mgr", envelope, self.key_mgr)

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -16,7 +16,6 @@ try:
         load_metadata_from_file,
         write_metadata_to_file,
     )
-    from conda_content_trust.signing import wrap_as_signable
 except ImportError:
     # _SignatureVerification.enabled handles the rest of this state
     class SignatureError(Exception):

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -229,7 +229,7 @@ class _SignatureVerification:
                 f"Invalid JSON returned from {signing_data_url}/{filename}"
             )
 
-    def __call__(self, info, fn, signatures, deepcopy=True):
+    def __call__(self, info, fn, signatures):
         if not self.enabled or fn not in signatures:
             return
 

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -206,7 +206,11 @@ def test_subdir_data_coverage(platform=OVERRIDE_PLATFORM):
 
         sd = SubdirData(channel)
         sd.load()
-        assert all(isinstance(p, PackageRecord) for p in sd._package_records[1:])
+
+        # this line was to cover _package_records slices, now unsupported
+        # assert all(isinstance(p, PackageRecord) for p in sd._package_records[1:])
+        with pytest.raises(NotImplementedError):
+            sd._package_records[1:]
 
         assert all(r.name == "zlib" for r in sd._iter_records_by_name("zlib"))  # type: ignore
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Resolves https://github.com/conda/conda/issues/13109

Verify signature records when creating PackageRecord but not before. Avoid verifying all signatures when conda usually only needs to handle a few packages.

Seems slow, not sure if this is avoiding the work yet.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
