### PR TITLE
use scandir() in find_commands.py to avoid stat() calls

### DIFF
--- a/conda/cli/find_commands.py
+++ b/conda/cli/find_commands.py
@@ -69,8 +69,8 @@ def find_commands(include_others=True):
     for dir_path in dir_paths:
         if not isdir(dir_path):
             continue
-        for fn in os.listdir(dir_path):
-            m = pat.match(fn)
-            if m and isfile(join(dir_path, fn)):
+        for entry in os.scandir(dir_path):
+            m = pat.match(entry.name)
+            if m and entry.is_file():
                 res.add(m.group(1))
     return tuple(sorted(res))

--- a/news/find-commands-scandir
+++ b/news/find-commands-scandir
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Use `os.scandir()` to find conda subcommands without `stat()` overhead.
+  (#13033)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This function was especially slow on WSL. In addition to the previous fix, use`scandir()` which should grab the `is_file` attribute without a separate syscall in most cases.

Fixes #13067 

See also #13071 which is backported to the 23.7.x branch.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
