### PR TITLE
Fix auxlib.logz.stringify excess memory allocation

### DIFF
--- a/conda/auxlib/logz.py
+++ b/conda/auxlib/logz.py
@@ -1,5 +1,5 @@
 from itertools import islice
-from json import JSONEncoder, dumps
+from json import JSONEncoder, dumps, loads
 from logging import getLogger, INFO, Formatter, StreamHandler, DEBUG
 from sys import stderr
 
@@ -138,9 +138,13 @@ def stringify(obj, content_max_len=0):
             builder.append('')
             content_type = response_object.headers.get('Content-Type')
             if content_type == 'application/json':
-                resp = response_object.json()
-                resp = dict(islice(resp.items(), content_max_len))
-                content = dumps(resp, indent=2)
+                text = response_object.text
+                if len(text) > content_max_len:
+                    content = text
+                else:
+                    resp = loads(text)
+                    resp = dict(islice(resp.items(), content_max_len))
+                    content = dumps(resp, indent=2)
                 content = content[:content_max_len] if len(content) > content_max_len else content
                 builder.append(content)
                 builder.append('')

--- a/news/13628-fix-auxlib-stringify-contenxt_max_len
+++ b/news/13628-fix-auxlib-stringify-contenxt_max_len
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix excess resource usage by log handling when fetching repodata. (#13541 via #13628)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This addresses the excess resource usage observed in gh-13541.

Essentially, the whole `repodata.json` is parsed via `requests.Response.json` and then dumped into a formatted string -- with both parts allocating multiple GB in RAM for large channels like `conda-forge`.
All this happens in a context only for (intended) debug logging output which is meant to constrain the log message length (and in turn memory usage); the proposed changes just apply the intended size constraints.

(It only handles the severe run time impact but doesn't fix the underlying cause for gh-13541.)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- ~~[ ] Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
