### PR TITLE
Add `raises` kwarg to `conda_cli`

### DIFF
--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -171,13 +171,14 @@ class CondaCLIFixture:
     def __call__(
         self,
         *argv: str | os.PathLike | Path,
-        raises: type[Exception] | tuple[type[Exception], ...] | None = None,
+        catch: type[Exception] | tuple[type[Exception], ...] | None = None,
     ) -> tuple[str, str, int]:
         """Test conda CLI. Mimic what is done in `conda.cli.main.main`.
 
         `conda ...` == `conda_cli(...)`
 
         :param argv: Arguments to parse
+        :param catch: Exception(s) to catch
         :return: Command results
         :rtype: tuple[stdout, stdout, exitcode]
         """
@@ -188,7 +189,7 @@ class CondaCLIFixture:
         argv = tuple(map(str, argv))
 
         code = None
-        with pytest.raises(raises) if raises else nullcontext():
+        with pytest.raises(catch) if catch else nullcontext():
             # mock legacy subcommands
             if argv[0] == "env":
                 from conda_env.cli.main import create_parser, do_call

--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -18,12 +18,12 @@ import os
 import sys
 import uuid
 import warnings
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from os.path import dirname, isfile, join, normpath
 from pathlib import Path
 from subprocess import check_output
-from typing import Iterator
+from typing import Iterable
 
 import pytest
 from pytest import CaptureFixture
@@ -168,7 +168,11 @@ def conda_check_versions_aligned():
 class CondaCLIFixture:
     capsys: CaptureFixture
 
-    def __call__(self, *argv: str) -> tuple[str, str, int]:
+    def __call__(
+        self,
+        *argv: str | os.PathLike | Path,
+        raises: type[Exception] | tuple[type[Exception], ...] | None = None,
+    ) -> tuple[str, str, int]:
         """Test conda CLI. Mimic what is done in `conda.cli.main.main`.
 
         `conda ...` == `conda_cli(...)`
@@ -183,29 +187,31 @@ class CondaCLIFixture:
         # ensure arguments are string
         argv = tuple(map(str, argv))
 
-        # mock legacy subcommands
-        if argv[0] == "env":
-            from conda_env.cli.main import create_parser, do_call
+        code = None
+        with pytest.raises(raises) if raises else nullcontext():
+            # mock legacy subcommands
+            if argv[0] == "env":
+                from conda_env.cli.main import create_parser, do_call
 
-            argv = argv[1:]
+                argv = argv[1:]
 
-            # parse arguments
-            parser = create_parser()
-            args = parser.parse_args(argv)
+                # parse arguments
+                parser = create_parser()
+                args = parser.parse_args(argv)
 
-            # initialize context and loggers
-            context.__init__(argparse_args=args)
-            init_loggers()
+                # initialize context and loggers
+                context.__init__(argparse_args=args)
+                init_loggers()
 
-            # run command
-            code = do_call(args, parser)
+                # run command
+                code = do_call(args, parser)
 
-        # all other subcommands
-        else:
-            from ..cli.main import main_subshell
+            # all other subcommands
+            else:
+                from ..cli.main import main_subshell
 
-            # run command
-            code = main_subshell(*argv)
+                # run command
+                code = main_subshell(*argv)
 
         # capture output
         out, err = self.capsys.readouterr()
@@ -267,7 +273,7 @@ class TmpEnvFixture:
         self,
         *packages: str,
         prefix: str | os.PathLike | None = None,
-    ) -> Iterator[Path]:
+    ) -> Iterable[Path]:
         """Generate a conda environment with the provided packages.
 
         :param packages: The packages to install into environment

--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -171,14 +171,14 @@ class CondaCLIFixture:
     def __call__(
         self,
         *argv: str | os.PathLike | Path,
-        catch: type[Exception] | tuple[type[Exception], ...] | None = None,
+        raises: type[Exception] | tuple[type[Exception], ...] | None = None,
     ) -> tuple[str, str, int]:
         """Test conda CLI. Mimic what is done in `conda.cli.main.main`.
 
         `conda ...` == `conda_cli(...)`
 
         :param argv: Arguments to parse
-        :param catch: Exception(s) to catch
+        :param raises: Expected exception to intercept
         :return: Command results
         :rtype: tuple[stdout, stdout, exitcode]
         """
@@ -189,7 +189,7 @@ class CondaCLIFixture:
         argv = tuple(map(str, argv))
 
         code = None
-        with pytest.raises(catch) if catch else nullcontext():
+        with pytest.raises(raises) if raises else nullcontext():
             # mock legacy subcommands
             if argv[0] == "env":
                 from conda_env.cli.main import create_parser, do_call

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1791,7 +1791,7 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
         "create",
         f"--prefix={prefix}",
         "--dry-run",
-        catch=DryRunExit,
+        raises=DryRunExit,
     )
     assert str(prefix) in stdout
     assert not stderr
@@ -1802,7 +1802,7 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
         f"--prefix={prefix}",
         "flask",
         "--dry-run",
-        catch=DryRunExit,
+        raises=DryRunExit,
     )
     assert ":flask" in stdout
     assert ":python" in stdout
