### PR TITLE
allow None for cache-control header, interpret as 0

### DIFF
--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -937,7 +937,8 @@ def cache_fn_url(url, repodata_fn=REPODATA_FN):
     return f"{md5.hexdigest()[:8]}.json"
 
 
-def get_cache_control_max_age(cache_control_value: str):
+def get_cache_control_max_age(cache_control_value: str | None):
+    cache_control_value = cache_control_value or ""
     max_age = re.search(r"max-age=(\d+)", cache_control_value)
     return int(max_age.groups()[0]) if max_age else 0
 

--- a/news/no-cache-control
+++ b/news/no-cache-control
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * Interpret missing `Cache-Control` header as `max-age=0` instead of exception.
+  (#13522)
 
 ### Deprecations
 

--- a/news/no-cache-control
+++ b/news/no-cache-control
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Interpret missing `Cache-Control` header as `max-age=0` instead of exception.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -39,6 +39,7 @@ from conda.gateways.repodata import (
     RepodataIsEmpty,
     RepodataState,
     conda_http_errors,
+    get_cache_control_max_age,
 )
 from conda.gateways.repodata.jlap.interface import JlapRepoInterface
 from conda.models.channel import Channel
@@ -373,3 +374,11 @@ def test_repodata_fetch_cached(
         for key in "mtime_ns", "size", "refresh_ns":
             state.pop(key)
         assert state == {}
+
+
+def test_get_cache_control_max_age():
+    """
+    Test that we are robust against None cache-control-max-age
+    """
+    assert get_cache_control_max_age('cache_control = "public, max-age=30"') == 30
+    assert get_cache_control_max_age(None) == 0


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I noticed this while using conda-build. Probably this is mainly an issue with older cache that contained the "save cache-control as None" bug, that we have also fixed by not writing bad cache state.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
