### PR TITLE
Pass traceback, not str, to exception formatter.

### DIFF
--- a/conda/exception_handler.py
+++ b/conda/exception_handler.py
@@ -52,7 +52,6 @@ class ExceptionHandler:
             CondaError,
             CondaMemoryError,
             NoSpaceLeftError,
-            _format_exc,
         )
 
         if isinstance(exc_val, CondaError):
@@ -68,7 +67,7 @@ class ExceptionHandler:
         if isinstance(exc_val, MemoryError):
             return self.handle_application_exception(CondaMemoryError(exc_val), exc_tb)
         if isinstance(exc_val, KeyboardInterrupt):
-            self._print_conda_exception(CondaError("KeyboardInterrupt"), _format_exc())
+            self._print_conda_exception(CondaError("KeyboardInterrupt"), exc_tb)
             return 1
         if isinstance(exc_val, SystemExit):
             return exc_val.code

--- a/news/13531-keyboardinterrupt-traceback
+++ b/news/13531-keyboardinterrupt-traceback
@@ -4,8 +4,8 @@
 
 ### Bug fixes
 
-* Print traceback on KeyboardInterrupt instead of raising another
-  AttributeError exception. (#13531)
+* Print traceback on `KeyboardInterrupt` instead of raising another
+  `AttributeError` exception. (#13531)
 
 ### Deprecations
 

--- a/news/13531-keyboardinterrupt-traceback
+++ b/news/13531-keyboardinterrupt-traceback
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 * Print traceback on `KeyboardInterrupt` instead of raising another
-  `AttributeError` exception. (#13531)
+  `AttributeError` exception, when conda debugging logs are enabled. (#13531)
 
 ### Deprecations
 

--- a/news/13531-keyboardinterrupt-traceback
+++ b/news/13531-keyboardinterrupt-traceback
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Print traceback on KeyboardInterrupt instead of raising another
+  AttributeError exception. (#13531)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
Fix #13531

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