@@ -1822,7 +1822,7 @@ def test_create_dry_run_json(
         "flask",
         "--dry-run",
         "--json",
-        catch=DryRunExit,
+        raises=DryRunExit,
     )
     names = {link["name"] for link in json.loads(stdout)["actions"]["LINK"]}
     assert "python" in names

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1812,7 +1812,8 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
 
 
 def test_create_dry_run_json(
-    path_factory: PathFactoryFixture, conda_cli: CondaCLIFixture
+    path_factory: PathFactoryFixture,
+    conda_cli: CondaCLIFixture,
 ):
     prefix = path_factory()
 
@@ -1831,11 +1832,11 @@ def test_create_dry_run_json(
     assert not code
 
 
-def test_create_dry_run_yes_safety():
-    with make_temp_env() as prefix:
+def test_create_dry_run_yes_safety(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture):
+    with tmp_env() as prefix:
         with pytest.raises(CondaValueError):
-            run_command(Commands.CREATE, prefix, "--dry-run", "--yes")
-        assert exists(prefix)
+            conda_cli("create", f"--prefix={prefix}", "--dry-run", "--yes")
+        assert prefix.exists()
 
 
 def test_packages_not_found():

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1811,22 +1811,24 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
     assert not code
 
 
-def test_create_dry_run_json():
-    prefix = "/some/place"
-    with pytest.raises(DryRunExit):
-        run_command(Commands.CREATE, prefix, "flask", "--dry-run", "--json")
-    output, _, _ = run_command(
-        Commands.CREATE,
-        prefix,
+def test_create_dry_run_json(
+    path_factory: PathFactoryFixture, conda_cli: CondaCLIFixture
+):
+    prefix = path_factory()
+
+    stdout, stderr, code = conda_cli(
+        "create",
+        f"--prefix={prefix}",
         "flask",
         "--dry-run",
         "--json",
-        use_exception_handler=True,
+        catch=DryRunExit,
     )
-    loaded = json.loads(output)
-    names = {d["name"] for d in loaded["actions"]["LINK"]}
+    names = {link["name"] for link in json.loads(stdout)["actions"]["LINK"]}
     assert "python" in names
     assert "flask" in names
+    assert not stderr
+    assert not code
 
 
 def test_create_dry_run_yes_safety():

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1783,27 +1783,32 @@ def test_create_default_packages_no_default_packages():
         rmtree(prefix, ignore_errors=True)
 
 
-def test_create_dry_run():
-    # Regression test for #3453
-    prefix = "/some/place"
-    with pytest.raises(DryRunExit):
-        run_command(Commands.CREATE, prefix, "--dry-run")
-    output, _, _ = run_command(
-        Commands.CREATE, prefix, "--dry-run", use_exception_handler=True
-    )
-    assert join("some", "place") in output
-    # TODO: This assert passes locally but fails on CI boxes; figure out why and re-enable
-    # assert "The following empty environments will be CREATED" in stdout
+def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFixture):
+    # regression test for #3453
+    prefix = path_factory()
 
-    prefix = "/another/place"
-    with pytest.raises(DryRunExit):
-        run_command(Commands.CREATE, prefix, "flask", "--dry-run")
-    output, _, _ = run_command(
-        Commands.CREATE, prefix, "flask", "--dry-run", use_exception_handler=True
+    stdout, stderr, code = conda_cli(
+        "create",
+        f"--prefix={prefix}",
+        "--dry-run",
+        raises=DryRunExit,
     )
-    assert ":flask" in output
-    assert ":python" in output
-    assert join("another", "place") in output
+    assert str(prefix) in stdout
+    assert not stderr
+    assert not code
+
+    stdout, stderr, code = conda_cli(
+        "create",
+        f"--prefix={prefix}",
+        "flask",
+        "--dry-run",
+        raises=DryRunExit,
+    )
+    assert ":flask" in stdout
+    assert ":python" in stdout
+    assert str(prefix) in stdout
+    assert not stderr
+    assert not code
 
 
 def test_create_dry_run_json():

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1791,7 +1791,7 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
         "create",
         f"--prefix={prefix}",
         "--dry-run",
-        raises=DryRunExit,
+        catch=DryRunExit,
     )
     assert str(prefix) in stdout
     assert not stderr
@@ -1802,7 +1802,7 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
         f"--prefix={prefix}",
         "flask",
         "--dry-run",
-        raises=DryRunExit,
+        catch=DryRunExit,
     )
     assert ":flask" in stdout
     assert ":python" in stdout


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Sometimes we expect conda_cli to raise an exception but we also wish to inspect the stdout/stderr. Currently that requires extra work:

```python
def test_foo(conda_cli: CondaCLIFixture, capsys: CaptureFixture):
    with pytest.raises(DryRunExit):
        conda_cli("create", "--name=foo", "--dry-run")
    stdout, stderr = capsys.readouterr()
```

With the change here we can instead do:

```python
def test_foo(conda_cli: CondaCLIFixture):
    stdout, stderr, code = conda_cli("create", "--name=foo", "--dry-run", catch=DryRunExit)
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
