### PR TITLE
Make `reset_environ` an `autouse` fixture

### DIFF
--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1326,7 +1326,7 @@ def test_cmd_exe_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     @SET "CONDA_PREFIX=%(converted_prefix)s"
     @SET "CONDA_SHLVL=1"
     @SET "CONDA_DEFAULT_ENV=%(native_prefix)s"
-    @SET "CONDA_PROMPT_MODIFIER=(%(native_prefix)s) "
+    @SET "CONDA_PROMPT_MODIFIER=%(conda_prompt_modifier)s"
     %(conda_exe_export)s
     @CALL "%(activate1)s"
     """
@@ -1339,6 +1339,7 @@ def test_cmd_exe_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
             join(shell_wrapper_unit, "etc", "conda", "activate.d", "activate1.bat")
         ),
         "conda_exe_export": conda_exe_export,
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
     }
     assert activate_data == e_activate_data
 
@@ -1364,7 +1365,7 @@ def test_cmd_exe_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     @CALL "%(deactivate1)s"
     @SET "PATH=%(new_path)s"
     @SET "CONDA_SHLVL=1"
-    @SET "CONDA_PROMPT_MODIFIER=(%(native_prefix)s) "
+    @SET "CONDA_PROMPT_MODIFIER=%(conda_prompt_modifier)s"
     @CALL "%(activate1)s"
     """
     ) % {
@@ -1388,6 +1389,7 @@ def test_cmd_exe_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
         ),
         "native_prefix": shell_wrapper_unit,
         "new_path": activator.pathsep_join(new_path_parts),
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
     }
 
     with captured() as c:
@@ -1448,7 +1450,7 @@ def test_csh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     setenv CONDA_PREFIX "%(native_prefix)s";
     setenv CONDA_SHLVL "1";
     setenv CONDA_DEFAULT_ENV "%(native_prefix)s";
-    setenv CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
+    setenv CONDA_PROMPT_MODIFIER "%(conda_prompt_modifier)s";
     %(conda_exe_export)s;
     source "%(activate1)s";
     """
@@ -1460,7 +1462,8 @@ def test_csh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
         "activate1": activator.path_conversion(
             join(shell_wrapper_unit, "etc", "conda", "activate.d", "activate1.csh")
         ),
-        "prompt": "(%s) " % shell_wrapper_unit + os.environ.get("prompt", ""),
+        "prompt": get_prompt(shell_wrapper_unit),
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
         "conda_exe_export": conda_exe_export,
     }
     assert activate_data == e_activate_data
@@ -1485,11 +1488,12 @@ def test_csh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     set prompt='%(prompt)s';
     setenv PATH "%(new_path)s";
     setenv CONDA_SHLVL "1";
-    setenv CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
+    setenv CONDA_PROMPT_MODIFIER "%(codna_prompt_modifier)s";
     source "%(activate1)s";
     """
     ) % {
-        "prompt": "(%s) " % shell_wrapper_unit + os.environ.get("prompt", ""),
+        "prompt": get_prompt(shell_wrapper_unit),
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
         "new_path": activator.pathsep_join(new_path_parts),
         "activate1": activator.path_conversion(
             join(
@@ -1549,7 +1553,7 @@ def test_csh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
                 "deactivate1.csh",
             )
         ),
-        "prompt": os.environ.get("prompt", ""),
+        "prompt": get_prompt(),
         "conda_exe_export": conda_exe_export,
     }
     assert deactivate_data == e_deactivate_data
@@ -1573,7 +1577,7 @@ def test_xonsh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     $CONDA_PREFIX = '%(native_prefix)s'
     $CONDA_SHLVL = '1'
     $CONDA_DEFAULT_ENV = '%(native_prefix)s'
-    $CONDA_PROMPT_MODIFIER = '(%(native_prefix)s) '
+    $CONDA_PROMPT_MODIFIER = '%(conda_prompt_modifier)s'
     %(conda_exe_export)s
     %(sourcer)s "%(activate1)s"
     """
@@ -1584,6 +1588,7 @@ def test_xonsh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
         "new_path": activator.pathsep_join(new_path_parts),
         "sys_executable": activator.path_conversion(sys.executable),
         "conda_exe_export": conda_exe_export,
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
     }
     if on_win:
         e_activate_info["sourcer"] = "source-cmd --suppress-skip-message"
@@ -1617,13 +1622,14 @@ def test_xonsh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     %(sourcer)s "%(deactivate1)s"
     $PATH = '%(new_path)s'
     $CONDA_SHLVL = '1'
-    $CONDA_PROMPT_MODIFIER = '(%(native_prefix)s) '
+    $CONDA_PROMPT_MODIFIER = '%(conda_prompt_modifier)s'
     %(sourcer)s "%(activate1)s"
     """
     )
     e_reactivate_info = {
         "new_path": activator.pathsep_join(new_path_parts),
         "native_prefix": shell_wrapper_unit,
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
     }
     if on_win:
         e_reactivate_info["sourcer"] = "source-cmd --suppress-skip-message"
