### PR TITLE
Only register `Enum` with `deepfreeze` once

### DIFF
--- a/conda/auxlib/entity.py
+++ b/conda/auxlib/entity.py
@@ -255,15 +255,15 @@ from .type_coercion import maybecall
 
 try:
     from frozendict import deepfreeze, frozendict
-    from frozendict import getFreezeTypes as _getFreezeTypes
+    from frozendict import getFreezeConversionMap as _getFreezeConversionMap
     from frozendict import register as _register
 
-    if Enum not in _getFreezeTypes():
+    if Enum not in _getFreezeConversionMap():
         # leave enums as is, deepfreeze will flatten it into a dict
         # see https://github.com/Marco-Sulla/python-frozendict/issues/98
         _register(Enum, lambda x : x)
 
-    del _getFreezeTypes
+    del _getFreezeConversionMap
     del _register
 except ImportError:
     from .._vendor.frozendict import frozendict

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -48,15 +48,15 @@ from .serialize import yaml_round_trip_load
 
 try:
     from frozendict import deepfreeze, frozendict
-    from frozendict import getFreezeTypes as _getFreezeTypes
+    from frozendict import getFreezeConversionMap as _getFreezeConversionMap
     from frozendict import register as _register
 
-    if Enum not in _getFreezeTypes():
+    if Enum not in _getFreezeConversionMap():
         # leave enums as is, deepfreeze will flatten it into a dict
         # see https://github.com/Marco-Sulla/python-frozendict/issues/98
         _register(Enum, lambda x: x)
 
-    del _getFreezeTypes
+    del _getFreezeConversionMap
     del _register
 except ImportError:
     from .._vendor.frozendict import frozendict


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`frozendict.deepfreeze`'s `register` raises a warning if a type is registered more than once:

```bash
$ conda -V
/Users/kodegard/.conda/devenv/Darwin/arm64/envs/devenv-3.10-c/lib/python3.10/site-packages/frozendict/cool.py:86: FreezeWarning: Enum is already in the conversion map
  warnings.warn(
conda 24.3.1.dev59+g0c38f5660
```

To avoid this warning we check wether `Enum` has been registered yet:

```bash
$ conda -V
conda 24.3.1.dev63+ga4dabada5
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
