### PR TITLE
add --no-repodata-zst flag

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -416,6 +416,7 @@ class Context(Configuration):
     )
     experimental = ParameterLoader(SequenceParameter(PrimitiveParameter("", str)))
     no_lock = ParameterLoader(PrimitiveParameter(False))
+    no_repodata_zst = ParameterLoader(PrimitiveParameter(False))
 
     ####################################################
     #               Solver Configuration               #
@@ -1163,6 +1164,7 @@ class Context(Configuration):
                 "fetch_threads",
                 "experimental",
                 "no_lock",
+                "no_jlap",
             ),
             "Basic Conda Configuration": (  # TODO: Is there a better category name here?
                 "envs_dirs",
@@ -1832,6 +1834,12 @@ class Context(Configuration):
             no_lock=dals(
                 """
                 Disable index cache lock (defaults to enabled).
+                """
+            ),
+            no_jlap=dals(
+                """
+                Disable `repodata.json.zst` and `repodata.jlap` incremental
+                index updates when supplied by the remote (defaults to enabled).
                 """
             ),
         )

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -222,6 +222,11 @@ def add_parser_channels(p: ArgumentParser) -> _ArgumentGroup:
         action="store_true",
         help="Disable locking when reading, updating index (repodata.json) cache. ",
     )
+    channel_customization_options.add_argument(
+        "--no-repodata-zst",
+        action="store_true",
+        help="Do not check for repodata.json.zst.",
+    )
     return channel_customization_options
 
 

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -106,12 +106,13 @@ def get_repo_interface() -> type[RepoInterface]:
                 f"Is the required jsonpatch package installed?  {e}"
             )
 
-    try:
-        from .jlap.interface import ZstdRepoInterface
+    if not context.no_repodata_zst:
+        try:
+            from .jlap.interface import ZstdRepoInterface
 
-        return ZstdRepoInterface
-    except ImportError:  # pragma: no cover
-        pass
+            return ZstdRepoInterface
+        except ImportError:  # pragma: no cover
+            pass
 
     return CondaRepoInterface
 

--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -255,6 +255,10 @@ def download_and_hash(
             for block in response.iter_content(chunk_size=1 << 14):
                 repodata.write(block)
     if response.request:
+        try:
+            length = int(response.headers["Content-Length"])
+        except (KeyError, ValueError, AttributeError):
+            pass
         log.info("Download %d bytes %r", length, response.request.headers)
     return response  # can be 304 not modified
 
@@ -424,7 +428,7 @@ def request_url_jlap_state(
                 with timeme("Write changed "), temp_path.open("wb") as repodata:
                     hasher = hash()
                     HashWriter(repodata, hasher).write(
-                        json.dumps(repodata_json).encode("utf-8")
+                        json.dumps(repodata_json, separators=(",", ":")).encode("utf-8")
                     )
 
                     # actual hash of serialized json

--- a/news/13491-no-repodata-zst-flag
+++ b/news/13491-no-repodata-zst-flag
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Add `--no-repodata-zst` flag to skip `repodata.json.zst` check. Useful if
+  remote returns unparseable `repodata.json.zst` instead of correct data or 404.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix #13491 

If remote returns valid data, or a normal 404 then `repdodata.json.zst` will provide a nice speedup or a weekly re-check and fallback to `repodata.json`. When a server returns unparseable `repodata.json.zst` or a bad error code, this flag enables the older network code and does not look for `repodata.json.zst` at all.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
