### PR TITLE
Fix `pluggy 1.5.0` failure in tests

### DIFF
--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -18,8 +18,9 @@ from conda.plugins.manager import CondaPluginManager
 log = logging.getLogger(__name__)
 this_module = sys.modules[__name__]
 
-# detect if this is an older pluggy
+# detect if this is an older/newer pluggy
 pluggy_v100 = Version(pluggy.__version__) <= Version("1.0.0")
+pluggy_v150 = Version(pluggy.__version__) >= Version("1.5.0")
 
 
 class VerboseSolver(solve.Solver):
@@ -131,7 +132,7 @@ def test_load_entrypoints_blocked(plugin_manager: CondaPluginManager):
     plugin_manager.set_blocked("test_plugin.blocked")
 
     assert plugin_manager.load_entrypoints("test_plugin", "blocked") == 0
-    if pluggy_v100:
+    if pluggy_v100 or pluggy_v150:
         assert plugin_manager.get_plugins() == set()
     else:
         assert plugin_manager.get_plugins() == {None}
@@ -193,7 +194,7 @@ def test_disable_external_plugins(plugin_manager: CondaPluginManager, plugin: ob
     assert plugin_manager.load_plugins(plugin) == 1
     assert plugin_manager.get_plugins() == {plugin}
     plugin_manager.disable_external_plugins()
-    if pluggy_v100:
+    if pluggy_v100 or pluggy_v150:
         assert plugin_manager.get_plugins() == set()
     else:
         assert plugin_manager.get_plugins() == {None}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The recent `pluggy 1.5.0` release corrected an issue first introduced in `pluggy 1.0.0` where when plugins are disabled `plugin_manager.get_plugins()` returns `{None}` instead of the expected `set()`. See https://github.com/pytest-dev/pluggy/pull/481.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
