### PR TITLE
Do not run solver=classic tests in PRs

### DIFF
--- a/.github/TEST_FAILURE_REPORT_TEMPLATE.md
+++ b/.github/TEST_FAILURE_REPORT_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+title: "{{ env.TITLE }} ({{ date | date("YYYY-MM-DD") }})"
+labels: [type::bug, type::testing]
+---
+
+The {{ workflow }} workflow failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC
+
+Full run: https://github.com/conda/conda/actions/runs/{{ env.RUN_ID }}
+
+(This post will be updated if another test fails today, as long as this issue remains open.)

--- a/.github/TEST_FAILURE_REPORT_TEMPLATE.md
+++ b/.github/TEST_FAILURE_REPORT_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 title: "{{ env.TITLE }} ({{ date | date("YYYY-MM-DD") }})"
-labels: [type::bug, type::testing]
+labels: [type::bug, type::testing, source::auto]
 ---
 
 The {{ workflow }} workflow failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,19 +69,15 @@ jobs:
       fail-fast: false
       matrix:
         # test lower version (w/ defaults) and upper version (w/ defaults and conda-forge)
-        # python-version: ['3.8', '3.12']
-        # default-channel: [defaults, conda-forge]
-        # test-type: [unit, integration]
-        # test-group: [1, 2, 3]
-        # exclude:
-        #   - default-channel: conda-forge
-        #     python-version: '3.8'
-        #   - test-type: unit
-        #     test-group: 3
-        python-version: ['3.12']
-        default-channel: [conda-forge]
-        test-type: [integration]
+        python-version: ['3.8', '3.12']
+        default-channel: [defaults, conda-forge]
+        test-type: [unit, integration]
         test-group: [1, 2, 3]
+        exclude:
+          - default-channel: conda-forge
+            python-version: '3.8'
+          - test-type: unit
+            test-group: 3
     env:
       ErrorActionPreference: Stop  # powershell exit immediately on error
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
@@ -110,7 +106,6 @@ jobs:
         with:
           condarc-file: .github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
-          miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
 
       - name: Conda Install
         run: conda install
@@ -170,25 +165,21 @@ jobs:
       fail-fast: false
       matrix:
         # test all lower versions (w/ defaults) and upper version (w/ defaults and conda-forge)
-        # python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        # default-channel: [defaults, conda-forge]
-        # test-type: [unit, integration]
-        # test-group: [1, 2, 3]
-        # exclude:
-        #   - python-version: '3.8'
-        #     default-channel: conda-forge
-        #   - python-version: '3.9'
-        #     default-channel: conda-forge
-        #   - python-version: '3.10'
-        #     default-channel: conda-forge
-        #   - python-version: '3.11'
-        #     default-channel: conda-forge
-        #   - test-type: unit
-        #     test-group: 3
-        python-version: ['3.12']
-        default-channel: [conda-forge]
-        test-type: [integration]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        default-channel: [defaults, conda-forge]
+        test-type: [unit, integration]
         test-group: [1, 2, 3]
+        exclude:
+          - python-version: '3.8'
+            default-channel: conda-forge
+          - python-version: '3.9'
+            default-channel: conda-forge
+          - python-version: '3.10'
+            default-channel: conda-forge
+          - python-version: '3.11'
+            default-channel: conda-forge
+          - test-type: unit
+            test-group: 3
     env:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
@@ -215,7 +206,6 @@ jobs:
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
-          miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
 
       - name: Conda Install
         run: conda install
@@ -264,8 +254,7 @@ jobs:
   linux-benchmarks:
     # only run test suite if there are code changes
     needs: changes
-    if: false
-    # needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
 
     runs-on: ubuntu-latest
     defaults:
@@ -332,8 +321,7 @@ jobs:
   linux-qemu:
     # only run test suite if there are code changes
     needs: changes
-    if: false
-    # needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
 
     # Run one single fast test per docker+qemu emulated linux platform to test that
     # test execution is possible there (container+tools+dependencies work). Can be
