### PR TITLE
Deprecate `conda._vendor.distro` in favor of `distro`.

### DIFF
--- a/conda/_vendor/distro.py
+++ b/conda/_vendor/distro.py
@@ -27,6 +27,8 @@ Still, there are many cases in which access to Linux distribution information
 is needed. See `Python issue 1322 <https://bugs.python.org/issue1322>`_ for
 more information.
 """
+from ..deprecations import deprecated
+deprecated.module("24.3", "24.9", addendum="Use `distro` instead.")
 
 import os
 import re

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1094,10 +1094,9 @@ class Context(Configuration):
         #   'Windows', '10.0.17134'
         platform_name = self.platform_system_release[0]
         if platform_name == "Linux":
-            from .._vendor.distro import id, version
-
             try:
-                distinfo = id(), version(best=True)
+                import distro
+                distinfo = distro.id(), distro.version(best=True)
             except Exception as e:
                 log.debug("%r", e, exc_info=True)
                 distinfo = ("Linux", "unknown")

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1095,7 +1095,10 @@ class Context(Configuration):
         platform_name = self.platform_system_release[0]
         if platform_name == "Linux":
             try:
-                import distro
+                try:
+                    import distro
+                except ImportError:
+                    from .._vendor import distro
 
                 distinfo = distro.id(), distro.version(best=True)
             except Exception as e:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1096,6 +1096,7 @@ class Context(Configuration):
         if platform_name == "Linux":
             try:
                 import distro
+
                 distinfo = distro.id(), distro.version(best=True)
             except Exception as e:
                 log.debug("%r", e, exc_info=True)

--- a/news/13317-distro
+++ b/news/13317-distro
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Deprecate `conda._vendor.distro` in favor of the `distro` package. (#13317)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "charset-normalizer",
   "conda-libmamba-solver >=23.11.0",
   "conda-package-handling >=1.3.0",
+  "distro >=1.5.0",
   "jsonpatch >=1.32",
   "menuinst >=1.4.11,<2 ; platform_system=='Windows'",
   "packaging",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - charset-normalizer
     - conda-libmamba-solver >=23.11.0
     - conda-package-handling >=2.2.0
+    - distro >=1.5.0
     - jsonpatch >=1.32
     - menuinst >=1.4.11,<2         # [win]
     - packaging >=23.0


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Resolves #12700.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
