### PR TITLE
Add reporter handler, output handler and reporter manager class structure to conda

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -694,7 +694,7 @@ class time_recorder(ContextDecorator):  # pragma: no cover
 
 
 Reporter = Dict[str, Union[bool, int, str]]
-DetailRecord = dict[str, Union[str, int, bool]]
+DetailRecord = Dict[str, Union[str, int, bool]]
 
 
 class ReporterHandlerBase(ABC):

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -23,7 +23,7 @@ from logging import CRITICAL, NOTSET, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
 from threading import Event, Lock, RLock, Thread
 from time import sleep, time
-from typing import Dict, Union
+from typing import TYPE_CHECKING
 
 from ..auxlib.decorators import memoizemethod
 from ..auxlib.logz import NullHandler
@@ -693,8 +693,9 @@ class time_recorder(ContextDecorator):  # pragma: no cover
             os.makedirs(dirname(self.record_file))
 
 
-Reporter = Dict[str, Union[bool, int, str]]
-DetailRecord = Dict[str, Union[str, int, bool]]
+if TYPE_CHECKING:
+    Reporter = dict[str, bool | int | str]
+    DetailRecord = dict[str, str | int | bool]
 
 
 class ReporterHandlerBase(ABC):

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -32,6 +32,10 @@ from .compat import encode_environment, on_win
 from .constants import NULL
 from .path import expand
 
+if TYPE_CHECKING:
+    Reporter = dict[str, bool | int | str]
+    DetailRecord = dict[str, str | int | bool]
+
 log = getLogger(__name__)
 IS_INTERACTIVE = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
 
@@ -691,11 +695,6 @@ class time_recorder(ContextDecorator):  # pragma: no cover
     def _ensure_dir(self):
         if not isdir(dirname(self.record_file)):
             os.makedirs(dirname(self.record_file))
-
-
-if TYPE_CHECKING:
-    Reporter = dict[str, bool | int | str]
-    DetailRecord = dict[str, str | int | bool]
 
 
 class ReporterHandlerBase(ABC):

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -23,7 +23,7 @@ from logging import CRITICAL, NOTSET, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
 from threading import Event, Lock, RLock, Thread
 from time import sleep, time
-from typing import Union
+from typing import Dict, Union
 
 from ..auxlib.decorators import memoizemethod
 from ..auxlib.logz import NullHandler
@@ -693,8 +693,8 @@ class time_recorder(ContextDecorator):  # pragma: no cover
             os.makedirs(dirname(self.record_file))
 
 
-Reporter = dict[str, Union[bool, int, str]]
-DetailRecord = dict[str, Union[str, int, bool]]
+Reporter = Dict[str, Union[bool, int, str]]
+DetailRecord = Dict[str, Union[str, int, bool]]
 
 
 class ReporterHandlerBase(ABC):

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -23,6 +23,7 @@ from logging import CRITICAL, NOTSET, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
 from threading import Event, Lock, RLock, Thread
 from time import sleep, time
+from typing import Union
 
 from ..auxlib.decorators import memoizemethod
 from ..auxlib.logz import NullHandler
@@ -692,8 +693,8 @@ class time_recorder(ContextDecorator):  # pragma: no cover
             os.makedirs(dirname(self.record_file))
 
 
-Reporter = dict[str, bool | int | str]
-DetailRecord = dict[str, str | int | bool]
+Reporter = dict[str, Union[bool, int, str]]
+DetailRecord = dict[str, Union[str, int, bool]]
 
 
 class ReporterHandlerBase(ABC):

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -703,13 +703,25 @@ class ReporterHandlerBase(ABC):
     """
 
     @abstractmethod
-    def detail_view(self, data: DetailRecord, **kwargs) -> str: ...
+    def detail_view(self, data: DetailRecord, **kwargs) -> str:
+        """
+        This method is responsible for generating the output in a "tabular" format.
+        """
+        ...
 
     @abstractmethod
-    def string_view(self, data: str, **kwargs) -> str: ...
+    def string_view(self, data: str, **kwargs) -> str:
+        """
+        This method returns simple string output.
+        """
+        ...
 
 
 class ConsoleHandler(ReporterHandlerBase):
+    """
+    Reporter handler for standard output (classic output).
+    """
+
     def detail_view(self, data: DetailRecord, **kwargs) -> str:
         table_str = ""
         longest_header = len(sorted(data.keys(), key=len).pop())
@@ -725,6 +737,10 @@ class ConsoleHandler(ReporterHandlerBase):
 
 
 class JSONHandler(ReporterHandlerBase):
+    """
+    Reporter handler for JSON output.
+    """
+
     def detail_view(self, data: DetailRecord, **kwargs) -> str:
         json_str = json.dumps(data)
 
@@ -758,7 +774,7 @@ class OutputHandlerBase(ABC):
 
 class StdoutHandler(OutputHandlerBase):
     """
