### PR TITLE
Bugfix issue #12330 and clean up whitespace treatment of ~= operator

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -118,7 +118,7 @@ def specs_from_args(args, json=False):
 
 spec_pat = re.compile(
     r"""
-    (?P<name>[^=<>!\s]+)                # package name
+    (?P<name>[^=<>!~\s]+)                # package name
     \s*                                 # ignore spaces
     (
         (?P<cc>=[^=]+(=[^=]+)?)         # conda constraint
@@ -142,12 +142,12 @@ def spec_from_line(line):
     if cc:
         return name + cc.replace("=", " ")
     elif pc:
-        if pc.startswith("~= "):
+        if pc.startswith("~="):
             assert (
                 pc.count("~=") == 1
             ), f"Overly complex 'Compatible release' spec not handled {line}"
             assert pc.count("."), f"No '.' in 'Compatible release' version {line}"
-            ver = pc.replace("~= ", "")
+            ver = pc.replace("~=", "")
             ver2 = ".".join(ver.split(".")[:-1]) + ".*"
             return name + " >=" + ver + ",==" + ver2
         else:

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -552,7 +552,7 @@ class VersionSpec(BaseSpec, metaclass=SingleStrArgCachingType):
                 raise InvalidVersionSpec(vspec_str, "invalid operator")
             operator_str, vo_str = m.groups()
             if vo_str[-2:] == ".*":
-                if operator_str in ("=", ">="):
+                if operator_str in ("=", ">=", "=="):
                     vo_str = vo_str[:-2]
                 elif operator_str == "!=":
                     vo_str = vo_str[:-2]

--- a/news/12330-compatible-version-spec
+++ b/news/12330-compatible-version-spec
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* The compatible version spec format "packagename ~= x.y" no longer raises an unrelated deprecation warning (#12330)
+
+*
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <new item>

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -1222,3 +1222,9 @@ def test_catch_invalid_regexes():
     # Inspired by above crasher
     with pytest.raises(InvalidMatchSpec):
         MatchSpec("^(aaaa$")
+
+
+def test_compatible_version_whitespace():
+    specs = ['asdf~=1.2', 'asdf ~=1.2', 'asdf~= 1.2', 'asdf ~= 1.2']
+    results = set([spec_from_line(spec) for spec in specs])
+    assert len(results) == 1

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -1225,6 +1225,6 @@ def test_catch_invalid_regexes():
 
 
 def test_compatible_version_whitespace():
-    specs = ['asdf~=1.2', 'asdf ~=1.2', 'asdf~= 1.2', 'asdf ~= 1.2']
+    specs = ["asdf~=1.2", "asdf ~=1.2", "asdf~= 1.2", "asdf ~= 1.2"]
     results = set([spec_from_line(spec) for spec in specs])
     assert len(results) == 1


### PR DESCRIPTION
### Description

Using a compatible version operator (~=) in a requirements.txt or environment.yml *sometimes* raises a deprecation warning, as reported in #12330 .  Whether or not it did depended on the usage of the optional whitespace between the package name, the relational operator, and the version number.

This PR does two things:

1. Removes whitespace conditions on how the compatible version operator is handled.  
2. Prevents VersionSpec from raising a deprecation warning for "==X.*", which was the cause of the issue.

I added a test for the whitespace, but I wasn't sure how to add a test for the deprecation warning.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?

