### PR TITLE
`test_plan.py`: Replace `env_var` with `monkeypatch.setenv`

### DIFF
--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -106,22 +106,23 @@ def test_display_actions_0():
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be downloaded:
-
-    package                    |            build
-    ---------------------------|-----------------
-    sympy-0.7.2                |           py27_0         4.2 MB
-    numpy-1.7.1                |           py27_0         5.7 MB
-    ------------------------------------------------------------
-                                           Total:         9.9 MB
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be downloaded:",
+                "",
+                "    package                    |            build",
+                "    ---------------------------|-----------------",
+                "    sympy-0.7.2                |           py27_0         4.2 MB",
+                "    numpy-1.7.1                |           py27_0         5.7 MB",
+                "    ------------------------------------------------------------",
+                "                                           Total:         9.9 MB",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -141,23 +142,24 @@ The following packages will be downloaded:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-  environment location: /Users/aaronmeurer/anaconda/envs/test
-
-
-The following NEW packages will be INSTALLED:
-
-    python:   3.3.2-0 \n\
-    readline: 6.2-0   \n\
-    sqlite:   3.7.13-0
-    tk:       8.5.13-0
-    zlib:     1.2.7-0 \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "  environment location: /Users/aaronmeurer/anaconda/envs/test",
+                "",
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    python:   3.3.2-0 ",
+                "    readline: 6.2-0   ",
+                "    sqlite:   3.7.13-0",
+                "    tk:       8.5.13-0",
+                "    zlib:     1.2.7-0 ",
+                "",
+                "",
+            )
         )
 
         actions["UNLINK"] = actions["LINK"]
@@ -166,23 +168,24 @@ The following NEW packages will be INSTALLED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-  environment location: /Users/aaronmeurer/anaconda/envs/test
-
-
-The following packages will be REMOVED:
-
-    python:   3.3.2-0 \n\
-    readline: 6.2-0   \n\
-    sqlite:   3.7.13-0
-    tk:       8.5.13-0
-    zlib:     1.2.7-0 \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "  environment location: /Users/aaronmeurer/anaconda/envs/test",
+                "",
+                "",
+                "The following packages will be REMOVED:",
+                "",
+                "    python:   3.3.2-0 ",
+                "    readline: 6.2-0   ",
+                "    sqlite:   3.7.13-0",
+                "    tk:       8.5.13-0",
+                "    zlib:     1.2.7-0 ",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -200,17 +203,18 @@ The following packages will be REMOVED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    cython: 0.19-py33_0 --> 0.19.1-py33_0
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython: 0.19-py33_0 --> 0.19.1-py33_0",
+                "",
+                "",
+            )
         )
 
         actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
@@ -218,17 +222,18 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be DOWNGRADED:
-
-    cython: 0.19.1-py33_0 --> 0.19-py33_0
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython: 0.19.1-py33_0 --> 0.19-py33_0",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -250,29 +255,30 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following NEW packages will be INSTALLED:
-
-    numpy:    1.7.1-py33_0
-
-The following packages will be REMOVED:
-
-    pip:      1.3.1-py33_1
-
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0  --> 0.19.1-py33_0
-
-The following packages will be DOWNGRADED:
-
-    dateutil: 2.1-py33_1   --> 1.5-py33_0   \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    numpy:    1.7.1-py33_0",
+                "",
+                "The following packages will be REMOVED:",
+                "",
+                "    pip:      1.3.1-py33_1",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0  --> 0.19.1-py33_0",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    dateutil: 2.1-py33_1   --> 1.5-py33_0   ",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -292,18 +298,19 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0 --> 0.19.1-py33_0
-    dateutil: 1.5-py33_0  --> 2.1-py33_1   \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0 --> 0.19.1-py33_0",
+                "    dateutil: 1.5-py33_0  --> 2.1-py33_1   ",
+                "",
+                "",
+            )
         )
 
         actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
@@ -311,18 +318,19 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be DOWNGRADED:
-
-    cython:   0.19.1-py33_0 --> 0.19-py33_0
-    dateutil: 2.1-py33_1    --> 1.5-py33_0 \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython:   0.19.1-py33_0 --> 0.19-py33_0",
+                "    dateutil: 2.1-py33_1    --> 1.5-py33_0 ",
+                "",
+                "",
+            )
         )
 
 
@@ -350,22 +358,23 @@ def test_display_actions_show_channel_urls():
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be downloaded:
-
-    package                    |            build
-    ---------------------------|-----------------
-    sympy-0.7.2                |           py27_0         4.2 MB  <unknown>
-    numpy-1.7.1                |           py27_0         5.7 MB  <unknown>
-    ------------------------------------------------------------
-                                           Total:         9.9 MB
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be downloaded:",
+                "",
+                "    package                    |            build",
+                "    ---------------------------|-----------------",
+                "    sympy-0.7.2                |           py27_0         4.2 MB  <unknown>",
+                "    numpy-1.7.1                |           py27_0         5.7 MB  <unknown>",
+                "    ------------------------------------------------------------",
+                "                                           Total:         9.9 MB",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -388,23 +397,24 @@ The following packages will be downloaded:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-  environment location: /Users/aaronmeurer/anaconda/envs/test
-
-
-The following NEW packages will be INSTALLED:
-
-    python:   3.3.2-0  channel-1
-    readline: 6.2-0    channel-1
-    sqlite:   3.7.13-0 channel-1
-    tk:       8.5.13-0 channel-1
-    zlib:     1.2.7-0  channel-1
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "  environment location: /Users/aaronmeurer/anaconda/envs/test",
+                "",
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    python:   3.3.2-0  channel-1",
+                "    readline: 6.2-0    channel-1",
+                "    sqlite:   3.7.13-0 channel-1",
+                "    tk:       8.5.13-0 channel-1",
+                "    zlib:     1.2.7-0  channel-1",
+                "",
+                "",
+            )
         )
 
         actions["UNLINK"] = actions["LINK"]
@@ -413,23 +423,24 @@ The following NEW packages will be INSTALLED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-  environment location: /Users/aaronmeurer/anaconda/envs/test
-
-
-The following packages will be REMOVED:
-
-    python:   3.3.2-0  channel-1
-    readline: 6.2-0    channel-1
-    sqlite:   3.7.13-0 channel-1
-    tk:       8.5.13-0 channel-1
-    zlib:     1.2.7-0  channel-1
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "  environment location: /Users/aaronmeurer/anaconda/envs/test",
+                "",
+                "",
+                "The following packages will be REMOVED:",
+                "",
+                "    python:   3.3.2-0  channel-1",
+                "    readline: 6.2-0    channel-1",
+                "    sqlite:   3.7.13-0 channel-1",
+                "    tk:       8.5.13-0 channel-1",
+                "    zlib:     1.2.7-0  channel-1",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -447,17 +458,18 @@ The following packages will be REMOVED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    cython: 0.19-py33_0 channel-1 --> 0.19.1-py33_0 channel-1
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython: 0.19-py33_0 channel-1 --> 0.19.1-py33_0 channel-1",
+                "",
+                "",
+            )
         )
 
         actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
