### PR TITLE
Fix token filter in logging so it doesn't choke on iterable arguments

### DIFF
--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -62,14 +62,10 @@ class TokenURLFilter(Filter):
             # This should always be the case but it's not checked so
             # we avoid any potential logging errors.
             return True
-        record.msg = self.TOKEN_REPLACE(record.msg)
         if record.args:
-            new_args = tuple(
-                self.TOKEN_REPLACE(arg) if isinstance(arg, str) else arg
-                for arg in record.args
-            )
-            record.msg = record.msg % new_args
+            record.msg = record.msg % record.args
             record.args = None
+        record.msg = self.TOKEN_REPLACE(record.msg)
         return True
 
 

--- a/news/13939-mask-token-logs
+++ b/news/13939-mask-token-logs
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Mask Anaconda.org tokens in verbose logs. (#13939)
+* Mask Anaconda.org tokens in verbose logs. (#13939, #13987)
 
 ### Deprecations
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We currently obtain `TypeError` for calls like this:

```python
log.debug("My template message: %s", {"key": "value", "another": "valuable"}
```

because `TokenURLFilter` iterates over the dict and accidentally turns it into a 2-tuple. By the time the `%` template processes it, it doesn't have enough placeholders.

Instead, let's render the message first, and _then_ we process it for tokens.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
