### PR TITLE
Fix deep links to Anaconda docs.

### DIFF
--- a/docs/source/user-guide/concepts/packages.rst
+++ b/docs/source/user-guide/concepts/packages.rst
@@ -130,7 +130,7 @@ Anaconda metapackage
 --------------------
 
 The Anaconda metapackage is used in the creation of the
-`Anaconda Distribution <https://docs.anaconda.com/anaconda/>`_
+`Anaconda Distribution <https://docs.anaconda.com/free/anaconda/>`_
 installers so that they have a set of packages associated with them.
 Each installer release has a version number, which corresponds
 to a particular collection of packages at specific versions.

--- a/docs/source/user-guide/getting-started.rst
+++ b/docs/source/user-guide/getting-started.rst
@@ -13,7 +13,7 @@ the major features of conda. You should understand how conda works
 when you finish this guide.
 
 SEE ALSO: `Getting started with Anaconda Navigator
-<https://docs.anaconda.com/anaconda/navigator/getting-started>`_, a
+<https://docs.anaconda.com/free/navigator/getting-started/>`_, a
 graphical user interface that lets you use conda in a web-like interface
 without having to enter manual commands. Compare the Getting started
 guides for each to see which program you prefer.
@@ -22,7 +22,7 @@ Before you start
 ================
 
 You should have already `installed
-Anaconda <https://docs.anaconda.com/anaconda/install/>`_.
+Anaconda <https://docs.anaconda.com/free/anaconda/install/>`_.
 
 Contents
 ========

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -350,7 +350,7 @@ not global.
    for "All Users", we add it to the *system* PATH. In the former case,
    you can end up with system PATH values taking precedence over
    your entries. In the latter case, you do not. *We do not recommend*
-   `multi-user installs <https://docs.anaconda.com/anaconda/install/multi-user/>`_.
+   `multi-user installs <https://docs.anaconda.com/free/anaconda/install/multi-user/>`_.
 
 To activate an environment: ``conda activate myenv``
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This might also need to be checked on the docs.anaconda.com side, to make sure the links correctly redirect for all the older versions of the conda docs. Especially for high traffic pages like the getting started guide!

I also noted that the 404 page on https://docs.anaconda.com/anaconda/install/ doesn't render for me in Safari, but that can't be fixed here.

![CleanShot 2023-12-17 at 18 23 14@2x](https://github.com/conda/conda/assets/1610/73036f38-da5a-4c4d-9dda-39430d44fa53)


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- ~[ ] Add / update necessary tests?~
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
