### PR TITLE
Add support for `conda env create -f environment.json`

### DIFF
--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -53,6 +53,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
             conda env create -n envname
             conda env create folder/envname
             conda env create -f /path/to/environment.yml
+            conda env create -f /path/to/environment.json
             conda env create -f /path/to/requirements.txt -n envname
             conda env create -f /path/to/requirements.txt -p /home/user/envname
 

--- a/conda/env/env.py
+++ b/conda/env/env.py
@@ -188,7 +188,7 @@ def from_file(filename):
                 yamlstr = yamlb.decode("utf-16")
         return from_yaml(yamlstr, filename=filename)
     elif filename.endswith("json"):
-        with open(filename, "r", encoding="utf-8") as fp:
+        with open(filename, encoding="utf-8") as fp:
             envstr = fp.read()
         return from_json(envstr, filename=filename)
 

--- a/conda/env/specs/__init__.py
+++ b/conda/env/specs/__init__.py
@@ -13,9 +13,9 @@ from ...exceptions import (
 from ...gateways.connection.session import CONDA_SESSION_SCHEMES
 from .binstar import BinstarSpec
 from .requirements import RequirementsSpec
-from .yaml_file import YamlFileSpec
+from .env_file import EnvironmentFileSpec
 
-FileSpecTypes = Union[Type[YamlFileSpec], Type[RequirementsSpec]]
+FileSpecTypes = Union[Type[EnvironmentFileSpec], Type[RequirementsSpec]]
 
 
 def get_spec_class_from_file(filename: str) -> FileSpecTypes:
@@ -25,7 +25,7 @@ def get_spec_class_from_file(filename: str) -> FileSpecTypes:
     :raises EnvironmentFileExtensionNotValid | EnvironmentFileNotFound:
     """
     # Check extensions
-    all_valid_exts = YamlFileSpec.extensions.union(RequirementsSpec.extensions)
+    all_valid_exts = EnvironmentFileSpec.extensions.union(RequirementsSpec.extensions)
     _, ext = os.path.splitext(filename)
 
     # First check if file exists and test the known valid extension for specs
@@ -35,15 +35,15 @@ def get_spec_class_from_file(filename: str) -> FileSpecTypes:
     if file_exists:
         if ext == "" or ext not in all_valid_exts:
             raise EnvironmentFileExtensionNotValid(filename)
-        elif ext in YamlFileSpec.extensions:
-            return YamlFileSpec
+        elif ext in EnvironmentFileSpec.extensions:
+            return EnvironmentFileSpec
         elif ext in RequirementsSpec.extensions:
             return RequirementsSpec
     else:
         raise EnvironmentFileNotFound(filename=filename)
 
 
-SpecTypes = Union[BinstarSpec, YamlFileSpec, RequirementsSpec]
+SpecTypes = Union[BinstarSpec, EnvironmentFileSpec, RequirementsSpec]
 
 
 def detect(

--- a/conda/env/specs/__init__.py
+++ b/conda/env/specs/__init__.py
@@ -12,8 +12,8 @@ from ...exceptions import (
 )
 from ...gateways.connection.session import CONDA_SESSION_SCHEMES
 from .binstar import BinstarSpec
-from .requirements import RequirementsSpec
 from .env_file import EnvironmentFileSpec
+from .requirements import RequirementsSpec
 
 FileSpecTypes = Union[Type[EnvironmentFileSpec], Type[RequirementsSpec]]
 

--- a/conda/env/specs/env_file.py
+++ b/conda/env/specs/env_file.py
@@ -6,9 +6,9 @@ from ...exceptions import EnvironmentFileEmpty, EnvironmentFileNotFound
 from .. import env
 
 
-class YamlFileSpec:
+class EnvironmentFileSpec:
     _environment = None
-    extensions = {".yaml", ".yml"}
+    extensions = {".json", ".yaml", ".yml"}
 
     def __init__(self, filename=None, **kwargs):
         self.filename = filename
@@ -25,7 +25,7 @@ class YamlFileSpec:
             self.msg = e.message
             return False
         except TypeError:
-            self.msg = f"{self.filename} is not a valid yaml file."
+            self.msg = f"{self.filename} is not a valid environment file."
             return False
 
     @property

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1173,7 +1173,7 @@ class EnvironmentFileNotFound(CondaEnvException):
 
 class EnvironmentFileExtensionNotValid(CondaEnvException):
     def __init__(self, filename, *args, **kwargs):
-        msg = f"'{filename}' file extension must be one of '.txt', '.yaml' or '.yml'"
+        msg = f"'{filename}' file extension must be one of '.txt', '.json', '.yaml' or '.yml'"
         self.filename = filename
         super().__init__(msg, *args, **kwargs)
 

--- a/conda_env/README.md
+++ b/conda_env/README.md
@@ -88,3 +88,8 @@ dependencies:
 ```
 
 **Recommendation:** Always create your `environment.yml` file by hand.
+
+## `environment.json`
+
+`environment.yml` works in the same way as `environment.yml`, i.e., it uses
+the same keys, but uses ``json`` instead of ``yaml`` as data format.

--- a/conda_env/cli/main_create.py
+++ b/conda_env/cli/main_create.py
@@ -33,6 +33,7 @@ examples:
     conda env create -n envname
     conda env create folder/envname
     conda env create -f /path/to/environment.yml
+    conda env create -f /path/to/environment.json
     conda env create -f /path/to/requirements.txt -n envname
     conda env create -f /path/to/requirements.txt -p /home/user/envname
 """

--- a/conda_env/specs/yaml_file.py
+++ b/conda_env/specs/yaml_file.py
@@ -7,5 +7,6 @@ Define YAML spec.
 
 from conda.deprecations import deprecated
 from conda.env.specs.env_file import EnvironmentFileSpec  # noqa
+from conda.env.specs.env_file import EnvironmentFileSpec as YamlFileSpec  # noqa
 
 deprecated.module("24.9", "25.3", addendum="Use `conda.env.specs.env_file` instead.")

--- a/conda_env/specs/yaml_file.py
+++ b/conda_env/specs/yaml_file.py
@@ -1,11 +1,11 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""DEPRECATED: Use `conda.env.specs.yaml_file` instead.
+"""DEPRECATED: Use `conda.env.specs.env_file` instead.
 
 Define YAML spec.
 """
 
 from conda.deprecations import deprecated
-from conda.env.specs.yaml_file import YamlFileSpec  # noqa
+from conda.env.specs.env_file import EnvironmentFileSpec  # noqa
 
-deprecated.module("24.9", "25.3", addendum="Use `conda.env.specs.yaml_file` instead.")
+deprecated.module("24.9", "25.3", addendum="Use `conda.env.specs.env_file` instead.")

--- a/docs/source/user-guide/tasks/creating-projects.rst
+++ b/docs/source/user-guide/tasks/creating-projects.rst
@@ -7,6 +7,12 @@ using an ``environment.yml`` file. This file will help you keep track of your
 dependencies and share your project with others. We cover how to create your
 project, add a simple Python program and update it with new dependencies.
 
+.. note::
+   Instead of using a ``environment.yml`` file you can also use
+   ``environment.json`` file.
+   It works in the same way as the ``environment.yml`` file, i.e., it uses the
+   same keys, but instead of the yaml data format, it is uses json.
+
 Requirements
 ============
 

--- a/docs/source/user-guide/tasks/manage-environments.rst
+++ b/docs/source/user-guide/tasks/manage-environments.rst
@@ -97,8 +97,8 @@ use the ``--no-default-packages`` flag:
 
 .. _create-env-from-file:
 
-Creating an environment from an environment.yml file
-====================================================
+Creating an environment from an environment file
+================================================
 
 Use the terminal for the following steps:
 
@@ -123,6 +123,11 @@ Use the terminal for the following steps:
 
    You can also use ``conda info --envs``.
 
+
+.. note::
+
+   You can also use the ``json`` data format to describe the environment and
+   then use ``conda env create -f environment.json`` to create the environment.
 
 .. _specifying-location:
 
@@ -754,6 +759,10 @@ Exporting the environment.yml file
 
 #. Email or copy the exported ``environment.yml`` file to the
    other person.
+
+.. note::
+   To export the environment in ``json`` format use
+   ``conda env export --json > environment.json``
 
 .. _export-platform:
 

--- a/news/12942-create-env-from-json
+++ b/news/12942-create-env-from-json
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add support for `conda env create -f environment.json`. (#12942)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Document support for `conda env create -f environment.json`. (#12942)
+
+### Other
+
+* <news item>

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -255,6 +255,17 @@ def test_conda_env_create_http(conda_cli: CondaCLIFixture, tmp_path: Path):
 
 
 @pytest.mark.integration
+def test_conda_env_create_http_json(conda_cli: CondaCLIFixture, tmp_path: Path):
+    """Test `conda env create --file=https://some-website.com/environment.json`."""
+    conda_cli(
+        *("env", "create"),
+        f"--prefix={tmp_path}",
+        "--file=https://raw.githubusercontent.com/swaldhoer/conda/gh-12942/tests/env/support/simple.json",
+    )
+    assert (tmp_path / "conda-meta" / "history").is_file()
+
+
+@pytest.mark.integration
 def test_update(env1: str, conda_cli: CondaCLIFixture):
     create_env(ENVIRONMENT_CA_CERTIFICATES)
     conda_cli("env", "create")

--- a/tests/env/specs/test_env_file.py
+++ b/tests/env/specs/test_env_file.py
@@ -4,30 +4,30 @@ import random
 from unittest import mock
 
 from conda.env import env
-from conda.env.specs.yaml_file import YamlFileSpec
+from conda.env.specs.env_file import EnvironmentFileSpec
 
 
 def test_no_environment_file():
-    spec = YamlFileSpec(name=None, filename="not-a-file")
+    spec = EnvironmentFileSpec(name=None, filename="not-a-file")
     assert not spec.can_handle()
 
 
 def test_environment_file_exist():
     with mock.patch.object(env, "from_file", return_value={}):
-        spec = YamlFileSpec(name=None, filename="environment.yaml")
+        spec = EnvironmentFileSpec(name=None, filename="environment.yaml")
         assert spec.can_handle()
 
 
 def test_get_environment():
     r = random.randint(100, 200)
     with mock.patch.object(env, "from_file", return_value=r):
-        spec = YamlFileSpec(name=None, filename="environment.yaml")
+        spec = EnvironmentFileSpec(name=None, filename="environment.yaml")
         assert spec.environment == r
 
 
 def test_filename():
     filename = f"filename_{random.randint(100, 200)}"
     with mock.patch.object(env, "from_file") as from_file:
-        spec = YamlFileSpec(filename=filename)
+        spec = EnvironmentFileSpec(filename=filename)
         spec.environment
     from_file.assert_called_with(filename)

--- a/tests/env/support/simple.json
+++ b/tests/env/support/simple.json
@@ -1,0 +1,6 @@
+{
+  "name": "nlp",
+  "dependencies": [
+    "nltk"
+  ]
+}

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -43,6 +43,10 @@ def get_simple_environment():
     return get_environment("simple.yml")
 
 
+def get_simple_environment_json():
+    return get_environment("simple.json")
+
+
 def get_valid_keys_environment():
     return get_environment("valid_keys.yml")
 
@@ -59,6 +63,11 @@ def test_returns_Environment():
 def test_retains_full_filename():
     e = get_simple_environment()
     assert support_file("simple.yml") == e.filename
+
+
+def test_retains_full_filename_json():
+    e = get_simple_environment_json()
+    assert support_file("simple.json") == e.filename
 
 
 def test_with_pip():
@@ -85,6 +94,15 @@ def test_http():
         "https://raw.githubusercontent.com/conda/conda/main/tests/env/support/simple.yml"
     )
     assert e.dependencies == f.dependencies
+    assert e.dependencies == f.dependencies
+
+
+@pytest.mark.integration
+def test_http_json():
+    e = get_simple_environment_json()
+    f = from_file(
+        "https://raw.githubusercontent.com/swaldhoer/conda/gh-12942/tests/env/support/simple.json"
+    )
     assert e.dependencies == f.dependencies
 
 

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -134,8 +134,8 @@ import pytest
             "conda.env.specs.requirements.RequirementsSpec",
         ),
         (
-            "conda_env.specs.yaml_file.EnvironmentFileSpec",
-            "conda.env.specs.yaml_file.EnvironmentFileSpec",
+            "conda_env.specs.yaml_file.YamlFileSpec",
+            "conda.env.specs.env_file.EnvironmentFileSpec",
         ),
     ],
 )

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -134,8 +134,8 @@ import pytest
             "conda.env.specs.requirements.RequirementsSpec",
         ),
         (
-            "conda_env.specs.yaml_file.YamlFileSpec",
-            "conda.env.specs.yaml_file.YamlFileSpec",
+            "conda_env.specs.yaml_file.EnvironmentFileSpec",
+            "conda.env.specs.yaml_file.EnvironmentFileSpec",
         ),
     ],
 )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Add support for

```shell
conda env create -f environment.json
```

The whole environment thing was very yaml specific (I mean obviously, it was the only supported format 😅) and for sure it will be staying like that, so tried to implement everything in a backwards compatible manner.

I add documentation (again the whole docs are very yaml centric), so I just added it a few points, so that one is able to create an `environment.json` file and create the environment from that `environment.json` file.

I added some basic tests, however, frankly speaking I am not sure whether these are sufficient.

Fix #12942 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
