### PR TITLE
Set `--use-repodata-zst` argument as `NULL`, rename `no_repodata_zst` to `use_repodata_zst`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ command line interface related to environment management. (#13168)
 * Provide a more useful warning when attempting to rename a non-existent prefix. (#13387)
 * Add a new flag `--keep-env` to be used with `conda remove --all`. It allows users to delete all packages in the environment while retaining the environment itself. (#13419)
 * Add a Y/N prompt warning users that `conda env remove` and `conda remove --all` deletes not only the conda packages but the entirety of the specified environment. (#13440)
-* Add `--use-repodata-zst/--no-use-repodata-zst` flag to control `repodata.json.zst` check; corresponding `use_repodata_zst: true/false` for `.condarc`. Default is to check for `repodata.json.zst`. Disable if remote returns unparseable `repodata.json.zst` instead of correct data or 404. (#13504)
+* Add `--repodata-use-zst/--no-repodata-use-zst` flag to control `repodata.json.zst` check; corresponding `repodata_use_zst: true/false` for `.condarc`. Default is to check for `repodata.json.zst`. Disable if remote returns unparseable `repodata.json.zst` instead of correct data or 404. (#13504)
 
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ command line interface related to environment management. (#13168)
 * Provide a more useful warning when attempting to rename a non-existent prefix. (#13387)
 * Add a new flag `--keep-env` to be used with `conda remove --all`. It allows users to delete all packages in the environment while retaining the environment itself. (#13419)
 * Add a Y/N prompt warning users that `conda env remove` and `conda remove --all` deletes not only the conda packages but the entirety of the specified environment. (#13440)
-* Add `--no-repodata-zst` flag to skip `repodata.json.zst` check. Useful if the repo returns unparseable `repodata.json.zst` instead of correct data or 404. (#13504)
+* Add `--use-repodata-zst/--no-use-repodata-zst` flag to control `repodata.json.zst` check; corresponding `use_repodata_zst: true/false` for `.condarc`. Default is to check for `repodata.json.zst`. Disable if remote returns unparseable `repodata.json.zst` instead of correct data or 404. (#13504)
+
 
 ### Bug fixes
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -416,7 +416,7 @@ class Context(Configuration):
     )
     experimental = ParameterLoader(SequenceParameter(PrimitiveParameter("", str)))
     no_lock = ParameterLoader(PrimitiveParameter(False))
-    use_repodata_zst = ParameterLoader(PrimitiveParameter(True))
+    repodata_use_zst = ParameterLoader(PrimitiveParameter(True))
 
     ####################################################
     #               Solver Configuration               #
@@ -1164,7 +1164,7 @@ class Context(Configuration):
                 "fetch_threads",
                 "experimental",
                 "no_lock",
-                "use_repodata_zst",
+                "repodata_use_zst",
             ),
             "Basic Conda Configuration": (  # TODO: Is there a better category name here?
                 "envs_dirs",
@@ -1836,7 +1836,7 @@ class Context(Configuration):
                 Disable index cache lock (defaults to enabled).
                 """
             ),
-            no_use_repodata_zst=dals(
+            repodata_use_zst=dals(
                 """
                 Disable check for `repodata.json.zst`; use `repodata.json` only.
                 """

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -416,7 +416,7 @@ class Context(Configuration):
     )
     experimental = ParameterLoader(SequenceParameter(PrimitiveParameter("", str)))
     no_lock = ParameterLoader(PrimitiveParameter(False))
-    no_repodata_zst = ParameterLoader(PrimitiveParameter(False), aliases=("no_use_repodata_zst",))
+    use_repodata_zst = ParameterLoader(PrimitiveParameter(True))
 
     ####################################################
     #               Solver Configuration               #
@@ -1164,7 +1164,7 @@ class Context(Configuration):
                 "fetch_threads",
                 "experimental",
                 "no_lock",
-                "no_repodata_zst",
+                "use_repodata_zst",
             ),
             "Basic Conda Configuration": (  # TODO: Is there a better category name here?
                 "envs_dirs",
@@ -1836,7 +1836,7 @@ class Context(Configuration):
                 Disable index cache lock (defaults to enabled).
                 """
             ),
-            no_repodata_zst=dals(
+            no_use_repodata_zst=dals(
                 """
                 Disable check for `repodata.json.zst`; use `repodata.json` only.
                 """

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -416,7 +416,7 @@ class Context(Configuration):
     )
     experimental = ParameterLoader(SequenceParameter(PrimitiveParameter("", str)))
     no_lock = ParameterLoader(PrimitiveParameter(False))
-    no_repodata_zst = ParameterLoader(PrimitiveParameter(False))
+    no_repodata_zst = ParameterLoader(PrimitiveParameter(False), aliases=("no_use_repodata_zst",))
 
     ####################################################
     #               Solver Configuration               #

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -18,24 +18,26 @@ try:
 except ImportError:
     # Python < 3.9
     from argparse import Action
+
     class BooleanOptionalAction(Action):
         # from Python 3.9+ argparse.py
-        def __init__(self,
-                    option_strings,
-                    dest,
-                    default=None,
-                    type=None,
-                    choices=None,
-                    required=False,
-                    help=None,
-                    metavar=None):
-
+        def __init__(
+            self,
+            option_strings,
+            dest,
+            default=None,
+            type=None,
+            choices=None,
+            required=False,
+            help=None,
+            metavar=None,
+        ):
             _option_strings = []
             for option_string in option_strings:
                 _option_strings.append(option_string)
 
-                if option_string.startswith('--'):
-                    option_string = '--no-' + option_string[2:]
+                if option_string.startswith("--"):
+                    option_string = "--no-" + option_string[2:]
                     _option_strings.append(option_string)
 
             super().__init__(
@@ -47,15 +49,15 @@ except ImportError:
                 choices=choices,
                 required=required,
                 help=help,
-                metavar=metavar)
-
+                metavar=metavar,
+            )
 
         def __call__(self, parser, namespace, values, option_string=None):
             if option_string in self.option_strings:
-                setattr(namespace, self.dest, not option_string.startswith('--no-'))
+                setattr(namespace, self.dest, not option_string.startswith("--no-"))
 
         def format_usage(self):
-            return ' | '.join(self.option_strings)
+            return " | ".join(self.option_strings)
 
 
 def add_parser_create_install_update(p, prefix_required=False):

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -15,7 +15,7 @@ from argparse import (
 
 try:
     from argparse import BooleanOptionalAction
-except:
+except ImportError:
     # Python < 3.9
     from argparse import Action
     class BooleanOptionalAction(Action):

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -225,6 +225,7 @@ def add_parser_channels(p: ArgumentParser) -> _ArgumentGroup:
     channel_customization_options.add_argument(
         "--no-repodata-zst",
         action="store_true",
+        default=NULL,
         help="Do not check for repodata.json.zst.",
     )
     return channel_customization_options

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -13,6 +13,50 @@ from argparse import (
     _MutuallyExclusiveGroup,
 )
 
+try:
+    from argparse import BooleanOptionalAction
+except:
+    # Python < 3.9
+    from argparse import Action
+    class BooleanOptionalAction(Action):
+        # from Python 3.9+ argparse.py
+        def __init__(self,
+                    option_strings,
+                    dest,
+                    default=None,
+                    type=None,
+                    choices=None,
+                    required=False,
+                    help=None,
+                    metavar=None):
+
+            _option_strings = []
+            for option_string in option_strings:
+                _option_strings.append(option_string)
+
+                if option_string.startswith('--'):
+                    option_string = '--no-' + option_string[2:]
+                    _option_strings.append(option_string)
+
+            super().__init__(
+                option_strings=_option_strings,
+                dest=dest,
+                nargs=0,
+                default=default,
+                type=type,
+                choices=choices,
+                required=required,
+                help=help,
+                metavar=metavar)
+
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            if option_string in self.option_strings:
+                setattr(namespace, self.dest, not option_string.startswith('--no-'))
+
+        def format_usage(self):
+            return ' | '.join(self.option_strings)
+
 
 def add_parser_create_install_update(p, prefix_required=False):
     from ..common.constants import NULL
@@ -222,11 +266,13 @@ def add_parser_channels(p: ArgumentParser) -> _ArgumentGroup:
         action="store_true",
         help="Disable locking when reading, updating index (repodata.json) cache. ",
     )
+
     channel_customization_options.add_argument(
-        "--no-repodata-zst",
-        action="store_true",
+        "--use-repodata-zst",
+        action=BooleanOptionalAction,
+        dest="use_repodata_zst",
         default=NULL,
-        help="Do not check for repodata.json.zst.",
+        help="Check for/do not check for repodata.json.zst. Enabled by default.",
     )
     return channel_customization_options
 

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -268,9 +268,9 @@ def add_parser_channels(p: ArgumentParser) -> _ArgumentGroup:
     )
 
     channel_customization_options.add_argument(
-        "--use-repodata-zst",
+        "--repodata-use-zst",
         action=BooleanOptionalAction,
-        dest="use_repodata_zst",
+        dest="repodata_use_zst",
         default=NULL,
         help="Check for/do not check for repodata.json.zst. Enabled by default.",
     )

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -106,7 +106,7 @@ def get_repo_interface() -> type[RepoInterface]:
                 f"Is the required jsonpatch package installed?  {e}"
             )
 
-    if not context.no_repodata_zst:
+    if context.use_repodata_zst:
         try:
             from .jlap.interface import ZstdRepoInterface
 

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -106,7 +106,7 @@ def get_repo_interface() -> type[RepoInterface]:
                 f"Is the required jsonpatch package installed?  {e}"
             )
 
-    if context.use_repodata_zst:
+    if context.repodata_use_zst:
         try:
             from .jlap.interface import ZstdRepoInterface
 

--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -369,7 +369,9 @@ def test_jlap_flag(use_jlap):
 
 @pytest.mark.parametrize("repodata_use_zst", [True, False])
 def test_repodata_use_zst(repodata_use_zst):
-    expected = CondaRepoInterface if not repodata_use_zst else interface.ZstdRepoInterface
+    expected = (
+        CondaRepoInterface if not repodata_use_zst else interface.ZstdRepoInterface
+    )
     with env_vars(
         {"CONDA_REPODATA_USE_ZST": repodata_use_zst},
         stack_callback=conda_tests_ctxt_mgmt_def_pol,

--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -367,11 +367,11 @@ def test_jlap_flag(use_jlap):
             assert get_repo_interface() is interface.JlapRepoInterface
 
 
-@pytest.mark.parametrize("no_repodata_zst", [True, False])
-def test_no_repodata_zst(no_repodata_zst):
-    expected = CondaRepoInterface if no_repodata_zst else interface.ZstdRepoInterface
+@pytest.mark.parametrize("use_repodata_zst", [True, False])
+def test_use_repodata_zst(use_repodata_zst):
+    expected = CondaRepoInterface if not use_repodata_zst else interface.ZstdRepoInterface
     with env_vars(
-        {"CONDA_NO_REPODATA_ZST": no_repodata_zst},
+        {"CONDA_USE_REPODATA_ZST": use_repodata_zst},
         stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
         assert get_repo_interface() is expected

--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -367,11 +367,11 @@ def test_jlap_flag(use_jlap):
             assert get_repo_interface() is interface.JlapRepoInterface
 
 
-@pytest.mark.parametrize("use_repodata_zst", [True, False])
-def test_use_repodata_zst(use_repodata_zst):
-    expected = CondaRepoInterface if not use_repodata_zst else interface.ZstdRepoInterface
+@pytest.mark.parametrize("repodata_use_zst", [True, False])
+def test_repodata_use_zst(repodata_use_zst):
+    expected = CondaRepoInterface if not repodata_use_zst else interface.ZstdRepoInterface
     with env_vars(
-        {"CONDA_USE_REPODATA_ZST": use_repodata_zst},
+        {"CONDA_REPODATA_USE_ZST": repodata_use_zst},
         stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
         assert get_repo_interface() is expected


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Use NULL in argparse default value to avoid argparse overriding config file or environment variable.

Fix #13528 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
