### PR TITLE
Add wildcard `conda remove` test

### DIFF
--- a/tests/cli/test_main_remove.py
+++ b/tests/cli/test_main_remove.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 import pytest
 
-from conda.base.context import context
+from conda.base.context import context, reset_context
 from conda.common.io import stderr_log_level
 from conda.exceptions import DryRunExit, PackagesNotFoundError
 from conda.gateways.disk.delete import path_is_clean
@@ -50,15 +50,15 @@ def test_remove_all_keep_env(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture)
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("parametrized_solver_fixture")
-@pytest.mark.xfail(
-    context.solver == "libmamba" and version("conda_libmamba_solver") <= "24.1.0",
-    reason="Removing using wildcards is not available in older versions of the libmamba solver.",
-)
 def test_remove_globbed_package_names(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
 ):
-    log.error(f"libmamba-solver version: {version('conda_libmamba_solver')}")
+    reset_context()
+    if context.solver == "libmamba" and version("conda_libmamba_solver") <= "24.1.0":
+        pytest.xfail(
+            reason="Removing using wildcards is not available in older versions of the libmamba solver.",
+        )
     with tmp_env("zlib", "ca-certificates") as prefix:
         stdout, stderr, _ = conda_cli(
             "remove",

--- a/tests/cli/test_main_remove.py
+++ b/tests/cli/test_main_remove.py
@@ -1,11 +1,25 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+import json
+from importlib.metadata import version
+from logging import getLogger
+
 import pytest
 
-from conda.exceptions import PackagesNotFoundError
+from conda.base.context import context
+from conda.common.io import stderr_log_level
+from conda.exceptions import DryRunExit, PackagesNotFoundError
 from conda.gateways.disk.delete import path_is_clean
 from conda.testing import CondaCLIFixture, TmpEnvFixture
-from conda.testing.integration import PYTHON_BINARY, package_is_installed
+from conda.testing.integration import (
+    PYTHON_BINARY,
+    TEST_LOG_LEVEL,
+    package_is_installed,
+)
+
+log = getLogger(__name__)
+stderr_log_level(TEST_LOG_LEVEL, "conda")
+stderr_log_level(TEST_LOG_LEVEL, "requests")
 
 
 def test_remove_all(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture):
@@ -32,3 +46,41 @@ def test_remove_all_keep_env(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture)
 
         conda_cli("remove", f"--prefix={prefix}", "--all", "--keep-env", "--yes")
         assert not path_is_clean(prefix)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("parametrized_solver_fixture")
+@pytest.mark.xfail(
+    context.solver == "libmamba" and version("conda_libmamba_solver") <= "24.1.0",
+    reason="Removing using wildcards is not available in older versions of the libmamba solver.",
+)
+def test_remove_globbed_package_names(
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+):
+    log.error(f"libmamba-solver version: {version('conda_libmamba_solver')}")
+    with tmp_env("zlib", "ca-certificates") as prefix:
+        stdout, stderr, _ = conda_cli(
+            "remove",
+            "--yes",
+            f"--prefix={prefix}",
+            "*lib*",
+            "--dry-run",
+            "--json",
+            f"--solver={context.solver}",
+            raises=DryRunExit,
+        )
+        log.info(stdout)
+        log.info(stderr)
+        data = json.loads(stdout)
+        assert data.get("success")
+        assert any(pkg["name"] == "zlib" for pkg in data["actions"]["UNLINK"])
+        if "LINK" in data["actions"]:
+            assert all(pkg["name"] != "zlib" for pkg in data["actions"]["LINK"])
+        # if ca-certificates is in the unlink list,
+        # it should also be in the link list (reinstall)
+        for package in data["actions"]["UNLINK"]:
+            if package["name"] == "ca-certificates":
+                assert any(
+                    pkg["name"] == "ca-certificates" for pkg in data["actions"]["LINK"]
+                )

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -53,6 +53,7 @@ class TestLibMambaSolver(SolverTests):
         }
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("solver", ("classic", "libmamba"))
 def test_remove_globbed_package_names(
     solver,

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -58,7 +58,7 @@ class TestLibMambaSolver(SolverTests):
 @pytest.mark.integration
 @pytest.mark.usefixtures("parametrized_solver_fixture")
 @pytest.mark.xfail(
-    context.solver == "libmamba" and version("conda_libmamba_solver") <= "24.1",
+    context.solver == "libmamba" and version("conda_libmamba_solver") <= "24.1.0",
     reason="Removing using wildcards is not available in older versions of the libmamba solver.",
 )
 def test_remove_globbed_package_names(

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -54,7 +54,7 @@ def test_remove_globbed_package_names(
 ):
     "https://github.com/conda/conda-libmamba-solver/issues/434"
     with tmp_env("zlib", "ca-certificates") as prefix:
-        process = conda_cli(
+        stdout, stderr, returncode = conda_cli(
             "remove",
             "--yes",
             f"--prefix={prefix}",
@@ -63,15 +63,16 @@ def test_remove_globbed_package_names(
             "--json",
             f"--solver={solver}",
         )
-        print(process.stdout)
-        print(process.stderr, file=sys.stderr)
-        assert process.returncode == 0
-        data = json.loads(process.stdout)
+        print(stdout)
+        print(stderr, file=sys.stderr)
+        assert returncode == 0
+        data = json.loads(stdout)
         assert data.get("success")
         assert any(pkg["name"] == "zlib" for pkg in data["actions"]["UNLINK"])
         if "LINK" in data["actions"]:
             assert all(pkg["name"] != "zlib" for pkg in data["actions"]["LINK"])
-        # if ca-certificates is in the unlink list, it should also be in the link list (reinstall)
+        # if ca-certificates is in the unlink list,
+        # it should also be in the link list (reinstall)
         for package in data["actions"]["UNLINK"]:
             if package["name"] == "ca-certificates":
                 assert any(

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 import json
-import sys
+from logging import getLogger
 
 import pytest
 
+from conda.common.io import stderr_log_level
 from conda.core.solve import Solver
+from conda.exceptions import DryRunExit
 from conda.testing import CondaCLIFixture, TmpEnvFixture
+from conda.testing.integration import TEST_LOG_LEVEL
 from conda.testing.solver_helpers import SolverTests
+
+log = getLogger(__name__)
+stderr_log_level(TEST_LOG_LEVEL, "conda")
+stderr_log_level(TEST_LOG_LEVEL, "requests")
 
 
 class TestClassicSolver(SolverTests):
@@ -62,9 +69,10 @@ def test_remove_globbed_package_names(
             "--dry-run",
             "--json",
             f"--solver={solver}",
+            raises=DryRunExit,
         )
-        print(stdout)
-        print(stderr, file=sys.stderr)
+        log.info(stdout)
+        log.info(stderr)
         assert returncode == 0
         data = json.loads(stdout)
         assert data.get("success")

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -65,6 +65,7 @@ def test_remove_globbed_package_names(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
 ):
+    log.error(f"libmamba-solver version: {version('conda_libmamba_solver')}")
     with tmp_env("zlib", "ca-certificates") as prefix:
         stdout, stderr, _ = conda_cli(
             "remove",

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -2,23 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import json
-from importlib.metadata import version
-from logging import getLogger
-
-import pytest
-
-from conda.base.context import context
-from conda.common.io import stderr_log_level
 from conda.core.solve import Solver
-from conda.exceptions import DryRunExit
-from conda.testing import CondaCLIFixture, TmpEnvFixture
-from conda.testing.integration import TEST_LOG_LEVEL
 from conda.testing.solver_helpers import SolverTests
-
-log = getLogger(__name__)
-stderr_log_level(TEST_LOG_LEVEL, "conda")
-stderr_log_level(TEST_LOG_LEVEL, "requests")
 
 
 class TestClassicSolver(SolverTests):
@@ -53,41 +38,3 @@ class TestLibMambaSolver(SolverTests):
                 "test_unintentional_feature_downgrade",
             ],
         }
-
-
-@pytest.mark.integration
-@pytest.mark.usefixtures("parametrized_solver_fixture")
-@pytest.mark.xfail(
-    context.solver == "libmamba" and version("conda_libmamba_solver") <= "24.1.0",
-    reason="Removing using wildcards is not available in older versions of the libmamba solver.",
-)
-def test_remove_globbed_package_names(
-    tmp_env: TmpEnvFixture,
-    conda_cli: CondaCLIFixture,
-):
-    log.error(f"libmamba-solver version: {version('conda_libmamba_solver')}")
-    with tmp_env("zlib", "ca-certificates") as prefix:
-        stdout, stderr, _ = conda_cli(
-            "remove",
-            "--yes",
-            f"--prefix={prefix}",
-            "*lib*",
-            "--dry-run",
-            "--json",
-            f"--solver={context.solver}",
-            raises=DryRunExit,
-        )
-        log.info(stdout)
-        log.info(stderr)
-        data = json.loads(stdout)
-        assert data.get("success")
-        assert any(pkg["name"] == "zlib" for pkg in data["actions"]["UNLINK"])
-        if "LINK" in data["actions"]:
-            assert all(pkg["name"] != "zlib" for pkg in data["actions"]["LINK"])
-        # if ca-certificates is in the unlink list,
-        # it should also be in the link list (reinstall)
-        for package in data["actions"]["UNLINK"]:
-            if package["name"] == "ca-certificates":
-                assert any(
-                    pkg["name"] == "ca-certificates" for pkg in data["actions"]["LINK"]
-                )

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import json
+import sys
+
+import pytest
+
 from conda.core.solve import Solver
+from conda.testing import CondaCLIFixture, TmpEnvFixture
 from conda.testing.solver_helpers import SolverTests
 
 
@@ -41,10 +47,14 @@ class TestLibMambaSolver(SolverTests):
 
 
 @pytest.mark.parametrize("solver", ("classic", "libmamba"))
-def test_remove_globbed_package_names(solver):
+def test_remove_globbed_package_names(
+    solver,
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+):
     "https://github.com/conda/conda-libmamba-solver/issues/434"
-    with make_temp_env("zlib", "ca-certificates") as prefix:
-        process = conda_subprocess(
+    with tmp_env("zlib", "ca-certificates") as prefix:
+        process = conda_cli(
             "remove",
             "--yes",
             f"--prefix={prefix}",
@@ -64,4 +74,6 @@ def test_remove_globbed_package_names(solver):
         # if ca-certificates is in the unlink list, it should also be in the link list (reinstall)
         for package in data["actions"]["UNLINK"]:
             if package["name"] == "ca-certificates":
-                assert any(pkg["name"] == "ca-certificates" for pkg in data["actions"]["LINK"])
+                assert any(
+                    pkg["name"] == "ca-certificates" for pkg in data["actions"]["LINK"]
+                )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

In https://github.com/conda/conda-libmamba-solver/pull/435, support for the use of wildcards with the `remove` command is added to the libmamba solver. The accompanying test, however, is not specific to the libmamba solver, but rather can be applied to any solver. In the spirit of moving towards a compliance suite of tests, this PR attempts to upstream the test into `conda`.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~ Not newsworthy.
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
