### PR TITLE
Add a docstring to is_server_available test

### DIFF
--- a/tests/gateways/test_jlap.py
+++ b/tests/gateways/test_jlap.py
@@ -41,6 +41,7 @@ from conda.models.channel import Channel
 
 
 def test_server_available(package_server: socket):
+    """Is the server available"""
     port = package_server.getsockname()[1]
     response = requests.get(f"http://127.0.0.1:{port}/notfound")
     assert response.status_code == 404


### PR DESCRIPTION
Adds a docstring to a test in `test_jlap.py`.

The primary purpose of this PR is to help identify the cause of the perf regression in #13721 but the change itself can be merged if desired.