### PR TITLE
Load config files from correct location.

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -21,9 +21,9 @@ from os.path import split as path_split
 from typing import TYPE_CHECKING
 
 try:
-    from platformdirs import user_data_dir
+    from platformdirs import user_config_dir
 except ImportError:  # pragma: no cover
-    from .._vendor.appdirs import user_data_dir
+    from .._vendor.appdirs import user_data_dir as user_config_dir
 
 try:
     from boltons.setutils import IndexedSet
@@ -132,7 +132,7 @@ def mockable_context_envs_dirs(root_writable, root_prefix, _envs_dirs):
             join(root_prefix, "envs"),
         ]
     if on_win:
-        fixed_dirs.append(join(user_data_dir(APP_NAME, APP_NAME), "envs"))
+        fixed_dirs.append(join(user_config_dir(APP_NAME, APP_NAME), "envs"))
     return tuple(IndexedSet(expand(path) for path in (*_envs_dirs, *fixed_dirs)))
 
 
@@ -685,7 +685,7 @@ class Context(Configuration):
                 join("~", ".conda"),
             )
             if on_win:
-                fixed_dirs += (user_data_dir(APP_NAME, APP_NAME),)
+                fixed_dirs += (user_config_dir(APP_NAME, APP_NAME),)
             return tuple(
                 IndexedSet(expand(join(p, cache_dir_name)) for p in (fixed_dirs))
             )

--- a/conda/gateways/anaconda_client.py
+++ b/conda/gateways/anaconda_client.py
@@ -8,9 +8,9 @@ from os.path import isdir, isfile, join
 from stat import S_IREAD, S_IWRITE
 
 try:
-    from platformdirs import user_data_dir
+    from platformdirs import user_config_dir
 except ImportError:  # pragma: no cover
-    from .._vendor.appdirs import user_data_dir
+    from .._vendor.appdirs import user_data_dir as user_config_dir
 
 from ..common.url import quote_plus, unquote_plus
 from ..deprecations import deprecated
@@ -52,7 +52,7 @@ def _get_binstar_token_directory():
     if "BINSTAR_CONFIG_DIR" in os.environ:
         return os.path.join(os.environ["BINSTAR_CONFIG_DIR"], "data")
     else:
-        return user_data_dir(appname="binstar", appauthor="ContinuumIO")
+        return user_config_dir(appname="binstar", appauthor="ContinuumIO")
 
 
 def read_binstar_tokens():

--- a/news/13517-userdata
+++ b/news/13517-userdata
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix the config file location where the integrated Anaconda client gateway
+  loads user configuration from. This is a regression introduced in conda
+  23.11.0 when the `platformdirs` library was adopted. (#13517)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix the config file location where the integrated Anaconda client gateway loads user configuration from. This is a regression introduced in conda 23.11.0 when the `platformdirs` library was adopted.

Closes #13517.


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
