### PR TITLE
Prevent accidental `context` reinitialization after using `make_temp_package_cache`

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -44,7 +44,7 @@ def generate_parser(*args, **kwargs):
     return generate_parser(*args, **kwargs)
 
 
-def main_subshell(*args, post_parse_hook=None, **kwargs):
+def main_subshell(*args, post_parse_hook=None, _context_search_path=None, **kwargs):
     """Entrypoint for the "subshell" invocation of CLI interface. E.g. `conda create`."""
     # defer import here so it doesn't hit the 'conda shell.*' subcommands paths
     from ..base.context import context
@@ -63,17 +63,17 @@ def main_subshell(*args, post_parse_hook=None, **kwargs):
         "verbosity": pre_args.verbosity,
     }
 
-    context.__init__(argparse_args=pre_args)
+    context.__init__(argparse_args=pre_args, search_path=_context_search_path)
     if context.no_plugins:
         context.plugin_manager.disable_external_plugins()
 
     # reinitialize in case any of the entrypoints modified the context
-    context.__init__(argparse_args=pre_args)
+    context.__init__(argparse_args=pre_args, search_path=_context_search_path)
 
     parser = generate_parser(add_help=True)
     args = parser.parse_args(args, override_args=override_args, namespace=pre_args)
 
-    context.__init__(argparse_args=args)
+    context.__init__(argparse_args=args, search_path=_context_search_path)
     init_loggers()
 
     # used with main_pip.py

--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -276,7 +276,14 @@ class TmpEnvFixture:
         prefix = Path(prefix or self.path_factory())
 
         with self.conda_cli.capsys.disabled():
