### PR TITLE
Add option to skip flexible search

### DIFF
--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -90,12 +90,16 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         default=NULL,
     )
     p.add_argument(
+        "--no-flexible-search",
+        action="store_true",
+        help="Do not perform flexible search if initial search fails.",
+    )
+    p.add_argument(
         "match_spec",
         default="*",
         nargs="?",
         help=SUPPRESS,
     )
-
     p.add_argument(
         "--canonical",
         action="store_true",
@@ -223,7 +227,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
             SubdirData.query_all(spec, channel_urls, subdirs),
             key=lambda rec: (rec.name, VersionOrder(rec.version), rec.build),
         )
-    if not matches and spec.get_exact_value("name"):
+    if not matches and not args.no_flexible_search and spec.get_exact_value("name"):
         flex_spec = MatchSpec(spec, name="*%s*" % spec.name)
         if not context.json:
             print(f"No match found for: {spec}. Search: {flex_spec}")

--- a/news/13315-skip-flexible-search-option
+++ b/news/13315-skip-flexible-search-option
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `--no-flexible-search` option to skip flexible search. (#13315)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_search.py
+++ b/tests/cli/test_main_search.py
@@ -159,3 +159,21 @@ def test_search_envs_json(conda_cli: CondaCLIFixture):
     assert isinstance(parsed, list)  # can be [] if package not found
     assert len(parsed), "empty search result"
     assert all(entry["package_records"][0]["name"] == search_for for entry in parsed)
+
+
+@pytest.mark.flaky(reruns=5)
+def test_search_inflexible(conda_cli: CondaCLIFixture):
+    # verify skipping flexible search
+    stdout, stderr, err = conda_cli(
+        "search",
+        "--platform",
+        "linux-64",
+        "--override-channels",
+        "--channel",
+        "defaults",
+        "--no-flexible-search",
+        "r-rcpparmadill",
+    )
+    assert "No match found for: r-rcpparmadill. Search: *r-rcpparmadill*" not in stdout
+    assert "PackagesNotFoundError" in stderr
+    assert err


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Adding option `--no-flexible-search` to `conda search` CLI allow users to skip fallback to flexible search. Default behavior is left intact.

Closes #13315 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
