### PR TITLE
Adds option for conda environments to ignore Python's user site packages

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -430,6 +430,8 @@ class Context(Configuration):
     no_lock = ParameterLoader(PrimitiveParameter(False))
     repodata_use_zst = ParameterLoader(PrimitiveParameter(True))
 
+    no_python_user_site_packages = ParameterLoader(PrimitiveParameter(False))
+
     ####################################################
     #               Solver Configuration               #
     ####################################################
@@ -1222,6 +1224,7 @@ class Context(Configuration):
                 "separate_format_cache",
                 "verify_threads",
                 "execute_threads",
+                "no_python_user_site_packages",
             ),
             "Conda-build Configuration": (
                 "bld_path",
@@ -1594,6 +1597,12 @@ class Context(Configuration):
             no_plugins=dals(
                 """
                 Disable all currently-registered plugins, except built-in conda plugins.
+                """
+            ),
+            no_python_user_site_packages=dals(
+                """
+                Disables using user site packages, which are installed via `pip install --user`,
+                in conda environments.
                 """
             ),
             non_admin_enabled=dals(

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -489,6 +489,14 @@ def add_parser_package_install_options(p: ArgumentParser) -> _ArgumentGroup:
         help="Install shortcuts only for this package name. Can be used several times.",
         dest="shortcuts_only",
     )
+    package_install_options.add_argument(
+        "--no-python-user-site-packages",
+        action="store_true",
+        help="Disables using user site packages, which are installed via `pip install --user`, in "
+        "conda environments.",
+        dest="no_python_user_site_packages",
+        default=NULL,
+    )
     return package_install_options
 
 

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -90,6 +90,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
 def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..base.context import context
     from ..common.path import paths_equal
+    from ..core.envs_manager import set_environment_no_site_packages
     from ..exceptions import CondaValueError
     from ..gateways.disk.delete import rm_rf
     from ..gateways.disk.test import is_conda_environment
@@ -122,4 +123,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
             dry_run=False,
         )
 
-    return install(args, parser, "create")
+    install(args, parser, "create")
+
+    if context.no_python_user_site_packages:
+        set_environment_no_site_packages(context.target_prefix)


### PR DESCRIPTION
Fixes: 13337

### Description

Please see the issue above for more background on why this is being done.

This pull request introduces a new `no_python_user_site_packages` configuration setting that can be set via a CLI option, environment variable or config file. When set to `true`, conda will create a `pyvenv.cfg` in the root of the conda environment with the following contents:

```ini
include-system-site-packages = false
```

The presence of this file will disable Python programs from looking in the user site packages location for additional libraries that can be imported.

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
