### PR TITLE
Catch `PermissionErrors` raised by `conda.cli.find_commands.find_commands`

### DIFF
--- a/conda/cli/find_commands.py
+++ b/conda/cli/find_commands.py
@@ -61,7 +61,7 @@ def find_commands(include_others=True):
     dir_paths.extend(os.environ.get("PATH", "").split(os.pathsep))
 
     if on_win:
-        pat = re.compile(r"conda-([\w\-]+)\.(exe|bat)?$")
+        pat = re.compile(r"conda-([\w\-]+)(\.(exe|bat))?$")
     else:
         pat = re.compile(r"conda-([\w\-]+)$")
 

--- a/conda/cli/find_commands.py
+++ b/conda/cli/find_commands.py
@@ -61,7 +61,7 @@ def find_commands(include_others=True):
     dir_paths.extend(os.environ.get("PATH", "").split(os.pathsep))
 
     if on_win:
-        pat = re.compile(r"conda-([\w\-]+)\.(exe|bat)$")
+        pat = re.compile(r"conda-([\w\-]+)\.(exe|bat)?$")
     else:
         pat = re.compile(r"conda-([\w\-]+)$")
 
@@ -69,8 +69,12 @@ def find_commands(include_others=True):
     for dir_path in dir_paths:
         if not isdir(dir_path):
             continue
-        for fn in os.listdir(dir_path):
-            m = pat.match(fn)
-            if m and isfile(join(dir_path, fn)):
-                res.add(m.group(1))
+        try:
+            for fn in os.listdir(dir_path):
+                m = pat.match(fn)
+                if m and isfile(join(dir_path, fn)):
+                    res.add(m.group(1))
+        except PermissionError:
+            # PermissionError: user doesn't have read access
+            continue
     return tuple(sorted(res))

--- a/news/13062-find-commands-permission-error
+++ b/news/13062-find-commands-permission-error
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Catch `PermissionError` raised by `conda.cli.find_commands.find_commands` when user's `$PATH` contains restricted paths. (#13062)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_find_commands.py
+++ b/tests/cli/test_find_commands.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+import os
+from pathlib import Path
+
+import pytest
+from pytest import MonkeyPatch
+
+from conda.cli.find_commands import find_commands, find_executable
+from conda.common.compat import on_win
+
+
+@pytest.fixture
+def faux_path(tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
+    if not on_win:
+        # make a read-only location, none of these should show up in the tests
+        permission = tmp_path / "permission"
+        permission.mkdir(mode=0o333, exist_ok=True)
+        (permission / "conda-permission").touch()
+        (permission / "conda-permission.bat").touch()
+        (permission / "conda-permission.exe").touch()
+        monkeypatch.setenv("PATH", str(permission), prepend=os.pathsep)
+
+    # bad executables
+    bad = tmp_path / "bad"
+    bad.mkdir(exist_ok=True)
+    (bad / "non-conda-bad").touch()
+    (bad / "non-conda-bad.bat").touch()
+    (bad / "non-conda-bad.exe").touch()
+    monkeypatch.setenv("PATH", str(bad), prepend=os.pathsep)
+
+    # good executables
+    bin_ = tmp_path / "bin"
+    bin_.mkdir(exist_ok=True)
+    (bin_ / "conda-bin").touch()
+    monkeypatch.setenv("PATH", str(bin_), prepend=os.pathsep)
+
+    bat = tmp_path / "bat"
+    bat.mkdir(exist_ok=True)
+    (bat / "conda-bat.bat").touch()
+    monkeypatch.setenv("PATH", str(bat), prepend=os.pathsep)
+
+    exe = tmp_path / "exe"
+    exe.mkdir(exist_ok=True)
+    (exe / "conda-exe.exe").touch()
+    monkeypatch.setenv("PATH", str(exe), prepend=os.pathsep)
+
+    yield tmp_path
+
+    if not on_win:
+        # undo read-only for clean removal
+        permission.chmod(permission.stat().st_mode | 0o444)
+
+
+def test_find_executable(faux_path: Path):
+    assert (faux_path / "bin" / "conda-bin").samefile(find_executable("conda-bin"))
+    if on_win:
+        assert (faux_path / "bat" / "conda-bat.bat").samefile(
+            find_executable("conda-bat")
+        )
+        assert (faux_path / "exe" / "conda-exe.exe").samefile(
+            find_executable("conda-exe")
+        )
+
+
+def test_find_commands(faux_path: Path):
+    find_commands.cache_clear()
+    if on_win:
+        assert {"bin", "bat", "exe"}.issubset(find_commands())
+    else:
+        assert {"bin"}.issubset(find_commands())

--- a/tests/gateways/test_connection.py
+++ b/tests/gateways/test_connection.py
@@ -221,9 +221,15 @@ def test_get_session_with_channel_settings_no_handler(mocker):
         "conda.gateways.connection.session.get_channel_name_from_url",
         return_value="defaults",
     )
-    mock_context = mocker.patch("conda.gateways.connection.session.context")
-    mock_context.plugin_manager.get_auth_handler.return_value = None
-    mock_context.channel_settings = ({"channel": "defaults", "auth": "dummy_two"},)
+    mock = mocker.patch(
+        "conda.plugins.manager.CondaPluginManager.get_auth_handler",
+        return_value=None,
+    )
+    mocker.patch(
+        "conda.base.context.Context.channel_settings",
+        new_callable=mocker.PropertyMock,
+        return_value=({"channel": "defaults", "auth": "dummy_two"},),
+    )
 
     url = "https://localhost/test2"
 
@@ -236,10 +242,7 @@ def test_get_session_with_channel_settings_no_handler(mocker):
     assert type(session_obj.auth) is CondaHttpAuth
 
     # Make sure we tried to retrieve our auth handler in this function
-    assert (
-        mocker.call("dummy_two")
-        in mock_context.plugin_manager.get_auth_handler.mock_calls
-    )
+    assert mocker.call("dummy_two") in mock.mock_calls
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While we check whether a path is a directory we don't also check whether the user has read access resulting in `PermissionError` if any paths are restricted.

Resolves #13058

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
