### PR TITLE
update `test_offline_with_empty_index_cache` for libmamba

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -6,6 +6,7 @@ import re
 import sys
 from datetime import datetime
 from glob import glob
+from importlib.metadata import version as metadata_version
 from itertools import zip_longest
 from json import loads as json_loads
 from logging import getLogger
@@ -2552,9 +2553,11 @@ def test_offline_with_empty_index_cache():
                             "flask",
                             "--offline",
                         )
-                        if context.solver == "libmamba":
-                            # libmamba solver expects repodata to be loaded into Repo objects
-                            # It doesn't use the info from the tarball cache as conda does
+                        if (
+                            context.solver == "libmamba"
+                            and metadata_version("conda-libmamba-solver") <= "23.12.0"
+                        ):
+                            # conda-libmamba-solver <=23.12.0 didn't load pkgs_dirs when offline
                             with pytest.raises((RuntimeError, UnsatisfiableError)):
                                 run_command(*command)
                         else:
@@ -2564,7 +2567,8 @@ def test_offline_with_empty_index_cache():
                             assert package_is_installed(prefix, "flask")
 
                             # The mock should have been called with our local channel URL though.
-                            assert result_dict.get("local_channel_seen")
+                            if context.solver != "libmamba":
+                                assert result_dict.get("local_channel_seen")
 
                         # Fails because pytz cannot be found in available channels.
                         # TODO: conda-libmamba-solver <=23.9.1 raises an ugly RuntimeError


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

With https://github.com/conda/conda-libmamba-solver/pull/423, conda-libmamba-solver will now load `pkgs_dirs` when invoked in offline mode. Update the test to reflect so.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
