### PR TITLE
Add search algorithm for environments.txt file (remove hardcoded path)

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -164,6 +164,9 @@ CONDA_LOGS_DIR = ".logs"
 UNKNOWN_CHANNEL = "<unknown>"
 REPODATA_FN = "repodata.json"
 
+#: Name of file where environment paths are listed
+ENVIRONMENTS_FN = "environments.txt"
+
 #: Default name of the notices file on the server we look for
 NOTICES_FN = "notices.json"
 


### PR DESCRIPTION
### Description

As seem on https://github.com/conda/conda/issues/13453, the `environments.txt` file is a configuration file that is currently hardcoded to `~/.conda/environments.txt` and is one (among many) files responsible for the creation of `~/.conda`. This commit tries to reduce the dependency on such directory.

The current behavior of `get_user_environments_txt_file` is ambiguous in that it may return a file to write (default behavior) or multiple files to read (during the execution of `list_all_known_prefixes`). This commit adds a search algorithm for it so that it is not written to `~/.conda` by default (but it's still able to find it there), and adds a docstring specifying the "file to write" behavior.

This commit expands `list_all_known_prefixes` search algorithm to include all config paths specified in <https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#searching-for-condarc>.

One should be aware that another user on the same computer may choose to set their `$XDG_CONFIG_HOME` to a value that is different from `$HOME/.config`. Since this was not dealt with before (and I'm not sure what should be the expected behavior when one lists environments with admin privileges), I choose not to implement this.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes? No.
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests? No.
- [x] Add / update outdated documentation? No.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
