### PR TITLE
fix "a bytes-like object is required, not 'str'"

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -852,7 +852,7 @@ def run_plan_elevated(plan):
                     rm_rf(temp_path)
 
         else:
-            stdin = json.dumps(plan, ensure_ascii=False, default=lambda x: x.__dict__)
+            stdin = json.dumps(plan, ensure_ascii=False, default=lambda x: x.__dict__).encode('utf-8')
             result = subprocess_call(
                 "sudo %s -m conda.core.initialize" % sys.executable,
                 env={},

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -856,7 +856,7 @@ def run_plan_elevated(plan):
                 plan,
                 ensure_ascii=False,
                 default=lambda x: x.__dict__,
-            ).encode('utf-8')
+            ).encode("utf-8")
             result = subprocess_call(
                 "sudo %s -m conda.core.initialize" % sys.executable,
                 env={},

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -852,7 +852,11 @@ def run_plan_elevated(plan):
                     rm_rf(temp_path)
 
         else:
-            stdin = json.dumps(plan, ensure_ascii=False, default=lambda x: x.__dict__).encode('utf-8')
+            stdin = json.dumps(
+                plan,
+                ensure_ascii=False,
+                default=lambda x: x.__dict__,
+            ).encode('utf-8')
             result = subprocess_call(
                 "sudo %s -m conda.core.initialize" % sys.executable,
                 env={},


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I run this cmd below in python 3.11:

```bash
conda init bash
```

I get this error:

```
    Traceback (most recent call last):
      File "/usr/lib/python3.11/site-packages/conda/exception_handler.py", line 17, in __call__
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/conda/cli/main.py", line 78, in main_subshell
        exit_code = do_call(args, parser)
                    ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/conda/cli/conda_argparse.py", line 166, in do_call
        result = getattr(module, func_name)(args, parser)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/conda/cli/main_init.py", line 36, in execute
        return initialize(
               ^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/conda/core/initialize.py", line 137, in initialize
        run_plan_elevated(plan2)
      File "/usr/lib/python3.11/site-packages/conda/core/initialize.py", line 853, in run_plan_elevated
        result = subprocess_call(
                 ^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/conda/gateways/subprocess.py", line 108, in subprocess_call
        stdout, stderr = process.communicate(input=stdin)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.11/subprocess.py", line 1209, in communicate
        stdout, stderr = self._communicate(input, endtime, timeout)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.11/subprocess.py", line 2088, in _communicate
        input_view = memoryview(self._input)
                     ^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: memoryview: a bytes-like object is required, not 'str'
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