-    Handles writing output strings to stdout
+    Handles writing output strings to stdout.
     """
 
     @property
@@ -771,8 +787,8 @@ class StdoutHandler(OutputHandlerBase):
 
 class ReporterManager:
     """
-    This is the glue that holds together our ``ReporterHandler`` implementations with our
-    ``OutputHandler`` implementations. We provide a single ``render`` method for rendering
+    This is the glue that holds together the ``ReporterHandler`` implementations with the
+    ``OutputHandler`` implementations. A single ``render`` method is provided for rendering
     our configured reporter handlers.
     """
 

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -728,8 +728,7 @@ class ConsoleHandler(ReporterHandlerBase):
         longest_header = max(map(len, data.keys()))
 
         for header, value in data.items():
-            row_header = header.ljust(longest_header, " ")
-            table_str += f"{row_header} : {value}\n"
+            table_str += f"{header:<{longest_header}} : {value}\n"
 
         return table_str
 

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -23,7 +23,7 @@ from logging import CRITICAL, NOTSET, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
 from threading import Event, Lock, RLock, Thread
 from time import sleep, time
-from typing import Union
+from typing import TypedDict, Union
 
 from ..auxlib.decorators import memoizemethod
 from ..auxlib.logz import NullHandler
@@ -693,8 +693,8 @@ class time_recorder(ContextDecorator):  # pragma: no cover
             os.makedirs(dirname(self.record_file))
 
 
-Reporter = dict[str, Union[bool, int, str]]
-DetailRecord = dict[str, Union[str, int, bool]]
+Reporter = TypedDict[str, Union[bool, int, str]]
+DetailRecord = TypedDict[str, Union[str, int, bool]]
 
 
 class ReporterHandlerBase(ABC):
@@ -779,7 +779,7 @@ class ReporterManager:
     def __init__(self, reporters: tuple[Reporter, ...]) -> None:
         self._reporters = reporters
         self._reporter_handlers = {
-            "stdlib": ConsoleHandler(),
+            "console": ConsoleHandler(),
             "json": JSONHandler(),
         }
         self._output_handlers = {

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -23,7 +23,7 @@ from logging import CRITICAL, NOTSET, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
 from threading import Event, Lock, RLock, Thread
 from time import sleep, time
-from typing import TypedDict, Union
+from typing import Dict, Union
 
 from ..auxlib.decorators import memoizemethod
 from ..auxlib.logz import NullHandler
@@ -693,8 +693,8 @@ class time_recorder(ContextDecorator):  # pragma: no cover
             os.makedirs(dirname(self.record_file))
 
 
-Reporter = TypedDict[str, Union[bool, int, str]]
-DetailRecord = TypedDict[str, Union[str, int, bool]]
+Reporter = Dict[str, Union[bool, int, str]]
+DetailRecord = dict[str, Union[str, int, bool]]
 
 
 class ReporterHandlerBase(ABC):

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -23,7 +23,6 @@ from logging import CRITICAL, NOTSET, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
 from threading import Event, Lock, RLock, Thread
 from time import sleep, time
-from typing import Dict, Union
 
 from ..auxlib.decorators import memoizemethod
 from ..auxlib.logz import NullHandler
@@ -693,8 +692,8 @@ class time_recorder(ContextDecorator):  # pragma: no cover
             os.makedirs(dirname(self.record_file))
 
 
-Reporter = Dict[str, Union[bool, int, str]]
-DetailRecord = Dict[str, Union[str, int, bool]]
+Reporter = dict[str, bool | int | str]
+DetailRecord = dict[str, str | int | bool]
 
 
 class ReporterHandlerBase(ABC):
@@ -705,14 +704,14 @@ class ReporterHandlerBase(ABC):
     @abstractmethod
     def detail_view(self, data: DetailRecord, **kwargs) -> str:
         """
-        This method is responsible for generating the output in a "tabular" format.
+        Render the output in a "tabular" format.
         """
         ...
 
     @abstractmethod
     def string_view(self, data: str, **kwargs) -> str:
         """
