### PR TITLE
Improve repodata lock API

### DIFF
--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -510,10 +510,7 @@ class RepodataCache:
     @property
     def cache_path_state(self):
         """Out-of-band etag and other state needed by the RepoInterface."""
-        return pathlib.Path(
-            self.cache_dir,
-            self.name + ("1" if context.use_only_tar_bz2 else "") + CACHE_STATE_SUFFIX,
-        )
+        return self.cache_path_json.with_suffix(CACHE_STATE_SUFFIX)
 
     def load(self, *, state_only=False) -> str:
         # read state and repodata.json with locking
@@ -523,7 +520,7 @@ class RepodataCache:
         # read repodata.json
         # check stat, if wrong clear cache information
 
-        with self.cache_path_state.open("r+") as state_file, lock(state_file):
+        with self.lock("r+") as state_file:
             # cannot use pathlib.read_text / write_text on any locked file, as
             # it will release the lock early
             state = json.loads(state_file.read())
@@ -606,7 +603,7 @@ class RepodataCache:
         Relies on path's mtime not changing on move. `temp_path` should be
         adjacent to `self.cache_path_json` to be on the same filesystem.
         """
-        with self.cache_path_state.open("a+") as state_file, lock(state_file):
+        with self.lock() as state_file:
             # "a+" creates the file if necessary, does not trunctate file.
             state_file.seek(0)
             state_file.truncate()
@@ -628,12 +625,22 @@ class RepodataCache:
         Update access time in cache info file to indicate a HTTP 304 Not Modified response.
         """
         # Note this is not thread-safe.
-        with self.cache_path_state.open("a+") as state_file, lock(state_file):
+        with self.lock() as state_file:
             # "a+" creates the file if necessary, does not trunctate file.
             state_file.seek(0)
             state_file.truncate()
             self.state["refresh_ns"] = refresh_ns or time.time_ns()
             state_file.write(json.dumps(dict(self.state), indent=2))
+
+    @contextmanager
+    def lock(self, mode="a+"):
+        """
+        Lock .info.json file. Hold lock while modifying related files.
+
+        mode: "a+" then seek(0) to write/create; "r+" to read.
+        """
+        with self.cache_path_state.open(mode) as state_file, lock(state_file):
+            yield state_file
 
     def stale(self):
         """

--- a/news/repodata-lock-api
+++ b/news/repodata-lock-api
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Improve lock API for repodata cache.
+* Improve lock API for repodata cache. (#13455)

--- a/news/repodata-lock-api
+++ b/news/repodata-lock-api
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Improve lock API for repodata cache.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Small change originating from https://github.com/conda/conda/tree/13120-jlap-benchmark

Add `self.lock()` as a context manager instead of two-step open/lock.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