@@ -465,17 +477,18 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be DOWNGRADED:
-
-    cython: 0.19.1-py33_0 channel-1 --> 0.19-py33_0 channel-1
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython: 0.19.1-py33_0 channel-1 --> 0.19-py33_0 channel-1",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -497,29 +510,30 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following NEW packages will be INSTALLED:
-
-    numpy:    1.7.1-py33_0 channel-1
-
-The following packages will be REMOVED:
-
-    pip:      1.3.1-py33_1 channel-1
-
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0  channel-1 --> 0.19.1-py33_0 channel-1
-
-The following packages will be DOWNGRADED:
-
-    dateutil: 2.1-py33_1   channel-1 --> 1.5-py33_0    channel-1
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    numpy:    1.7.1-py33_0 channel-1",
+                "",
+                "The following packages will be REMOVED:",
+                "",
+                "    pip:      1.3.1-py33_1 channel-1",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0  channel-1 --> 0.19.1-py33_0 channel-1",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    dateutil: 2.1-py33_1   channel-1 --> 1.5-py33_0    channel-1",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -539,18 +553,19 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0 channel-1 --> 0.19.1-py33_0 channel-1
-    dateutil: 1.5-py33_0  channel-1 --> 2.1-py33_1    channel-1
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0 channel-1 --> 0.19.1-py33_0 channel-1",
+                "    dateutil: 1.5-py33_0  channel-1 --> 2.1-py33_1    channel-1",
+                "",
+                "",
+            )
         )
 
         actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
@@ -558,18 +573,19 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be DOWNGRADED:
-
-    cython:   0.19.1-py33_0 channel-1 --> 0.19-py33_0 channel-1
-    dateutil: 2.1-py33_1    channel-1 --> 1.5-py33_0  channel-1
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython:   0.19.1-py33_0 channel-1 --> 0.19-py33_0 channel-1",
+                "    dateutil: 2.1-py33_1    channel-1 --> 1.5-py33_0  channel-1",
+                "",
+                "",
+            )
         )
 
         cython_prec = PackageRecord.from_objects(
@@ -597,18 +613,19 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0 channel-1  --> 0.19.1-py33_0 my_channel
-    dateutil: 1.5-py33_0  my_channel --> 2.1-py33_1    channel-1 \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0 channel-1  --> 0.19.1-py33_0 my_channel",
+                "    dateutil: 1.5-py33_0  my_channel --> 2.1-py33_1    channel-1 ",
+                "",
+                "",
+            )
         )
 
         actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
@@ -616,18 +633,19 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be DOWNGRADED:
-
-    cython:   0.19.1-py33_0 my_channel --> 0.19-py33_0 channel-1 \n\
-    dateutil: 2.1-py33_1    channel-1  --> 1.5-py33_0  my_channel
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython:   0.19.1-py33_0 my_channel --> 0.19-py33_0 channel-1 ",
+                "    dateutil: 2.1-py33_1    channel-1  --> 1.5-py33_0  my_channel",
+                "",
+                "",
+            )
         )
 
 
@@ -659,21 +677,21 @@ def test_display_actions_link_type():
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following NEW packages will be INSTALLED:
-
-    cython:   0.19.1-py33_0 (softlink)
-    dateutil: 1.5-py33_0    (softlink)
-    numpy:    1.7.1-py33_0  (softlink)
-    python:   3.3.2-0       (softlink)
-    readline: 6.2-0         (softlink)
-    sqlite:   3.7.13-0      (softlink)
-    tk:       8.5.13-0      (softlink)
-    zlib:     1.2.7-0       (softlink)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    cython:   0.19.1-py33_0 (softlink)",
+                "    dateutil: 1.5-py33_0    (softlink)",
+                "    numpy:    1.7.1-py33_0  (softlink)",
+                "    python:   3.3.2-0       (softlink)",
+                "    readline: 6.2-0         (softlink)",
+                "    sqlite:   3.7.13-0      (softlink)",
+                "    tk:       8.5.13-0      (softlink)",
+                "    zlib:     1.2.7-0       (softlink)",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -687,15 +705,15 @@ The following NEW packages will be INSTALLED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0 --> 0.19.1-py33_0 (softlink)
-    dateutil: 1.5-py33_0  --> 2.1-py33_1    (softlink)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0 --> 0.19.1-py33_0 (softlink)",
+                "    dateutil: 1.5-py33_0  --> 2.1-py33_1    (softlink)",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -709,15 +727,15 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following packages will be DOWNGRADED:
-
-    cython:   0.19.1-py33_0 --> 0.19-py33_0 (softlink)
-    dateutil: 2.1-py33_1    --> 1.5-py33_0  (softlink)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython:   0.19.1-py33_0 --> 0.19-py33_0 (softlink)",
+                "    dateutil: 2.1-py33_1    --> 1.5-py33_0  (softlink)",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -739,21 +757,21 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following NEW packages will be INSTALLED:
-
-    cython:   0.19.1-py33_0
-    dateutil: 1.5-py33_0   \n\
-    numpy:    1.7.1-py33_0 \n\
-    python:   3.3.2-0      \n\
-    readline: 6.2-0        \n\
-    sqlite:   3.7.13-0     \n\
-    tk:       8.5.13-0     \n\
-    zlib:     1.2.7-0      \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    cython:   0.19.1-py33_0",
+                "    dateutil: 1.5-py33_0   ",
+                "    numpy:    1.7.1-py33_0 ",
+                "    python:   3.3.2-0      ",
+                "    readline: 6.2-0        ",
+                "    sqlite:   3.7.13-0     ",
+                "    tk:       8.5.13-0     ",
+                "    zlib:     1.2.7-0      ",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -767,15 +785,15 @@ The following NEW packages will be INSTALLED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0 --> 0.19.1-py33_0
-    dateutil: 1.5-py33_0  --> 2.1-py33_1   \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0 --> 0.19.1-py33_0",
+                "    dateutil: 1.5-py33_0  --> 2.1-py33_1   ",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -789,15 +807,15 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following packages will be DOWNGRADED:
-
-    cython:   0.19.1-py33_0 --> 0.19-py33_0
-    dateutil: 2.1-py33_1    --> 1.5-py33_0 \n\
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython:   0.19.1-py33_0 --> 0.19-py33_0",
+                "    dateutil: 2.1-py33_1    --> 1.5-py33_0 ",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -819,21 +837,21 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following NEW packages will be INSTALLED:
-
-    cython:   0.19.1-py33_0 (copy)
-    dateutil: 1.5-py33_0    (copy)
-    numpy:    1.7.1-py33_0  (copy)
-    python:   3.3.2-0       (copy)
-    readline: 6.2-0         (copy)
-    sqlite:   3.7.13-0      (copy)
-    tk:       8.5.13-0      (copy)
-    zlib:     1.2.7-0       (copy)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    cython:   0.19.1-py33_0 (copy)",
+                "    dateutil: 1.5-py33_0    (copy)",
+                "    numpy:    1.7.1-py33_0  (copy)",
+                "    python:   3.3.2-0       (copy)",
+                "    readline: 6.2-0         (copy)",
+                "    sqlite:   3.7.13-0      (copy)",
+                "    tk:       8.5.13-0      (copy)",
+                "    zlib:     1.2.7-0       (copy)",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -847,15 +865,15 @@ The following NEW packages will be INSTALLED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0 --> 0.19.1-py33_0 (copy)
-    dateutil: 1.5-py33_0  --> 2.1-py33_1    (copy)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0 --> 0.19.1-py33_0 (copy)",
+                "    dateutil: 1.5-py33_0  --> 2.1-py33_1    (copy)",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -869,15 +887,15 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following packages will be DOWNGRADED:
-
-    cython:   0.19.1-py33_0 --> 0.19-py33_0 (copy)
-    dateutil: 2.1-py33_1    --> 1.5-py33_0  (copy)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython:   0.19.1-py33_0 --> 0.19-py33_0 (copy)",
+                "    dateutil: 2.1-py33_1    --> 1.5-py33_0  (copy)",
+                "",
+            )
         )
     with env_var(
         "CONDA_SHOW_CHANNEL_URLS", "True", stack_callback=conda_tests_ctxt_mgmt_def_pol
@@ -907,21 +925,21 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following NEW packages will be INSTALLED:
-
-    cython:   0.19.1-py33_0 my_channel (copy)
-    dateutil: 1.5-py33_0    my_channel (copy)
-    numpy:    1.7.1-py33_0  <unknown>  (copy)
-    python:   3.3.2-0       <unknown>  (copy)
-    readline: 6.2-0         <unknown>  (copy)
-    sqlite:   3.7.13-0      <unknown>  (copy)
-    tk:       8.5.13-0      <unknown>  (copy)
-    zlib:     1.2.7-0       <unknown>  (copy)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    cython:   0.19.1-py33_0 my_channel (copy)",
+                "    dateutil: 1.5-py33_0    my_channel (copy)",
+                "    numpy:    1.7.1-py33_0  <unknown>  (copy)",
+                "    python:   3.3.2-0       <unknown>  (copy)",
+                "    readline: 6.2-0         <unknown>  (copy)",
+                "    sqlite:   3.7.13-0      <unknown>  (copy)",
+                "    tk:       8.5.13-0      <unknown>  (copy)",
+                "    zlib:     1.2.7-0       <unknown>  (copy)",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -935,15 +953,15 @@ The following NEW packages will be INSTALLED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following packages will be UPDATED:
-
-    cython:   0.19-py33_0 <unknown>  --> 0.19.1-py33_0 my_channel (copy)
-    dateutil: 1.5-py33_0  my_channel --> 2.1-py33_1    <unknown>  (copy)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    cython:   0.19-py33_0 <unknown>  --> 0.19.1-py33_0 my_channel (copy)",
+                "    dateutil: 1.5-py33_0  my_channel --> 2.1-py33_1    <unknown>  (copy)",
+                "",
+            )
         )
 
         actions = defaultdict(
@@ -957,15 +975,15 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-The following packages will be DOWNGRADED:
-
-    cython:   0.19.1-py33_0 my_channel --> 0.19-py33_0 <unknown>  (copy)
-    dateutil: 2.1-py33_1    <unknown>  --> 1.5-py33_0  my_channel (copy)
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    cython:   0.19.1-py33_0 my_channel --> 0.19-py33_0 <unknown>  (copy)",
+                "    dateutil: 2.1-py33_1    <unknown>  --> 1.5-py33_0  my_channel (copy)",
+                "",
+            )
         )
 
 
