### PR TITLE
Add `platformdirs` to host section in recipe to fix canary builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     # for `conda init` in build/script above
     - boltons >=23.0.0
     - menuinst >=2
+    - platformdirs >=3.10.0
     - requests >=2.28.0,<3
     - ruamel.yaml >=0.11.14,<0.19
     - tqdm >=4


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Follow-up to #14077 (af37e285909afe068cdad7e9c8481d915e9d5a19) which removed the `appdirs` dependency, which now triggers an import error that prevents canary builds from successfully building. See https://github.com/conda/conda/actions/runs/10298401199/job/28503483287 for more details.

Refs #14077.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
