### PR TITLE
Add emscripten-wasm32 and wasi-wasm32 platforms to known platforms

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -68,6 +68,8 @@ DEFAULTS_CHANNEL_NAME = "defaults"
 
 KNOWN_SUBDIRS = PLATFORM_DIRECTORIES = (
     "noarch",
+    "emscripten-wasm32",
+    "wasi-wasm32",
     "freebsd-64",
     "linux-32",
     "linux-64",

--- a/news/13095-wasm-platforms
+++ b/news/13095-wasm-platforms
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `emscripten-wasm32` and `wasi-wasm32` platforms to known platforms. (#13095)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
This adds two new platforms to conda's list of known platforms, to unblock some of the [experimental work happening on emscripten-forge](https://github.com/emscripten-forge/recipes/issues/293). Names are derived from what CPython and Rust have chosen to use.