@@ -986,18 +1004,19 @@ def test_display_actions_features():
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following NEW packages will be INSTALLED:
-
-    cython: 0.19-py33_0  \n\
-    numpy:  1.7.1-py33_p0 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    cython: 0.19-py33_0  ",
+                "    numpy:  1.7.1-py33_p0 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1013,18 +1032,19 @@ The following NEW packages will be INSTALLED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be REMOVED:
-
-    cython: 0.19-py33_0  \n\
-    numpy:  1.7.1-py33_p0 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be REMOVED:",
+                "",
+                "    cython: 0.19-py33_0  ",
+                "    numpy:  1.7.1-py33_p0 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1042,17 +1062,18 @@ The following packages will be REMOVED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be DOWNGRADED:
-
-    numpy: 1.7.1-py33_p0 [mkl] --> 1.7.0-py33_p0 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    numpy: 1.7.1-py33_p0 [mkl] --> 1.7.0-py33_p0 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1070,17 +1091,18 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    numpy: 1.7.0-py33_p0 [mkl] --> 1.7.1-py33_p0 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    numpy: 1.7.0-py33_p0 [mkl] --> 1.7.1-py33_p0 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1099,17 +1121,18 @@ The following packages will be UPDATED:
             display_actions(actions, index)
 
         # NB: Packages whose version do not changed are put in UPDATED
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    numpy: 1.7.1-py33_0 --> 1.7.1-py33_p0 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    numpy: 1.7.1-py33_0 --> 1.7.1-py33_p0 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1127,17 +1150,18 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    numpy: 1.7.1-py33_p0 [mkl] --> 1.7.1-py33_0
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    numpy: 1.7.1-py33_p0 [mkl] --> 1.7.1-py33_0",
+                "",
+                "",
+            )
         )
     with env_var(
         "CONDA_SHOW_CHANNEL_URLS", "True", stack_callback=conda_tests_ctxt_mgmt_def_pol
@@ -1155,18 +1179,19 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following NEW packages will be INSTALLED:
-
-    cython: 0.19-py33_0   channel-1
-    numpy:  1.7.1-py33_p0 channel-1 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following NEW packages will be INSTALLED:",
+                "",
+                "    cython: 0.19-py33_0   channel-1",
+                "    numpy:  1.7.1-py33_p0 channel-1 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1182,18 +1207,19 @@ The following NEW packages will be INSTALLED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be REMOVED:
-
-    cython: 0.19-py33_0   channel-1
-    numpy:  1.7.1-py33_p0 channel-1 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be REMOVED:",
+                "",
+                "    cython: 0.19-py33_0   channel-1",
+                "    numpy:  1.7.1-py33_p0 channel-1 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1211,17 +1237,18 @@ The following packages will be REMOVED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be DOWNGRADED:
-
-    numpy: 1.7.1-py33_p0 channel-1 [mkl] --> 1.7.0-py33_p0 channel-1 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be DOWNGRADED:",
+                "",
+                "    numpy: 1.7.1-py33_p0 channel-1 [mkl] --> 1.7.0-py33_p0 channel-1 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1239,17 +1266,18 @@ The following packages will be DOWNGRADED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    numpy: 1.7.0-py33_p0 channel-1 [mkl] --> 1.7.1-py33_p0 channel-1 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    numpy: 1.7.0-py33_p0 channel-1 [mkl] --> 1.7.1-py33_p0 channel-1 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1268,17 +1296,18 @@ The following packages will be UPDATED:
             display_actions(actions, index)
 
         # NB: Packages whose version do not changed are put in UPDATED
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    numpy: 1.7.1-py33_0 channel-1 --> 1.7.1-py33_p0 channel-1 [mkl]
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    numpy: 1.7.1-py33_0 channel-1 --> 1.7.1-py33_p0 channel-1 [mkl]",
+                "",
+                "",
+            )
         )
 
         actions = defaultdict(list)
@@ -1296,17 +1325,18 @@ The following packages will be UPDATED:
         with captured() as c:
             display_actions(actions, index)
 
