### PR TITLE
Fix context mocking for CondaSession test

### DIFF
--- a/tests/gateways/test_connection.py
+++ b/tests/gateways/test_connection.py
@@ -221,9 +221,15 @@ def test_get_session_with_channel_settings_no_handler(mocker):
         "conda.gateways.connection.session.get_channel_name_from_url",
         return_value="defaults",
     )
-    mock_context = mocker.patch("conda.gateways.connection.session.context")
-    mock_context.plugin_manager.get_auth_handler.return_value = None
-    mock_context.channel_settings = ({"channel": "defaults", "auth": "dummy_two"},)
+    mock = mocker.patch(
+        "conda.plugins.manager.CondaPluginManager.get_auth_handler",
+        return_value=None,
+    )
+    mocker.patch(
+        "conda.base.context.Context.channel_settings",
+        new_callable=mocker.PropertyMock,
+        return_value=({"channel": "defaults", "auth": "dummy_two"},),
+    )
 
     url = "https://localhost/test2"
 
@@ -236,10 +242,7 @@ def test_get_session_with_channel_settings_no_handler(mocker):
     assert type(session_obj.auth) is CondaHttpAuth
 
     # Make sure we tried to retrieve our auth handler in this function
-    assert (
-        mocker.call("dummy_two")
-        in mock_context.plugin_manager.get_auth_handler.mock_calls
-    )
+    assert mocker.call("dummy_two") in mock.mock_calls
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Discovered in https://github.com/conda/conda/pull/13062#discussion_r1316066996:

> With the addition of new tests above the testing order was shuffled and exposed incorrect context mocking in this unrelated test, see https://github.com/conda/conda/actions/runs/6079217031/job/16498615642#step:8:909
> 
> ...
> 
> The failure can be replicated on main with the following test order:
> 
> ```
> pytest \
>     "tests/gateways/test_connection.py::test_get_session_with_channel_settings_no_handler" \
>     "tests/gateways/test_jlap.py::test_jlap_fetch" \
>     "tests/gateways/test_jlap.py::test_jlap_fetch_file" \
>     "tests/gateways/test_jlap.py::test_download_and_hash" \
>     "tests/gateways/test_jlap.py::test_jlap_cache_clock[True]"
> ```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
