### PR TITLE
Update download links to use "Apple Silicon"

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ We recommend the following methods to install conda:
                 .. button-link:: https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg
                     :color: primary
 
-                    macOS with Intel chip 64-bit :octicon:`download`
+                    macOS with Intel CPU 64-bit :octicon:`download`
 
     .. tab-item:: Linux :fab:`linux`
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,14 +37,14 @@ We recommend the following methods to install conda:
                 .. button-link:: https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg
                     :color: primary
 
-                    macOS with Apple Silicon (arm64) 64-bit :octicon:`download`
+                    macOS with Apple Silicon 64-bit :octicon:`download`
 
             .. grid-item::
 
                 .. button-link:: https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg
                     :color: primary
 
-                    macOS with Intel (x86) 64-bit :octicon:`download`
+                    macOS with Intel chip 64-bit :octicon:`download`
 
     .. tab-item:: Linux :fab:`linux`
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,17 +34,17 @@ We recommend the following methods to install conda:
 
             .. grid-item::
 
-                .. button-link:: https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg
-                    :color: primary
-
-                    macOS x86 64-bit :octicon:`download`
-
-            .. grid-item::
-
                 .. button-link:: https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg
                     :color: primary
 
-                    macOS M1 64-bit :octicon:`download`
+                    macOS with Apple Silicon (arm64) 64-bit :octicon:`download`
+
+            .. grid-item::
+
+                .. button-link:: https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg
+                    :color: primary
+
+                    macOS with Intel (x86) 64-bit :octicon:`download`
 
     .. tab-item:: Linux :fab:`linux`
 


### PR DESCRIPTION
Since there are now M1-M4 available and Apple uses "Apple Silicon" themselves. Also move Apple Silicon before Intel chips now that there are no more Intel macs released.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
