### PR TITLE
ensure `PackageRecord.timestamp` is dumped in milliseconds

### DIFF
--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -220,12 +220,14 @@ def _export_subdir_data_to_repodata(subdir_data: SubdirData):
     packages = {}
     packages_conda = {}
     for pkg in subdir_data.iter_records():
+        if pkg.timestamp:
+            # ensure timestamp is dumped as int in milliseconds
+            # (pkg.timestamp is a kept as a float in seconds)
+            pkg.__fields__["timestamp"]._in_dump = True
         data = pkg.dump()
         if subdir == "noarch" and getattr(pkg, "noarch", None):
             data["subdir"] = "noarch"
             data["platform"] = data["arch"] = None
-        if pkg.timestamp:
-            data["timestamp"] = pkg.timestamp
         if "features" in data:
             # Features are deprecated, so they are not implemented
             # in modern solvers like mamba. Mamba does implement


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This is needed for https://github.com/conda/conda-libmamba-solver/pull/414, which identifies a bug in how we export synthetic repodata to disk. `PackageRecord.timestamp` returns a `float` in seconds, but the JSON repodata should have an `int` in milliseconds. `TimestampField` has the necessary logic but it's not active by default; we are simply flipping that `in_dump` value so `PackageRecord.dump()` includes it.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