@@ -356,7 +344,6 @@ jobs:
             platform: ppc64le
           - image: 'condaforge/miniforge3:latest'
             platform: s390x
-    env:
 
     steps:
       - name: Checkout Source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,6 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests\requirements-truststore.txt' || '' }}
-      CI_DEFAULT_CHANNEL: ${{ matrix.default-channel }}
 
     steps:
       - name: Checkout Source
@@ -193,7 +192,6 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests/requirements-truststore.txt' || '' }}
-      CI_DEFAULT_CHANNEL: ${{ matrix.default-channel }}
 
     steps:
       - name: Checkout Source
@@ -357,7 +355,6 @@ jobs:
           - image: 'condaforge/miniforge3:latest'
             platform: s390x
     env:
-      CI_DEFAULT_CHANNEL: ${{ matrix.image == 'condaforge/miniforge3:latest' && 'conda-forge' || 'defaults' }}
 
     steps:
       - name: Checkout Source
@@ -431,7 +428,6 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests/requirements-truststore.txt' || '' }}
-      CI_DEFAULT_CHANNEL: ${{ matrix.default-channel }}
 
     steps:
       - name: Checkout Source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,15 +69,19 @@ jobs:
       fail-fast: false
       matrix:
         # test lower version (w/ defaults) and upper version (w/ defaults and conda-forge)
-        python-version: ['3.8', '3.12']
-        default-channel: [defaults, conda-forge]
-        test-type: [unit, integration]
+        # python-version: ['3.8', '3.12']
+        # default-channel: [defaults, conda-forge]
+        # test-type: [unit, integration]
+        # test-group: [1, 2, 3]
+        # exclude:
+        #   - default-channel: conda-forge
+        #     python-version: '3.8'
+        #   - test-type: unit
+        #     test-group: 3
+        python-version: ['3.12']
+        default-channel: [conda-forge]
+        test-type: [integration]
         test-group: [1, 2, 3]
-        exclude:
-          - default-channel: conda-forge
-            python-version: '3.8'
-          - test-type: unit
-            test-group: 3
     env:
       ErrorActionPreference: Stop  # powershell exit immediately on error
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
@@ -105,6 +109,7 @@ jobs:
         with:
           condarc-file: .github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
+          miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
 
       - name: Conda Install
         run: conda install
@@ -164,21 +169,25 @@ jobs:
       fail-fast: false
       matrix:
         # test all lower versions (w/ defaults) and upper version (w/ defaults and conda-forge)
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        default-channel: [defaults, conda-forge]
-        test-type: [unit, integration]
+        # python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        # default-channel: [defaults, conda-forge]
+        # test-type: [unit, integration]
+        # test-group: [1, 2, 3]
+        # exclude:
+        #   - python-version: '3.8'
+        #     default-channel: conda-forge
+        #   - python-version: '3.9'
+        #     default-channel: conda-forge
+        #   - python-version: '3.10'
+        #     default-channel: conda-forge
+        #   - python-version: '3.11'
+        #     default-channel: conda-forge
+        #   - test-type: unit
+        #     test-group: 3
+        python-version: ['3.12']
+        default-channel: [conda-forge]
+        test-type: [integration]
         test-group: [1, 2, 3]
-        exclude:
-          - python-version: '3.8'
-            default-channel: conda-forge
-          - python-version: '3.9'
-            default-channel: conda-forge
-          - python-version: '3.10'
-            default-channel: conda-forge
-          - python-version: '3.11'
-            default-channel: conda-forge
-          - test-type: unit
-            test-group: 3
     env:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
@@ -204,6 +213,7 @@ jobs:
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
+          miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
 
       - name: Conda Install
         run: conda install
@@ -379,7 +389,8 @@ jobs:
   macos:
     # only run test suite if there are code changes
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: false
+    # needs.changes.outputs.code == 'true'
 
     runs-on: ${{ (matrix.arch == 'osx-64' && 'macos-13') || 'macos-14' }}
     defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,7 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests\requirements-truststore.txt' || '' }}
