### PR TITLE
Define RepodataState.__contains__ for Python 3.12

### DIFF
--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -464,12 +464,16 @@ class RepodataState(UserDict):
             item = ""
         return super().__setitem__(key, item)
 
+    # required for Python 3.12 .get() (https://github.com/python/cpython/issues/105524)
+    def __contains__(self, key: str):
+        return key in self.data or (
+            key in self._aliased and self._aliased[key] in self.data
+        )
+
     def __missing__(self, key: str):
         if key in self._aliased:
             key = self._aliased[key]
-        else:
-            raise KeyError(key)
-        return super().__getitem__(key)
+        return self.data[key]
 
 
 class RepodataCache:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Was causing a unit test failure in Python 3.12. (RepodataState has backwards-compatible aliases from underscore-prefixed etag etc.)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