-            self.conda_cli("create", "--prefix", prefix, *packages, "--yes", context_search_path=context_search_path)
+            self.conda_cli(
+                "create",
+                "--prefix",
+                prefix,
+                *packages,
+                "--yes",
+                context_search_path=context_search_path,
+            )
         yield prefix
 
         # no need to remove prefix since it is in a temporary directory

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -80,7 +80,9 @@ def test_clean_force_pkgs_dirs(
         assert pkgs_dir.is_dir()
 
         with tmp_env(pkg, context_search_path=()):
-            stdout, _, _ = conda_cli("clean", "--force-pkgs-dirs", "--yes", "--json", context_search_path=())
+            stdout, _, _ = conda_cli(
+                "clean", "--force-pkgs-dirs", "--yes", "--json", context_search_path=()
+            )
             json.loads(stdout)  # assert valid json
 
             # pkgs_dir is removed
@@ -107,14 +109,26 @@ def test_clean_and_packages(
             assert has_pkg(pkg, _get_pkgs(pkgs_dir))
 
             # --json flag is regression test for #5451
-            stdout, _, _ = conda_cli("clean", "--packages", "--yes", "--json", context_search_path=())
+            stdout, _, _ = conda_cli(
+                "clean", "--packages", "--yes", "--json", context_search_path=()
+            )
             json.loads(stdout)  # assert valid json
 
             # pkg still exists since its in use by temp env
             assert has_pkg(pkg, _get_pkgs(pkgs_dir))
 
-            conda_cli("remove", "--prefix", prefix, pkg, "--yes", "--json", context_search_path=())
-            stdout, _, _ = conda_cli("clean", "--packages", "--yes", "--json", context_search_path=())
+            conda_cli(
+                "remove",
+                "--prefix",
+                prefix,
+                pkg,
+                "--yes",
+                "--json",
+                context_search_path=(),
+            )
+            stdout, _, _ = conda_cli(
+                "clean", "--packages", "--yes", "--json", context_search_path=()
+            )
             json.loads(stdout)  # assert valid json
 
             # pkg is removed
@@ -141,7 +155,9 @@ def test_clean_tarballs(
             assert has_pkg(pkg, _get_tars(pkgs_dir))
 
             # --json flag is regression test for #5451
-            stdout, _, _ = conda_cli("clean", "--tarballs", "--yes", "--json", context_search_path=())
+            stdout, _, _ = conda_cli(
+                "clean", "--tarballs", "--yes", "--json", context_search_path=()
+            )
             json.loads(stdout)  # assert valid json
 
             # tarball is removed
@@ -167,7 +183,9 @@ def test_clean_index_cache(
             # index cache exists
             assert _get_index_cache()
 
-            stdout, _, _ = conda_cli("clean", "--index-cache", "--yes", "--json", context_search_path=())
+            stdout, _, _ = conda_cli(
+                "clean", "--index-cache", "--yes", "--json", context_search_path=()
+            )
             json.loads(stdout)  # assert valid json
 
             # index cache is cleared
@@ -210,7 +228,12 @@ def test_clean_tempfiles(
 
             # --json flag is regression test for #5451
             stdout, _, _ = conda_cli(
-                "clean", "--tempfiles", pkgs_dir, "--yes", "--json", context_search_path=(),
+                "clean",
+                "--tempfiles",
+                pkgs_dir,
+                "--yes",
+                "--json",
+                context_search_path=(),
             )
             json.loads(stdout)  # assert valid json
 
@@ -249,7 +272,9 @@ def test_clean_logfiles(
             assert path in _get_logfiles(pkgs_dir)
 
             # --json flag is regression test for #5451
-            stdout, _, _ = conda_cli("clean", "--logfiles", "--yes", "--json", context_search_path=())
+            stdout, _, _ = conda_cli(
+                "clean", "--logfiles", "--yes", "--json", context_search_path=()
+            )
             json.loads(stdout)  # assert valid json
 
             # logfiles removed
@@ -334,7 +359,9 @@ def test_clean_all_mock_lstat(
     if as_json:
         args = (*args, "--json")
 
-    with make_temp_package_cache() as pkgs_dir, tmp_env(pkg, context_search_path=()) as prefix:
+    with make_temp_package_cache() as pkgs_dir, tmp_env(
+        pkg, context_search_path=()
+    ) as prefix:
         # pkg, tarball, & index cache exists
         pkgs, tars, cache = _get_all(pkgs_dir)
         assert has_pkg(pkg, pkgs)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2590,6 +2590,7 @@ def test_offline_with_empty_index_cache():
 def test_create_from_extracted():
     with make_temp_package_cache() as pkgs_dir:
         assert context.pkgs_dirs == (pkgs_dir,)
+
         # NOTE: Using conda_cli or derivatives (tmp_env) WILL require
         # 'context_search_path=()' to avoid re-loading custom config from ~/.condarc
         def pkgs_dir_has_tarball(tarball_prefix):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2590,7 +2590,8 @@ def test_offline_with_empty_index_cache():
 def test_create_from_extracted():
     with make_temp_package_cache() as pkgs_dir:
         assert context.pkgs_dirs == (pkgs_dir,)
-
+        # NOTE: Using conda_cli or derivatives (tmp_env) WILL require
+        # 'context_search_path=()' to avoid re-loading custom config from ~/.condarc
         def pkgs_dir_has_tarball(tarball_prefix):
             return any(
                 f.startswith(tarball_prefix)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This fixes a tricky issue seen in https://github.com/conda/conda-libmamba-solver/pull/423#issuecomment-1898149457 and then https://github.com/conda/conda-libmamba-solver/pull/426.

It all starts with these errors:

```
FAILED tests/cli/test_main_clean.py::test_clean_tarballs - AssertionError: assert False
 +  where False = has_pkg('zlib', [])
 +    where [] = _get_tars('/var/folders/mm/pltwc2yj1jx192t6dzy9zsrr0000gn/T/1dd3 dcafbe/pkgs')
FAILED tests/cli/test_main_clean.py::test_clean_all[True] - AssertionError: assert False
 +  where False = has_pkg('zlib', [PosixPath('/var/folders/mm/pltwc2yj1jx192t6dzy9zsrr0000gn/T/9650 cbfdae/pkgs/cache')])
FAILED tests/cli/test_main_clean.py::test_clean_all_mock_lstat[True] - AssertionError: assert False
 +  where False = has_pkg('zlib', [PosixPath('/var/folders/mm/pltwc2yj1jx192t6dzy9zsrr0000gn/T/beba ecfdab/pkgs/cache')])
```

In other words, the tests expect to find a certain tarball in those paths. These have been set up as a temporary package cache location. It should be the _only_ path in `context.pkgs_dirs`, `make_temp_package_cache` had ensured that the context object was reset with an empty `search_path=()` to ignore the user configuration. In fact, there's an assertion to make sure that's the case:

https://github.com/conda/conda/blob/f825c702c4a1f915cbe5aaef627ed349c4205826/conda/testing/integration.py#L344

However, when `tmp_env` and `conda_cli` are used right after, they end up calling `conda.cli.main.main_subshell`, which mercilessly resets the context with the default search path. Since some OSs in our CI uses setup-miniconda, which sets up `pkgs_dirs` to `~/conda_pkgs_dirs` in `~/.condarc`, this ends up leaking back into the tests.

In some cases, `ProgressiveFetchExtract` ends up choosing `~/conda_pkgs_dirs` instead of the temporary location, and the test assertion fails.

My proposed fix is to expose `search_path` privately in `conda.cli.main.main_subshell` so then it can be invoked properly from `conda_cli` and friends. However, this is a bit too verbose in the tests. There might be a better way?

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
