### PR TITLE
update prompt message due to 'activate' option is gone

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -114,7 +114,7 @@ def print_activate(env_name_or_prefix):  # pragma: no cover
         #
         # To activate this environment, use
         #
-        #     $ conda activate {env_name_or_prefix}
+        #     $ source activate {env_name_or_prefix}
         #
         # To deactivate an active environment, use
         #

--- a/conda_env/README.md
+++ b/conda_env/README.md
@@ -52,7 +52,7 @@ Solving package specifications: .Linking packages ...
 [      COMPLETE      ] |#################################################| 100%
 #
 # To activate this environment, use:
-# $ conda activate stats
+# $ source activate stats
 #
 # To deactivate this environment, use:
 # $ conda deactivate


### PR DESCRIPTION
'activate' option has been removed
However, after 'conda create', prompt message is still this:
```
...
Preparing transaction: done                                                                                                                
Verifying transaction: done                                                                                                                
Executing transaction: done                                                                                                                
#                                                                                                                                          
# To activate this environment, use                                                                                                        
#                                                                                                                                          
#     $ conda activate xxx
#                                                                                                                                          
# To deactivate an active environment, use                                                                                                 
#                                                                                                                                          
#     $ conda deactivate  
```

