### PR TITLE
Document ssl_verify: truststore

### DIFF
--- a/docs/source/user-guide/configuration/settings.rst
+++ b/docs/source/user-guide/configuration/settings.rst
@@ -244,7 +244,7 @@ connection's normal security and is not recommended:
 If the certificate authority is already trusted by the operating
 system, for instance because it was installed by a system
 administrator, you can tell conda to use the operating system
-certificate store.
+certificate store by setting ``ssl_verify`` to "truststore":
 
 .. code-block:: yaml
 

--- a/docs/source/user-guide/configuration/settings.rst
+++ b/docs/source/user-guide/configuration/settings.rst
@@ -238,6 +238,17 @@ connection's normal security and is not recommended:
 
   ssl_verify: False
 
+If the certificate authority is already trusted by the operating
+system, for instance because it was installed by a system
+administrator, you can tell conda to use the operating system
+certificate store.
+
+This feature is only available with Python 3.10 or later.
+
+.. code-block:: yaml
+
+  ssl_verify: truststore
+
 You can also set ``ssl_verify`` to a string path to a certificate,
 which can be used to verify SSL connections:
 

--- a/docs/source/user-guide/configuration/settings.rst
+++ b/docs/source/user-guide/configuration/settings.rst
@@ -238,12 +238,13 @@ connection's normal security and is not recommended:
 
   ssl_verify: False
 
+.. versionadded:: 23.9.0
+   The ``ssl_verify: truststore`` setting is only available with conda 23.9.0 or later and using Python 3.10 or later.
+
 If the certificate authority is already trusted by the operating
 system, for instance because it was installed by a system
 administrator, you can tell conda to use the operating system
 certificate store.
-
-This feature is only available with Python 3.10 or later.
 
 .. code-block:: yaml
 

--- a/news/13935-doc-truststore
+++ b/news/13935-doc-truststore
@@ -1,0 +1,3 @@
+### Docs
+
+* Added `ssl_verify: truststore` to the user guide. (#13935)


### PR DESCRIPTION
### Description

On  #13075 I submitted a contribution to use the operating system certificate store. It got merged some months ago.

While the introduced feature had tests and basic docs it did not appear in the user guide.

This pull request just aims to complete the previous pull request adding a paragraph to the user guide.

I think it is relevant because for many corporate users behind an SSL proxy the `ssl_verify: truststore` option will make configuration and certificate management easier.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests? **Does not apply**
- [x] Add / update outdated documentation? **Done**