-        assert (
-            c.stdout
-            == """
-## Package Plan ##
-
-
-The following packages will be UPDATED:
-
-    numpy: 1.7.1-py33_p0 channel-1 [mkl] --> 1.7.1-py33_0 channel-1
-
-"""
+        assert c.stdout == "\n".join(
+            (
+                "",
+                "## Package Plan ##",
+                "",
+                "",
+                "The following packages will be UPDATED:",
+                "",
+                "    numpy: 1.7.1-py33_p0 channel-1 [mkl] --> 1.7.1-py33_0 channel-1",
+                "",
+                "",
+            )
         )
 
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -335,319 +335,320 @@ def test_display_actions_0(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_display_actions_show_channel_urls():
-    with env_var(
-        "CONDA_SHOW_CHANNEL_URLS", "True", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        actions = defaultdict(list)
-        sympy_prec = PackageRecord.from_objects(
-            get_matchspec_from_index(index, "channel-1::sympy==0.7.2=py27_0")
+def test_display_actions_show_channel_urls(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("CONDA_SHOW_CHANNEL_URLS", "True")
+    reset_context()
+    assert context.show_channel_urls
+
+    actions = defaultdict(list)
+    sympy_prec = PackageRecord.from_objects(
+        get_matchspec_from_index(index, "channel-1::sympy==0.7.2=py27_0")
+    )
+    numpy_prec = PackageRecord.from_objects(
+        get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py27_0")
+    )
+    numpy_prec.channel = sympy_prec.channel = Channel(None)
+    actions.update(
+        {
+            "FETCH": [
+                sympy_prec,
+                numpy_prec,
+            ]
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be downloaded:",
+            "",
+            "    package                    |            build",
+            "    ---------------------------|-----------------",
+            "    sympy-0.7.2                |           py27_0         4.2 MB  <unknown>",
+            "    numpy-1.7.1                |           py27_0         5.7 MB  <unknown>",
+            "    ------------------------------------------------------------",
+            "                                           Total:         9.9 MB",
+            "",
+            "",
         )
-        numpy_prec = PackageRecord.from_objects(
-            get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py27_0")
+    )
+
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "PREFIX": "/Users/aaronmeurer/anaconda/envs/test",
+            "SYMLINK_CONDA": [
+                "/Users/aaronmeurer/anaconda",
+            ],
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::python==3.3.2=0"),
+                get_matchspec_from_index(index, "channel-1::readline==6.2=0"),
+                get_matchspec_from_index(index, "channel-1::sqlite==3.7.13=0"),
+                get_matchspec_from_index(index, "channel-1::tk==8.5.13=0"),
+                get_matchspec_from_index(index, "channel-1::zlib==1.2.7=0"),
+            ],
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "  environment location: /Users/aaronmeurer/anaconda/envs/test",
+            "",
+            "",
+            "The following NEW packages will be INSTALLED:",
+            "",
+            "    python:   3.3.2-0  channel-1",
+            "    readline: 6.2-0    channel-1",
+            "    sqlite:   3.7.13-0 channel-1",
+            "    tk:       8.5.13-0 channel-1",
+            "    zlib:     1.2.7-0  channel-1",
+            "",
+            "",
         )
-        numpy_prec.channel = sympy_prec.channel = Channel(None)
-        actions.update(
-            {
-                "FETCH": [
-                    sympy_prec,
-                    numpy_prec,
-                ]
-            }
+    )
+
+    actions["UNLINK"] = actions["LINK"]
+    actions["LINK"] = []
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "  environment location: /Users/aaronmeurer/anaconda/envs/test",
+            "",
+            "",
+            "The following packages will be REMOVED:",
+            "",
+            "    python:   3.3.2-0  channel-1",
+            "    readline: 6.2-0    channel-1",
+            "    sqlite:   3.7.13-0 channel-1",
+            "    tk:       8.5.13-0 channel-1",
+            "    zlib:     1.2.7-0  channel-1",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::cython==0.19.1=py33_0"),
+            ],
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
+            ],
+        }
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be downloaded:",
-                "",
-                "    package                    |            build",
-                "    ---------------------------|-----------------",
-                "    sympy-0.7.2                |           py27_0         4.2 MB  <unknown>",
-                "    numpy-1.7.1                |           py27_0         5.7 MB  <unknown>",
-                "    ------------------------------------------------------------",
-                "                                           Total:         9.9 MB",
-                "",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    cython: 0.19-py33_0 channel-1 --> 0.19.1-py33_0 channel-1",
+            "",
+            "",
         )
+    )
 
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "PREFIX": "/Users/aaronmeurer/anaconda/envs/test",
-                "SYMLINK_CONDA": [
-                    "/Users/aaronmeurer/anaconda",
-                ],
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::python==3.3.2=0"),
-                    get_matchspec_from_index(index, "channel-1::readline==6.2=0"),
-                    get_matchspec_from_index(index, "channel-1::sqlite==3.7.13=0"),
-                    get_matchspec_from_index(index, "channel-1::tk==8.5.13=0"),
-                    get_matchspec_from_index(index, "channel-1::zlib==1.2.7=0"),
-                ],
-            }
+    actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    cython: 0.19.1-py33_0 channel-1 --> 0.19-py33_0 channel-1",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::cython==0.19.1=py33_0"),
+                get_matchspec_from_index(index, "channel-1::dateutil==1.5=py33_0"),
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
+            ],
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
+                get_matchspec_from_index(index, "channel-1::dateutil==2.1=py33_1"),
+                get_matchspec_from_index(index, "channel-1::pip==1.3.1=py33_1"),
+            ],
+        }
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "  environment location: /Users/aaronmeurer/anaconda/envs/test",
-                "",
-                "",
-                "The following NEW packages will be INSTALLED:",
-                "",
-                "    python:   3.3.2-0  channel-1",
-                "    readline: 6.2-0    channel-1",
-                "    sqlite:   3.7.13-0 channel-1",
-                "    tk:       8.5.13-0 channel-1",
-                "    zlib:     1.2.7-0  channel-1",
-                "",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following NEW packages will be INSTALLED:",
+            "",
+            "    numpy:    1.7.1-py33_0 channel-1",
+            "",
+            "The following packages will be REMOVED:",
+            "",
+            "    pip:      1.3.1-py33_1 channel-1",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    cython:   0.19-py33_0  channel-1 --> 0.19.1-py33_0 channel-1",
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    dateutil: 2.1-py33_1   channel-1 --> 1.5-py33_0    channel-1",
+            "",
+            "",
         )
+    )
 
-        actions["UNLINK"] = actions["LINK"]
-        actions["LINK"] = []
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::cython==0.19.1=py33_0"),
+                get_matchspec_from_index(index, "channel-1::dateutil==2.1=py33_1"),
+            ],
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
+                get_matchspec_from_index(index, "channel-1::dateutil==1.5=py33_0"),
+            ],
+        }
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    with captured() as c:
+        display_actions(actions, index)
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "  environment location: /Users/aaronmeurer/anaconda/envs/test",
-                "",
-                "",
-                "The following packages will be REMOVED:",
-                "",
-                "    python:   3.3.2-0  channel-1",
-                "    readline: 6.2-0    channel-1",
-                "    sqlite:   3.7.13-0 channel-1",
-                "    tk:       8.5.13-0 channel-1",
-                "    zlib:     1.2.7-0  channel-1",
-                "",
-                "",
-            )
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    cython:   0.19-py33_0 channel-1 --> 0.19.1-py33_0 channel-1",
+            "    dateutil: 1.5-py33_0  channel-1 --> 2.1-py33_1    channel-1",
+            "",
+            "",
         )
