### PR TITLE
`test_fetch.py`: Replace `env_var` with `monkeypatch.setenv`

### DIFF
--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -55,7 +55,7 @@ def test_download_connectionerror(monkeypatch: MonkeyPatch, tmp_path: Path) -> N
     assert context.remote_read_timeout_secs == 1
     assert context.remote_max_retries == 1
 
-    with pytest.raises(CondaHTTPError, match=r"Connection error:"):
+    with pytest.raises(CondaHTTPError, match=r"CONNECTION FAILED for url"):
         url = "http://240.0.0.0/"
         download(url, tmp_path)
 
@@ -70,7 +70,7 @@ def test_fetchrepodate_connectionerror(monkeypatch: MonkeyPatch) -> None:
     assert context.remote_read_timeout_secs == 1
     assert context.remote_max_retries == 1
 
-    with pytest.raises(CondaHTTPError, match=r"Connection error:"):
+    with pytest.raises(CondaHTTPError, match=r"CONNECTION FAILED for url"):
         url = "http://240.0.0.0/channel/osx-64"
         SubdirData(Channel(url)).repo_fetch.fetch_latest()
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Replace `env_var` usage in `tests/test_fetch.py` with `monkeypatch.setenv`.

Xref #14095

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
