### PR TITLE
Add `ISC`/`TCH`/`T10`/`FA` lints

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -15,7 +15,6 @@ import json
 import os
 import re
 import sys
-from collections.abc import Callable, Iterable
 from logging import getLogger
 from os.path import (
     abspath,
@@ -29,6 +28,7 @@ from os.path import (
 )
 from pathlib import Path
 from textwrap import dedent
+from typing import TYPE_CHECKING
 
 # Since we have to have configuration context here, anything imported by
 #   conda.base.context is fair game, but nothing more.
@@ -42,6 +42,9 @@ from .base.constants import (
 from .base.context import ROOT_ENV_NAME, context, locate_prefix_by_name
 from .common.compat import FILESYSTEM_ENCODING, on_win
 from .common.path import paths_equal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 log = getLogger(__name__)
 

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -5,13 +5,11 @@ Collection of helper functions to standardize reused CLI arguments.
 """
 from __future__ import annotations
 
-from argparse import (
-    SUPPRESS,
-    ArgumentParser,
-    _ArgumentGroup,
-    _HelpAction,
-    _MutuallyExclusiveGroup,
-)
+from argparse import SUPPRESS, _HelpAction
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, _ArgumentGroup, _MutuallyExclusiveGroup
 
 try:
     from argparse import BooleanOptionalAction

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -10,10 +10,11 @@ import os
 import sys
 from logging import getLogger
 from os.path import isdir, join
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace, _SubParsersAction
+    from typing import Any, Iterable
 
 log = getLogger(__name__)
 

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import os
 import sys
-from argparse import ArgumentParser, Namespace, _SubParsersAction
 from logging import getLogger
 from os.path import isdir, join
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 log = getLogger(__name__)
 

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import logging
 import os
-from argparse import ArgumentParser, Namespace, _SubParsersAction
 from os.path import abspath, expanduser, expandvars
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 log = logging.getLogger(__name__)
 

--- a/conda/cli/main_env.py
+++ b/conda/cli/main_env.py
@@ -3,9 +3,13 @@
 """Entry point for all conda-env subcommands."""
 from __future__ import annotations
 
-from argparse import ArgumentParser, Namespace, _SubParsersAction
+from argparse import ArgumentParser
+from typing import TYPE_CHECKING
 
 from ..deprecations import deprecated
+
+if TYPE_CHECKING:
+    from argparse import Namespace, _SubParsersAction
 
 
 def configure_parser(sub_parsers: _SubParsersAction | None, **kwargs) -> ArgumentParser:

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -10,21 +10,18 @@ import json
 import os
 import re
 import sys
-from argparse import (
-    SUPPRESS,
-    ArgumentParser,
-    Namespace,
-    _StoreTrueAction,
-    _SubParsersAction,
-)
+from argparse import SUPPRESS, _StoreTrueAction
 from logging import getLogger
 from os.path import exists, expanduser, isfile, join
 from textwrap import wrap
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING
 
 from ..deprecations import deprecated
 
 if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
+    from typing import Any, Iterable
+
     from ..models.records import PackageRecord
 
 log = getLogger(__name__)

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -6,8 +6,12 @@ Prepares the user's profile for running conda, and sets up the conda shell inter
 """
 from __future__ import annotations
 
-from argparse import SUPPRESS, ArgumentParser, Namespace, _SubParsersAction
+from argparse import SUPPRESS
 from logging import getLogger
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 log = getLogger(__name__)
 

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -4,6 +4,8 @@
 
 Prepares the user's profile for running conda, and sets up the conda shell interface.
 """
+from __future__ import annotations
+
 from argparse import SUPPRESS, ArgumentParser, Namespace, _SubParsersAction
 from logging import getLogger
 

--- a/conda/cli/main_rename.py
+++ b/conda/cli/main_rename.py
@@ -7,11 +7,14 @@ Renames an existing environment by cloning it and then removing the original env
 from __future__ import annotations
 
 import os
-from argparse import ArgumentParser, Namespace, _SubParsersAction
 from functools import partial
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ..deprecations import deprecated
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -6,12 +6,14 @@ Query channels for packages matching the provided package spec.
 """
 from __future__ import annotations
 
-from argparse import SUPPRESS, ArgumentParser, Namespace, _SubParsersAction
+from argparse import SUPPRESS
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
+
     from ..models.records import PackageRecord
 
 

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -25,13 +25,14 @@ from logging import getLogger
 from os import environ
 from os.path import expandvars
 from pathlib import Path
-from re import IGNORECASE, VERBOSE, Match, compile
+from re import IGNORECASE, VERBOSE, compile
 from string import Template
 from typing import TYPE_CHECKING
 
 from ..deprecations import deprecated
 
 if TYPE_CHECKING:  # pragma: no cover
+    from re import Match
     from typing import Any, Hashable, Iterable, Sequence
 
 try:

--- a/conda/common/iterators.py
+++ b/conda/common/iterators.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import collections
 import itertools
-from typing import Any, Generator, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Generator, Sequence
 
 
 def groupby_to_dict(keyfunc, sequence):

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -19,11 +19,14 @@ from os.path import (
     split,
     splitext,
 )
-from typing import Iterable, Sequence
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from .. import CondaError
 from .compat import on_win
+
+if TYPE_CHECKING:
+    from typing import Iterable, Sequence
 
 log = getLogger(__name__)
 

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -97,7 +97,7 @@ CONDA_INITIALIZE_RE_BLOCK = (
 )
 
 CONDA_INITIALIZE_PS_RE_BLOCK = (
-    r"^#region conda initialize(?:\n|\r\n)" r"([\s\S]*?)" r"#endregion(?:\n|\r\n)?"
+    r"^#region conda initialize(?:\n|\r\n)([\s\S]*?)#endregion(?:\n|\r\n)?"
 )
 
 
@@ -1076,7 +1076,7 @@ def install_deactivate_bat(target_path, conda_prefix):
 def install_activate(target_path, conda_prefix):
     # target_path: join(conda_prefix, get_bin_directory_short_path(), 'activate')
     src_path = join(CONDA_PACKAGE_ROOT, "shell", "bin", "activate")
-    file_content = ("#!/bin/sh\n" '_CONDA_ROOT="%s"\n') % conda_prefix
+    file_content = '#!/bin/sh\n_CONDA_ROOT="%s"\n' % conda_prefix
     with open(src_path) as fsrc:
         file_content += fsrc.read()
     return _install_file(target_path, file_content)
@@ -1085,7 +1085,7 @@ def install_activate(target_path, conda_prefix):
 def install_deactivate(target_path, conda_prefix):
     # target_path: join(conda_prefix, get_bin_directory_short_path(), 'deactivate')
     src_path = join(CONDA_PACKAGE_ROOT, "shell", "bin", "deactivate")
-    file_content = ("#!/bin/sh\n" '_CONDA_ROOT="%s"\n') % conda_prefix
+    file_content = '#!/bin/sh\n_CONDA_ROOT="%s"\n' % conda_prefix
     with open(src_path) as fsrc:
         file_content += fsrc.read()
     return _install_file(target_path, file_content)

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -14,7 +14,7 @@ from os.path import basename, dirname, isdir, join
 from pathlib import Path
 from textwrap import indent
 from traceback import format_exception_only
-from typing import Iterable, NamedTuple
+from typing import TYPE_CHECKING, Iterable, NamedTuple
 
 from .. import CondaError, CondaMultiError, conda_signal_handler
 from ..auxlib.collection import first
@@ -58,8 +58,6 @@ from ..gateways.disk.test import (
 )
 from ..gateways.subprocess import subprocess_call
 from ..models.enums import LinkType
-from ..models.package_info import PackageInfo
-from ..models.records import PackageRecord
 from ..models.version import VersionOrder
 from ..resolve import MatchSpec
 from ..utils import get_comspec, human_bytes, wrap_subprocess_call
@@ -81,6 +79,10 @@ from .path_actions import (
     _Action,
 )
 from .prefix_data import PrefixData, get_python_version_for_prefix
+
+if TYPE_CHECKING:
+    from ..models.package_info import PackageInfo
+    from ..models.records import PackageRecord
 
 log = getLogger(__name__)
 

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -14,7 +14,7 @@ from os.path import basename, dirname, isdir, join
 from pathlib import Path
 from textwrap import indent
 from traceback import format_exception_only
-from typing import TYPE_CHECKING, Iterable, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from .. import CondaError, CondaMultiError, conda_signal_handler
 from ..auxlib.collection import first
@@ -76,13 +76,15 @@ from .path_actions import (
     UnlinkPathAction,
     UnregisterEnvironmentLocationAction,
     UpdateHistoryAction,
-    _Action,
 )
 from .prefix_data import PrefixData, get_python_version_for_prefix
 
 if TYPE_CHECKING:
+    from typing import Iterable
+
     from ..models.package_info import PackageInfo
     from ..models.records import PackageRecord
+    from .path_actions import _Action
 
 log = getLogger(__name__)
 

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import codecs
 import os
 from collections import defaultdict
-from concurrent.futures import CancelledError, Future, ThreadPoolExecutor, as_completed
+from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 from errno import EACCES, ENOENT, EPERM, EROFS
 from functools import partial
 from itertools import chain
@@ -58,6 +58,7 @@ from ..utils import human_bytes
 from .path_actions import CacheUrlAction, ExtractPackageAction
 
 if TYPE_CHECKING:
+    from concurrent.futures import Future
     from pathlib import Path
 
 log = getLogger(__name__)

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -14,9 +14,9 @@ from json import JSONDecodeError
 from logging import getLogger
 from os import scandir
 from os.path import basename, dirname, getsize, join
-from pathlib import Path
 from sys import platform
 from tarfile import ReadError
+from typing import TYPE_CHECKING
 
 from .. import CondaError, CondaMultiError, conda_signal_handler
 from ..auxlib.collection import first
@@ -56,6 +56,9 @@ from ..models.match_spec import MatchSpec
 from ..models.records import PackageCacheRecord, PackageRecord
 from ..utils import human_bytes
 from .path_actions import CacheUrlAction, ExtractPackageAction
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 log = getLogger(__name__)
 

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -9,7 +9,6 @@ from itertools import chain
 from logging import DEBUG, getLogger
 from os.path import join
 from textwrap import dedent
-from typing import Iterable
 
 from genericpath import exists
 
@@ -49,6 +48,8 @@ from .prefix_data import PrefixData
 from .subdir_data import SubdirData
 
 if TYPE_CHECKING:
+    from typing import Iterable
+
     from ..models.records import PackageRecord
 
 log = getLogger(__name__)

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -18,6 +18,8 @@ try:
 except ImportError:  # pragma: no cover
     from .._vendor.boltons.setutils import IndexedSet
 
+from typing import TYPE_CHECKING
+
 from .. import CondaError
 from .. import __version__ as CONDA_VERSION
 from ..auxlib.collection import frozendict
@@ -39,13 +41,15 @@ from ..models.channel import Channel
 from ..models.enums import NoarchType
 from ..models.match_spec import MatchSpec
 from ..models.prefix_graph import PrefixGraph
-from ..models.records import PackageRecord
 from ..models.version import VersionOrder
 from ..resolve import Resolve
 from .index import _supplement_index_with_system, get_reduced_index
 from .link import PrefixSetup, UnlinkLinkTransaction
 from .prefix_data import PrefixData
 from .subdir_data import SubdirData
+
+if TYPE_CHECKING:
+    from ..models.records import PackageRecord
 
 log = getLogger(__name__)
 

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -20,6 +20,8 @@ try:
 except ImportError:  # pragma: no cover
     from .._vendor.boltons.setutils import IndexedSet
 
+from typing import TYPE_CHECKING
+
 from ..auxlib.ish import dals
 from ..base.constants import CONDA_PACKAGE_EXTENSION_V1, REPODATA_FN
 from ..base.context import context
@@ -33,11 +35,9 @@ from ..gateways.disk.delete import rm_rf
 from ..gateways.repodata import (
     CACHE_STATE_SUFFIX,
     CondaRepoInterface,
-    RepodataCache,
     RepodataFetch,
     RepodataIsEmpty,
     RepodataState,
-    RepoInterface,
     cache_fn_url,
     create_cache_dir,
     get_repo_interface,
@@ -48,6 +48,9 @@ from ..gateways.repodata import (
 from ..models.channel import Channel, all_channel_urls
 from ..models.match_spec import MatchSpec
 from ..models.records import PackageRecord
+
+if TYPE_CHECKING:
+    from ..gateways.repodata import RepodataCache, RepoInterface
 
 log = getLogger(__name__)
 

--- a/conda/env/specs/binstar.py
+++ b/conda/env/specs/binstar.py
@@ -7,12 +7,14 @@ import re
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from ...env.env import Environment, from_yaml
+from ...env.env import from_yaml
 from ...exceptions import EnvironmentFileNotDownloaded
 from ...models.version import normalized_version
 
 if TYPE_CHECKING:
     from types import ModuleType
+
+    from ...env.env import Environment
 
 ENVIRONMENT_TYPE = "env"
 

--- a/conda/env/specs/binstar.py
+++ b/conda/env/specs/binstar.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import re
 from functools import cached_property
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 from ...env.env import Environment, from_yaml
 from ...exceptions import EnvironmentFileNotDownloaded
 from ...models.version import normalized_version
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 ENVIRONMENT_TYPE = "env"
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -11,8 +11,8 @@ from logging import getLogger
 from os.path import join
 from textwrap import dedent
 from traceback import format_exception, format_exception_only
+from typing import TYPE_CHECKING
 
-import requests
 from requests.exceptions import JSONDecodeError
 
 from . import CondaError, CondaExitZero, CondaMultiError
@@ -28,6 +28,9 @@ from .common.url import join_url, maybe_unquote
 from .deprecations import DeprecatedError  # noqa: F401
 from .exception_handler import ExceptionHandler, conda_exception_handler  # noqa: F401
 from .models.channel import Channel
+
+if TYPE_CHECKING:
+    import requests
 
 log = getLogger(__name__)
 

--- a/conda/gateways/connection/adapters/s3.py
+++ b/conda/gateways/connection/adapters/s3.py
@@ -6,10 +6,14 @@ from __future__ import annotations
 import json
 from logging import LoggerAdapter, getLogger
 from tempfile import SpooledTemporaryFile
+from typing import TYPE_CHECKING
 
 from ....common.compat import ensure_binary
 from ....common.url import url_to_s3_info
-from .. import BaseAdapter, CaseInsensitiveDict, PreparedRequest, Response
+from .. import BaseAdapter, CaseInsensitiveDict, Response
+
+if TYPE_CHECKING:
+    from .. import PreparedRequest
 
 log = getLogger(__name__)
 stderrlog = LoggerAdapter(getLogger("conda.stderrlog"), extra=dict(terminator="\n"))

--- a/conda/gateways/connection/session.py
+++ b/conda/gateways/connection/session.py
@@ -168,7 +168,7 @@ class CondaSession(Session, metaclass=CondaSessionType):
             except ImportError:
                 raise CondaError(
                     "The `ssl_verify: truststore` setting is only supported on"
-                    + "Python 3.10 or later."
+                    "Python 3.10 or later."
                 )
             self.verify = True
         else:

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -309,7 +309,7 @@ def create_fake_executable_softlink(src, dst):
     src_root, _ = splitext(src)
     # TODO: this open will clobber, consider raising
     with open(dst, "w") as f:
-        f.write("@echo off\n" 'call "%s" %%*\n' "" % src_root)
+        f.write('@echo off\ncall "%s" %%*\n' % src_root)
     return dst
 
 

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -14,7 +14,7 @@ from itertools import chain
 from logging import getLogger
 from os.path import isdir, isfile, join  # noqa
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING
 
 from ...auxlib.collection import first
 from ...auxlib.compat import shlex_split_unicode
@@ -35,6 +35,9 @@ from ...models.package_info import PackageInfo, PackageMetadata
 from ...models.records import PathData, PathDataV1, PathsData, PrefixRecord
 from .create import TemporaryDirectory
 from .link import islink, lexists  # noqa
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 log = getLogger(__name__)
 

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -17,8 +17,7 @@ import warnings
 from collections import UserDict
 from contextlib import contextmanager
 from os.path import dirname
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
 from ... import CondaError
 from ...auxlib.logz import stringify
@@ -42,12 +41,17 @@ from ..connection import (
     InsecureRequestWarning,
     InvalidSchema,
     RequestsProxyError,
-    Response,
     SSLError,
 )
 from ..connection.session import get_session
 from ..disk import mkdir_p_sudo_safe
 from ..disk.lock import lock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
+
+    from ..connection import Response
 
 log = logging.getLogger(__name__)
 stderrlog = logging.getLogger("conda.stderrlog")

--- a/conda/gateways/repodata/jlap/core.py
+++ b/conda/gateways/repodata/jlap/core.py
@@ -7,7 +7,10 @@ import logging
 from collections import UserList
 from hashlib import blake2b
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, Iterator
 
 log = logging.getLogger(__name__)
 

--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -6,13 +6,12 @@ from __future__ import annotations
 import io
 import json
 import logging
-import pathlib
 import pprint
 import re
 import time
 from contextlib import contextmanager
 from hashlib import blake2b
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 import jsonpatch
 import zstandard
@@ -21,7 +20,6 @@ from requests import HTTPError
 from conda.common.url import mask_anaconda_token
 
 from ....base.context import context
-from ...connection import Response, Session
 from .. import (
     ETAG_KEY,
     LAST_MODIFIED_KEY,
@@ -29,6 +27,11 @@ from .. import (
     RepodataState,
 )
 from .core import JLAP
+
+if TYPE_CHECKING:
+    import pathlib
+
+    from ...connection import Response, Session
 
 log = logging.getLogger(__name__)
 

--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -11,7 +11,7 @@ import re
 import time
 from contextlib import contextmanager
 from hashlib import blake2b
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 import jsonpatch
 import zstandard
@@ -20,18 +20,15 @@ from requests import HTTPError
 from conda.common.url import mask_anaconda_token
 
 from ....base.context import context
-from .. import (
-    ETAG_KEY,
-    LAST_MODIFIED_KEY,
-    RepodataCache,
-    RepodataState,
-)
+from .. import ETAG_KEY, LAST_MODIFIED_KEY, RepodataState
 from .core import JLAP
 
 if TYPE_CHECKING:
     import pathlib
+    from typing import Iterator
 
     from ...connection import Response, Session
+    from .. import RepodataCache
 
 log = logging.getLogger(__name__)
 

--- a/conda/gateways/repodata/jlap/interface.py
+++ b/conda/gateways/repodata/jlap/interface.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from ....base.context import context
 from ...connection.download import disable_ssl_verify_warning
@@ -14,7 +15,6 @@ from .. import (
     ETAG_KEY,
     LAST_MODIFIED_KEY,
     URL_KEY,
-    RepodataCache,
     RepodataOnDisk,
     RepodataState,
     RepoInterface,
@@ -22,6 +22,9 @@ from .. import (
     conda_http_errors,
 )
 from . import fetch
+
+if TYPE_CHECKING:
+    from .. import RepodataCache
 
 log = logging.getLogger(__name__)
 

--- a/conda/notices/cache.py
+++ b/conda/notices/cache.py
@@ -14,7 +14,7 @@ import os
 from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 try:
     from platformdirs import user_cache_dir
@@ -23,7 +23,12 @@ except ImportError:  # pragma: no cover
 
 from ..base.constants import APP_NAME, NOTICES_CACHE_FN, NOTICES_CACHE_SUBDIR
 from ..utils import ensure_dir_exists
-from .types import ChannelNotice, ChannelNoticeResponse
+from .types import ChannelNoticeResponse
+
+if TYPE_CHECKING:
+    from typing import Sequence
+
+    from .types import ChannelNotice
 
 logger = logging.getLogger(__name__)
 

--- a/conda/notices/core.py
+++ b/conda/notices/core.py
@@ -6,13 +6,20 @@ from __future__ import annotations
 import logging
 import time
 from functools import wraps
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 from ..base.constants import NOTICES_DECORATOR_DISPLAY_INTERVAL, NOTICES_FN
-from ..base.context import Context, context
-from ..models.channel import Channel, MultiChannel, get_channel_objs
+from ..base.context import context
+from ..models.channel import get_channel_objs
 from . import cache, fetch, views
-from .types import ChannelNotice, ChannelNoticeResponse, ChannelNoticeResultSet
+from .types import ChannelNoticeResultSet
+
+if TYPE_CHECKING:
+    from typing import Sequence
+
+    from ..base.context import Context
+    from ..models.channel import Channel, MultiChannel
+    from .types import ChannelNotice, ChannelNoticeResponse
 
 # Used below in type hints
 ChannelName = str

--- a/conda/notices/fetch.py
+++ b/conda/notices/fetch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 import requests
 
@@ -13,6 +13,9 @@ from ..common.io import Spinner
 from ..gateways.connection.session import get_session
 from .cache import cached_response
 from .types import ChannelNoticeResponse
+
+if TYPE_CHECKING:
+    from typing import Sequence
 
 logger = logging.getLogger(__name__)
 

--- a/conda/notices/types.py
+++ b/conda/notices/types.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 
 import hashlib
 from datetime import datetime
-from typing import TYPE_CHECKING, NamedTuple, Sequence
+from typing import TYPE_CHECKING, NamedTuple
 
 from ..base.constants import NoticeLevel
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Sequence
 
 #: Value to use for message ID when it is not provided
 UNDEFINED_MESSAGE_ID = "undefined"

--- a/conda/notices/types.py
+++ b/conda/notices/types.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import hashlib
 from datetime import datetime
-from pathlib import Path
-from typing import NamedTuple, Sequence
+from typing import TYPE_CHECKING, NamedTuple, Sequence
 
 from ..base.constants import NoticeLevel
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 #: Value to use for message ID when it is not provided
 UNDEFINED_MESSAGE_ID = "undefined"

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -9,21 +9,24 @@ an example of how to use it.
 """
 from __future__ import annotations
 
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import pluggy
 
-from .types import (
-    CondaAuthHandler,
-    CondaHealthCheck,
-    CondaPostCommand,
-    CondaPostSolve,
-    CondaPreCommand,
-    CondaPreSolve,
-    CondaSolver,
-    CondaSubcommand,
-    CondaVirtualPackage,
-)
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from .types import (
+        CondaAuthHandler,
+        CondaHealthCheck,
+        CondaPostCommand,
+        CondaPostSolve,
+        CondaPreCommand,
+        CondaPreSolve,
+        CondaSolver,
+        CondaSubcommand,
+        CondaVirtualPackage,
+    )
 
 spec_name = "conda"
 """Name used for organizing conda hook specifications"""

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -13,7 +13,7 @@ import functools
 import logging
 from importlib.metadata import distributions
 from inspect import getmodule, isclass
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, overload
 
 import pluggy
 
@@ -25,6 +25,8 @@ from .hookspec import CondaSpecs, spec_name
 from .subcommands.doctor import health_checks
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from requests.auth import AuthBase
 
     from ..core.solve import Solver

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -13,31 +13,34 @@ import functools
 import logging
 from importlib.metadata import distributions
 from inspect import getmodule, isclass
-from typing import Literal, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 import pluggy
-from requests.auth import AuthBase
 
 from ..auxlib.ish import dals
 from ..base.context import context
-from ..core.solve import Solver
 from ..exceptions import CondaValueError, PluginError
-from ..models.match_spec import MatchSpec
-from ..models.records import PackageRecord
 from . import post_solves, solvers, subcommands, virtual_packages
 from .hookspec import CondaSpecs, spec_name
 from .subcommands.doctor import health_checks
-from .types import (
-    CondaAuthHandler,
-    CondaHealthCheck,
-    CondaPostCommand,
-    CondaPostSolve,
-    CondaPreCommand,
-    CondaPreSolve,
-    CondaSolver,
-    CondaSubcommand,
-    CondaVirtualPackage,
-)
+
+if TYPE_CHECKING:
+    from requests.auth import AuthBase
+
+    from ..core.solve import Solver
+    from ..models.match_spec import MatchSpec
+    from ..models.records import PackageRecord
+    from .types import (
+        CondaAuthHandler,
+        CondaHealthCheck,
+        CondaPostCommand,
+        CondaPostSolve,
+        CondaPreCommand,
+        CondaPreSolve,
+        CondaSolver,
+        CondaSubcommand,
+        CondaVirtualPackage,
+    )
 
 log = logging.getLogger(__name__)
 

--- a/conda/plugins/subcommands/doctor/__init__.py
+++ b/conda/plugins/subcommands/doctor/__init__.py
@@ -7,7 +7,7 @@ corruption.
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, Namespace
+from typing import TYPE_CHECKING
 
 from ....base.context import context
 from ....cli.helpers import (
@@ -17,6 +17,9 @@ from ....cli.helpers import (
 )
 from ....deprecations import deprecated
 from ... import CondaSubcommand, hookimpl
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
 
 
 @deprecated(

--- a/conda/plugins/subcommands/doctor/health_checks.py
+++ b/conda/plugins/subcommands/doctor/health_checks.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import json
-import os
 from logging import getLogger
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ....base.context import context
 from ....core.envs_manager import get_user_environments_txt_file
@@ -14,6 +14,9 @@ from ....deprecations import deprecated
 from ....exceptions import CondaError
 from ....gateways.disk.read import compute_sum
 from ... import CondaHealthCheck, hookimpl
+
+if TYPE_CHECKING:
+    import os
 
 logger = getLogger(__name__)
 

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -9,12 +9,13 @@ Each type corresponds to the plugin hook for which it is used.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from requests.auth import AuthBase
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
+    from typing import Callable
 
     from ..core.solve import Solver
     from ..models.match_spec import MatchSpec

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -8,15 +8,17 @@ Each type corresponds to the plugin hook for which it is used.
 """
 from __future__ import annotations
 
-from argparse import ArgumentParser, Namespace
 from dataclasses import dataclass, field
-from typing import Callable, NamedTuple
+from typing import TYPE_CHECKING, Callable, NamedTuple
 
 from requests.auth import AuthBase
 
-from ..core.solve import Solver
-from ..models.match_spec import MatchSpec
-from ..models.records import PackageRecord
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+    from ..core.solve import Solver
+    from ..models.match_spec import MatchSpec
+    from ..models.records import PackageRecord
 
 
 @dataclass

--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -24,10 +24,9 @@ from logging import getLogger
 from os.path import dirname, isfile, join, normpath
 from pathlib import Path
 from subprocess import check_output
-from typing import TYPE_CHECKING, Iterable, overload
+from typing import TYPE_CHECKING, overload
 
 import pytest
-from pytest import CaptureFixture, ExceptionInfo, MonkeyPatch
 
 from ..base.constants import PACKAGE_CACHE_MAGIC_FILE
 from ..base.context import context, reset_context
@@ -37,6 +36,9 @@ from ..core.package_cache_data import PackageCacheData
 from ..deprecations import deprecated
 
 if TYPE_CHECKING:
+    from typing import Iterable
+
+    from pytest import CaptureFixture, ExceptionInfo, MonkeyPatch
     from pytest_mock import MockerFixture
 
 log = getLogger(__name__)

--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -24,11 +24,10 @@ from logging import getLogger
 from os.path import dirname, isfile, join, normpath
 from pathlib import Path
 from subprocess import check_output
-from typing import Iterable, overload
+from typing import TYPE_CHECKING, Iterable, overload
 
 import pytest
 from pytest import CaptureFixture, ExceptionInfo, MonkeyPatch
-from pytest_mock import MockerFixture
 
 from ..base.constants import PACKAGE_CACHE_MAGIC_FILE
 from ..base.context import context, reset_context
@@ -36,6 +35,9 @@ from ..cli.main import main_subshell
 from ..common.compat import on_win
 from ..core.package_cache_data import PackageCacheData
 from ..deprecations import deprecated
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 log = getLogger(__name__)
 

--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -4,11 +4,10 @@
 from __future__ import annotations
 
 import warnings
-from typing import Iterable, Literal, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 import py
 import pytest
-from pytest import FixtureRequest, MonkeyPatch
 
 from ..auxlib.ish import dals
 from ..base.context import conda_tests_ctxt_mgmt_def_pol, context, reset_context
@@ -17,6 +16,11 @@ from ..common.io import env_vars
 from ..common.serialize import yaml_round_trip_load
 from ..core.subdir_data import SubdirData
 from ..gateways.disk.create import TemporaryDirectory
+
+if TYPE_CHECKING:
+    from typing import Iterable
+
+    from pytest import FixtureRequest, MonkeyPatch
 
 
 @pytest.fixture(autouse=True)

--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -19,6 +19,7 @@ from random import sample
 from shutil import copyfile, rmtree
 from subprocess import check_output
 from tempfile import gettempdir
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
@@ -49,8 +50,11 @@ from ..gateways.disk.link import link
 from ..gateways.disk.update import touch
 from ..gateways.logging import DEBUG
 from ..models.match_spec import MatchSpec
-from ..models.records import PackageRecord, PrefixRecord
+from ..models.records import PackageRecord
 from ..utils import massage_arguments
+
+if TYPE_CHECKING:
+    from ..models.records import PrefixRecord
 
 TEST_LOG_LEVEL = DEBUG
 PYTHON_BINARY = "python.exe" if on_win else "bin/python"

--- a/conda/testing/notices/helpers.py
+++ b/conda/testing/notices/helpers.py
@@ -9,14 +9,17 @@ import os
 import uuid
 from itertools import chain
 from pathlib import Path
-from typing import Sequence
-from unittest import mock
+from typing import TYPE_CHECKING, Sequence
 
-from ...base.context import Context
 from ...models.channel import get_channel_objs
 from ...notices.cache import get_notices_cache_file
 from ...notices.core import get_channel_name_and_urls
 from ...notices.types import ChannelNoticeResponse
+
+if TYPE_CHECKING:
+    from unittest import mock
+
+    from ...base.context import Context
 
 DEFAULT_NOTICE_MESG = "Here is an example message that will be displayed to users"
 

--- a/conda/testing/notices/helpers.py
+++ b/conda/testing/notices/helpers.py
@@ -9,7 +9,7 @@ import os
 import uuid
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from ...models.channel import get_channel_objs
 from ...notices.cache import get_notices_cache_file
@@ -17,6 +17,7 @@ from ...notices.core import get_channel_name_and_urls
 from ...notices.types import ChannelNoticeResponse
 
 if TYPE_CHECKING:
+    from typing import Sequence
     from unittest import mock
 
     from ...base.context import Context

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -25,14 +25,18 @@ except ImportError:
         pass
 
 
+from typing import TYPE_CHECKING
+
 from ..base.constants import CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2
 from ..base.context import context
 from ..common.url import join_url
 from ..core.subdir_data import SubdirData
 from ..gateways.connection import HTTPError, InsecureRequestWarning
 from ..gateways.connection.session import get_session
-from ..models.records import PackageRecord
 from .constants import INITIAL_TRUST_ROOT, KEY_MGR_FILE
+
+if TYPE_CHECKING:
+    from ..models.records import PackageRecord
 
 log = getLogger(__name__)
 

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -8,11 +8,11 @@ import re
 import sys
 from contextlib import contextmanager
 from functools import lru_cache, wraps
-from os import PathLike, environ
+from os import environ
 from os.path import abspath, basename, dirname, isfile, join
 from pathlib import Path
 from shutil import which
-from typing import Literal
+from typing import TYPE_CHECKING
 
 from . import CondaError
 from .auxlib.compat import Utf8NamedTemporaryFile, shlex_split_unicode
@@ -21,6 +21,10 @@ from .common.path import win_path_to_unix
 from .common.url import path_to_url
 from .deprecations import deprecated
 from .gateways.disk.read import compute_sum
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Literal
 
 log = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,9 @@ target-version = "py38"
 # UP = pyupgrade
 # ISC = flake8-implicit-str-concat
 # TCH = flake8-type-checking
+# T10 = flake8-debugger
 # see also https://docs.astral.sh/ruff/rules/
-select = ["E", "W", "F", "I", "D1", "UP", "ISC", "TCH"]
+select = ["E", "W", "F", "I", "D1", "UP", "ISC", "TCH", "T10"]
 # E402 module level import not at top of file
 # E501 line too long
 # E722 do not use bare 'except'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ select = ["E", "W", "F", "I", "D1", "UP", "ISC", "TCH", "T10", "FA"]
 ignore = ["E402", "E501", "E722", "E731", "D101", "D102", "D103", "D104", "D105", "D107"]
 extend-per-file-ignores = {"docs/*" = ["D1"], "tests/*" = ["D1"]}
 pydocstyle = {convention = "pep257"}
+flake8-type-checking = {exempt-modules = [], strict = true}
 
 [tool.pytest.ini_options]
 minversion = 3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,9 @@ target-version = "py38"
 # ISC = flake8-implicit-str-concat
 # TCH = flake8-type-checking
 # T10 = flake8-debugger
+# FA = flake8-future-annotations
 # see also https://docs.astral.sh/ruff/rules/
-select = ["E", "W", "F", "I", "D1", "UP", "ISC", "TCH", "T10"]
+select = ["E", "W", "F", "I", "D1", "UP", "ISC", "TCH", "T10", "FA"]
 # E402 module level import not at top of file
 # E501 line too long
 # E722 do not use bare 'except'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,10 @@ target-version = "py38"
 # I = isort
 # D = pydocstyle
 # UP = pyupgrade
+# ISC = flake8-implicit-str-concat
+# TCH = flake8-type-checking
 # see also https://docs.astral.sh/ruff/rules/
-select = ["E", "W", "F", "I", "D1", "UP"]
+select = ["E", "W", "F", "I", "D1", "UP", "ISC", "TCH"]
 # E402 module level import not at top of file
 # E501 line too long
 # E722 do not use bare 'except'

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import pytest
-from pytest_mock import MockerFixture
 
 from conda.base.constants import (
     CONDA_LOGS_DIR,
@@ -18,7 +17,11 @@ from conda.base.constants import (
 from conda.cli.main_clean import _get_size
 from conda.core.subdir_data import create_cache_dir
 from conda.gateways.logging import set_verbosity
-from conda.testing import CondaCLIFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda.testing import CondaCLIFixture, TmpEnvFixture
 
 
 def _get_pkgs(pkgs_dir: str | Path) -> list[Path]:

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -19,6 +19,8 @@ from conda.core.subdir_data import create_cache_dir
 from conda.gateways.logging import set_verbosity
 
 if TYPE_CHECKING:
+    from typing import Iterable
+
     from pytest_mock import MockerFixture
 
     from conda.testing import CondaCLIFixture, TmpEnvFixture

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
 
 from conda.base.context import context, locate_prefix_by_name
 from conda.core.envs_manager import list_all_known_prefixes
 from conda.exceptions import CondaEnvException, CondaError, EnvironmentNameNotFound
 
 if TYPE_CHECKING:
+    from typing import Iterable
+
+    from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
     from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import pytest
 from pytest import MonkeyPatch
-from pytest_mock import MockerFixture
 
 from conda.base.context import context, locate_prefix_by_name
 from conda.core.envs_manager import list_all_known_prefixes
 from conda.exceptions import CondaEnvException, CondaError, EnvironmentNameNotFound
-from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 
 
 @pytest.fixture

--- a/tests/cli/test_subcommands.py
+++ b/tests/cli/test_subcommands.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from conda.common.compat import on_win
-from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 
 pytestmark = pytest.mark.usefixtures("parametrized_solver_fixture")
 

--- a/tests/common/test_url.py
+++ b/tests/common/test_url.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from logging import getLogger
-from typing import NamedTuple, Union
+from typing import NamedTuple
 
 import pytest
 
@@ -83,7 +85,7 @@ class UrlTest(NamedTuple):
     username: str = None
     password: str = None
     hostname: str = None
-    port: Union[int, str] = None
+    port: int | str = None
 
 
 URLPARSE_TEST_DATA = [

--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -11,7 +11,7 @@ import math
 import sys
 import time
 from pathlib import Path
-from socket import socket
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -43,6 +43,9 @@ from conda.gateways.repodata import (
 )
 from conda.gateways.repodata.jlap.interface import JlapRepoInterface
 from conda.models.channel import Channel
+
+if TYPE_CHECKING:
+    from socket import socket
 
 
 def test_save(tmp_path):

--- a/tests/plugins/subcommands/doctor/test_health_checks.py
+++ b/tests/plugins/subcommands/doctor/test_health_checks.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import json
 import uuid
-from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import pytest
 from pytest import MonkeyPatch
-from pytest_mock import MockerFixture
 
 from conda.base.context import reset_context
 from conda.plugins.subcommands.doctor.health_checks import (
@@ -23,6 +21,11 @@ from conda.plugins.subcommands.doctor.health_checks import (
     find_packages_with_missing_files,
     missing_files,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/tests/plugins/subcommands/doctor/test_health_checks.py
+++ b/tests/plugins/subcommands/doctor/test_health_checks.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
 
 from conda.base.context import reset_context
 from conda.plugins.subcommands.doctor.health_checks import (
@@ -24,7 +23,9 @@ from conda.plugins.subcommands.doctor.health_checks import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Iterable
 
+    from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
 

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import pytest
 from pytest import CaptureFixture
-from pytest_mock import MockerFixture
 
 from conda import plugins
 from conda.auxlib.ish import dals
 from conda.base.context import context
 from conda.cli.conda_argparse import BUILTIN_COMMANDS, generate_parser
 from conda.plugins.types import CondaSubcommand
-from conda.testing import CondaCLIFixture
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda.testing import CondaCLIFixture
 
 
 @dataclass(frozen=True)

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import CaptureFixture
 
 from conda import plugins
 from conda.auxlib.ish import dals
@@ -15,6 +14,9 @@ from conda.cli.conda_argparse import BUILTIN_COMMANDS, generate_parser
 from conda.plugins.types import CondaSubcommand
 
 if TYPE_CHECKING:
+    from typing import Callable
+
+    from pytest import CaptureFixture
     from pytest_mock import MockerFixture
 
     from conda.testing import CondaCLIFixture

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
 
 import conda.core.index
 from conda import plugins
@@ -19,6 +18,10 @@ from conda.plugins.virtual_packages import cuda
 from conda.testing.solver_helpers import package_dict
 
 if TYPE_CHECKING:
+    from typing import Iterable
+
+    from pytest import MonkeyPatch
+
     from conda.models.records import PackageRecord
 
 

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import pytest
 from pytest import MonkeyPatch
@@ -14,10 +14,12 @@ from conda.__version__ import __version__
 from conda.base.context import context, reset_context
 from conda.common.io import env_var
 from conda.exceptions import PluginError
-from conda.models.records import PackageRecord
 from conda.plugins.types import CondaVirtualPackage
 from conda.plugins.virtual_packages import cuda
 from conda.testing.solver_helpers import package_dict
+
+if TYPE_CHECKING:
+    from conda.models.records import PackageRecord
 
 
 class VirtualPackagesPlugin:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -15,11 +15,10 @@ from shutil import which
 from signal import SIGINT
 from subprocess import CalledProcessError, check_output
 from tempfile import gettempdir
-from typing import TYPE_CHECKING, Callable, Iterable
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
-from pytest import MonkeyPatch
 
 from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT, CondaError
 from conda import __version__ as conda_version
@@ -54,6 +53,10 @@ from conda.testing.integration import SPACER_CHARACTER
 from conda.utils import quote_for_shell
 
 if TYPE_CHECKING:
+    from typing import Callable, Iterable
+
+    from pytest import MonkeyPatch
+
     from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -15,7 +15,7 @@ from shutil import which
 from signal import SIGINT
 from subprocess import CalledProcessError, check_output
 from tempfile import gettempdir
-from typing import Callable, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable
 from uuid import uuid4
 
 import pytest
@@ -49,10 +49,13 @@ from conda.exceptions import EnvironmentLocationNotFound, EnvironmentNameNotFoun
 from conda.gateways.disk.create import mkdir_p
 from conda.gateways.disk.delete import rm_rf
 from conda.gateways.disk.update import touch
-from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 from conda.testing.helpers import tempdir
 from conda.testing.integration import SPACER_CHARACTER
 from conda.utils import quote_for_shell
+
+if TYPE_CHECKING:
+    from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+
 
 log = getLogger(__name__)
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
 
 from conda.history import History
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/tests/trust/test_signature_verification.py
+++ b/tests/trust/test_signature_verification.py
@@ -6,10 +6,9 @@ import json
 from pathlib import Path
 from shutil import copyfile
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
 
 from conda.base.constants import REPODATA_FN
 from conda.base.context import context, reset_context
@@ -20,6 +19,9 @@ from conda.trust.constants import KEY_MGR_FILE
 from conda.trust.signature_verification import SignatureError, _SignatureVerification
 
 if TYPE_CHECKING:
+    from typing import Callable
+
+    from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
     from conda.testing import PathFactoryFixture

--- a/tests/trust/test_signature_verification.py
+++ b/tests/trust/test_signature_verification.py
@@ -6,20 +6,24 @@ import json
 from pathlib import Path
 from shutil import copyfile
 from types import SimpleNamespace
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import pytest
 from pytest import MonkeyPatch
-from pytest_mock import MockerFixture
 
 from conda.base.constants import REPODATA_FN
 from conda.base.context import context, reset_context
 from conda.gateways.connection import HTTPError
 from conda.models.channel import Channel
 from conda.models.records import PackageRecord
-from conda.testing import PathFactoryFixture
 from conda.trust.constants import KEY_MGR_FILE
 from conda.trust.signature_verification import SignatureError, _SignatureVerification
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda.testing import PathFactoryFixture
+
 
 TESTDATA = Path(__file__).parent / "testdata"
 HTTP404 = HTTPError(response=SimpleNamespace(status_code=404))

--- a/tests/trust/testdata/keys/generate
+++ b/tests/trust/testdata/keys/generate
@@ -6,9 +6,12 @@ from pathlib import Path
 from subprocess import run
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
-from typing import Literal
+from typing import TYPE_CHECKING
 
 from securesystemslib.gpg.functions import export_pubkey
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 
 def generate_keyring(root: Path) -> Path | Literal[False]:

--- a/tools/durations/combine.py
+++ b/tools/durations/combine.py
@@ -16,6 +16,8 @@ $ git commit -m "Update test durations"
 $ git push
 ```
 """
+from __future__ import annotations
+
 import json
 from pathlib import Path
 from statistics import fmean


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Enable more lints:
- `ISC` ([flake8-implicit-str-concat](https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc))
- `TCH` lints ([flake8-type-checking-tch](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch))
- `T10` lints ([flake8-debugger](https://docs.astral.sh/ruff/rules/#flake8-debugger-t10))
- `FA` lints ([flake8-future-annotations](https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa))

Xref https://github.com/conda/conda-build/pull/5178

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