-        This method returns simple string output.
+        Render a simple string.
         """
         ...
 
@@ -724,7 +723,7 @@ class ConsoleHandler(ReporterHandlerBase):
 
     def detail_view(self, data: DetailRecord, **kwargs) -> str:
         table_str = ""
-        longest_header = len(sorted(data.keys(), key=len).pop())
+        longest_header = max(map(len, data.keys()))
 
         for header, value in data.items():
             row_header = header.ljust(longest_header, " ")

--- a/news/13818-add-reporter-handler
+++ b/news/13818-add-reporter-handler
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add ReporterHandler, OutputHandler, and ReporterManager class structure.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -159,9 +159,8 @@ def test_reporter_manager(capsys: CaptureFixture):
     assert expected_string_view_str in stdout
 
     # test fails
-    with pytest.raises(AttributeError) as err:
+    with pytest.raises(
+        AttributeError,
+        match="'non_existent_view' is not a valid reporter handler component",
+    ):
         reporter_manager_object.render("non_existent_view", test_data)
-    assert (
-        str(err.value)
-        == "'non_existent_view' is not a valid reporter handler component"
-    )

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -95,6 +95,9 @@ def test_attach_stderr_handler():
 
 
 def test_console_handler():
+    """
+    Tests the ConsoleHandler ReporterHandler class
+    """
     test_data = {"one": "value_one", "two": "value_two", "three": "value_three"}
     test_str = "a string value"
     expected_table_str = "one   : value_one\ntwo   : value_two\nthree : value_three\n"
@@ -106,6 +109,9 @@ def test_console_handler():
 
 
 def test_json_handler():
+    """
+    Tests the JsonHandler ReporterHandler class
+    """
     test_data = {"one": "value_one", "two": "value_two", "three": "value_three"}
     test_str = "a string value"
     json_handler_object = JSONHandler()
@@ -114,6 +120,9 @@ def test_json_handler():
 
 
 def test_std_out_handler(capsys: CaptureFixture):
+    """
+    Tests the StdoutHandler OutputHandler class
+    """
     test_str = "a string value"
     std_out_handler_object = StdoutHandler()
     assert std_out_handler_object.name == "stdout"
@@ -123,6 +132,9 @@ def test_std_out_handler(capsys: CaptureFixture):
 
 
 def test_reporter_manager(capsys: CaptureFixture):
+    """
+    Tests the ReporterManager class
+    """
     reporters = (
         {"backend": "console", "output": "stdout"},
         {"backend": "json", "output": "stdout"},

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -102,9 +102,8 @@ def test_console_handler():
     test_str = "a string value"
     expected_table_str = "one   : value_one\ntwo   : value_two\nthree : value_three\n"
     console_handler_object = ConsoleHandler()
-    table_str = console_handler_object.detail_view(test_data)
 
-    assert table_str == expected_table_str
+    assert console_handler_object.detail_view(test_data) == expected_table_str
     assert console_handler_object.string_view(test_str) == test_str
 
 
@@ -127,8 +126,8 @@ def test_std_out_handler(capsys: CaptureFixture):
     std_out_handler_object = StdoutHandler()
     assert std_out_handler_object.name == "stdout"
     std_out_handler_object.render(test_str)
-    stdout = capsys.readouterr()
-    assert test_str in stdout
+    stdout, _ = capsys.readouterr()
+    assert stdout == test_str
 
 
 def test_reporter_manager(capsys: CaptureFixture):
@@ -150,13 +149,13 @@ def test_reporter_manager(capsys: CaptureFixture):
 
     # test detail view passes
     reporter_manager_object.render("detail_view", test_data)
-    stdout = capsys.readouterr()
-    assert expected_detail_view_str in stdout
+    stdout, _ = capsys.readouterr()
+    assert stdout == expected_detail_view_str
 
     # test string view passes
     reporter_manager_object.render("string_view", test_str)
-    stdout = capsys.readouterr()
-    assert expected_string_view_str in stdout
+    stdout, _ = capsys.readouterr()
+    assert stdout == expected_string_view_str
 
     # test fails
     with pytest.raises(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR adds the `ReporterHandler` and `OutputHandler` abstract classes and the `ReporterManager` class to conda. 
This structure will be used to update the output of various conda commands to use the new reporter setting. 

resolves #13814. 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
