### PR TITLE
Deprecate redundant helper functions and move testing helper function to test suite

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -617,7 +617,8 @@ class _Activator(metaclass=abc.ABCMeta):
         path_split = path.split(os.pathsep)
         return path_split
 
-    def _get_path_dirs(self, prefix, extra_library_bin=False):
+    @deprecated.argument("24.9", "25.3", "extra_library_bin")
+    def _get_path_dirs(self, prefix):
         if on_win:  # pragma: unix no cover
             yield prefix.rstrip("\\")
             yield self.sep.join((prefix, "Library", "mingw-w64", "bin"))

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -43,6 +43,7 @@ from .base.constants import (
 from .base.context import ROOT_ENV_NAME, context, locate_prefix_by_name
 from .common.compat import FILESYSTEM_ENCODING, on_win
 from .common.path import paths_equal
+from .deprecations import deprecated
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -129,14 +130,17 @@ class _Activator(metaclass=abc.ABCMeta):
 
         return export_vars, unset_vars
 
-    # Used in tests only.
+    @deprecated(
+        "24.9",
+        "25.3",
+        addendum="Use `conda.activate._Activator.get_export_unset_vars` instead.",
+    )
     def add_export_unset_vars(self, export_vars, unset_vars, **kwargs):
         new_export_vars, new_unset_vars = self.get_export_unset_vars(**kwargs)
-        if export_vars is not None:
-            export_vars = {**export_vars, **new_export_vars}
-        if unset_vars is not None:
-            unset_vars = [*unset_vars, *new_unset_vars]
-        return export_vars, unset_vars
+        return {
+            {**(export_vars or {}), **new_export_vars},
+            [*(unset_vars or []), *new_unset_vars],
+        }
 
     # Used in tests only.
     def get_scripts_export_unset_vars(self, **kwargs):

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -1192,14 +1192,14 @@ class JSONFormatMixin(_Activator):
                 "_CONDA_EXE": context.conda_exe,
             }
 
+    @deprecated(
+        "24.9",
+        "25.3",
+        addendum="Use `conda.activate._Activator.get_export_unset_vars` instead.",
+    )
     def get_scripts_export_unset_vars(self, **kwargs):
         export_vars, unset_vars = self.get_export_unset_vars(**kwargs)
-        script_export_vars = script_unset_vars = None
-        if export_vars:
-            script_export_vars = dict(export_vars.items())
-        if unset_vars:
-            script_unset_vars = unset_vars
-        return script_export_vars or {}, script_unset_vars or []
+        return export_vars or {}, unset_vars or []
 
     def _finalize(self, commands, ext):
         merged = {}

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -143,13 +143,15 @@ class _Activator(metaclass=abc.ABCMeta):
         }
 
     @deprecated("24.9", "25.3", addendum="For testing only. Moved to test suite.")
-    def get_scripts_export_unset_vars(self, **kwargs):
+    def get_scripts_export_unset_vars(self, **kwargs) -> tuple[str, str]:
         export_vars, unset_vars = self.get_export_unset_vars(**kwargs)
         return (
-            self.command_join(
+            self.command_join.join(
                 self.export_var_tmpl % (k, v) for k, v in (export_vars or {}).items()
             ),
-            self.command_join(self.unset_var_tmpl % (k) for k in (unset_vars or [])),
+            self.command_join.join(
+                self.unset_var_tmpl % (k) for k in (unset_vars or [])
+            ),
         )
 
     def _finalize(self, commands, ext):

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -142,19 +142,15 @@ class _Activator(metaclass=abc.ABCMeta):
             [*(unset_vars or []), *new_unset_vars],
         }
 
-    # Used in tests only.
+    @deprecated("24.9", "25.3", addendum="For testing only. Moved to test suite.")
     def get_scripts_export_unset_vars(self, **kwargs):
         export_vars, unset_vars = self.get_export_unset_vars(**kwargs)
-        script_export_vars = script_unset_vars = None
-        if export_vars:
-            script_export_vars = self.command_join.join(
-                [self.export_var_tmpl % (k, v) for k, v in export_vars.items()]
-            )
-        if unset_vars:
-            script_unset_vars = self.command_join.join(
-                [self.unset_var_tmpl % (k) for k in unset_vars]
-            )
-        return script_export_vars or "", script_unset_vars or ""
+        return (
+            self.command_join(
+                self.export_var_tmpl % (k, v) for k, v in (export_vars or {}).items()
+            ),
+            self.command_join(self.unset_var_tmpl % (k) for k in (unset_vars or [])),
+        )
 
     def _finalize(self, commands, ext):
         commands = (*commands, "")  # add terminating newline

