### PR TITLE
change retry logic for 400 <= status < 500

### DIFF
--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -267,8 +267,7 @@ def download_and_hash(
 
 def _is_http_error_most_400_codes(e: HTTPError) -> bool:
     """
-    Return True if HTTPError is a fatal error, False if we should check the same
-    URL again next time.
+    Determine whether the `HTTPError` is an HTTP 400 error code (except for 416).
     """
     if e.response is None:  # 404 e.response is falsey
         return False

--- a/news/13573-skip-zst-on-4xx
+++ b/news/13573-skip-zst-on-4xx
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fallback to `repodata.json` from `repodata.json.zst` on most 4xx error codes
+  (#13573)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

"Mark format as unavailable if code is in the 400's" 

This is about how it will look, but I feel this logic is not correct on the first commit. Do we need more than True/False? Should we show a different error if the /request/ type was `GET` or `Partial GET`?

Fix #13573 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