+    )
 
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::cython==0.19.1=py33_0"),
-                ],
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
-                ],
-            }
+    actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    cython:   0.19.1-py33_0 channel-1 --> 0.19-py33_0 channel-1",
+            "    dateutil: 2.1-py33_1    channel-1 --> 1.5-py33_0  channel-1",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    cython_prec = PackageRecord.from_objects(
+        get_matchspec_from_index(index, "channel-1::cython==0.19.1=py33_0")
+    )
+    dateutil_prec = PackageRecord.from_objects(
+        get_matchspec_from_index(index, "channel-1::dateutil==1.5=py33_0")
+    )
+    cython_prec.channel = dateutil_prec.channel = Channel("my_channel")
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    cython: 0.19-py33_0 channel-1 --> 0.19.1-py33_0 channel-1",
-                "",
-                "",
-            )
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                cython_prec,
+                get_matchspec_from_index(index, "channel-1::dateutil==2.1=py33_1"),
+            ],
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
+                dateutil_prec,
+            ],
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    cython:   0.19-py33_0 channel-1  --> 0.19.1-py33_0 my_channel",
+            "    dateutil: 1.5-py33_0  my_channel --> 2.1-py33_1    channel-1 ",
+            "",
+            "",
         )
+    )
 
-        actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
+    actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
 
-        with captured() as c:
-            display_actions(actions, index)
+    with captured() as c:
+        display_actions(actions, index)
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    cython: 0.19.1-py33_0 channel-1 --> 0.19-py33_0 channel-1",
-                "",
-                "",
-            )
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    cython:   0.19.1-py33_0 my_channel --> 0.19-py33_0 channel-1 ",
+            "    dateutil: 2.1-py33_1    channel-1  --> 1.5-py33_0  my_channel",
+            "",
+            "",
         )
-
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::cython==0.19.1=py33_0"),
-                    get_matchspec_from_index(index, "channel-1::dateutil==1.5=py33_0"),
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
-                ],
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
-                    get_matchspec_from_index(index, "channel-1::dateutil==2.1=py33_1"),
-                    get_matchspec_from_index(index, "channel-1::pip==1.3.1=py33_1"),
-                ],
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following NEW packages will be INSTALLED:",
-                "",
-                "    numpy:    1.7.1-py33_0 channel-1",
-                "",
-                "The following packages will be REMOVED:",
-                "",
-                "    pip:      1.3.1-py33_1 channel-1",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    cython:   0.19-py33_0  channel-1 --> 0.19.1-py33_0 channel-1",
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    dateutil: 2.1-py33_1   channel-1 --> 1.5-py33_0    channel-1",
-                "",
-                "",
-            )
-        )
-
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::cython==0.19.1=py33_0"),
-                    get_matchspec_from_index(index, "channel-1::dateutil==2.1=py33_1"),
-                ],
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
-                    get_matchspec_from_index(index, "channel-1::dateutil==1.5=py33_0"),
-                ],
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    cython:   0.19-py33_0 channel-1 --> 0.19.1-py33_0 channel-1",
-                "    dateutil: 1.5-py33_0  channel-1 --> 2.1-py33_1    channel-1",
-                "",
-                "",
-            )
-        )
-
-        actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    cython:   0.19.1-py33_0 channel-1 --> 0.19-py33_0 channel-1",
-                "    dateutil: 2.1-py33_1    channel-1 --> 1.5-py33_0  channel-1",
-                "",
-                "",
-            )
-        )
-
-        cython_prec = PackageRecord.from_objects(
-            get_matchspec_from_index(index, "channel-1::cython==0.19.1=py33_0")
-        )
-        dateutil_prec = PackageRecord.from_objects(
-            get_matchspec_from_index(index, "channel-1::dateutil==1.5=py33_0")
-        )
-        cython_prec.channel = dateutil_prec.channel = Channel("my_channel")
-
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    cython_prec,
-                    get_matchspec_from_index(index, "channel-1::dateutil==2.1=py33_1"),
-                ],
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
-                    dateutil_prec,
-                ],
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    cython:   0.19-py33_0 channel-1  --> 0.19.1-py33_0 my_channel",
-                "    dateutil: 1.5-py33_0  my_channel --> 2.1-py33_1    channel-1 ",
-                "",
-                "",
-            )
-        )
-
-        actions["LINK"], actions["UNLINK"] = actions["UNLINK"], actions["LINK"]
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    cython:   0.19.1-py33_0 my_channel --> 0.19-py33_0 channel-1 ",
-                "    dateutil: 2.1-py33_1    channel-1  --> 1.5-py33_0  my_channel",
-                "",
-                "",
-            )
-        )
+    )
 
 
 @pytest.mark.xfail(

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -656,337 +656,340 @@ def test_display_actions_show_channel_urls(monkeypatch: MonkeyPatch) -> None:
     reason="Not reporting link type until refactoring display_actions "
     "after txn.verify()",
 )
