### PR TITLE
Add `boltons` to `requirements.txt` file for conda docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+boltons==23.1.1
 conda-sphinx-theme==0.2.1
 linkify-it-py==2.0.2
 myst-parser==2.0.0


### PR DESCRIPTION
`boltons` is missing as a docs requirement, which is making documentation pages not render correctly (see screenshots below for examples):

_stable (this is what the docs should look like)_
<img width="1602" alt="Screenshot 2024-03-11 at 10 22 15 AM" src="https://github.com/conda/conda/assets/28930622/b576671a-7cdb-488d-a684-5543ea6c1f4a">

_latest (currently broken, will be fixed by this PR)_
<img width="1605" alt="Screenshot 2024-03-11 at 10 24 04 AM" src="https://github.com/conda/conda/assets/28930622/0e20b7c7-4e5e-42cc-8fc6-0ed0627482f1">
