### PR TITLE
Correct HTTP path to `conda_env` test data and remove empty `conda.env.cli` submodule

### DIFF
--- a/conda/env/cli/__init__.py
+++ b/conda/env/cli/__init__.py
@@ -1,2 +1,0 @@
-# Copyright (C) 2012 Anaconda, Inc
-# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -267,7 +267,7 @@ def test_conda_env_create_http(conda_cli: CondaCLIFixture):
     try:
         conda_cli(
             *("env", "create"),
-            "--file=https://raw.githubusercontent.com/conda/conda/main/tests/conda_env/support/simple.yml",
+            "--file=https://raw.githubusercontent.com/conda/conda/main/tests/env/support/simple.yml",
         )
         assert env_is_created("nlp")
     finally:

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -87,7 +87,7 @@ def test_add_pip():
 def test_http():
     e = get_simple_environment()
     f = from_file(
-        "https://raw.githubusercontent.com/conda/conda/main/tests/conda_env/support/simple.yml"
+        "https://raw.githubusercontent.com/conda/conda/main/tests/env/support/simple.yml"
     )
     assert e.dependencies == f.dependencies
     assert e.dependencies == f.dependencies
@@ -97,7 +97,7 @@ def test_http():
 def test_http_raises():
     with pytest.raises(CondaHTTPError):
         from_file(
-            "https://raw.githubusercontent.com/conda/conda/main/tests/conda_env/support/does-not-exist.yml"
+            "https://raw.githubusercontent.com/conda/conda/main/tests/env/support/does-not-exist.yml"
         )
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Followup to #13168

Missed updating a few HTTP urls pointing to the old `tests/conda_env` path.

And remove empty `conda.env.cli` submodule.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
