### PR TITLE
[23.7.x backport] Fix key sorting for `json.dumps` in `conda config` (#13076)

### DIFF
--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -158,7 +158,10 @@ def execute_config(args, parser):
         if context.json:
             stdout_write(
                 json.dumps(
-                    context.collect_all(),
+                    {
+                        str(source): values
+                        for source, values in context.collect_all().items()
+                    },
                     sort_keys=True,
                     indent=2,
                     separators=(",", ": "),

--- a/news/13076-json-sort-pathlib
+++ b/news/13076-json-sort-pathlib
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix sorting error for `conda config --show-sources --json`. (#13076)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_config.py
+++ b/tests/cli/test_main_config.py
@@ -65,3 +65,11 @@ def test_config_get_missing(
     assert Path(parsed["rc_path"]) == path
     assert parsed["success"]
     assert "warnings" in parsed
+
+
+def test_config_show_sources_json(conda_cli: CondaCLIFixture):
+    stdout, stderr, err = conda_cli("config", "--show-sources", "--json")
+    parsed = json.loads(stdout.strip())
+    assert "error" not in parsed  # not an error rendered as a json
+    assert not stderr
+    assert not err


### PR DESCRIPTION
See https://github.com/conda/conda/pull/13076