### PR TITLE
Deprecate `tests.env.utils.make_temp_envs_dir`

### DIFF
--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -353,8 +353,8 @@ def tmp_envs_dir(
     mocker.patch(
         "conda.base.context.Context.envs_dirs",
         new_callable=mocker.PropertyMock,
-        return_value=(envs_dirs := (str(envs_dir))),
+        return_value=(envs_dir_str := str(envs_dir),),
     )
-    assert context.envs_dirs == envs_dirs
+    assert context.envs_dirs == (envs_dir_str,)
 
     yield envs_dir

--- a/news/14093-deprecate-make_temp_envs_dir
+++ b/news/14093-deprecate-make_temp_envs_dir
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `tests.env.utils.make_temp_envs_dir` as pending deprecation. Use `tmp_envs_dir` fixture instead. (#14093)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -15,7 +15,6 @@ from conda.testing import CondaCLIFixture, PathFactoryFixture
 from conda.testing.integration import package_is_installed
 
 from . import support_file
-from .utils import make_temp_envs_dir
 
 
 def get_env_vars(prefix):
@@ -27,229 +26,210 @@ def get_env_vars(prefix):
 
 
 @pytest.mark.integration
-def test_create_update(conda_cli: CondaCLIFixture, monkeypatch: MonkeyPatch):
-    with make_temp_envs_dir() as envs_dir:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", envs_dir)
-        reset_context()
-        assert context.envs_dirs[0] == envs_dir
+def test_create_update(
+    conda_cli: CondaCLIFixture, monkeypatch: MonkeyPatch, tmp_envs_dir: Path
+):
+    env_name = uuid4().hex[:8]
+    prefix = tmp_envs_dir / env_name
 
-        env_name = str(uuid4())[:8]
-        prefix = Path(envs_dir, env_name)
+    conda_cli(
+        *("env", "create"),
+        *("--name", env_name),
+        *("--file", support_file("example/environment_pinned.yml")),
+    )
+    assert prefix.exists()
+    assert package_is_installed(prefix, "python")
+    assert package_is_installed(prefix, "flask=2.0.2")
 
-        conda_cli(
-            *("env", "create"),
-            *("--name", env_name),
-            *("--file", support_file("example/environment_pinned.yml")),
-        )
-        assert prefix.exists()
-        assert package_is_installed(prefix, "python")
-        assert package_is_installed(prefix, "flask=2.0.2")
+    env_vars = get_env_vars(prefix)
+    assert env_vars["FIXED"] == "fixed"
+    assert env_vars["CHANGES"] == "original_value"
+    assert env_vars["GETS_DELETED"] == "not_actually_removed_though"
+    assert "NEW_VAR" not in env_vars
 
-        env_vars = get_env_vars(prefix)
-        assert env_vars["FIXED"] == "fixed"
-        assert env_vars["CHANGES"] == "original_value"
-        assert env_vars["GETS_DELETED"] == "not_actually_removed_though"
-        assert "NEW_VAR" not in env_vars
+    stdout, stderr, err = conda_cli(
+        *("env", "update"),
+        *("--name", env_name),
+        *("--file", support_file("example/environment_pinned_updated.yml")),
+    )
+    PrefixData._cache_.clear()
+    assert package_is_installed(prefix, "flask=2.0.3")
+    assert not package_is_installed(prefix, "flask=2.0.2")
 
-        stdout, stderr, err = conda_cli(
-            *("env", "update"),
-            *("--name", env_name),
-            *("--file", support_file("example/environment_pinned_updated.yml")),
-        )
-        PrefixData._cache_.clear()
-        assert package_is_installed(prefix, "flask=2.0.3")
-        assert not package_is_installed(prefix, "flask=2.0.2")
+    env_vars = get_env_vars(prefix)
+    assert env_vars["FIXED"] == "fixed"
+    assert env_vars["CHANGES"] == "updated_value"
+    assert env_vars["NEW_VAR"] == "new_var"
 
-        env_vars = get_env_vars(prefix)
-        assert env_vars["FIXED"] == "fixed"
-        assert env_vars["CHANGES"] == "updated_value"
-        assert env_vars["NEW_VAR"] == "new_var"
-
-        # This ends up sticking around since there is no real way of knowing that an environment
-        # variable _used_ to be in the variables dict, but isn't any more.
-        assert env_vars["GETS_DELETED"] == "not_actually_removed_though"
+    # This ends up sticking around since there is no real way of knowing that an environment
+    # variable _used_ to be in the variables dict, but isn't any more.
+    assert env_vars["GETS_DELETED"] == "not_actually_removed_though"
 
 
 @pytest.mark.skip(reason="Need to find an appropriate server to test this on.")
 @pytest.mark.integration
-def test_create_host_port(monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture):
-    with make_temp_envs_dir() as envs_dir:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", envs_dir)
-        reset_context()
-        assert context.envs_dirs[0] == envs_dir
+def test_create_host_port(
+    monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture, tmp_envs_dir: Path
+):
+    env_name = uuid4().hex[:8]
+    prefix = tmp_envs_dir / env_name
 
-        env_name = str(uuid4())[:8]
-        prefix = Path(envs_dir, env_name)
-
-        conda_cli(
-            *("env", "create"),
-            *("--name", env_name),
-            *("--file", support_file("example/environment_host_port.yml")),
-        )
-        assert prefix.exists()
-        assert package_is_installed(prefix, "python")
-        assert package_is_installed(prefix, "flask=2.0.3")
+    conda_cli(
+        *("env", "create"),
+        *("--name", env_name),
+        *("--file", support_file("example/environment_host_port.yml")),
+    )
+    assert prefix.exists()
+    assert package_is_installed(prefix, "python")
+    assert package_is_installed(prefix, "flask=2.0.3")
 
 
 @pytest.mark.integration
-def test_create_advanced_pip(monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture):
-    with make_temp_envs_dir() as envs_dir:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", envs_dir)
-        reset_context()
-        assert context.envs_dirs[0] == envs_dir
+def test_create_advanced_pip(
+    monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture, tmp_envs_dir: Path
+):
+    env_name = uuid4().hex[:8]
+    prefix = tmp_envs_dir / env_name
 
-        env_name = uuid4().hex[:8]
-        prefix = Path(envs_dir, env_name)
+    stdout, stderr, _ = conda_cli(
+        *("env", "create"),
+        *("--name", env_name),
+        *("--file", support_file("advanced-pip/environment.yml")),
+    )
 
-        stdout, stderr, _ = conda_cli(
-            *("env", "create"),
-            *("--name", env_name),
-            *("--file", support_file("advanced-pip/environment.yml")),
-        )
-
-        PrefixData._cache_.clear()
-        assert prefix.exists()
-        assert package_is_installed(prefix, "python")
-        assert package_is_installed(prefix, "argh")
-        assert package_is_installed(prefix, "module-to-install-in-editable-mode")
-        assert package_is_installed(prefix, "six")
-        assert package_is_installed(prefix, "xmltodict=0.10.2")
+    PrefixData._cache_.clear()
+    assert prefix.exists()
+    assert package_is_installed(prefix, "python")
+    assert package_is_installed(prefix, "argh")
+    assert package_is_installed(prefix, "module-to-install-in-editable-mode")
+    assert package_is_installed(prefix, "six")
+    assert package_is_installed(prefix, "xmltodict=0.10.2")
 
 
 @pytest.mark.integration
-def test_create_empty_env(monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture):
-    with make_temp_envs_dir() as envs_dir:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", envs_dir)
-        reset_context()
-        assert context.envs_dirs[0] == envs_dir
+def test_create_empty_env(
+    monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture, tmp_envs_dir: Path
+):
+    env_name = uuid4().hex[:8]
+    prefix = tmp_envs_dir / env_name
 
-        env_name = str(uuid4())[:8]
-        prefix = Path(envs_dir, env_name)
-
-        conda_cli(
-            *("env", "create"),
-            *("--name", env_name),
-            *("--file", support_file("empty_env.yml")),
-        )
-        assert prefix.exists()
+    conda_cli(
+        *("env", "create"),
+        *("--name", env_name),
+        *("--file", support_file("empty_env.yml")),
+    )
+    assert prefix.exists()
 
 
 @pytest.mark.integration
 def test_create_env_default_packages(
-    monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture
+    monkeypatch: MonkeyPatch,
+    conda_cli: CondaCLIFixture,
+    tmp_envs_dir: Path,
 ):
     # use "cheap" packages with no dependencies
     monkeypatch.setenv("CONDA_CREATE_DEFAULT_PACKAGES", "favicon,zlib")
     reset_context()
     assert context.create_default_packages == ("favicon", "zlib")
 
-    with make_temp_envs_dir() as envs_dir:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", envs_dir)
-        reset_context()
-        assert context.envs_dirs[0] == envs_dir
+    env_name = uuid4().hex[:8]
+    prefix = tmp_envs_dir / env_name
 
-        env_name = uuid4().hex[:8]
-        prefix = Path(envs_dir, env_name)
-
-        conda_cli(
-            *("env", "create"),
-            *("--name", env_name),
-            *("--file", support_file("env_with_dependencies.yml")),
-        )
-        assert prefix.exists()
-        assert package_is_installed(prefix, "python")
-        assert package_is_installed(prefix, "pytz")
-        assert package_is_installed(prefix, "favicon")
-        assert package_is_installed(prefix, "zlib")
+    conda_cli(
+        *("env", "create"),
+        *("--name", env_name),
+        *("--file", support_file("env_with_dependencies.yml")),
+    )
+    assert prefix.exists()
+    assert package_is_installed(prefix, "python")
+    assert package_is_installed(prefix, "pytz")
+    assert package_is_installed(prefix, "favicon")
+    assert package_is_installed(prefix, "zlib")
 
 
 @pytest.mark.integration
 def test_create_env_no_default_packages(
-    monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture
+    monkeypatch: MonkeyPatch,
+    conda_cli: CondaCLIFixture,
+    tmp_envs_dir: Path,
 ):
     # use "cheap" packages with no dependencies
     monkeypatch.setenv("CONDA_CREATE_DEFAULT_PACKAGES", "favicon,zlib")
     reset_context()
     assert context.create_default_packages == ("favicon", "zlib")
 
-    with make_temp_envs_dir() as envs_dir:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", envs_dir)
-        reset_context()
-        assert context.envs_dirs[0] == envs_dir
+    env_name = uuid4().hex[:8]
+    prefix = tmp_envs_dir / env_name
 
-        env_name = str(uuid4())[:8]
-        prefix = Path(envs_dir, env_name)
-
-        conda_cli(
-            *("env", "create"),
-            *("--name", env_name),
-            *("--file", support_file("env_with_dependencies.yml")),
-            "--no-default-packages",
-        )
-        assert prefix.exists()
-        assert package_is_installed(prefix, "python")
-        assert package_is_installed(prefix, "pytz")
-        assert not package_is_installed(prefix, "favicon")
-        assert not package_is_installed(prefix, "zlib")
+    conda_cli(
+        *("env", "create"),
+        *("--name", env_name),
+        *("--file", support_file("env_with_dependencies.yml")),
+        "--no-default-packages",
+    )
+    assert prefix.exists()
+    assert package_is_installed(prefix, "python")
+    assert package_is_installed(prefix, "pytz")
+    assert not package_is_installed(prefix, "favicon")
+    assert not package_is_installed(prefix, "zlib")
 
 
 @pytest.mark.integration
 def test_create_update_remote_env_file(
-    support_file_server_port, monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture
+    support_file_server_port,
+    monkeypatch: MonkeyPatch,
+    conda_cli: CondaCLIFixture,
+    tmp_envs_dir: Path,
 ):
-    with make_temp_envs_dir() as envs_dir:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", envs_dir)
-        reset_context()
-        assert context.envs_dirs[0] == envs_dir
+    env_name = uuid4().hex[:8]
+    prefix = tmp_envs_dir / env_name
 
-        env_name = str(uuid4())[:8]
-        prefix = Path(envs_dir, env_name)
-        conda_cli(
-            *("env", "create"),
-            *("--name", env_name),
-            *(
-                "--file",
-                support_file(
-                    "example/environment_pinned.yml",
-                    remote=True,
-                    port=support_file_server_port,
-                ),
+    conda_cli(
+        *("env", "create"),
+        *("--name", env_name),
+        *(
+            "--file",
+            support_file(
+                "example/environment_pinned.yml",
+                remote=True,
+                port=support_file_server_port,
             ),
-        )
-        assert prefix.exists()
-        assert package_is_installed(prefix, "python")
-        assert package_is_installed(prefix, "flask=2.0.2")
+        ),
+    )
+    assert prefix.exists()
+    assert package_is_installed(prefix, "python")
+    assert package_is_installed(prefix, "flask=2.0.2")
 
-        env_vars = get_env_vars(prefix)
-        assert env_vars["FIXED"] == "fixed"
-        assert env_vars["CHANGES"] == "original_value"
-        assert env_vars["GETS_DELETED"] == "not_actually_removed_though"
-        assert "NEW_VAR" not in env_vars
+    env_vars = get_env_vars(prefix)
+    assert env_vars["FIXED"] == "fixed"
+    assert env_vars["CHANGES"] == "original_value"
+    assert env_vars["GETS_DELETED"] == "not_actually_removed_though"
+    assert "NEW_VAR" not in env_vars
 
-        conda_cli(
-            *("env", "update"),
-            *("--name", env_name),
-            *(
-                "--file",
-                support_file(
-                    "example/environment_pinned_updated.yml",
-                    remote=True,
-                    port=support_file_server_port,
-                ),
+    conda_cli(
+        *("env", "update"),
+        *("--name", env_name),
+        *(
+            "--file",
+            support_file(
+                "example/environment_pinned_updated.yml",
+                remote=True,
+                port=support_file_server_port,
             ),
-        )
-        PrefixData._cache_.clear()
-        assert package_is_installed(prefix, "flask=2.0.3")
-        assert not package_is_installed(prefix, "flask=2.0.2")
+        ),
+    )
+    PrefixData._cache_.clear()
+    assert package_is_installed(prefix, "flask=2.0.3")
+    assert not package_is_installed(prefix, "flask=2.0.2")
 
-        env_vars = get_env_vars(prefix)
-        assert env_vars["FIXED"] == "fixed"
-        assert env_vars["CHANGES"] == "updated_value"
-        assert env_vars["NEW_VAR"] == "new_var"
+    env_vars = get_env_vars(prefix)
+    assert env_vars["FIXED"] == "fixed"
+    assert env_vars["CHANGES"] == "updated_value"
+    assert env_vars["NEW_VAR"] == "new_var"
 
-        # This ends up sticking around since there is no real way of knowing that an environment
-        # variable _used_ to be in the variables dict, but isn't any more.
-        assert env_vars["GETS_DELETED"] == "not_actually_removed_though"
+    # This ends up sticking around since there is no real way of knowing that an environment
+    # variable _used_ to be in the variables dict, but isn't any more.
+    assert env_vars["GETS_DELETED"] == "not_actually_removed_though"
 
 
 @pytest.mark.skipif(on_win, reason="Test is invalid on Windows")

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -27,7 +27,9 @@ def get_env_vars(prefix):
 
 @pytest.mark.integration
 def test_create_update(
-    conda_cli: CondaCLIFixture, monkeypatch: MonkeyPatch, tmp_envs_dir: Path
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+    tmp_envs_dir: Path,
 ):
     env_name = uuid4().hex[:8]
     prefix = tmp_envs_dir / env_name
@@ -69,7 +71,9 @@ def test_create_update(
 @pytest.mark.skip(reason="Need to find an appropriate server to test this on.")
 @pytest.mark.integration
 def test_create_host_port(
-    monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture, tmp_envs_dir: Path
+    monkeypatch: MonkeyPatch,
+    conda_cli: CondaCLIFixture,
+    tmp_envs_dir: Path,
 ):
     env_name = uuid4().hex[:8]
     prefix = tmp_envs_dir / env_name
@@ -86,7 +90,9 @@ def test_create_host_port(
 
 @pytest.mark.integration
 def test_create_advanced_pip(
-    monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture, tmp_envs_dir: Path
+    monkeypatch: MonkeyPatch,
+    conda_cli: CondaCLIFixture,
+    tmp_envs_dir: Path,
 ):
     env_name = uuid4().hex[:8]
     prefix = tmp_envs_dir / env_name
@@ -108,7 +114,9 @@ def test_create_advanced_pip(
 
 @pytest.mark.integration
 def test_create_empty_env(
-    monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture, tmp_envs_dir: Path
+    monkeypatch: MonkeyPatch,
+    conda_cli: CondaCLIFixture,
+    tmp_envs_dir: Path,
 ):
     env_name = uuid4().hex[:8]
     prefix = tmp_envs_dir / env_name

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import pytest
 from pytest import MonkeyPatch
 
-from conda.base.context import context, reset_context
 from conda.common.serialize import yaml_round_trip_load
 from conda.core.prefix_data import PrefixData
 from conda.env.env import (
@@ -24,7 +23,6 @@ from conda.testing import CondaCLIFixture, PathFactoryFixture
 from conda.testing.integration import package_is_installed
 
 from . import support_file
-from .utils import make_temp_envs_dir
 
 
 class FakeStream:
@@ -314,24 +312,20 @@ def test_create_advanced_pip(
     monkeypatch: MonkeyPatch,
     conda_cli: CondaCLIFixture,
     path_factory: PathFactoryFixture,
+    tmp_envs_dir: Path,
 ):
     monkeypatch.setenv("CONDA_DLL_SEARCH_MODIFICATION_ENABLE", "true")
 
-    with make_temp_envs_dir() as envs_dir:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", envs_dir)
-        reset_context()
-        assert context.envs_dirs[0] == envs_dir
-
-        prefix = path_factory()
-        assert not prefix.exists()
-        conda_cli(
-            *("env", "create"),
-            *("--prefix", prefix),
-            *("--file", support_file("pip_argh.yml")),
-        )
-        assert prefix.exists()
-        PrefixData._cache_.clear()
-        assert package_is_installed(prefix, "argh==0.26.2")
+    prefix = path_factory()
+    assert not prefix.exists()
+    conda_cli(
+        *("env", "create"),
+        *("--prefix", prefix),
+        *("--file", support_file("pip_argh.yml")),
+    )
+    assert prefix.exists()
+    PrefixData._cache_.clear()
+    assert package_is_installed(prefix, "argh==0.26.2")
 
 
 def test_from_history():

--- a/tests/env/utils.py
+++ b/tests/env/utils.py
@@ -27,6 +27,7 @@ parser_config = {
 
 
 @contextmanager
+@deprecated("25.3", "25.9", addendum="Use `conda.testing.tmp_envs_dir` instead.")
 def make_temp_envs_dir():
     envs_dir = mkdtemp()
     try:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Implement a new fixture, `tmp_envs_dir`, mirroring the `tmp_pkgs_dir` fixture to replace `make_temp_envs_dir` which required additional manual setup.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
