### PR TITLE
Replace `env_var`/`env_vars` in `test_activate.py` with `monkeypatch.setenv`

### DIFF
--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -525,7 +525,10 @@ def test_build_activate_shlvl_0(
 
 
 @pytest.mark.skipif(bash_unsupported_win(), reason=bash_unsupported_win_because())
-def test_build_activate_shlvl_1(reset_environ: None):
+def test_build_activate_shlvl_1(
+    reset_environ: None,
+    monkeypatch: MonkeyPatch,
+):
     with tempdir() as td:
         mkdir_p(join(td, "conda-meta"))
         activate_d_dir = mkdir_p(join(td, "etc", "conda", "activate.d"))
@@ -544,92 +547,81 @@ def test_build_activate_shlvl_1(reset_environ: None):
         activator = PosixActivator()
         old_path = activator.pathsep_join(activator._add_prefix_to_path(old_prefix))
 
-        with env_vars(
-            {
-                "CONDA_SHLVL": "1",
-                "CONDA_PREFIX": old_prefix,
-                "PATH": old_path,
-                "CONDA_ENV_PROMPT": "({default_env})",
-            },
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            activator = PosixActivator()
-            builder = activator.build_activate(td)
-            new_path = activator.pathsep_join(
-                activator._replace_prefix_in_path(old_prefix, td)
-            )
-            conda_prompt_modifier = "(%s)" % td
-            ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
+        monkeypatch.setenv("CONDA_SHLVL", "1")
+        monkeypatch.setenv("CONDA_PREFIX", old_prefix)
+        monkeypatch.setenv("PATH", old_path)
+        monkeypatch.setenv("CONDA_ENV_PROMPT", env_prompt := "({default_env})")
+        reset_context()
+        assert context.env_prompt == env_prompt
 
-            assert activator.path_conversion(td) in new_path
-            assert old_prefix not in new_path
+        activator = PosixActivator()
+        builder = activator.build_activate(td)
+        new_path = activator.pathsep_join(
+            activator._replace_prefix_in_path(old_prefix, td)
+        )
+        conda_prompt_modifier = "(%s)" % td
+        ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
 
-            set_vars = {"PS1": ps1}
-            export_vars, unset_vars = activator.get_export_unset_vars(
-                PATH=new_path,
-                CONDA_PREFIX=td,
-                CONDA_PREFIX_1=old_prefix,
-                CONDA_SHLVL=2,
-                CONDA_DEFAULT_ENV=td,
-                CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
-                PKG_A_ENV="yerp",
-                PKG_B_ENV="berp",
-                ENV_ONE="one",
-                ENV_TWO="you",
-                ENV_THREE="me",
-                ENV_WITH_SAME_VALUE="with_same_value",
-            )
-            assert builder["unset_vars"] == unset_vars
-            assert builder["set_vars"] == set_vars
-            assert builder["export_vars"] == export_vars
-            assert builder["activate_scripts"] == (
-                activator.path_conversion(activate_d_1),
-            )
-            assert builder["deactivate_scripts"] == ()
+        assert activator.path_conversion(td) in new_path
+        assert old_prefix not in new_path
 
-            with env_vars(
-                {
-                    "PATH": new_path,
-                    "CONDA_PREFIX": td,
-                    "CONDA_PREFIX_1": old_prefix,
-                    "CONDA_SHLVL": 2,
-                    "CONDA_DEFAULT_ENV": td,
-                    "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                    "PKG_B_ENV": "berp",
-                    "PKG_A_ENV": "yerp",
-                    "ENV_ONE": "one",
-                    "ENV_TWO": "you",
-                    "ENV_THREE": "me",
-                    "ENV_WITH_SAME_VALUE": "with_same_value",
-                }
-            ):
-                activator = PosixActivator()
-                builder = activator.build_deactivate()
+        set_vars = {"PS1": ps1}
+        export_vars, unset_vars = activator.get_export_unset_vars(
+            PATH=new_path,
+            CONDA_PREFIX=td,
+            CONDA_PREFIX_1=old_prefix,
+            CONDA_SHLVL=2,
+            CONDA_DEFAULT_ENV=td,
+            CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+            PKG_A_ENV="yerp",
+            PKG_B_ENV="berp",
+            ENV_ONE="one",
+            ENV_TWO="you",
+            ENV_THREE="me",
+            ENV_WITH_SAME_VALUE="with_same_value",
+        )
+        assert builder["unset_vars"] == unset_vars
+        assert builder["set_vars"] == set_vars
+        assert builder["export_vars"] == export_vars
+        assert builder["activate_scripts"] == (activator.path_conversion(activate_d_1),)
+        assert builder["deactivate_scripts"] == ()
 
-                assert builder["set_vars"] == {
-                    "PS1": "(/old/prefix)",
-                }
-                export_path = {
-                    "PATH": old_path,
-                }
-                export_vars, unset_vars = activator.get_export_unset_vars(
-                    CONDA_PREFIX=old_prefix,
-                    CONDA_SHLVL=1,
-                    CONDA_DEFAULT_ENV=old_prefix,
-                    CONDA_PROMPT_MODIFIER="(%s)" % old_prefix,
-                    CONDA_PREFIX_1=None,
-                    PKG_A_ENV=None,
-                    PKG_B_ENV=None,
-                    ENV_ONE=None,
-                    ENV_TWO=None,
-                    ENV_THREE=None,
-                    ENV_WITH_SAME_VALUE=None,
-                )
-                assert builder["unset_vars"] == unset_vars
-                assert builder["export_vars"] == export_vars
-                assert builder["export_path"] == export_path
-                assert builder["activate_scripts"] == ()
-                assert builder["deactivate_scripts"] == ()
+        monkeypatch.setenv("PATH", new_path)
+        monkeypatch.setenv("CONDA_PREFIX", td)
+        monkeypatch.setenv("CONDA_PREFIX_1", old_prefix)
+        monkeypatch.setenv("CONDA_SHLVL", 2)
+        monkeypatch.setenv("CONDA_DEFAULT_ENV", td)
+        monkeypatch.setenv("CONDA_PROMPT_MODIFIER", conda_prompt_modifier)
+        monkeypatch.setenv("PKG_B_ENV", "berp")
+        monkeypatch.setenv("PKG_A_ENV", "yerp")
+        monkeypatch.setenv("ENV_ONE", "one")
+        monkeypatch.setenv("ENV_TWO", "you")
+        monkeypatch.setenv("ENV_THREE", "me")
+        monkeypatch.setenv("ENV_WITH_SAME_VALUE", "with_same_value")
+
+        activator = PosixActivator()
+        builder = activator.build_deactivate()
+
+        assert builder["set_vars"] == {"PS1": "(/old/prefix)"}
+        export_path = {"PATH": old_path}
+        export_vars, unset_vars = activator.get_export_unset_vars(
+            CONDA_PREFIX=old_prefix,
+            CONDA_SHLVL=1,
+            CONDA_DEFAULT_ENV=old_prefix,
+            CONDA_PROMPT_MODIFIER="(%s)" % old_prefix,
+            CONDA_PREFIX_1=None,
+            PKG_A_ENV=None,
+            PKG_B_ENV=None,
+            ENV_ONE=None,
+            ENV_TWO=None,
+            ENV_THREE=None,
+            ENV_WITH_SAME_VALUE=None,
+        )
+        assert builder["unset_vars"] == unset_vars
+        assert builder["export_vars"] == export_vars
+        assert builder["export_path"] == export_path
+        assert builder["activate_scripts"] == ()
+        assert builder["deactivate_scripts"] == ()
 
 
 @pytest.mark.skipif(bash_unsupported_win(), reason=bash_unsupported_win_because())

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -41,7 +41,7 @@ from conda.base.constants import (
     PREFIX_STATE_FILE,
     ROOT_ENV_NAME,
 )
-from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context, reset_context
+from conda.base.context import context, reset_context
 from conda.cli.main import main_sourced
 from conda.common.compat import on_win
 from conda.common.io import captured, env_vars
@@ -1056,7 +1056,10 @@ def test_get_env_vars_empty_file(reset_environ: None):
 
 
 @pytest.mark.skipif(bash_unsupported_win(), reason=bash_unsupported_win_because())
-def test_build_activate_restore_unset_env_vars(reset_environ: None):
+def test_build_activate_restore_unset_env_vars(
+    reset_environ: None,
+    monkeypatch: MonkeyPatch,
+):
     with tempdir() as td:
         mkdir_p(join(td, "conda-meta"))
         activate_d_dir = mkdir_p(join(td, "etc", "conda", "activate.d"))
@@ -1075,99 +1078,88 @@ def test_build_activate_restore_unset_env_vars(reset_environ: None):
         activator = PosixActivator()
         old_path = activator.pathsep_join(activator._add_prefix_to_path(old_prefix))
 
-        with env_vars(
-            {
-                "CONDA_SHLVL": "1",
-                "CONDA_PREFIX": old_prefix,
-                "PATH": old_path,
-                "CONDA_ENV_PROMPT": "({default_env})",
-                "ENV_ONE": "already_set_env_var",
-                "ENV_WITH_SAME_VALUE": "with_same_value",
-            },
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            activator = PosixActivator()
-            builder = activator.build_activate(td)
-            new_path = activator.pathsep_join(
-                activator._replace_prefix_in_path(old_prefix, td)
-            )
-            conda_prompt_modifier = "(%s)" % td
-            ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
+        monkeypatch.setenv("CONDA_SHLVL", "1")
+        monkeypatch.setenv("CONDA_PREFIX", old_prefix)
+        monkeypatch.setenv("PATH", old_path)
+        monkeypatch.setenv("CONDA_ENV_PROMPT", env_prompt := "({default_env})")
+        monkeypatch.setenv("ENV_ONE", "already_set_env_var")
+        monkeypatch.setenv("ENV_WITH_SAME_VALUE", "with_same_value")
+        reset_context()
+        assert context.env_prompt == env_prompt
 
-            assert activator.path_conversion(td) in new_path
-            assert old_prefix not in new_path
+        activator = PosixActivator()
+        builder = activator.build_activate(td)
+        new_path = activator.pathsep_join(
+            activator._replace_prefix_in_path(old_prefix, td)
+        )
+        conda_prompt_modifier = "(%s)" % td
+        ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
 
-            set_vars = {"PS1": ps1}
-            export_vars, unset_vars = activator.get_export_unset_vars(
-                PATH=new_path,
-                CONDA_PREFIX=td,
-                CONDA_PREFIX_1=old_prefix,
-                CONDA_SHLVL=2,
-                CONDA_DEFAULT_ENV=td,
-                CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
-                PKG_A_ENV="yerp",
-                PKG_B_ENV="berp",
-                ENV_ONE="one",
-                ENV_TWO="you",
-                ENV_THREE="me",
-                ENV_WITH_SAME_VALUE="with_same_value",
-                __CONDA_SHLVL_1_ENV_ONE="already_set_env_var",
-                __CONDA_SHLVL_1_ENV_WITH_SAME_VALUE="with_same_value",
-            )
+        assert activator.path_conversion(td) in new_path
+        assert old_prefix not in new_path
 
-            assert builder["unset_vars"] == unset_vars
-            assert builder["set_vars"] == set_vars
-            assert builder["export_vars"] == export_vars
-            assert builder["activate_scripts"] == (
-                activator.path_conversion(activate_d_1),
-            )
-            assert builder["deactivate_scripts"] == ()
+        set_vars = {"PS1": ps1}
+        export_vars, unset_vars = activator.get_export_unset_vars(
+            PATH=new_path,
+            CONDA_PREFIX=td,
+            CONDA_PREFIX_1=old_prefix,
+            CONDA_SHLVL=2,
+            CONDA_DEFAULT_ENV=td,
+            CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+            PKG_A_ENV="yerp",
+            PKG_B_ENV="berp",
+            ENV_ONE="one",
+            ENV_TWO="you",
+            ENV_THREE="me",
+            ENV_WITH_SAME_VALUE="with_same_value",
+            __CONDA_SHLVL_1_ENV_ONE="already_set_env_var",
+            __CONDA_SHLVL_1_ENV_WITH_SAME_VALUE="with_same_value",
+        )
 
-            with env_vars(
-                {
-                    "PATH": new_path,
-                    "CONDA_PREFIX": td,
-                    "CONDA_PREFIX_1": old_prefix,
-                    "CONDA_SHLVL": 2,
-                    "CONDA_DEFAULT_ENV": td,
-                    "CONDA_PROMPT_MODIFIER": conda_prompt_modifier,
-                    "__CONDA_SHLVL_1_ENV_ONE": "already_set_env_var",
-                    "PKG_B_ENV": "berp",
-                    "PKG_A_ENV": "yerp",
-                    "ENV_ONE": "one",
-                    "ENV_TWO": "you",
-                    "ENV_THREE": "me",
-                    "ENV_WITH_SAME_VALUE": "with_same_value",
-                }
-            ):
-                activator = PosixActivator()
-                builder = activator.build_deactivate()
+        assert builder["unset_vars"] == unset_vars
+        assert builder["set_vars"] == set_vars
+        assert builder["export_vars"] == export_vars
+        assert builder["activate_scripts"] == (activator.path_conversion(activate_d_1),)
+        assert builder["deactivate_scripts"] == ()
 
-                assert builder["set_vars"] == {
-                    "PS1": "(/old/prefix)",
-                }
-                export_path = {
-                    "PATH": old_path,
-                }
-                export_vars, unset_vars = activator.get_export_unset_vars(
-                    CONDA_PREFIX=old_prefix,
-                    CONDA_SHLVL=1,
-                    CONDA_DEFAULT_ENV=old_prefix,
-                    CONDA_PROMPT_MODIFIER=f"({old_prefix})",
-                    CONDA_PREFIX_1=None,
-                    PKG_A_ENV=None,
-                    PKG_B_ENV=None,
-                    ENV_ONE=None,
-                    ENV_TWO=None,
-                    ENV_THREE=None,
-                    ENV_WITH_SAME_VALUE=None,
-                )
-                export_vars["ENV_ONE"] = "already_set_env_var"
-                assert builder["unset_vars"] == unset_vars
-                assert builder["export_vars"] == export_vars
-                assert builder["export_path"] == export_path
-                assert builder["activate_scripts"] == ()
-                assert builder["deactivate_scripts"] == ()
+        monkeypatch.setenv("PATH", new_path)
+        monkeypatch.setenv("CONDA_PREFIX", td)
+        monkeypatch.setenv("CONDA_PREFIX_1", old_prefix)
+        monkeypatch.setenv("CONDA_SHLVL", 2)
+        monkeypatch.setenv("CONDA_DEFAULT_ENV", td)
+        monkeypatch.setenv("CONDA_PROMPT_MODIFIER", conda_prompt_modifier)
+        monkeypatch.setenv("__CONDA_SHLVL_1_ENV_ONE", "already_set_env_var")
+        monkeypatch.setenv("PKG_B_ENV", "berp")
+        monkeypatch.setenv("PKG_A_ENV", "yerp")
+        monkeypatch.setenv("ENV_ONE", "one")
+        monkeypatch.setenv("ENV_TWO", "you")
+        monkeypatch.setenv("ENV_THREE", "me")
+        monkeypatch.setenv("ENV_WITH_SAME_VALUE", "with_same_value")
+
+        activator = PosixActivator()
+        builder = activator.build_deactivate()
+
+        assert builder["set_vars"] == {"PS1": "(/old/prefix)"}
+        export_path = {"PATH": old_path}
+        export_vars, unset_vars = activator.get_export_unset_vars(
+            CONDA_PREFIX=old_prefix,
+            CONDA_SHLVL=1,
+            CONDA_DEFAULT_ENV=old_prefix,
+            CONDA_PROMPT_MODIFIER=f"({old_prefix})",
+            CONDA_PREFIX_1=None,
+            PKG_A_ENV=None,
+            PKG_B_ENV=None,
+            ENV_ONE=None,
+            ENV_TWO=None,
+            ENV_THREE=None,
+            ENV_WITH_SAME_VALUE=None,
+        )
+        export_vars["ENV_ONE"] = "already_set_env_var"
+        assert builder["unset_vars"] == unset_vars
+        assert builder["export_vars"] == export_vars
+        assert builder["export_path"] == export_path
+        assert builder["activate_scripts"] == ()
+        assert builder["deactivate_scripts"] == ()
 
 
 @pytest.fixture

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -418,7 +418,10 @@ def test_build_activate_dont_activate_unset_var(
         assert builder["deactivate_scripts"] == ()
 
 
-def test_build_activate_shlvl_warn_clobber_vars(reset_environ: None):
+def test_build_activate_shlvl_warn_clobber_vars(
+    reset_environ: None,
+    monkeypatch: MonkeyPatch,
+):
     with tempdir() as td:
         mkdir_p(join(td, "conda-meta"))
         activate_d_dir = mkdir_p(join(td, "etc", "conda", "activate.d"))
@@ -444,34 +447,33 @@ def test_build_activate_shlvl_warn_clobber_vars(reset_environ: None):
 
         write_pkg_env_vars(td)
 
-        with env_var("CONDA_SHLVL", "0"):
-            with env_var("CONDA_PREFIX", ""):
-                activator = PosixActivator()
-                builder = activator.build_activate(td)
-                new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
-                conda_prompt_modifier = "(%s) " % td
-                ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
+        monkeypatch.setenv("CONDA_SHLVL", "0")
+        monkeypatch.setenv("CONDA_PREFIX", "")
 
-                set_vars = {"PS1": ps1}
-                export_vars, unset_vars = activator.get_export_unset_vars(
-                    PATH=new_path,
-                    CONDA_PREFIX=td,
-                    CONDA_SHLVL=1,
-                    CONDA_DEFAULT_ENV=td,
-                    CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
-                    PKG_A_ENV="teamnope",
-                    PKG_B_ENV="berp",
-                    ENV_ONE="one",
-                    ENV_TWO="you",
-                    ENV_THREE="me",
-                )
-                assert builder["unset_vars"] == unset_vars
-                assert builder["set_vars"] == set_vars
-                assert builder["export_vars"] == export_vars
-                assert builder["activate_scripts"] == (
-                    activator.path_conversion(activate_d_1),
-                )
-                assert builder["deactivate_scripts"] == ()
+        activator = PosixActivator()
+        builder = activator.build_activate(td)
+        new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
+        conda_prompt_modifier = "(%s) " % td
+        ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
+
+        set_vars = {"PS1": ps1}
+        export_vars, unset_vars = activator.get_export_unset_vars(
+            PATH=new_path,
+            CONDA_PREFIX=td,
+            CONDA_SHLVL=1,
+            CONDA_DEFAULT_ENV=td,
+            CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+            PKG_A_ENV="teamnope",
+            PKG_B_ENV="berp",
+            ENV_ONE="one",
+            ENV_TWO="you",
+            ENV_THREE="me",
+        )
+        assert builder["unset_vars"] == unset_vars
+        assert builder["set_vars"] == set_vars
+        assert builder["export_vars"] == export_vars
+        assert builder["activate_scripts"] == (activator.path_conversion(activate_d_1),)
+        assert builder["deactivate_scripts"] == ()
 
 
 def test_build_activate_shlvl_0(reset_environ: None):

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1743,7 +1743,7 @@ def test_xonsh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     assert deactivate_data == e_deactivate_data
 
 
-def test_fish_basic(shell_wrapper_unit: str):
+def test_fish_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     activator = FishActivator()
     make_dot_d_files(shell_wrapper_unit, activator.script_extension)
 
@@ -1777,92 +1777,89 @@ def test_fish_basic(shell_wrapper_unit: str):
     }
     assert activate_data == e_activate_data
 
-    with env_vars(
-        {
-            "CONDA_PREFIX": shell_wrapper_unit,
-            "CONDA_SHLVL": "1",
-            "PATH": os.pathsep.join((*new_path_parts, os.environ["PATH"])),
-        }
-    ):
-        activator = FishActivator()
-        with captured() as c:
-            rc = main_sourced("shell.fish", *reactivate_args)
-        assert not c.stderr
-        assert rc == 0
-        reactivate_data = c.stdout
+    monkeypatch.setenv("CONDA_PREFIX", shell_wrapper_unit)
+    monkeypatch.setenv("CONDA_SHLVL", "1")
+    monkeypatch.setenv("PATH", os.pathsep.join((*new_path_parts, os.environ["PATH"])))
 
-        new_path_parts = activator._replace_prefix_in_path(
-            shell_wrapper_unit, shell_wrapper_unit
-        )
-        e_reactivate_data = dals(
-            """
-        source "%(deactivate1)s";
-        set -gx PATH "%(new_path)s";
-        set -gx CONDA_SHLVL "1";
-        set -gx CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
-        source "%(activate1)s";
+    activator = FishActivator()
+    with captured() as c:
+        rc = main_sourced("shell.fish", *reactivate_args)
+    assert not c.stderr
+    assert rc == 0
+    reactivate_data = c.stdout
+
+    new_path_parts = activator._replace_prefix_in_path(
+        shell_wrapper_unit, shell_wrapper_unit
+    )
+    e_reactivate_data = dals(
         """
-        ) % {
-            "new_path": activator.pathsep_join(new_path_parts),
-            "activate1": activator.path_conversion(
-                join(
-                    shell_wrapper_unit,
-                    "etc",
-                    "conda",
-                    "activate.d",
-                    "activate1.fish",
-                )
-            ),
-            "deactivate1": activator.path_conversion(
-                join(
-                    shell_wrapper_unit,
-                    "etc",
-                    "conda",
-                    "deactivate.d",
-                    "deactivate1.fish",
-                )
-            ),
-            "native_prefix": shell_wrapper_unit,
-        }
-        assert reactivate_data == e_reactivate_data
+    source "%(deactivate1)s";
+    set -gx PATH "%(new_path)s";
+    set -gx CONDA_SHLVL "1";
+    set -gx CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
+    source "%(activate1)s";
+    """
+    ) % {
+        "new_path": activator.pathsep_join(new_path_parts),
+        "activate1": activator.path_conversion(
+            join(
+                shell_wrapper_unit,
+                "etc",
+                "conda",
+                "activate.d",
+                "activate1.fish",
+            )
+        ),
+        "deactivate1": activator.path_conversion(
+            join(
+                shell_wrapper_unit,
+                "etc",
+                "conda",
+                "deactivate.d",
+                "deactivate1.fish",
+            )
+        ),
+        "native_prefix": shell_wrapper_unit,
+    }
+    assert reactivate_data == e_reactivate_data
 
-        with captured() as c:
-            rc = main_sourced("shell.fish", *deactivate_args)
-        assert not c.stderr
-        assert rc == 0
-        deactivate_data = c.stdout
+    with captured() as c:
+        rc = main_sourced("shell.fish", *deactivate_args)
+    assert not c.stderr
+    assert rc == 0
+    deactivate_data = c.stdout
 
-        new_path = activator.pathsep_join(
-            activator._remove_prefix_from_path(shell_wrapper_unit)
-        )
-        (
-            conda_exe_export,
-            conda_exe_unset,
-        ) = get_scripts_export_unset_vars(activator)
-        e_deactivate_data = dals(
-            """
-        set -gx PATH "%(new_path)s";
-        source "%(deactivate1)s";
-        set -e CONDA_PREFIX;
-        set -e CONDA_DEFAULT_ENV;
-        set -e CONDA_PROMPT_MODIFIER;
-        set -gx CONDA_SHLVL "0";
-        %(conda_exe_export)s;
+    new_path = activator.pathsep_join(
+        activator._remove_prefix_from_path(shell_wrapper_unit)
+    )
+    (
+        conda_exe_export,
+        conda_exe_unset,
+    ) = get_scripts_export_unset_vars(activator)
+    e_deactivate_data = dals(
         """
-        ) % {
-            "new_path": new_path,
-            "deactivate1": activator.path_conversion(
-                join(
-                    shell_wrapper_unit,
-                    "etc",
-                    "conda",
-                    "deactivate.d",
-                    "deactivate1.fish",
-                )
-            ),
-            "conda_exe_export": conda_exe_export,
-        }
-        assert deactivate_data == e_deactivate_data
+    set -gx PATH "%(new_path)s";
+    source "%(deactivate1)s";
+    set -e CONDA_PREFIX;
+    set -e CONDA_DEFAULT_ENV;
+    set -e CONDA_PROMPT_MODIFIER;
+    set -gx CONDA_SHLVL "0";
+    %(conda_exe_export)s;
+    """
+    ) % {
+        "new_path": new_path,
+        "deactivate1": activator.path_conversion(
+            join(
+                shell_wrapper_unit,
+                "etc",
+                "conda",
+                "deactivate.d",
+                "deactivate1.fish",
+            )
+        ),
+        "conda_exe_export": conda_exe_export,
+    }
+    assert deactivate_data == e_deactivate_data
 
 
 def test_powershell_basic(shell_wrapper_unit: str):

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -768,7 +768,10 @@ def test_activate_same_environment(
 
 
 @pytest.mark.skipif(bash_unsupported_win(), reason=bash_unsupported_win_because())
-def test_build_deactivate_shlvl_2_from_stack(reset_environ: None):
+def test_build_deactivate_shlvl_2_from_stack(
+    reset_environ: None,
+    monkeypatch: MonkeyPatch,
+):
     with tempdir() as td:
         mkdir_p(join(td, "conda-meta"))
         deactivate_d_dir = mkdir_p(join(td, "etc", "conda", "deactivate.d"))
@@ -816,63 +819,57 @@ def test_build_deactivate_shlvl_2_from_stack(reset_environ: None):
         original_path = activator.pathsep_join(
             activator._add_prefix_to_path(old_prefix)
         )
-        with env_var("PATH", original_path):
-            activator = PosixActivator()
-            starting_path = activator.pathsep_join(activator._add_prefix_to_path(td))
 
-            with env_vars(
-                {
-                    "CONDA_SHLVL": "2",
-                    "CONDA_PREFIX_1": old_prefix,
-                    "CONDA_PREFIX": td,
-                    "CONDA_STACKED_2": "true",
-                    "PATH": starting_path,
-                    "ENV_ONE": "one",
-                    "ENV_TWO": "you",
-                    "ENV_THREE": "me",
-                    "ENV_FOUR": "roar",
-                    "ENV_FIVE": "hive",
-                    "PKG_A_ENV": "yerp",
-                    "PKG_B_ENV": "berp",
-                },
-                stack_callback=conda_tests_ctxt_mgmt_def_pol,
-            ):
-                activator = PosixActivator()
-                builder = activator.build_deactivate()
+        monkeypatch.setenv("PATH", original_path)
 
-                conda_prompt_modifier = "(%s) " % old_prefix
-                ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
+        activator = PosixActivator()
+        starting_path = activator.pathsep_join(activator._add_prefix_to_path(td))
 
-                set_vars = {"PS1": ps1}
-                export_path = {
-                    "PATH": original_path,
-                }
-                export_vars, unset_vars = activator.get_export_unset_vars(
-                    CONDA_PREFIX=old_prefix,
-                    CONDA_SHLVL=1,
-                    CONDA_DEFAULT_ENV=old_prefix,
-                    CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
-                    PKG_B_ENV="berp",
-                    ENV_FOUR="roar",
-                    ENV_FIVE="hive",
-                    CONDA_PREFIX_1=None,
-                    CONDA_STACKED_2=None,
-                    PKG_A_ENV=None,
-                    ENV_ONE=None,
-                    ENV_TWO=None,
-                    ENV_THREE=None,
-                    ENV_WITH_SAME_VALUE=None,
-                )
-                assert builder["unset_vars"] == unset_vars
-                assert builder["set_vars"] == set_vars
-                assert builder["export_vars"] == export_vars
-                assert builder["export_path"] == export_path
-                assert builder["activate_scripts"] == (
-                    activator.path_conversion(activate_d_1),
-                )
-                assert builder["deactivate_scripts"] == (
-                    activator.path_conversion(deactivate_d_1),
-                )
+        monkeypatch.setenv("CONDA_SHLVL", "2")
+        monkeypatch.setenv("CONDA_PREFIX_1", old_prefix)
+        monkeypatch.setenv("CONDA_PREFIX", td)
+        monkeypatch.setenv("CONDA_STACKED_2", "true")
+        monkeypatch.setenv("PATH", starting_path)
+        monkeypatch.setenv("ENV_ONE", "one")
+        monkeypatch.setenv("ENV_TWO", "you")
+        monkeypatch.setenv("ENV_THREE", "me")
+        monkeypatch.setenv("ENV_FOUR", "roar")
+        monkeypatch.setenv("ENV_FIVE", "hive")
+        monkeypatch.setenv("PKG_A_ENV", "yerp")
+        monkeypatch.setenv("PKG_B_ENV", "berp")
+
+        activator = PosixActivator()
+        builder = activator.build_deactivate()
+
+        conda_prompt_modifier = "(%s) " % old_prefix
+        ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
+
+        set_vars = {"PS1": ps1}
+        export_path = {"PATH": original_path}
+        export_vars, unset_vars = activator.get_export_unset_vars(
+            CONDA_PREFIX=old_prefix,
+            CONDA_SHLVL=1,
+            CONDA_DEFAULT_ENV=old_prefix,
+            CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+            PKG_B_ENV="berp",
+            ENV_FOUR="roar",
+            ENV_FIVE="hive",
+            CONDA_PREFIX_1=None,
+            CONDA_STACKED_2=None,
+            PKG_A_ENV=None,
+            ENV_ONE=None,
+            ENV_TWO=None,
+            ENV_THREE=None,
+            ENV_WITH_SAME_VALUE=None,
+        )
+        assert builder["unset_vars"] == unset_vars
+        assert builder["set_vars"] == set_vars
+        assert builder["export_vars"] == export_vars
+        assert builder["export_path"] == export_path
+        assert builder["activate_scripts"] == (activator.path_conversion(activate_d_1),)
+        assert builder["deactivate_scripts"] == (
+            activator.path_conversion(deactivate_d_1),
+        )
 
 
 @pytest.mark.skipif(bash_unsupported_win(), reason=bash_unsupported_win_because())

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1965,19 +1965,17 @@ def test_powershell_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     }
 
 
-def test_unicode(shell_wrapper_unit: str):
-    shell = "shell.posix"
-    prompt = "PS1"
-    prompt_value = "%{\xc2\xbb".encode(sys.getfilesystemencoding())
-    with env_vars({prompt: prompt_value}):
-        # use a file as output stream to simulate PY2 default stdout
-        with tempdir() as td:
-            with open(join(td, "stdout"), "w") as stdout:
-                with captured(stdout=stdout):
-                    main_sourced(shell, *activate_args, shell_wrapper_unit)
+def test_unicode(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("PS1", "%{\xc2\xbb".encode())
+
+    # use a file as output stream to simulate PY2 default stdout
+    with tempdir() as td:
+        with open(join(td, "stdout"), "w") as stdout:
+            with captured(stdout=stdout):
+                main_sourced("shell.posix", *activate_args, shell_wrapper_unit)
 
 
-def test_json_basic(shell_wrapper_unit: str):
+def test_json_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     activator = _build_activator_cls("posix+json")()
     make_dot_d_files(shell_wrapper_unit, activator.script_extension)
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -327,7 +327,7 @@ def test_replace_prefix_in_path_1(reset_environ: None):
 
 
 @pytest.mark.skipif(not on_win, reason="windows-specific test")
-def test_replace_prefix_in_path_2(reset_environ: None):
+def test_replace_prefix_in_path_2(reset_environ: None, monkeypatch: MonkeyPatch):
     path1 = join("c:\\", "temp", "6663 31e0")
     path2 = join("c:\\", "temp", "6663 31e0", "envs", "charizard")
     one_more = join("d:\\", "one", "more")
@@ -336,16 +336,16 @@ def test_replace_prefix_in_path_2(reset_environ: None):
     activator = CmdExeActivator()
     old_path = activator.pathsep_join(activator._add_prefix_to_path(path1))
     old_path = one_more + ";" + old_path
-    with env_var("PATH", old_path):
-        activator = PosixActivator()
-        path_elements = activator._replace_prefix_in_path(path1, path2)
-    old_path = native_path_to_unix(old_path.split(";"))
+
+    monkeypatch.setenv("PATH", old_path)
+    activator = PosixActivator()
+    path_elements = activator._replace_prefix_in_path(path1, path2)
 
     assert path_elements[0] == native_path_to_unix(one_more)
     assert path_elements[1] == native_path_to_unix(
         next(activator._get_path_dirs(path2))
     )
-    assert len(path_elements) == len(old_path)
+    assert len(path_elements) == len(old_path.split(";"))
 
 
 def test_default_env(reset_environ: None):

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -359,7 +359,10 @@ def test_default_env(reset_environ: None):
         assert "named-env" == activator._default_env(p)
 
 
-def test_build_activate_dont_activate_unset_var(reset_environ: None):
+def test_build_activate_dont_activate_unset_var(
+    reset_environ: None,
+    monkeypatch: MonkeyPatch,
+):
     with tempdir() as td:
         mkdir_p(join(td, "conda-meta"))
         activate_d_dir = mkdir_p(join(td, "etc", "conda", "activate.d"))
@@ -387,33 +390,32 @@ def test_build_activate_dont_activate_unset_var(reset_environ: None):
 
         write_pkg_env_vars(td)
 
-        with env_var("CONDA_SHLVL", "0"):
-            with env_var("CONDA_PREFIX", ""):
-                activator = PosixActivator()
-                builder = activator.build_activate(td)
-                new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
-                conda_prompt_modifier = "(%s) " % td
-                ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
+        monkeypatch.setenv("CONDA_SHLVL", "0")
+        monkeypatch.setenv("CONDA_PREFIX", "")
 
-                set_vars = {"PS1": ps1}
-                export_vars, unset_vars = activator.get_export_unset_vars(
-                    PATH=new_path,
-                    CONDA_PREFIX=td,
-                    CONDA_SHLVL=1,
-                    CONDA_DEFAULT_ENV=td,
-                    CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
-                    PKG_A_ENV="yerp",
-                    PKG_B_ENV="berp",
-                    ENV_ONE="one",
-                    ENV_TWO="you",
-                )
-                assert builder["unset_vars"] == unset_vars
-                assert builder["set_vars"] == set_vars
-                assert builder["export_vars"] == export_vars
-                assert builder["activate_scripts"] == (
-                    activator.path_conversion(activate_d_1),
-                )
-                assert builder["deactivate_scripts"] == ()
+        activator = PosixActivator()
+        builder = activator.build_activate(td)
+        new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
+        conda_prompt_modifier = "(%s) " % td
+        ps1 = conda_prompt_modifier + os.environ.get("PS1", "")
+
+        set_vars = {"PS1": ps1}
+        export_vars, unset_vars = activator.get_export_unset_vars(
+            PATH=new_path,
+            CONDA_PREFIX=td,
+            CONDA_SHLVL=1,
+            CONDA_DEFAULT_ENV=td,
+            CONDA_PROMPT_MODIFIER=conda_prompt_modifier,
+            PKG_A_ENV="yerp",
+            PKG_B_ENV="berp",
+            ENV_ONE="one",
+            ENV_TWO="you",
+        )
+        assert builder["unset_vars"] == unset_vars
+        assert builder["set_vars"] == set_vars
+        assert builder["export_vars"] == export_vars
+        assert builder["activate_scripts"] == (activator.path_conversion(activate_d_1),)
+        assert builder["deactivate_scripts"] == ()
 
 
 def test_build_activate_shlvl_warn_clobber_vars(reset_environ: None):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Using `monkeypatch.setenv` results in less nesting/code complexity.

Split from https://github.com/conda/conda/pull/13620

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
