### PR TITLE
Avoid `RuntimeError` in module detection

### DIFF
--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -353,7 +353,9 @@ class DeprecationHandler:
                 # AttributeError: frame.f_code.co_filename is undefined
                 pass
             else:
-                for loaded in sys.modules.values():
+                # use a copy of sys.modules to avoid RuntimeError during iteration
+                # see https://github.com/conda/conda/issues/13754
+                for loaded in tuple(sys.modules.values()):
                     if not isinstance(loaded, ModuleType):
                         continue
                     if not hasattr(loaded, "__file__"):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

If modules are loaded (e.g. lazily loaded modules) while iterating over `sys.modules` a `RuntimeError` is thrown. We avoid this by creating a copy of the module.

Resolves https://github.com/conda/conda/issues/13754

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
