### PR TITLE
Fix CONDA_FETCH_THREADS parameter

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -206,9 +206,9 @@ class Context(Configuration):
     _repodata_threads = ParameterLoader(
         PrimitiveParameter(0, element_type=int), aliases=("repodata_threads",)
     )
-    # download packages; determined experimentally
+    # download packages
     _fetch_threads = ParameterLoader(
-        PrimitiveParameter(5, element_type=int), aliases=("fetch_threads",)
+        PrimitiveParameter(0, element_type=int), aliases=("fetch_threads",)
     )
     _verify_threads = ParameterLoader(
         PrimitiveParameter(0, element_type=int), aliases=("verify_threads",)
@@ -567,6 +567,11 @@ class Context(Configuration):
 
     @property
     def fetch_threads(self) -> int | None:
+        """
+        If both are not overriden (0), return experimentally-determined value of 5
+        """
+        if self._fetch_threads == 0 and self._default_threads == 0:
+            return 5
         return self._fetch_threads or self.default_threads
 
     @property

--- a/news/context-fetch-threads
+++ b/news/context-fetch-threads
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Allow `CONDA_FETCH_THREADS`/`fetch_threads`, which sets parallel package
+  downloads, to be overridden from its default value of `5`.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/context-fetch-threads
+++ b/news/context-fetch-threads
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 * Allow `CONDA_FETCH_THREADS`/`fetch_threads`, which sets parallel package
-  downloads, to be overridden from its default value of `5`.
+  downloads, to be overridden from its default value of `5`. (#13263)
 
 ### Deprecations
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Would always be the default of 5 even if `CONDA_DEFAULT_THREADS` was set. IIRC I was also unable to set `fetch_threads` in `~/.condarc`?

What is the correct precedence? I think when default threads is overridden, then all other thread counts must be set or else they equal default threads. Otherwise the individual tunables should win out.

We could try to preserve a distinction between 0 (use DummyExecutor, do not use threading at all), 1 (use a single real Thread), and None (pick a default based on testing or core count/system resources). The current code doesn't seem well suited for that.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
