### PR TITLE
Refactoring tests for `test_create.py`

### DIFF
--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -232,7 +232,7 @@ class CondaCLIFixture:
         # restore to prior state
         reset_context()
 
-        return out, err, code or exception
+        return out, err, exception if raises else code
 
 
 @pytest.fixture

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -418,8 +418,13 @@ def test_not_writable_env_raises_EnvironmentNotWritableError(
     with tmp_env() as prefix:
         make_read_only(prefix / PREFIX_MAGIC_FILE)
 
-        with pytest.raises(CondaMultiError) as exc:
-            conda_cli("install", f"--prefix={prefix}", "ca-certificates", "--yes")
+        _, _, exc = conda_cli(
+            "install",
+            f"--prefix={prefix}",
+            "ca-certificates",
+            "--yes",
+            raises=CondaMultiError,
+        )
 
         assert len(exc.value.errors) == 1
         assert isinstance(exc.value.errors[0], EnvironmentNotWritableError)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -60,6 +60,7 @@ from conda.exceptions import (
     DisallowedPackageError,
     DryRunExit,
     EnvironmentLocationNotFound,
+    EnvironmentNotWritableError,
     OperationNotAllowed,
     PackageNotInstalledError,
     PackagesNotFoundError,
@@ -406,92 +407,100 @@ def test_json_create_install_update_remove():
         rmtree(prefix, ignore_errors=True)
 
 
-def test_not_writable_env_raises_EnvironmentNotWritableError():
-    with make_temp_env() as prefix:
+def test_not_writable_env_raises_EnvironmentNotWritableError(
+    tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
+):
+    """
+    Make sure that an ``EnvironmentNotWritableError`` is raised when the ``PREFIX_MAGIC_FILE`` is
+    not writable. This magic file is used to determined whether it's possible to write to an
+    environment.
+    """
+    with tmp_env() as prefix:
         make_read_only(join(prefix, PREFIX_MAGIC_FILE))
-        stdout, stderr, _ = run_command(
-            Commands.INSTALL, prefix, "openssl", use_exception_handler=True
+
+        with pytest.raises(CondaMultiError) as exc:
+            conda_cli("install", f"--prefix={prefix}", "ca-certificates", "--yes")
+
+        assert len(exc.value.errors) == 1
+        assert type(exc.value.errors[0]) is EnvironmentNotWritableError
+
+
+def test_conda_update_package_not_installed(
+    tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
+):
+    """
+    Runs the update command twice with invalid input:
+
+    1. Package is not currently installed (package should not exist)
+    2. Invalid specification for a packaage
+    """
+    with tmp_env() as prefix:
+        conda_cli(
+            "update",
+            f"--prefix={prefix}",
+            "test-test-test",
+            raises=PackageNotInstalledError,
         )
-        assert "EnvironmentNotWritableError" in stderr
-        assert prefix in stderr
-
-
-def test_conda_update_package_not_installed():
-    with make_temp_env() as prefix:
-        with pytest.raises(PackageNotInstalledError):
-            run_command(Commands.UPDATE, prefix, "sqlite", "openssl")
 
         with pytest.raises(CondaError) as conda_error:
-            run_command(Commands.UPDATE, prefix, "conda-forge::*")
+            conda_cli("update", f"--prefix={prefix}", "conda-forge::*")
+
         assert conda_error.value.message.startswith("Invalid spec for 'conda update'")
 
 
-def test_noarch_python_package_with_entry_points():
-    # this channel has an ancient flask that is incompatible with jinja2>=3.1.0
-    with make_temp_env("-c", "conda-test", "flask", "jinja2<3.1") as prefix:
+def test_noarch_python_package_with_entry_points(
+    tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
+):
+    """
+    Makes sure that entry point file is installed.
+
+    This test uses "pygments" as a Python package because it has no other dependencies and has an
+    entry point script, "pygmentize".
+    """
+    with tmp_env("pygments") as prefix:
         py_ver = get_python_version_for_prefix(prefix)
         sp_dir = get_python_site_packages_short_path(py_ver)
-        py_file = sp_dir + "/flask/__init__.py"
+        py_file = sp_dir + "/pygments/__init__.py"
         pyc_file = pyc_path(py_file, py_ver).replace("/", os.sep)
         assert isfile(join(prefix, py_file))
         assert isfile(join(prefix, pyc_file))
-        exe_path = join(prefix, get_bin_directory_short_path(), "flask")
+        exe_path = join(prefix, get_bin_directory_short_path(), "pygmentize")
         if on_win:
             exe_path += ".exe"
         assert isfile(exe_path)
         output = check_output([exe_path, "--help"], text=True)
-        assert "Usage: flask" in output
+        assert "usage: pygmentize" in output
 
-        run_command(Commands.REMOVE, prefix, "flask")
+        conda_cli("remove", f"--prefix={prefix}", "pygments", "--yes")
 
         assert not isfile(join(prefix, py_file))
         assert not isfile(join(prefix, pyc_file))
         assert not isfile(exe_path)
 
 
-def test_noarch_python_package_without_entry_points():
-    # regression test for #4546
-    with make_temp_env("-c", "conda-test", "itsdangerous") as prefix:
+def test_noarch_python_package_without_entry_points(
+    tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
+):
+    """
+    Regression test for issue:
+
+    - https://github.com/conda/conda/issues/4546
+
+    This test uses "itsdangerous" as a dependency because it is a relatively small package and
+    has no entry point scripts.
+    """
+    with tmp_env("itsdangerous") as prefix:
         py_ver = get_python_version_for_prefix(prefix)
         sp_dir = get_python_site_packages_short_path(py_ver)
-        py_file = sp_dir + "/itsdangerous.py"
+        py_file = sp_dir + "/itsdangerous/__init__.py"
         pyc_file = pyc_path(py_file, py_ver).replace("/", os.sep)
         assert isfile(join(prefix, py_file))
         assert isfile(join(prefix, pyc_file))
 
-        run_command(Commands.REMOVE, prefix, "itsdangerous")
+        conda_cli("remove", f"--prefix={prefix}", "itsdangerous", "--yes")
 
         assert not isfile(join(prefix, py_file))
         assert not isfile(join(prefix, pyc_file))
-
-
-def test_noarch_python_package_reinstall_on_pyver_change():
-    with make_temp_env(
-        "-c",
-        "conda-test",
-        "itsdangerous=0.24",
-        "python=3",
-        use_restricted_unicode=on_win,
-    ) as prefix:
-        py_ver = get_python_version_for_prefix(prefix)
-        assert py_ver.startswith("3")
-        sp_dir = get_python_site_packages_short_path(py_ver)
-        py_file = sp_dir + "/itsdangerous.py"
-        pyc_file_py3 = pyc_path(py_file, py_ver).replace("/", os.sep)
-        assert isfile(join(prefix, py_file))
-        assert isfile(join(prefix, pyc_file_py3))
-
-        run_command(Commands.INSTALL, prefix, "python=2")
-        assert not isfile(join(prefix, pyc_file_py3))  # python3 pyc file should be gone
-
-        py_ver = get_python_version_for_prefix(prefix)
-        assert py_ver.startswith("2")
-        sp_dir = get_python_site_packages_short_path(py_ver)
-        py_file = sp_dir + "/itsdangerous.py"
-        pyc_file_py2 = pyc_path(py_file, py_ver).replace("/", os.sep)
-
-        assert isfile(join(prefix, py_file))
-        assert isfile(join(prefix, pyc_file_py2))
 
 
 def test_noarch_generic_package():

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -442,10 +442,8 @@ def test_conda_update_package_not_installed(
             raises=PackageNotInstalledError,
         )
 
-        with pytest.raises(CondaError) as conda_error:
+        with pytest.raises(CondaError, match="Invalid spec for 'conda update'"):
             conda_cli("update", f"--prefix={prefix}", "conda-forge::*")
-
-        assert conda_error.value.message.startswith("Invalid spec for 'conda update'")
 
 
 def test_noarch_python_package_with_entry_points(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -422,7 +422,7 @@ def test_not_writable_env_raises_EnvironmentNotWritableError(
             conda_cli("install", f"--prefix={prefix}", "ca-certificates", "--yes")
 
         assert len(exc.value.errors) == 1
-        assert type(exc.value.errors[0]) is EnvironmentNotWritableError
+        assert isinstance(exc.value.errors[0], EnvironmentNotWritableError)
 
 
 def test_conda_update_package_not_installed(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1830,7 +1830,7 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
     # regression test for #3453
     prefix = path_factory()
 
-    stdout, stderr, code = conda_cli(
+    stdout, stderr, _ = conda_cli(
         "create",
         f"--prefix={prefix}",
         "--dry-run",
@@ -1838,9 +1838,8 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
     )
     assert str(prefix) in stdout
     assert not stderr
-    assert not code
 
-    stdout, stderr, code = conda_cli(
+    stdout, stderr, _ = conda_cli(
         "create",
         f"--prefix={prefix}",
         "flask",
@@ -1851,7 +1850,6 @@ def test_create_dry_run(path_factory: PathFactoryFixture, conda_cli: CondaCLIFix
     assert ":python" in stdout
     assert str(prefix) in stdout
     assert not stderr
-    assert not code
 
 
 def test_create_dry_run_json(
@@ -1860,7 +1858,7 @@ def test_create_dry_run_json(
 ):
     prefix = path_factory()
 
-    stdout, stderr, code = conda_cli(
+    stdout, stderr, _ = conda_cli(
         "create",
         f"--prefix={prefix}",
         "flask",
@@ -1872,7 +1870,6 @@ def test_create_dry_run_json(
     assert "python" in names
     assert "flask" in names
     assert not stderr
-    assert not code
 
 
 def test_create_dry_run_yes_safety(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture):


### PR DESCRIPTION
### Description

xref: https://github.com/conda/conda/issues/13292

I decided to just delete the test, "test_noarch_python_package_reinstall_on_pyver_change" because it does not make sense to have around any more. It is probably very seldom that users are actually switching major Python versions and this test is very slow to run.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