-def test_display_actions_link_type():
-    with env_var(
-        "CONDA_SHOW_CHANNEL_URLS", "False", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        actions = defaultdict(
-            list,
-            {
-                "LINK": [
-                    "cython-0.19.1-py33_0 2",
-                    "dateutil-1.5-py33_0 2",
-                    "numpy-1.7.1-py33_0 2",
-                    "python-3.3.2-0 2",
-                    "readline-6.2-0 2",
-                    "sqlite-3.7.13-0 2",
-                    "tk-8.5.13-0 2",
-                    "zlib-1.2.7-0 2",
-                ]
-            },
+def test_display_actions_link_type(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("CONDA_SHOW_CHANNEL_URLS", "False")
+    reset_context()
+    assert not context.show_channel_urls
+
+    actions = defaultdict(
+        list,
+        {
+            "LINK": [
+                "cython-0.19.1-py33_0 2",
+                "dateutil-1.5-py33_0 2",
+                "numpy-1.7.1-py33_0 2",
+                "python-3.3.2-0 2",
+                "readline-6.2-0 2",
+                "sqlite-3.7.13-0 2",
+                "tk-8.5.13-0 2",
+                "zlib-1.2.7-0 2",
+            ]
+        },
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following NEW packages will be INSTALLED:",
+            "",
+            "    cython:   0.19.1-py33_0 (softlink)",
+            "    dateutil: 1.5-py33_0    (softlink)",
+            "    numpy:    1.7.1-py33_0  (softlink)",
+            "    python:   3.3.2-0       (softlink)",
+            "    readline: 6.2-0         (softlink)",
+            "    sqlite:   3.7.13-0      (softlink)",
+            "    tk:       8.5.13-0      (softlink)",
+            "    zlib:     1.2.7-0       (softlink)",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(
+        list,
+        {
+            "LINK": ["cython-0.19.1-py33_0 2", "dateutil-2.1-py33_1 2"],
+            "UNLINK": ["cython-0.19-py33_0", "dateutil-1.5-py33_0"],
+        },
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following NEW packages will be INSTALLED:",
-                "",
-                "    cython:   0.19.1-py33_0 (softlink)",
-                "    dateutil: 1.5-py33_0    (softlink)",
-                "    numpy:    1.7.1-py33_0  (softlink)",
-                "    python:   3.3.2-0       (softlink)",
-                "    readline: 6.2-0         (softlink)",
-                "    sqlite:   3.7.13-0      (softlink)",
-                "    tk:       8.5.13-0      (softlink)",
-                "    zlib:     1.2.7-0       (softlink)",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    cython:   0.19-py33_0 --> 0.19.1-py33_0 (softlink)",
+            "    dateutil: 1.5-py33_0  --> 2.1-py33_1    (softlink)",
+            "",
         )
+    )
 
-        actions = defaultdict(
-            list,
-            {
-                "LINK": ["cython-0.19.1-py33_0 2", "dateutil-2.1-py33_1 2"],
-                "UNLINK": ["cython-0.19-py33_0", "dateutil-1.5-py33_0"],
-            },
+    actions = defaultdict(
+        list,
+        {
+            "LINK": ["cython-0.19-py33_0 2", "dateutil-1.5-py33_0 2"],
+            "UNLINK": ["cython-0.19.1-py33_0", "dateutil-2.1-py33_1"],
+        },
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    cython:   0.19.1-py33_0 --> 0.19-py33_0 (softlink)",
+            "    dateutil: 2.1-py33_1    --> 1.5-py33_0  (softlink)",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(
+        list,
+        {
+            "LINK": [
+                "cython-0.19.1-py33_0 1",
+                "dateutil-1.5-py33_0 1",
+                "numpy-1.7.1-py33_0 1",
+                "python-3.3.2-0 1",
+                "readline-6.2-0 1",
+                "sqlite-3.7.13-0 1",
+                "tk-8.5.13-0 1",
+                "zlib-1.2.7-0 1",
+            ]
+        },
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    cython:   0.19-py33_0 --> 0.19.1-py33_0 (softlink)",
-                "    dateutil: 1.5-py33_0  --> 2.1-py33_1    (softlink)",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following NEW packages will be INSTALLED:",
+            "",
+            "    cython:   0.19.1-py33_0",
+            "    dateutil: 1.5-py33_0   ",
+            "    numpy:    1.7.1-py33_0 ",
+            "    python:   3.3.2-0      ",
+            "    readline: 6.2-0        ",
+            "    sqlite:   3.7.13-0     ",
+            "    tk:       8.5.13-0     ",
+            "    zlib:     1.2.7-0      ",
+            "",
         )
+    )
 
-        actions = defaultdict(
-            list,
-            {
-                "LINK": ["cython-0.19-py33_0 2", "dateutil-1.5-py33_0 2"],
-                "UNLINK": ["cython-0.19.1-py33_0", "dateutil-2.1-py33_1"],
-            },
+    actions = defaultdict(
+        list,
+        {
+            "LINK": ["cython-0.19.1-py33_0 1", "dateutil-2.1-py33_1 1"],
+            "UNLINK": ["cython-0.19-py33_0", "dateutil-1.5-py33_0"],
+        },
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    cython:   0.19-py33_0 --> 0.19.1-py33_0",
+            "    dateutil: 1.5-py33_0  --> 2.1-py33_1   ",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(
+        list,
+        {
+            "LINK": ["cython-0.19-py33_0 1", "dateutil-1.5-py33_0 1"],
+            "UNLINK": ["cython-0.19.1-py33_0", "dateutil-2.1-py33_1"],
+        },
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    cython:   0.19.1-py33_0 --> 0.19-py33_0 (softlink)",
-                "    dateutil: 2.1-py33_1    --> 1.5-py33_0  (softlink)",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    cython:   0.19.1-py33_0 --> 0.19-py33_0",
+            "    dateutil: 2.1-py33_1    --> 1.5-py33_0 ",
+            "",
         )
+    )
 
-        actions = defaultdict(
-            list,
-            {
-                "LINK": [
-                    "cython-0.19.1-py33_0 1",
-                    "dateutil-1.5-py33_0 1",
-                    "numpy-1.7.1-py33_0 1",
-                    "python-3.3.2-0 1",
-                    "readline-6.2-0 1",
-                    "sqlite-3.7.13-0 1",
-                    "tk-8.5.13-0 1",
-                    "zlib-1.2.7-0 1",
-                ]
-            },
+    actions = defaultdict(
+        list,
+        {
+            "LINK": [
+                "cython-0.19.1-py33_0 3",
+                "dateutil-1.5-py33_0 3",
+                "numpy-1.7.1-py33_0 3",
+                "python-3.3.2-0 3",
+                "readline-6.2-0 3",
+                "sqlite-3.7.13-0 3",
+                "tk-8.5.13-0 3",
+                "zlib-1.2.7-0 3",
+            ]
+        },
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following NEW packages will be INSTALLED:",
+            "",
+            "    cython:   0.19.1-py33_0 (copy)",
+            "    dateutil: 1.5-py33_0    (copy)",
+            "    numpy:    1.7.1-py33_0  (copy)",
+            "    python:   3.3.2-0       (copy)",
+            "    readline: 6.2-0         (copy)",
+            "    sqlite:   3.7.13-0      (copy)",
+            "    tk:       8.5.13-0      (copy)",
+            "    zlib:     1.2.7-0       (copy)",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(
+        list,
+        {
+            "LINK": ["cython-0.19.1-py33_0 3", "dateutil-2.1-py33_1 3"],
+            "UNLINK": ["cython-0.19-py33_0", "dateutil-1.5-py33_0"],
+        },
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following NEW packages will be INSTALLED:",
-                "",
-                "    cython:   0.19.1-py33_0",
-                "    dateutil: 1.5-py33_0   ",
-                "    numpy:    1.7.1-py33_0 ",
-                "    python:   3.3.2-0      ",
-                "    readline: 6.2-0        ",
-                "    sqlite:   3.7.13-0     ",
-                "    tk:       8.5.13-0     ",
-                "    zlib:     1.2.7-0      ",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    cython:   0.19-py33_0 --> 0.19.1-py33_0 (copy)",
+            "    dateutil: 1.5-py33_0  --> 2.1-py33_1    (copy)",
+            "",
         )
+    )
 
-        actions = defaultdict(
-            list,
-            {
-                "LINK": ["cython-0.19.1-py33_0 1", "dateutil-2.1-py33_1 1"],
-                "UNLINK": ["cython-0.19-py33_0", "dateutil-1.5-py33_0"],
-            },
+    actions = defaultdict(
+        list,
+        {
+            "LINK": ["cython-0.19-py33_0 3", "dateutil-1.5-py33_0 3"],
+            "UNLINK": ["cython-0.19.1-py33_0", "dateutil-2.1-py33_1"],
+        },
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    cython:   0.19.1-py33_0 --> 0.19-py33_0 (copy)",
+            "    dateutil: 2.1-py33_1    --> 1.5-py33_0  (copy)",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    monkeypatch.setenv("CONDA_SHOW_CHANNEL_URLS", "True")
+    reset_context()
+    assert context.show_channel_urls
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    cython:   0.19-py33_0 --> 0.19.1-py33_0",
-                "    dateutil: 1.5-py33_0  --> 2.1-py33_1   ",
-                "",
-            )
+    d = Dist("cython-0.19.1-py33_0.tar.bz2")
+    index[d] = PackageRecord.from_objects(index[d], channel="my_channel")
+
+    d = Dist("dateutil-1.5-py33_0.tar.bz2")
+    index[d] = PackageRecord.from_objects(index[d], channel="my_channel")
+
+    actions = defaultdict(
+        list,
+        {
+            "LINK": [
+                "cython-0.19.1-py33_0 3",
+                "dateutil-1.5-py33_0 3",
+                "numpy-1.7.1-py33_0 3",
+                "python-3.3.2-0 3",
+                "readline-6.2-0 3",
+                "sqlite-3.7.13-0 3",
+                "tk-8.5.13-0 3",
+                "zlib-1.2.7-0 3",
+            ]
+        },
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following NEW packages will be INSTALLED:",
+            "",
+            "    cython:   0.19.1-py33_0 my_channel (copy)",
+            "    dateutil: 1.5-py33_0    my_channel (copy)",
+            "    numpy:    1.7.1-py33_0  <unknown>  (copy)",
+            "    python:   3.3.2-0       <unknown>  (copy)",
+            "    readline: 6.2-0         <unknown>  (copy)",
+            "    sqlite:   3.7.13-0      <unknown>  (copy)",
+            "    tk:       8.5.13-0      <unknown>  (copy)",
+            "    zlib:     1.2.7-0       <unknown>  (copy)",
+            "",
         )
+    )
 
-        actions = defaultdict(
-            list,
-            {
-                "LINK": ["cython-0.19-py33_0 1", "dateutil-1.5-py33_0 1"],
-                "UNLINK": ["cython-0.19.1-py33_0", "dateutil-2.1-py33_1"],
-            },
+    actions = defaultdict(
+        list,
+        {
+            "LINK": ["cython-0.19.1-py33_0 3", "dateutil-2.1-py33_1 3"],
+            "UNLINK": ["cython-0.19-py33_0", "dateutil-1.5-py33_0"],
+        },
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    cython:   0.19-py33_0 <unknown>  --> 0.19.1-py33_0 my_channel (copy)",
+            "    dateutil: 1.5-py33_0  my_channel --> 2.1-py33_1    <unknown>  (copy)",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(
+        list,
+        {
+            "LINK": ["cython-0.19-py33_0 3", "dateutil-1.5-py33_0 3"],
+            "UNLINK": ["cython-0.19.1-py33_0", "dateutil-2.1-py33_1"],
+        },
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    cython:   0.19.1-py33_0 --> 0.19-py33_0",
-                "    dateutil: 2.1-py33_1    --> 1.5-py33_0 ",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    cython:   0.19.1-py33_0 my_channel --> 0.19-py33_0 <unknown>  (copy)",
+            "    dateutil: 2.1-py33_1    <unknown>  --> 1.5-py33_0  my_channel (copy)",
+            "",
         )
-
-        actions = defaultdict(
-            list,
-            {
-                "LINK": [
-                    "cython-0.19.1-py33_0 3",
-                    "dateutil-1.5-py33_0 3",
-                    "numpy-1.7.1-py33_0 3",
-                    "python-3.3.2-0 3",
-                    "readline-6.2-0 3",
-                    "sqlite-3.7.13-0 3",
-                    "tk-8.5.13-0 3",
-                    "zlib-1.2.7-0 3",
-                ]
-            },
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following NEW packages will be INSTALLED:",
-                "",
-                "    cython:   0.19.1-py33_0 (copy)",
-                "    dateutil: 1.5-py33_0    (copy)",
-                "    numpy:    1.7.1-py33_0  (copy)",
-                "    python:   3.3.2-0       (copy)",
-                "    readline: 6.2-0         (copy)",
-                "    sqlite:   3.7.13-0      (copy)",
-                "    tk:       8.5.13-0      (copy)",
-                "    zlib:     1.2.7-0       (copy)",
-                "",
-            )
-        )
-
-        actions = defaultdict(
-            list,
-            {
-                "LINK": ["cython-0.19.1-py33_0 3", "dateutil-2.1-py33_1 3"],
-                "UNLINK": ["cython-0.19-py33_0", "dateutil-1.5-py33_0"],
-            },
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    cython:   0.19-py33_0 --> 0.19.1-py33_0 (copy)",
-                "    dateutil: 1.5-py33_0  --> 2.1-py33_1    (copy)",
-                "",
-            )
-        )
-
-        actions = defaultdict(
-            list,
-            {
-                "LINK": ["cython-0.19-py33_0 3", "dateutil-1.5-py33_0 3"],
-                "UNLINK": ["cython-0.19.1-py33_0", "dateutil-2.1-py33_1"],
-            },
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    cython:   0.19.1-py33_0 --> 0.19-py33_0 (copy)",
-                "    dateutil: 2.1-py33_1    --> 1.5-py33_0  (copy)",
-                "",
-            )
-        )
-    with env_var(
-        "CONDA_SHOW_CHANNEL_URLS", "True", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        d = Dist("cython-0.19.1-py33_0.tar.bz2")
-        index[d] = PackageRecord.from_objects(index[d], channel="my_channel")
-
-        d = Dist("dateutil-1.5-py33_0.tar.bz2")
-        index[d] = PackageRecord.from_objects(index[d], channel="my_channel")
-
-        actions = defaultdict(
-            list,
-            {
-                "LINK": [
-                    "cython-0.19.1-py33_0 3",
-                    "dateutil-1.5-py33_0 3",
-                    "numpy-1.7.1-py33_0 3",
-                    "python-3.3.2-0 3",
-                    "readline-6.2-0 3",
-                    "sqlite-3.7.13-0 3",
-                    "tk-8.5.13-0 3",
-                    "zlib-1.2.7-0 3",
-                ]
-            },
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following NEW packages will be INSTALLED:",
-                "",
-                "    cython:   0.19.1-py33_0 my_channel (copy)",
-                "    dateutil: 1.5-py33_0    my_channel (copy)",
-                "    numpy:    1.7.1-py33_0  <unknown>  (copy)",
-                "    python:   3.3.2-0       <unknown>  (copy)",
-                "    readline: 6.2-0         <unknown>  (copy)",
-                "    sqlite:   3.7.13-0      <unknown>  (copy)",
-                "    tk:       8.5.13-0      <unknown>  (copy)",
-                "    zlib:     1.2.7-0       <unknown>  (copy)",
-                "",
-            )
-        )
-
-        actions = defaultdict(
-            list,
-            {
-                "LINK": ["cython-0.19.1-py33_0 3", "dateutil-2.1-py33_1 3"],
-                "UNLINK": ["cython-0.19-py33_0", "dateutil-1.5-py33_0"],
-            },
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    cython:   0.19-py33_0 <unknown>  --> 0.19.1-py33_0 my_channel (copy)",
-                "    dateutil: 1.5-py33_0  my_channel --> 2.1-py33_1    <unknown>  (copy)",
-                "",
-            )
-        )
-
-        actions = defaultdict(
-            list,
-            {
-                "LINK": ["cython-0.19-py33_0 3", "dateutil-1.5-py33_0 3"],
-                "UNLINK": ["cython-0.19.1-py33_0", "dateutil-2.1-py33_1"],
-            },
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    cython:   0.19.1-py33_0 my_channel --> 0.19-py33_0 <unknown>  (copy)",
-                "    dateutil: 2.1-py33_1    <unknown>  --> 1.5-py33_0  my_channel (copy)",
-                "",
-            )
-        )
+    )
 
 
 def test_display_actions_features():

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1467,17 +1467,17 @@ def generate_remove_action(prefix, unlink):
     return action
 
 
-def test_pinned_specs_CONDA_PINNED_PACKAGES():
+def test_pinned_specs_CONDA_PINNED_PACKAGES(monkeypatch: MonkeyPatch) -> None:
     # Test pinned specs environment variable
     specs = ("numpy 1.11", "python >3")
-    with env_var(
-        "CONDA_PINNED_PACKAGES",
-        "&".join(specs),
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        pinned_specs = get_pinned_specs("/none")
-        assert pinned_specs != specs
-        assert pinned_specs == tuple(MatchSpec(spec, optional=True) for spec in specs)
+
+    monkeypatch.setenv("CONDA_PINNED_PACKAGES", "&".join(specs))
+    reset_context()
+    assert context.pinned_packages == specs
+
+    pinned_specs = get_pinned_specs("/none")
+    assert pinned_specs != specs
+    assert pinned_specs == tuple(MatchSpec(spec, optional=True) for spec in specs)
 
 
 def test_pinned_specs_conda_meta_pinned(tmp_env: TmpEnvFixture):

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -992,357 +992,360 @@ def test_display_actions_link_type(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_display_actions_features():
-    with env_var(
-        "CONDA_SHOW_CHANNEL_URLS", "False", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                    get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
-                ]
-            }
+def test_display_actions_features(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("CONDA_SHOW_CHANNEL_URLS", "False")
+    reset_context()
+    assert not context.show_channel_urls
+
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+                get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
+            ]
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following NEW packages will be INSTALLED:",
+            "",
+            "    cython: 0.19-py33_0  ",
+            "    numpy:  1.7.1-py33_p0 [mkl]",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+                get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
+            ]
+        }
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following NEW packages will be INSTALLED:",
-                "",
-                "    cython: 0.19-py33_0  ",
-                "    numpy:  1.7.1-py33_p0 [mkl]",
-                "",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be REMOVED:",
+            "",
+            "    cython: 0.19-py33_0  ",
+            "    numpy:  1.7.1-py33_p0 [mkl]",
+            "",
+            "",
         )
