### PR TITLE
Add spec and tests to enable reading environment table from pyproject.toml

### DIFF
--- a/conda/env/specs/__init__.py
+++ b/conda/env/specs/__init__.py
@@ -13,6 +13,7 @@ from ...exceptions import (
 from ...gateways.connection.session import CONDA_SESSION_SCHEMES
 from .binstar import BinstarSpec
 from .requirements import RequirementsSpec
+from .pyproject import PyProjectSpec
 from .yaml_file import YamlFileSpec
 
 FileSpecTypes = Union[Type[YamlFileSpec], Type[RequirementsSpec]]
@@ -25,7 +26,9 @@ def get_spec_class_from_file(filename: str) -> FileSpecTypes:
     :raises EnvironmentFileExtensionNotValid | EnvironmentFileNotFound:
     """
     # Check extensions
-    all_valid_exts = YamlFileSpec.extensions.union(RequirementsSpec.extensions)
+    all_valid_exts = set().union(
+        YamlFileSpec.extensions, RequirementsSpec.extensions, PyProjectSpec.extensions
+    )
     _, ext = os.path.splitext(filename)
 
     # First check if file exists and test the known valid extension for specs
@@ -39,11 +42,13 @@ def get_spec_class_from_file(filename: str) -> FileSpecTypes:
             return YamlFileSpec
         elif ext in RequirementsSpec.extensions:
             return RequirementsSpec
+        elif ext in PyProjectSpec.extensions:
+            return PyProjectSpec
     else:
         raise EnvironmentFileNotFound(filename=filename)
 
 
-SpecTypes = Union[BinstarSpec, YamlFileSpec, RequirementsSpec]
+SpecTypes = Union[BinstarSpec, YamlFileSpec, RequirementsSpec, PyProjectSpec]
 
 
 def detect(

--- a/conda/env/specs/pyproject.py
+++ b/conda/env/specs/pyproject.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Define pyproject.toml spec."""
+
+import os
+from pathlib import Path
+import sys
+from typing import Union
+
+if sys.version_info >= (3, 11):
+    from tomllib import TOMLDecodeError
+    from tomllib import load as toml_load
+
+from .. import env
+from ...common.serialize import yaml_safe_dump
+
+
+class PyProjectSpec:
+    """Reads dependencies from a ``pyproject.toml`` file
+    and returns an :class:`Environment` object from it.
+    
+    Initially only specification of dependencies in a
+    ``[tool.conda.environment]`` table is supported until
+    PEP-735 (https://peps.python.org/pep-0735/) or a
+    suitable replacement is approved to indicate how
+    arbitrary lists of dependencies may be included in a
+    ``pyproject.toml`` file.
+
+    The structure of a ``[tool.conda.environment]`` table
+    and the syntax of the dependency specifications should
+    be identical to that used for a standard ``environment.yml``
+    file, with YAML syntax simply translated to TOML.
+    For maximum compatibility, the parsed TOML table is simply
+    converted to YAML and passed to the normal YAML parser.
+    """
+
+    extensions = {".toml"}
+
+    def __init__(self, filename: os.PathLike, name: Union[str, None] = None, **kwargs):
+        self.filename: Path = Path(filename)
+        self.name: str = name
+        self._environment = None
+        self.msg = None
+
+    def _valid_file(self):
+        if self.filename.exists():
+            return True
+        else:
+            self.msg = f"File {self.filename} does not exist."
+            return False
+
+    def can_handle(self):
+        if not self._valid_file():
+            print("Invalid file")
+            return False
+        try:
+            with open(self.filename, "rb") as f:
+                toml = toml_load(f)
+        except NameError:
+            self.msg = "Reading from TOML files is only supported from Python >=3.11"
+            print(self.msg)
+            return False
+        except TOMLDecodeError as e:
+            self.msg = f"{self.filename} is not a valid TOML file: {e}"
+            print(self.msg)
+            return False
+        environment_table = (
+            toml
+            .get("tool", {})
+            .get("conda", {})
+            .get("environment", None)
+        )
+        if environment_table is None:
+            self.msg = f"{self.filename} does not contain a [tool.conda.environment] table."
+            print(self.msg)
+            return False
+        # Check the [project] table for a name if one wasn't passed as an argument
+        # A name given in the environment table will still be used preferentially though
+        if self.name and "project" in toml:
+            try:
+                # Supporting this is kind of abuse of what the [project] table is for,
+                # but if we don't have any other name to go with then using one from
+                # here is better than throwing an error
+                # A [project] table is not actually mandatory for a pyproject.toml that
+                # is not designed to be built and distributed, but if it is present, it
+                # must have entries for a name and a version to be valid
+                self.name = toml["project"]["name"]
+            except KeyError:
+                self.msg = (
+                    f"{self.filename} is not a valid pyproject.toml file, as a [project] table is invalid without name and version fields."
+                )
+                print(self.msg)
+                return False
+        try:
+            environment_yaml = yaml_safe_dump(environment_table)
+        except Exception as e:
+            self.msg = (
+                f"The [tool.conda.environment] table could not be converted to valid YAML: {e}"
+            )
+            print(self.msg)
+            return False
+        try:
+            self._environment = env.from_yaml(environment_yaml)
+            return True
+        except Exception as e:
+            self.msg = (
+                f"The [tool.conda.environment] table could not be processed as an environment.yml file: {e}"
+            )
+            print(self.msg)
+            return False
+
+    @property
+    def environment(self):
+        if not self._environment:
+            if not self.can_handle():
+                print("Can't handle")
+                return None
+        # Make sure there's a name if at all possible
+        if self._environment.name is None:
+            self._environment.name = self.name
+        return self._environment

--- a/tests/env/specs/test_pyproject_file.py
+++ b/tests/env/specs/test_pyproject_file.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from pathlib import Path
+import sys
+
+from .. import support_file
+from conda.env import env
+from conda.env.specs.pyproject import PyProjectSpec
+
+toml_dir = Path(__file__).parent.parent / "support/example-pyproject"
+yaml_dir = toml_dir.with_name("example")
+
+
+def test_only_simple_environment_table():
+    toml_file = toml_dir / "demo-simple.toml"
+    spec = PyProjectSpec(filename=toml_file)
+    # Python<3.11 not supported as doesn't ship tomllib
+    if not sys.version_info >= (3, 11):
+        assert spec.environment is None
+    else:
+        assert isinstance(spec.environment, env.Environment)
+        assert spec.environment.name == "demo"
+        assert spec.environment.dependencies == {'conda': ['pytorch', 'pytorch-cuda', 'torchaudio', 'torchvision', 'pip'], 'pip': ['requests']}
+
+
+def convert_environment_examples():
+    """Automatically convert all the YAML examples to TOML for the test below.
+    
+    Shouldn't be necessary to ever run this unless extra examples are added or the
+    current ones are changed, but it's left here just in case."""
+    from ruamel.yaml import YAML
+    import tomli_w
+
+    yaml = YAML(typ="safe")
+
+    toml_dir = Path(__file__).parent
+    yaml_dir = Path(__file__).parent.parent / "example"
+
+    for y in yaml_dir.iterdir():
+        env = yaml.load(y)
+        toml = {"tool": {"conda": {"environment": env}}}
+        dest = (toml_dir / y.name).with_suffix(".toml")
+        with open(dest, "wb") as f:
+            tomli_w.dump(toml, f)
+
+
+def test_environment_examples_equivalence():
+    yaml_examples = [
+        "environment_host_port.yml",
+        "environment_pinned.yml",
+        "environment.yml",
+        "environment_pinned_updated.yml",
+        "environment_with_pip.yml",
+    ]
+    for example in yaml_examples:
+        print(f"Testing {example}")
+        yaml_file = yaml_dir / example
+        toml_file = (toml_dir / example).with_suffix(".toml")
+        yaml_env = env.from_file(str(yaml_file))
+        spec = PyProjectSpec(filename=toml_file)
+        # Python<3.11 not supported as doesn't ship tomllib
+        if not sys.version_info >= (3, 11):
+            assert spec.environment is None
+        else:
+            toml_env = spec.environment
+            assert yaml_env.name == toml_env.name
+            assert yaml_env.channels == toml_env.channels
+            assert yaml_env.dependencies == toml_env.dependencies

--- a/tests/env/support/example-pyproject/demo-simple.toml
+++ b/tests/env/support/example-pyproject/demo-simple.toml
@@ -1,0 +1,15 @@
+[tool.conda.environment]
+name = "demo"
+channels = [
+    "pytorch",
+    "nvidia",
+    "defaults",
+]
+dependencies = [
+    "pytorch",
+    "pytorch-cuda",
+    "torchaudio",
+    "torchvision",
+    "pip",
+    {pip = ["requests"]},
+]

--- a/tests/env/support/example-pyproject/environment.toml
+++ b/tests/env/support/example-pyproject/environment.toml
@@ -1,0 +1,5 @@
+[tool.conda.environment]
+name = "test"
+dependencies = [
+    "numpy",
+]

--- a/tests/env/support/example-pyproject/environment_host_port.toml
+++ b/tests/env/support/example-pyproject/environment_host_port.toml
@@ -1,0 +1,5 @@
+[tool.conda.environment]
+name = "test"
+dependencies = [
+    "https://104.17.92.24:443::flask=1.0.2",
+]

--- a/tests/env/support/example-pyproject/environment_pinned.toml
+++ b/tests/env/support/example-pyproject/environment_pinned.toml
@@ -1,0 +1,10 @@
+[tool.conda.environment]
+name = "test"
+dependencies = [
+    "flask==2.0.2",
+]
+
+[tool.conda.environment.variables]
+FIXED = "fixed"
+CHANGES = "original_value"
+GETS_DELETED = "not_actually_removed_though"

--- a/tests/env/support/example-pyproject/environment_pinned_updated.toml
+++ b/tests/env/support/example-pyproject/environment_pinned_updated.toml
@@ -1,0 +1,10 @@
+[tool.conda.environment]
+name = "test"
+dependencies = [
+    "flask==2.0.3",
+]
+
+[tool.conda.environment.variables]
+FIXED = "fixed"
+CHANGES = "updated_value"
+NEW_VAR = "new_var"

--- a/tests/env/support/example-pyproject/environment_with_pip.toml
+++ b/tests/env/support/example-pyproject/environment_with_pip.toml
@@ -1,0 +1,7 @@
+[tool.conda.environment]
+name = "test"
+dependencies = [
+    "pip",
+    "python",
+    { pip = ["httpx"] },
+]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Added a spec to demonstrate how conda could enable the creation of a conda environment from a `pyproject.toml` file, if the user desires. This has been quite a popular request, see #12462 

Closes #10633 

The approach is that I put forward in #10633:

- The contents of an ordinary conda `environment.yml` can alternatively be included in a `pyproject.toml` file under a `[tool.conda.environment]` table.
- The support is read-only (a conda environment cannot be exported to a pyproject.toml)
- The table has to be formatted with TOML syntax, naturally, so it must be translated from YAML syntax, but this is trivial
- The syntax for requirement strings is identical to a normal conda environment file
- The parsed table is passed directly to the normal YAML parser, so anything that works in a normal `environment.yml` works here too

Unlike previous approaches (#12666 and #14057), no premature judgement or decision is made on how to process dependencies specified in other tables of the TOML, as the officially correct(/at all acceptable) place to store arbitrary lists of dependencies for an environment in a `pyproject.toml` is [yet to be finalized](https://peps.python.org/pep-0735/), and as I understand it there are remaining technical challenges when it comes to passing PEP-440 (PyPI-style) dependency specifications. Such functionality could be added at a later date, when an appropriate approach crystallizes. For now, this solution provides a stop-gap.

As such, this would not allow users to use a single dependency list for both PyPI tools and conda tools, but it would allow consolidation into a single file that can support two sets of users.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
