### PR TITLE
[DRAFT] Warn for problematic chars in env name on Windows

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -185,11 +185,7 @@ PREFIX_NAME_DISALLOWED_CHARS = {
     "#",
 }
 # Includes disallowed characters from constructor
-PREFIX_NAME_DISALLOWED_CHARS_WIN = {
-    "/",
-    " ",
-    ":",
-    "#",
+PREFIX_NAME_DISCOURAGED_CHARS_WIN = {
     "^",
     "%",
     "!",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This is a suggestion to handle @jezdez's comment from https://github.com/conda/conda/issues/12558#issuecomment-2245951439 :
> I’d suggest to work on an improved patch that only presents users with a note that future versions of conda will change env name handling.

This is only composed quickly and is untested, carries no news file, etc.
Since I'm not able to work on this further, please do feel free to amend or incorporate into gh-14065 as you see fit.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
