### PR TITLE
Convert canary builds to be noarch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,8 +411,6 @@ jobs:
         include:
           - runner: ubuntu-latest
             subdir: linux-64
-          - runner: macos-latest
-            subdir: osx-64
           - runner: windows-latest
             subdir: win-64
     runs-on: ${{ matrix.runner }}

--- a/news/13244-canary-noarch
+++ b/news/13244-canary-noarch
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Convert canary builds to be noarch to be able to test them on all platform / python version combinations

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,3 @@
-python:
-  - 3.8
-  - 3.9
-  - 3.10
-  - 3.11
+target_os:
+  - unix  # [unix]
+  - win   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,7 @@ source:
   git_url: ../
 
 build:
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv && {{ PYTHON }} -m conda init --install
   # These are present when the new environment is created
   # so we have to exempt them from the list of initial files
@@ -23,7 +24,7 @@ requirements:
   build:
     - git  # for source/git_url above
   host:
-    - python
+    - python >=3.8
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
@@ -34,6 +35,7 @@ requirements:
     - ruamel.yaml >=0.11.14,<0.18
     - tqdm >=4
   run:
+    - __{{ target_os }}
     - archspec
     - boltons >=23.0.0
     - conda-package-handling >=2.2.0
@@ -42,7 +44,7 @@ requirements:
     - packaging >=23.0
     - pluggy >=1.0.0
     - pycosat >=0.6.3
-    - python
+    - python >=3.8
     - requests >=2.27.0,<3
     - ruamel.yaml >=0.11.14,<0.18
     - setuptools >=60.0.0


### PR DESCRIPTION
There is no technical reason why a package build on macos-{64, arm64} or linux-{64, ppc64le, s390x} should be any different. So building two noarch variants of conda, one for unix and one for windows. The run constrain ensures that only the right variant can be installed.

While its is the goal of prod/defaults to build recipes for all platform / python combination to e.g. reveal if dependencies are missing in some of the combinations, the the goal of conda canary releases may differ in this regards to make canary builds as easy testable as possible on all platforms / python combinations.

Inspired by https://github.com/conda-forge/constructor-feedstock/blob/main/recipe/meta.yaml

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
