### PR TITLE
Ensure `DeprecationWarnings` are displayed

### DIFF
--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 from . import __version__
 
+warnings.filterwarnings("default", category=DeprecationWarning, module="conda")
+
 
 class DeprecatedError(RuntimeError):
     pass

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -3,6 +3,8 @@
 import json
 from os.path import isdir
 
+import pytest
+
 from conda.common.io import env_var
 from conda.testing import CondaCLIFixture
 
@@ -37,7 +39,7 @@ def test_info_unsafe_channels(reset_conda_context: None, conda_cli: CondaCLIFixt
         assert not err
 
 
-# conda info --all | --envs | --system
+# conda info --verbose | --envs | --system
 def test_info(conda_cli: CondaCLIFixture):
     stdout_basic, stderr, err = conda_cli("info")
     assert "platform" in stdout_basic
@@ -66,12 +68,21 @@ def test_info(conda_cli: CondaCLIFixture):
     assert not stderr
     assert not err
 
-    stdout_all, stderr, err = conda_cli("info", "--all")
-    assert stdout_basic in stdout_all, "`conda info` not in `conda info --all`"
-    assert stdout_envs in stdout_all, "`conda info --envs` not in `conda info --all`"
-    assert stdout_sys in stdout_all, "`conda info --system` not in `conda info --all`"
+    stdout_all, stderr, err = conda_cli("info", "--verbose")
+    assert stdout_basic in stdout_all
+    assert stdout_envs in stdout_all
+    assert stdout_sys in stdout_all
     assert not stderr
     assert not err
+
+
+# conda info --all
+def test_info_all(conda_cli: CondaCLIFixture):
+    with pytest.warns(
+        DeprecationWarning,
+        match="`--all` is deprecated and will be removed in 24.9. Use `--verbose` instead.",
+    ):
+        conda_cli("info", "--all")
 
 
 # conda info --json

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -69,23 +69,20 @@ def test_info(conda_cli: CondaCLIFixture):
     assert not stderr
     assert not err
 
-    stdout_all, stderr, err = conda_cli("info", "--verbose")
-    assert stdout_basic in stdout_all
-    assert stdout_envs in stdout_all
-    assert stdout_sys in stdout_all
+    stdout_verbose, stderr, err = conda_cli("info", "--verbose")
+    assert stdout_basic in stdout_verbose
+    assert stdout_envs in stdout_verbose
+    assert stdout_sys in stdout_verbose
     assert not stderr
     assert not err
 
 
 # conda info --all
-@pytest.mark.skipif(
-    deprecated._version_less_than("24.3.0"),
-    reason="DeprecationWarning is only displayed after 24.3.0.",
-)
 def test_info_all(conda_cli: CondaCLIFixture):
     with pytest.warns(
-        DeprecationWarning,
-        match="`--all` is deprecated and will be removed in 24.9. Use `--verbose` instead.",
+        PendingDeprecationWarning
+        if deprecated._version_less_than("24.3")
+        else DeprecationWarning,
     ):
         conda_cli("info", "--all")
 

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -3,10 +3,7 @@
 import json
 from os.path import isdir
 
-import pytest
-
 from conda.common.io import env_var
-from conda.deprecations import deprecated
 from conda.testing import CondaCLIFixture
 
 
@@ -40,7 +37,7 @@ def test_info_unsafe_channels(reset_conda_context: None, conda_cli: CondaCLIFixt
         assert not err
 
 
-# conda info --verbose | --envs | --system
+# conda info --all | --envs | --system
 def test_info(conda_cli: CondaCLIFixture):
     stdout_basic, stderr, err = conda_cli("info")
     assert "platform" in stdout_basic
@@ -69,22 +66,12 @@ def test_info(conda_cli: CondaCLIFixture):
     assert not stderr
     assert not err
 
-    stdout_verbose, stderr, err = conda_cli("info", "--verbose")
-    assert stdout_basic in stdout_verbose
-    assert stdout_envs in stdout_verbose
-    assert stdout_sys in stdout_verbose
+    stdout_all, stderr, err = conda_cli("info", "--all")
+    assert stdout_basic in stdout_all, "`conda info` not in `conda info --all`"
+    assert stdout_envs in stdout_all, "`conda info --envs` not in `conda info --all`"
+    assert stdout_sys in stdout_all, "`conda info --system` not in `conda info --all`"
     assert not stderr
     assert not err
-
-
-# conda info --all
-def test_info_all(conda_cli: CondaCLIFixture):
-    with pytest.warns(
-        PendingDeprecationWarning
-        if deprecated._version_less_than("24.3")
-        else DeprecationWarning,
-    ):
-        conda_cli("info", "--all")
 
 
 # conda info --json

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -6,6 +6,7 @@ from os.path import isdir
 import pytest
 
 from conda.common.io import env_var
+from conda.deprecations import deprecated
 from conda.testing import CondaCLIFixture
 
 
@@ -77,6 +78,10 @@ def test_info(conda_cli: CondaCLIFixture):
 
 
 # conda info --all
+@pytest.mark.skipif(
+    deprecated._version_less_than("24.3.0"),
+    reason="DeprecationWarning is only displayed after 24.3.0.",
+)
 def test_info_all(conda_cli: CondaCLIFixture):
     with pytest.warns(
         DeprecationWarning,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Previously users would have to explicitly run `conda` with `PYTHONWARNINGS=d` or similar to see deprecation warnings. This is not ideal especially when we try to deprecate CLI arguments.

Resolves https://github.com/conda/conda/issues/13704

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
