### PR TITLE
Update conda.xsh: support xonsh >= 0.18.0

### DIFF
--- a/conda/shell/conda.xsh
+++ b/conda/shell/conda.xsh
@@ -3,7 +3,13 @@
 # Much of this forked from https://github.com/gforsyth/xonda
 # Copyright (c) 2016, Gil Forsyth, All rights reserved.
 # Original code licensed under BSD-3-Clause.
-from xonsh.lazyasd import lazyobject
+
+try:
+    # xonsh >= 0.18.0
+    from xonsh.lib.lazyasd import lazyobject
+except:
+    # xonsh < 0.18.0
+    from xonsh.lazyasd import lazyobject
 
 if 'CONDA_EXE' not in ${...}:
     ![python -m conda init --dev out> conda-dev-init.sh]

--- a/news/14047-update-xonsh-support
+++ b/news/14047-update-xonsh-support
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Update xonsh support to accomodate deprecated import path (#14047)


### PR DESCRIPTION
Added support xonsh >= [0.18.0](https://github.com/xonsh/xonsh/releases/tag/0.18.0)

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~