### PR TITLE
Deprecate `conda.models.dist.IndexRecord`

### DIFF
--- a/conda/exports.py
+++ b/conda/exports.py
@@ -119,7 +119,13 @@ LinkError = LinkError
 CondaOSError = CondaOSError
 # PathNotFoundError is the conda 4.4.x name for it - let's plan ahead.
 CondaFileNotFoundError = PathNotFoundError
-IndexRecord = PackageRecord
+deprecated.constant(
+    "24.3",
+    "24.9",
+    "IndexRecord",
+    PackageRecord,
+    addendum="Use `conda.models.records.PackageRecord` instead.",
+)
 # Replacements for six exports for compatibility
 PY3 = True  # noqa: F401
 string_types = str  # noqa: F401

--- a/conda/models/dist.py
+++ b/conda/models/dist.py
@@ -16,6 +16,7 @@ from ..base.context import context
 from ..common.compat import ensure_text_type
 from ..common.constants import NULL
 from ..common.url import has_platform, is_url, join_url
+from ..deprecations import deprecated
 from .channel import Channel
 from .package_info import PackageInfo
 from .records import PackageRecord
@@ -32,7 +33,13 @@ class DistDetails(NamedTuple):
     fmt: str
 
 
-IndexRecord = PackageRecord  # for conda-build backward compat
+deprecated.constant(
+    "24.3",
+    "24.9",
+    "IndexRecord",
+    PackageRecord,
+    addendum="Use `conda.models.records.PackageRecord` instead.",
+)
 
 
 class DistType(EntityType):

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -245,7 +245,7 @@ class MatchSpec(metaclass=MatchSpecType):
 
     def match(self, rec):
         """
-        Accepts an `IndexRecord` or a dict, and matches can pull from any field
+        Accepts a `PackageRecord` or a dict, and matches can pull from any field
         in that record.  Returns True for a match, and False for no match.
         """
         if isinstance(rec, dict):

--- a/news/13193-deprecate-IndexRecord
+++ b/news/13193-deprecate-IndexRecord
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.models.dist.IndexRecord` as pending deprecation for removal in 24.9. (#13193)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1315,7 +1315,7 @@ def test_execute_plan(monkeypatch: MonkeyPatch):
 
 def generate_mocked_resolve(pkgs, install=None):
     mock_package = namedtuple(
-        "IndexRecord", ["preferred_env", "name", "schannel", "version", "fn"]
+        "PacakgeRecord", ["preferred_env", "name", "schannel", "version", "fn"]
     )
     mock_resolve = namedtuple(
         "Resolve",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Xref https://github.com/conda/conda/issues/13192

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