+      CONDA_TEST_SOLVERS: ${{ github.event_name == 'pull_request' && 'libmamba' || 'libmamba,classic' }}
 
     steps:
       - name: Checkout Source
@@ -192,6 +193,7 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests/requirements-truststore.txt' || '' }}
+      CONDA_TEST_SOLVERS: ${{ github.event_name == 'pull_request' && 'libmamba' || 'libmamba,classic' }}
 
     steps:
       - name: Checkout Source
@@ -392,8 +394,7 @@ jobs:
   macos:
     # only run test suite if there are code changes
     needs: changes
-    if: false
-    # needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
 
     runs-on: ${{ (matrix.arch == 'osx-64' && 'macos-13') || 'macos-14' }}
     defaults:
@@ -428,6 +429,7 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests/requirements-truststore.txt' || '' }}
+      CONDA_TEST_SOLVERS: ${{ github.event_name == 'pull_request' && 'libmamba' || 'libmamba,classic' }}
 
     steps:
       - name: Checkout Source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,7 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests\requirements-truststore.txt' || '' }}
+      CI_DEFAULT_CHANNEL: ${{ matrix.default-channel }}
 
     steps:
       - name: Checkout Source
@@ -192,6 +193,7 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests/requirements-truststore.txt' || '' }}
+      CI_DEFAULT_CHANNEL: ${{ matrix.default-channel }}
 
     steps:
       - name: Checkout Source
@@ -262,7 +264,8 @@ jobs:
   linux-benchmarks:
     # only run test suite if there are code changes
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: false
+    # needs.changes.outputs.code == 'true'
 
     runs-on: ubuntu-latest
     defaults:
@@ -329,7 +332,8 @@ jobs:
   linux-qemu:
     # only run test suite if there are code changes
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: false
+    # needs.changes.outputs.code == 'true'
 
     # Run one single fast test per docker+qemu emulated linux platform to test that
     # test execution is possible there (container+tools+dependencies work). Can be
@@ -352,6 +356,8 @@ jobs:
             platform: ppc64le
           - image: 'condaforge/miniforge3:latest'
             platform: s390x
+    env:
+      CI_DEFAULT_CHANNEL: ${{ matrix.image == 'condaforge/miniforge3:latest' && 'conda-forge' || 'defaults' }}
 
     steps:
       - name: Checkout Source
@@ -425,6 +431,7 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12', matrix.python-version) && '--file tests/requirements-truststore.txt' || '' }}
+      CI_DEFAULT_CHANNEL: ${{ matrix.default-channel }}
 
     steps:
       - name: Checkout Source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -520,10 +520,27 @@ jobs:
     steps:
       - name: Determine Success
         uses: re-actors/alls-green@v1.2.2
+        id: alls-green
         with:
           # permit jobs to be skipped if there are no code changes (see changes job)
           allowed-skips: ${{ toJSON(needs) }}
           jobs: ${{ toJSON(needs) }}
+
+      # CONDA-LIBMAMBA-SOLVER CHANGE
+      - name: Checkout our source
+        uses: actions/checkout@v3
+        if: always() && github.event_name != 'pull_request' && steps.alls-green.outputs.result == 'failure'
+
+      - name: Report failures
+        if: always() && github.event_name != 'pull_request' && steps.alls-green.outputs.result == 'failure'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONDA_ISSUES }}
+          RUN_ID: ${{ github.run_id }}
+          TITLE: "Tests failed"
+        with:
+          filename: .github/TEST_FAILURE_REPORT_TEMPLATE.md
+          update_existing: false
 
   # canary builds
   build:

--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -95,14 +95,10 @@ def temp_package_cache(tmp_path_factory):
         yield pkgs_dir
 
 
