### PR TITLE
Adapt for logging lock internal changes in Python 3.13

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -269,11 +269,16 @@ def argv(args_list):
 
 @contextmanager
 def _logger_lock():
-    logging._acquireLock()
+    try:
+        # Python 3.13+
+        acquire, release = logging._prepareFork, logging._afterFork
+    except AttributeError:
+        acquire, release = logging._acquireLock, logging._releaseLock
+    acquire()
     try:
         yield
     finally:
-        logging._releaseLock()
+        release()
 
 
 @contextmanager


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

In Fedora Rawhide (the development version), the system Python is now 3.13.0rc1. We are therefore testing conda (and everything else) on Python 3.13 regardless of whether “official” support is ready or not.

This PR fixes errors like:

```
+ conda info
Traceback (most recent call last):
  […]
  File "/builddir/build/BUILD/conda-24.7.1-build/BUILDROOT/usr/lib/python3.13/site-packages/conda/common/io.py", line 272, in _logger_lock
    logging._acquireLock()
    ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'logging' has no attribute '_acquireLock'
```

Currently in Python 3.13, the `logging` functions `_prepareFork` and `_afterFork` correspond closely to the old `_acquireLock` and `_releaseLock`, which have been removed.

As long as conda is already using non-public APIs, it’s easiest to just call *those* on Python 3.13. That approach could perhaps break in the future if these functions start doing something other than acquire/release a module lock, but copying their contents could *also* break if the internal locking semantics change in a future Python, so :shrug:.

(See also https://github.com/celery/billiard/pull/404.)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes? **I didn’t consider this “significant” enough for an entry, but let me know if I need to add one.**
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests? **Covered by existing tests, when executed on Python 3.13**
- [x] Add / update outdated documentation? **Nothing to do.**

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
