### PR TITLE
Fix binary_replace not matching chunks that end with `\n`

### DIFF
--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -194,7 +194,7 @@ def binary_replace(
         return match.group().replace(search, replacement) + b"\0" * padding
 
     original_data_len = len(data)
-    pat = re.compile(re.escape(search) + b"(?:(?!(?:" + zeros + b")).)*" + zeros)
+    pat = re.compile(re.escape(search) + b"(?:(?!(?:" + zeros + b"))[\\s\\S])*" + zeros)
     data = pat.sub(replace, data)
     assert len(data) == original_data_len
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -104,6 +104,17 @@ def test_multiple(subdir):
     with pytest.raises(_PaddingError):
         binary_replace(b"aaaacaaaa\x00", b"aaaa", b"bbbbb", subdir=subdir)
 
+@pytest.mark.parametrize("subdir", ["linux-64", "win-64", "noarch"], indirect=True)
+def test_ends_with_newl(subdir):
+    assert (
+        binary_replace(b"fooaa\n\x00", b"foo", b"bar", subdir=subdir)
+        == b"baraa\n\x00"
+    )
+    assert (
+        binary_replace(b"fooaafoo\n\x00", b"foo", b"fo", subdir=subdir)
+        == b"foaafo\n\x00\x00\x00"
+    )
+
 
 @pytest.mark.integration
 @pytest.mark.skipif(not on_win, reason="exe entry points only necessary on win")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes bug described in https://github.com/conda/conda/issues/14043

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
