### PR TITLE
Fix `conda info --all` tests to reflect deprecation

### DIFF
--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -3,6 +3,10 @@
 import json
 from os.path import isdir
 
+import pytest
+from packaging.version import parse
+
+import conda
 from conda.common.io import env_var
 from conda.testing import CondaCLIFixture
 
@@ -37,7 +41,7 @@ def test_info_unsafe_channels(reset_conda_context: None, conda_cli: CondaCLIFixt
         assert not err
 
 
-# conda info --all | --envs | --system
+# conda info --verbose | --envs | --system
 def test_info(conda_cli: CondaCLIFixture):
     stdout_basic, stderr, err = conda_cli("info")
     assert "platform" in stdout_basic
@@ -66,12 +70,22 @@ def test_info(conda_cli: CondaCLIFixture):
     assert not stderr
     assert not err
 
-    stdout_all, stderr, err = conda_cli("info", "--all")
-    assert stdout_basic in stdout_all, "`conda info` not in `conda info --all`"
-    assert stdout_envs in stdout_all, "`conda info --envs` not in `conda info --all`"
-    assert stdout_sys in stdout_all, "`conda info --system` not in `conda info --all`"
+    stdout_verbose, stderr, err = conda_cli("info", "--verbose")
+    assert stdout_basic in stdout_verbose
+    assert stdout_envs in stdout_verbose
+    assert stdout_sys in stdout_verbose
     assert not stderr
     assert not err
+
+
+# conda info --all
+def test_info_all(conda_cli: CondaCLIFixture):
+    with pytest.warns(
+        PendingDeprecationWarning
+        if parse(conda.__version__) < parse("24.3")
+        else FutureWarning,
+    ):
+        conda_cli("info", "--all")
 
 
 # conda info --json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,6 @@ import conda
 from conda.base.context import context, reset_context
 
 from . import http_test_server
-from .fixtures_jlap import (  # noqa: F401
-    package_repository_base,
-    package_server,
-    package_server_ssl,
-)
 
 pytest_plugins = (
     # Add testing fixtures and internal pytest plugins here
@@ -21,6 +16,7 @@ pytest_plugins = (
     "conda.testing.gateways.fixtures",
     "conda.testing.notices.fixtures",
     "conda.testing.fixtures",
+    "tests.fixtures_jlap",
 )
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Testing for the upcoming `conda info --all` deprecation in favor of `conda info --verbose`.

Split from #12771

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
