### PR TITLE
Refactor `main_config` into a modular API

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -11,6 +11,7 @@ conda.cli.main_remove for the entry points into this module.
 import os
 from logging import getLogger
 from os.path import abspath, basename, exists, isdir, isfile, join
+from pathlib import Path
 
 from .. import CondaError
 from ..auxlib.ish import dals
@@ -47,7 +48,7 @@ from ..models.match_spec import MatchSpec
 from ..plan import revert_actions
 from . import common
 from .common import check_non_admin
-from .python_api import Commands, run_command
+from .main_config import set_keys
 
 log = getLogger(__name__)
 stderrlog = getLogger("conda.stderr")
@@ -482,13 +483,9 @@ def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
     if newenv:
         touch_nonadmin(prefix)
         if context.subdir != context._native_subdir():
-            run_command(
-                Commands.CONFIG,
-                "--file",
-                os.path.join(prefix, ".condarc"),
-                "--set",
-                "subdir",
-                context.subdir,
+            set_keys(
+                ("subdir", context.subdir),
+                path=Path(prefix, ".condarc"),
             )
         print_activate(args.name or prefix)
 

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -5,15 +5,23 @@
 Allows for programmatically interacting with conda's configuration files (e.g., `~/.condarc`).
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys
-from argparse import SUPPRESS, ArgumentParser, Namespace, _SubParsersAction
+from argparse import SUPPRESS
 from collections.abc import Mapping, Sequence
 from itertools import chain
 from logging import getLogger
 from os.path import isfile, join
+from pathlib import Path
 from textwrap import wrap
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
+    from typing import Any
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
@@ -195,7 +203,6 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     )
     config_modifiers.add_argument(
         "--remove-key",
-        nargs=1,
         action="append",
         help="""Remove a configuration key (and all its values).""",
         default=[],
@@ -346,9 +353,119 @@ def print_config_item(key, value):
                 stdout_write(" ".join(("--add", key, repr(item))))
 
 
-def execute_config(args, parser):
+def get_key(
+    key: str, config: dict, *, json: dict[str, Any] = {}, warnings: list[str] = []
+):
+    from ..base.context import context
+
+    key_parts = key.split(".")
+
+    if key_parts[0] not in context.list_parameters():
+        if context.json:
+            warnings.append(f"Unknown key: {key_parts[0]}")
+        else:
+            print(f"Unknown key: {key_parts[0]}", file=sys.stderr)
+        return
+
+    sub_config = config
+    try:
+        for part in key_parts:
+            sub_config = sub_config[part]
+    except KeyError:
+        # KeyError: part not found, nothing to get
+        pass
+    else:
+        if context.json:
+            json[key] = sub_config
+        else:
+            print_config_item(key, sub_config)
+
+
+def set_key(key: str, item: Any, config: dict):
+    from ..base.context import context
+
+    key_parts = key.split(".")
+    try:
+        parameter_type = context.describe_parameter(key_parts[0])["parameter_type"]
+    except KeyError:
+        # KeyError: key_parts[0] is not a known parameter
+        from ..exceptions import CondaValueError
+
+        raise CondaValueError(f"Key '{key}' is not a known primitive parameter.")
+
+    if parameter_type == "primitive" and len(key_parts) == 1:
+        (key,) = key_parts
+        config[key] = context.typify_parameter(key, item, "--set parameter")
+    elif parameter_type == "map" and len(key_parts) == 2:
+        key, subkey = key_parts
+        config.setdefault(key, {})[subkey] = item
+    else:
+        from ..exceptions import CondaValueError
+
+        raise CondaValueError(f"Key '{key}' is not a known primitive parameter.")
+
+
+def remove_item(key: str, item: Any, config: dict):
+    from ..base.context import context
+
+    key_parts = key.split(".")
+    try:
+        parameter_type = context.describe_parameter(key_parts[0])["parameter_type"]
+    except KeyError:
+        # KeyError: key_parts[0] is not a known parameter
+        from ..exceptions import CondaValueError
+
+        raise CondaValueError(f"Key '{key}' is not a known sequence parameter.")
+
+    if parameter_type == "sequence" and len(key_parts) == 1:
+        (key,) = key_parts
+        if key not in config:
+            if key != "channels":
+                from ..exceptions import CondaKeyError
+
+                raise CondaKeyError(key, f"key {key!r} is not in the config file")
+            config[key] = ["defaults"]
+
+        if item not in config[key]:
+            from ..exceptions import CondaKeyError
+
+            raise CondaKeyError(
+                key, f"{item!r} is not in the {key!r} key of the config file"
+            )
+        config[key] = [i for i in config[key] if i != item]
+    else:
+        from ..exceptions import CondaValueError
+
+        raise CondaValueError(f"Key '{key}' is not a known sequence parameter.")
+
+
+def remove_key(key: str, config: dict):
+    key_parts = key.split(".")
+
+    sub_config = config
+    try:
+        for part in key_parts[:-1]:
+            sub_config = sub_config[part]
+        del sub_config[key_parts[-1]]
+    except KeyError:
+        # KeyError: part not found, nothing to remove
+        from ..exceptions import CondaKeyError
+
+        raise CondaKeyError(key, f"key {key!r} is not in the config file")
+
+
+def read_rc(path: str | os.PathLike | Path) -> dict:
+    from ..common.serialize import yaml_round_trip_load
+
+    try:
+        return yaml_round_trip_load(Path(path).read_text()) or {}
+    except FileNotFoundError:
+        # FileNotFoundError: path does not exist
+        return {}
+
+
+def write_rc(path: str | os.PathLike | Path, config: dict) -> None:
     from .. import CondaError
-    from ..auxlib.entity import EntityEncoder
     from ..base.constants import (
         ChannelPriority,
         DepsModifier,
@@ -357,10 +474,54 @@ def execute_config(args, parser):
         SatSolverChoice,
         UpdateModifier,
     )
+    from ..common.serialize import yaml, yaml_round_trip_dump
+
+    # Add representers for enums.
+    # Because a representer cannot be added for the base Enum class (it must be added for
+    # each specific Enum subclass - and because of import rules), I don't know of a better
+    # location to do this.
+    def enum_representer(dumper, data):
+        return dumper.represent_str(str(data))
+
+    yaml.representer.RoundTripRepresenter.add_representer(
+        SafetyChecks, enum_representer
+    )
+    yaml.representer.RoundTripRepresenter.add_representer(
+        PathConflict, enum_representer
+    )
+    yaml.representer.RoundTripRepresenter.add_representer(
+        DepsModifier, enum_representer
+    )
+    yaml.representer.RoundTripRepresenter.add_representer(
+        UpdateModifier, enum_representer
+    )
+    yaml.representer.RoundTripRepresenter.add_representer(
+        ChannelPriority, enum_representer
+    )
+    yaml.representer.RoundTripRepresenter.add_representer(
+        SatSolverChoice, enum_representer
+    )
+
+    try:
+        Path(path).write_text(yaml_round_trip_dump(config))
+    except OSError as e:
+        raise CondaError(f"Cannot write to condarc file at {path}\nCaused by {e!r}")
+
+
+def set_keys(*args: tuple[str, Any], path: str | os.PathLike | Path) -> None:
+    config = read_rc(path)
+    for key, value in args:
+        set_key(key, value, config)
+    write_rc(path, config)
+
+
+def execute_config(args, parser):
+    from .. import CondaError
+    from ..auxlib.entity import EntityEncoder
     from ..base.context import context, sys_rc_path, user_rc_path
     from ..common.io import timeout
     from ..common.iterators import groupby_to_dict as groupby
-    from ..common.serialize import yaml, yaml_round_trip_dump, yaml_round_trip_load
+    from ..common.serialize import yaml_round_trip_load
 
     stdout_write = getLogger("conda.stdout").info
     stderr_write = getLogger("conda.stderr").info
@@ -543,43 +704,15 @@ def execute_config(args, parser):
         lambda p: context.describe_parameter(p)["parameter_type"],
         context.list_parameters(),
     )
