### PR TITLE
Fix failing tests due to env name collisions

### DIFF
--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -25,7 +25,6 @@ pytestmark = pytest.mark.usefixtures("parametrized_solver_fixture")
 
 # Environment names we use during our tests
 TEST_ENV_NAME_1 = "env-1"
-TEST_ENV_NAME_2 = "snowflakes"
 TEST_ENV_NAME_42 = "env-42"
 TEST_ENV_NAME_PIP = "env-pip"
 
@@ -522,102 +521,92 @@ def env_is_created(env_name):
 
 
 @pytest.fixture
-def env_name_2(conda_cli: CondaCLIFixture) -> None:
-    # It *can* happen that this does not remove the env directory and then
-    # the CREATE fails. Keep your eyes out! We could use rm_rf, but do we
-    # know which conda install we're talking about? Now? Forever? I'd feel
-    # safer adding an `rm -rf` if we had a `Commands.ENV_NAME_TO_PREFIX` to
-    # tell us which folder to remove.
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-
-    yield
-
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
+def env2(conda_cli: CondaCLIFixture) -> str:
+    env = "env2"
+    conda_cli("remove", f"--name={env}", "--all", "--yes")
+    yield env
+    conda_cli("remove", f"--name={env}", "--all", "--yes")
 
 
 @pytest.mark.integration
 def test_env_export(
-    env_name_2: None, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
+    env2: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
 ):
     """Test conda env export."""
