### PR TITLE
Enable `conda rename` to not throw a `TypeError` when conda is not activated

### DIFF
--- a/conda/cli/main_rename.py
+++ b/conda/cli/main_rename.py
@@ -92,7 +92,7 @@ def validate_src() -> str:
         )
     if prefix.samefile(context.root_prefix):
         raise CondaEnvException("The 'base' environment cannot be renamed")
-    if prefix.samefile(context.active_prefix):
+    if context.active_prefix and prefix.samefile(context.active_prefix):
         raise CondaEnvException("Cannot rename the active environment")
 
     return context.target_prefix

--- a/news/13565-conda-can-rename-while-inactive
+++ b/news/13565-conda-can-rename-while-inactive
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* `conda rename` command no longer throws an error when conda is not active. (# 13565)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes https://github.com/conda/conda/issues/11850