### PR TITLE
Enable fast coverage tracking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  COVERAGE_CORE: sysmon
+
 jobs:
   # detect whether any code changes are included in this PR
   changes:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -187,6 +187,7 @@ jobs:
           --rm -v ${PWD}:/opt/conda-src
           -e TEST_SPLITS
           -e TEST_GROUP
+          -e COVERAGE_CORE
           ghcr.io/conda/conda-ci:main-linux-python${{ matrix.python-version }}${{ matrix.default-channel == 'conda-forge' && '-conda-forge' || '' }}
           /opt/conda-src/dev/linux/${{ matrix.test-type }}.sh
 
@@ -234,6 +235,7 @@ jobs:
           run: >
             docker run
             --rm -v ${PWD}:/opt/conda-src
+            -e COVERAGE_CORE
             ghcr.io/conda/conda-ci:main-linux-python${{ matrix.python-version }}
             /opt/conda-src/dev/linux/benchmarks.sh
 
@@ -272,6 +274,7 @@ jobs:
         run: >
           docker run
           --rm -v ${PWD}:/opt/conda-src
+          -e COVERAGE_CORE
           --platform linux/${{ matrix.platform }}
           ghcr.io/conda/conda-ci:main-linux-python${{ matrix.python-version }}${{ matrix.default-channel == 'conda-forge' && '-conda-forge' || '' }}
           /opt/conda-src/dev/linux/qemu.sh

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,7 @@ boltons >=23.0.0
 charset-normalizer
 conda-content-trust
 conda-forge::anaconda-client
+conda-forge::coverage >=7.4.0
 conda-forge::pytest-split
 conda-forge::pytest-xprocess
 conda-forge::xdoctest


### PR DESCRIPTION
See also:

* https://github.com/nedbat/coveragepy/releases/tag/7.4.0
* https://docs.python.org/3/whatsnew/3.12.html#pep-669-low-impact-monitoring-for-cpython
* https://nedbatchelder.com/blog/202312/coveragepy_with_sysmonitoring.html

Trying the option as inspired by @jaimergp to see
* what is the potential speed gain from it
* what breaks
* if that correctly falls back to the old method in case of Python <3.12.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
