### PR TITLE
Fix `test_install_update_deps_only_deps_flags`

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1134,15 +1134,18 @@ def test_install_only_deps_flag():
         assert not package_is_installed(prefix, "flask")
 
 
-def test_install_update_deps_only_deps_flags():
-    with make_temp_env("flask=2.0.1", "jinja2=3.0.1") as prefix:
-        python = join(prefix, PYTHON_BINARY)
+def test_install_update_deps_only_deps_flags(
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+):
+    with tmp_env("flask=2.0.1", "jinja2=3.0.1") as prefix:
+        python = prefix / PYTHON_BINARY
         result_before = subprocess_call_with_clean_env([python, "--version"])
         assert package_is_installed(prefix, "flask=2.0.1")
         assert package_is_installed(prefix, "jinja2=3.0.1")
-        run_command(
-            Commands.INSTALL,
-            prefix,
+        conda_cli(
+            "install",
+            f"--prefix={prefix}",
             "flask",
             "python",
             "--update-deps",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1138,8 +1138,8 @@ def test_install_update_deps_only_deps_flags(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
 ):
-    with tmp_env("flask=2.0.1", "jinja2=3.0.1") as prefix:
-        python = prefix / PYTHON_BINARY
+    with tmp_env("flask=2.0.1", "jinja2=3.0.1", "python>=3.12") as prefix:
+        python = str(prefix / PYTHON_BINARY)
         result_before = subprocess_call_with_clean_env([python, "--version"])
         assert package_is_installed(prefix, "flask=2.0.1")
         assert package_is_installed(prefix, "jinja2=3.0.1")
@@ -1150,6 +1150,7 @@ def test_install_update_deps_only_deps_flags(
             "python",
             "--update-deps",
             "--only-deps",
+            "--yes",
         )
         result_after = subprocess_call_with_clean_env([python, "--version"])
         assert result_before == result_after


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

As part of the Python 3.12 build out, pip was re-released as `23.3` (not `23.3.1`). This causes an inconsistency between classic and libmamba with the former choosing `23.3.1` and the latter choosing `23.3`.

<details>
<summary><code>conda create -n scratch --solver=classic jinja2=3.0.1 --dry-run</code></summary>

```
  bzip2              pkgs/main/osx-arm64::bzip2-1.0.8-h620ffc9_4
  ca-certificates    pkgs/main/osx-arm64::ca-certificates-2023.08.22-hca03da5_0
  jinja2             pkgs/main/noarch::jinja2-3.0.1-pyhd3eb1b0_0
  libffi             pkgs/main/osx-arm64::libffi-3.4.4-hca03da5_0
  markupsafe         pkgs/main/osx-arm64::markupsafe-2.1.1-py311h80987f9_0
  ncurses            pkgs/main/osx-arm64::ncurses-6.4-h313beb8_0
  openssl            pkgs/main/osx-arm64::openssl-3.0.12-h1a28f6b_0
  pip                pkgs/main/osx-arm64::pip-23.3.1-py311hca03da5_0
  python             pkgs/main/osx-arm64::python-3.11.5-hb885b13_0
  readline           pkgs/main/osx-arm64::readline-8.2-h1a28f6b_0
  setuptools         pkgs/main/osx-arm64::setuptools-68.0.0-py311hca03da5_0
  sqlite             pkgs/main/osx-arm64::sqlite-3.41.2-h80987f9_0
  tk                 pkgs/main/osx-arm64::tk-8.6.12-hb8d0fd4_0
  tzdata             pkgs/main/noarch::tzdata-2023c-h04d1e81_0
  wheel              pkgs/main/osx-arm64::wheel-0.41.2-py311hca03da5_0
  xz                 pkgs/main/osx-arm64::xz-5.4.2-h80987f9_0
  zlib               pkgs/main/osx-arm64::zlib-1.2.13-h5a0b063_0
```

</details>

<details>
<summary><code>conda create -n scratch --solver=libmamba jinja2=3.0.1 --dry-run</code></summary>

```
  bzip2              pkgs/main/osx-arm64::bzip2-1.0.8-h620ffc9_4
  ca-certificates    pkgs/main/osx-arm64::ca-certificates-2023.08.22-hca03da5_0
  expat              pkgs/main/osx-arm64::expat-2.5.0-h313beb8_0
  jinja2             pkgs/main/noarch::jinja2-3.0.1-pyhd3eb1b0_0
  libcxx             pkgs/main/osx-arm64::libcxx-14.0.6-h848a8c0_0
  libffi             pkgs/main/osx-arm64::libffi-3.4.4-hca03da5_0
  markupsafe         pkgs/main/osx-arm64::markupsafe-2.1.1-py312h80987f9_0
  ncurses            pkgs/main/osx-arm64::ncurses-6.4-h313beb8_0
  openssl            pkgs/main/osx-arm64::openssl-3.0.12-h1a28f6b_0
  pip                pkgs/main/osx-arm64::pip-23.3-py312hca03da5_0
  python             pkgs/main/osx-arm64::python-3.12.0-h99e199e_0
  readline           pkgs/main/osx-arm64::readline-8.2-h1a28f6b_0
  setuptools         pkgs/main/osx-arm64::setuptools-68.0.0-py312hca03da5_0
  sqlite             pkgs/main/osx-arm64::sqlite-3.41.2-h80987f9_0
  tk                 pkgs/main/osx-arm64::tk-8.6.12-hb8d0fd4_0
  tzdata             pkgs/main/noarch::tzdata-2023c-h04d1e81_0
  wheel              pkgs/main/osx-arm64::wheel-0.41.2-py312hca03da5_0
  xz                 pkgs/main/osx-arm64::xz-5.4.2-h80987f9_0
  zlib               pkgs/main/osx-arm64::zlib-1.2.13-h5a0b063_0
```

</details>

Fixes https://github.com/conda/conda/issues/13360
Xref https://github.com/conda/conda/issues/13292

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
