### PR TITLE
Deprecate unnecessary `conda.cli.python_api.generate_parser` wrapper/backport

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -29,6 +29,11 @@ def init_loggers():
     set_log_level(context.log_level)
 
 
+@deprecated(
+    "24.3",
+    "24.9",
+    addendum="Use `conda.cli.conda_argparse.generate_parser` instead.",
+)
 def generate_parser(*args, **kwargs):
     """
     Some code paths import this function directly from this module instead

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -10,8 +10,7 @@ from ..common.io import CaptureTarget, argv, captured
 from ..deprecations import deprecated
 from ..exceptions import conda_exception_handler
 from ..gateways.logging import initialize_std_loggers
-from .conda_argparse import do_call
-from .main import generate_parser
+from .conda_argparse import do_call, generate_parser
 
 deprecated.module("24.3", "24.9", addendum="Use `conda.testing.conda_cli` instead.")
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Deprecate the thin wrapper/backport `conda.cli.python_api.generate_parser` in favor of the actual `conda.cli.conda_argparse.generate_parser`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
