### PR TITLE
_vendor.appdirs: Fix SyntaxWarning: invalid escape sequence '\D'

### DIFF
--- a/conda/_vendor/appdirs.py
+++ b/conda/_vendor/appdirs.py
@@ -79,7 +79,7 @@ def user_data_dir(appname, appauthor=None, version=None, roaming=False):
 
 
 def site_data_dir(appname, appauthor=None, version=None):
-    """Return full path to the user-shared data dir for this application.
+    r"""Return full path to the user-shared data dir for this application.
 
         "appname" is the name of application.
         "appauthor" (only required and used on Windows) is the name of the


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda._vendor.appdirs` has a single "non-raw" doc string that contains backslash-separated Windows paths.
This leads to a `SyntaxWarning` for Python 3.12.
N.B.: Normally users will not see this since the warning will not be shown if the source file has already been compiled (as is the case in our `conda` packages).
```sh
# >/dev/null 2>&1 conda create -qyp/home/conda/conda23.10-py3.12 conda=23.10 python=3.12
# . /home/conda/conda23.10-py3.12/etc/profile.d/conda.sh
# conda activate
(base) # conda activate
(base) # find "${CONDA_EXE%/*}"/../lib/python3.1?/site-packages/conda -type f -name \*.pyc -delete
(base) # conda activate
/home/conda/conda23.10-py3.12/lib/python3.12/site-packages/conda/_vendor/appdirs.py:82: SyntaxWarning: invalid escape sequence '\D'
  """Return full path to the user-shared data dir for this application.
(base) # conda activate
(base) # 
```

(Just a minor fix, not `news`-worthy.)
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
