### PR TITLE
Fix `context` bug with `CONDA_REPODATA_FNS` and improve some tests in `test_solve`

### DIFF
--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -3170,10 +3170,10 @@ def test_freeze_deps_1(tmpdir):
 
 def test_current_repodata_usage(tmpdir):
     # force this to False, because otherwise tests fail when run with old conda-build
-    with env_var(
-        "CONDA_USE_ONLY_TAR_BZ2", False, stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        solver = context.plugin_manager.get_cached_solver_backend()(
+    # explicitly set env var so libmamba recognizes the explicit setting (ignored otherwise)
+    config = {"CONDA_USE_ONLY_TAR_BZ2": False, "CONDA_REPODATA_FN": "current_repodata.json"}
+    with env_vars(config, stack_callback=conda_tests_ctxt_mgmt_def_pol):
+        solver = context.plugin_manager.get_solver_backend()(
             tmpdir.strpath,
             (Channel(CHANNEL_DIR),),
             ("win-64",),
@@ -3194,7 +3194,7 @@ def test_current_repodata_usage(tmpdir):
 
 
 def test_current_repodata_fallback(tmpdir):
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir.strpath,
         (Channel(CHANNEL_DIR),),
         ("win-64",),
@@ -3341,7 +3341,7 @@ def test_packages_in_solution_change_already_newest(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.1")]}
     post_packages = {"mypkg": [("mypkg", "0.1.1")]}
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[specs]
     )
     constrained = solver.get_constrained_packages(
@@ -3354,7 +3354,7 @@ def test_packages_in_solution_change_needs_update(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.0")]}
     post_packages = {"mypkg": [("mypkg", "0.1.1")]}
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[specs]
     )
     constrained = solver.get_constrained_packages(
@@ -3367,7 +3367,7 @@ def test_packages_in_solution_change_constrained(tmpdir):
     specs = MatchSpec("mypkg")
     pre_packages = {"mypkg": [("mypkg", "0.1.0")]}
     post_packages = {"mypkg": [("mypkg", "0.1.0")]}
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[specs]
     )
     constrained = solver.get_constrained_packages(
@@ -3408,7 +3408,7 @@ def test_determine_constricting_specs_conflicts(tmpdir):
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[spec]
     )
     constricting = solver.determine_constricting_specs(spec, solution_prec)
@@ -3447,7 +3447,7 @@ def test_determine_constricting_specs_conflicts_upperbound(tmpdir):
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[spec]
     )
     constricting = solver.determine_constricting_specs(spec, solution_prec)
@@ -3500,7 +3500,7 @@ def test_determine_constricting_specs_multi_conflicts(tmpdir):
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[spec]
     )
     constricting = solver.determine_constricting_specs(spec, solution_prec)
@@ -3540,7 +3540,7 @@ def test_determine_constricting_specs_no_conflicts_upperbound_compound_depends(t
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[spec]
     )
     constricting = solver.determine_constricting_specs(spec, solution_prec)
@@ -3579,7 +3579,7 @@ def test_determine_constricting_specs_no_conflicts_version_star(tmpdir):
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[spec]
     )
     constricting = solver.determine_constricting_specs(spec, solution_prec)
@@ -3604,7 +3604,7 @@ def test_determine_constricting_specs_no_conflicts_free(tmpdir):
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[spec]
     )
     constricting = solver.determine_constricting_specs(spec, solution_prec)
@@ -3643,7 +3643,7 @@ def test_determine_constricting_specs_no_conflicts_no_upperbound(tmpdir):
         ),
     ]
     spec = MatchSpec("mypkg")
-    solver = context.plugin_manager.get_cached_solver_backend()(
+    solver = context.plugin_manager.get_solver_backend()(
         tmpdir, (Channel(CHANNEL_DIR),), ("linux-64",), specs_to_add=[spec]
     )
     constricting = solver.determine_constricting_specs(spec, solution_prec)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Some tests in `test_solve` were using the cached solver backend, so the solver parametrization was not working properly.

Additionally, we explicitly set `CONDA_REPODATA_FNS` so libmamba can recognize it was asked for (and not injected in `conda.cli.install`). 

While doing this I discovered that the current `conda` will crash if `CONDA_REPODATA_FNS` is set to something _not_ including `repodata.json` because a list is expected but `context` returns a tuple.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