-    primitive_parameters = grouped_paramaters["primitive"]
     sequence_parameters = grouped_paramaters["sequence"]
     map_parameters = grouped_paramaters["map"]
-    all_parameters = primitive_parameters + sequence_parameters + map_parameters
 
     # Get
     if args.get is not None:
         context.validate_all()
-        if args.get == []:
-            args.get = sorted(rc_config.keys())
 
-        value_not_found = object()
-        for key in args.get:
-            key_parts = key.split(".")
-
-            if key_parts[0] not in all_parameters:
-                message = "unknown key %s" % key_parts[0]
-                if not context.json:
-                    stderr_write(message)
-                else:
-                    json_warnings.append(message)
-                continue
-
-            remaining_rc_config = rc_config
-            for k in key_parts:
-                if k in remaining_rc_config:
-                    remaining_rc_config = remaining_rc_config[k]
-                else:
-                    remaining_rc_config = value_not_found
-                    break
-
-            if remaining_rc_config is value_not_found:
-                pass
-            elif context.json:
-                json_get[key] = remaining_rc_config
-            else:
-                print_config_item(key, remaining_rc_config)
+        for key in args.get or sorted(rc_config.keys()):
+            get_key(key, rc_config, json=json_get, warnings=json_warnings)
 
     if args.stdin:
         content = timeout(5, sys.stdin.read)