--- a/news/13720-deprecate-activate-testing-helpers
+++ b/news/13720-deprecate-activate-testing-helpers
@@ -1,0 +1,22 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.activate._Activator.add_export_unset_vars` as pending deprecation. Use `conda.activate._Activator.get_export_unset_vars` instead. (#13720)
+* Mark `conda.activate._Activator.get_scripts_export_unset_vars` as pending deprecation. Use `get_scripts_export_unset_vars` helper function in `test_activate.py` instead. (#13720)
+* Mark `conda.activate._Activator._get_path_dirs(extra_library_bin)` as pending deprecation. Unused argument. (#13720)
+* Mark `conda.activate.JSONFormatMixin.get_scripts_export_unset_vars` as pending deprecation. Use `conda.activate._Activator.get_export_unset_vars` instead. (#13720)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -187,10 +187,10 @@ def get_scripts_export_unset_vars(
 ) -> tuple[str, str]:
     export_vars, unset_vars = activator.get_export_unset_vars(**kwargs)
     return (
-        activator.command_join(
+        activator.command_join.join(
             activator.export_var_tmpl % (k, v) for k, v in (export_vars or {}).items()
         ),
-        activator.command_join(
+        activator.command_join.join(
             activator.unset_var_tmpl % (k) for k in (unset_vars or [])
         ),
     )

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
 
     from pytest import MonkeyPatch
 
+    from conda.activate import _Activator
     from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 
 
@@ -178,6 +179,21 @@ def write_pkg_env_vars(prefix):
         f.write(PKG_A_ENV_VARS)
     with open(join(activate_pkg_env_vars, "pkg_b.json"), "w") as f:
         f.write(PKG_B_ENV_VARS)
+
+
+def get_scripts_export_unset_vars(
+    activator: _Activator,
+    **kwargs: str,
+) -> tuple[str, str]:
+    export_vars, unset_vars = activator.get_export_unset_vars(**kwargs)
+    return (
+        activator.command_join(
+            activator.export_var_tmpl % (k, v) for k, v in (export_vars or {}).items()
+        ),
+        activator.command_join(
+            activator.unset_var_tmpl % (k) for k in (unset_vars or [])
+        ),
+    )
 
 
 def test_activate_environment_not_found(reset_environ: None):
@@ -1233,7 +1249,7 @@ def test_posix_basic(shell_wrapper_unit: str):
     activate_data = c.stdout
 
     new_path_parts = activator._add_prefix_to_path(shell_wrapper_unit)
-    conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
+    conda_exe_export, conda_exe_unset = get_scripts_export_unset_vars(activator)
 
     e_activate_data = dals(
         """
@@ -1319,7 +1335,7 @@ def test_posix_basic(shell_wrapper_unit: str):
         (
             conda_exe_export,
             conda_exe_unset,
-        ) = activator.get_scripts_export_unset_vars()
+        ) = get_scripts_export_unset_vars(activator)
 
         e_deactivate_data = dals(
             """
@@ -1369,7 +1385,7 @@ def test_cmd_exe_basic(shell_wrapper_unit: str):
     rm_rf(activate_result)
 
     new_path_parts = activator._add_prefix_to_path(shell_wrapper_unit)
-    conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
+    conda_exe_export, conda_exe_unset = get_scripts_export_unset_vars(activator)
 
     e_activate_data = dals(
         """
@@ -1493,7 +1509,7 @@ def test_csh_basic(shell_wrapper_unit: str):
     activate_data = c.stdout
 
     new_path_parts = activator._add_prefix_to_path(shell_wrapper_unit)
-    conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
+    conda_exe_export, conda_exe_unset = get_scripts_export_unset_vars(activator)
 
     e_activate_data = dals(
         """
@@ -1582,7 +1598,7 @@ def test_csh_basic(shell_wrapper_unit: str):
         (
             conda_exe_export,
             conda_exe_unset,
-        ) = activator.get_scripts_export_unset_vars()
+        ) = get_scripts_export_unset_vars(activator)
 
         e_deactivate_data = dals(
             """
@@ -1623,7 +1639,7 @@ def test_xonsh_basic(shell_wrapper_unit: str):
     activate_data = c.stdout
 
     new_path_parts = activator._add_prefix_to_path(shell_wrapper_unit)
-    conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
+    conda_exe_export, conda_exe_unset = get_scripts_export_unset_vars(activator)
     e_activate_template = dals(
         """
     $PATH = '%(new_path)s'
@@ -1724,7 +1740,7 @@ def test_xonsh_basic(shell_wrapper_unit: str):
         (
             conda_exe_export,
             conda_exe_unset,
-        ) = activator.get_scripts_export_unset_vars()
+        ) = get_scripts_export_unset_vars(activator)
         e_deactivate_template = dals(
             """
         $PATH = '%(new_path)s'
@@ -1773,7 +1789,7 @@ def test_fish_basic(shell_wrapper_unit: str):
     activate_data = c.stdout
 
     new_path_parts = activator._add_prefix_to_path(shell_wrapper_unit)
-    conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
+    conda_exe_export, conda_exe_unset = get_scripts_export_unset_vars(activator)
     e_activate_data = dals(
         """
     set -gx PATH "%(new_path)s";
@@ -1857,7 +1873,7 @@ def test_fish_basic(shell_wrapper_unit: str):
         (
             conda_exe_export,
             conda_exe_unset,
-        ) = activator.get_scripts_export_unset_vars()
+        ) = get_scripts_export_unset_vars(activator)
         e_deactivate_data = dals(
             """
         set -gx PATH "%(new_path)s";
@@ -1895,7 +1911,7 @@ def test_powershell_basic(shell_wrapper_unit: str):
     activate_data = c.stdout
 
     new_path_parts = activator._add_prefix_to_path(shell_wrapper_unit)
-    conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
+    conda_exe_export, conda_exe_unset = get_scripts_export_unset_vars(activator)
     e_activate_data = dals(
         """
     $Env:PATH = "%(new_path)s"

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -378,22 +378,18 @@ def test_build_activate_dont_activate_unset_var(reset_environ: None):
                 new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
                 conda_prompt_modifier = "(%s) " % td
                 ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
-                unset_vars = []
 
                 set_vars = {"PS1": ps1}
-                export_vars = {
-                    "PATH": new_path,
-                    "CONDA_PREFIX": td,
-                    "CONDA_SHLVL": 1,
-                    "CONDA_DEFAULT_ENV": td,
-                    "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                    "PKG_A_ENV": "yerp",
-                    "PKG_B_ENV": "berp",
-                    "ENV_ONE": "one",
-                    "ENV_TWO": "you",
-                }
-                export_vars, unset_vars = activator.add_export_unset_vars(
-                    export_vars, unset_vars
+                export_vars, unset_vars = activator.get_export_unset_vars(
+                    PATH=new_path,
+                    CONDA_PREFIX=td,
+                    CONDA_SHLVL=1,
+                    CONDA_DEFAULT_ENV=td,
+                    CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+                    PKG_A_ENV="yerp",
+                    PKG_B_ENV="berp",
+                    ENV_ONE="one",
+                    ENV_TWO="you",
                 )
                 assert builder["unset_vars"] == unset_vars
                 assert builder["set_vars"] == set_vars
@@ -437,23 +433,19 @@ def test_build_activate_shlvl_warn_clobber_vars(reset_environ: None):
                 new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
                 conda_prompt_modifier = "(%s) " % td
                 ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
-                unset_vars = []
 
                 set_vars = {"PS1": ps1}
-                export_vars = {
-                    "PATH": new_path,
-                    "CONDA_PREFIX": td,
-                    "CONDA_SHLVL": 1,
-                    "CONDA_DEFAULT_ENV": td,
-                    "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                    "PKG_A_ENV": "teamnope",
-                    "PKG_B_ENV": "berp",
-                    "ENV_ONE": "one",
-                    "ENV_TWO": "you",
-                    "ENV_THREE": "me",
-                }
-                export_vars, unset_vars = activator.add_export_unset_vars(
-                    export_vars, unset_vars
+                export_vars, unset_vars = activator.get_export_unset_vars(
+                    PATH=new_path,
+                    CONDA_PREFIX=td,
+                    CONDA_SHLVL=1,
+                    CONDA_DEFAULT_ENV=td,
+                    CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+                    PKG_A_ENV="teamnope",
+                    PKG_B_ENV="berp",
+                    ENV_ONE="one",
+                    ENV_TWO="you",
+                    ENV_THREE="me",
                 )
                 assert builder["unset_vars"] == unset_vars
                 assert builder["set_vars"] == set_vars
@@ -486,24 +478,20 @@ def test_build_activate_shlvl_0(reset_environ: None):
                 new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
                 conda_prompt_modifier = "(%s) " % td
                 ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
-                unset_vars = []
 
                 set_vars = {"PS1": ps1}
-                export_vars = {
-                    "PATH": new_path,
-                    "CONDA_PREFIX": td,
-                    "CONDA_SHLVL": 1,
-                    "CONDA_DEFAULT_ENV": td,
-                    "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                    "PKG_A_ENV": "yerp",
-                    "PKG_B_ENV": "berp",
-                    "ENV_ONE": "one",
-                    "ENV_TWO": "you",
-                    "ENV_THREE": "me",
-                    "ENV_WITH_SAME_VALUE": "with_same_value",
-                }
-                export_vars, unset_vars = activator.add_export_unset_vars(
-                    export_vars, unset_vars
+                export_vars, unset_vars = activator.get_export_unset_vars(
+                    PATH=new_path,
+                    CONDA_PREFIX=td,
+                    CONDA_SHLVL=1,
+                    CONDA_DEFAULT_ENV=td,
+                    CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+                    PKG_A_ENV="yerp",
+                    PKG_B_ENV="berp",
+                    ENV_ONE="one",
+                    ENV_TWO="you",
+                    ENV_THREE="me",
+                    ENV_WITH_SAME_VALUE="with_same_value",
                 )
                 assert builder["unset_vars"] == unset_vars
                 assert builder["set_vars"] == set_vars
@@ -554,28 +542,21 @@ def test_build_activate_shlvl_1(reset_environ: None):
             assert activator.path_conversion(td) in new_path
             assert old_prefix not in new_path
 
-            unset_vars = []
-
             set_vars = {"PS1": ps1}
-            export_vars = {
-                "PATH": new_path,
-                "CONDA_PREFIX": td,
-                "CONDA_SHLVL": 2,
-                "CONDA_DEFAULT_ENV": td,
-                "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                "PKG_A_ENV": "yerp",
-                "PKG_B_ENV": "berp",
-                "ENV_ONE": "one",
-                "ENV_TWO": "you",
-                "ENV_THREE": "me",
-                "ENV_WITH_SAME_VALUE": "with_same_value",
-            }
-            export_vars, _ = activator.add_export_unset_vars(export_vars, None)
-            export_vars["CONDA_PREFIX_1"] = old_prefix
-            export_vars, unset_vars = activator.add_export_unset_vars(
-                export_vars, unset_vars
+            export_vars, unset_vars = activator.get_export_unset_vars(
+                PATH=new_path,
+                CONDA_PREFIX=td,
+                CONDA_PREFIX_1=old_prefix,
+                CONDA_SHLVL=2,
+                CONDA_DEFAULT_ENV=td,
+                CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+                PKG_A_ENV="yerp",
+                PKG_B_ENV="berp",
+                ENV_ONE="one",
+                ENV_TWO="you",
+                ENV_THREE="me",
+                ENV_WITH_SAME_VALUE="with_same_value",
             )
-
             assert builder["unset_vars"] == unset_vars
             assert builder["set_vars"] == set_vars
             assert builder["export_vars"] == export_vars
@@ -603,29 +584,24 @@ def test_build_activate_shlvl_1(reset_environ: None):
                 activator = PosixActivator()
                 builder = activator.build_deactivate()
 
-                unset_vars = [
-                    "CONDA_PREFIX_1",
-                    "PKG_A_ENV",
-                    "PKG_B_ENV",
-                    "ENV_ONE",
-                    "ENV_TWO",
-                    "ENV_THREE",
-                    "ENV_WITH_SAME_VALUE",
-                ]
                 assert builder["set_vars"] == {
                     "PS1": "(/old/prefix)",
-                }
-                export_vars = {
-                    "CONDA_PREFIX": old_prefix,
-                    "CONDA_SHLVL": 1,
-                    "CONDA_DEFAULT_ENV": old_prefix,
-                    "CONDA_PROMPT_MODIFIER": "(%s)" % old_prefix,
                 }
                 export_path = {
                     "PATH": old_path,
                 }
-                export_vars, unset_vars = activator.add_export_unset_vars(
-                    export_vars, unset_vars
+                export_vars, unset_vars = activator.get_export_unset_vars(
+                    CONDA_PREFIX=old_prefix,
+                    CONDA_SHLVL=1,
+                    CONDA_DEFAULT_ENV=old_prefix,
+                    CONDA_PROMPT_MODIFIER="(%s)" % old_prefix,
+                    CONDA_PREFIX_1=None,
+                    PKG_A_ENV=None,
+                    PKG_B_ENV=None,
+                    ENV_ONE=None,
+                    ENV_TWO=None,
+                    ENV_THREE=None,
+                    ENV_WITH_SAME_VALUE=None,
                 )
                 assert builder["unset_vars"] == unset_vars
                 assert builder["export_vars"] == export_vars
@@ -673,23 +649,21 @@ def test_build_stack_shlvl_1(reset_environ: None):
             assert old_prefix in new_path
 
             set_vars = {"PS1": ps1}
-            export_vars = {
-                "PATH": new_path,
-                "CONDA_PREFIX": td,
-                "CONDA_SHLVL": 2,
-                "CONDA_DEFAULT_ENV": td,
-                "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                "PKG_A_ENV": "yerp",
-                "PKG_B_ENV": "berp",
-                "ENV_ONE": "one",
-                "ENV_TWO": "you",
-                "ENV_THREE": "me",
-                "ENV_WITH_SAME_VALUE": "with_same_value",
-            }
-            export_vars, unset_vars = activator.add_export_unset_vars(export_vars, [])
-            export_vars["CONDA_PREFIX_1"] = old_prefix
-            export_vars["CONDA_STACKED_2"] = "true"
-
+            export_vars, unset_vars = activator.get_export_unset_vars(
+                PATH=new_path,
+                CONDA_PREFIX=td,
+                CONDA_PREFIX_1=old_prefix,
+                CONDA_SHLVL=2,
+                CONDA_DEFAULT_ENV=td,
+                CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+                CONDA_STACKED_2="true",
+                PKG_A_ENV="yerp",
+                PKG_B_ENV="berp",
+                ENV_ONE="one",
+                ENV_TWO="you",
+                ENV_THREE="me",
+                ENV_WITH_SAME_VALUE="with_same_value",
+            )
             assert builder["unset_vars"] == unset_vars
             assert builder["set_vars"] == set_vars
             assert builder["export_vars"] == export_vars
@@ -717,27 +691,22 @@ def test_build_stack_shlvl_1(reset_environ: None):
                 activator = PosixActivator()
                 builder = activator.build_deactivate()
 
-                unset_vars = [
-                    "CONDA_PREFIX_1",
-                    "CONDA_STACKED_2",
-                    "PKG_A_ENV",
-                    "PKG_B_ENV",
-                    "ENV_ONE",
-                    "ENV_TWO",
-                    "ENV_THREE",
-                    "ENV_WITH_SAME_VALUE",
-                ]
                 assert builder["set_vars"] == {
                     "PS1": "(/old/prefix)",
                 }
-                export_vars = {
-                    "CONDA_PREFIX": old_prefix,
-                    "CONDA_SHLVL": 1,
-                    "CONDA_DEFAULT_ENV": old_prefix,
-                    "CONDA_PROMPT_MODIFIER": f"({old_prefix})",
-                }
-                export_vars, unset_vars = activator.add_export_unset_vars(
-                    export_vars, unset_vars
+                export_vars, unset_vars = activator.get_export_unset_vars(
+                    CONDA_PREFIX=old_prefix,
+                    CONDA_SHLVL=1,
+                    CONDA_DEFAULT_ENV=old_prefix,
+                    CONDA_PROMPT_MODIFIER=f"({old_prefix})",
+                    CONDA_PREFIX_1=None,
+                    CONDA_STACKED_2=None,
+                    PKG_A_ENV=None,
+                    PKG_B_ENV=None,
+                    ENV_ONE=None,
+                    ENV_TWO=None,
+                    ENV_THREE=None,
+                    ENV_WITH_SAME_VALUE=None,
                 )
                 assert builder["unset_vars"] == unset_vars
                 assert builder["export_vars"] == export_vars
@@ -863,34 +832,28 @@ def test_build_deactivate_shlvl_2_from_stack(reset_environ: None):
                 activator = PosixActivator()
                 builder = activator.build_deactivate()
 
-                unset_vars = [
-                    "CONDA_PREFIX_1",
-                    "CONDA_STACKED_2",
-                    "PKG_A_ENV",
-                    "ENV_ONE",
-                    "ENV_TWO",
-                    "ENV_THREE",
-                    "ENV_WITH_SAME_VALUE",
-                ]
-
                 conda_prompt_modifier = "(%s) " % old_prefix
                 ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
 
                 set_vars = {"PS1": ps1}
-                export_vars = {
-                    "CONDA_PREFIX": old_prefix,
-                    "CONDA_SHLVL": 1,
-                    "CONDA_DEFAULT_ENV": old_prefix,
-                    "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                    "PKG_B_ENV": "berp",
-                    "ENV_FOUR": "roar",
-                    "ENV_FIVE": "hive",
-                }
                 export_path = {
                     "PATH": original_path,
                 }
-                export_vars, unset_vars = activator.add_export_unset_vars(
-                    export_vars, unset_vars
+                export_vars, unset_vars = activator.get_export_unset_vars(
+                    CONDA_PREFIX=old_prefix,
+                    CONDA_SHLVL=1,
+                    CONDA_DEFAULT_ENV=old_prefix,
+                    CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+                    PKG_B_ENV="berp",
+                    ENV_FOUR="roar",
+                    ENV_FIVE="hive",
+                    CONDA_PREFIX_1=None,
+                    CONDA_STACKED_2=None,
+                    PKG_A_ENV=None,
+                    ENV_ONE=None,
+                    ENV_TWO=None,
+                    ENV_THREE=None,
+                    ENV_WITH_SAME_VALUE=None,
                 )
                 assert builder["unset_vars"] == unset_vars
                 assert builder["set_vars"] == set_vars
@@ -971,33 +934,27 @@ def test_build_deactivate_shlvl_2_from_activate(reset_environ: None):
             activator = PosixActivator()
             builder = activator.build_deactivate()
 
-            unset_vars = [
-                "CONDA_PREFIX_1",
-                "PKG_A_ENV",
-                "ENV_ONE",
-                "ENV_TWO",
-                "ENV_THREE",
-                "ENV_WITH_SAME_VALUE",
-            ]
-
             conda_prompt_modifier = "(%s) " % old_prefix
             ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
 
             set_vars = {"PS1": ps1}
-            export_vars = {
-                "CONDA_PREFIX": old_prefix,
-                "CONDA_SHLVL": 1,
-                "CONDA_DEFAULT_ENV": old_prefix,
-                "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                "PKG_B_ENV": "berp",
-                "ENV_FOUR": "roar",
-                "ENV_FIVE": "hive",
-            }
             export_path = {
                 "PATH": original_path,
             }
-            export_vars, unset_vars = activator.add_export_unset_vars(
-                export_vars, unset_vars
+            export_vars, unset_vars = activator.get_export_unset_vars(
+                CONDA_PREFIX=old_prefix,
+                CONDA_SHLVL=1,
+                CONDA_DEFAULT_ENV=old_prefix,
+                CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+                PKG_B_ENV="berp",
+                ENV_FOUR="roar",
+                ENV_FIVE="hive",
+                CONDA_PREFIX_1=None,
+                PKG_A_ENV=None,
+                ENV_ONE=None,
+                ENV_TWO=None,
+                ENV_THREE=None,
+                ENV_WITH_SAME_VALUE=None,
             )
 
             assert builder["unset_vars"] == unset_vars
@@ -1036,19 +993,17 @@ def test_build_deactivate_shlvl_1(reset_environ: None):
                 new_path = activator.pathsep_join(
                     activator.path_conversion(original_path)
                 )
-                export_vars, unset_vars = activator.add_export_unset_vars(
-                    {"CONDA_SHLVL": 0},
-                    [
-                        "CONDA_PREFIX",
-                        "CONDA_DEFAULT_ENV",
-                        "CONDA_PROMPT_MODIFIER",
-                        "PKG_A_ENV",
-                        "PKG_B_ENV",
-                        "ENV_ONE",
-                        "ENV_TWO",
-                        "ENV_THREE",
-                        "ENV_WITH_SAME_VALUE",
-                    ],
+                export_vars, unset_vars = activator.get_export_unset_vars(
+                    CONDA_SHLVL=0,
+                    CONDA_PREFIX=None,
+                    CONDA_DEFAULT_ENV=None,
+                    CONDA_PROMPT_MODIFIER=None,
+                    PKG_A_ENV=None,
+                    PKG_B_ENV=None,
+                    ENV_ONE=None,
+                    ENV_TWO=None,
+                    ENV_THREE=None,
+                    ENV_WITH_SAME_VALUE=None,
                 )
                 assert builder["set_vars"] == {"PS1": os.environ.get("PS1", "")}
                 assert builder["export_vars"] == export_vars
@@ -1137,28 +1092,22 @@ def test_build_activate_restore_unset_env_vars(reset_environ: None):
             assert activator.path_conversion(td) in new_path
             assert old_prefix not in new_path
 
-            unset_vars = []
-
             set_vars = {"PS1": ps1}
-            export_vars = {
-                "PATH": new_path,
-                "CONDA_PREFIX": td,
-                "CONDA_SHLVL": 2,
-                "CONDA_DEFAULT_ENV": td,
-                "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                "PKG_A_ENV": "yerp",
-                "PKG_B_ENV": "berp",
-                "ENV_ONE": "one",
-                "ENV_TWO": "you",
-                "ENV_THREE": "me",
-                "ENV_WITH_SAME_VALUE": "with_same_value",
-                "__CONDA_SHLVL_1_ENV_ONE": "already_set_env_var",
-                "__CONDA_SHLVL_1_ENV_WITH_SAME_VALUE": "with_same_value",
-            }
-            export_vars, _ = activator.add_export_unset_vars(export_vars, None)
-            export_vars["CONDA_PREFIX_1"] = old_prefix
-            export_vars, unset_vars = activator.add_export_unset_vars(
-                export_vars, unset_vars
+            export_vars, unset_vars = activator.get_export_unset_vars(
+                PATH=new_path,
+                CONDA_PREFIX=td,
+                CONDA_PREFIX_1=old_prefix,
+                CONDA_SHLVL=2,
+                CONDA_DEFAULT_ENV=td,
+                CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+                PKG_A_ENV="yerp",
+                PKG_B_ENV="berp",
+                ENV_ONE="one",
+                ENV_TWO="you",
+                ENV_THREE="me",
+                ENV_WITH_SAME_VALUE="with_same_value",
+                __CONDA_SHLVL_1_ENV_ONE="already_set_env_var",
+                __CONDA_SHLVL_1_ENV_WITH_SAME_VALUE="with_same_value",
             )
 
             assert builder["unset_vars"] == unset_vars
@@ -1189,29 +1138,24 @@ def test_build_activate_restore_unset_env_vars(reset_environ: None):
                 activator = PosixActivator()
                 builder = activator.build_deactivate()
 
-                unset_vars = [
-                    "CONDA_PREFIX_1",
-                    "PKG_A_ENV",
-                    "PKG_B_ENV",
-                    "ENV_ONE",
-                    "ENV_TWO",
-                    "ENV_THREE",
-                    "ENV_WITH_SAME_VALUE",
-                ]
                 assert builder["set_vars"] == {
                     "PS1": "(/old/prefix)",
-                }
-                export_vars = {
-                    "CONDA_PREFIX": old_prefix,
-                    "CONDA_SHLVL": 1,
-                    "CONDA_DEFAULT_ENV": old_prefix,
-                    "CONDA_PROMPT_MODIFIER": f"({old_prefix})",
                 }
                 export_path = {
                     "PATH": old_path,
                 }
-                export_vars, unset_vars = activator.add_export_unset_vars(
-                    export_vars, unset_vars
+                export_vars, unset_vars = activator.get_export_unset_vars(
+                    CONDA_PREFIX=old_prefix,
+                    CONDA_SHLVL=1,
+                    CONDA_DEFAULT_ENV=old_prefix,
+                    CONDA_PROMPT_MODIFIER=f"({old_prefix})",
+                    CONDA_PREFIX_1=None,
+                    PKG_A_ENV=None,
+                    PKG_B_ENV=None,
+                    ENV_ONE=None,
+                    ENV_TWO=None,
+                    ENV_THREE=None,
+                    ENV_WITH_SAME_VALUE=None,
                 )
                 export_vars["ENV_ONE"] = "already_set_env_var"
                 assert builder["unset_vars"] == unset_vars

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2013,23 +2013,18 @@ def test_json_basic(shell_wrapper_unit: str):
     activate_data = c.stdout
 
     new_path_parts = activator._add_prefix_to_path(shell_wrapper_unit)
-    conda_exe_export, conda_exe_unset = activator.get_scripts_export_unset_vars()
+    export_vars, unset_vars = activator.get_export_unset_vars(
+        CONDA_PREFIX=shell_wrapper_unit,
+        CONDA_SHLVL=1,
+        CONDA_DEFAULT_ENV=shell_wrapper_unit,
+        CONDA_PROMPT_MODIFIER="(%s) " % shell_wrapper_unit,
+    )
     e_activate_data = {
-        "path": {
-            "PATH": list(new_path_parts),
-        },
+        "path": {"PATH": list(new_path_parts)},
         "vars": {
-            "export": dict(
-                CONDA_PREFIX=shell_wrapper_unit,
-                CONDA_SHLVL=1,
-                CONDA_DEFAULT_ENV=shell_wrapper_unit,
-                CONDA_PROMPT_MODIFIER="(%s) " % shell_wrapper_unit,
-                **conda_exe_export,
-            ),
-            "set": {
-                "PS1": "(%s) " % shell_wrapper_unit,
-            },
-            "unset": [],
+            "export": export_vars,
+            "set": {"PS1": "(%s) " % shell_wrapper_unit},
+            "unset": unset_vars,
         },
         "scripts": {
             "activate": [
@@ -2062,17 +2057,13 @@ def test_json_basic(shell_wrapper_unit: str):
             shell_wrapper_unit, shell_wrapper_unit
         )
         e_reactivate_data = {
-            "path": {
-                "PATH": list(new_path_parts),
-            },
+            "path": {"PATH": list(new_path_parts)},
             "vars": {
                 "export": {
                     "CONDA_SHLVL": 1,
                     "CONDA_PROMPT_MODIFIER": "(%s) " % shell_wrapper_unit,
                 },
-                "set": {
-                    "PS1": "(%s) " % shell_wrapper_unit,
-                },
+                "set": {"PS1": "(%s) " % shell_wrapper_unit},
                 "unset": [],
             },
             "scripts": {
@@ -2111,24 +2102,18 @@ def test_json_basic(shell_wrapper_unit: str):
         new_path = activator.pathsep_join(
             activator._remove_prefix_from_path(shell_wrapper_unit)
         )
-        (
-            conda_exe_export,
-            conda_exe_unset,
-        ) = activator.get_scripts_export_unset_vars()
+        export_vars, unset_vars = activator.get_export_unset_vars(
+            CONDA_SHLVL=0,
+            CONDA_PREFIX=None,
+            CONDA_DEFAULT_ENV=None,
+            CONDA_PROMPT_MODIFIER=None,
+        )
         e_deactivate_data = {
-            "path": {
-                "PATH": list(new_path),
-            },
+            "path": {"PATH": list(new_path)},
             "vars": {
-                "export": dict(CONDA_SHLVL=0, **conda_exe_export),
-                "set": {
-                    "PS1": "",
-                },
-                "unset": [
-                    "CONDA_PREFIX",
-                    "CONDA_DEFAULT_ENV",
-                    "CONDA_PROMPT_MODIFIER",
-                ],
+                "export": export_vars,
+                "set": {"PS1": ""},
+                "unset": unset_vars,
             },
             "scripts": {
                 "activate": [],


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Deprecating redundant helper functions:
- `conda.activate._Activator.add_export_unset_vars`, use `conda.activate._Activator.get_export_unset_vars` instead
- `conda.activate.JSONFormatMixin.get_scripts_export_unset_vars`, use `conda.activate._Activator.get_export_unset_vars` instead

Deprecate unused keyword argument:
- `conda.activate._Activator._get_path_dirs(extra_library_bin)`

Move testing helper function to test_activate.py:
- `conda.activate._Activator.get_scripts_export_unset_vars`, for testing only

Split out from https://github.com/conda/conda/pull/13620

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
