### PR TITLE
Move `urllib3_logger_error` to `conftest.py`

### DIFF
--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,11 +1,2 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import logging
-
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def urllib3_logger_error(caplog):
-    "Increasing the level to error to prevent retries show up in the stderr"
-    caplog.set_level(logging.ERROR, logger="urllib3.connectionpool")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -7,5 +7,5 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def urllib3_logger_error(caplog):
-    "Increasing the level to error to prevent retries show up in the stderr"
+    """Increase log level to error to prevent retries from polluting stderr."""
     caplog.set_level(logging.ERROR, logger="urllib3.connectionpool")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def urllib3_logger_error(caplog):
+    "Increasing the level to error to prevent retries show up in the stderr"
+    caplog.set_level(logging.ERROR, logger="urllib3.connectionpool")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Followup to https://github.com/conda/conda/pull/13291

Fixtures need to be defined in the `conftest.py` (not `__init__.py`) to be discoverable for tests within that submodule.

Explicitly targeting the `forward-23.10.0` branch so we can confirm this works for `23.10.x`.

I have tested this locally by defining the following test in `tests/cli/test_subcommands.py`:

```
def test_logging_level():
    assert logging.getLogger("urllib3.connectionpool").getEffectiveLevel() == logging.ERROR
```

This test passes after moving the fixture to `conftest.py`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
