### PR TITLE
`conda list --explicit` should not include auth details by default

### DIFF
--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -117,9 +117,9 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     )
     p.add_argument(
         "--auth",
-        action="store_true",
-        default=False,
-        dest="auth",
+        action="store_false",
+        default=True,
+        dest="remove_auth",
         help="In explicit mode, leave authentication details in package URLs. "
         "They are removed by default otherwise.",
     )
@@ -244,10 +244,10 @@ def print_packages(
     return exitcode
 
 
-def print_explicit(prefix, add_md5=False, with_auth=False):
+def print_explicit(prefix, add_md5=False, remove_auth=True):
     from ..base.constants import UNKNOWN_CHANNEL
     from ..base.context import context
-    from ..common.url import remove_auth, split_anaconda_token
+    from ..common import url as common_url
     from ..core.prefix_data import PrefixData
 
     if not isdir(prefix):
@@ -261,8 +261,8 @@ def print_explicit(prefix, add_md5=False, with_auth=False):
         if not url or url.startswith(UNKNOWN_CHANNEL):
             print("# no URL for: {}".format(prefix_record["fn"]))
             continue
-        if not with_auth:
-            url = remove_auth(split_anaconda_token(url)[0])
+        if remove_auth:
+            url = common_url.remove_auth(common_url.split_anaconda_token(url)[0])
         md5 = prefix_record.get("md5")
         print(url + (f"#{md5}" if add_md5 and md5 else ""))
 
@@ -297,7 +297,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         return 0
 
     if args.explicit:
-        print_explicit(prefix, args.md5, args.auth)
+        print_explicit(prefix, args.md5, args.remove_auth)
         return 0
 
     if args.canonical:

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -121,7 +121,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         default=False,
         dest="auth",
         help="In explicit mode, leave authentication details in package URLs. "
-        "They are removed by default otherwise."
+        "They are removed by default otherwise.",
     )
     p.add_argument(
         "regex",

--- a/news/13936-list-auth
+++ b/news/13936-list-auth
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* `conda list --explicit` will not print authentication details by default. A new flag `--auth` has been added so folks can opt-in to this behaviour. (#13936)
+* **Breaking change**  `conda list --explicit` will not print authentication details by default. A new flag `--auth` has been added so folks can opt-in to this behaviour. (#13936)
 
 ### Bug fixes
 

--- a/news/13936-list-auth
+++ b/news/13936-list-auth
@@ -1,0 +1,19 @@
+### Enhancements
+
+* `conda list --explicit` will not print authentication details by default. A new flag `--auth` has been added so folks can opt-in to this behaviour. (#13936)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_list.py
+++ b/tests/cli/test_main_list.py
@@ -95,13 +95,18 @@ def test_list_explicit(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture):
     pkg = "curl"  # has dependencies
     with tmp_env(pkg) as prefix:
         stdout, _, _ = conda_cli("list", "--prefix", prefix, "--json")
-        curl = next((item for item in json.loads(stdout) if item["name"] == "curl"), None)
+        curl = next(
+            (item for item in json.loads(stdout) if item["name"] == "curl"), None
+        )
         assert curl
 
         # Plant a fake token to make sure we can remove it if needed
         json_file = prefix / "conda-meta" / (curl["dist_name"] + ".json")
         json_data = json.loads(json_file.read_text())
-        json_data["url"] = f"https://conda.anaconda.org/t/some-fake-token/{json_data['channel']}/{json_data['subdir']}/{json_data['fn']}"
+        json_data["url"] = (
+            "https://conda.anaconda.org/t/some-fake-token/"
+            f"{json_data['channel']}/{json_data['subdir']}/{json_data['fn']}"
+        )
         json_file.write_text(json.dumps(json_data))
 
         PrefixData(prefix)._cache_.clear()

--- a/tests/cli/test_main_list.py
+++ b/tests/cli/test_main_list.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from pytest_mock import MockerFixture
 
+from conda.core.prefix_data import PrefixData
 from conda.exceptions import EnvironmentLocationNotFound
 from conda.testing import CondaCLIFixture, TmpEnvFixture
 
@@ -88,3 +89,26 @@ def test_list_package(tmp_envs_dirs: Path, conda_cli: CondaCLIFixture):
     stdout, _, _ = conda_cli("list", "ipython", "--json")
     parsed = json.loads(stdout.strip())
     assert isinstance(parsed, list)
+
+
+def test_list_explicit(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture):
+    pkg = "curl"  # has dependencies
+    with tmp_env(pkg) as prefix:
+        stdout, _, _ = conda_cli("list", "--prefix", prefix, "--json")
+        curl = next((item for item in json.loads(stdout) if item["name"] == "curl"), None)
+        assert curl
+
+        # Plant a fake token to make sure we can remove it if needed
+        json_file = prefix / "conda-meta" / (curl["dist_name"] + ".json")
+        json_data = json.loads(json_file.read_text())
+        json_data["url"] = f"https://conda.anaconda.org/t/some-fake-token/{json_data['channel']}/{json_data['subdir']}/{json_data['fn']}"
+        json_file.write_text(json.dumps(json_data))
+
+        PrefixData(prefix)._cache_.clear()
+        stdout, _, _ = conda_cli("list", "--prefix", prefix, "--explicit")
+        assert curl["dist_name"] in stdout
+        assert "/t/some-fake-token/" not in stdout  # by default we should not see this
+
+        stdout, _, _ = conda_cli("list", "--prefix", prefix, "--explicit", "--auth")
+        assert curl["dist_name"] in stdout
+        assert "/t/some-fake-token/" in stdout  # with --auth we do


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

I noticed that some of my `conda-meta/*.json` files have auth details in them. `conda list --explicit` will happily include the auth details in the URL by default IN PLAIN TEXT. For a file that is meant to be shared, I think that default option is too big of a security risk so in this PR:

- I changed the default behaviour so it does NOT print auth details.
- I add an `--auth` flag to `conda list` to opt-in including auth details (in case this is used internally with additional security measurements in place).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
