### PR TITLE
Adding test for "Accept-Ranges: none" scenario with partial downloads

### DIFF
--- a/tests/fixtures_jlap.py
+++ b/tests/fixtures_jlap.py
@@ -53,6 +53,17 @@ def download_file(subdir, name):
     return flask.send_from_directory(Path(base, subdir), name)
 
 
+@app.route("/none-accept-ranges/")
+def none_accept_ranges():
+    """
+    Returns an empty request with "Accept-Ranges" set to "none"
+    """
+    response = flask.Response("test content test content test content")
+    response.headers["Accept-Ranges"] = "none"
+
+    return response
+
+
 class NoLoggingWSGIRequestHandler(WSGIRequestHandler):
     def log(self, format, *args):
         pass


### PR DESCRIPTION

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes: #13671 


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