+    )
 
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                    get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
-                ]
-            }
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+            ],
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.0=py33_p0"),
+            ],
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    numpy: 1.7.1-py33_p0 [mkl] --> 1.7.0-py33_p0 [mkl]",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+            ],
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.0=py33_p0"),
+            ],
+        }
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be REMOVED:",
-                "",
-                "    cython: 0.19-py33_0  ",
-                "    numpy:  1.7.1-py33_p0 [mkl]",
-                "",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    numpy: 1.7.0-py33_p0 [mkl] --> 1.7.1-py33_p0 [mkl]",
+            "",
+            "",
         )
+    )
 
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                ],
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.0=py33_p0"),
-                ],
-            }
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+            ],
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
+            ],
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    # NB: Packages whose version do not changed are put in UPDATED
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    numpy: 1.7.1-py33_0 --> 1.7.1-py33_p0 [mkl]",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+            ],
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
+            ],
+        }
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    numpy: 1.7.1-py33_p0 [mkl] --> 1.7.0-py33_p0 [mkl]",
-                "",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    numpy: 1.7.1-py33_p0 [mkl] --> 1.7.1-py33_0",
+            "",
+            "",
         )
+    )
 
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                ],
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.0=py33_p0"),
-                ],
-            }
+    monkeypatch.setenv("CONDA_SHOW_CHANNEL_URLS", "True")
+    reset_context()
+    assert context.show_channel_urls
+
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+                get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
+            ]
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following NEW packages will be INSTALLED:",
+            "",
+            "    cython: 0.19-py33_0   channel-1",
+            "    numpy:  1.7.1-py33_p0 channel-1 [mkl]",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+                get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
+            ]
+        }
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    numpy: 1.7.0-py33_p0 [mkl] --> 1.7.1-py33_p0 [mkl]",
-                "",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be REMOVED:",
+            "",
+            "    cython: 0.19-py33_0   channel-1",
+            "    numpy:  1.7.1-py33_p0 channel-1 [mkl]",
+            "",
+            "",
         )
