### PR TITLE
Deprecate `-m`/`--mkdir` from `conda install`

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -200,28 +200,25 @@ def install(args, parser, command="install"):
                 "Creating new environment for a non-native platform %s",
                 context.subdir,
             )
-    else:
-        if isdir(prefix):
-            delete_trash(prefix)
-            if not isfile(join(prefix, "conda-meta", "history")):
-                if paths_equal(prefix, context.conda_prefix):
-                    raise NoBaseEnvironmentError()
-                else:
-                    if not path_is_clean(prefix):
-                        raise DirectoryNotACondaEnvironmentError(prefix)
+    elif isdir(prefix):
+        delete_trash(prefix)
+        if not isfile(join(prefix, "conda-meta", "history")):
+            if paths_equal(prefix, context.conda_prefix):
+                raise NoBaseEnvironmentError()
             else:
-                # fall-through expected under normal operation
-                pass
+                if not path_is_clean(prefix):
+                    raise DirectoryNotACondaEnvironmentError(prefix)
         else:
-            if hasattr(args, "mkdir") and args.mkdir:
-                try:
-                    mkdir_p(prefix)
-                except OSError as e:
-                    raise CondaOSError(
-                        "Could not create directory: %s" % prefix, caused_by=e
-                    )
-            else:
-                raise EnvironmentLocationNotFound(prefix)
+            # fall-through expected under normal operation
+            pass
+    elif getattr(args, "mkdir", False):
+        # --mkdir is deprecated and marked for removal in conda 25.3
+        try:
+            mkdir_p(prefix)
+        except OSError as e:
+            raise CondaOSError("Could not create directory: %s" % prefix, caused_by=e)
+    else:
+        raise EnvironmentLocationNotFound(prefix)
 
     args_packages = [s.strip("\"'") for s in args.packages]
     if newenv and not args.no_default_packages:

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -5,11 +5,18 @@
 Creates new conda environments with the specified packages.
 """
 
-from argparse import SUPPRESS, ArgumentParser, Namespace, _SubParsersAction
+from __future__ import annotations
+
+from argparse import _StoreTrueAction
 from logging import getLogger
 from os.path import isdir
+from typing import TYPE_CHECKING
 
+from ..deprecations import deprecated
 from ..notices import notices
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 log = getLogger(__name__)
 
@@ -70,8 +77,12 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     p.add_argument(
         "-m",
         "--mkdir",
-        action="store_true",
-        help=SUPPRESS,
+        action=deprecated.action(
+            "24.9",
+            "25.3",
+            _StoreTrueAction,
+            addendum="Redundant argument.",
+        ),
     )
     p.add_argument(
         "--dev",

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -5,10 +5,17 @@
 Installs the specified packages into an existing environment.
 """
 
-import sys
-from argparse import ArgumentParser, Namespace, _SubParsersAction
+from __future__ import annotations
 
+import sys
+from argparse import _StoreTrueAction
+from typing import TYPE_CHECKING
+
+from ..deprecations import deprecated
 from ..notices import notices
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
@@ -99,8 +106,12 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     package_install_options.add_argument(
         "-m",
         "--mkdir",
-        action="store_true",
-        help="Create the environment directory, if necessary.",
+        action=deprecated.action(
+            "24.9",
+            "25.3",
+            _StoreTrueAction,
+            addendum="Use `conda create` instead.",
+        ),
     )
     package_install_options.add_argument(
         "--clobber",

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -5,10 +5,15 @@
 Updates the specified packages in an existing environment.
 """
 
+from __future__ import annotations
+
 import sys
-from argparse import ArgumentParser, Namespace, _SubParsersAction
+from typing import TYPE_CHECKING
 
 from ..notices import notices
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:

--- a/news/13751-deprecate-mkdir
+++ b/news/13751-deprecate-mkdir
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda create --mkdir` as pending deprecation. The argument is redundant and unnecessary. (#13751)
+* Mark `conda install --mkdir` as pending deprecation. Use `conda create` instead. (#13751)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

There are two ways to create a new environment by listing the packages to install:
1. `conda create ...` (recommended and documented)
2. `conda install --mkdir ...` (not recommended and undocumented)

Here we remove `--mkdir` in favor of the more explicit `conda create`.

Originally introduced in `conda 2.3` (see https://github.com/conda/conda/commit/ad37b47cc1cdd98fad44f937cb3c84eda73a0723)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
