### PR TITLE
Use stricter version parsing in `.deprecations`

### DIFF
--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -47,8 +47,11 @@ class DeprecationHandler:
         :param version: Version string to parse.
         """
         try:
-            return tuple(int(part) for part in version.strip().split(".")) or None
-        except (AttributeError, ValueError):
+            version = version.strip()
+            if not set(version).issubset(".0123456789"):
+                raise ValueError
+            return tuple(int(part) for part in version.split(".")) or None
+        except (AttributeError, TypeError, ValueError):
             return None
 
     def _version_less_than(self, version: str) -> bool:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Use stricter version parsing in `.deprecations` to ensure `DeprecationHandler._get_version_tuple` only ever parses a subset of what is valid for `packaging.version.parse`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
