### PR TITLE
Implement a `envvars_force_uppercase` flag defaulting to True

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -114,19 +114,35 @@ class _Activator(metaclass=abc.ABCMeta):
         # split provided environment variables into exports vs unsets
         for name, value in kwargs.items():
             if value is None:
-                unset_vars.append(name.upper())
+                if context.envvars_force_uppercase:
+                    unset_vars.append(name.upper())
+                else:
+                    unset_vars.append(name)
+
             else:
-                export_vars[name.upper()] = value
+                if context.envvars_force_uppercase:
+                    export_vars[name.upper()] = value
+                else:
+                    export_vars[name] = value
 
         if export_metavars:
             # split meta variables into exports vs unsets
             for name, value in context.conda_exe_vars_dict.items():
                 if value is None:
-                    unset_vars.append(name.upper())
+                    if context.envvars_force_uppercase:
+                        unset_vars.append(name.upper())
+                    else:
+                        unset_vars.append(name)
                 elif "/" in value or "\\" in value:
-                    export_vars[name.upper()] = self.path_conversion(value)
+                    if context.envvars_force_uppercase:
+                        export_vars[name.upper()] = self.path_conversion(value)
+                    else:
+                        export_vars[name] = self.path_conversion(value)
                 else:
-                    export_vars[name.upper()] = value
+                    if context.envvars_force_uppercase:
+                        export_vars[name.upper()] = value
+                    else:
+                        export_vars[name] = value
         else:
             # unset all meta variables
             unset_vars.extend(context.conda_exe_vars_dict)

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1285,6 +1285,7 @@ class Context(Configuration):
                 "unsatisfiable_hints",
                 "unsatisfiable_hints_check_depth",
                 "number_channel_notices",
+                "envvars_force_uppercase",
             ),
             "CLI-only": (
                 "deps_modifier",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1903,7 +1903,7 @@ class Context(Configuration):
             ),
             envvars_force_uppercase=dals(
                 """
-                Force uppercase for new environment variable names. Defaults to True. Used
+                Force uppercase for new environment variable names. Defaults to True.
                 """
             ),
         )

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1903,7 +1903,7 @@ class Context(Configuration):
             ),
             envvars_force_uppercase=dals(
                 """
-                Force uppercase for new environment variable names. Defaults to True. Used 
+                Force uppercase for new environment variable names. Defaults to True. Used
                 """
             ),
         )

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -441,6 +441,7 @@ class Context(Configuration):
     experimental = ParameterLoader(SequenceParameter(PrimitiveParameter("", str)))
     no_lock = ParameterLoader(PrimitiveParameter(False))
     repodata_use_zst = ParameterLoader(PrimitiveParameter(True))
+    envvars_force_uppercase = ParameterLoader(PrimitiveParameter(True))
 
     ####################################################
     #               Solver Configuration               #
@@ -1898,6 +1899,11 @@ class Context(Configuration):
                 """
                 Disable check for `repodata.json.zst`; use `repodata.json` only.
                 """
+            ),
+            envvars_force_uppercase=dals(
+                """
+            Force uppercase for new environment variable name. Defaults to True.
+            """
             ),
         )
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1903,8 +1903,8 @@ class Context(Configuration):
             ),
             envvars_force_uppercase=dals(
                 """
-            Force uppercase for new environment variable name. Defaults to True.
-            """
+                Force uppercase for new environment variable names. Defaults to True. Used 
+                """
             ),
         )
 

--- a/news/13943-envvars-force-uppercase
+++ b/news/13943-envvars-force-uppercase
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add an `envvars_force_uppercase` setting defaulting to `True`. (#13713 via #13943)
+Add an `envvars_force_uppercase` setting which defaults to `True`, uppercasing all environment variables (thereby justifying `conda`'s current behaviour); when `envvars_force_uppercase` is set to `False`, conda will only save preserved-case variable names. (#13713 via #13943)
 
 ### Bug fixes
 

--- a/news/13943-envvars-force-uppercase
+++ b/news/13943-envvars-force-uppercase
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add an `envvars_force_uppercase` setting defaulting to `True`. (#13713 via #13943)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -3437,3 +3437,71 @@ def test_MSYS2_PATH(
         # ensure unexpected bin directories are not included in %PATH%/$env:PATH
         for path in unexpected:
             assert activator.path_conversion(str(library / path / "bin")) not in paths
+
+
+@pytest.mark.parametrize("force_uppercase_boolean", [True, False])
+def test_force_uppercase(monkeypatch: MonkeyPatch, force_uppercase_boolean):
+    monkeypatch.setenv("CONDA_ENVVARS_FORCE_UPPERCASE", force_uppercase_boolean)
+    reset_context()
+    assert context.envvars_force_uppercase is force_uppercase_boolean
+
+    activator = PosixActivator()
+    export_vars, unset_vars = activator.get_export_unset_vars(
+        one=1,
+        TWO=2,
+        three=None,
+        FOUR=None,
+    )
+
+    # preserved case vars present if  keep_case is True
+    assert ("one" in export_vars) is not force_uppercase_boolean
+    assert ("three" in unset_vars) is not force_uppercase_boolean
+
+    # vars uppercased when keep_case is False
+    assert ("ONE" in export_vars) is force_uppercase_boolean
+    assert ("THREE" in unset_vars) is force_uppercase_boolean
+
+    # original uppercase
+    assert "TWO" in export_vars
+    assert "FOUR" in unset_vars
+
+
+@pytest.mark.parametrize("force_uppercase_boolean", [True, False])
+def test_metavars_force_uppercase(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch, force_uppercase_boolean: bool
+):
+    monkeypatch.setenv("CONDA_ENVVARS_FORCE_UPPERCASE", force_uppercase_boolean)
+    reset_context()
+    assert context.envvars_force_uppercase is force_uppercase_boolean
+
+    returned_dict = {
+        "ONE": "1",
+        "two": "2",
+        "three": None,
+        "FOUR": None,
+        "five": "a/path/to/something",
+        "SIX": "a\\path",
+    }
+    mocker.patch(
+        "conda.base.context.Context.conda_exe_vars_dict",
+        new_callable=mocker.PropertyMock,
+        return_value=returned_dict,
+    )
+    assert context.conda_exe_vars_dict == returned_dict
+
+    activator = PosixActivator()
+    export_vars, unset_vars = activator.get_export_unset_vars()
+
+    # preserved case vars present if keep_case is True
+    assert ("two" in export_vars) is not force_uppercase_boolean
+    assert ("three" in unset_vars) is not force_uppercase_boolean
+    assert ("five" in export_vars) is not force_uppercase_boolean
+
+    # vars uppercased when keep_case is False
+    assert ("TWO" in export_vars) is force_uppercase_boolean
+    assert ("THREE" in unset_vars) is force_uppercase_boolean
+
+    # original uppercase
+    assert "ONE" in export_vars
+    assert "FOUR" in unset_vars
+    assert "SIX" in export_vars


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

resolves #13713 
Please also check #13904 and #13938 to see the other possible solutions for the linked issue.

This PR adds an `envvars_force_uppercase` flag. 
This flag defaults to `True` thereby justifying the current behavior of `conda` (i.e. uppercasing all environment variables).
When this flag is set to False, `conda` will only save preserved case variable names. 

The plan is to deprecate this flag (and therefore the uppercasing behavior) in the future. 


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
