### PR TITLE
Issue #10319 resolved (Enhancements to Channel Cloning and RSS Feed Documentation)

### DIFF
--- a/docs/source/user-guide/concepts/channels.rst
+++ b/docs/source/user-guide/concepts/channels.rst
@@ -105,3 +105,70 @@ per standard RSS practice.
         </item>
 
 .. _`default channel`: https://repo.anaconda.com/pkgs/
+
+
+
+
+.. _cloning-channels:
+
+Cloning Channels
+====================
+
+Sometimes it is beneficial to clone a channel, creating a local copy of its packages and metadata. This can be particularly useful in scenarios where a reliable, offline source of packages is required, or for maintaining a consistent package state across different environments.
+
+What is Channel Cloning?
+------------------------
+
+Channel cloning involves duplicating an existing channel, creating an independent copy that can be hosted locally or on a different server. Unlike manually copying files, which can be error-prone and result in an invalid state due to potential I/O errors, channel cloning provides a more robust and reliable approach.
+
+How to Clone a Channel
+----------------------
+
+To clone a channel, follow these steps:
+
+1. **Create a Local Copy:**
+   To create a local clone of a channel, copy the entire content, including packages and metadata. This ensures that all necessary information is retained.
+
+2. **Host the Cloned Channel:**
+   Host the cloned channel on a server or in a local directory accessible to your Conda environment. This could be achieved using a web server or by providing the path to a local directory.
+
+3. **Specify the Cloned Channel:**
+   When installing packages from the cloned channel, use the `--channel` flag along with the URL or path to the cloned channel:
+
+   ```bash
+   $ conda install <package-name> --channel file:/path/to/cloned-channel
+   ```
+
+   Ensure to replace `<package-name>` with the actual name of the package you want to install.
+
+4. **Explore the Cloned Channel:**
+   After successfully cloning and specifying the channel, you can explore its content and available packages. Use commands like `conda search` to check for available packages in the cloned channel.
+
+Channel Cloning RSS Feed
+-------------------------
+
+Conda provides an RSS feed to track and monitor the activities related to cloned channels. The feed includes information about package additions, removals, and sync operations.
+
+To access the RSS feed for a specific channel, use the following format:
+
+```markdown
+[<Channel Name> channel RSS feed](https://conda-static.anaconda.org/<Channel Name>/rss.xml)
+```
+
+Replace `<Channel Name>` with the name of the cloned channel.
+
+The RSS feed entries provide details such as the subdirectory of the package, the action taken (addition or removal), the name of the package, and the publishing date.
+
+Example:
+
+```xml
+<item>
+  <title>linux-64:add:jupyterlab-1.0.4-py36_0.tar.bz2</title>
+  <pubDate>26 Jul 2019 19:26:36 UTC</pubDate>
+</item>
+```
+
+This entry indicates the addition of the `jupyterlab-1.0.4-py36_0` package for Linux-64 on the specified date.
+
+By utilizing channel cloning and monitoring the RSS feed, users can maintain reliable, customized Conda environments tailored to specific requirements.
+```


### PR DESCRIPTION
Channel Cloning Overview:

Clarified the concept of channel cloning in Conda, explaining its purpose and the advantages over manual copying.

Channel Cloning Process:
Provided a step-by-step guide on how to clone a channel, including creating a local copy, hosting the cloned channel, specifying it during package installation, and exploring its content.

Robustness of Channel Cloning:
Emphasized the robustness of channel cloning as a method, highlighting its reliability in comparison to manual file copying, which may lead to potential I/O errors.

Channel Cloning RSS Feed Integration:
Introduced the Channel Cloning RSS Feed as a valuable tool for tracking and monitoring activities related to cloned channels.

RSS Feed Details:
Explained the structure of the RSS feed entries, providing insights into the information available, such as package additions, removals, subdirectories, and publishing dates.

Example Usage:
Included an illustrative example of how to access the RSS feed for a specific cloned channel and interpret an entry within the feed.

Practical Application:
Highlighted the practical application of channel cloning and RSS feed monitoring, allowing users to maintain reliable, customized Conda environments tailored to their specific requirements.