### PR TITLE
report traceback on plugin loading for certain verbosities

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -104,7 +104,7 @@ class CondaPluginManager(pluggy.PluginManager):
             raise PluginError(
                 f"Error while loading conda plugin: "
                 f"{name or self.get_canonical_name(plugin)} ({err})"
-            )
+            ) from err
 
     def load_plugins(self, *plugins) -> int:
         """
@@ -142,9 +142,12 @@ class CondaPluginManager(pluggy.PluginManager):
                     # not using exc_info=True here since the CLI loggers are
                     # set up after CLI initialization and argument parsing,
                     # meaning that it comes too late to properly render
-                    # a traceback
+                    # a traceback; instead we pass exc_info conditionally on
+                    # context.verbosity
+                    kwargs = {"exc_info": err} if context.verbosity >= 2 else {}
                     log.warning(
-                        f"Error while loading conda entry point: {entry_point.name} ({err})"
+                        f"Error while loading conda entry point: {entry_point.name} ({err})",
+                        **kwargs,
                     )
                     continue
 

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -144,10 +144,9 @@ class CondaPluginManager(pluggy.PluginManager):
                     # meaning that it comes too late to properly render
                     # a traceback; instead we pass exc_info conditionally on
                     # context.verbosity
-                    kwargs = {"exc_info": err} if context.verbosity >= 2 else {}
                     log.warning(
                         f"Error while loading conda entry point: {entry_point.name} ({err})",
-                        **kwargs,
+                        exc_info=err if context.info else None,
                     )
                     continue
 

--- a/news/13846-debug-plugin-exceptions
+++ b/news/13846-debug-plugin-exceptions
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Report traceback of plugin loading errors with verbosity 2 or higher (`-vv` or more). (#13742 via #13846)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes https://github.com/conda/conda/issues/13742

This is the only way I came up with. Not too clean but not horrible either, I think?

We cannot always pass `exc_info` because that will muddle the warnings with the traceback. Instead we only do it depending on the verbosity. With `-vv` (INFO) you'll get the traceback:

```
# conda info -vv
Error while loading conda entry point: conda-libmamba-solver (name 'AAAY' is not defined)
Traceback (most recent call last):
  File "/workspaces/conda/conda/plugins/manager.py", line 140, in load_entrypoints
    plugin = entry_point.load()
             ^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/conda/lib/python3.12/site-packages/conda_libmamba_solver/__init__.py", line 19, in <module>
    AAAY
NameError: name 'AAAY' is not defined

     active environment : base
    active env location : /opt/conda
            shell level : 1
       user config file : /root/.condarc
 populated config files : 
          conda version : 24.1.3.dev120+gbeeaa6fbd
    conda-build version : not installed
         python version : 3.12.2.final.0
                 solver : libmamba (default)
...
```

With `-v` or none:

```
$ conda info -v
Error while loading conda entry point: conda-libmamba-solver (name 'AAAY' is not defined)

     active environment : base
    active env location : /opt/conda
            shell level : 1
       user config file : /root/.condarc
 populated config files : 
          conda version : 24.1.3.dev120+gbeeaa6fbd
    conda-build version : not installed
         python version : 3.12.2.final.0
                 solver : libmamba (default)
...
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
