### PR TITLE
Allow `test_install_features` to xpass and other test patches

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1147,7 +1147,6 @@ def test_install_features(clear_package_cache: None, request):
         pytest.mark.xfail(
             context.solver == "libmamba",
             reason="Features not supported in libmamba",
-            strict=True,
         )
     )
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -94,7 +94,11 @@ def test_explicit_missing_cache_entries(
     def one_url_from_packagecache():
         "some entries in the package cache might have a null URL"
         return next(
-            (pkg.url for pkg in PackageCacheData.get_all_extracted_entries() if pkg.url),
+            (
+                pkg.url
+                for pkg in PackageCacheData.get_all_extracted_entries()
+                if pkg.url
+            ),
             None,
         )
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -91,8 +91,15 @@ def test_explicit_missing_cache_entries(
     """Test that explicit() raises and notifies if some of the specs were not found in the cache."""
     from conda.core.package_cache_data import PackageCacheData
 
+    def one_url_from_packagecache():
+        "some entries in the package cache might have a null URL"
+        return next((pkg for pkg in PackageCacheData.get_all_extracted_entries() if pkg.url), None)
+
     with tmp_env() as prefix:  # ensure writable env
-        if len(PackageCacheData.get_all_extracted_entries()) == 0:
+        if (
+            len(PackageCacheData.get_all_extracted_entries()) == 0
+            or not one_url_from_packagecache()
+        ):
             # Package cache e.g. ./devenv/Darwin/x86_64/envs/devenv-3.9-c/pkgs/ can
             # be empty in certain cases (Noted in OSX with Python 3.9, when
             # Miniconda installs Python 3.10). Install a small package.
@@ -110,7 +117,7 @@ def test_explicit_missing_cache_entries(
             explicit(
                 [
                     "http://test/pkgs/linux-64/foo-1.0.0-py_0.tar.bz2",  # does not exist
-                    PackageCacheData.get_all_extracted_entries()[0].url,  # exists
+                    one_url_from_packagecache(),  # exists
                 ],
                 prefix,
             )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -93,7 +93,10 @@ def test_explicit_missing_cache_entries(
 
     def one_url_from_packagecache():
         "some entries in the package cache might have a null URL"
-        return next((pkg for pkg in PackageCacheData.get_all_extracted_entries() if pkg.url), None)
+        return next(
+            (pkg for pkg in PackageCacheData.get_all_extracted_entries() if pkg.url),
+            None,
+        )
 
     with tmp_env() as prefix:  # ensure writable env
         if (

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -94,7 +94,7 @@ def test_explicit_missing_cache_entries(
     def one_url_from_packagecache():
         "some entries in the package cache might have a null URL"
         return next(
-            (pkg for pkg in PackageCacheData.get_all_extracted_entries() if pkg.url),
+            (pkg.url for pkg in PackageCacheData.get_all_extracted_entries() if pkg.url),
             None,
         )
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Comes from https://github.com/conda/conda-libmamba-solver/pull/370

- Apparently https://github.com/conda/conda-libmamba-solver/commit/671b9c1bbb8d7c4d4e237cac17ad2cd3f5870aa1 fixed this test so it's now passing and making CI fail in `conda/conda-libmamba-solver`.
- Under some circumstances, a `PackageCacheData` entry can have a null `url` field which breaks a test.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~ 
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