@@ -1716,7 +1722,7 @@ def test_fish_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     set -gx CONDA_PREFIX "%(native_prefix)s";
     set -gx CONDA_SHLVL "1";
     set -gx CONDA_DEFAULT_ENV "%(native_prefix)s";
-    set -gx CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
+    set -gx CONDA_PROMPT_MODIFIER "%(conda_prompt_modifier)s";
     %(conda_exe_export)s;
     source "%(activate1)s";
     """
@@ -1729,6 +1735,7 @@ def test_fish_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
             join(shell_wrapper_unit, "etc", "conda", "activate.d", "activate1.fish")
         ),
         "conda_exe_export": conda_exe_export,
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
     }
     assert activate_data == e_activate_data
 
@@ -1751,7 +1758,7 @@ def test_fish_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     source "%(deactivate1)s";
     set -gx PATH "%(new_path)s";
     set -gx CONDA_SHLVL "1";
-    set -gx CONDA_PROMPT_MODIFIER "(%(native_prefix)s) ";
+    set -gx CONDA_PROMPT_MODIFIER "%(conda_prompt_modifier)s";
     source "%(activate1)s";
     """
     ) % {
@@ -1775,6 +1782,7 @@ def test_fish_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
             )
         ),
         "native_prefix": shell_wrapper_unit,
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
     }
     assert reactivate_data == e_reactivate_data
 
@@ -1835,7 +1843,7 @@ def test_powershell_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     $Env:CONDA_PREFIX = "%(prefix)s"
     $Env:CONDA_SHLVL = "1"
     $Env:CONDA_DEFAULT_ENV = "%(prefix)s"
-    $Env:CONDA_PROMPT_MODIFIER = "(%(prefix)s) "
+    $Env:CONDA_PROMPT_MODIFIER = "%(conda_prompt_modifier)s"
     %(conda_exe_export)s
     . "%(activate1)s"
     """
@@ -1847,6 +1855,7 @@ def test_powershell_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
             shell_wrapper_unit, "etc", "conda", "activate.d", "activate1.ps1"
         ),
         "conda_exe_export": conda_exe_export,
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
     }
     assert activate_data == e_activate_data
 
@@ -1869,7 +1878,7 @@ def test_powershell_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     . "%(deactivate1)s"
     $Env:PATH = "%(new_path)s"
     $Env:CONDA_SHLVL = "1"
-    $Env:CONDA_PROMPT_MODIFIER = "(%(prefix)s) "
+    $Env:CONDA_PROMPT_MODIFIER = "%(conda_prompt_modifier)s"
     . "%(activate1)s"
     """
     ) % {
@@ -1885,6 +1894,7 @@ def test_powershell_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
         ),
         "prefix": shell_wrapper_unit,
         "new_path": activator.pathsep_join(new_path_parts),
+        "conda_prompt_modifier": get_prompt_modifier(shell_wrapper_unit),
     }
 
     with captured() as c:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -225,11 +225,12 @@ def test_activate_environment_not_found(reset_environ: None):
 
 
 def test_PS1(tmp_path: Path):
+    conda_prompt_modifier = get_prompt_modifier(ROOT_ENV_NAME)
     activator = PosixActivator()
-    assert activator._prompt_modifier(tmp_path, ROOT_ENV_NAME) == f"({ROOT_ENV_NAME}) "
+    assert activator._prompt_modifier(tmp_path, ROOT_ENV_NAME) == conda_prompt_modifier
 
     instructions = activator.build_activate("base")
-    assert instructions["export_vars"]["CONDA_PROMPT_MODIFIER"] == f"({ROOT_ENV_NAME}) "
+    assert instructions["export_vars"]["CONDA_PROMPT_MODIFIER"] == conda_prompt_modifier
 
 
 def test_PS1_no_changeps1(monkeypatch: MonkeyPatch, tmp_path: Path):

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1489,7 +1489,7 @@ def test_csh_basic(shell_wrapper_unit: str, monkeypatch: MonkeyPatch):
     set prompt='%(prompt)s';
     setenv PATH "%(new_path)s";
     setenv CONDA_SHLVL "1";
-    setenv CONDA_PROMPT_MODIFIER "%(codna_prompt_modifier)s";
+    setenv CONDA_PROMPT_MODIFIER "%(conda_prompt_modifier)s";
     source "%(activate1)s";
     """
     ) % {


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Almost every test in `test_activate.py` uses the `reset_environ` fixture. Furthermore there's nothing wrong with the remaining tests to also use the fixture to clear out any conda related environment variables prior to running a test.

Split out from https://github.com/conda/conda/pull/13620

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