-    conda_cli("create", "--name", TEST_ENV_NAME_2, "flask", "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    conda_cli("create", "--name", env2, "flask", "--yes")
+    assert env_is_created(env2)
 
-    stdout, _, _ = conda_cli("env", "export", "--name", TEST_ENV_NAME_2)
+    stdout, _, _ = conda_cli("env", "export", "--name", env2)
 
     env_yml = path_factory(suffix=".yml")
     env_yml.write_text(stdout)
 
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-    assert not env_is_created(TEST_ENV_NAME_2)
+    conda_cli("env", "remove", "--name", env2, "--yes")
+    assert not env_is_created(env2)
     conda_cli("env", "create", "--file", env_yml, "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    assert env_is_created(env2)
 
     # regression test for #6220
-    stdout, stderr, _ = conda_cli(
-        "env", "export", "--name", TEST_ENV_NAME_2, "--no-builds"
-    )
+    stdout, stderr, _ = conda_cli("env", "export", "--name", env2, "--no-builds")
     assert not stderr
     env_description = yaml_safe_load(stdout)
     assert len(env_description["dependencies"])
     for spec_str in env_description["dependencies"]:
         assert spec_str.count("=") == 1
 
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-    assert not env_is_created(TEST_ENV_NAME_2)
+    conda_cli("env", "remove", "--name", env2, "--yes")
+    assert not env_is_created(env2)
 
 
 @pytest.mark.integration
 def test_env_export_with_variables(
-    env_name_2: None, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
+    env2: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
 ):
     """Test conda env export."""
-    conda_cli("create", "--name", TEST_ENV_NAME_2, "flask", "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    conda_cli("create", "--name", env2, "flask", "--yes")
+    assert env_is_created(env2)
 
     conda_cli(
         *("env", "config", "vars", "set"),
-        *("--name", TEST_ENV_NAME_2),
+        *("--name", env2),
         "DUDE=woah",
         "SWEET=yaaa",
     )
 
-    stdout, _, _ = conda_cli("env", "export", "--name", TEST_ENV_NAME_2)
+    stdout, _, _ = conda_cli("env", "export", "--name", env2)
 
     env_yml = path_factory(suffix=".yml")
     env_yml.write_text(stdout)
 
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-    assert not env_is_created(TEST_ENV_NAME_2)
+    conda_cli("env", "remove", "--name", env2, "--yes")
+    assert not env_is_created(env2)
     conda_cli("env", "create", "--file", env_yml, "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    assert env_is_created(env2)
 
-    stdout, stderr, _ = conda_cli(
-        "env", "export", "--name", TEST_ENV_NAME_2, "--no-builds"
-    )
+    stdout, stderr, _ = conda_cli("env", "export", "--name", env2, "--no-builds")
     assert not stderr
     env_description = yaml_safe_load(stdout)
     assert len(env_description["variables"])
     assert env_description["variables"].keys()
 
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-    assert not env_is_created(TEST_ENV_NAME_2)
+    conda_cli("env", "remove", "--name", env2, "--yes")
+    assert not env_is_created(env2)
 
 
 @pytest.mark.integration
-def test_env_export_json(env_name_2: None, conda_cli: CondaCLIFixture):
+def test_env_export_json(env2: str, conda_cli: CondaCLIFixture):
     """Test conda env export."""
-    conda_cli("create", "--name", TEST_ENV_NAME_2, "flask", "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    conda_cli("create", "--name", env2, "flask", "--yes")
+    assert env_is_created(env2)
 
-    stdout, _, _ = conda_cli("env", "export", "--name", TEST_ENV_NAME_2, "--json")
+    stdout, _, _ = conda_cli("env", "export", "--name", env2, "--json")
 
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-    assert not env_is_created(TEST_ENV_NAME_2)
+    conda_cli("env", "remove", "--name", env2, "--yes")
+    assert not env_is_created(env2)
 
     # regression test for #6220
     stdout, stderr, _ = conda_cli(
-        "env", "export", "--name", TEST_ENV_NAME_2, "--no-builds", "--json"
+        "env", "export", "--name", env2, "--no-builds", "--json"
     )
     assert not stderr
 
@@ -626,78 +615,75 @@ def test_env_export_json(env_name_2: None, conda_cli: CondaCLIFixture):
     for spec_str in env_description["dependencies"]:
         assert spec_str.count("=") == 1
 
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-    assert not env_is_created(TEST_ENV_NAME_2)
+    conda_cli("env", "remove", "--name", env2, "--yes")
+    assert not env_is_created(env2)
 
 
 @pytest.mark.integration
-def test_list(
-    env_name_2: None, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
-):
+def test_list(env2: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture):
     """Test conda list -e and conda create from txt."""
-    conda_cli("create", "--name", TEST_ENV_NAME_2, "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    conda_cli("create", "--name", env2, "--yes")
+    assert env_is_created(env2)
 
-    stdout, _, _ = conda_cli("list", "--name", TEST_ENV_NAME_2, "--export")
+    stdout, _, _ = conda_cli("list", "--name", env2, "--export")
 
     env_txt = path_factory(suffix=".txt")
     env_txt.write_text(stdout)
 
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-    assert not env_is_created(TEST_ENV_NAME_2)
-    conda_cli("create", "--name", TEST_ENV_NAME_2, "--file", env_txt, "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    conda_cli("env", "remove", "--name", env2, "--yes")
+    assert not env_is_created(env2)
+    conda_cli("create", "--name", env2, "--file", env_txt, "--yes")
+    assert env_is_created(env2)
 
-    stdout2, _, _ = conda_cli("list", "--name", TEST_ENV_NAME_2, "--export")
+    stdout2, _, _ = conda_cli("list", "--name", env2, "--export")
     assert stdout == stdout2
 
 
 @pytest.mark.integration
 def test_export_multi_channel(
-    env_name_2: None, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
+    env2: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
 ):
     """Test conda env export."""
     from conda.core.prefix_data import PrefixData
 
     PrefixData._cache_.clear()
-    conda_cli("create", "--name", TEST_ENV_NAME_2, "python", "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    conda_cli("create", "--name", env2, "python", "--yes")
+    assert env_is_created(env2)
 
     # install something from other channel not in config file
     conda_cli(
         "install",
-        *("--name", TEST_ENV_NAME_2),
+        *("--name", env2),
         *("--channel", "conda-test"),
         "test_timestamp_sort",
         "--yes",
     )
-    stdout, _, _ = conda_cli("env", "export", "--name", TEST_ENV_NAME_2)
+    stdout, _, _ = conda_cli("env", "export", "--name", env2)
     assert "conda-test" in stdout
 
-    stdout1, _, _ = conda_cli("list", "--name", TEST_ENV_NAME_2, "--explicit")
+    stdout1, _, _ = conda_cli("list", "--name", env2, "--explicit")
 
     env_yml = path_factory(suffix=".yml")
     env_yml.write_text(stdout)
 
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_2, "--yes")
-    assert not env_is_created(TEST_ENV_NAME_2)
+    conda_cli("env", "remove", "--name", env2, "--yes")
+    assert not env_is_created(env2)
     conda_cli("env", "create", "--file", env_yml, "--yes")
-    assert env_is_created(TEST_ENV_NAME_2)
+    assert env_is_created(env2)
 
     # check explicit that we have same file
-    stdout2, _, _ = conda_cli("list", "--name", TEST_ENV_NAME_2, "--explicit")
+    stdout2, _, _ = conda_cli("list", "--name", env2, "--explicit")
     assert stdout1 == stdout2
 
 
 @pytest.mark.integration
-def test_non_existent_file(env_name_2: None, conda_cli: CondaCLIFixture):
+def test_non_existent_file(conda_cli: CondaCLIFixture):
     with pytest.raises(EnvironmentFileNotFound):
         conda_cli("env", "create", "--file", "i_do_not_exist.yml", "--yes")
 
 
 @pytest.mark.integration
 def test_invalid_extensions(
-    env_name_2: None,
     conda_cli: CondaCLIFixture,
     path_factory: PathFactoryFixture,
 ):

--- a/tests/conda_env/test_cli.py
+++ b/tests/conda_env/test_cli.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import json
-import os
-import tempfile
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
+from conda.auxlib.ish import dals
 from conda.base.constants import ROOT_ENV_NAME
 from conda.base.context import context
 from conda.common.serialize import yaml_safe_load
@@ -24,121 +24,111 @@ from conda.testing import CondaCLIFixture, PathFactoryFixture
 pytestmark = pytest.mark.usefixtures("parametrized_solver_fixture")
 
 # Environment names we use during our tests
-TEST_ENV_NAME_1 = "env-1"
-TEST_ENV_NAME_42 = "env-42"
-TEST_ENV_NAME_PIP = "env-pip"
+TEST_ENV1 = "env1"
 
 # Environment config files we use for out tests
-ENVIRONMENT_1 = f"""
-name: {TEST_ENV_NAME_1}
-dependencies:
-  - python
-channels:
-  - defaults
-"""
+ENVIRONMENT_1 = dals(
+    f"""
+    name: {TEST_ENV1}
+    dependencies:
+      - python
+    channels:
+      - defaults
+    """
+)
 
-ENVIRONMENT_1_WITH_VARIABLES = f"""
-name: {TEST_ENV_NAME_1}
-dependencies:
-  - python
-channels:
-  - defaults
-variables:
-  DUDE: woah
-  SWEET: yaaa
-  API_KEY: AaBbCcDd===EeFf
+ENVIRONMENT_1_WITH_VARIABLES = dals(
+    f"""
+    name: {TEST_ENV1}
+    dependencies:
+      - python
+    channels:
+      - defaults
+    variables:
+      DUDE: woah
+      SWEET: yaaa
+      API_KEY: AaBbCcDd===EeFf
+    """
+)
 
-"""
+ENVIRONMENT_2 = dals(
+    f"""
+    name: {TEST_ENV1}
+    dependencies:
+      - python
+      - flask
+    channels:
+      - defaults
+    """
+)
 
-ENVIRONMENT_2 = f"""
-name: {TEST_ENV_NAME_1}
-dependencies:
-  - python
-  - flask
-channels:
-  - defaults
-"""
+ENVIRONMENT_3_INVALID = dals(
+    f"""
+    name: {TEST_ENV1}
+    dependecies:
+      - python
+      - flask
+    channels:
+      - defaults
+    foo: bar
+    """
+)
 
-ENVIRONMENT_3_INVALID = f"""
-name: {TEST_ENV_NAME_1}
-dependecies:
-  - python
-  - flask
-channels:
-  - defaults
-foo: bar
-"""
+ENVIRONMENT_PYTHON_PIP_CLICK = dals(
+    f"""
+    name: {TEST_ENV1}
+    dependencies:
+      - python=3
+      - pip
+      - pip:
+        - click
+    channels:
+      - defaults
+    """
+)
 
-ENVIRONMENT_PYTHON_PIP_CLICK = f"""
-name: {TEST_ENV_NAME_1}
-dependencies:
-  - python=3
-  - pip
-  - pip:
-    - click
-channels:
-  - defaults
-"""
+ENVIRONMENT_PYTHON_PIP_CLICK_ATTRS = dals(
+    f"""
+    name: {TEST_ENV1}
+    dependencies:
+      - python=3
+      - pip
+      - pip:
+        - click
+        - attrs
+    channels:
+      - defaults
+    """
+)
 
-ENVIRONMENT_PYTHON_PIP_CLICK_ATTRS = f"""
-name: {TEST_ENV_NAME_1}
-dependencies:
-  - python=3
-  - pip
-  - pip:
-    - click
-    - attrs
-channels:
-  - defaults
-"""
-
-ENVIRONMENT_PYTHON_PIP_NONEXISTING = f"""
-name: {TEST_ENV_NAME_1}
-dependencies:
-  - python=3
-  - pip
-  - pip:
-    - nonexisting_
-channels:
-  - defaults
-"""
-
-
-def escape_for_winpath(p):
-    if p:
-        return p.replace("\\", "\\\\")
+ENVIRONMENT_PYTHON_PIP_NONEXISTING = dals(
+    f"""
+    name: {TEST_ENV1}
+    dependencies:
+      - python=3
+      - pip
+      - pip:
+        - nonexisting_
+    channels:
+      - defaults
+    """
+)
 
 
 def create_env(content, filename="environment.yml"):
-    path = Path(filename)
-    path.write_text(content)
-
-
-def remove_env_file(filename="environment.yml"):
-    Path(filename).unlink()
+    Path(filename).write_text(content)
 
 
 @pytest.fixture
-def env_name_1(conda_cli: CondaCLIFixture) -> None:
+def env1(conda_cli: CondaCLIFixture) -> str:
+    conda_cli("remove", "--name", TEST_ENV1, "--all", "--yes")
+    yield TEST_ENV1
+    conda_cli("remove", "--name", TEST_ENV1, "--all", "--yes")
     rm_rf("environment.yml")
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_1, "--yes")
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_42, "--yes")
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_PIP, "--yes")
-    for env_nb in range(1, 6):
-        conda_cli("env", "remove", "--name", f"envjson-{env_nb}", "--yes")
-
-    yield
-
-    rm_rf("environment.yml")
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_1, "--yes")
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_42, "--yes")
-    conda_cli("env", "remove", "--name", TEST_ENV_NAME_PIP, "--yes")
-    for env_nb in range(1, 6):
-        conda_cli("env", "remove", "--name", f"envjson-{env_nb}", "--yes")
 
 
 @pytest.mark.integration
-def test_conda_env_create_no_file(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_conda_env_create_no_file(conda_cli: CondaCLIFixture):
     """
     Test `conda env create` without an environment.yml file
     Should fail
@@ -148,9 +138,7 @@ def test_conda_env_create_no_file(env_name_1: None, conda_cli: CondaCLIFixture):
 
 
 @pytest.mark.integration
-def test_conda_env_create_no_existent_file(
-    env_name_1: None, conda_cli: CondaCLIFixture
-):
+def test_conda_env_create_no_existent_file(conda_cli: CondaCLIFixture):
     """
     Test `conda env create --file=not_a_file.txt` with a file that does not
     exist.
@@ -160,9 +148,7 @@ def test_conda_env_create_no_existent_file(
 
 
 @pytest.mark.integration
-def test_conda_env_create_no_existent_file_with_name(
-    env_name_1: None, conda_cli: CondaCLIFixture
-):
+def test_conda_env_create_no_existent_file_with_name(conda_cli: CondaCLIFixture):
     """
     Test `conda env create --file=not_a_file.txt` with a file that does not
     exist.
@@ -172,41 +158,45 @@ def test_conda_env_create_no_existent_file_with_name(
 
 
 @pytest.mark.integration
-def test_create_valid_remote_env(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_create_valid_remote_env(conda_cli: CondaCLIFixture):
     """
     Test retrieving an environment using the BinstarSpec (i.e. it retrieves it from anaconda.org)
 
     This tests the `remote_origin` command line argument.
     """
-    conda_cli("env", "create", "conda-test/env-42")
-    assert env_is_created(TEST_ENV_NAME_42)
+    try:
+        conda_cli("env", "create", "conda-test/env-42")
+        assert env_is_created("env-42")
 
-    stdout, _, _ = conda_cli("info", "--json")
+        stdout, _, _ = conda_cli("info", "--json")
 
-    parsed = json.loads(stdout)
-    assert [env for env in parsed["envs"] if env.endswith(TEST_ENV_NAME_42)]
+        parsed = json.loads(stdout)
+        assert [env for env in parsed["envs"] if env.endswith("env-42")]
+    finally:
+        # manual cleanup
+        conda_cli("remove", "--name=env-42", "--all", "--yes")
 
 
 @pytest.mark.integration
-def test_create_valid_env(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_create_valid_env(env1: str, conda_cli: CondaCLIFixture):
     """
     Creates an environment.yml file and
     creates and environment with it
     """
     create_env(ENVIRONMENT_1)
     conda_cli("env", "create")
-    assert env_is_created(TEST_ENV_NAME_1)
+    assert env_is_created(env1)
 
     stdout, _, _ = conda_cli("info", "--json")
     parsed = json.loads(stdout)
-    assert [env for env in parsed["envs"] if env.endswith(TEST_ENV_NAME_1)]
+    assert [env for env in parsed["envs"] if env.endswith(env1)]
 
 
 @pytest.mark.integration
-def test_create_dry_run_yaml(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_create_dry_run_yaml(env1: str, conda_cli: CondaCLIFixture):
     create_env(ENVIRONMENT_1)
     stdout, _, _ = conda_cli("env", "create", "--dry-run")
-    assert not env_is_created(TEST_ENV_NAME_1)
+    assert not env_is_created(env1)
 
     # Find line where the YAML output starts (stdout might change if plugins involved)
     lines = stdout.splitlines()
@@ -217,34 +207,34 @@ def test_create_dry_run_yaml(env_name_1: None, conda_cli: CondaCLIFixture):
         pytest.fail("Didn't find YAML data in output")
 
     output = yaml_safe_load("\n".join(lines[lineno:]))
-    assert output["name"] == "env-1"
+    assert output["name"] == env1
     assert len(output["dependencies"]) > 0
 
 
 @pytest.mark.integration
-def test_create_dry_run_json(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_create_dry_run_json(env1: str, conda_cli: CondaCLIFixture):
     create_env(ENVIRONMENT_1)
     stdout, _, _ = conda_cli("env", "create", "--dry-run", "--json")
-    assert not env_is_created(TEST_ENV_NAME_1)
+    assert not env_is_created(env1)
 
     output = json.loads(stdout)
-    assert output.get("name") == "env-1"
+    assert output.get("name") == env1
     assert len(output["dependencies"])
 
 
 @pytest.mark.integration
-def test_create_valid_env_with_variables(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_create_valid_env_with_variables(env1: str, conda_cli: CondaCLIFixture):
     """
     Creates an environment.yml file and
     creates and environment with it
     """
     create_env(ENVIRONMENT_1_WITH_VARIABLES)
     conda_cli("env", "create")
-    assert env_is_created(TEST_ENV_NAME_1)
+    assert env_is_created(env1)
 
     stdout, _, _ = conda_cli(
         *("env", "config", "vars", "list"),
-        *("--name", TEST_ENV_NAME_1),
+        f"--name={env1}",
         "--json",
     )
     output_env_vars = json.loads(stdout)
@@ -256,82 +246,73 @@ def test_create_valid_env_with_variables(env_name_1: None, conda_cli: CondaCLIFi
 
     stdout, _, _ = conda_cli("info", "--json")
     parsed = json.loads(stdout)
-    assert [env for env in parsed["envs"] if env.endswith(TEST_ENV_NAME_1)]
+    assert [env for env in parsed["envs"] if env.endswith(env1)]
 
 
 @pytest.mark.integration
-def test_conda_env_create_empty_file(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_conda_env_create_empty_file(
+    conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
+):
     """Test `conda env create --file=file_name.yml` where file_name.yml is empty."""
-    tmp_file = tempfile.NamedTemporaryFile(suffix=".yml", delete=False)
+    tmp_file = path_factory(suffix=".yml")
+    tmp_file.touch()
 
     with pytest.raises(SpecNotFound):
-        conda_cli("env", "create", "--file", tmp_file.name)
-
-    tmp_file.close()
-    os.unlink(tmp_file.name)
+        conda_cli("env", "create", "--file", tmp_file)
 
 
 @pytest.mark.integration
-def test_conda_env_create_http(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_conda_env_create_http(conda_cli: CondaCLIFixture):
     """Test `conda env create --file=https://some-website.com/environment.yml`."""
-    conda_cli(
-        *("env", "create"),
-        *(
-            "--file",
-            "https://raw.githubusercontent.com/conda/conda/main/tests/conda_env/support/simple.yml",
-        ),
-    )
     try:
+        conda_cli(
+            *("env", "create"),
+            "--file=https://raw.githubusercontent.com/conda/conda/main/tests/conda_env/support/simple.yml",
+        )
         assert env_is_created("nlp")
     finally:
-        conda_cli("env", "remove", "--name", "nlp", "--yes")
+        # manual cleanup
+        conda_cli("remove", "--name=nlp", "--all", "--yes")
 
 
 @pytest.mark.integration
-def test_update(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_update(env1: str, conda_cli: CondaCLIFixture):
     create_env(ENVIRONMENT_1)
     conda_cli("env", "create")
     create_env(ENVIRONMENT_2)
 
-    conda_cli("env", "update", "--name", TEST_ENV_NAME_1)
+    conda_cli("env", "update", "--name", env1)
 
-    stdout, _, _ = conda_cli("list", "--name", TEST_ENV_NAME_1, "flask", "--json")
+    stdout, _, _ = conda_cli("list", "--name", env1, "flask", "--json")
     parsed = json.loads(stdout)
     assert parsed
 
 
 @pytest.mark.integration
-def test_name(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_name(env1: str, conda_cli: CondaCLIFixture):
     """
     # smoke test for gh-254
     Test that --name can override the `name` key inside an environment.yml
     """
     create_env(ENVIRONMENT_1)
-    env_name = "smoke-gh-254"
 
-    # It might be the case that you need to run this test more than once!
-    try:
-        conda_cli("env", "remove", "--name", env_name, "--yes")
-    except:
-        pass
-
-    conda_cli("env", "create", "--file", "environment.yml", "--name", env_name, "--yes")
+    conda_cli("env", "create", "--file", "environment.yml", "--name", env1, "--yes")
 
     stdout, _, _ = conda_cli("info", "--json")
 
     parsed = json.loads(stdout)
-    assert [env for env in parsed["envs"] if env.endswith(env_name)]
+    assert [env for env in parsed["envs"] if env.endswith(env1)]
 
 
 @pytest.mark.integration
-def test_create_valid_env_json_output(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_create_valid_env_json_output(env1: str, conda_cli: CondaCLIFixture):
     """
     Creates an environment from an environment.yml file with conda packages (no pip)
     Check the json output
     """
     create_env(ENVIRONMENT_1)
     stdout, _, _ = conda_cli(
-        "env", "create", "--name", "envjson-1", "--quiet", "--json", "--yes"
+        "env", "create", "--name", env1, "--quiet", "--json", "--yes"
     )
     output = json.loads(stdout)
     assert output["success"] is True
@@ -341,7 +322,7 @@ def test_create_valid_env_json_output(env_name_1: None, conda_cli: CondaCLIFixtu
 
 @pytest.mark.integration
 def test_create_valid_env_with_conda_and_pip_json_output(
-    env_name_1: None, conda_cli: CondaCLIFixture
+    env1: str, conda_cli: CondaCLIFixture
 ):
     """
     Creates an environment from an environment.yml file with conda and pip dependencies
@@ -349,7 +330,7 @@ def test_create_valid_env_with_conda_and_pip_json_output(
     """
     create_env(ENVIRONMENT_PYTHON_PIP_CLICK)
     stdout, _, _ = conda_cli(
-        "env", "create", "--name", "envjson-2", "--quiet", "--json", "--yes"
+        "env", "create", "--name", env1, "--quiet", "--json", "--yes"
     )
     output = json.loads(stdout)
     assert len(output["actions"]["LINK"]) > 0
@@ -357,17 +338,15 @@ def test_create_valid_env_with_conda_and_pip_json_output(
 
 
 @pytest.mark.integration
-def test_update_env_json_output(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_update_env_json_output(env1: str, conda_cli: CondaCLIFixture):
     """
     Update an environment by adding a conda package
     Check the json output
     """
     create_env(ENVIRONMENT_1)
-    conda_cli("env", "create", "--name", "envjson-3", "--json", "--yes")
+    conda_cli("env", "create", "--name", env1, "--json", "--yes")
     create_env(ENVIRONMENT_2)
-    stdout, _, _ = conda_cli(
-        "env", "update", "--name", "envjson-3", "--quiet", "--json"
-    )
+    stdout, _, _ = conda_cli("env", "update", "--name", env1, "--quiet", "--json")
     output = json.loads(stdout)
     assert output["success"] is True
     assert len(output["actions"]["LINK"]) > 0
@@ -376,7 +355,7 @@ def test_update_env_json_output(env_name_1: None, conda_cli: CondaCLIFixture):
 
 @pytest.mark.integration
 def test_update_env_only_pip_json_output(
-    env_name_1: None, conda_cli: CondaCLIFixture, request
+    env1: str, conda_cli: CondaCLIFixture, request
 ):
     """
     Update an environment by adding only a pip package
@@ -389,11 +368,9 @@ def test_update_env_only_pip_json_output(
         )
     )
     create_env(ENVIRONMENT_PYTHON_PIP_CLICK)
-    conda_cli("env", "create", "--name", "envjson-4", "--json", "--yes")
+    conda_cli("env", "create", "--name", env1, "--json", "--yes")
     create_env(ENVIRONMENT_PYTHON_PIP_CLICK_ATTRS)
-    stdout, _, _ = conda_cli(
-        "env", "update", "--name", "envjson-4", "--quiet", "--json"
-    )
+    stdout, _, _ = conda_cli("env", "update", "--name", env1, "--quiet", "--json")
     output = json.loads(stdout)
     assert output["success"] is True
     # No conda actions (FETCH/LINK), only pip
@@ -405,7 +382,7 @@ def test_update_env_only_pip_json_output(
 
 @pytest.mark.integration
 def test_update_env_no_action_json_output(
-    env_name_1: None, conda_cli: CondaCLIFixture, request
+    env1: str, conda_cli: CondaCLIFixture, request
 ):
     """
     Update an already up-to-date environment
@@ -418,38 +395,35 @@ def test_update_env_no_action_json_output(
         )
     )
     create_env(ENVIRONMENT_PYTHON_PIP_CLICK)
-    conda_cli("env", "create", "--name", "envjson-5", "--json", "--yes")
-    stdout, _, _ = conda_cli(
-        "env", "update", "--name", "envjson-5", "--quiet", "--json"
-    )
+    conda_cli("env", "create", "--name", env1, "--json", "--yes")
+    stdout, _, _ = conda_cli("env", "update", "--name", env1, "--quiet", "--json")
     output = json.loads(stdout)
     assert output["message"] == "All requested packages already installed."
 
 
 @pytest.mark.integration
-def test_remove_dry_run(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_remove_dry_run(env1: str, conda_cli: CondaCLIFixture):
     # Test for GH-10231
     create_env(ENVIRONMENT_1)
     conda_cli("env", "create")
-    conda_cli("env", "remove", "--name", "env-1", "--dry-run")
-    assert env_is_created("env-1")
+    conda_cli("env", "remove", "--name", env1, "--dry-run")
+    assert env_is_created(env1)
 
 
 @pytest.mark.integration
-def test_set_unset_env_vars(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_set_unset_env_vars(env1: str, conda_cli: CondaCLIFixture):
     create_env(ENVIRONMENT_1)
     conda_cli("env", "create")
-    env_name = "env-1"
     conda_cli(
         *("env", "config", "vars", "set"),
-        *("--name", env_name),
+        *("--name", env1),
         "DUDE=woah",
         "SWEET=yaaa",
         "API_KEY=AaBbCcDd===EeFf",
     )
     stdout, _, _ = conda_cli(
         *("env", "config", "vars", "list"),
-        *("--name", env_name),
+        *("--name", env1),
         "--json",
     )
     output_env_vars = json.loads(stdout)
@@ -461,14 +435,14 @@ def test_set_unset_env_vars(env_name_1: None, conda_cli: CondaCLIFixture):
 
     conda_cli(
         *("env", "config", "vars", "unset"),
-        *("--name", env_name),
+        *("--name", env1),
         "DUDE",
         "SWEET",
         "API_KEY",
     )
     stdout, _, _ = conda_cli(
         *("env", "config", "vars", "list"),
-        *("--name", env_name),
+        *("--name", env1),
         "--json",
     )
     output_env_vars = json.loads(stdout)
@@ -476,14 +450,11 @@ def test_set_unset_env_vars(env_name_1: None, conda_cli: CondaCLIFixture):
 
 
 @pytest.mark.integration
-def test_set_unset_env_vars_env_no_exist(env_name_1: None, conda_cli: CondaCLIFixture):
-    create_env(ENVIRONMENT_1)
-    conda_cli("env", "create")
-    env_name = "env-11"
+def test_set_unset_env_vars_env_no_exist(conda_cli: CondaCLIFixture):
     with pytest.raises(EnvironmentLocationNotFound):
         conda_cli(
             *("env", "config", "vars", "set"),
-            *("--name", env_name),
+            *("--name", uuid4().hex),
             "DUDE=woah",
             "SWEET=yaaa",
             "API_KEY=AaBbCcDd===EeFf",
@@ -491,7 +462,7 @@ def test_set_unset_env_vars_env_no_exist(env_name_1: None, conda_cli: CondaCLIFi
 
 
 @pytest.mark.integration
-def test_pip_error_is_propagated(env_name_1: None, conda_cli: CondaCLIFixture):
+def test_pip_error_is_propagated(env1: str, conda_cli: CondaCLIFixture):
     """
     Creates an environment from an environment.yml file with conda and incorrect pip dependencies
     The output must clearly show pip error.
@@ -499,7 +470,7 @@ def test_pip_error_is_propagated(env_name_1: None, conda_cli: CondaCLIFixture):
     """
     create_env(ENVIRONMENT_PYTHON_PIP_NONEXISTING)
     with pytest.raises(CondaEnvException, match="Pip failed"):
-        conda_cli("env", "create", "--name", TEST_ENV_NAME_PIP)
+        conda_cli("env", "create")
 
 
 def env_is_created(env_name):
@@ -520,93 +491,85 @@ def env_is_created(env_name):
     return False
 
 
-@pytest.fixture
-def env2(conda_cli: CondaCLIFixture) -> str:
-    env = "env2"
-    conda_cli("remove", f"--name={env}", "--all", "--yes")
-    yield env
-    conda_cli("remove", f"--name={env}", "--all", "--yes")
-
-
 @pytest.mark.integration
 def test_env_export(
-    env2: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
+    env1: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
 ):
     """Test conda env export."""
-    conda_cli("create", "--name", env2, "flask", "--yes")
-    assert env_is_created(env2)
+    conda_cli("create", "--name", env1, "flask", "--yes")
+    assert env_is_created(env1)
 
-    stdout, _, _ = conda_cli("env", "export", "--name", env2)
+    stdout, _, _ = conda_cli("env", "export", "--name", env1)
 
     env_yml = path_factory(suffix=".yml")
     env_yml.write_text(stdout)
 
-    conda_cli("env", "remove", "--name", env2, "--yes")
-    assert not env_is_created(env2)
+    conda_cli("env", "remove", "--name", env1, "--yes")
+    assert not env_is_created(env1)
     conda_cli("env", "create", "--file", env_yml, "--yes")
-    assert env_is_created(env2)
+    assert env_is_created(env1)
 
     # regression test for #6220
-    stdout, stderr, _ = conda_cli("env", "export", "--name", env2, "--no-builds")
+    stdout, stderr, _ = conda_cli("env", "export", "--name", env1, "--no-builds")
     assert not stderr
     env_description = yaml_safe_load(stdout)
     assert len(env_description["dependencies"])
     for spec_str in env_description["dependencies"]:
         assert spec_str.count("=") == 1
 
-    conda_cli("env", "remove", "--name", env2, "--yes")
-    assert not env_is_created(env2)
+    conda_cli("env", "remove", "--name", env1, "--yes")
+    assert not env_is_created(env1)
 
 
 @pytest.mark.integration
 def test_env_export_with_variables(
-    env2: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
+    env1: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
 ):
     """Test conda env export."""
-    conda_cli("create", "--name", env2, "flask", "--yes")
-    assert env_is_created(env2)
+    conda_cli("create", "--name", env1, "flask", "--yes")
+    assert env_is_created(env1)
 
     conda_cli(
         *("env", "config", "vars", "set"),
-        *("--name", env2),
+        *("--name", env1),
         "DUDE=woah",
         "SWEET=yaaa",
     )
 
-    stdout, _, _ = conda_cli("env", "export", "--name", env2)
+    stdout, _, _ = conda_cli("env", "export", "--name", env1)
 
     env_yml = path_factory(suffix=".yml")
     env_yml.write_text(stdout)
 
-    conda_cli("env", "remove", "--name", env2, "--yes")
-    assert not env_is_created(env2)
+    conda_cli("env", "remove", "--name", env1, "--yes")
+    assert not env_is_created(env1)
     conda_cli("env", "create", "--file", env_yml, "--yes")
-    assert env_is_created(env2)
+    assert env_is_created(env1)
 
-    stdout, stderr, _ = conda_cli("env", "export", "--name", env2, "--no-builds")
+    stdout, stderr, _ = conda_cli("env", "export", "--name", env1, "--no-builds")
     assert not stderr
     env_description = yaml_safe_load(stdout)
     assert len(env_description["variables"])
     assert env_description["variables"].keys()
 
-    conda_cli("env", "remove", "--name", env2, "--yes")
-    assert not env_is_created(env2)
+    conda_cli("env", "remove", "--name", env1, "--yes")
+    assert not env_is_created(env1)
 
 
 @pytest.mark.integration
-def test_env_export_json(env2: str, conda_cli: CondaCLIFixture):
+def test_env_export_json(env1: str, conda_cli: CondaCLIFixture):
     """Test conda env export."""
-    conda_cli("create", "--name", env2, "flask", "--yes")
-    assert env_is_created(env2)
+    conda_cli("create", "--name", env1, "flask", "--yes")
+    assert env_is_created(env1)
 
-    stdout, _, _ = conda_cli("env", "export", "--name", env2, "--json")
+    stdout, _, _ = conda_cli("env", "export", "--name", env1, "--json")
 
-    conda_cli("env", "remove", "--name", env2, "--yes")
-    assert not env_is_created(env2)
+    conda_cli("env", "remove", "--name", env1, "--yes")
+    assert not env_is_created(env1)
 
     # regression test for #6220
     stdout, stderr, _ = conda_cli(
-        "env", "export", "--name", env2, "--no-builds", "--json"
+        "env", "export", "--name", env1, "--no-builds", "--json"
     )
     assert not stderr
 
@@ -615,64 +578,64 @@ def test_env_export_json(env2: str, conda_cli: CondaCLIFixture):
     for spec_str in env_description["dependencies"]:
         assert spec_str.count("=") == 1
 
-    conda_cli("env", "remove", "--name", env2, "--yes")
-    assert not env_is_created(env2)
+    conda_cli("env", "remove", "--name", env1, "--yes")
+    assert not env_is_created(env1)
 
 
 @pytest.mark.integration
-def test_list(env2: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture):
+def test_list(env1: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture):
     """Test conda list -e and conda create from txt."""
-    conda_cli("create", "--name", env2, "--yes")
-    assert env_is_created(env2)
+    conda_cli("create", "--name", env1, "--yes")
+    assert env_is_created(env1)
 
-    stdout, _, _ = conda_cli("list", "--name", env2, "--export")
+    stdout, _, _ = conda_cli("list", "--name", env1, "--export")
 
     env_txt = path_factory(suffix=".txt")
     env_txt.write_text(stdout)
 
-    conda_cli("env", "remove", "--name", env2, "--yes")
-    assert not env_is_created(env2)
-    conda_cli("create", "--name", env2, "--file", env_txt, "--yes")
-    assert env_is_created(env2)
+    conda_cli("env", "remove", "--name", env1, "--yes")
+    assert not env_is_created(env1)
+    conda_cli("create", "--name", env1, "--file", env_txt, "--yes")
+    assert env_is_created(env1)
 
-    stdout2, _, _ = conda_cli("list", "--name", env2, "--export")
+    stdout2, _, _ = conda_cli("list", "--name", env1, "--export")
     assert stdout == stdout2
 
 
 @pytest.mark.integration
 def test_export_multi_channel(
-    env2: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
+    env1: str, conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
 ):
     """Test conda env export."""
     from conda.core.prefix_data import PrefixData
 
     PrefixData._cache_.clear()
-    conda_cli("create", "--name", env2, "python", "--yes")
-    assert env_is_created(env2)
+    conda_cli("create", "--name", env1, "python", "--yes")
+    assert env_is_created(env1)
 
     # install something from other channel not in config file
     conda_cli(
         "install",
-        *("--name", env2),
+        *("--name", env1),
         *("--channel", "conda-test"),
         "test_timestamp_sort",
         "--yes",
     )
-    stdout, _, _ = conda_cli("env", "export", "--name", env2)
+    stdout, _, _ = conda_cli("env", "export", "--name", env1)
     assert "conda-test" in stdout
 
-    stdout1, _, _ = conda_cli("list", "--name", env2, "--explicit")
+    stdout1, _, _ = conda_cli("list", "--name", env1, "--explicit")
 
     env_yml = path_factory(suffix=".yml")
     env_yml.write_text(stdout)
 
-    conda_cli("env", "remove", "--name", env2, "--yes")
-    assert not env_is_created(env2)
+    conda_cli("env", "remove", "--name", env1, "--yes")
+    assert not env_is_created(env1)
     conda_cli("env", "create", "--file", env_yml, "--yes")
-    assert env_is_created(env2)
+    assert env_is_created(env1)
 
     # check explicit that we have same file
-    stdout2, _, _ = conda_cli("list", "--name", env2, "--explicit")
+    stdout2, _, _ = conda_cli("list", "--name", env1, "--explicit")
     assert stdout1 == stdout2
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

https://github.com/conda/conda/pull/12984 results in many tests running twice, potentially on the same runner and sequentially. This causes such tests to fail if they, e.g., leave behind a statically named environment.

Combine `env_name_1` and `env_name_2` fixtures into a new (and simpler) `env1` fixture.

Remove unused `escape_for_winpath` and `remove_env_file`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
