### PR TITLE
Re-enable pyupgrade via ruff

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -318,8 +318,7 @@ class _Activator(metaclass=abc.ABCMeta):
                 from .exceptions import ArgumentError
 
                 raise ArgumentError(
-                    "%s does not accept arguments\nremainder_args: %s\n"
-                    % (command, remainder_args)
+                    f"{command} does not accept arguments\nremainder_args: {remainder_args}\n"
                 )
 
         self.command = command

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1035,11 +1035,11 @@ class Context(Configuration):
     @memoizedproperty
     def user_agent(self):
         builder = [f"conda/{CONDA_VERSION} requests/{self.requests_version}"]
-        builder.append("%s/%s" % self.python_implementation_name_version)
-        builder.append("%s/%s" % self.platform_system_release)
-        builder.append("%s/%s" % self.os_distribution_name_version)
+        builder.append("{}/{}".format(*self.python_implementation_name_version))
+        builder.append("{}/{}".format(*self.platform_system_release))
+        builder.append("{}/{}".format(*self.os_distribution_name_version))
         if self.libc_family_version[0]:
-            builder.append("%s/%s" % self.libc_family_version)
+            builder.append("{}/{}".format(*self.libc_family_version))
         if self.solver != "classic":
             builder.append(self.solver_user_agent())
         return " ".join(builder)

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -102,10 +102,9 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     location.add_argument(
         "--env",
         action="store_true",
-        help="Write to the active conda environment .condarc file (%s). "
-        "If no environment is active, write to the user config file (%s)."
-        ""
-        % (
+        help="Write to the active conda environment .condarc file ({}). "
+        "If no environment is active, write to the user config file ({})."
+        "".format(
             context.active_prefix or "<no active environment>",
             escaped_user_rc_path,
         ),

--- a/conda/cli/main_package.py
+++ b/conda/cli/main_package.py
@@ -252,7 +252,7 @@ def make_tarbz2(prefix, name="unknown", version="0.0", build_number=0, files=Non
         requires_py = False
 
     info = create_info(name, version, build_number, requires_py)
-    tarbz2_fn = ("%(name)s-%(version)s-%(build)s" % info) + CONDA_PACKAGE_EXTENSION_V1
+    tarbz2_fn = ("{name}-{version}-{build}".format(**info)) + CONDA_PACKAGE_EXTENSION_V1
     create_conda_pkg(prefix, files, info, tarbz2_fn)
     print("# success")
     print(tarbz2_fn)

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -7,6 +7,7 @@
 # If it's only used in one module, keep it in that module, preferably near the top.
 # This module should contain ONLY stdlib imports.
 
+import builtins
 import sys
 
 on_win = bool(sys.platform == "win32")
@@ -53,14 +54,13 @@ def isiterable(obj):
 # #############################
 
 from collections import OrderedDict as odict  # noqa: F401
-from io import open as io_open  # NOQA
 
 
 def open(
     file, mode="r", buffering=-1, encoding=None, errors=None, newline=None, closefd=True
 ):
     if "b" in mode:
-        return io_open(
+        return builtins.open(
             file,
             str(mode),
             buffering=buffering,
@@ -69,7 +69,7 @@ def open(
             closefd=closefd,
         )
     else:
-        return io_open(
+        return builtins.open(
             file,
             str(mode),
             buffering=buffering,

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -101,10 +101,9 @@ class MultipleKeysError(ValidationError):
         self.source = source
         self.keys = keys
         msg = (
-            "Multiple aliased keys in file %s:\n"
-            "%s\n"
-            "Must declare only one. Prefer '%s'"
-            % (source, pretty_list(keys), preferred_key)
+            f"Multiple aliased keys in file {source}:\n"
+            f"{pretty_list(keys)}\n"
+            f"Must declare only one. Prefer '{preferred_key}'"
         )
         super().__init__(preferred_key, None, source, msg=msg)
 
@@ -117,9 +116,8 @@ class InvalidTypeError(ValidationError):
         self.valid_types = valid_types
         if msg is None:
             msg = (
-                "Parameter %s = %r declared in %s has type %s.\n"
-                "Valid types:\n%s"
-                % (
+                "Parameter {} = {!r} declared in {} has type {}.\n"
+                "Valid types:\n{}".format(
                     parameter_name,
                     parameter_value,
                     source,

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -499,8 +499,7 @@ class ProgressBar:
                 if self.json:
                     with self.get_lock():
                         sys.stdout.write(
-                            '{"fetch":"%s","finished":false,"maxval":1,"progress":%f}\n\0'
-                            % (self.description, fraction)
+                            f'{{"fetch":"{self.description}","finished":false,"maxval":1,"progress":{fraction:f}}}\n\0'
                         )
                 elif IS_INTERACTIVE:
                     self.pbar.update(fraction - self.pbar.n)

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -1250,7 +1250,7 @@ def init_fish_user(target_path, conda_prefix, reverse):
         rc_content = re.sub(
             r"^[ \t]*[^#\n]?[ \t]*((?:source|\.) .*etc\/fish\/conf\.d\/conda\.fish.*?)\n"
             r"(conda activate.*?)$",
-            r"# \1  {0}\n# \2  {0}".format(conda_init_comment),
+            rf"# \1  {conda_init_comment}\n# \2  {conda_init_comment}",
             rc_content,
             flags=re.MULTILINE,
         )
@@ -1490,7 +1490,7 @@ def init_sh_user(target_path, conda_prefix, shell, reverse=False):
         rc_content = re.sub(
             r"^[ \t]*[^#\n]?[ \t]*((?:source|\.) .*etc\/profile\.d\/conda\.sh.*?)\n"
             r"(conda activate.*?)$",
-            r"# \1  {0}\n# \2  {0}".format(conda_init_comment),
+            rf"# \1  {conda_init_comment}\n# \2  {conda_init_comment}",
             rc_content,
             flags=re.MULTILINE,
         )
@@ -1628,7 +1628,7 @@ def init_cmd_exe_registry(target_path, conda_prefix, reverse=False):
         value_type = winreg.REG_EXPAND_SZ
 
     old_hook_path = '"{}"'.format(join(conda_prefix, "condabin", "conda_hook.bat"))
-    new_hook = "if exist {hp} {hp}".format(hp=old_hook_path)
+    new_hook = f"if exist {old_hook_path} {old_hook_path}"
     if reverse:
         # we can't just reset it to None and remove it, because there may be other contents here.
         #   We need to strip out our part, and if there's nothing left, remove the key.
@@ -1716,14 +1716,14 @@ def _powershell_profile_content(conda_prefix):
         conda_exe = join(conda_prefix, "bin", "conda")
 
     conda_powershell_module = dals(
-        """
+        f"""
     #region conda initialize
     # !! Contents within this block are managed by 'conda init' !!
     If (Test-Path "{conda_exe}") {{
         (& "{conda_exe}" "shell.powershell" "hook") | Out-String | ?{{$_}} | Invoke-Expression
     }}
     #endregion
-    """.format(conda_exe=conda_exe)
+    """
     )
 
     return conda_powershell_module

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1598,9 +1598,7 @@ def run_script(
                 rm_rf(script_caller)
             else:
                 log.warning(
-                    "CONDA_TEST_SAVE_TEMPS :: retaining run_script {}".format(
-                        script_caller
-                    )
+                    f"CONDA_TEST_SAVE_TEMPS :: retaining run_script {script_caller}"
                 )
 
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -447,11 +447,7 @@ class Solver:
 
         print(f"\n\nUpdating {spec.name} is constricted by \n")
         for const in hard_constricting:
-            print(
-                "{package} -> requires {conflict_dep}".format(
-                    package=const[0], conflict_dep=const[1]
-                )
-            )
+            print(f"{const[0]} -> requires {const[1]}")
         print(
             "\nIf you are sure you want an update of your package either try "
             "`conda update --all` or install a specific version of the "

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -6,7 +6,7 @@ import functools
 import os
 import sys
 import threading
-from builtins import input  # noqa: F401
+from builtins import input  # noqa: F401, UP029
 from collections.abc import Hashable as _Hashable
 from io import StringIO  # noqa: F401, for conda-build
 

--- a/conda/gateways/connection/session.py
+++ b/conda/gateways/connection/session.py
@@ -276,11 +276,11 @@ class CondaHttpAuth(AuthBase):
         if proxy_scheme not in proxies:
             raise ProxyError(
                 dals(
-                    """
-            Could not find a proxy for {!r}. See
-            {}/docs/html#configure-conda-for-use-behind-a-proxy-server
+                    f"""
+            Could not find a proxy for {proxy_scheme!r}. See
+            {CONDA_HOMEPAGE_URL}/docs/html#configure-conda-for-use-behind-a-proxy-server
             for more information on how to configure proxies.
-            """.format(proxy_scheme, CONDA_HOMEPAGE_URL)
+            """
                 )
             )
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -269,14 +269,11 @@ def make_menu(prefix, file_path, remove=False):
 def create_hard_link_or_copy(src, dst):
     if islink(src):
         message = dals(
-            """
+            f"""
         Cannot hard link a soft link
-          source: {source_path}
-          destination: {destination_path}
-        """.format(
-                source_path=src,
-                destination_path=dst,
-            )
+          source: {src}
+          destination: {dst}
+        """
         )
         raise CondaOSError(message)
 

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -88,16 +88,12 @@ def rmtree(path, *args, **kwargs):
             except CalledProcessError as e:
                 if e.returncode != 5:
                     log.error(
-                        "Removing folder {} the fast way failed.  Output was: {}".format(
-                            name, out
-                        )
+                        f"Removing folder {name} the fast way failed.  Output was: {out}"
                     )
                     raise
                 else:
                     log.debug(
-                        "removing dir contents the fast way failed.  Output was: {}".format(
-                            out
-                        )
+                        f"removing dir contents the fast way failed.  Output was: {out}"
                     )
     else:
         try:
@@ -173,9 +169,7 @@ def unlink_or_rename_to_trash(path):
                         )
                     except CalledProcessError:
                         log.debug(
-                            "renaming file path {} to trash failed.  Output was: {}".format(
-                                path, out
-                            )
+                            f"renaming file path {path} to trash failed.  Output was: {out}"
                         )
 
                 else:

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -57,9 +57,7 @@ def any_subprocess(args, prefix, env=None, cwd=None):
             rm_rf(script_caller)
         else:
             log.warning(
-                "CONDA_TEST_SAVE_TEMPS :: retaining pip run_script {}".format(
-                    script_caller
-                )
+                f"CONDA_TEST_SAVE_TEMPS :: retaining pip run_script {script_caller}"
             )
     if hasattr(stdout, "decode"):
         stdout = stdout.decode("utf-8", errors="replace")

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -63,8 +63,7 @@ class MatchSpecType(type):
                     return spec
             else:
                 raise CondaValueError(
-                    "Invalid MatchSpec:\n  spec_arg=%s\n  kwargs=%s"
-                    % (spec_arg, kwargs)
+                    f"Invalid MatchSpec:\n  spec_arg={spec_arg}\n  kwargs={kwargs}"
                 )
         else:
             return super().__call__(**kwargs)
@@ -281,7 +280,7 @@ class MatchSpec(metaclass=MatchSpecType):
             return fn_field
         vals = tuple(self.get_exact_value(x) for x in ("name", "version", "build"))
         if not any(x is None for x in vals):
-            return ("%s-%s-%s" % vals) + CONDA_PACKAGE_EXTENSION_V1
+            return ("{}-{}-{}".format(*vals)) + CONDA_PACKAGE_EXTENSION_V1
         else:
             return None
 
@@ -814,8 +813,7 @@ class MatchInterface(metaclass=ABCMeta):
     def merge(self, other):
         if self.raw_value != other.raw_value:
             raise ValueError(
-                "Incompatible component merge:\n  - %r\n  - %r"
-                % (self.raw_value, other.raw_value)
+                f"Incompatible component merge:\n  - {self.raw_value!r}\n  - {other.raw_value!r}"
             )
         return self.raw_value
 

--- a/conda/models/package_info.py
+++ b/conda/models/package_info.py
@@ -60,9 +60,7 @@ class PackageInfo(ImmutableEntity):
     paths_data = ComposableField(PathsData)
 
     def dist_str(self):
-        return "{}::{}-{}-{}".format(
-            self.channel.canonical_name, self.name, self.version, self.build
-        )
+        return f"{self.channel.canonical_name}::{self.name}-{self.version}-{self.build}"
 
     @property
     def name(self):

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -687,8 +687,7 @@ class BuildNumberMatch(BaseSpec, metaclass=SingleStrArgCachingType):
     def merge(self, other):
         if self.raw_value != other.raw_value:
             raise ValueError(
-                "Incompatible component merge:\n  - %r\n  - %r"
-                % (self.raw_value, other.raw_value)
+                f"Incompatible component merge:\n  - {self.raw_value!r}\n  - {other.raw_value!r}"
             )
         return self.raw_value
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -1638,9 +1638,8 @@ class Resolve:
             diffs = [sorted(set(sol) - common) for sol in psols2]
             if not context.json:
                 stdoutlog.info(
-                    "\nWarning: %s possible package resolutions "
-                    "(only showing differing packages):%s%s"
-                    % (
+                    "\nWarning: {} possible package resolutions "
+                    "(only showing differing packages):{}{}".format(
                         ">10" if nsol > 10 else nsol,
                         dashlist(", ".join(diff) for diff in diffs),
                         "\n  ... and others" if nsol > 10 else "",

--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -139,12 +139,10 @@ def _get_temp_prefix(name=None, use_restricted_unicode=False):
         link(src, dst)
     except OSError:
         print(
-            "\nWARNING :: You are testing `conda` with `tmpdir`:-\n           {}\n"
-            "           not on the same FS as `sys.prefix`:\n           {}\n"
+            f"\nWARNING :: You are testing `conda` with `tmpdir`:-\n           {tmpdir}\n"
+            f"           not on the same FS as `sys.prefix`:\n           {sys.prefix}\n"
             "           this will be slow and unlike the majority of end-user installs.\n"
-            "           Please pass `--basetemp=<somewhere-else>` instead.".format(
-                tmpdir, sys.prefix
-            )
+            "           Please pass `--basetemp=<somewhere-else>` instead."
         )
     try:
         rm_rf(dst)

--- a/conda_env/env.py
+++ b/conda_env/env.py
@@ -38,9 +38,9 @@ def validate_keys(data, kwargs):
         verb = "are" if len(invalid_keys) != 1 else "is"
         plural = "s" if len(invalid_keys) != 1 else ""
         print(
-            "\nEnvironmentSectionNotValid: The following section{plural} on "
-            "'{filename}' {verb} invalid and will be ignored:"
-            "".format(filename=filename, plural=plural, verb=verb)
+            f"\nEnvironmentSectionNotValid: The following section{plural} on "
+            f"'{filename}' {verb} invalid and will be ignored:"
+            ""
         )
         for key in invalid_keys:
             print(f" - {key}")

--- a/conda_env/specs/binstar.py
+++ b/conda_env/specs/binstar.py
@@ -104,9 +104,9 @@ class BinstarSpec:
             return self.binstar.package(self.username, self.packagename)
         except (IndexError, AttributeError):
             self.msg = (
-                "{} was not found on anaconda.org.\n"
+                f"{self.name} was not found on anaconda.org.\n"
                 "You may need to be logged in. Try running:\n"
-                "    anaconda login".format(self.name)
+                "    anaconda login"
             )
 
     @cached_property

--- a/news/13433-re-enable-pyupgrade-via-ruff
+++ b/news/13433-re-enable-pyupgrade-via-ruff
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Re-enable+apply pyupgrade via ruff: #13272 replaced black + pyupgrade via ruff format, but did not
+  enable the pyupgrade rules for ruff. (#13433)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,9 @@ exclude_lines = [
 # F = pyflakes
 # I = isort
 # D = pydocstyle
-select = ["E", "W", "F", "I", "D1"]
+# UP = pyupgrade
+# see also https://docs.astral.sh/ruff/rules/
+select = ["E", "W", "F", "I", "D1", "UP"]
 # E402 module level import not at top of file
 # E501 line too long
 # E722 do not use bare 'except'

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -1006,7 +1006,7 @@ def test_init_cmd_exe_registry(verbose):
     def _read_windows_registry_mock(target_path, value=None):
         if not value:
             value = "yada\\yada\\conda_hook.bat"
-        return 'echo hello & if exist "{v}" "{v}" & echo "world"'.format(v=value), None
+        return f'echo hello & if exist "{value}" "{value}" & echo "world"', None
 
     from conda.core import initialize
 

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -56,7 +56,7 @@ def verbose():
 def test_get_python_info(verbose):
     python_exe, python_version, site_packages_dir = _get_python_info(sys.prefix)
     assert realpath(python_exe) == realpath(sys.executable)
-    assert python_version == "%s.%s.%s" % sys.version_info[:3]
+    assert python_version == "{}.{}.{}".format(*sys.version_info[:3])
     assert site_packages_dir == get_path("platlib")
 
 

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -323,12 +323,12 @@ def test_cuda_constrain_unsat(tmpdir, clear_cuda_version):
                 solver.solve_final_state()
 
     assert str(exc.value).strip() == dals(
-        """The following specifications were found to be incompatible with your system:
+        f"""The following specifications were found to be incompatible with your system:
 
-  - feature:|@/{}::__cuda==8.0=0
+  - feature:|@/{context.subdir}::__cuda==8.0=0
   - __cuda[version='>=10.0'] -> feature:/linux-64::__cuda==8.0=0
 
-Your installed version is: 8.0""".format(context.subdir)
+Your installed version is: 8.0"""
     )
 
 
@@ -357,12 +357,12 @@ def test_cuda_glibc_unsat_depend(tmpdir, clear_cuda_version):
                 solver.solve_final_state()
 
     assert str(exc.value).strip() == dals(
-        """The following specifications were found to be incompatible with your system:
+        f"""The following specifications were found to be incompatible with your system:
 
-  - feature:|@/{}::__cuda==8.0=0
+  - feature:|@/{context.subdir}::__cuda==8.0=0
   - __cuda[version='>=10.0'] -> feature:/linux-64::__cuda==8.0=0
 
-Your installed version is: 8.0""".format(context.subdir)
+Your installed version is: 8.0"""
     )
 
 

--- a/tests/gateways/disk/test_permissions.py
+++ b/tests/gateways/disk/test_permissions.py
@@ -114,7 +114,7 @@ def test_make_writable_dir_EPERM():
     from conda.gateways.disk.permissions import make_writable
 
     with patch.object(conda.gateways.disk.permissions, "chmod") as chmod_mock:
-        chmod_mock.side_effect = IOError(EPERM, "some message", "foo")
+        chmod_mock.side_effect = OSError(EPERM, "some message", "foo")
         with tempdir() as td:
             assert not make_writable(td)
 
@@ -124,7 +124,7 @@ def test_make_writable_dir_EACCES():
     from conda.gateways.disk.permissions import make_writable
 
     with patch.object(conda.gateways.disk.permissions, "chmod") as chmod_mock:
-        chmod_mock.side_effect = IOError(EACCES, "some message", "foo")
+        chmod_mock.side_effect = OSError(EACCES, "some message", "foo")
         with tempdir() as td:
             assert not make_writable(td)
 
@@ -134,7 +134,7 @@ def test_make_writable_dir_EROFS():
     from conda.gateways.disk.permissions import make_writable
 
     with patch.object(conda.gateways.disk.permissions, "chmod") as chmod_mock:
-        chmod_mock.side_effect = IOError(EROFS, "some message", "foo")
+        chmod_mock.side_effect = OSError(EROFS, "some message", "foo")
         with tempdir() as td:
             assert not make_writable(td)
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1659,7 +1659,7 @@ def test_shortcut_creation_installs_shortcut():
     shortcut_dir = get_shortcut_dir()
     shortcut_dir = join(
         shortcut_dir,
-        "Anaconda{} ({}-bit)".format(sys.version_info.major, context.bits),
+        f"Anaconda{sys.version_info.major} ({context.bits}-bit)",
     )
 
     prefix = make_temp_prefix(str(uuid4())[:7])
@@ -1688,7 +1688,7 @@ def test_shortcut_absent_does_not_barf_on_uninstall():
     shortcut_dir = get_shortcut_dir()
     shortcut_dir = join(
         shortcut_dir,
-        "Anaconda{} ({}-bit)".format(sys.version_info.major, context.bits),
+        f"Anaconda{sys.version_info.major} ({context.bits}-bit)",
     )
 
     prefix = make_temp_prefix(str(uuid4())[:7])
@@ -1716,7 +1716,7 @@ def test_shortcut_absent_when_condarc_set():
     shortcut_dir = get_shortcut_dir()
     shortcut_dir = join(
         shortcut_dir,
-        "Anaconda{} ({}-bit)".format(sys.version_info.major, context.bits),
+        f"Anaconda{sys.version_info.major} ({context.bits}-bit)",
     )
 
     prefix = make_temp_prefix(str(uuid4())[:7])
@@ -1984,10 +1984,10 @@ def test_conda_pip_interop_pip_clobbers_conda():
         if not on_win:
             output, _, _ = run_command(Commands.RUN, prefix, which_or_where, "python")
             assert prefix.lower() in output.lower(), (
-                "We should be running python in {}\n"
-                "We are running {}\n"
+                f"We should be running python in {prefix}\n"
+                f"We are running {output}\n"
                 "Please check the CONDA_PREFIX PATH promotion in tests/__init__.py\n"
-                "for a likely place to add more fixes".format(prefix, output)
+                "for a likely place to add more fixes"
             )
         output, _, _ = run_command(
             Commands.RUN, prefix, "python", "-m", "pip", "freeze"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

#13272 replaced black + pyupgrade via ruff format, but forgot to actually enable the pyupgrade rules for ruff.

This PR enables pyupgrade via ruff again and applies it.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
