### PR TITLE
Remove redundant `monkeypatch.setenv`

### DIFF
--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -392,9 +392,6 @@ def test_build_activate_dont_activate_unset_var(monkeypatch: MonkeyPatch):
 
         write_pkg_env_vars(td)
 
-        monkeypatch.setenv("CONDA_SHLVL", "0")
-        monkeypatch.setenv("CONDA_PREFIX", "")
-
         activator = PosixActivator()
         builder = activator.build_activate(td)
         new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
@@ -444,9 +441,6 @@ def test_build_activate_shlvl_warn_clobber_vars(monkeypatch: MonkeyPatch):
 
         write_pkg_env_vars(td)
 
-        monkeypatch.setenv("CONDA_SHLVL", "0")
-        monkeypatch.setenv("CONDA_PREFIX", "")
-
         activator = PosixActivator()
         builder = activator.build_activate(td)
         new_path = activator.pathsep_join(activator._add_prefix_to_path(td))
@@ -485,9 +479,6 @@ def test_build_activate_shlvl_0(monkeypatch: MonkeyPatch):
             f.write(ENV_VARS_FILE)
 
         write_pkg_env_vars(td)
-
-        monkeypatch.setenv("CONDA_SHLVL", "0")
-        monkeypatch.setenv("CONDA_PREFIX", "")
 
         activator = PosixActivator()
         builder = activator.build_activate(td)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Both `CONDA_SHLVL` and `CONDA_PREFIX` are cleared by `reset_environ`:

https://github.com/conda/conda/blob/32ea42b9e0b8037ff4c59277738295f2b48553c9/tests/test_activate.py#L162-L172

So these `monkeypatch.setenv` calls are redundant and can be removed.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
