### PR TITLE
Enforce `on_linux`, `on_mac`, and `on_win` usage and remove some Python 2.7 code

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -18,7 +18,6 @@ from argparse import (
 from argparse import ArgumentParser as ArgumentParserBase
 from importlib import import_module
 from logging import getLogger
-from os.path import abspath, expanduser, join
 from subprocess import Popen
 from textwrap import dedent
 
@@ -31,18 +30,16 @@ from ..base.constants import (
     DepsModifier,
     UpdateModifier,
 )
-from ..base.context import context
+from ..base.context import context, sys_rc_path, user_rc_path
+from ..common.compat import on_win
 from ..common.constants import NULL
 from ..deprecations import deprecated
 from .find_commands import find_commands, find_executable
 
 log = getLogger(__name__)
 
-# duplicated code in the interest of import efficiency
-on_win = bool(sys.platform == "win32")
-user_rc_path = abspath(expanduser("~/.condarc"))
 escaped_user_rc_path = user_rc_path.replace("%", "%%")
-escaped_sys_rc_path = abspath(join(sys.prefix, ".condarc")).replace("%", "%%")
+escaped_sys_rc_path = sys_rc_path.replace("%", "%%")
 
 #: List of built-in commands; these cannot be overridden by plugin subcommands
 BUILTIN_COMMANDS = {

--- a/conda/common/_os/linux.py
+++ b/conda/common/_os/linux.py
@@ -1,11 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import sys
 from functools import lru_cache
 from logging import getLogger
-from os import scandir
+from os import confstr, confstr_names, readlink, scandir
 
 from genericpath import exists
+
+from ..compat import on_linux
 
 log = getLogger(__name__)
 
@@ -13,10 +14,8 @@ log = getLogger(__name__)
 @lru_cache(maxsize=None)
 def linux_get_libc_version():
     """If on linux, returns (libc_family, version), otherwise (None, None)."""
-    if not sys.platform.startswith("linux"):
+    if not on_linux:
         return None, None
-
-    from os import confstr, confstr_names, readlink
 
     # Python 2.7 does not have either of these keys in confstr_names, so provide
     # hard-coded defaults and assert if the key is in confstr_names but differs.

--- a/conda/common/_os/linux.py
+++ b/conda/common/_os/linux.py
@@ -2,11 +2,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from logging import getLogger
-from os import confstr, readlink, scandir
-
-from genericpath import exists
+from os.path import exists
 
 from ..compat import on_linux
 
@@ -21,8 +20,8 @@ def linux_get_libc_version() -> tuple[str, str] | tuple[None, None]:
 
     for name in ("CS_GNU_LIBC_VERSION", "CS_GNU_LIBPTHREAD_VERSION"):
         try:
-            # check if confstr returned None
-            if value := confstr(name):
+            # check if os.confstr returned None
+            if value := os.confstr(name):
                 family, version = value.strip().split(" ")
                 break
         except ValueError:
@@ -38,13 +37,13 @@ def linux_get_libc_version() -> tuple[str, str] | tuple[None, None]:
         )
 
     # NPTL is just the name of the threading library, even though the
-    # version refers to that of uClibc. readlink() can help to try to
+    # version refers to that of uClibc. os.readlink() can help to try to
     # figure out a better name instead.
     if family == "NPTL":  # pragma: no cover
         for clib in (
-            entry.path for entry in scandir("/lib") if entry.name[:7] == "libc.so"
+            entry.path for entry in os.scandir("/lib") if entry.name[:7] == "libc.so"
         ):
-            clib = readlink(clib)
+            clib = os.readlink(clib)
             if exists(clib):
                 if clib.startswith("libuClibc"):
                     if version.startswith("0."):

--- a/conda/common/_os/linux.py
+++ b/conda/common/_os/linux.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from functools import lru_cache
 from logging import getLogger
-from os import confstr, confstr_names, readlink, scandir
+from os import confstr, readlink, scandir
 
 from genericpath import exists
 
@@ -12,44 +14,28 @@ log = getLogger(__name__)
 
 
 @lru_cache(maxsize=None)
-def linux_get_libc_version():
+def linux_get_libc_version() -> tuple[str | None, str | None]:
     """If on linux, returns (libc_family, version), otherwise (None, None)."""
     if not on_linux:
         return None, None
 
-    # Python 2.7 does not have either of these keys in confstr_names, so provide
-    # hard-coded defaults and assert if the key is in confstr_names but differs.
-    # These are defined by POSIX anyway so should never change.
-    confstr_names_fallback = {
-        "CS_GNU_LIBC_VERSION": 2,
-        "CS_GNU_LIBPTHREAD_VERSION": 3,
-    }
-
-    val = None
-    for k, v in confstr_names_fallback.items():
-        assert (
-            k not in confstr_names or confstr_names[k] == v
-        ), "confstr_names_fallback for %s is %s yet in confstr_names it is %s" "" % (
-            k,
-            confstr_names_fallback[k],
-            confstr_names[k],
-        )
+    for name in ("CS_GNU_LIBC_VERSION", "CS_GNU_LIBPTHREAD_VERSION"):
         try:
-            val = str(confstr(v))
-        except Exception:  # pragma: no cover
-            pass
-        else:
-            if val:
+            # check if confstr returned None
+            if value := confstr(name):
+                family, version = value.strip().split(" ")
                 break
-
-    if not val:  # pragma: no cover
-        # Weird, play it safe and assume glibc 2.5
+        except ValueError:
+            # ValueError: name is not defined in os.confstr_names
+            # ValueError: value is not of the form "<family> <version>"
+            pass
+    else:
         family, version = "glibc", "2.5"
         log.warning(
-            "Failed to detect libc family and version, assuming %s/%s", family, version
+            "Failed to detect libc family and version, assuming %s/%s",
+            family,
+            version,
         )
-        return family, version
-    family, version = val.split(" ")
 
     # NPTL is just the name of the threading library, even though the
     # version refers to that of uClibc. readlink() can help to try to
@@ -65,11 +51,14 @@ def linux_get_libc_version():
                         family = "uClibc"
                     else:
                         family = "uClibc-ng"
-                    return family, version
-        # This could be some other C library; it is unlikely though.
-        family = "uClibc"
-        log.warning(
-            "Failed to detect non-glibc family, assuming %s (%s)", family, version
-        )
-        return family, version
+                    break
+        else:
+            # This could be some other C library; it is unlikely though.
+            family = "uClibc"
+            log.warning(
+                "Failed to detect non-glibc family, assuming %s/%s",
+                family,
+                version,
+            )
+
     return family, version

--- a/conda/common/_os/linux.py
+++ b/conda/common/_os/linux.py
@@ -14,7 +14,7 @@ log = getLogger(__name__)
 
 
 @lru_cache(maxsize=None)
-def linux_get_libc_version() -> tuple[str | None, str | None]:
+def linux_get_libc_version() -> tuple[str, str] | tuple[None, None]:
     """If on linux, returns (libc_family, version), otherwise (None, None)."""
     if not on_linux:
         return None, None

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -7,14 +7,13 @@ import os
 import re
 import struct
 import subprocess
-import sys
 from logging import getLogger
 from os.path import basename, realpath
 
 from ..auxlib.ish import dals
 from ..base.constants import PREFIX_PLACEHOLDER
 from ..base.context import context
-from ..common.compat import on_linux, on_win
+from ..common.compat import on_linux, on_mac, on_win
 from ..exceptions import BinaryPrefixReplacementError, CondaIOError
 from ..gateways.disk.update import CancelOperation, update_file_in_place_as_binary
 from ..models.enums import FileMode
@@ -85,12 +84,7 @@ def update_prefix(
 
     updated = update_file_in_place_as_binary(realpath(path), _update_prefix)
 
-    if (
-        updated
-        and mode == FileMode.binary
-        and subdir == "osx-arm64"
-        and sys.platform == "darwin"
-    ):
+    if updated and mode == FileMode.binary and subdir == "osx-arm64" and on_mac:
         # Apple arm64 needs signed executables
         subprocess.run(
             ["/usr/bin/codesign", "-s", "-", "-f", realpath(path)], capture_output=True

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -15,7 +15,7 @@ from ... import CondaError
 from ...auxlib.ish import dals
 from ...base.constants import CONDA_PACKAGE_EXTENSION_V1, PACKAGE_CACHE_MAGIC_FILE
 from ...base.context import context
-from ...common.compat import on_win
+from ...common.compat import on_linux, on_win
 from ...common.path import ensure_pad, expand, win_path_double_escape, win_path_ok
 from ...common.serialize import json_dump
 from ...exceptions import BasicClobberError, CondaOSError, maybe_raise
@@ -236,7 +236,7 @@ def extract_tarball(
     if hasattr(conda_package_handling.api, "THREADSAFE_EXTRACT"):
         return  # indicates conda-package-handling 2.x, which implements --no-same-owner
 
-    if sys.platform.startswith("linux") and os.getuid() == 0:  # pragma: no cover
+    if on_linux and os.getuid() == 0:  # pragma: no cover
         # When extracting as root, tarfile will by restore ownership
         # of extracted files.  However, we want root to be the owner
         # (our implementation of --no-same-owner).

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from os.path import abspath, dirname, exists, isdir, isfile, join, relpath
 
 from .base.context import context
-from .common.compat import on_win, open
+from .common.compat import on_mac, on_win, open
 from .common.path import expand
 from .common.url import is_url, join_url, path_to_url
 from .core.index import get_index
@@ -167,7 +167,7 @@ def walk_prefix(prefix, ignore_predefined_files=True, windows_forward_slashes=Tr
         ".nonadmin",
     }
     binignore = {"conda", "activate", "deactivate"}
-    if sys.platform == "darwin":
+    if on_mac:
         ignore.update({"python.app", "Launcher.app"})
     for fn in (entry.name for entry in os.scandir(prefix)):
         if ignore_predefined_files and fn in ignore:
@@ -200,7 +200,7 @@ def untracked(prefix, exclude_self_build=False):
         for path in walk_prefix(prefix) - conda_files
         if not (
             path.endswith("~")
-            or sys.platform == "darwin"
+            or on_mac
             and path.endswith(".DS_Store")
             or path.endswith(".pyc")
             and path[:-1] in conda_files

--- a/conda/models/enums.py
+++ b/conda/models/enums.py
@@ -47,14 +47,7 @@ class Platform(Enum):
 
     @classmethod
     def from_sys(cls):
-        p = sys.platform
-        if p.startswith("linux"):
-            # Changed in version 2.7.3: Since lots of code check for sys.platform == 'linux2',
-            # and there is no essential change between Linux 2.x and 3.x, sys.platform is always
-            # set to 'linux2', even on Linux 3.x. In Python 3.3 and later, the value will always
-            # be set to 'linux'
-            p = "linux"
-        return cls(p)
+        return cls(sys.platform)
 
     def __json__(self):
         return self.value

--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -140,7 +140,7 @@ def conda_check_versions_aligned():
     else:
         version_from_file = None
 
-    git_exe = "git.exe" if sys.platform == "win32" else "git"
+    git_exe = "git.exe" if on_win else "git"
     version_from_git = None
     for pe in os.environ.get("PATH", "").split(os.pathsep):
         if isfile(join(pe, git_exe)):

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -11,7 +11,7 @@ import pytest
 from conda._vendor.cpuinfo import get_cpu_info
 from conda.auxlib.ish import dals
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
-from conda.common.compat import on_linux
+from conda.common.compat import on_linux, on_mac, on_win
 from conda.common.io import env_var, env_vars
 from conda.core.solve import DepsModifier, UpdateModifier
 from conda.exceptions import SpecsConfigurationConflictError, UnsatisfiableError
@@ -218,14 +218,14 @@ def test_cuda_fail_1(tmpdir, clear_cuda_version):
             with pytest.raises(UnsatisfiableError) as exc:
                 solver.solve_final_state()
 
-    if sys.platform == "darwin":
+    if on_mac:
         if "ARM_8" in get_cpu_info()["arch"]:
             plat = "osx-arm64"
         else:
             plat = "osx-64"
-    elif sys.platform == "linux":
+    elif on_linux:
         plat = "linux-64"
-    elif sys.platform == "win32":
+    elif on_win:
         if platform.architecture()[0] == "32bit":
             plat = "win-32"
         else:

--- a/tests/gateways/test_repodata_lock.py
+++ b/tests/gateways/test_repodata_lock.py
@@ -9,6 +9,7 @@ import traceback
 import pytest
 
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
+from conda.common.compat import on_win
 from conda.common.io import env_vars
 from conda.gateways.repodata import RepodataCache, lock
 
@@ -77,9 +78,7 @@ def test_lock_can_lock(tmp_path, use_lock: bool):
             assert p.exitcode == 0
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="emulate windows behavior for code coverage"
-)
+@pytest.mark.skipif(on_win, reason="emulate windows behavior for code coverage")
 def test_lock_rename(tmp_path):
     class PunyPath(type(tmp_path)):
         def rename(self, path):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,13 +1,13 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import codecs
-import sys
 import warnings
 from unittest.mock import patch
 
 import pytest
 from pytest_mock import MockerFixture
 
+from conda.common.compat import on_mac
 from conda.core.subdir_data import cache_fn_url
 from conda.misc import explicit, url_pat, walk_prefix
 from conda.testing import CondaCLIFixture, TmpEnvFixture
@@ -148,7 +148,7 @@ def test_walk_prefix(tmpdir):  # tmpdir is a py.test utility
         "testdir1/testfile",
         "testdir1/testdir2/testfile",
     }
-    if sys.platform != "darwin":
+    if not on_mac:
         answer.add("python.app")
 
     assert walk_prefix(tmpdir.strpath) == answer


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Consistently use the `on_linux`, `on_mac`, and `on_win` constants. Removed some remaining Python 2.7 fallback codes.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
