### PR TITLE
add zstandard as a run dependency

### DIFF
--- a/docs/source/user-guide/concepts/conda-plugins.rst
+++ b/docs/source/user-guide/concepts/conda-plugins.rst
@@ -30,8 +30,7 @@ Below is an example of a very basic plugin "hook":
 
 
    @conda.plugins.hookimpl
-   def conda_subcommands():
-       ...
+   def conda_subcommands(): ...
 
 
 Packaging using a pyproject.toml file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "setuptools >=60.0.0",
   "tqdm >=4",
   "truststore >=0.8.0; python_version>='3.10'",
+  "zstandard >=0.15",
 ]
 description = "OS-agnostic, system-level binary package manager."
 dynamic = ["version"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,7 @@ requirements:
     - setuptools >=60.0.0
     - tqdm >=4
     - truststore >=0.8.0           # [py>=310]
+    - zstandard >=0.15
   run_constrained:
     - conda-build >=3.27
     - conda-content-trust >=0.1.1


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Add zstandard as a runtime dependency (was transitively included via conda-package-handling / streaming). Used to fetch repodata.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
