### PR TITLE
Stop using `log.trace(...)`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -47,6 +47,7 @@ from ..common.iterators import unique
 from ..common.path import expand, paths_equal
 from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..deprecations import deprecated
+from ..gateways.logging import trace
 from .constants import (
     APP_NAME,
     DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
@@ -2109,7 +2110,7 @@ def _first_writable_envs_dir():
                 open(envs_dir_magic_file, "a").close()
                 return envs_dir
             except OSError:
-                log.trace("Tried envs_dir but not writable: %s", envs_dir)
+                trace(log, "Tried envs_dir but not writable: %s", envs_dir)
         else:
             from ..gateways.disk.create import create_envs_directory
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -47,7 +47,7 @@ from ..common.iterators import unique
 from ..common.path import expand, paths_equal
 from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..deprecations import deprecated
-from ..gateways.logging import trace
+from ..gateways.logging import TRACE
 from .constants import (
     APP_NAME,
     DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
@@ -2110,7 +2110,7 @@ def _first_writable_envs_dir():
                 open(envs_dir_magic_file, "a").close()
                 return envs_dir
             except OSError:
-                trace(log, "Tried envs_dir but not writable: %s", envs_dir)
+                log.log(TRACE, "Tried envs_dir but not writable: %s", envs_dir)
         else:
             from ..gateways.disk.create import create_envs_directory
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -47,7 +47,6 @@ from ..common.iterators import unique
 from ..common.path import expand, paths_equal
 from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..deprecations import deprecated
-from ..gateways.logging import TRACE
 from .constants import (
     APP_NAME,
     DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -5,6 +5,8 @@ from array import array
 from itertools import combinations
 from logging import DEBUG, getLogger
 
+from conda.gateways.logging import trace
+
 log = getLogger(__name__)
 
 
@@ -588,7 +590,7 @@ class Clauses:
         nterms = len(coeffs)
         if nterms and coeffs[-1] > hi:
             nprune = sum(c > hi for c in coeffs)
-            log.trace("Eliminating %d/%d terms for bound violation" % (nprune, nterms))
+            trace(log, "Eliminating %d/%d terms for bound violation" % (nprune, nterms))
             nterms -= nprune
         else:
             nprune = 0
@@ -686,10 +688,10 @@ class Clauses:
         try0 = 0
         for peak in (True, False) if maxval > 1 else (False,):
             if peak:
-                log.trace("Beginning peak minimization")
+                trace(log, "Beginning peak minimization")
                 objval = peak_val
             else:
-                log.trace("Beginning sum minimization")
+                trace(log, "Beginning sum minimization")
                 objval = sum_val
 
             objective_dict = {a: c for c, a in zip(coeffs, lits)}
@@ -706,7 +708,7 @@ class Clauses:
             if trymax and not peak:
                 try0 = hi - 1
 
-            log.trace("Initial range (%d,%d)" % (lo, hi))
+            trace(log, "Initial range (%d,%d)" % (lo, hi))
             while True:
                 if try0 is None:
                     mid = (lo + hi) // 2
@@ -722,14 +724,14 @@ class Clauses:
                     self.Require(self.LinearBound, lits, coeffs, lo, mid, False)
 
                 if log.isEnabledFor(DEBUG):
-                    log.trace(
+                    trace(log, 
                         "Bisection attempt: (%d,%d), (%d+%d) clauses"
                         % (lo, mid, nz, self.get_clause_count() - nz)
                     )
                 newsol = self.sat()
                 if newsol is None:
                     lo = mid + 1
-                    log.trace("Bisection failure, new range=(%d,%d)" % (lo, hi))
+                    trace(log, "Bisection failure, new range=(%d,%d)" % (lo, hi))
                     if lo > hi:
                         # FIXME: This is not supposed to happen!
                         # TODO: Investigate and fix the cause.
@@ -742,7 +744,7 @@ class Clauses:
                     bestsol = newsol
                     bestval = objval(newsol, objective_dict)
                     hi = bestval
-                    log.trace("Bisection success, new range=(%d,%d)" % (lo, hi))
+                    trace(log, "Bisection success, new range=(%d,%d)" % (lo, hi))
                     if done:
                         break
                 self.m = m_orig

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -590,7 +590,9 @@ class Clauses:
         nterms = len(coeffs)
         if nterms and coeffs[-1] > hi:
             nprune = sum(c > hi for c in coeffs)
-            log.log(TRACE, "Eliminating %d/%d terms for bound violation" % (nprune, nterms))
+            log.log(
+                TRACE, "Eliminating %d/%d terms for bound violation" % (nprune, nterms)
+            )
             nterms -= nprune
         else:
             nprune = 0

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -724,9 +724,10 @@ class Clauses:
                     self.Require(self.LinearBound, lits, coeffs, lo, mid, False)
 
                 if log.isEnabledFor(DEBUG):
-                    trace(log, 
+                    trace(
+                        log,
                         "Bisection attempt: (%d,%d), (%d+%d) clauses"
-                        % (lo, mid, nz, self.get_clause_count() - nz)
+                        % (lo, mid, nz, self.get_clause_count() - nz),
                     )
                 newsol = self.sat()
                 if newsol is None:

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -5,7 +5,7 @@ from array import array
 from itertools import combinations
 from logging import DEBUG, getLogger
 
-from conda.gateways.logging import TRACE
+from .constants import TRACE
 
 log = getLogger(__name__)
 

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -729,7 +729,10 @@ class Clauses:
                     log.log(
                         TRACE,
                         "Bisection attempt: (%d,%d), (%d+%d) clauses",
-                        lo, mid, nz, self.get_clause_count() - nz,
+                        lo,
+                        mid,
+                        nz,
+                        self.get_clause_count() - nz,
                     )
                 newsol = self.sat()
                 if newsol is None:

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -747,7 +747,7 @@ class Clauses:
                     bestsol = newsol
                     bestval = objval(newsol, objective_dict)
                     hi = bestval
-                    log.log(TRACE, "Bisection success, new range=(%d,%d)" % (lo, hi))
+                    log.log(TRACE, "Bisection success, new range=(%d,%d)", lo, hi)
                     if done:
                         break
                 self.m = m_orig

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -591,7 +591,7 @@ class Clauses:
         if nterms and coeffs[-1] > hi:
             nprune = sum(c > hi for c in coeffs)
             log.log(
-                TRACE, "Eliminating %d/%d terms for bound violation" % (nprune, nterms)
+                TRACE, "Eliminating %d/%d terms for bound violation", nprune, nterms
             )
             nterms -= nprune
         else:
@@ -710,7 +710,7 @@ class Clauses:
             if trymax and not peak:
                 try0 = hi - 1
 
-            log.log(TRACE, "Initial range (%d,%d)" % (lo, hi))
+            log.log(TRACE, "Initial range (%d,%d)", lo, hi)
             while True:
                 if try0 is None:
                     mid = (lo + hi) // 2
@@ -728,13 +728,13 @@ class Clauses:
                 if log.isEnabledFor(DEBUG):
                     log.log(
                         TRACE,
-                        "Bisection attempt: (%d,%d), (%d+%d) clauses"
-                        % (lo, mid, nz, self.get_clause_count() - nz),
+                        "Bisection attempt: (%d,%d), (%d+%d) clauses",
+                        lo, mid, nz, self.get_clause_count() - nz,
                     )
                 newsol = self.sat()
                 if newsol is None:
                     lo = mid + 1
-                    log.log(TRACE, "Bisection failure, new range=(%d,%d)" % (lo, hi))
+                    log.log(TRACE, "Bisection failure, new range=(%d,%d)", lo, hi)
                     if lo > hi:
                         # FIXME: This is not supposed to happen!
                         # TODO: Investigate and fix the cause.

--- a/conda/common/_logic.py
+++ b/conda/common/_logic.py
@@ -5,7 +5,7 @@ from array import array
 from itertools import combinations
 from logging import DEBUG, getLogger
 
-from conda.gateways.logging import trace
+from conda.gateways.logging import TRACE
 
 log = getLogger(__name__)
 
@@ -590,7 +590,7 @@ class Clauses:
         nterms = len(coeffs)
         if nterms and coeffs[-1] > hi:
             nprune = sum(c > hi for c in coeffs)
-            trace(log, "Eliminating %d/%d terms for bound violation" % (nprune, nterms))
+            log.log(TRACE, "Eliminating %d/%d terms for bound violation" % (nprune, nterms))
             nterms -= nprune
         else:
             nprune = 0
@@ -688,10 +688,10 @@ class Clauses:
         try0 = 0
         for peak in (True, False) if maxval > 1 else (False,):
             if peak:
-                trace(log, "Beginning peak minimization")
+                log.log(TRACE, "Beginning peak minimization")
                 objval = peak_val
             else:
-                trace(log, "Beginning sum minimization")
+                log.log(TRACE, "Beginning sum minimization")
                 objval = sum_val
 
             objective_dict = {a: c for c, a in zip(coeffs, lits)}
@@ -708,7 +708,7 @@ class Clauses:
             if trymax and not peak:
                 try0 = hi - 1
 
-            trace(log, "Initial range (%d,%d)" % (lo, hi))
+            log.log(TRACE, "Initial range (%d,%d)" % (lo, hi))
             while True:
                 if try0 is None:
                     mid = (lo + hi) // 2
@@ -724,15 +724,15 @@ class Clauses:
                     self.Require(self.LinearBound, lits, coeffs, lo, mid, False)
 
                 if log.isEnabledFor(DEBUG):
-                    trace(
-                        log,
+                    log.log(
+                        TRACE,
                         "Bisection attempt: (%d,%d), (%d+%d) clauses"
                         % (lo, mid, nz, self.get_clause_count() - nz),
                     )
                 newsol = self.sat()
                 if newsol is None:
                     lo = mid + 1
-                    trace(log, "Bisection failure, new range=(%d,%d)" % (lo, hi))
+                    log.log(TRACE, "Bisection failure, new range=(%d,%d)" % (lo, hi))
                     if lo > hi:
                         # FIXME: This is not supposed to happen!
                         # TODO: Investigate and fix the cause.
@@ -745,7 +745,7 @@ class Clauses:
                     bestsol = newsol
                     bestval = objval(newsol, objective_dict)
                     hi = bestval
-                    trace(log, "Bisection success, new range=(%d,%d)" % (lo, hi))
+                    log.log(TRACE, "Bisection success, new range=(%d,%d)" % (lo, hi))
                     if done:
                         break
                 self.m = m_orig

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -29,7 +29,7 @@ from ..base.constants import (
     PACKAGE_CACHE_MAGIC_FILE,
 )
 from ..base.context import context
-from ..common.constants import NULL
+from ..common.constants import NULL, TRACE
 from ..common.io import IS_INTERACTIVE, ProgressBar, time_recorder
 from ..common.iterators import groupby_to_dict as groupby
 from ..common.path import expand, strip_pkg_extension, url_to_path
@@ -53,7 +53,6 @@ from ..gateways.disk.read import (
     read_repodata_json,
 )
 from ..gateways.disk.test import file_path_is_writable
-from ..gateways.logging import TRACE
 from ..models.match_spec import MatchSpec
 from ..models.records import PackageCacheRecord, PackageRecord
 from ..utils import human_bytes

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -53,6 +53,7 @@ from ..gateways.disk.read import (
     read_repodata_json,
 )
 from ..gateways.disk.test import file_path_is_writable
+from ..gateways.logging import trace
 from ..models.match_spec import MatchSpec
 from ..models.records import PackageCacheRecord, PackageRecord
 from ..utils import human_bytes
@@ -321,7 +322,7 @@ class PackageCacheData(metaclass=PackageCacheType):
             self.__is_writable = i_wri
             log.debug("package cache directory '%s' writable: %s", self.pkgs_dir, i_wri)
         else:
-            log.trace("package cache directory '%s' does not exist", self.pkgs_dir)
+            trace(log, "package cache directory '%s' does not exist", self.pkgs_dir)
             self.__is_writable = i_wri = None
         return i_wri
 
@@ -361,7 +362,7 @@ class PackageCacheData(metaclass=PackageCacheType):
         from conda_package_handling.api import InvalidArchiveError
 
         package_tarball_full_path = join(self.pkgs_dir, package_filename)
-        log.trace("adding to package cache %s", package_tarball_full_path)
+        trace(log, "adding to package cache %s", package_tarball_full_path)
         extracted_package_dir, pkg_ext = strip_pkg_extension(package_tarball_full_path)
 
         # try reading info/repodata_record.json

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -53,7 +53,7 @@ from ..gateways.disk.read import (
     read_repodata_json,
 )
 from ..gateways.disk.test import file_path_is_writable
-from ..gateways.logging import trace
+from ..gateways.logging import TRACE
 from ..models.match_spec import MatchSpec
 from ..models.records import PackageCacheRecord, PackageRecord
 from ..utils import human_bytes
@@ -322,7 +322,7 @@ class PackageCacheData(metaclass=PackageCacheType):
             self.__is_writable = i_wri
             log.debug("package cache directory '%s' writable: %s", self.pkgs_dir, i_wri)
         else:
-            trace(log, "package cache directory '%s' does not exist", self.pkgs_dir)
+            log.log(TRACE, "package cache directory '%s' does not exist", self.pkgs_dir)
             self.__is_writable = i_wri = None
         return i_wri
 
@@ -362,7 +362,7 @@ class PackageCacheData(metaclass=PackageCacheType):
         from conda_package_handling.api import InvalidArchiveError
 
         package_tarball_full_path = join(self.pkgs_dir, package_filename)
-        trace(log, "adding to package cache %s", package_tarball_full_path)
+        log.log(TRACE, "adding to package cache %s", package_tarball_full_path)
         extracted_package_dir, pkg_ext = strip_pkg_extension(package_tarball_full_path)
 
         # try reading info/repodata_record.json

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -16,6 +16,7 @@ from ..auxlib.ish import dals
 from ..base.constants import CONDA_TEMP_EXTENSION
 from ..base.context import context
 from ..common.compat import on_win
+from ..common.constants import TRACE
 from ..common.path import (
     get_bin_directory_short_path,
     get_leaf_directories,
@@ -50,7 +51,6 @@ from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.permissions import make_writable
 from ..gateways.disk.read import compute_sum, islink, lexists, read_index_json
 from ..gateways.disk.update import backoff_rename, touch
-from ..gateways.logging import TRACE
 from ..history import History
 from ..models.channel import Channel
 from ..models.enums import LinkType, NoarchType, PathType

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -508,7 +508,9 @@ class PrefixReplaceLinkAction(LinkPathAction):
             self.transaction_context["temp_dir"], str(uuid4())
         )
 
-        log.log(TRACE, "copying %s => %s", self.source_full_path, self.intermediate_path)
+        log.log(
+            TRACE, "copying %s => %s", self.source_full_path, self.intermediate_path
+        )
         create_link(self.source_full_path, self.intermediate_path, LinkType.copy)
         make_writable(self.intermediate_path)
 
@@ -721,7 +723,9 @@ class CompileMultiPycAction(MultiPathAction):
     def reverse(self):
         # this removes all pyc files even if they were not created
         if self._execute_successful:
-            log.log(TRACE, "reversing pyc creation %s", " ".join(self.target_full_paths))
+            log.log(
+                TRACE, "reversing pyc creation %s", " ".join(self.target_full_paths)
+            )
             for target_full_path in self.target_full_paths:
                 rm_rf(target_full_path)
 
@@ -962,7 +966,9 @@ class CreatePrefixRecordAction(CreateInPrefixPathAction):
         self._execute_successful = True
 
     def reverse(self):
-        log.log(TRACE, "reversing linked package record creation %s", self.target_full_path)
+        log.log(
+            TRACE, "reversing linked package record creation %s", self.target_full_path
+        )
         if self._execute_successful:
             PrefixData(self.target_prefix).remove(
                 self.package_info.repodata_record.name
@@ -1367,7 +1373,9 @@ class ExtractPackageAction(PathAction):
         # The alternative is passing the the classes to ExtractPackageAction __init__
         from .package_cache_data import PackageCacheData
 
-        log.log(TRACE, "extracting %s => %s", self.source_full_path, self.target_full_path)
+        log.log(
+            TRACE, "extracting %s => %s", self.source_full_path, self.target_full_path
+        )
 
         if lexists(self.target_full_path):
             rm_rf(self.target_full_path)

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -495,7 +495,8 @@ class PrefixReplaceLinkAction(LinkPathAction):
             return validation_error
 
         if islink(self.source_full_path):
-            trace(log, 
+            trace(
+                log,
                 "ignoring prefix update for symlink with source path %s",
                 self.source_full_path,
             )
@@ -841,7 +842,9 @@ class CreatePythonEntryPointAction(CreateInPrefixPathAction):
 
     def reverse(self):
         if self._execute_successful:
-            trace(log, "reversing python entry point creation %s", self.target_full_path)
+            trace(
+                log, "reversing python entry point creation %s", self.target_full_path
+            )
             rm_rf(self.target_full_path)
 
 
@@ -1097,14 +1100,18 @@ class UnlinkPathAction(RemoveFromPrefixPathAction):
 
     def execute(self):
         if self.link_type != LinkType.directory:
-            trace(log, 
-                "renaming %s => %s", self.target_short_path, self.holding_short_path
+            trace(
+                log,
+                "renaming %s => %s",
+                self.target_short_path,
+                self.holding_short_path,
             )
             backoff_rename(self.target_full_path, self.holding_full_path, force=True)
 
     def reverse(self):
         if self.link_type != LinkType.directory and lexists(self.holding_full_path):
-            trace(log, 
+            trace(
+                log,
                 "reversing rename %s => %s",
                 self.holding_short_path,
                 self.target_short_path,

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -22,7 +22,7 @@ from ..auxlib.decorators import memoizedproperty
 from ..auxlib.ish import dals
 from ..base.constants import REPODATA_FN, UNKNOWN_CHANNEL, DepsModifier, UpdateModifier
 from ..base.context import context
-from ..common.constants import NULL
+from ..common.constants import NULL, TRACE
 from ..common.io import Spinner, dashlist, time_recorder
 from ..common.iterators import groupby_to_dict as groupby
 from ..common.path import get_major_minor_version, paths_equal
@@ -31,7 +31,6 @@ from ..exceptions import (
     SpecsConfigurationConflictError,
     UnsatisfiableError,
 )
-from ..gateways.logging import TRACE
 from ..history import History
 from ..models.channel import Channel
 from ..models.enums import NoarchType

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -31,7 +31,7 @@ from ..exceptions import (
     SpecsConfigurationConflictError,
     UnsatisfiableError,
 )
-from ..gateways.logging import trace
+from ..gateways.logging import TRACE
 from ..history import History
 from ..models.channel import Channel
 from ..models.enums import NoarchType
@@ -604,7 +604,7 @@ class Solver:
                 # If the spec was a track_features spec, then we need to also remove every
                 # package with a feature that matches the track_feature. The
                 # `graph.remove_spec()` method handles that for us.
-                trace(log, "using PrefixGraph to remove records for %s", spec)
+                log.log(TRACE, "using PrefixGraph to remove records for %s", spec)
                 removed_records = graph.remove_spec(spec)
                 if removed_records:
                     all_removed_records.extend(removed_records)

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -31,6 +31,7 @@ from ..exceptions import (
     SpecsConfigurationConflictError,
     UnsatisfiableError,
 )
+from ..gateways.logging import trace
 from ..history import History
 from ..models.channel import Channel
 from ..models.enums import NoarchType
@@ -603,7 +604,7 @@ class Solver:
                 # If the spec was a track_features spec, then we need to also remove every
                 # package with a feature that matches the track_feature. The
                 # `graph.remove_spec()` method handles that for us.
-                log.trace("using PrefixGraph to remove records for %s", spec)
+                trace(log, "using PrefixGraph to remove records for %s", spec)
                 removed_records = graph.remove_spec(spec)
                 if removed_records:
                     all_removed_records.extend(removed_records)

--- a/conda/gateways/disk/__init__.py
+++ b/conda/gateways/disk/__init__.py
@@ -33,7 +33,7 @@ def exp_backoff_fn(fn, *args, **kwargs):
         sleep_time = ((2**n) + random.random()) * 0.1
         caller_frame = sys._getframe(1)
         log.log(
-                TRACE,
+            TRACE,
             "retrying %s/%s %s() in %g sec",
             basename(caller_frame.f_code.co_filename),
             caller_frame.f_lineno,

--- a/conda/gateways/disk/__init__.py
+++ b/conda/gateways/disk/__init__.py
@@ -32,7 +32,8 @@ def exp_backoff_fn(fn, *args, **kwargs):
             raise
         sleep_time = ((2**n) + random.random()) * 0.1
         caller_frame = sys._getframe(1)
-        trace(log, 
+        trace(
+            log,
             "retrying %s/%s %s() in %g sec",
             basename(caller_frame.f_code.co_filename),
             caller_frame.f_lineno,
@@ -104,7 +105,8 @@ def mkdir_p_sudo_safe(path):
         try:
             os.chmod(path, 0o2775)
         except OSError as e:
-            trace(log, 
+            trace(
+                log,
                 "Failed to set permissions to 2775 on %s (%d %d)",
                 path,
                 e.errno,

--- a/conda/gateways/disk/__init__.py
+++ b/conda/gateways/disk/__init__.py
@@ -9,7 +9,7 @@ from subprocess import CalledProcessError
 from time import sleep
 
 from ...common.compat import on_win
-from ..logging import TRACE
+from ...common.constants import TRACE
 
 log = getLogger(__name__)
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -21,6 +21,7 @@ from ...common.path import ensure_pad, expand, win_path_double_escape, win_path_
 from ...common.serialize import json_dump
 from ...exceptions import BasicClobberError, CondaOSError, maybe_raise
 from ...models.enums import LinkType
+from ..logging import trace
 from . import mkdir_p
 from .delete import path_is_clean, rm_rf
 from .link import islink, lexists, link, readlink, symlink
@@ -110,7 +111,7 @@ if __name__ == '__main__':
 
 
 def write_as_json_to_file(file_path, obj):
-    log.trace("writing json to file %s", file_path)
+    trace(log, "writing json to file %s", file_path)
     with codecs.open(file_path, mode="wb", encoding="utf-8") as fo:
         json_str = json_dump(obj)
         fo.write(json_str)
@@ -279,7 +280,7 @@ def create_hard_link_or_copy(src, dst):
         raise CondaOSError(message)
 
     try:
-        log.trace("creating hard link %s => %s", src, dst)
+        trace(log, "creating hard link %s => %s", src, dst)
         link(src, dst)
     except OSError:
         log.info("hard link failed, so copying %s => %s", src, dst)
@@ -301,7 +302,7 @@ def _do_softlink(src, dst):
         # A future optimization will be to copy code from @mingwandroid's virtualenv patch.
         copy(src, dst)
     else:
-        log.trace("soft linking %s => %s", src, dst)
+        trace(log, "soft linking %s => %s", src, dst)
         symlink(src, dst)
 
 
@@ -320,14 +321,14 @@ def copy(src, dst):
         src_points_to = readlink(src)
         if not src_points_to.startswith("/"):
             # copy relative symlinks as symlinks
-            log.trace("soft linking %s => %s", src, dst)
+            trace(log, "soft linking %s => %s", src, dst)
             symlink(src_points_to, dst)
             return
     _do_copy(src, dst)
 
 
 def _do_copy(src, dst):
-    log.trace("copying %s => %s", src, dst)
+    trace(log, "copying %s => %s", src, dst)
     # src and dst are always files. So we can bypass some checks that shutil.copy does.
     # Also shutil.copy calls shutil.copymode, which we can skip because we are explicitly
     # calling copystat.
@@ -375,7 +376,7 @@ def create_link(src, dst, link_type=LinkType.hardlink, force=False):
         if isdir(src):
             raise CondaError("Cannot hard link a directory. %s" % src)
         try:
-            log.trace("hard linking %s => %s", src, dst)
+            trace(log, "hard linking %s => %s", src, dst)
             link(src, dst)
         except OSError as e:
             log.debug("%r", e)
@@ -421,7 +422,7 @@ def compile_multiple_pyc(
             command.extend(["-j", "0"])
         command[0:0] = [python_exe_full_path]
         # command[0:0] = ['--cwd', prefix, '--dev', '-p', prefix, python_exe_full_path]
-        log.trace(command)
+        trace(log, command)
         from ..subprocess import any_subprocess
 
         # from ...common.io import env_vars
@@ -465,13 +466,13 @@ def compile_multiple_pyc(
 def create_package_cache_directory(pkgs_dir):
     # returns False if package cache directory cannot be created
     try:
-        log.trace("creating package cache directory '%s'", pkgs_dir)
+        trace(log, "creating package cache directory '%s'", pkgs_dir)
         sudo_safe = expand(pkgs_dir).startswith(expand("~"))
         touch(join(pkgs_dir, PACKAGE_CACHE_MAGIC_FILE), mkdir=True, sudo_safe=sudo_safe)
         touch(join(pkgs_dir, "urls"), sudo_safe=sudo_safe)
     except OSError as e:
         if e.errno in (EACCES, EPERM, EROFS):
-            log.trace("cannot create package cache directory '%s'", pkgs_dir)
+            trace(log, "cannot create package cache directory '%s'", pkgs_dir)
             return False
         else:
             raise
@@ -486,12 +487,12 @@ def create_envs_directory(envs_dir):
     # This value is duplicated in conda.base.context._first_writable_envs_dir().
     envs_dir_magic_file = join(envs_dir, ".conda_envs_dir_test")
     try:
-        log.trace("creating envs directory '%s'", envs_dir)
+        trace(log, "creating envs directory '%s'", envs_dir)
         sudo_safe = expand(envs_dir).startswith(expand("~"))
         touch(join(envs_dir, envs_dir_magic_file), mkdir=True, sudo_safe=sudo_safe)
     except OSError as e:
         if e.errno in (EACCES, EPERM, EROFS):
-            log.trace("cannot create envs directory '%s'", envs_dir)
+            trace(log, "cannot create envs directory '%s'", envs_dir)
             return False
         else:
             raise

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -17,11 +17,11 @@ from ...auxlib.ish import dals
 from ...base.constants import CONDA_PACKAGE_EXTENSION_V1, PACKAGE_CACHE_MAGIC_FILE
 from ...base.context import context
 from ...common.compat import on_linux, on_win
+from ...common.constants import TRACE
 from ...common.path import ensure_pad, expand, win_path_double_escape, win_path_ok
 from ...common.serialize import json_dump
 from ...exceptions import BasicClobberError, CondaOSError, maybe_raise
 from ...models.enums import LinkType
-from ..logging import TRACE
 from . import mkdir_p
 from .delete import path_is_clean, rm_rf
 from .link import islink, lexists, link, readlink, symlink

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -24,7 +24,7 @@ from subprocess import STDOUT, CalledProcessError, check_output
 from ...base.constants import CONDA_TEMP_EXTENSION
 from ...base.context import context
 from ...common.compat import on_win
-from ..logging import TRACE
+from ...common.constants import TRACE
 from . import MAX_TRIES, exp_backoff_fn
 from .link import islink, lexists
 from .permissions import make_writable, recursive_make_writable

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -24,6 +24,7 @@ from subprocess import STDOUT, CalledProcessError, check_output
 from ...base.constants import CONDA_TEMP_EXTENSION
 from ...base.context import context
 from ...common.compat import on_win
+from ..logging import trace
 from . import MAX_TRIES, exp_backoff_fn
 from .link import islink, lexists
 from .permissions import make_writable, recursive_make_writable
@@ -202,13 +203,13 @@ def rm_rf(path, max_retries=5, trash=True, clean_empty_parents=False, *args, **k
     """
     try:
         path = abspath(path)
-        log.trace("rm_rf %s", path)
+        trace(log, "rm_rf %s", path)
         if isdir(path) and not islink(path):
             backoff_rmdir(path)
         elif lexists(path):
             unlink_or_rename_to_trash(path)
         else:
-            log.trace("rm_rf failed. Not a link, file, or directory: %s", path)
+            trace(log, "rm_rf failed. Not a link, file, or directory: %s", path)
     finally:
         if lexists(path):
             log.info("rm_rf failed for %s", path)
@@ -258,7 +259,7 @@ def backoff_rmdir(dirpath, max_tries=MAX_TRIES):
             exp_backoff_fn(rmtree, path, onerror=retry, max_tries=max_tries)
         except OSError as e:
             if e.errno == ENOENT:
-                log.trace("no such file or directory: %s", path)
+                trace(log, "no such file or directory: %s", path)
             else:
                 raise
 

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -24,7 +24,7 @@ from subprocess import STDOUT, CalledProcessError, check_output
 from ...base.constants import CONDA_TEMP_EXTENSION
 from ...base.context import context
 from ...common.compat import on_win
-from ..logging import trace
+from ..logging import TRACE
 from . import MAX_TRIES, exp_backoff_fn
 from .link import islink, lexists
 from .permissions import make_writable, recursive_make_writable
@@ -203,13 +203,13 @@ def rm_rf(path, max_retries=5, trash=True, clean_empty_parents=False, *args, **k
     """
     try:
         path = abspath(path)
-        trace(log, "rm_rf %s", path)
+        log.log(TRACE, "rm_rf %s", path)
         if isdir(path) and not islink(path):
             backoff_rmdir(path)
         elif lexists(path):
             unlink_or_rename_to_trash(path)
         else:
-            trace(log, "rm_rf failed. Not a link, file, or directory: %s", path)
+            log.log(TRACE, "rm_rf failed. Not a link, file, or directory: %s", path)
     finally:
         if lexists(path):
             log.info("rm_rf failed for %s", path)
@@ -259,7 +259,7 @@ def backoff_rmdir(dirpath, max_tries=MAX_TRIES):
             exp_backoff_fn(rmtree, path, onerror=retry, max_tries=max_tries)
         except OSError as e:
             if e.errno == ENOENT:
-                trace(log, "no such file or directory: %s", path)
+                log.log(TRACE, "no such file or directory: %s", path)
             else:
                 raise
 

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -10,7 +10,7 @@ from os.path import isdir, isfile, join
 from stat import S_IEXEC, S_IMODE, S_ISDIR, S_ISREG, S_IWRITE, S_IXGRP, S_IXOTH, S_IXUSR
 
 from ...common.compat import on_win
-from ..logging import trace
+from ..logging import TRACE
 from . import MAX_TRIES, exp_backoff_fn
 from .link import islink, lchmod
 
@@ -76,7 +76,7 @@ def recursive_make_writable(path, max_tries=MAX_TRIES):
 def make_executable(path):
     if isfile(path):
         mode = lstat(path).st_mode
-        trace(log, "chmod +x %s", path)
+        log.log(TRACE, "chmod +x %s", path)
         chmod(path, S_IMODE(mode) | S_IXUSR | S_IXGRP | S_IXOTH)
     else:
         log.error("Cannot make path '%s' executable", path)

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -10,6 +10,7 @@ from os.path import isdir, isfile, join
 from stat import S_IEXEC, S_IMODE, S_ISDIR, S_ISREG, S_IWRITE, S_IXGRP, S_IXOTH, S_IXUSR
 
 from ...common.compat import on_win
+from ..logging import trace
 from . import MAX_TRIES, exp_backoff_fn
 from .link import islink, lchmod
 
@@ -75,7 +76,7 @@ def recursive_make_writable(path, max_tries=MAX_TRIES):
 def make_executable(path):
     if isfile(path):
         mode = lstat(path).st_mode
-        log.trace("chmod +x %s", path)
+        trace(log, "chmod +x %s", path)
         chmod(path, S_IMODE(mode) | S_IXUSR | S_IXGRP | S_IXOTH)
     else:
         log.error("Cannot make path '%s' executable", path)

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -10,7 +10,7 @@ from os.path import isdir, isfile, join
 from stat import S_IEXEC, S_IMODE, S_ISDIR, S_ISREG, S_IWRITE, S_IXGRP, S_IXOTH, S_IXUSR
 
 from ...common.compat import on_win
-from ..logging import TRACE
+from ...common.constants import TRACE
 from . import MAX_TRIES, exp_backoff_fn
 from .link import islink, lchmod
 

--- a/conda/gateways/disk/test.py
+++ b/conda/gateways/disk/test.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from ...base.constants import PREFIX_MAGIC_FILE
 from ...common.path import expand
 from ...models.enums import LinkType
+from ..logging import trace
 from .create import create_link
 from .delete import rm_rf
 from .link import islink, lexists
@@ -20,7 +21,7 @@ log = getLogger(__name__)
 
 def file_path_is_writable(path):
     path = expand(path)
-    log.trace("checking path is writable %s", path)
+    trace(log, "checking path is writable %s", path)
     if isdir(dirname(path)):
         path_existed = lexists(path)
         try:
@@ -52,12 +53,12 @@ def hardlink_supported(source_file, dest_dir):
         create_link(source_file, test_file, LinkType.hardlink, force=True)
         is_supported = not islink(test_file)
         if is_supported:
-            log.trace("hard link supported for %s => %s", source_file, dest_dir)
+            trace(log, "hard link supported for %s => %s", source_file, dest_dir)
         else:
-            log.trace("hard link IS NOT supported for %s => %s", source_file, dest_dir)
+            trace(log, "hard link IS NOT supported for %s => %s", source_file, dest_dir)
         return is_supported
     except OSError:
-        log.trace("hard link IS NOT supported for %s => %s", source_file, dest_dir)
+        trace(log, "hard link IS NOT supported for %s => %s", source_file, dest_dir)
         return False
     finally:
         rm_rf(test_file)
@@ -67,7 +68,7 @@ def hardlink_supported(source_file, dest_dir):
 def softlink_supported(source_file, dest_dir):
     # On Windows, softlink creation is restricted to Administrative users by default. It can
     # optionally be enabled for non-admin users through explicit registry modification.
-    log.trace("checking soft link capability for %s => %s", source_file, dest_dir)
+    trace(log, "checking soft link capability for %s => %s", source_file, dest_dir)
     test_path = join(dest_dir, ".tmp." + basename(source_file))
     assert isfile(source_file), source_file
     assert isdir(dest_dir), dest_dir

--- a/conda/gateways/disk/test.py
+++ b/conda/gateways/disk/test.py
@@ -55,7 +55,9 @@ def hardlink_supported(source_file, dest_dir):
         if is_supported:
             log.log(TRACE, "hard link supported for %s => %s", source_file, dest_dir)
         else:
-            log.log(TRACE, "hard link IS NOT supported for %s => %s", source_file, dest_dir)
+            log.log(
+                TRACE, "hard link IS NOT supported for %s => %s", source_file, dest_dir
+            )
         return is_supported
     except OSError:
         log.log(TRACE, "hard link IS NOT supported for %s => %s", source_file, dest_dir)

--- a/conda/gateways/disk/test.py
+++ b/conda/gateways/disk/test.py
@@ -9,9 +9,9 @@ from os.path import basename, dirname, isdir, isfile, join
 from uuid import uuid4
 
 from ...base.constants import PREFIX_MAGIC_FILE
+from ...common.constants import TRACE
 from ...common.path import expand
 from ...models.enums import LinkType
-from ..logging import TRACE
 from .create import create_link
 from .delete import rm_rf
 from .link import islink, lexists

--- a/conda/gateways/disk/test.py
+++ b/conda/gateways/disk/test.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 from ...base.constants import PREFIX_MAGIC_FILE
 from ...common.path import expand
 from ...models.enums import LinkType
-from ..logging import trace
+from ..logging import TRACE
 from .create import create_link
 from .delete import rm_rf
 from .link import islink, lexists
@@ -21,7 +21,7 @@ log = getLogger(__name__)
 
 def file_path_is_writable(path):
     path = expand(path)
-    trace(log, "checking path is writable %s", path)
+    log.log(TRACE, "checking path is writable %s", path)
     if isdir(dirname(path)):
         path_existed = lexists(path)
         try:
@@ -53,12 +53,12 @@ def hardlink_supported(source_file, dest_dir):
         create_link(source_file, test_file, LinkType.hardlink, force=True)
         is_supported = not islink(test_file)
         if is_supported:
-            trace(log, "hard link supported for %s => %s", source_file, dest_dir)
+            log.log(TRACE, "hard link supported for %s => %s", source_file, dest_dir)
         else:
-            trace(log, "hard link IS NOT supported for %s => %s", source_file, dest_dir)
+            log.log(TRACE, "hard link IS NOT supported for %s => %s", source_file, dest_dir)
         return is_supported
     except OSError:
-        trace(log, "hard link IS NOT supported for %s => %s", source_file, dest_dir)
+        log.log(TRACE, "hard link IS NOT supported for %s => %s", source_file, dest_dir)
         return False
     finally:
         rm_rf(test_file)
@@ -68,7 +68,7 @@ def hardlink_supported(source_file, dest_dir):
 def softlink_supported(source_file, dest_dir):
     # On Windows, softlink creation is restricted to Administrative users by default. It can
     # optionally be enabled for non-admin users through explicit registry modification.
-    trace(log, "checking soft link capability for %s => %s", source_file, dest_dir)
+    log.log(TRACE, "checking soft link capability for %s => %s", source_file, dest_dir)
     test_path = join(dest_dir, ".tmp." + basename(source_file))
     assert isfile(source_file), source_file
     assert isdir(dest_dir), dest_dir

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -87,7 +87,8 @@ def rename(source_path, destination_path, force=False):
             elif e.errno in (EINVAL, EXDEV, EPERM):
                 # https://github.com/conda/conda/issues/6811
                 # https://github.com/conda/conda/issues/6711
-                trace(log, 
+                trace(
+                    log,
                     "Could not rename %s => %s due to errno [%s]. Falling back"
                     " to copy/unlink",
                     source_path,

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -19,7 +19,7 @@ from ...base.context import context
 from ...common.compat import on_win
 from ...common.path import expand
 from ...exceptions import NotWritableError
-from ..logging import trace
+from ..logging import TRACE
 from . import exp_backoff_fn, mkdir_p, mkdir_p_sudo_safe
 from .delete import rm_rf
 from .link import lexists
@@ -40,7 +40,7 @@ def update_file_in_place_as_binary(file_full_path, callback):
     fh = None
     try:
         fh = exp_backoff_fn(open, file_full_path, "rb+")
-        trace(log, "in-place update path locked for %s", file_full_path)
+        log.log(TRACE, "in-place update path locked for %s", file_full_path)
         data = fh.read()
         fh.seek(0)
         try:
@@ -59,7 +59,7 @@ def rename(source_path, destination_path, force=False):
     if lexists(destination_path) and force:
         rm_rf(destination_path)
     if lexists(source_path):
-        trace(log, "renaming %s => %s", source_path, destination_path)
+        log.log(TRACE, "renaming %s => %s", source_path, destination_path)
         try:
             os.rename(source_path, destination_path)
         except OSError as e:
@@ -87,8 +87,8 @@ def rename(source_path, destination_path, force=False):
             elif e.errno in (EINVAL, EXDEV, EPERM):
                 # https://github.com/conda/conda/issues/6811
                 # https://github.com/conda/conda/issues/6711
-                trace(
-                    log,
+                log.log(
+                    TRACE,
                     "Could not rename %s => %s due to errno [%s]. Falling back"
                     " to copy/unlink",
                     source_path,
@@ -101,7 +101,7 @@ def rename(source_path, destination_path, force=False):
             else:
                 raise
     else:
-        trace(log, "cannot rename; source path does not exist '%s'", source_path)
+        log.log(TRACE, "cannot rename; source path does not exist '%s'", source_path)
 
 
 @contextmanager
@@ -143,7 +143,7 @@ def touch(path, mkdir=False, sudo_safe=False):
     # raises: NotWritableError, which is also an OSError having attached errno
     try:
         path = expand(path)
-        trace(log, "touching path %s", path)
+        log.log(TRACE, "touching path %s", path)
         if lexists(path):
             os.utime(path, None)
             return True
@@ -165,7 +165,7 @@ def touch(path, mkdir=False, sudo_safe=False):
             # if sudo_safe and not on_win and os.environ.get('SUDO_UID') is not None:
             #     uid = int(os.environ['SUDO_UID'])
             #     gid = int(os.environ.get('SUDO_GID', -1))
-            #     trace(log, "chowning %s:%s %s", uid, gid, path)
+            #     log.log(TRACE, "chowning %s:%s %s", uid, gid, path)
             #     os.chown(path, uid, gid)
             return False
     except OSError as e:

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -19,6 +19,7 @@ from ...base.context import context
 from ...common.compat import on_win
 from ...common.path import expand
 from ...exceptions import NotWritableError
+from ..logging import trace
 from . import exp_backoff_fn, mkdir_p, mkdir_p_sudo_safe
 from .delete import rm_rf
 from .link import lexists
@@ -39,7 +40,7 @@ def update_file_in_place_as_binary(file_full_path, callback):
     fh = None
     try:
         fh = exp_backoff_fn(open, file_full_path, "rb+")
-        log.trace("in-place update path locked for %s", file_full_path)
+        trace(log, "in-place update path locked for %s", file_full_path)
         data = fh.read()
         fh.seek(0)
         try:
@@ -58,7 +59,7 @@ def rename(source_path, destination_path, force=False):
     if lexists(destination_path) and force:
         rm_rf(destination_path)
     if lexists(source_path):
-        log.trace("renaming %s => %s", source_path, destination_path)
+        trace(log, "renaming %s => %s", source_path, destination_path)
         try:
             os.rename(source_path, destination_path)
         except OSError as e:
@@ -86,7 +87,7 @@ def rename(source_path, destination_path, force=False):
             elif e.errno in (EINVAL, EXDEV, EPERM):
                 # https://github.com/conda/conda/issues/6811
                 # https://github.com/conda/conda/issues/6711
-                log.trace(
+                trace(log, 
                     "Could not rename %s => %s due to errno [%s]. Falling back"
                     " to copy/unlink",
                     source_path,
@@ -99,7 +100,7 @@ def rename(source_path, destination_path, force=False):
             else:
                 raise
     else:
-        log.trace("cannot rename; source path does not exist '%s'", source_path)
+        trace(log, "cannot rename; source path does not exist '%s'", source_path)
 
 
 @contextmanager
@@ -141,7 +142,7 @@ def touch(path, mkdir=False, sudo_safe=False):
     # raises: NotWritableError, which is also an OSError having attached errno
     try:
         path = expand(path)
-        log.trace("touching path %s", path)
+        trace(log, "touching path %s", path)
         if lexists(path):
             os.utime(path, None)
             return True
@@ -163,7 +164,7 @@ def touch(path, mkdir=False, sudo_safe=False):
             # if sudo_safe and not on_win and os.environ.get('SUDO_UID') is not None:
             #     uid = int(os.environ['SUDO_UID'])
             #     gid = int(os.environ.get('SUDO_GID', -1))
-            #     log.trace("chowning %s:%s %s", uid, gid, path)
+            #     trace(log, "chowning %s:%s %s", uid, gid, path)
             #     os.chown(path, uid, gid)
             return False
     except OSError as e:

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -17,9 +17,9 @@ from subprocess import PIPE, Popen
 from ...base.constants import DRY_RUN_PREFIX
 from ...base.context import context
 from ...common.compat import on_win
+from ...common.constants import TRACE
 from ...common.path import expand
 from ...exceptions import NotWritableError
-from ..logging import TRACE
 from . import exp_backoff_fn, mkdir_p, mkdir_p_sudo_safe
 from .delete import rm_rf
 from .link import lexists

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -234,6 +234,11 @@ def set_log_level(log_level: int):
     log.debug("log_level set to %d", log_level)
 
 
+@deprecated(
+    "24.5",
+    "24.11",
+    addendum="Use `logging.getLogger(__name__)(conda.common.constants.TRACE, ...)` instead.",
+)
 def trace(self, message, *args, **kwargs):
     if self.isEnabledFor(TRACE):
         self._log(TRACE, message, args, **kwargs)

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -128,7 +128,7 @@ def subprocess_call(
         log.info(formatted_output)
         raise CalledProcessError(rc, command, output=formatted_output)
     if log.isEnabledFor(TRACE):
-        log.trace(formatted_output)
+        log.log(TRACE, formatted_output)
 
     return Response(stdout, stderr, int(rc))
 

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -17,9 +17,9 @@ from ..auxlib.compat import shlex_split_unicode
 from ..auxlib.ish import dals
 from ..base.context import context
 from ..common.compat import encode_environment, isiterable
+from ..common.constants import TRACE
 from ..gateways.disk.delete import rm_rf
 from ..utils import wrap_subprocess_call
-from .logging import TRACE
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -24,6 +24,7 @@ from .core.index import LAST_CHANNEL_URLS, _supplement_index_with_prefix
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.solve import diff_for_unlink_link_precs
 from .exceptions import CondaIndexError, PackagesNotFoundError
+from .gateways.logging import trace
 from .history import History
 from .instructions import FETCH, LINK, SYMLINK_CONDA, UNLINK
 from .models.channel import Channel, prioritize_channels
@@ -367,10 +368,10 @@ def _plan_from_actions(actions, index):  # pragma: no cover
     log.debug(f"Adding plans for operations: {op_order}")
     for op in op_order:
         if op not in actions:
-            log.trace(f"action {op} not in actions")
+            trace(log, f"action {op} not in actions")
             continue
         if not actions[op]:
-            log.trace(f"action {op} has None value")
+            trace(log, f"action {op} has None value")
             continue
         if "_" not in op:
             plan.append((PRINT, "%sing packages ..." % op.capitalize()))

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -24,7 +24,7 @@ from .core.index import LAST_CHANNEL_URLS, _supplement_index_with_prefix
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.solve import diff_for_unlink_link_precs
 from .exceptions import CondaIndexError, PackagesNotFoundError
-from .gateways.logging import trace
+from .gateways.logging import TRACE
 from .history import History
 from .instructions import FETCH, LINK, SYMLINK_CONDA, UNLINK
 from .models.channel import Channel, prioritize_channels
@@ -368,10 +368,10 @@ def _plan_from_actions(actions, index):  # pragma: no cover
     log.debug(f"Adding plans for operations: {op_order}")
     for op in op_order:
         if op not in actions:
-            trace(log, f"action {op} not in actions")
+            log.log(TRACE, f"action {op} not in actions")
             continue
         if not actions[op]:
-            trace(log, f"action {op} has None value")
+            log.log(TRACE, f"action {op} has None value")
             continue
         if "_" not in op:
             plan.append((PRINT, "%sing packages ..." % op.capitalize()))

--- a/conda/plan.py
+++ b/conda/plan.py
@@ -18,13 +18,13 @@ from boltons.setutils import IndexedSet
 
 from .base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
 from .base.context import context, reset_context
+from .common.constants import TRACE
 from .common.io import dashlist, env_vars, time_recorder
 from .common.iterators import groupby_to_dict as groupby
 from .core.index import LAST_CHANNEL_URLS, _supplement_index_with_prefix
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.solve import diff_for_unlink_link_precs
 from .exceptions import CondaIndexError, PackagesNotFoundError
-from .gateways.logging import TRACE
 from .history import History
 from .instructions import FETCH, LINK, SYMLINK_CONDA, UNLINK
 from .models.channel import Channel, prioritize_channels

--- a/news/13732-log-trace
+++ b/news/13732-log-trace
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Deprecate `Logger.trace(msg)` patch. Use `Logger.log(conda.common.constants.TRACE, msg)` instead. (#13732)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This is a long-standing issue that prevents `conda` from being used as a library. We can't test `SubdirData` in isolation unless we first call `conda.gateways.logging.initialize_logging` which, among other things, patches `logger.Logger` to have a new method `.trace()` which essentially does `Logger.log(5, ...)`.

I recommend we deprecate it and stop using it. This is the first step to allow easier testability / library usage in other projects.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
