### PR TITLE
Remove empty PATH entry on Windows

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -611,6 +611,9 @@ class _Activator(metaclass=abc.ABCMeta):
             "PATH",
             clean_paths[sys.platform] if sys.platform in clean_paths else "/usr/bin",
         )
+        if sys.platform == "win32":
+            # Windows 10+ has a trailing semicolon by default, remove it to prevent empty entry
+            path = path.strip(os.pathsep)
         path_split = path.split(os.pathsep)
         return path_split
 


### PR DESCRIPTION
With the Windows 10 release, Microsoft added an interactive editor for the PATH variable e.g. [the workflow described here](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net80#no-net-sdk-was-found). This normalizes the PATH entry by appending a `;` at the end of all entries. Here, because we split on the `;`, we'll end up with an empty entry. Later in the activation code, the paths are normalized with `os.path.normpath` which will expand this to `.` which can affect downstream code and can cause users concern since `.` has a special meaning on POSIX based systems.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
