### PR TITLE
Move `path_identity` to `conda.common.path`

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -46,6 +46,7 @@ from .base.constants import (
 )
 from .base.context import ROOT_ENV_NAME, context, locate_prefix_by_name
 from .common.compat import FILESYSTEM_ENCODING, on_win
+from .common.path import path_identity as _path_identity
 from .common.path import paths_equal
 from .deprecations import deprecated
 
@@ -1001,7 +1002,7 @@ def native_path_to_unix(
     if paths is None:
         return None
     elif not on_win:
-        return path_identity(paths)
+        return _path_identity(paths)
 
     # short-circuit if we don't get any paths
     paths = paths if isinstance(paths, str) else tuple(paths)
@@ -1052,7 +1053,7 @@ def unix_path_to_native(
     if paths is None:
         return None
     elif not on_win:
-        return path_identity(paths)
+        return _path_identity(paths)
 
     # short-circuit if we don't get any paths
     paths = paths if isinstance(paths, str) else tuple(paths)
@@ -1100,13 +1101,13 @@ def unix_path_to_native(
         return tuple(win_path.split(ntpath.pathsep))
 
 
-def path_identity(paths: str | Iterable[str] | None) -> str | tuple[str, ...] | None:
-    if paths is None:
-        return None
-    elif isinstance(paths, str):
-        return os.path.normpath(paths)
-    else:
-        return tuple(os.path.normpath(path) for path in paths)
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "path_identity",
+    _path_identity,
+    addendum="Use `conda.common.path.path_identity` instead.",
+)
 
 
 def backslash_to_forwardslash(
@@ -1230,7 +1231,7 @@ class XonshActivator(_Activator):
     pathsep_join = ";".join if on_win else ":".join
     sep = "/"
     path_conversion = staticmethod(
-        backslash_to_forwardslash if on_win else path_identity
+        backslash_to_forwardslash if on_win else _path_identity
     )
     # 'scripts' really refer to de/activation scripts, not scripts in the language per se
     # xonsh can piggy-back activation scripts from other languages depending on the platform
@@ -1257,7 +1258,7 @@ class XonshActivator(_Activator):
 class CmdExeActivator(_Activator):
     pathsep_join = ";".join
     sep = "\\"
-    path_conversion = staticmethod(path_identity)
+    path_conversion = staticmethod(_path_identity)
     script_extension = ".bat"
     tempfile_extension = ".bat"
     command_join = "\n"
@@ -1322,7 +1323,7 @@ class FishActivator(_Activator):
 class PowerShellActivator(_Activator):
     pathsep_join = ";".join if on_win else ":".join
     sep = "\\" if on_win else "/"
-    path_conversion = staticmethod(path_identity)
+    path_conversion = staticmethod(_path_identity)
     script_extension = ".ps1"
     tempfile_extension = None  # output to stdout
     command_join = "\n"

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -402,3 +402,17 @@ def is_package_file(path):
     # NOTE: not using CONDA_TARBALL_EXTENSION_V1 or CONDA_TARBALL_EXTENSION_V2 to comply with
     #       import rules and to avoid a global lookup.
     return path[-6:] == ".conda" or path[-8:] == ".tar.bz2"
+
+
+PathType = str | os.PathLike
+
+
+def path_identity(
+    paths: PathType | Iterable[PathType] | None,
+) -> str | tuple[str, ...] | None:
+    if paths is None:
+        return None
+    elif isinstance(paths, (str, os.PathLike)):
+        return os.path.normpath(paths)
+    else:
+        return tuple(os.path.normpath(path) for path in paths)

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -29,6 +29,8 @@ from .compat import on_win
 if TYPE_CHECKING:
     from typing import Iterable, Sequence
 
+    PathType = str | os.PathLike
+
 log = getLogger(__name__)
 
 PATH_MATCH_REGEX = (
@@ -402,9 +404,6 @@ def is_package_file(path):
     # NOTE: not using CONDA_TARBALL_EXTENSION_V1 or CONDA_TARBALL_EXTENSION_V2 to comply with
     #       import rules and to avoid a global lookup.
     return path[-6:] == ".conda" or path[-8:] == ".tar.bz2"
-
-
-PathType = str | os.PathLike
 
 
 def path_identity(

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -16,6 +16,7 @@ from shutil import which
 from . import CondaError
 from .auxlib.compat import Utf8NamedTemporaryFile, shlex_split_unicode
 from .common.compat import isiterable, on_win
+from .common.path import path_identity as _path_identity
 from .common.path import win_path_to_unix
 from .common.url import path_to_url
 from .deprecations import deprecated
@@ -23,9 +24,13 @@ from .deprecations import deprecated
 log = logging.getLogger(__name__)
 
 
-def path_identity(path):
-    """Used as a dummy path converter where no conversion necessary"""
-    return path
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "path_identity",
+    _path_identity,
+    addendum="Use `conda.common.path.path_identity` instead.",
+)
 
 
 def unix_path_to_win(path, root_prefix=""):
@@ -111,8 +116,8 @@ _UNIX_SHELL_BASE = dict(
     echo="echo",
     env_script_suffix=".sh",
     nul="2>/dev/null",
-    path_from=path_identity,
-    path_to=path_identity,
+    path_from=_path_identity,
+    path_to=_path_identity,
     pathsep=":",
     printdefaultenv="echo $CONDA_DEFAULT_ENV",
     printpath="echo $PATH",
@@ -168,8 +173,8 @@ if on_win:
         #    printdefaultenv='echo $CONDA_DEFAULT_ENV',
         #    printpath="echo %PATH%",
         #    exe="powershell.exe",
-        #    path_from=path_identity,
-        #    path_to=path_identity,
+        #    path_from=_path_identity,
+        #    path_to=_path_identity,
         #    slash_convert = ("/", "\\"),
         # ),
         "cmd.exe": dict(
@@ -191,8 +196,8 @@ if on_win:
             printpath="@echo %PATH%",
             exe="cmd.exe",
             shell_args=["/d", "/c"],
-            path_from=path_identity,
-            path_to=path_identity,
+            path_from=_path_identity,
+            path_to=_path_identity,
             slash_convert=("/", "\\"),
             sep="\\",
             pathsep=";",

--- a/news/14068-path-identity
+++ b/news/14068-path-identity
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.activate.path_identity` as pending deprecation. Use `conda.common.path.path_identity` instead. (#14068)
+* Mark `conda.utils.path_identity` as pending deprecation. Use `conda.common.path.path_identity` instead. (#14068)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/common/test_path.py
+++ b/tests/common/test_path.py
@@ -1,10 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from logging import getLogger
+from pathlib import Path
 
 from conda.common.path import (
     get_major_minor_version,
     missing_pyc_files,
+    path_identity,
     url_to_path,
     win_path_backout,
 )
@@ -168,3 +170,26 @@ def test_get_major_minor_version_no_dot():
     assert get_major_minor_version("bin/python3.10", False) == "310"
     assert get_major_minor_version("lib/python310/site-packages/", False) == "310"
     assert get_major_minor_version("python3", False) is None
+
+
+def test_path_identity(tmp_path: Path) -> None:
+    # None
+    assert path_identity(None) is None
+
+    # str | os.PathLike
+    assert path_identity("") == "."
+    assert path_identity(".") == "."
+    assert path_identity("./") == "."
+    assert path_identity("relative") == "relative"
+    assert path_identity(str(tmp_path)) == str(tmp_path)
+    assert path_identity(tmp_path) == str(tmp_path)
+
+    # Iterable[str | os.PathLike]
+    assert path_identity(("", ".", "./", "relative", str(tmp_path), tmp_path)) == (
+        ".",
+        ".",
+        ".",
+        "relative",
+        str(tmp_path),
+        str(tmp_path),
+    )

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 import sys
+from contextlib import nullcontext
 from functools import lru_cache
 from itertools import chain
 from logging import getLogger
@@ -21,7 +22,7 @@ from uuid import uuid4
 
 import pytest
 
-from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT, CondaError
+from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT, CondaError, activate
 from conda import __version__ as conda_version
 from conda.activate import (
     CmdExeActivator,
@@ -3505,3 +3506,15 @@ def test_metavars_force_uppercase(
     assert "ONE" in export_vars
     assert "FOUR" in unset_vars
     assert "SIX" in export_vars
+
+
+@pytest.mark.parametrize(
+    "function,raises",
+    [
+        ("path_identity", TypeError),
+    ],
+)
+def test_deprecations(function: str, raises: type[Exception] | None) -> None:
+    raises_context = pytest.raises(raises) if raises else nullcontext()
+    with pytest.deprecated_call(), raises_context:
+        getattr(activate, function)()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -253,6 +253,7 @@ def test_ensure_dir_errors():
         ("win_path_to_cygwin", TypeError),
         ("cygwin_path_to_win", TypeError),
         ("translate_stream", TypeError),
+        ("path_identity", TypeError),
     ],
 )
 def test_deprecations(function: str, raises: type[Exception] | None) -> None:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Move `conda.activate.path_identity` to `conda.common.path.path_identity` (marking original as deprecated). Mark `conda.utils.path_identity` as deprecated in favor of the updated `conda.common.path.path_identity`.

Split from https://github.com/conda/conda/pull/14029

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
