### PR TITLE
`test_exceptions.py`: Replace `env_var` with `monkeypatch.setenv`

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -672,19 +672,23 @@ def test_print_unexpected_error_message_upload_username_with_unicode(
 
 @patch("requests.post", return_value=None)
 @patch("builtins.input", return_value="n")
-def test_print_unexpected_error_message_opt_out_1(input_mock, post_mock):
-    with env_var(
-        "CONDA_REPORT_ERRORS", "false", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        AssertionError()
-        with captured() as c:
-            ExceptionHandler()(_raise_helper, AssertionError())
+def test_print_unexpected_error_message_opt_out_1(
+    input_mock,
+    post_mock,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONDA_REPORT_ERRORS", "false")
+    reset_context()
+    assert not context.report_errors
 
-        assert input_mock.call_count == 0
-        assert post_mock.call_count == 0
-        assert c.stdout == ""
-        print(c.stderr, file=sys.stderr)
-        assert "conda version" in c.stderr
+    with captured() as c:
+        ExceptionHandler()(_raise_helper, AssertionError())
+
+    assert input_mock.call_count == 0
+    assert post_mock.call_count == 0
+    assert c.stdout == ""
+    print(c.stderr, file=sys.stderr)
+    assert "conda version" in c.stderr
 
 
 @patch("requests.post", return_value=None)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -138,17 +138,17 @@ def test_KnownPackageClobberError(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_UnknownPackageClobberError():
+def test_UnknownPackageClobberError(monkeypatch: MonkeyPatch) -> None:
     target_path = "siebel/center/for/c.s"
     colliding_dist_being_linked = "Groot"
     exc = UnknownPackageClobberError(target_path, colliding_dist_being_linked, context)
-    with env_var(
-        "CONDA_PATH_CONFLICT",
-        "prevent",
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+
+    monkeypatch.setenv("CONDA_PATH_CONFLICT", "prevent")
+    reset_context()
+    assert context.path_conflict == PathConflict.prevent
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
     assert (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -650,19 +650,24 @@ def test_print_unexpected_error_message_upload_username_with_spaces(
     ),
 )
 @patch("getpass.getuser", return_value="my√nameΩ")
-def test_print_unexpected_error_message_upload_username_with_unicode(pwuid, post_mock):
-    with env_var(
-        "CONDA_REPORT_ERRORS", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        with captured() as c:
-            ExceptionHandler()(_raise_helper, AssertionError())
+def test_print_unexpected_error_message_upload_username_with_unicode(
+    pwuid,
+    post_mock,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONDA_REPORT_ERRORS", "true")
+    reset_context()
+    assert context.report_errors
 
-        error_data = json.loads(post_mock.call_args[1].get("data"))
-        assert error_data.get("has_spaces") is False
-        assert error_data.get("is_ascii") is False
-        assert post_mock.call_count == 2
-        assert c.stdout == ""
-        assert "conda version" in c.stderr
+    with captured() as c:
+        ExceptionHandler()(_raise_helper, AssertionError())
+
+    error_data = json.loads(post_mock.call_args[1].get("data"))
+    assert error_data.get("has_spaces") is False
+    assert error_data.get("is_ascii") is False
+    assert post_mock.call_count == 2
+    assert c.stdout == ""
+    assert "conda version" in c.stderr
 
 
 @patch("requests.post", return_value=None)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -419,13 +419,16 @@ def test_CondaHTTPError(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_CommandNotFoundError_simple():
+def test_CommandNotFoundError_simple(monkeypatch: MonkeyPatch) -> None:
     cmd = "instate"
     exc = CommandNotFoundError(cmd)
 
-    with env_var("CONDA_JSON", "yes", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+    monkeypatch.setenv("CONDA_JSON", "yes")
+    reset_context()
+    assert context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     json_obj = json.loads(c.stdout)
     assert not c.stderr
@@ -435,9 +438,12 @@ def test_CommandNotFoundError_simple():
     assert json_obj["message"] == str(exc)
     assert json_obj["error"] == repr(exc)
 
-    with env_var("CONDA_JSON", "no", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+    monkeypatch.setenv("CONDA_JSON", "no")
+    reset_context()
+    assert not context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
     assert c.stderr.strip() == (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -43,14 +43,18 @@ def username_not_in_post_mock(post_mock, username):
     return True
 
 
-def test_TooManyArgumentsError():
+def test_TooManyArgumentsError(monkeypatch: MonkeyPatch) -> None:
     expected = 2
     received = 5
     offending_arguments = "groot"
     exc = TooManyArgumentsError(expected, received, offending_arguments)
-    with env_var("CONDA_JSON", "yes", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+
+    monkeypatch.setenv("CONDA_JSON", "yes")
+    reset_context()
+    assert context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     json_obj = json.loads(c.stdout)
     assert not c.stderr
@@ -64,9 +68,12 @@ def test_TooManyArgumentsError():
     assert json_obj["received"] == 5
     assert json_obj["offending_arguments"] == "groot"
 
-    with env_var("CONDA_JSON", "no", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+    monkeypatch.setenv("CONDA_JSON", "no")
+    reset_context()
+    assert not context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
     assert (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -108,20 +108,20 @@ def test_BasicClobberError(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_KnownPackageClobberError():
+def test_KnownPackageClobberError(monkeypatch: MonkeyPatch) -> None:
     target_path = "some/where/on/goodwin.ave"
     colliding_dist_being_linked = "Groot"
     colliding_linked_dist = "Liquid"
     exc = KnownPackageClobberError(
         target_path, colliding_dist_being_linked, colliding_linked_dist, context
     )
-    with env_var(
-        "CONDA_PATH_CONFLICT",
-        "prevent",
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+
+    monkeypatch.setenv("CONDA_PATH_CONFLICT", "prevent")
+    reset_context()
+    assert context.path_conflict == PathConflict.prevent
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
     assert (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -452,13 +452,16 @@ def test_CommandNotFoundError_simple(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_CommandNotFoundError_conda_build():
+def test_CommandNotFoundError_conda_build(monkeypatch: MonkeyPatch) -> None:
     cmd = "build"
     exc = CommandNotFoundError(cmd)
 
-    with env_var("CONDA_JSON", "yes", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+    monkeypatch.setenv("CONDA_JSON", "yes")
+    reset_context()
+    assert context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     json_obj = json.loads(c.stdout)
     assert not c.stderr
@@ -468,9 +471,12 @@ def test_CommandNotFoundError_conda_build():
     assert json_obj["message"] == str(exc)
     assert json_obj["error"] == repr(exc)
 
-    with env_var("CONDA_JSON", "no", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+    monkeypatch.setenv("CONDA_JSON", "no")
+    reset_context()
+    assert not context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
     assert c.stderr.strip() == (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -190,12 +190,16 @@ def test_SharedLinkPathClobberError(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_CondaFileNotFoundError():
+def test_CondaFileNotFoundError(monkeypatch: MonkeyPatch) -> None:
     filename = "Groot"
     exc = PathNotFoundError(filename)
-    with env_var("CONDA_JSON", "yes", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+
+    monkeypatch.setenv("CONDA_JSON", "yes")
+    reset_context()
+    assert context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     json_obj = json.loads(c.stdout)
     assert not c.stderr
@@ -204,9 +208,12 @@ def test_CondaFileNotFoundError():
     assert json_obj["message"] == str(exc)
     assert json_obj["error"] == repr(exc)
 
-    with env_var("CONDA_JSON", "no", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+    monkeypatch.setenv("CONDA_JSON", "no")
+    reset_context()
+    assert not context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
     assert c.stderr.strip() == "PathNotFoundError: Groot"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -165,17 +165,17 @@ def test_UnknownPackageClobberError(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_SharedLinkPathClobberError():
+def test_SharedLinkPathClobberError(monkeypatch: MonkeyPatch) -> None:
     target_path = "some/where/in/shampoo/banana"
     incompatible_package_dists = "Groot"
     exc = SharedLinkPathClobberError(target_path, incompatible_package_dists, context)
-    with env_var(
-        "CONDA_PATH_CONFLICT",
-        "prevent",
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+
+    monkeypatch.setenv("CONDA_PATH_CONFLICT", "prevent")
+    reset_context()
+    assert context.path_conflict == PathConflict.prevent
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
     assert (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -219,12 +219,16 @@ def test_CondaFileNotFoundError(monkeypatch: MonkeyPatch) -> None:
     assert c.stderr.strip() == "PathNotFoundError: Groot"
 
 
-def test_DirectoryNotFoundError():
+def test_DirectoryNotFoundError(monkeypatch: MonkeyPatch) -> None:
     directory = "Groot"
     exc = DirectoryNotFoundError(directory)
-    with env_var("CONDA_JSON", "yes", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+
+    monkeypatch.setenv("CONDA_JSON", "yes")
+    reset_context()
+    assert context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     json_obj = json.loads(c.stdout)
     assert not c.stderr
@@ -237,9 +241,12 @@ def test_DirectoryNotFoundError():
     assert json_obj["error"] == repr(exc)
     assert json_obj["path"] == "Groot"
 
-    with env_var("CONDA_JSON", "no", stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        with captured() as c:
-            conda_exception_handler(_raise_helper, exc)
+    monkeypatch.setenv("CONDA_JSON", "no")
+    reset_context()
+    assert not context.json
+
+    with captured() as c:
+        conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
     assert c.stderr.strip() == "DirectoryNotFoundError: Groot"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -10,7 +10,6 @@ from pytest import CaptureFixture, MonkeyPatch
 from pytest_mock import MockerFixture
 
 from conda.auxlib.collection import AttrDict
-from conda.auxlib.ish import dals
 from conda.base.constants import PathConflict
 from conda.base.context import context, reset_context
 from conda.common.io import captured
@@ -78,9 +77,13 @@ def test_TooManyArgumentsError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        c.stderr.strip()
-        == "TooManyArgumentsError:  Got 5 arguments (g, r, o, o, t) but expected 2."
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "TooManyArgumentsError:  Got 5 arguments (g, r, o, o, t) but expected 2.",
+            "",
+            "",
+        )
     )
 
 
@@ -97,15 +100,17 @@ def test_BasicClobberError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        c.stderr.strip()
-        == dals(
-            """
-    ClobberError: Conda was asked to clobber an existing path.
-      source path: some/path/on/goodwin.ave
-      target path: some/path/to/wright.st
-    """
-        ).strip()
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "ClobberError: Conda was asked to clobber an existing path.",
+            "  source path: some/path/on/goodwin.ave",
+            "  target path: some/path/to/wright.st",
+            "",
+            "",
+            "",
+            "",
+        )
     )
 
 
@@ -125,17 +130,19 @@ def test_KnownPackageClobberError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        c.stderr.strip()
-        == dals(
-            """
-    ClobberError: The package 'Groot' cannot be installed due to a
-    path collision for 'some/where/on/goodwin.ave'.
-    This path already exists in the target prefix, and it won't be removed by
-    an uninstall action in this transaction. The path appears to be coming from
-    the package 'Liquid', which is already installed in the prefix.
-    """
-        ).strip()
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "ClobberError: The package 'Groot' cannot be installed due to a",
+            "path collision for 'some/where/on/goodwin.ave'.",
+            "This path already exists in the target prefix, and it won't be removed by",
+            "an uninstall action in this transaction. The path appears to be coming from",
+            "the package 'Liquid', which is already installed in the prefix.",
+            "",
+            "",
+            "",
+            "",
+        )
     )
 
 
@@ -152,17 +159,19 @@ def test_UnknownPackageClobberError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        c.stderr.strip()
-        == dals(
-            """
-    ClobberError: The package 'Groot' cannot be installed due to a
-    path collision for 'siebel/center/for/c.s'.
-    This path already exists in the target prefix, and it won't be removed
-    by an uninstall action in this transaction. The path is one that conda
-    doesn't recognize. It may have been created by another package manager.
-    """
-        ).strip()
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "ClobberError: The package 'Groot' cannot be installed due to a",
+            "path collision for 'siebel/center/for/c.s'.",
+            "This path already exists in the target prefix, and it won't be removed",
+            "by an uninstall action in this transaction. The path is one that conda",
+            "doesn't recognize. It may have been created by another package manager.",
+            "",
+            "",
+            "",
+            "",
+        )
     )
 
 
@@ -179,15 +188,17 @@ def test_SharedLinkPathClobberError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        c.stderr.strip()
-        == dals(
-            """
-    ClobberError: This transaction has incompatible packages due to a shared path.
-      packages: G, r, o, o, t
-      path: 'some/where/in/shampoo/banana'
-    """
-        ).strip()
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "ClobberError: This transaction has incompatible packages due to a shared path.",
+            "  packages: G, r, o, o, t",
+            "  path: 'some/where/in/shampoo/banana'",
+            "",
+            "",
+            "",
+            "",
+        )
     )
 
 
@@ -217,7 +228,7 @@ def test_CondaFileNotFoundError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert c.stderr.strip() == "PathNotFoundError: Groot"
+    assert c.stderr == "\n".join(("", "PathNotFoundError: Groot", "", ""))
 
 
 def test_DirectoryNotFoundError(monkeypatch: MonkeyPatch) -> None:
@@ -250,7 +261,7 @@ def test_DirectoryNotFoundError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert c.stderr.strip() == "DirectoryNotFoundError: Groot"
+    assert c.stderr == "\n".join(("", "DirectoryNotFoundError: Groot", "", ""))
 
 
 def test_MD5MismatchError(monkeypatch: MonkeyPatch) -> None:
@@ -290,17 +301,18 @@ def test_MD5MismatchError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        c.stderr.strip()
-        == dals(
-            """
-    ChecksumMismatchError: Conda detected a mismatch between the expected content and downloaded content
-    for url 'https://download.url/path/to/file.tar.bz2'.
-      download saved to: /some/path/on/disk/another-name.tar.bz2
-      expected md5: abc123
-      actual md5: deadbeef
-    """
-        ).strip()
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "ChecksumMismatchError: Conda detected a mismatch between the expected content and downloaded content",
+            "for url 'https://download.url/path/to/file.tar.bz2'.",
+            "  download saved to: /some/path/on/disk/another-name.tar.bz2",
+            "  expected md5: abc123",
+            "  actual md5: deadbeef",
+            "",
+            "",
+            "",
+        )
     )
 
 
@@ -331,14 +343,15 @@ def test_PackageNotFoundError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        c.stderr.strip()
-        == dals(
-            """
-    PackagesNotFoundError: The following packages are missing from the target environment:
-      - Potato
-    """
-        ).strip()
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "PackagesNotFoundError: The following packages are missing from the target environment:",
+            "  - Potato",
+            "",
+            "",
+            "",
+        )
     )
 
 
@@ -370,7 +383,9 @@ def test_CondaKeyError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert c.stderr.strip() == "CondaKeyError: 'Potato': Potato is not a key."
+    assert c.stderr == "\n".join(
+        ("", "CondaKeyError: 'Potato': Potato is not a key.", "", "")
+    )
 
 
 def test_CondaHTTPError(monkeypatch: MonkeyPatch) -> None:
@@ -407,16 +422,16 @@ def test_CondaHTTPError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        dals(
-            """
-            CondaHTTPError: HTTP Potato COULD NOT CONNECT for url <https://download.url/path/to/Potato.tar.gz>
-            Elapsed: 1.24
-
-            Potato
-            """
-        ).strip()
-        in c.stderr.strip()
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "CondaHTTPError: HTTP Potato COULD NOT CONNECT for url <https://download.url/path/to/Potato.tar.gz>",
+            "Elapsed: 1.24",
+            "",
+            "Potato",
+            "",
+            "",
+        )
     )
 
 
@@ -447,9 +462,14 @@ def test_CommandNotFoundError_simple(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert c.stderr.strip() == (
-        "CommandNotFoundError: No command 'conda instate'.\n"
-        "Did you mean 'conda install'?"
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "CommandNotFoundError: No command 'conda instate'.",
+            "Did you mean 'conda install'?",
+            "",
+            "",
+        )
     )
 
 
@@ -480,8 +500,13 @@ def test_CommandNotFoundError_conda_build(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert c.stderr.strip() == (
-        "CommandNotFoundError: To use 'conda build', install conda-build."
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "CommandNotFoundError: To use 'conda build', install conda-build.",
+            "",
+            "",
+        )
     )
 
 
@@ -745,18 +770,19 @@ def test_BinaryPrefixReplacementError(monkeypatch: MonkeyPatch) -> None:
         conda_exception_handler(_raise_helper, exc)
 
     assert not c.stdout
-    assert (
-        c.stderr.strip()
-        == dals(
-            """
-    BinaryPrefixReplacementError: Refusing to replace mismatched data length in binary file.
-      path: some/where/by/boneyard/creek
-      placeholder: save/my/spot/in/374
-      new prefix: some/where/on/goodwin.ave
-      original data Length: 1404
-      new data length: 1104
-    """
-        ).strip()
+    assert c.stderr == "\n".join(
+        (
+            "",
+            "BinaryPrefixReplacementError: Refusing to replace mismatched data length in binary file.",
+            "  path: some/where/by/boneyard/creek",
+            "  placeholder: save/my/spot/in/374",
+            "  new prefix: some/where/on/goodwin.ave",
+            "  original data Length: 1404",
+            "  new data length: 1104",
+            "",
+            "",
+            "",
+        )
     )
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -618,19 +618,24 @@ def test_print_unexpected_error_message_upload_3(
     ),
 )
 @patch("getpass.getuser", return_value="some name")
-def test_print_unexpected_error_message_upload_username_with_spaces(pwuid, post_mock):
-    with env_var(
-        "CONDA_REPORT_ERRORS", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        with captured() as c:
-            ExceptionHandler()(_raise_helper, AssertionError())
+def test_print_unexpected_error_message_upload_username_with_spaces(
+    pwuid,
+    post_mock,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONDA_REPORT_ERRORS", "true")
+    reset_context()
+    assert context.report_errors
 
-        error_data = json.loads(post_mock.call_args[1].get("data"))
-        assert error_data.get("has_spaces") is True
-        assert error_data.get("is_ascii") is True
-        assert post_mock.call_count == 2
-        assert c.stdout == ""
-        assert "conda version" in c.stderr
+    with captured() as c:
+        ExceptionHandler()(_raise_helper, AssertionError())
+
+    error_data = json.loads(post_mock.call_args[1].get("data"))
+    assert error_data.get("has_spaces") is True
+    assert error_data.get("is_ascii") is True
+    assert post_mock.call_count == 2
+    assert c.stdout == ""
+    assert "conda version" in c.stderr
 
 
 @patch(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Replace `env_var` usage in `tests/test_exceptions.py` with `monkeypatch.setenv`.

The largest change is very superficial, changing unindented multiline strings into `"\n".join(...)` multiline strings instead for better code indentation.

Xref #14095


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
