### PR TITLE
Deprecate unused compat functions

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -867,6 +867,7 @@ def expand(path):
     return abspath(expanduser(expandvars(path)))
 
 
+@deprecated("25.3", "25.9", addendum="Use `conda.common.compat.ensure_binary` instead.")
 def ensure_binary(value):
     try:
         return value.encode("utf-8")

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -877,6 +877,7 @@ def ensure_binary(value):
         return value
 
 
+@deprecated("25.3", "25.9")
 def ensure_fs_path_encoding(value):
     try:
         return value.decode(FILESYSTEM_ENCODING)

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -247,7 +247,7 @@ class ValueEnum(Enum):
         return f"{self.value}"
 
 
-class ChannelPriorityNew(ValueEnum, metaclass=ChannelPriorityMeta):
+class ChannelPriority(ValueEnum, metaclass=ChannelPriorityMeta):
     __name__ = "ChannelPriority"
 
     STRICT = "strict"

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -12,7 +12,7 @@ import struct
 from enum import Enum, EnumMeta
 from os.path import join
 
-from ..common.compat import on_win, six_with_metaclass
+from ..common.compat import on_win
 
 PREFIX_PLACEHOLDER = (
     "/opt/anaconda1anaconda2"
@@ -247,7 +247,7 @@ class ValueEnum(Enum):
         return f"{self.value}"
 
 
-class ChannelPriority(six_with_metaclass(ChannelPriorityMeta, ValueEnum)):
+class ChannelPriorityNew(ValueEnum, metaclass=ChannelPriorityMeta):
     __name__ = "ChannelPriority"
 
     STRICT = "strict"

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -140,6 +140,7 @@ def ensure_unicode(value):
         return value
 
 
+@deprecated("25.3", "25.9")
 def ensure_fs_path_encoding(value):
     try:
         return value.encode(FILESYSTEM_ENCODING)

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -80,6 +80,7 @@ def open(
         )
 
 
+@deprecated("25.3", "25.9", addendum="Use class' `metadata=` keyword argument instead.")
 def six_with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
 

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -86,7 +86,7 @@ def open(
         )
 
 
-@deprecated("25.3", "25.9", addendum="Use class' `metadata=` keyword argument instead.")
+@deprecated("25.3", "25.9", addendum="Use class' `metaclass=` keyword argument instead.")
 def six_with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
 

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -56,6 +56,7 @@ def isiterable(obj):
 from collections import OrderedDict as odict  # noqa: F401
 
 
+@deprecated("25.3", "25.9", addendum="Use builtin `open` instead.")
 def open(
     file, mode="r", buffering=-1, encoding=None, errors=None, newline=None, closefd=True
 ):

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -16,7 +16,12 @@ on_win = bool(sys.platform == "win32")
 on_mac = bool(sys.platform == "darwin")
 on_linux = bool(sys.platform == "linux")
 
-FILESYSTEM_ENCODING = sys.getfilesystemencoding()
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "FILESYSTEM_ENCODING",
+    _FILESYSTEM_ENCODING := sys.getfilesystemencoding(),
+)
 
 # Control some tweakables that will be removed finally.
 ENCODE_ENVIRONMENT = True
@@ -143,7 +148,7 @@ def ensure_unicode(value):
 @deprecated("25.3", "25.9")
 def ensure_fs_path_encoding(value):
     try:
-        return value.encode(FILESYSTEM_ENCODING)
+        return value.encode(_FILESYSTEM_ENCODING)
     except AttributeError:
         return value
     except UnicodeEncodeError:

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -86,7 +86,11 @@ def open(
         )
 
 
-@deprecated("25.3", "25.9", addendum="Use class' `metaclass=` keyword argument instead.")
+@deprecated(
+    "25.3",
+    "25.9",
+    addendum="Use class' `metaclass=` keyword argument instead.",
+)
 def six_with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
 

--- a/conda/common/compat.py
+++ b/conda/common/compat.py
@@ -130,6 +130,7 @@ def ensure_text_type(value) -> str:
         return value
 
 
