### PR TITLE
Update `test_metadata_cache_clearing`

### DIFF
--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -272,6 +272,7 @@ def test_metadata_cache_clearing(mocker, platform=OVERRIDE_PLATFORM):
             fetcher = mocker.patch.object(
                 RepoInterface, "repodata_parsed", return_value={}
             )
+        SubdirData(channel).cache_path_json.touch()
 
         sd_a = SubdirData(channel)
         precs_a = tuple(sd_a.query("zlib"))


### PR DESCRIPTION
Fixes the `tests/core/test_subdir_data.py::test_metadata_cache_clearing` test to eliminate situations where it can't detect the metadata cache file (due to a possible race condition in some instances where the test is trying to access the file before it has been fully created).