### PR TITLE
Replace logger.warn w/ logger.warning

### DIFF
--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -51,7 +51,7 @@ def register_env(location):
     try:
         os.makedirs(user_environments_txt_directory, exist_ok=True)
     except OSError as exc:
-        log.warn(
+        log.warning(
             "Unable to register environment. "
             f"Could not create {user_environments_txt_directory}. "
             f"Reason: {exc}"
@@ -64,7 +64,7 @@ def register_env(location):
             fh.write("\n")
     except OSError as e:
         if e.errno in (EACCES, EROFS, ENOENT):
-            log.warn(
+            log.warning(
                 "Unable to register environment. Path not writable or missing.\n"
                 "  environment location: %s\n"
                 "  registry file: %s",

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1587,7 +1587,7 @@ def run_script(
                     )
                 raise LinkError(message)
             else:
-                log.warn(
+                log.warning(
                     "%s script failed for package %s\n"
                     "consider notifying the package maintainer",
                     action,

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1047,7 +1047,7 @@ class RegisterEnvironmentLocationAction(PathAction):
             touch(user_environments_txt_file, mkdir=True, sudo_safe=True)
             self._verified = True
         except NotWritableError:
-            log.warn(
+            log.warning(
                 "Unable to create environments file. Path not writable.\n"
                 "  environment location: %s\n",
                 user_environments_txt_file,

--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -231,7 +231,7 @@ class PrefixData(metaclass=PrefixDataType):
                 ):
                     raise ValueError()
             except ValueError:
-                log.warn(
+                log.warning(
                     "Ignoring malformed prefix record at: %s", prefix_record_json_path
                 )
                 # TODO: consider just deleting here this record file in the future
@@ -353,7 +353,7 @@ class PrefixData(metaclass=PrefixDataType):
                 import traceback
 
                 tb = traceback.format_exception(exc_type, exc_value, exc_traceback)
-                log.warn(
+                log.warning(
                     "Problem reading non-conda package record at %s. Please verify that you "
                     "still need this, and if so, that this is still installed correctly. "
                     "Reinstalling this package may help.",

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -813,7 +813,7 @@ class Solver:
                     ssc.specs_map[s.name] = MatchSpec(s, optional=False)
                     pin_overrides.add(s.name)
                 else:
-                    log.warn(
+                    log.warning(
                         "pinned spec %s conflicts with explicit specs.  "
                         "Overriding pinned spec.",
                         s,

--- a/conda/exception_handler.py
+++ b/conda/exception_handler.py
@@ -165,7 +165,7 @@ class ExceptionHandler:
                         get_main_info_str(error_report["conda_info"])
                     )
                 except Exception as e:
-                    log.warn("%r", e, exc_info=True)
+                    log.warning("%r", e, exc_info=True)
                     message_builder.append("conda info could not be constructed.")
                     message_builder.append(f"{e!r}")
             message_builder.extend(
@@ -213,7 +213,7 @@ class ExceptionHandler:
                         get_main_info_str(error_report["conda_info"])
                     )
                 except Exception as e:
-                    log.warn("%r", e, exc_info=True)
+                    log.warning("%r", e, exc_info=True)
                     message_builder.append("conda info could not be constructed.")
                     message_builder.append(f"{e!r}")
             message_builder.append("")

--- a/conda/gateways/disk/__init__.py
+++ b/conda/gateways/disk/__init__.py
@@ -54,7 +54,7 @@ def exp_backoff_fn(fn, *args, **kwargs):
                 # errno.ENOTEMPTY OSError(41, 'The directory is not empty')
                 raise
             else:
-                log.warn(
+                log.warning(
                     "Uncaught backoff with errno %s %d", errorcode[e.errno], e.errno
                 )
                 raise

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -179,7 +179,7 @@ def unlink_or_rename_to_trash(path):
                         f"{trash_script} is missing.  Conda was not installed correctly or has been "
                         "corrupted.  Please file an issue on the conda github repo."
                     )
-            log.warn(
+            log.warning(
                 f"Could not remove or rename {path}.  Please remove this file manually (you "
                 "may need to reboot to free file handles)"
             )

--- a/conda/gateways/disk/permissions.py
+++ b/conda/gateways/disk/permissions.py
@@ -38,7 +38,7 @@ def make_writable(path):
             log.debug("tried make writable but failed: %s\n%r", path, e)
             return False
         else:
-            log.warn("Error making path writable: %s\n%r", path, e)
+            log.warning("Error making path writable: %s\n%r", path, e)
             raise
 
 

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -253,6 +253,3 @@ def trace(self, message, *args, **kwargs):
 
 logging.addLevelName(TRACE, "TRACE")
 logging.Logger.trace = trace  # type: ignore[attr-defined]
-
-# suppress DeprecationWarning for warn method
-logging.Logger.warn = logging.Logger.warning  # type: ignore[method-assign]

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -438,7 +438,7 @@ class RepodataState(UserDict):
             value = bool(obj["value"])
             return (value, last_checked)
         except (KeyError, ValueError, TypeError) as e:
-            log.warn(
+            log.warning(
                 f"error parsing `has_` object from `<cache key>{CACHE_STATE_SUFFIX}`",
                 exc_info=e,
             )

--- a/conda/gateways/repodata/jlap/fetch.py
+++ b/conda/gateways/repodata/jlap/fetch.py
@@ -444,7 +444,7 @@ def request_url_jlap_state(
                     # bail with 'repodata on disk' (indicating another process
                     # downloaded repodata.json in parallel with us)
                     if have != cache.state.get(NOMINAL_HASH):  # or check mtime_ns?
-                        log.warn("repodata cache changed during jlap fetch.")
+                        log.warning("repodata cache changed during jlap fetch.")
                         return None
 
                 apply_patches(repodata_json, apply)

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -359,5 +359,5 @@ def _get_best_prec_match(precs):
             break
     else:
         prec_matches = precs
-    log.warn("Multiple packages found: %s", dashlist(prec_matches))
+    log.warning("Multiple packages found: %s", dashlist(prec_matches))
     return prec_matches[0]

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -84,7 +84,9 @@ class _SignatureVerification:
 
         # ensure the key_mgr exists
         if self.key_mgr is None:
-            log.warning("could not find key_mgr data for metadata signature verification")
+            log.warning(
+                "could not find key_mgr data for metadata signature verification"
+            )
             return False
 
         # signature verification is enabled

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -56,7 +56,7 @@ class _SignatureVerification:
 
         # signing url must be defined
         if not context.signing_metadata_url_base:
-            log.warn(
+            log.warning(
                 "metadata signature verification requested, "
                 "but no metadata URL base has not been specified."
             )
@@ -66,7 +66,7 @@ class _SignatureVerification:
         try:
             import conda_content_trust  # noqa: F401
         except ImportError:
-            log.warn(
+            log.warning(
                 "metadata signature verification requested, "
                 "but `conda-content-trust` is not installed."
             )
@@ -77,14 +77,14 @@ class _SignatureVerification:
 
         # ensure the trusted_root exists
         if self.trusted_root is None:
-            log.warn(
+            log.warning(
                 "could not find trusted_root data for metadata signature verification"
             )
             return False
 
         # ensure the key_mgr exists
         if self.key_mgr is None:
-            log.warn("could not find key_mgr data for metadata signature verification")
+            log.warning("could not find key_mgr data for metadata signature verification")
             return False
 
         # signature verification is enabled
@@ -178,11 +178,11 @@ class _SignatureVerification:
 
             verify_delegation("key_mgr", untrusted, self.trusted_root)
         except ConnectionError as err:
-            log.warn(err)
+            log.warning(err)
         except HTTPError as err:
             # sometimes the HTTPError message is blank, when that occurs include the
             # HTTP status code
-            log.warn(
+            log.warning(
                 str(err) or f"{err.__class__.__name__} ({err.response.status_code})"
             )
         else:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -490,7 +490,7 @@ def get_comspec():
                 environ["COMSPEC"] = comspec
                 break
         else:
-            log.warn(
+            log.warning(
                 "cmd.exe could not be found. Looked in SystemRoot and windir env vars.\n"
             )
 

--- a/news/13963-warn-to-warning
+++ b/news/13963-warn-to-warning
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Replace calls to logger.warn with logger.warning (#13963)

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -55,7 +55,7 @@ def test_attach_stderr_handler():
 
     with captured() as c:
         attach_stderr_handler(WARN, name)
-        logr.warn("test message")
+        logr.warning("test message")
         logr.debug(debug_message)
 
     assert len(logr.handlers) == 1
@@ -69,7 +69,7 @@ def test_attach_stderr_handler():
     # round two, with debug
     with captured() as c:
         attach_stderr_handler(DEBUG, name)
-        logr.warn("test message")
+        logr.warning("test message")
         logr.debug(debug_message)
         logr.info("info message")
 

--- a/tests/core/test_envs_manager.py
+++ b/tests/core/test_envs_manager.py
@@ -181,8 +181,8 @@ def test_register_env_directory_creation_error(mocker):
     conda_dir = os.path.dirname(get_user_environments_txt_file())
 
     assert value is None
-    assert len(mock_log.warn.mock_calls) == 1
+    assert len(mock_log.warning.mock_calls) == 1
 
-    mock_call, *_ = mock_log.warn.mock_calls
+    mock_call, *_ = mock_log.warning.mock_calls
 
     assert f"Could not create {conda_dir}" in mock_call.args[0]

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -374,7 +374,7 @@ def test_json_create_install_update_remove(
             for string in content and content.split("\0") or ():
                 json.loads(string)
         except Exception as e:
-            log.warn(
+            log.warning(
                 "Problem parsing json output.\n"
                 "  content: %s\n"
                 "  string: %s\n"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This replaces calls to `logger.warn` with `logger.warning`. The former has been deprecated since Python 3.3 and generates `DeprecationWarning`s that can make output particularly in debugging and testing more noisy than necessary.

Sibling to conda/conda-build#5364.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

As this is a purely internal change, I don't thing any of the following items apply.
However, it does remove the hack in gateways.logging to suppress the deprecation warnings.
Does that need special consideration?

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

### Other repos
@jezdez noted that the same issue is present in other repos in the ecosystem.
They may be addressed in a similar manner and in detail are the following:

- [x] conda/conda-index (conda/conda-index#173)
- [x] conda/conda-libmamba-solver (conda/conda-libmamba-solver#476)
- [x] conda/conda-lock (conda/conda-lock#646)
- [x] conda/conda-verify (conda/conda-verify#115)
- [x] conda/menuinst (conda/menuinst#220)