+@deprecated("25.3", "25.9")
 def ensure_unicode(value):
     try:
         return value.decode("unicode_escape")

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -148,9 +148,6 @@ def env_vars(var_map=None, callback=None, stack_callback=None):
 
 @contextmanager
 def env_var(name, value, callback=None, stack_callback=None):
-    # Maybe, but in env_vars, not here:
-    #    from .compat import ensure_fs_path_encoding
-    #    d = dict({name: ensure_fs_path_encoding(value)})
     d = {name: value}
     with env_vars(d, callback=callback, stack_callback=stack_callback) as es:
         yield es

--- a/news/14144-deprecate-unused-compat
+++ b/news/14144-deprecate-unused-compat
@@ -10,7 +10,7 @@
 
 Mark `conda.activate.ensure_binary` as pending deprecation. Use `conda.common.compat.ensure_binary` instead. (#14144)
 Mark `conda.activate.ensure_fs_path_encoding` as pending deprecation. (#14144)
-Mark `conda.common.compat.six_with_metaclass` as pending deprecation. Use class' `metadata=` keyword argument instead. (#14144)
+Mark `conda.common.compat.six_with_metaclass` as pending deprecation. Use class' `metaclass=` keyword argument instead. (#14144)
 Mark `conda.common.compat.open` as pending deprecation. Use builtin `open` instead. (#14144)
 Mark `conda.common.compat.ensure_unicode` as pending deprecation. (#14144)
 Mark `conda.common.compat.ensure_fs_path_encoding` as pending deprecation. (#14144)

--- a/news/14144-deprecate-unused-compat
+++ b/news/14144-deprecate-unused-compat
@@ -1,0 +1,25 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+Mark `conda.activate.ensure_binary` as pending deprecation. Use `conda.common.compat.ensure_binary` instead. (#14144)
+Mark `conda.activate.ensure_fs_path_encoding` as pending deprecation. (#14144)
+Mark `conda.common.compat.six_with_metaclass` as pending deprecation. Use class' `metadata=` keyword argument instead. (#14144)
+Mark `conda.common.compat.open` as pending deprecation. Use builtin `open` instead. (#14144)
+Mark `conda.common.compat.ensure_unicode` as pending deprecation. (#14144)
+Mark `conda.common.compat.ensure_fs_path_encoding` as pending deprecation. (#14144)
+Mark `conda.common.compat.FILESYSTEM_ENCODING` as pending deprecation. (#14144)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/common/test_compat.py
+++ b/tests/common/test_compat.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+
+from conda.common import compat
+
+
+@pytest.mark.parametrize(
+    "function,raises",
+    [
+        ("FILESYSTEM_ENCODING", TypeError),
+        ("open", TypeError),
+        ("six_with_metaclass", TypeError),
+        ("ensure_unicode", TypeError),
+        ("ensure_fs_path_encoding", TypeError),
+    ],
+)
+def test_deprecations(function: str, raises: type[Exception] | None) -> None:
+    raises_context = pytest.raises(raises) if raises else nullcontext()
+    with pytest.deprecated_call(), raises_context:
+        getattr(compat, function)()

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -3512,6 +3512,8 @@ def test_metavars_force_uppercase(
     "function,raises",
     [
         ("path_identity", TypeError),
+        ("ensure_binary", TypeError),
+        ("ensure_fs_path_encoding", TypeError),
     ],
 )
 def test_deprecations(function: str, raises: type[Exception] | None) -> None:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Deprecates:
- Deprecate `conda.activate.ensure_binary`
- Deprecate `conda.activate.ensure_fs_path_encoding`
- Deprecate `conda.common.compat.six_with_metaclass`
- Deprecate `conda.common.compat.open`
- Deprecate `conda.common.compat.ensure_unicode`
- Deprecate `conda.common.compat.ensure_fs_path_encoding`
- Deprecate `conda.common.compat.FILESYSTEM_ENCODING`

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
