### PR TITLE
reindex test repository, fixing checksums

### DIFF
--- a/tests/data/conda_format_repo/linux-64/current_repodata.json
+++ b/tests/data/conda_format_repo/linux-64/current_repodata.json
@@ -2,21 +2,7 @@
   "info": {
     "subdir": "linux-64"
   },
-  "packages": {
-    "libgcc-ng-8.2.0-hdf63c60_1.tar.bz2": {
-      "build": "hdf63c60_1",
-      "build_number": 1,
-      "depends": [],
-      "license": "GPL",
-      "md5": "7d17c0d663e285a5e6cd7bfa8eed1cd8",
-      "name": "libgcc-ng",
-      "sha256": "1b6c9018bdfbd3c6b998ba072a244bb45f52d88b8774f4d458263bd3ac91c53f",
-      "size": 7996349,
-      "subdir": "linux-64",
-      "timestamp": 1534516107109,
-      "version": "8.2.0"
-    }
-  },
+  "packages": {},
   "packages.conda": {
     "zlib-1.2.11-h7b6447c_3.conda": {
       "build": "h7b6447c_3",
@@ -27,10 +13,10 @@
       "legacy_bz2_md5": "2e5b81671cc2b53177b94b258b1658b2",
       "license": "zlib",
       "license_family": "Other",
-      "md5": "2e5b81671cc2b53177b94b258b1658b2",
+      "md5": "cb23839f06da92ec92c6d2d2d5e0cb4a",
       "name": "zlib",
-      "sha256": "1f07873d6aa0cd18760a7b215d9956f7fa63c2f2761b03f293c659fe982923fa",
-      "size": 122456,
+      "sha256": "f33afff2144e1d6c4cf2e3e184937db8bf825b4537df74662aea5ee207b6a31b",
+      "size": 105917,
       "subdir": "linux-64",
       "timestamp": 1542814864621,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/linux-64/current_repodata.json
+++ b/tests/data/conda_format_repo/linux-64/current_repodata.json
@@ -2,7 +2,21 @@
   "info": {
     "subdir": "linux-64"
   },
-  "packages": {},
+  "packages": {
+    "libgcc-ng-8.2.0-hdf63c60_1.tar.bz2": {
+      "build": "hdf63c60_1",
+      "build_number": 1,
+      "depends": [],
+      "license": "GPL",
+      "md5": "7d17c0d663e285a5e6cd7bfa8eed1cd8",
+      "name": "libgcc-ng",
+      "sha256": "1b6c9018bdfbd3c6b998ba072a244bb45f52d88b8774f4d458263bd3ac91c53f",
+      "size": 7996349,
+      "subdir": "linux-64",
+      "timestamp": 1534516107109,
+      "version": "8.2.0"
+    }
+  },
   "packages.conda": {
     "zlib-1.2.11-h7b6447c_3.conda": {
       "build": "h7b6447c_3",

--- a/tests/data/conda_format_repo/linux-64/repodata.json
+++ b/tests/data/conda_format_repo/linux-64/repodata.json
@@ -42,10 +42,10 @@
       ],
       "license": "zlib",
       "license_family": "Other",
-      "md5": "2e5b81671cc2b53177b94b258b1658b2",
+      "md5": "cb23839f06da92ec92c6d2d2d5e0cb4a",
       "name": "zlib",
-      "sha256": "1f07873d6aa0cd18760a7b215d9956f7fa63c2f2761b03f293c659fe982923fa",
-      "size": 122456,
+      "sha256": "f33afff2144e1d6c4cf2e3e184937db8bf825b4537df74662aea5ee207b6a31b",
+      "size": 105917,
       "subdir": "linux-64",
       "timestamp": 1542814864621,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/osx-64/current_repodata.json
+++ b/tests/data/conda_format_repo/osx-64/current_repodata.json
@@ -11,10 +11,10 @@
       "legacy_bz2_md5": "5eab2de4933e1914f86d1586a8a40c39",
       "license": "zlib",
       "license_family": "Other",
-      "md5": "5eab2de4933e1914f86d1586a8a40c39",
+      "md5": "a1b03ba4ff40c83e4eb9c8fae40315a7",
       "name": "zlib",
-      "sha256": "9b73eb4e3197eccb485250709c6f4782a83a8688d5b8251a212251c451d9b9ad",
-      "size": 106948,
+      "sha256": "857293f389b188ba1fb02401a873fca5098db612ce6646c684efee77ad807f77",
+      "size": 91992,
       "subdir": "osx-64",
       "timestamp": 1542815100324,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/osx-64/repodata.json
+++ b/tests/data/conda_format_repo/osx-64/repodata.json
@@ -25,10 +25,10 @@
       "depends": [],
       "license": "zlib",
       "license_family": "Other",
-      "md5": "5eab2de4933e1914f86d1586a8a40c39",
+      "md5": "a1b03ba4ff40c83e4eb9c8fae40315a7",
       "name": "zlib",
-      "sha256": "9b73eb4e3197eccb485250709c6f4782a83a8688d5b8251a212251c451d9b9ad",
-      "size": 106948,
+      "sha256": "857293f389b188ba1fb02401a873fca5098db612ce6646c684efee77ad807f77",
+      "size": 91992,
       "subdir": "osx-64",
       "timestamp": 1542815100324,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/win-32/current_repodata.json
+++ b/tests/data/conda_format_repo/win-32/current_repodata.json
@@ -13,10 +13,10 @@
       "legacy_bz2_md5": "d56715ca9b345d3c51f2b19dba1dbf04",
       "license": "zlib",
       "license_family": "Other",
-      "md5": "d56715ca9b345d3c51f2b19dba1dbf04",
+      "md5": "1d40234f3fa0006e3a77c15c5aa6f2b7",
       "name": "zlib",
-      "sha256": "ea899e1c10ab22e565a201df1ee9d69b9260aa8ad4527b37d2dcd21a28f3a11d",
-      "size": 115056,
+      "sha256": "1f3fe788d266c16e35d1e737fd9b7c82dd1f1ba4d3973f0907c8a7634c5d484b",
+      "size": 99106,
       "subdir": "win-32",
       "timestamp": 1542815118406,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/win-32/repodata.json
+++ b/tests/data/conda_format_repo/win-32/repodata.json
@@ -29,10 +29,10 @@
       ],
       "license": "zlib",
       "license_family": "Other",
-      "md5": "d56715ca9b345d3c51f2b19dba1dbf04",
+      "md5": "1d40234f3fa0006e3a77c15c5aa6f2b7",
       "name": "zlib",
-      "sha256": "ea899e1c10ab22e565a201df1ee9d69b9260aa8ad4527b37d2dcd21a28f3a11d",
-      "size": 115056,
+      "sha256": "1f3fe788d266c16e35d1e737fd9b7c82dd1f1ba4d3973f0907c8a7634c5d484b",
+      "size": 99106,
       "subdir": "win-32",
       "timestamp": 1542815118406,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/win-64/current_repodata.json
+++ b/tests/data/conda_format_repo/win-64/current_repodata.json
@@ -43,10 +43,10 @@
       "legacy_bz2_md5": "a46cf10ba0eece37dffcec2d45a1f4ec",
       "license": "zlib",
       "license_family": "Other",
-      "md5": "a46cf10ba0eece37dffcec2d45a1f4ec",
+      "md5": "edad165fc3d25636d4f0a61c42873fbc",
       "name": "zlib",
-      "sha256": "10363f6c023d7fb3d11fdb4cc8de59b5ad5c6affdf960210dd95a252a3fced2b",
-      "size": 131285,
+      "sha256": "2fb5900c4a2ca7e0f509ebc344b3508815d7647c86cfb6721a1690365222e55a",
+      "size": 112305,
       "subdir": "win-64",
       "timestamp": 1542815182812,
       "version": "1.2.11"

--- a/tests/data/conda_format_repo/win-64/repodata.json
+++ b/tests/data/conda_format_repo/win-64/repodata.json
@@ -32,6 +32,18 @@
       "timestamp": 1556552671141,
       "version": "14.15.26706"
     },
+    "zlib-1.2.8-0.tar.bz2": {
+      "build": "0",
+      "build_number": 0,
+      "depends": [],
+      "license": "zlib (http://zlib.net/zlib_license.html)",
+      "md5": "a69dce7d2135e5001038db73750a0e2f",
+      "name": "zlib",
+      "requires": [],
+      "sha256": "ced73bbc08d44813bf0a60b8ea04494e50c482d145b089fa3a7f360b3e570838",
+      "size": 118439,
+      "version": "1.2.8"
+    },
     "zlib-1.2.11-h62dcd97_3.tar.bz2": {
       "build": "h62dcd97_3",
       "build_number": 3,
@@ -47,18 +59,6 @@
       "subdir": "win-64",
       "timestamp": 1542815182812,
       "version": "1.2.11"
-    },
-    "zlib-1.2.8-0.tar.bz2": {
-      "build": "0",
-      "build_number": 0,
-      "depends": [],
-      "license": "zlib (http://zlib.net/zlib_license.html)",
-      "md5": "a69dce7d2135e5001038db73750a0e2f",
-      "name": "zlib",
-      "requires": [],
-      "sha256": "ced73bbc08d44813bf0a60b8ea04494e50c482d145b089fa3a7f360b3e570838",
-      "size": 118439,
-      "version": "1.2.8"
     }
   },
   "packages.conda": {
@@ -70,10 +70,10 @@
       ],
       "license": "zlib",
       "license_family": "Other",
-      "md5": "a46cf10ba0eece37dffcec2d45a1f4ec",
+      "md5": "edad165fc3d25636d4f0a61c42873fbc",
       "name": "zlib",
-      "sha256": "10363f6c023d7fb3d11fdb4cc8de59b5ad5c6affdf960210dd95a252a3fced2b",
-      "size": 131285,
+      "sha256": "2fb5900c4a2ca7e0f509ebc344b3508815d7647c86cfb6721a1690365222e55a",
+      "size": 112305,
       "subdir": "win-64",
       "timestamp": 1542815182812,
       "version": "1.2.11"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Some of the test suite repository checksums were incorrect, matching the .tar.bz2 versions of those packages. This makes it impossible to install those `.conda`-format packages in tests. Fixed by running conda-index and preserving the packages that are only in index.json but not on disk used for solver tests.
