### PR TITLE
Fix missing envvar for durations file

### DIFF
--- a/dev/linux/integration.sh
+++ b/dev/linux/integration.sh
@@ -17,7 +17,7 @@ export TMP=$HOME/pytesttmp
 mkdir -p $TMP
 python -m pytest \
     --cov=conda \
-    --durations-path=./tools/durations/${OS}.json \
+    --durations-path=./tools/durations/Linux.json \
     --basetemp=$TMP \
     -m "integration" \
     --splits=${TEST_SPLITS} \

--- a/dev/linux/unit.sh
+++ b/dev/linux/unit.sh
@@ -19,7 +19,7 @@ export TMP=$HOME/pytesttmp
 mkdir -p $TMP
 python -m pytest \
     --cov=conda \
-    --durations-path=./tools/durations/${OS}.json \
+    --durations-path=./tools/durations/Linux.json \
     --basetemp=$TMP \
     -m "not integration" \
     --splits=${TEST_SPLITS} \

--- a/dev/macos/integration.sh
+++ b/dev/macos/integration.sh
@@ -9,7 +9,7 @@ eval "$(sudo python -m conda init bash --dev)"
 conda info
 python -m pytest \
     --cov=conda \
-    --durations-path=./tools/durations/${OS}.json \
+    --durations-path=./tools/durations/macOS.json \
     -m "integration" \
     --splits=${TEST_SPLITS} \
     --group=${TEST_GROUP}

--- a/dev/macos/unit.sh
+++ b/dev/macos/unit.sh
@@ -9,7 +9,7 @@ eval "$(sudo python -m conda init bash --dev)"
 conda info
 python -m pytest \
     --cov=conda \
-    --durations-path=./tools/durations/${OS}.json \
+    --durations-path=./tools/durations/macOS.json \
     -m "not integration" \
     --splits=${TEST_SPLITS} \
     --group=${TEST_GROUP}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The Linux and macOS tests are not properly detecting duration files:

https://github.com/conda/conda/actions/runs/6709237086/job/18231881358?pr=13246#step:3:158
https://github.com/conda/conda/actions/runs/6709237086/job/18231877310?pr=13246#step:3:91

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
