### PR TITLE
Add (de)activate to --help command list

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -390,6 +390,7 @@ def configure_parser_mock_activate(sub_parsers):
         help="Activate a conda environment.",
     )
     p.set_defaults(func=".main_mock_activate.execute")
+    p.add_argument("args", action="store", nargs="*", help=SUPPRESS)
 
 
 def configure_parser_mock_deactivate(sub_parsers):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -108,6 +108,8 @@ def generate_parser(**kwargs) -> ArgumentParser:
         action=_GreedySubParsersAction,
     )
 
+    configure_parser_mock_activate(sub_parsers)
+    configure_parser_mock_deactivate(sub_parsers)
     configure_parser_clean(sub_parsers)
     configure_parser_compare(sub_parsers)
     configure_parser_config(sub_parsers)
@@ -380,6 +382,22 @@ def configure_parser_plugins(sub_parsers) -> None:
         parser.greedy = True
 
         parser.set_defaults(_executable=name)
+
+
+def configure_parser_mock_activate(sub_parsers):
+    p = sub_parsers.add_parser(
+        "activate",
+        help="Activate a conda environment.",
+    )
+    p.set_defaults(func=".main_mock_activate.execute")
+
+
+def configure_parser_mock_deactivate(sub_parsers):
+    p = sub_parsers.add_parser(
+        "deactivate",
+        help="Deactivate the current active conda environment.",
+    )
+    p.set_defaults(func=".main_mock_deactivate.execute")
 
 
 def configure_parser_clean(sub_parsers):
@@ -832,16 +850,6 @@ def configure_parser_init(sub_parsers):
     #
     #
     # """)