@@ -633,79 +766,19 @@ def execute_config(args, parser):
 
     # Set
     for key, item in args.set:
-        key, subkey = key.split(".", 1) if "." in key else (key, None)
-        if key in primitive_parameters:
-            value = context.typify_parameter(key, item, "--set parameter")
-            rc_config[key] = value
-        elif key in map_parameters:
-            argmap = rc_config.setdefault(key, {})
-            argmap[subkey] = item
-        else:
-            from ..exceptions import CondaValueError
-
-            raise CondaValueError("Key '%s' is not a known primitive parameter." % key)
+        set_key(key, item, rc_config)
 
     # Remove
     for key, item in args.remove:
-        key, subkey = key.split(".", 1) if "." in key else (key, None)
-        if key not in rc_config:
-            if key != "channels":
-                from ..exceptions import CondaKeyError
-
-                raise CondaKeyError(key, "key %r is not in the config file" % key)
-            rc_config[key] = ["defaults"]
-        if item not in rc_config[key]:
-            from ..exceptions import CondaKeyError
-
-            raise CondaKeyError(
-                key, f"{item!r} is not in the {key!r} key of the config file"
-            )
-        rc_config[key] = [i for i in rc_config[key] if i != item]
+        remove_item(key, item, rc_config)
 
     # Remove Key
-    for (key,) in args.remove_key:
-        key, subkey = key.split(".", 1) if "." in key else (key, None)
-        if key not in rc_config:
-            from ..exceptions import CondaKeyError
-
-            raise CondaKeyError(key, "key %r is not in the config file" % key)
-        del rc_config[key]
+    for key in args.remove_key:
+        remove_key(key, rc_config)
 
     # config.rc_keys
     if not args.get:
-        # Add representers for enums.
-        # Because a representer cannot be added for the base Enum class (it must be added for
-        # each specific Enum subclass - and because of import rules), I don't know of a better
-        # location to do this.
-        def enum_representer(dumper, data):
-            return dumper.represent_str(str(data))
-
-        yaml.representer.RoundTripRepresenter.add_representer(
-            SafetyChecks, enum_representer
-        )
-        yaml.representer.RoundTripRepresenter.add_representer(
-            PathConflict, enum_representer
-        )
-        yaml.representer.RoundTripRepresenter.add_representer(
-            DepsModifier, enum_representer
-        )
-        yaml.representer.RoundTripRepresenter.add_representer(
-            UpdateModifier, enum_representer
-        )
-        yaml.representer.RoundTripRepresenter.add_representer(
-            ChannelPriority, enum_representer
-        )
-        yaml.representer.RoundTripRepresenter.add_representer(
-            SatSolverChoice, enum_representer
-        )
-
-        try:
-            with open(rc_path, "w") as rc:
-                rc.write(yaml_round_trip_dump(rc_config))
-        except OSError as e:
-            raise CondaError(
-                f"Cannot write to condarc file at {rc_path}\nCaused by {e!r}"
-            )
+        write_rc(rc_path, rc_config)
 
     if context.json:
         from .common import stdout_json_success

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -473,7 +473,7 @@ class CondaFileIOError(CondaIOError):
 class CondaKeyError(CondaError, KeyError):
     def __init__(self, key, message, *args):
         self.key = key
