### PR TITLE
Remove outdated test xfails that are now xpass related to the conda-libmamba-solver release

### DIFF
--- a/tests/cli/test_subcommands.py
+++ b/tests/cli/test_subcommands.py
@@ -35,12 +35,6 @@ def test_clean(conda_cli: CondaCLIFixture):
 
 
 def test_create(conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture, request):
-    request.applymarker(
-        pytest.mark.xfail(
-            context.solver == "libmamba",
-            reason="Dealt with in https://github.com/conda/conda-libmamba-solver/pull/316; pending release",
-        )
-    )
     out, err, code = conda_cli("create", "--prefix", path_factory(), "--yes")
     assert out
     assert not err
@@ -102,12 +96,6 @@ def test_init(conda_cli: CondaCLIFixture):
 
 
 def test_install(conda_cli: CondaCLIFixture, tmp_env: TmpEnvFixture, request):
-    request.applymarker(
-        pytest.mark.xfail(
-            context.solver == "libmamba",
-            reason="Dealt with in https://github.com/conda/conda-libmamba-solver/pull/316; pending release",
-        )
-    )
     with tmp_env() as prefix:
         out, err, code = conda_cli(
             "install",
@@ -197,12 +185,6 @@ def test_search(conda_cli: CondaCLIFixture):
 def test_update(
     subcommand: str, conda_cli: CondaCLIFixture, tmp_env: TmpEnvFixture, request
 ):
-    request.applymarker(
-        pytest.mark.xfail(
-            context.solver == "libmamba",
-            reason="Dealt with in https://github.com/conda/conda-libmamba-solver/pull/316; pending release",
-        )
-    )
     with tmp_env("ca-certificates<2023") as prefix:
         out, err, code = conda_cli(subcommand, "--prefix", prefix, "--all", "--yes")
         assert out
@@ -235,12 +217,6 @@ def test_env_create(
     environment_yml: Path,
     request,
 ):
-    request.applymarker(
-        pytest.mark.xfail(
-            context.solver == "libmamba",
-            reason="Dealt with in https://github.com/conda/conda-libmamba-solver/pull/316; pending release",
-        )
-    )
     out, err, code = conda_cli(
         "env",
         "create",
@@ -258,12 +234,6 @@ def test_env_update(
     environment_yml: Path,
     request,
 ):
-    request.applymarker(
-        pytest.mark.xfail(
-            context.solver == "libmamba",
-            reason="Dealt with in https://github.com/conda/conda-libmamba-solver/pull/316; pending release",
-        )
-    )
     with tmp_env("ca-certificates<2023") as prefix:
         out, err, code = conda_cli(
             "env",

--- a/tests/cli/test_subcommands.py
+++ b/tests/cli/test_subcommands.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from conda.base.context import context
 from conda.common.compat import on_win
 from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -19,12 +19,6 @@ def test_export(
     request,
 ):
     """Test that `conda list --export` output can be used to create a similar environment."""
-    request.applymarker(
-        pytest.mark.xfail(
-            context.solver == "libmamba",
-            reason="Known issue in libmamba 1.5.x: pkgs/main not supported as channel spec",
-        )
-    )
     monkeypatch.setenv("CONDA_CHANNELS", "defaults")
     reset_context()
     # assert context.channels == ("defaults",)
@@ -53,13 +47,6 @@ def test_explicit(
     request,
 ):
     """Test that `conda list --explicit` output can be used to recreate an identical environment."""
-    request.applymarker(
-        pytest.mark.xfail(
-            context.solver == "libmamba",
-            reason="Known issue in libmamba 1.5.x: pkgs/main not supported as channel spec",
-        )
-    )
-
     # use "cheap" packages with no dependencies
     with tmp_env("pkgs/main::zlib", "conda-forge::ca-certificates") as prefix:
         assert package_is_installed(prefix, "pkgs/main::zlib")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest import MonkeyPatch
 
-from conda.base.context import context, reset_context
+from conda.base.context import reset_context
 from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 from conda.testing.integration import package_is_installed
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

These xfails were part of 23.10 before we cut conda-libmamba-solver 23.11. These are obsolete with the latest batch of releases (incl. libmambapy 1.5.3).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~ 
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