-
-    # Add mock entries for the (de)activate shell commands
-    sub_parsers.add_parser(
-        "activate",
-        help="Activate a conda environment.",
-    )
-    sub_parsers.add_parser(
-        "deactivate",
-        help="Deactivate the current active conda environment.",
-    )
 
     p = sub_parsers.add_parser(
         "init",

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -44,10 +44,12 @@ escaped_sys_rc_path = sys_rc_path.replace("%", "%%")
 
 #: List of built-in commands; these cannot be overridden by plugin subcommands
 BUILTIN_COMMANDS = {
+    "activate",  # Mock entry for shell command
     "clean",
     "compare",
     "config",
     "create",
+    "deactivate",  # Mock entry for shell command
     "info",
     "init",
     "install",
@@ -830,6 +832,16 @@ def configure_parser_init(sub_parsers):
     #
     #
     # """)
+
+    # Add mock entries for the (de)activate shell commands
+    sub_parsers.add_parser(
+        "activate",
+        help="Activate a conda environment.",
+    )
+    sub_parsers.add_parser(
+        "deactivate",
+        help="Deactivate the current active conda environment.",
+    )
 
     p = sub_parsers.add_parser(
         "init",

--- a/conda/cli/main_mock_activate.py
+++ b/conda/cli/main_mock_activate.py
@@ -7,4 +7,4 @@ A mock implementation of the activate shell command for better UX.
 
 
 def execute(args, parser):
-    print("ERROR Run `conda init` before `conda activate`")
+    print("ERROR: Run 'conda init' before 'conda activate'")

--- a/conda/cli/main_mock_activate.py
+++ b/conda/cli/main_mock_activate.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Mock CLI implementation for `conda activate`.
+
+A mock implementation of the activate shell command for better UX.
+"""
+
+
+def execute(args, parser):
+    print("ERROR Run `conda init` before `conda activate`")

--- a/conda/cli/main_mock_activate.py
+++ b/conda/cli/main_mock_activate.py
@@ -8,3 +8,4 @@ A mock implementation of the activate shell command for better UX.
 
 def execute(args, parser):
     print("ERROR: Run 'conda init' before 'conda activate'")
+    return 1

--- a/conda/cli/main_mock_activate.py
+++ b/conda/cli/main_mock_activate.py
@@ -4,8 +4,8 @@
 
 A mock implementation of the activate shell command for better UX.
 """
+from .. import CondaError
 
 
 def execute(args, parser):
-    print("ERROR: Run 'conda init' before 'conda activate'")
-    return 1
+    raise CondaError("Run 'conda init' before 'conda activate'")

--- a/conda/cli/main_mock_deactivate.py
+++ b/conda/cli/main_mock_deactivate.py
@@ -7,4 +7,4 @@ A mock implementation of the deactivate shell command for better UX.
 
 
 def execute(args, parser):
-    print("ERROR Run `conda init` before `conda deactivate`")
+    print("ERROR: Run 'conda init' before 'conda deactivate'")

--- a/conda/cli/main_mock_deactivate.py
+++ b/conda/cli/main_mock_deactivate.py
@@ -4,8 +4,8 @@
 
 A mock implementation of the deactivate shell command for better UX.
 """
+from .. import CondaError
 
 
 def execute(args, parser):
-    print("ERROR: Run 'conda init' before 'conda deactivate'")
-    return 1
+    raise CondaError("Run 'conda init' before 'conda deactivate'")

--- a/conda/cli/main_mock_deactivate.py
+++ b/conda/cli/main_mock_deactivate.py
@@ -8,3 +8,4 @@ A mock implementation of the deactivate shell command for better UX.
 
 def execute(args, parser):
     print("ERROR: Run 'conda init' before 'conda deactivate'")
+    return 1

--- a/conda/cli/main_mock_deactivate.py
+++ b/conda/cli/main_mock_deactivate.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Mock CLI implementation for `conda deactivate`.
+
+A mock implementation of the deactivate shell command for better UX.
+"""
+
+
+def execute(args, parser):
+    print("ERROR Run `conda init` before `conda deactivate`")

--- a/news/13191-add-activate-to-help
+++ b/news/13191-add-activate-to-help
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `activate` and `deactivate` to `--help` command list. (#13191)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 import pytest
 from pytest import MonkeyPatch
 
-from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT
+from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT, CondaError
 from conda import __version__ as conda_version
 from conda.activate import (
     CmdExeActivator,
@@ -3346,14 +3346,20 @@ def test_stacking(create_stackable_envs, auto_stack, stack, run, expected):
 
 def test_activate_and_deactivate_for_uninitialized_env(conda_cli):
     # Call activate (with and without env argument) and check that the proper error shows up
-    assert "ERROR: Run 'conda init' before 'conda activate'" in conda_cli("activate")[0]
-    assert (
-        "ERROR: Run 'conda init' before 'conda activate'"
-        in conda_cli("activate", "env")[0]
+    with pytest.raises(CondaError) as conda_error:
+        conda_cli("activate")
+    assert conda_error.value.message.startswith(
+        "Run 'conda init' before 'conda activate'"
+    )
+    with pytest.raises(CondaError) as conda_error:
+        conda_cli("activate", "env")
+    assert conda_error.value.message.startswith(
+        "Run 'conda init' before 'conda activate'"
     )
 
     # Call deactivate and check that the proper error shows up
-    assert (
-        "ERROR: Run 'conda init' before 'conda deactivate'"
-        in conda_cli("deactivate")[0]
+    with pytest.raises(CondaError) as conda_error:
+        conda_cli("deactivate")
+    assert conda_error.value.message.startswith(
+        "Run 'conda init' before 'conda deactivate'"
     )

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -3342,3 +3342,14 @@ def test_stacking(create_stackable_envs, auto_stack, stack, run, expected):
         )
         == expected
     )
+
+
+def test_activate_and_deactivate_for_uninitialized_env(conda_cli):
+    # Call activate and check that the proper error shows up
+    assert "ERROR: Run 'conda init' before 'conda activate'" in conda_cli("activate")[0]
+
+    # Call deactivate and check that the proper error shows up
+    assert (
+        "ERROR: Run 'conda init' before 'conda deactivate'"
+        in conda_cli("deactivate")[0]
+    )

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -3345,8 +3345,12 @@ def test_stacking(create_stackable_envs, auto_stack, stack, run, expected):
 
 
 def test_activate_and_deactivate_for_uninitialized_env(conda_cli):
-    # Call activate and check that the proper error shows up
+    # Call activate (with and without env argument) and check that the proper error shows up
     assert "ERROR: Run 'conda init' before 'conda activate'" in conda_cli("activate")[0]
+    assert (
+        "ERROR: Run 'conda init' before 'conda activate'"
+        in conda_cli("activate", "env")[0]
+    )
 
     # Call deactivate and check that the proper error shows up
     assert (


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Add two mock entries to the configure_parser_init() so the `activate` and `deactivate` shell commands are displayed in the --help.

Before:
```
$ conda --help
...
commands:
  The following built-in and plugins subcommands are available.

  COMMAND
    clean             Remove unused packages and caches.
    compare           Compare packages between conda environments.
    config            Modify configuration values in .condarc.
    content-trust     See `conda content-trust --help`.
    create            Create a new conda environment from a list of specified packages.
    doctor            Display a health report for your environment.
    env               See `conda env --help`.
    info              Display information about current conda install.
    init              Initialize conda for shell interaction.
    install           Install a list of packages into a specified conda environment.
    list              List installed packages in a conda environment.
    notices           Retrieve latest channel notifications.
    pack              See `conda pack --help`.
    package           Create low-level conda packages. (EXPERIMENTAL)
    remove (uninstall)
                      Remove a list of packages from a specified conda environment.
    rename            Rename an existing environment.
    repoquery         Advanced search for repodata.
    run               Run an executable in a conda environment.
    search            Search for packages and display associated information using the MatchSpec format.
    server            See `conda server --help`.
    update (upgrade)  Update conda packages to the latest compatible version.
    verify            See `conda verify --help`.
```
After:
```
$ conda --help
...
commands:
  The following built-in and plugins subcommands are available.

  COMMAND
    activate          Activate a conda environment.
    clean             Remove unused packages and caches.
    compare           Compare packages between conda environments.
    config            Modify configuration values in .condarc.
    content-trust     See `conda content-trust --help`.
    create            Create a new conda environment from a list of specified packages.
    deactivate        Deactivate the current active conda environment.
    doctor            Display a health report for your environment.
    env               See `conda env --help`.
    info              Display information about current conda install.
    init              Initialize conda for shell interaction.
    install           Install a list of packages into a specified conda environment.
    list              List installed packages in a conda environment.
    notices           Retrieve latest channel notifications.
    pack              See `conda pack --help`.
    package           Create low-level conda packages. (EXPERIMENTAL)
    remove (uninstall)
                      Remove a list of packages from a specified conda environment.
    rename            Rename an existing environment.
    repoquery         Advanced search for repodata.
    run               Run an executable in a conda environment.
    search            Search for packages and display associated information using the MatchSpec format.
    server            See `conda server --help`.
    update (upgrade)  Update conda packages to the latest compatible version.
    verify            See `conda verify --help`.
```

This is arguably a hack, but is the correct way to resolve the issue according to #6353. I'm not 100% if they should be listed in `BUILTIN_COMMANDS`, but it seems right to me.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
