### PR TITLE
Disallow additional characters in prefix names for Windows

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -178,9 +178,26 @@ NOTICES_CACHE_SUBDIR = "notices"
 NOTICES_DECORATOR_DISPLAY_INTERVAL = 86400  # in seconds
 
 DRY_RUN_PREFIX = "Dry run action:"
-PREFIX_NAME_DISALLOWED_CHARS = {"/", " ", ":", "#"}
+PREFIX_NAME_DISALLOWED_CHARS = {
+    "/",
+    " ",
+    ":",
+    "#",
+}
 # Includes disallowed characters from constructor
-PREFIX_NAME_DISALLOWED_CHARS_WIN = {"/", " ", ":", "#", "^", "%", "!", "=", "(", ")", "\\"}
+PREFIX_NAME_DISALLOWED_CHARS_WIN = {
+    "/",
+    " ",
+    ":",
+    "#",
+    "^",
+    "%",
+    "!",
+    "=",
+    "(",
+    ")",
+    "\\",
+}
 
 
 class SafetyChecks(Enum):

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -179,6 +179,8 @@ NOTICES_DECORATOR_DISPLAY_INTERVAL = 86400  # in seconds
 
 DRY_RUN_PREFIX = "Dry run action:"
 PREFIX_NAME_DISALLOWED_CHARS = {"/", " ", ":", "#"}
+# Includes disallowed characters from constructor
+PREFIX_NAME_DISALLOWED_CHARS_WIN = {"/", " ", ":", "#", "^", "%", "!", "=", "(", ")", "\\"}
 
 
 class SafetyChecks(Enum):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -62,6 +62,7 @@ from .constants import (
     NO_PLUGINS,
     PREFIX_MAGIC_FILE,
     PREFIX_NAME_DISALLOWED_CHARS,
+    PREFIX_NAME_DISALLOWED_CHARS_WIN,
     REPODATA_FN,
     ROOT_ENV_NAME,
     SEARCH_PATH,
@@ -2059,13 +2060,13 @@ def locate_prefix_by_name(name, envs_dirs=None):
 def validate_prefix_name(prefix_name: str, ctx: Context, allow_base=True) -> str:
     """Run various validations to make sure prefix_name is valid"""
     from ..exceptions import CondaValueError
-
-    if PREFIX_NAME_DISALLOWED_CHARS.intersection(prefix_name):
+    disallowed = PREFIX_NAME_DISALLOWED_CHARS_WIN if on_win else PREFIX_NAME_DISALLOWED_CHARS
+    if disallowed.intersection(prefix_name):
         raise CondaValueError(
             dals(
                 f"""
                 Invalid environment name: {prefix_name!r}
-                Characters not allowed: {PREFIX_NAME_DISALLOWED_CHARS}
+                Characters not allowed: {disallowed}
                 If you are specifying a path to an environment, the `-p`
                 flag should be used instead.
                 """

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -2062,7 +2062,7 @@ def validate_prefix_name(prefix_name: str, ctx: Context, allow_base=True) -> str
     from ..exceptions import CondaValueError
 
     disallowed = (
-        PREFIX_NAME_DISALLOWED_CHARS_WIN if on_win else PREFIX_NAME_DISALLOWED_CHARS_WIN
+        PREFIX_NAME_DISALLOWED_CHARS_WIN if on_win else PREFIX_NAME_DISALLOWED_CHARS
     )
     if disallowed.intersection(prefix_name):
         if "%" in disallowed:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -2060,7 +2060,10 @@ def locate_prefix_by_name(name, envs_dirs=None):
 def validate_prefix_name(prefix_name: str, ctx: Context, allow_base=True) -> str:
     """Run various validations to make sure prefix_name is valid"""
     from ..exceptions import CondaValueError
-    disallowed = PREFIX_NAME_DISALLOWED_CHARS_WIN if on_win else PREFIX_NAME_DISALLOWED_CHARS
+
+    disallowed = (
+        PREFIX_NAME_DISALLOWED_CHARS_WIN if on_win else PREFIX_NAME_DISALLOWED_CHARS
+    )
     if disallowed.intersection(prefix_name):
         raise CondaValueError(
             dals(

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -2062,9 +2062,15 @@ def validate_prefix_name(prefix_name: str, ctx: Context, allow_base=True) -> str
     from ..exceptions import CondaValueError
 
     disallowed = (
-        PREFIX_NAME_DISALLOWED_CHARS_WIN if on_win else PREFIX_NAME_DISALLOWED_CHARS
+        PREFIX_NAME_DISALLOWED_CHARS_WIN if on_win else PREFIX_NAME_DISALLOWED_CHARS_WIN
     )
     if disallowed.intersection(prefix_name):
+        if "%" in disallowed:
+            # This symbol causes formatting errors in the message below when raised.
+            # It needs to be escaped as a double %% in order to be rendered correctly.
+            # Raw strings didn't help.
+            disallowed.remove("%")
+            disallowed.add("%%")
         raise CondaValueError(
             dals(
                 f"""

--- a/news/13975-disallow-characters-windows
+++ b/news/13975-disallow-characters-windows
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Disallow some more characters in Windows (`^`, `%`, `!`, `=`, `(`, `)`, `\`). These characters complicate or prevent environment activation if present. (#12558 via #13975)
+* Disallow some more characters in Windows for prefix names (`^`, `%`, `!`, `=`, `(`, `)`, `\`). These characters complicate or prevent environment activation if present. (#12558 via #13975)
 
 ### Deprecations
 

--- a/news/13975-disallow-characters-windows
+++ b/news/13975-disallow-characters-windows
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Disallow some more characters in Windows (`^`, `%`, `!`, `=`, `(`, `)`, `\`). These characters complicate or prevent environment activation if present. (#12558 via #13975)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->


Closes https://github.com/conda/conda/issues/12558

These characters are problematic in Windows activation.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
