### PR TITLE
Add `boltons` to `requirements.txt` file for conda docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+boltons==23.1.1
 conda-sphinx-theme==0.2.1
 linkify-it-py==2.0.2
 myst-parser==2.0.0


### PR DESCRIPTION
`boltons` is missing as a docs requirement, which is making documentation pages not render correctly for `24.3.x`, the latest release branch (see screenshots below for examples):

_`24.1.x` (this is what the docs should look like)_
<img width="1607" alt="Screenshot 2024-03-11 at 11 22 33 AM" src="https://github.com/conda/conda/assets/28930622/b2022da2-20eb-4861-ac54-82a94bc731cf">

_`24.3.x` (currently broken, will be fixed by this PR)_
<img width="1604" alt="Screenshot 2024-03-11 at 10 21 57 AM" src="https://github.com/conda/conda/assets/28930622/4325f14b-344e-455b-bf97-fa764308cff9">