-_solver_params = ["libmamba"]
-if os.environ.get("CI") and os.environ.get("GITHUB_EVENT_NAME") != "pull_request":
-    # Do not test the classic solver on PR runs
-    # Local tests and runs on the main branch will test both solvers
-    _solver_params.append("classic")
-
-
-@pytest.fixture(params=_solver_params)
+@pytest.fixture(
+    # allow CI to set the solver backends via the CONDA_TEST_SOLVERS env var
+    params=os.environ.get("CONDA_TEST_SOLVERS", "libmamba,classic").split(",")
+)
 def parametrized_solver_fixture(
     request: FixtureRequest,
     monkeypatch: MonkeyPatch,

--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -3,6 +3,7 @@
 """Collection of pytest fixtures used in conda tests."""
 from __future__ import annotations
 
+import os
 import warnings
 from typing import TYPE_CHECKING, Literal, TypeVar
 
@@ -93,7 +94,13 @@ def temp_package_cache(tmp_path_factory):
         yield pkgs_dir
 
 
-@pytest.fixture(params=["libmamba", "classic"])
+_solver_params = ["libmamba"]
+if os.environ.get("CI_DEFAULT_CHANNEL") != "conda-forge":
+    # Do not test conda-forge with solver=classic to save some time on GHA
+    # Locally, this env var won't be set, so we will test both solvers
+    _solver_params.append("classic")
+
+@pytest.fixture(params=_solver_params)
 def parametrized_solver_fixture(
     request: FixtureRequest,
     monkeypatch: MonkeyPatch,

--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 """Collection of pytest fixtures used in conda tests."""
+
 from __future__ import annotations
 
 import os
@@ -95,10 +96,11 @@ def temp_package_cache(tmp_path_factory):
 
 
 _solver_params = ["libmamba"]
-if os.environ.get("CI_DEFAULT_CHANNEL") != "conda-forge":
-    # Do not test conda-forge with solver=classic to save some time on GHA
-    # Locally, this env var won't be set, so we will test both solvers
+if os.environ.get("CI") and os.environ.get("GITHUB_EVENT_NAME") != "pull_request":
+    # Do not test the classic solver on PR runs
+    # Local tests and runs on the main branch will test both solvers
     _solver_params.append("classic")
+
 
 @pytest.fixture(params=_solver_params)
 def parametrized_solver_fixture(

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -248,7 +248,7 @@ def test_conda_env_create_http(conda_cli: CondaCLIFixture, tmp_path: Path):
     """Test `conda env create --file=https://some-website.com/environment.yml`."""
     conda_cli(
         *("env", "create"),
-        f"--path={tmp_path}",
+        f"--prefix={tmp_path}",
         "--file=https://raw.githubusercontent.com/conda/conda/main/tests/env/support/simple.yml",
     )
     assert (tmp_path / "conda-meta" / "history").is_file()

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -244,17 +244,14 @@ def test_conda_env_create_empty_file(
 
 
 @pytest.mark.integration
-def test_conda_env_create_http(conda_cli: CondaCLIFixture):
+def test_conda_env_create_http(conda_cli: CondaCLIFixture, tmp_path: Path):
     """Test `conda env create --file=https://some-website.com/environment.yml`."""
-    try:
-        conda_cli(
-            *("env", "create"),
-            "--file=https://raw.githubusercontent.com/conda/conda/main/tests/env/support/simple.yml",
-        )
-        assert env_is_created("nlp")
-    finally:
-        # manual cleanup
-        conda_cli("remove", "--name=nlp", "--all", "--yes")
+    conda_cli(
+        *("env", "create"),
+        f"--path={tmp_path}",
+        "--file=https://raw.githubusercontent.com/conda/conda/main/tests/env/support/simple.yml",
+    )
+    assert (tmp_path / "conda-meta" / "history").is_file()
 
 
 @pytest.mark.integration

--- a/tests/cli/test_main_remove.py
+++ b/tests/cli/test_main_remove.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 import pytest
 
-from conda.base.context import context, reset_context
+from conda.base.context import context
 from conda.common.io import stderr_log_level
 from conda.exceptions import DryRunExit, PackagesNotFoundError
 from conda.gateways.disk.delete import path_is_clean

--- a/tests/cli/test_main_remove.py
+++ b/tests/cli/test_main_remove.py
@@ -54,12 +54,12 @@ def test_remove_globbed_package_names(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
 ):
-    reset_context()
     if context.solver == "libmamba" and version("conda_libmamba_solver") <= "24.1.0":
         pytest.xfail(
             reason="Removing using wildcards is not available in older versions of the libmamba solver.",
         )
-    with tmp_env("zlib", "ca-certificates") as prefix:
+    channels = "--override-channels", "--channel=defaults"
+    with tmp_env("zlib", "ca-certificates", *channels) as prefix:
         stdout, stderr, _ = conda_cli(
             "remove",
             "--yes",
@@ -68,6 +68,7 @@ def test_remove_globbed_package_names(
             "--dry-run",
             "--json",
             f"--solver={context.solver}",
+            *channels,
             raises=DryRunExit,
         )
         log.info(stdout)

--- a/tests/cli/test_main_remove.py
+++ b/tests/cli/test_main_remove.py
@@ -58,8 +58,7 @@ def test_remove_globbed_package_names(
         pytest.xfail(
             reason="Removing using wildcards is not available in older versions of the libmamba solver.",
         )
-    channels = "--override-channels", "--channel=defaults"
-    with tmp_env("zlib", "ca-certificates", *channels) as prefix:
+    with tmp_env("zlib", "ca-certificates") as prefix:
         stdout, stderr, _ = conda_cli(
             "remove",
             "--yes",
@@ -68,7 +67,6 @@ def test_remove_globbed_package_names(
             "--dry-run",
             "--json",
             f"--solver={context.solver}",
-            *channels,
             raises=DryRunExit,
         )
         log.info(stdout)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Adds an environment variable to control the solvers exported by the fixture. It expects a comma separated list of strings (e.g. `libmamba,classic`).

<details>

<summary>Timings in main</summary>

Integration tests for Windows & Linux take almost 1h for each job if the default channel is conda-forge.

| Windows Integration 1 | `main` |
|-----------------------|--------|
| tests/cli/test_env.py::test_conda_env_create_http[classic] | 526.82s call |
| tests/cli/test_main_remove.py::test_remove_globbed_package_names[classic] | 282.98s call |
| tests/test_create.py::test_dont_remove_conda_2[classic] | 257.13s call |
| tests/cli/test_env.py::test_create_valid_env_with_conda_and_pip_json_output[classic] | 208.85s call |
| tests/test_create.py::test_conda_pip_interop_pip_clobbers_conda[classic] | 122.29s call |
| tests/test_create.py::test_channel_usage_replacing_python[libmamba] | 84.23s call |
| tests/test_create.py::test_strict_resolve_get_reduced_index[classic] | 73.46s call |
| tests/test_create.py::test_shortcut_creation_installs_shortcut[classic] | 53.32s call |
| tests/test_create.py::test_update_all_updates_pip_pkg[libmamba] | 52.05s call |
| tests/test_create.py::test_noarch_python_package_reinstall_on_pyver_change[libmamba] | 47.09s call |
| tests/test_create.py::test_conda_pip_interop_conda_editable_package[classic] | 45.55s call |
| tests/test_create.py::test_noarch_python_package_with_entry_points[libmamba] | 44.36s call |
| tests/core/test_solve.py::test_freeze_deps_1[classic] | 43.48s call |
| tests/env/test_create.py::test_create_env_default_packages | 43.13s call |
| tests/test_create.py::test_update_all_updates_pip_pkg[classic] | 43.08s call |
| tests/cli/test_env.py::test_update_env_only_pip_json_output[libmamba] | 38.71s call |

| Windows Integration 2 | `main` |
|-----------------------|--------|
| tests/cli/test_env.py::test_update_env_only_pip_json_output[classic] | 402.99s call |
| tests/test_create.py::test_conda_downgrade[classic] | 324.85s call |
| tests/cli/test_cli_install.py::test_find_conflicts_called_once[classic] | 290.01s call |
| tests/test_create.py::test_conda_downgrade[libmamba] | 256.51s call |
| tests/test_create.py::test_force_remove[classic] | 180.75s call |
| tests/test_create.py::test_create_install_update_remove_smoketest[classic] | 154.47s call |
| tests/test_create.py::test_create_install_update_remove_smoketest[libmamba] | 116.99s call |
| tests/test_create.py::test_strict_resolve_get_reduced_index[libmamba] | 73.87s call |
| tests/test_create.py::test_dont_remove_conda_1[libmamba] | 72.42s call |
| tests/test_create.py::test_dont_remove_conda_2[libmamba] | 64.08s call |
| tests/test_create.py::test_list_with_pip_wheel[libmamba] | 54.81s call |
| tests/test_create.py::test_conda_pip_interop_compatible_release_operator[libmamba] | 51.08s call |
| tests/test_create.py::test_shortcut_absent_does_not_barf_on_uninstall[classic] | 50.53s call |
| tests/test_create.py::test_shortcut_creation_installs_shortcut[libmamba] | 49.65s call |
| tests/test_create.py::test_shortcut_absent_when_condarc_set[libmamba] | 49.14s call |
| tests/test_create.py::test_noarch_python_package_with_entry_points[classic] | 48.91s call |

| Windows Integration 3 | `main` |
|-----------------------|--------|
| tests/cli/test_env.py::test_update_env_no_action_json_output[classic] | 532.92s call |
| tests/test_create.py::test_dont_remove_conda_1[classic] | 272.38s call |
| tests/cli/test_env.py::test_pip_error_is_propagated[classic] | 204.77s call |
| tests/test_create.py::test_conda_pip_interop_compatible_release_operator[classic] | 170.34s call |
| tests/test_create.py::test_channel_usage_replacing_python[classic] | 155.08s call |
| tests/test_create.py::test_cross_channel_incompatibility[classic] | 121.94s call |
| tests/test_create.py::test_conda_pip_interop_conda_editable_package[libmamba] | 76.51s call |
| tests/test_create.py::test_install_prune_flag[classic] | 74.91s call |
| tests/test_create.py::test_json_create_install_update_remove[libmamba] | 69.15s call |
| tests/test_create.py::test_shortcut_absent_does_not_barf_on_uninstall[libmamba] | 61.30s call |
| tests/test_create.py::test_list_with_pip_wheel[classic] | 57.60s call |
| tests/test_create.py::test_noarch_python_package_without_entry_points[classic] | 56.26s call |
| tests/test_create.py::test_conda_pip_interop_pip_clobbers_conda[libmamba] | 55.12s call |
| tests/test_create.py::test_shortcut_absent_when_condarc_set[classic] | 47.62s call |
| tests/cli/test_env.py::test_update_env_no_action_json_output[libmamba] | 42.27s call |
| tests/test_create.py::test_safety_checks_disabled[libmamba] | 39.32s call |

| Linux Integration 1 | `main` |
|-----------------------|--------|
| tests/cli/test_main_remove.py::test_remove_globbed_package_names[classic] | 501.59s call |
| tests/test_create.py::test_conda_pip_interop_compatible_release_operator[classic] | 335.41s call |
| tests/test_create.py::test_create_install_update_remove_smoketest[classic] | 294.98s call |
| tests/cli/test_env.py::test_update_env_json_output[classic] | 225.76s call |
| tests/test_create.py::test_force_remove[classic] | 219.67s call |
| tests/test_create.py::test_create_install_update_remove_smoketest[libmamba] | 104.12s call |
| tests/test_create.py::test_strict_resolve_get_reduced_index[libmamba] | 66.92s call |
| tests/test_create.py::test_strict_resolve_get_reduced_index[classic] | 64.97s call |
| tests/test_create.py::test_json_create_install_update_remove[libmamba] | 51.21s call |
| tests/test_create.py::test_dont_remove_conda_1[libmamba] | 41.80s call |
| tests/test_create.py::test_disallowed_packages[classic] | 37.11s call |
| tests/test_create.py::test_conda_pip_interop_conda_editable_package[classic] | 34.83s call |
| tests/test_create.py::test_conda_pip_interop_compatible_release_operator[libmamba] | 31.83s call |
| tests/cli/test_env.py::test_export_multi_channel[libmamba] | 29.88s call |
| tests/core/test_solve.py::test_freeze_deps_1[classic] | 28.15s call |
| tests/test_activate.py::test_stacking[5-base,has-has-has,base,sys] | 26.34s setup |

| Linux Integration 2 | `main` |
|-----------------------|--------|
| tests/cli/test_cli_install.py::test_find_conflicts_called_once[classic] | 546.48s call |
| tests/test_create.py::test_dont_remove_conda_2[classic] | 363.28s call |
| tests/test_create.py::test_conda_pip_interop_pip_clobbers_conda[classic] | 308.35s call |
| tests/test_create.py::test_conda_downgrade[libmamba] | 257.59s call |
| tests/test_create.py::test_cross_channel_incompatibility[classic] | 199.67s call |
| tests/test_create.py::test_noarch_python_package_with_entry_points[classic] | 108.58s call |
| tests/cli/test_env.py::test_create_valid_env_with_conda_and_pip_json_output[classic] | 106.27s call |
| tests/cli/test_env.py::test_pip_error_is_propagated[classic] | 105.55s call |
| tests/cli/test_env.py::test_update[classic] | 105.24s call |
| tests/cli/test_env.py::test_env_export_with_variables[classic] | 77.86s call |
| tests/test_create.py::test_dont_remove_conda_2[libmamba] | 38.24s call |
| tests/test_create.py::test_offline_with_empty_index_cache[classic] | 32.07s call |
| tests/test_create.py::test_conda_pip_interop_pip_clobbers_conda[libmamba] | 31.29s call |
| tests/test_activate.py::test_stacking[5-base,not-has-has,base,sys] | 28.80s setup |
| tests/test_create.py::test_list_with_pip_wheel[libmamba] | 28.04s call |
| tests/test_activate.py::test_stacking[5-base,has-base-base,has,base,sys] | 27.58s setup |

| Linux Integration 3 | `main` |
|-----------------------|--------|
| tests/cli/test_env.py::test_conda_env_create_http[classic] | 516.02s call |
| tests/test_create.py::test_dont_remove_conda_1[classic] | 356.09s call |
| tests/test_create.py::test_conda_downgrade[classic] | 273.08s call |
| tests/cli/test_env.py::test_update_env_only_pip_json_output[classic] | 209.76s call |
| tests/test_create.py::test_json_create_install_update_remove[classic] | 199.16s call |
| tests/cli/test_env.py::test_update_env_no_action_json_output[classic] | 191.51s call |
| tests/test_create.py::test_neutering_of_historic_specs[classic] | 155.14s call |
| tests/test_create.py::test_install_prune_flag[classic] | 114.34s call |
| tests/test_create.py::test_noarch_python_package_without_entry_points[classic] | 103.31s call |
| tests/cli/test_env.py::test_export_multi_channel[classic] | 102.21s call |
| tests/cli/test_env.py::test_env_export[classic] | 100.97s call |
| tests/test_create.py::test_channel_usage_replacing_python[classic] | 63.19s call |
| tests/test_create.py::test_channel_usage_replacing_python[libmamba] | 50.30s call |
| tests/test_create.py::test_list_with_pip_wheel[classic] | 37.16s call |
| tests/test_create.py::test_conda_pip_interop_conda_editable_package[libmamba] | 36.64s call |
| tests/test_create.py::test_neutering_of_historic_specs[libmamba] | 36.56s call |

</details>

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
