### PR TITLE
Remove `os.environ` copy from `conda.activate._Activator`

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -92,7 +92,6 @@ class _Activator(metaclass=abc.ABCMeta):
 
     def __init__(self, arguments=None):
         self._raw_arguments = arguments
-        self.environ = os.environ.copy()
 
     def get_export_unset_vars(self, export_metavars=True, **kwargs):
         """
@@ -366,8 +365,8 @@ class _Activator(metaclass=abc.ABCMeta):
             prefix = locate_prefix_by_name(env_name_or_prefix)
 
         # get prior shlvl and prefix
-        old_conda_shlvl = int(self.environ.get("CONDA_SHLVL", "").strip() or 0)
-        old_conda_prefix = self.environ.get("CONDA_PREFIX")
+        old_conda_shlvl = int(os.getenv("CONDA_SHLVL", "").strip() or 0)
+        old_conda_prefix = os.getenv("CONDA_PREFIX")
 
         # if the prior active prefix is this prefix we are actually doing a reactivate
         if old_conda_prefix == prefix and old_conda_shlvl > 0:
@@ -384,11 +383,11 @@ class _Activator(metaclass=abc.ABCMeta):
         }
 
         # get clobbered environment variables
-        clobber_vars = set(env_vars.keys()).intersection(os.environ.keys())
+        clobber_vars = set(env_vars).intersection(os.environ)
         overwritten_clobber_vars = [
             clobber_var
             for clobber_var in clobber_vars
-            if os.environ[clobber_var] != env_vars[clobber_var]
+            if os.getenv(clobber_var) != env_vars[clobber_var]
         ]
         if overwritten_clobber_vars:
             print(
@@ -397,7 +396,7 @@ class _Activator(metaclass=abc.ABCMeta):
             )
             print(f"overwriting variable {overwritten_clobber_vars}", file=sys.stderr)
         for name in clobber_vars:
-            env_vars[f"__CONDA_SHLVL_{old_conda_shlvl}_{name}"] = os.environ.get(name)
+            env_vars[f"__CONDA_SHLVL_{old_conda_shlvl}_{name}"] = os.getenv(name)
 
         if old_conda_shlvl == 0:
             export_vars, unset_vars = self.get_export_unset_vars(
@@ -454,8 +453,8 @@ class _Activator(metaclass=abc.ABCMeta):
     def build_deactivate(self):
         self._deactivate = True
         # query environment
-        old_conda_prefix = self.environ.get("CONDA_PREFIX")
-        old_conda_shlvl = int(self.environ.get("CONDA_SHLVL", "").strip() or 0)
+        old_conda_prefix = os.getenv("CONDA_PREFIX")
+        old_conda_shlvl = int(os.getenv("CONDA_SHLVL", "").strip() or 0)
         if not old_conda_prefix or old_conda_shlvl < 1:
             # no active environment, so cannot deactivate; do nothing
             return {
@@ -496,12 +495,12 @@ class _Activator(metaclass=abc.ABCMeta):
             }
         else:
             assert old_conda_shlvl > 1
-            new_prefix = self.environ.get("CONDA_PREFIX_%d" % new_conda_shlvl)
+            new_prefix = os.getenv("CONDA_PREFIX_%d" % new_conda_shlvl)
             conda_default_env = self._default_env(new_prefix)
             conda_prompt_modifier = self._prompt_modifier(new_prefix, conda_default_env)
             new_conda_environment_env_vars = self._get_environment_env_vars(new_prefix)
 
-            old_prefix_stacked = "CONDA_STACKED_%d" % old_conda_shlvl in self.environ
+            old_prefix_stacked = "CONDA_STACKED_%d" % old_conda_shlvl in os.environ
             new_path = ""
 
             unset_vars = ["CONDA_PREFIX_%d" % new_conda_shlvl]
@@ -534,8 +533,8 @@ class _Activator(metaclass=abc.ABCMeta):
         for env_var in old_conda_environment_env_vars.keys():
             unset_vars.append(env_var)
             save_var = f"__CONDA_SHLVL_{new_conda_shlvl}_{env_var}"
-            if save_var in os.environ.keys():
-                export_vars[env_var] = os.environ[save_var]
+            if save_value := os.getenv(save_var):
+                export_vars[env_var] = save_value
         return {
             "unset_vars": unset_vars,
             "set_vars": set_vars,
@@ -547,8 +546,8 @@ class _Activator(metaclass=abc.ABCMeta):
 
     def build_reactivate(self):
         self._reactivate = True
-        conda_prefix = self.environ.get("CONDA_PREFIX")
-        conda_shlvl = int(self.environ.get("CONDA_SHLVL", "").strip() or 0)
+        conda_prefix = os.getenv("CONDA_PREFIX")
+        conda_shlvl = int(os.getenv("CONDA_SHLVL", "").strip() or 0)
         if not conda_prefix or conda_shlvl < 1:
             # no active environment, so cannot reactivate; do nothing
             return {
@@ -558,7 +557,7 @@ class _Activator(metaclass=abc.ABCMeta):
                 "deactivate_scripts": (),
                 "activate_scripts": (),
             }
-        conda_default_env = self.environ.get(
+        conda_default_env = os.getenv(
             "CONDA_DEFAULT_ENV", self._default_env(conda_prefix)
         )
         new_path = self.pathsep_join(
@@ -606,7 +605,7 @@ class _Activator(metaclass=abc.ABCMeta):
             "C:\\Windows\\System32\\Wbem;"
             "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\",
         }
-        path = self.environ.get(
+        path = os.getenv(
             "PATH",
             clean_paths[sys.platform] if sys.platform in clean_paths else "/usr/bin",
         )
@@ -635,7 +634,7 @@ class _Activator(metaclass=abc.ABCMeta):
         # the condabin directory is included in the path list.
         # Under normal conditions, if the shell hook is working correctly, this should
         # never trigger.
-        old_conda_shlvl = int(self.environ.get("CONDA_SHLVL", "").strip() or 0)
+        old_conda_shlvl = int(os.getenv("CONDA_SHLVL", "").strip() or 0)
         if not old_conda_shlvl and not any(p.endswith("condabin") for p in path_list):
             condabin_dir = self.path_conversion(join(context.conda_prefix, "condabin"))
             path_list.insert(0, condabin_dir)
@@ -705,15 +704,15 @@ class _Activator(metaclass=abc.ABCMeta):
             # Get current environment and prompt stack
             env_stack = []
             prompt_stack = []
-            old_shlvl = int(self.environ.get("CONDA_SHLVL", "0").rstrip())
+            old_shlvl = int(os.getenv("CONDA_SHLVL", "0").rstrip())
             for i in range(1, old_shlvl + 1):
                 if i == old_shlvl:
-                    env_i = self._default_env(self.environ.get("CONDA_PREFIX", ""))
+                    env_i = self._default_env(os.getenv("CONDA_PREFIX", ""))
                 else:
                     env_i = self._default_env(
-                        self.environ.get(f"CONDA_PREFIX_{i}", "").rstrip()
+                        os.getenv(f"CONDA_PREFIX_{i}", "").rstrip()
                     )
-                stacked_i = bool(self.environ.get(f"CONDA_STACKED_{i}", "").rstrip())
+                stacked_i = bool(os.getenv(f"CONDA_STACKED_{i}", "").rstrip())
                 env_stack.append(env_i)
                 if not stacked_i:
                     prompt_stack = prompt_stack[0:-1]
@@ -725,9 +724,7 @@ class _Activator(metaclass=abc.ABCMeta):
             if deactivate:
                 prompt_stack = prompt_stack[0:-1]
                 env_stack = env_stack[0:-1]
-                stacked = bool(
-                    self.environ.get(f"CONDA_STACKED_{old_shlvl}", "").rstrip()
-                )
+                stacked = bool(os.getenv(f"CONDA_STACKED_{old_shlvl}", "").rstrip())
                 if not stacked and env_stack:
                     prompt_stack.append(env_stack[-1])
             elif reactivate:
@@ -936,11 +933,11 @@ class PosixActivator(_Activator):
     )
 
     def _update_prompt(self, set_vars, conda_prompt_modifier):
-        ps1 = self.environ.get("PS1", "")
+        ps1 = os.getenv("PS1", "")
         if "POWERLINE_COMMAND" in ps1:
             # Defer to powerline (https://github.com/powerline/powerline) if it's in use.
             return
-        current_prompt_modifier = self.environ.get("CONDA_PROMPT_MODIFIER")
+        current_prompt_modifier = os.getenv("CONDA_PROMPT_MODIFIER")
         if current_prompt_modifier:
             ps1 = re.sub(re.escape(current_prompt_modifier), r"", ps1)
         # Because we're using single-quotes to set shell variables, we need to handle the
@@ -989,8 +986,8 @@ class CshActivator(_Activator):
     )
 
     def _update_prompt(self, set_vars, conda_prompt_modifier):
-        prompt = self.environ.get("prompt", "")
-        current_prompt_modifier = self.environ.get("CONDA_PROMPT_MODIFIER")
+        prompt = os.getenv("prompt", "")
+        current_prompt_modifier = os.getenv("CONDA_PROMPT_MODIFIER")
         if current_prompt_modifier:
             prompt = re.sub(re.escape(current_prompt_modifier), r"", prompt)
         set_vars.update(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Creating a copy of `os.environ` is expensive to do when it doesn't serve any purpose.

Split out from https://github.com/conda/conda/pull/13620

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
