### PR TITLE
Optimize import time for `conda activate`

### DIFF
--- a/conda/auxlib/compat.py
+++ b/conda/auxlib/compat.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict as odict  # noqa: F401
 import os
 from shlex import split
-from tempfile import NamedTemporaryFile
 
 from ..deprecations import deprecated
 
@@ -33,6 +32,8 @@ def utf8_writer(fp):
 def Utf8NamedTemporaryFile(
     mode="w+b", buffering=-1, newline=None, suffix=None, prefix=None, dir=None, delete=True
 ):
+    from tempfile import NamedTemporaryFile
+
     if "CONDA_TEST_SAVE_TEMPS" in os.environ:
         delete = False
     encoding = None

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -46,11 +46,11 @@ from ..common.configuration import (
     SequenceParameter,
     ValidationError,
 )
+from ..common.constants import TRACE
 from ..common.iterators import unique
 from ..common.path import expand, paths_equal
 from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..deprecations import deprecated
-from ..gateways.logging import TRACE
 from .constants import (
     APP_NAME,
     DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -21,11 +21,6 @@ from os.path import split as path_split
 from typing import TYPE_CHECKING
 
 try:
-    from platformdirs import user_data_dir
-except ImportError:  # pragma: no cover
-    from .._vendor.appdirs import user_data_dir
-
-try:
     from boltons.setutils import IndexedSet
 except ImportError:  # pragma: no cover
     from .._vendor.boltons.setutils import IndexedSet
@@ -78,6 +73,8 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from ..plugins.manager import CondaPluginManager
 
 
@@ -118,6 +115,21 @@ _arch_names = {
 
 user_rc_path = abspath(expanduser("~/.condarc"))
 sys_rc_path = join(sys.prefix, ".condarc")
+
+
+def user_data_dir(
+    appname: str | None = None,
+    appauthor: str | None | Literal[False] = None,
+    version: str | None = None,
+    roaming: bool = False,
+):
+    # Defer platformdirs import to reduce import time for conda activate.
+    global user_data_dir
+    try:
+        from platformdirs import user_data_dir
+    except ImportError:  # pragma: no cover
+        from .._vendor.appdirs import user_data_dir
+    return user_data_dir(appname, appauthor=appauthor, version=version, roaming=roaming)
 
 
 def mockable_context_envs_dirs(root_writable, root_prefix, _envs_dirs):

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -95,7 +95,6 @@ def main_sourced(shell, *args, **kwargs):
     from ..base.context import context
 
     context.__init__()
-    init_loggers()
 
     from ..activate import _build_activator_cls
 

--- a/conda/common/constants.py
+++ b/conda/common/constants.py
@@ -8,3 +8,6 @@ from ..auxlib import NULL
 #   to null, or the key didn't exist at all.  There could be a bit of potential confusion here,
 #   because in python null == None, while here I'm defining NULL to mean 'not defined'.
 NULL = NULL
+
+# Custom "trace" logging level for output more verbose than debug logs (logging.DEBUG == 10).
+TRACE = 5

--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -25,8 +25,8 @@ class DeprecatedError(RuntimeError):
 # inspired by deprecation (https://deprecation.readthedocs.io/en/latest/) and
 # CPython's warnings._deprecated
 class DeprecationHandler:
-    _version_str: str
-    _version_tuple: tuple[int, ...]
+    _version_str: str | None
+    _version_tuple: tuple[int, ...] | None
     _version_object: Version | None
 
     def __init__(self, version: Version | str):
@@ -40,7 +40,10 @@ class DeprecationHandler:
         if version is not None:
             self._version_str = str(version)
             if not isinstance(version, str):
-                self._version_object = version
+                from packaging.version import Version
+
+                if isinstance(version, Version):
+                    self._version_object = version
             # Try to parse the version string as a simple tuple[int, ...] to
             # avoid packaging.version import and costlier version comparisons.
             self._version_tuple = self._get_version_tuple(self._version_str)

--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 
 import sys
 import warnings
-from argparse import Action
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import Action
+    from typing import Any, Callable
 
 from packaging.version import Version, parse
 

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -18,6 +18,7 @@ from logging import (
 )
 
 from .. import CondaError
+from ..common.constants import TRACE
 from ..common.io import _FORMATTER, attach_stderr_handler
 from ..deprecations import deprecated
 
@@ -28,7 +29,7 @@ _VERBOSITY_LEVELS = {
     1: WARN,  # -v, detailed output
     2: INFO,  # -vv, info logging
     3: DEBUG,  # -vvv, debug logging
-    4: (TRACE := 5),  # -vvvv, trace logging
+    4: TRACE,  # -vvvv, trace logging
 }
 deprecated.constant("24.3", "24.9", "VERBOSITY_LEVELS", _VERBOSITY_LEVELS)
 

--- a/news/13568-import-activate-perf
+++ b/news/13568-import-activate-perf
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Optimize module imports to speed up `conda activate`. (#13567 via 13568)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -261,5 +261,8 @@ def test_topic_remove(deprecated_v3: DeprecationHandler):
 
 def test_version_fallback():
     """Test that conda can run even if deprecations can't parse the version."""
-    version = DeprecationHandler(None)._version  # type: ignore
+    deprecated = DeprecationHandler(None)  # type: ignore
+    assert deprecated._version_less_than("0")
+    assert deprecated._version_tuple is None
+    version = deprecated._version_object  # type: ignore
     assert version.major == version.minor == version.micro == 0


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Avoid some imports to speed up `conda activate`.

Fixes gh-13567.

| `python`<br />`=3.8.18`,<br />`ruamel.yaml`<br />`=0.16.12` | `python`<br />`=3.11.7`,<br />`ruamel.yaml`<br />`=0.16.12` | `python`<br />`=3.8.18`,<br />`ruamel.yaml` <br /> `=0.18.5` | `python`<br />`=3.11.7`,<br />`ruamel.yaml`<br />`=0.18.5` | `python`<br />`=3.8.18`,<br />`ruamel.yaml` <br /> `=0.18.6` | `python`<br />`=3.11.7`,<br />`ruamel.yaml`<br />`=0.18.6` | changes |
|-------|-------|-------|-------|-------|-------|-------|
| 0.089 | 0.093 | 0.093 | 0.098 | 0.090 | 0.95 | base commit 59af01b from `main` |
| 0.084 | 0.088 | 0.089 | 0.093 | | | `Avoid costly .gateways.logging import for activate` |
| 0.086 | 0.091 | 0.091 | 0.096 | | | `Avoid costly argparse import for activate` |
| 0.086 | 0.090 | 0.090 | 0.095 | | | `Use packaging.version in .deprecations only if needed` |
| 0.080 | 0.081 | 0.086 | 0.093 | | | `Avoid costly inspect.getmodule in .deprecations` |
| 0.086 | 0.090 | 0.090 | 0.095 | | | `Defer platformdirs import for conda activate` |
| 0.068 | 0.071 | 0.074 | 0.081 | 0.069 | 0.072 | everything above combined |
| 0.065 | 0.068 | | | 0.065 | 0.68 | everything above plus `Defer tempfile import for auxlib.compat` |

(Edit: Added `ruamel.yaml=0.18.6` timings after improvements re. https://sourceforge.net/p/ruamel-yaml/tickets/504/ .)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- ~~[ ] Add / update necessary tests?~~
- ~~[ ] Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
