### PR TITLE
Remove & deprecated unused args/helpers from `conda.gateways.disk.delete`

### DIFF
--- a/conda/exports.py
+++ b/conda/exports.py
@@ -54,7 +54,6 @@ from .gateways.connection.download import download as _download  # noqa: F401
 from .gateways.connection.session import CondaSession  # noqa: F401
 from .gateways.disk.create import TemporaryDirectory  # noqa: F401
 from .gateways.disk.delete import delete_trash, move_to_trash  # noqa: F401
-from .gateways.disk.delete import rm_rf as _rm_rf
 from .gateways.disk.link import lchmod  # noqa: F401
 from .gateways.subprocess import ACTIVE_SUBPROCESSES, subprocess_call  # noqa: F401
 from .misc import untracked, walk_prefix  # noqa: F401
@@ -145,7 +144,9 @@ class InstalledPackages:
 
 
 def rm_rf(path, max_retries=5, trash=True):
-    _rm_rf(path, max_retries, trash)
+    from .gateways.disk.delete import rm_rf
+
+    rm_rf(path)
     delete_prefix_from_linked_data(path)
 
 

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -24,6 +24,7 @@ from ...base.constants import CONDA_TEMP_EXTENSION
 from ...base.context import context
 from ...common.compat import on_win
 from ...common.constants import TRACE
+from ...deprecations import deprecated
 from . import MAX_TRIES
 from .link import islink, lexists
 from .permissions import make_writable
@@ -35,7 +36,7 @@ if not on_win:
 log = getLogger(__name__)
 
 
-def rmtree(path, *args, **kwargs):
+def rmtree(path):
     # subprocessing to delete large folders can be quite a bit faster
     path = normpath(path)
     if on_win:
@@ -193,7 +194,9 @@ def remove_empty_parent_paths(path):
         parent_path = dirname(parent_path)
 
 
-def rm_rf(path, max_retries=5, trash=True, clean_empty_parents=False, *args, **kw):
+@deprecated.argument("25.3", "25.9", "max_retries")
+@deprecated.argument("25.3", "25.9", "trash")
+def rm_rf(path, clean_empty_parents=False):
     """
     Completely delete path
     max_retries is the number of times to retry on failure. The default is 5. This only applies
@@ -221,7 +224,9 @@ def rm_rf(path, max_retries=5, trash=True, clean_empty_parents=False, *args, **k
 
 
 # aliases that all do the same thing (legacy compat)
-try_rmdir_all_empty = move_to_trash = move_path_to_trash = rm_rf
+deprecated.constant("25.3", "25.9", "try_rmdir_all_empty", rm_rf)
+deprecated.constant("25.3", "25.9", "move_to_trash", rm_rf)
+deprecated.constant("25.3", "25.9", "move_path_to_trash", rm_rf)
 
 
 def delete_trash(prefix):

--- a/news/14094-cleanup-conda.gateways.disk.delete
+++ b/news/14094-cleanup-conda.gateways.disk.delete
@@ -1,0 +1,23 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.gateways.disk.delete.rm_rf(max_retries)` as pending deprecated. (#14094)
+* Mark `conda.gateways.disk.delete.rm_rf(trash)` as pending deprecated. (#14094)
+* Mark `conda.gateways.disk.delete.try_rmdir_all_empty` as pending deprecated. Use `conda.gateways.disk.delete.rm_rf` instead. (#14094)
+* Mark `conda.gateways.disk.delete.move_to_trash` as pending deprecated. Use `conda.gateways.disk.delete.rm_rf` instead. (#14094)
+* Mark `conda.gateways.disk.delete.move_path_to_trash` as pending deprecated. Use `conda.gateways.disk.delete.rm_rf` instead. (#14094)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda.gateways.disk.delete` has evolved extensively in the past leaving old code and legacy arguments that are no longer in use. Removed and deprecated as applicable.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
