### PR TITLE
Checksum comparisons should be case insensitive - use bytes directly

### DIFF
--- a/conda/gateways/connection/download.py
+++ b/conda/gateways/connection/download.py
@@ -180,7 +180,7 @@ def download_partial_file(
             checksum = sha256 if sha256 else md5
             try:
                 checksum_bytes = bytes.fromhex(checksum)
-            except ValueError as exc:
+            except (ValueError, TypeError) as exc:
                 raise CondaValueError(exc) from exc
             hasher = hashlib.new(checksum_type)
             target.seek(0)

--- a/conda/gateways/connection/download.py
+++ b/conda/gateways/connection/download.py
@@ -176,7 +176,7 @@ def download_partial_file(
         target.seek(0)
         if md5 or sha256:
             checksum_type = "sha256" if sha256 else "md5"
-            checksum = sha256 if sha256 else md5
+            checksum = (sha256 if sha256 else md5).lower()
             hasher = hashlib.new(checksum_type)
             target.seek(0)
             while read := target.read(CHUNK_SIZE):

--- a/news/13969-hash-case
+++ b/news/13969-hash-case
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Checksum comparisons are not case sensitive anymore. (#13969)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/13969-hash-case
+++ b/news/13969-hash-case
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Checksum comparisons are not case sensitive anymore. (#13969)
+* Checksum comparisons in `conda.gateways.connection.download.download()` are not case sensitive anymore. (#13969)
 
 ### Deprecations
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -350,7 +350,7 @@ def test_download_http_errors():
         raise HTTPError(response=Response(401))
 
 
-@pytest.mark.parametrize("sha256_type", ("original", "upper", "gibberish"))
+@pytest.mark.parametrize("sha256_type", ("original", "upper", "gibberish", "bad-type"))
 def test_checksum_checks_bytes(
     tmp_path: Path, package_repository_base, package_server, sha256_type
 ):
@@ -363,9 +363,14 @@ def test_checksum_checks_bytes(
     size = package_path.stat().st_size
     output_path = tmp_path / package_name
 
-    if sha256_type == "gibberish":
+    if sha256_type in ("gibberish", "bad-type"):
         with pytest.raises(CondaValueError):
-            download(url, output_path, size=size, sha256="not-an-hex-string")
+            download(
+                url,
+                output_path,
+                size=size,
+                sha256=123456 if sha256_type == "bad-type" else "not-an-hex-string",
+            )
     else:
         download(
             url,

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -347,3 +347,23 @@ def test_download_http_errors():
         "https://example.org/file"
     ):
         raise HTTPError(response=Response(401))
+
+
+@pytest.mark.parametrize("upper", (True, False))
+def test_checksum_case_insensitive(tmp_path: Path, package_repository_base, package_server, upper):
+    host, port = package_server.getsockname()
+    base = f"http://{host}:{port}/test"
+    package_name = "zlib-1.2.11-h7b6447c_3.conda"
+    url = f"{base}/linux-64/{package_name}"
+    package_path = package_repository_base / "linux-64" / package_name
+    sha256 = checksum(package_path, algorithm="sha256")
+    size = package_path.stat().st_size
+    output_path = tmp_path / package_name
+
+    # try full download
+    download(
+        url,
+        output_path,
+        size=size,
+        sha256=sha256.upper() if upper else sha256
+    )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`rattler` returns `sha256` with uppercase alpha characters. Python's `hashlib.hexdigest()` returns it with lowercase. Either works and both are ok since SHA256 should be case insensitive. We just need to make our comparisons insensitive too.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