+    )
 
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                ],
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
-                ],
-            }
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+            ],
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.0=py33_p0"),
+            ],
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be DOWNGRADED:",
+            "",
+            "    numpy: 1.7.1-py33_p0 channel-1 [mkl] --> 1.7.0-py33_p0 channel-1 [mkl]",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+            ],
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.0=py33_p0"),
+            ],
+        }
+    )
 
-        # NB: Packages whose version do not changed are put in UPDATED
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    numpy: 1.7.1-py33_0 --> 1.7.1-py33_p0 [mkl]",
-                "",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    numpy: 1.7.0-py33_p0 channel-1 [mkl] --> 1.7.1-py33_p0 channel-1 [mkl]",
+            "",
+            "",
         )
+    )
 
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                ],
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
-                ],
-            }
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+            ],
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
+            ],
+        }
+    )
+
+    with captured() as c:
+        display_actions(actions, index)
+
+    # NB: Packages whose version do not changed are put in UPDATED
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    numpy: 1.7.1-py33_0 channel-1 --> 1.7.1-py33_p0 channel-1 [mkl]",
+            "",
+            "",
         )
+    )
 
-        with captured() as c:
-            display_actions(actions, index)
+    actions = defaultdict(list)
+    actions.update(
+        {
+            "UNLINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
+            ],
+            "LINK": [
+                get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
+            ],
+        }
+    )
 
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    numpy: 1.7.1-py33_p0 [mkl] --> 1.7.1-py33_0",
-                "",
-                "",
-            )
+    with captured() as c:
+        display_actions(actions, index)
+
+    assert c.stdout == "\n".join(
+        (
+            "",
+            "## Package Plan ##",
+            "",
+            "",
+            "The following packages will be UPDATED:",
+            "",
+            "    numpy: 1.7.1-py33_p0 channel-1 [mkl] --> 1.7.1-py33_0 channel-1",
+            "",
+            "",
         )
-    with env_var(
-        "CONDA_SHOW_CHANNEL_URLS", "True", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                    get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
-                ]
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following NEW packages will be INSTALLED:",
-                "",
-                "    cython: 0.19-py33_0   channel-1",
-                "    numpy:  1.7.1-py33_p0 channel-1 [mkl]",
-                "",
-                "",
-            )
-        )
-
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                    get_matchspec_from_index(index, "channel-1::cython==0.19=py33_0"),
-                ]
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be REMOVED:",
-                "",
-                "    cython: 0.19-py33_0   channel-1",
-                "    numpy:  1.7.1-py33_p0 channel-1 [mkl]",
-                "",
-                "",
-            )
-        )
-
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                ],
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.0=py33_p0"),
-                ],
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be DOWNGRADED:",
-                "",
-                "    numpy: 1.7.1-py33_p0 channel-1 [mkl] --> 1.7.0-py33_p0 channel-1 [mkl]",
-                "",
-                "",
-            )
-        )
-
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                ],
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.0=py33_p0"),
-                ],
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    numpy: 1.7.0-py33_p0 channel-1 [mkl] --> 1.7.1-py33_p0 channel-1 [mkl]",
-                "",
-                "",
-            )
-        )
-
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                ],
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
-                ],
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        # NB: Packages whose version do not changed are put in UPDATED
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    numpy: 1.7.1-py33_0 channel-1 --> 1.7.1-py33_p0 channel-1 [mkl]",
-                "",
-                "",
-            )
-        )
-
-        actions = defaultdict(list)
-        actions.update(
-            {
-                "UNLINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_p0"),
-                ],
-                "LINK": [
-                    get_matchspec_from_index(index, "channel-1::numpy==1.7.1=py33_0"),
-                ],
-            }
-        )
-
-        with captured() as c:
-            display_actions(actions, index)
-
-        assert c.stdout == "\n".join(
-            (
-                "",
-                "## Package Plan ##",
-                "",
-                "",
-                "The following packages will be UPDATED:",
-                "",
-                "    numpy: 1.7.1-py33_p0 channel-1 [mkl] --> 1.7.1-py33_0 channel-1",
-                "",
-                "",
-            )
-        )
+    )
 
 
 def test_update_old_plan():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Replace `env_var` usage in `tests/test_plan.py` with `monkeypatch.setenv`.

The largest change is very superficial, changing unindented multiline strings into `"\n".join(...)` multiline strings instead for better code indentation.

Xref #14095

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