-        self.msg = f"'{key}': {message}"
+        self.msg = f"{key!r}: {message}"
         super().__init__(self.msg, *args)
 
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -228,7 +228,7 @@ def test_channels_remove_duplicate(conda_cli: CondaCLIFixture):
 
         with pytest.raises(
             CondaKeyError,
-            match="'channels': 'test' is not in the 'channels' key of the config file",
+            match=r"'channels': value 'test' not present in config",
         ):
             conda_cli(
                 "config",
@@ -273,7 +273,7 @@ def test_get_all(conda_cli: CondaCLIFixture):
             --add create_default_packages 'ipython'
             """
         )
-        assert stderr.strip() == "Unknown key: invalid_key"
+        assert stderr.strip() == "Unknown key: 'invalid_key'"
 
 
 def test_get_all_inc_maps(conda_cli: CondaCLIFixture):
@@ -291,7 +291,7 @@ def test_get_all_inc_maps(conda_cli: CondaCLIFixture):
             --set proxy_servers.https 1.2.3.4:5678
             """
         )
-        assert stderr.strip() == "Unknown key: invalid_key"
+        assert stderr.strip() == "Unknown key: 'invalid_key'"
 
 
 def test_get_channels_list(conda_cli: CondaCLIFixture):
@@ -408,7 +408,7 @@ def test_get_invalid_key(conda_cli: CondaCLIFixture):
     with make_temp_condarc(condarc) as rc:
         stdout, stderr, _ = conda_cli("config", "--file", rc, "--get", "invalid_key")
         assert stdout == ""
-        assert stderr.strip() == "Unknown key: invalid_key"
+        assert stderr.strip() == "Unknown key: 'invalid_key'"
 
 
 def test_set_key(conda_cli: CondaCLIFixture):
@@ -456,9 +456,7 @@ def test_set_unconfigured_key(conda_cli: CondaCLIFixture):
 def test_set_invalid_key(conda_cli: CondaCLIFixture):
     key, to_val = "invalid_key", "a_bogus_value"
     with make_temp_condarc(CONDARC_BASE) as rc:
-        with pytest.raises(
-            CondaValueError, match=f"Key '{key}' is not a known primitive parameter."
-        ):
+        with pytest.raises(CondaKeyError, match=r"'invalid_key': unknown parameter"):
             conda_cli("config", "--file", rc, "--set", key, to_val)
 
         assert _read_test_condarc(rc) == CONDARC_BASE
@@ -501,9 +499,7 @@ def test_remove_key_duplicate(conda_cli: CondaCLIFixture):
     with make_temp_condarc(CONDARC_BASE) as rc:
         conda_cli("config", "--file", rc, "--remove-key", key)
 
-        with pytest.raises(
-            CondaKeyError, match=f"'{key}': key '{key}' is not in the config file"
-        ):
+        with pytest.raises(CondaKeyError, match=r"'changeps1': undefined in config"):
             conda_cli("config", "--file", rc, "--remove-key", key)
 
         assert f"{key}: {value}\n" not in _read_test_condarc(rc)
@@ -513,7 +509,8 @@ def test_remove_unconfigured_key(conda_cli: CondaCLIFixture):
     key = "restore_free_channel"
     with make_temp_condarc(CONDARC_BASE) as rc:
         with pytest.raises(
-            CondaKeyError, match=f"'{key}': key '{key}' is not in the config file"
+            CondaKeyError,
+            match=r"'restore_free_channel': undefined in config",
         ):
             conda_cli("config", "--file", rc, "--remove-key", key)
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -273,7 +273,7 @@ def test_get_all(conda_cli: CondaCLIFixture):
             --add create_default_packages 'ipython'
             """
         )
-        assert stderr.strip() == "unknown key invalid_key"
+        assert stderr.strip() == "Unknown key: invalid_key"
 
 
 def test_get_all_inc_maps(conda_cli: CondaCLIFixture):
@@ -291,7 +291,7 @@ def test_get_all_inc_maps(conda_cli: CondaCLIFixture):
             --set proxy_servers.https 1.2.3.4:5678
             """
         )
