### PR TITLE
Deprecate `conda._vendor.cpuinfo`

### DIFF
--- a/conda/_vendor/cpuinfo/__init__.py
+++ b/conda/_vendor/cpuinfo/__init__.py
@@ -2,4 +2,7 @@
 import sys
 from .cpuinfo import *
 
+from ...deprecations import deprecated
+
+deprecated.module("24.3", "24.9")
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1116,7 +1116,8 @@ class Context(Configuration):
         libc_family, libc_version = linux_get_libc_version()
         return libc_family, libc_version
 
-    @memoizedproperty
+    @property
+    @deprecated("24.3", "24.9")
     def cpu_flags(self):
         # DANGER: This is rather slow
         info = _get_cpu_info()
@@ -1919,6 +1920,7 @@ def replace_context_default(pushing=None, argparse_args=None):
 conda_tests_ctxt_mgmt_def_pol = replace_context_default
 
 
+@deprecated("24.3", "24.9")
 @lru_cache(maxsize=None)
 def _get_cpu_info():
     # DANGER: This is rather slow

--- a/news/13313-deprecate-cpuinfo
+++ b/news/13313-deprecate-cpuinfo
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda._vendor.cpuinfo` as pending deprecation. (#13313)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Resolves #13312 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