-        assert stderr.strip() == "unknown key invalid_key"
+        assert stderr.strip() == "Unknown key: invalid_key"
 
 
 def test_get_channels_list(conda_cli: CondaCLIFixture):
@@ -408,7 +408,7 @@ def test_get_invalid_key(conda_cli: CondaCLIFixture):
     with make_temp_condarc(condarc) as rc:
         stdout, stderr, _ = conda_cli("config", "--file", rc, "--get", "invalid_key")
         assert stdout == ""
-        assert stderr.strip() == "unknown key invalid_key"
+        assert stderr.strip() == "Unknown key: invalid_key"
 
 
 def test_set_key(conda_cli: CondaCLIFixture):

--- a/tests/cli/test_main_config.py
+++ b/tests/cli/test_main_config.py
@@ -1,14 +1,31 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import json
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING
 
 import pytest
 
-from conda.base.context import context
-from conda.cli.main_config import set_keys
-from conda.testing import CondaCLIFixture, PathFactoryFixture
+from conda.base.context import context, reset_context
+from conda.cli.main_config import (
+    _get_key,
+    _read_rc,
+    _remove_item,
+    _remove_key,
+    _set_key,
+    _write_rc,
+    set_keys,
+)
+from conda.exceptions import CondaKeyError
+
+if TYPE_CHECKING:
+    from typing import Any, Iterable
+
+    from pytest import MonkeyPatch
+
+    from conda.testing import CondaCLIFixture, PathFactoryFixture
 
 
 @pytest.mark.parametrize(
@@ -74,6 +91,147 @@ def test_config_show_sources_json(conda_cli: CondaCLIFixture):
     assert "error" not in parsed  # not an error rendered as a json
     assert not stderr
     assert not err
+
+
+def test_config_get_key(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("CONDA_JSON", "true")
+    reset_context()
+    assert context.json
+
+    json: dict[str, Any]
+    warnings: list[str]
+
+    # undefined
+    _get_key("changeps1", {}, json=(json := {}), warnings=(warnings := []))
+    assert not json
+    assert not warnings
+
+    # defined
+    config = {"changeps1": True, "auto_stack": 5, "channels": ["foo", "bar"]}
+    _get_key("changeps1", config, json=(json := {}), warnings=(warnings := []))
+    assert json == {"changeps1": True}
+    assert not warnings
+
+    _get_key("auto_stack", config, json=(json := {}), warnings=(warnings := []))
+    assert json == {"auto_stack": 5}
+    assert not warnings
+
+    _get_key("channels", config, json=(json := {}), warnings=(warnings := []))
+    assert json == {"channels": ["foo", "bar"]}
+    assert not warnings
+
+    # unknown
+    _get_key("unknown", {}, json=(json := {}), warnings=(warnings := []))
+    assert not json
+    assert warnings == ["Unknown key: 'unknown'"]
+
+
+def test_config_set_key() -> None:
+    config: dict[str, Any] = {}
+
+    # unknown
+    with pytest.raises(CondaKeyError, match=r"'unknown': unknown parameter"):
+        _set_key("unknown", None, config)
+
+    # undefined
+    _set_key("changeps1", True, config)
+    assert config["changeps1"]
+
+    _set_key("proxy_servers.http", "http://example.com", config)
+    assert config["proxy_servers"]["http"] == "http://example.com"
+
+    # defined
+    _set_key("changeps1", False, config)
+    assert not config["changeps1"]
+
+    _set_key("proxy_servers.http", "http://other.com", config)
+    assert config["proxy_servers"]["http"] == "http://other.com"
+
+    # invalid
+    with pytest.raises(CondaKeyError, match=r"'channels': invalid parameter"):
+        _set_key("channels", None, config)
+
+
+def test_config_remove_item() -> None:
+    config: dict[str, Any] = {}
+
+    # unknown
+    with pytest.raises(CondaKeyError, match=r"'unknown': unknown parameter"):
+        _remove_item("unknown", None, config)
+
+    # undefined
+    with pytest.raises(
+        CondaKeyError,
+        match=r"'create_default_packages': undefined in config",
+    ):
+        _remove_item("create_default_packages", "python", config)
+
+    # defined
+    _remove_item("channels", "defaults", config)
+    assert config["channels"] == []
+
+    config = {"channels": ["foo", "bar"]}
+
+    _remove_item("channels", "foo", config)
+    assert config["channels"] == ["bar"]
+
+    _remove_item("channels", "bar", config)
+    assert config["channels"] == []
+
+    # missing
+    with pytest.raises(
+        CondaKeyError,
+        match=r"'channels': value 'bar' not present in config",
+    ):
+        _remove_item("channels", "bar", config)
+
+    # invalid
+    with pytest.raises(CondaKeyError, match=r"'changeps1': invalid parameter"):
+        _remove_item("changeps1", None, config)
+
+
+def test_config_remove_key() -> None:
+    config: dict[str, Any] = {}
+
+    # unknown/undefined
+    with pytest.raises(CondaKeyError, match=r"'unknown': undefined in config"):
+        _remove_key("unknown", config)
+
+    with pytest.raises(CondaKeyError, match=r"'changeps1': undefined in config"):
+        _remove_key("changeps1", config)
+
+    # defined
+    config = {
+        "auto_stack": 5,
+        "channels": ["foo", "bar"],
+        "conda_build": {"foo": {"bar": 1}},
+    }
+
+    _remove_key("auto_stack", config)
+    assert "auto_stack" not in config
+
+    _remove_key("channels", config)
+    assert "channels" not in config
+
+    _remove_key("conda_build.foo.bar", config)
+    assert "bar" not in config["conda_build"]["foo"]
+
+    _remove_key("conda_build", config)
+    assert "conda_build" not in config
+
+
+def test_config_read_rc(tmp_path: Path) -> None:
+    condarc = tmp_path / ".condarc"
+    condarc.write_text("changeps1: false\nauto_stack: 5\n")
+
+    assert _read_rc(path=condarc) == {"changeps1": False, "auto_stack": 5}
+
+
+def test_config_write_rc(tmp_path: Path) -> None:
+    condarc = tmp_path / ".condarc"
+
+    _write_rc(condarc, {"changeps1": False, "auto_stack": 5})
+    assert condarc.read_text() == "changeps1: false\nauto_stack: 5\n"
 
 
 def test_config_set_keys(tmp_path: Path) -> None:

--- a/tests/cli/test_main_config.py
+++ b/tests/cli/test_main_config.py
@@ -7,6 +7,7 @@ from typing import Iterable
 import pytest
 
 from conda.base.context import context
+from conda.cli.main_config import set_keys
 from conda.testing import CondaCLIFixture, PathFactoryFixture
 
 
@@ -73,3 +74,16 @@ def test_config_show_sources_json(conda_cli: CondaCLIFixture):
     assert "error" not in parsed  # not an error rendered as a json
     assert not stderr
     assert not err
+
+
+def test_config_set_keys(tmp_path: Path) -> None:
+    condarc = tmp_path / ".condarc"
+
+    set_keys(("changeps1", True), path=condarc)
+    assert condarc.read_text() == "changeps1: true\n"
+
+    set_keys(("changeps1", False), path=condarc)
+    assert condarc.read_text() == "changeps1: false\n"
+
+    set_keys(("auto_stack", 5), path=condarc)
+    assert condarc.read_text() == "changeps1: false\nauto_stack: 5\n"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`main_config` previously defined a god-function (and still does). This made it difficult to programmatically interact with the `conda config` functionality.

Here we extract individual components from the god-function (e.g., `get_key`, `set_key`, `remove_item`, `remove_key`, `read_rc`, `write_rc`, `set_keys`). These can then be easily called from other parts of conda as well as from the god-function.

Cherry picked from https://github.com/conda/conda/pull/12771

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
