### PR TITLE
Windows 10+ relevance

### DIFF
--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -101,9 +101,8 @@ Conda looks in the following locations for a ``.condarc`` file:
 
   if on_win:
       SEARCH_PATH = (
-          "C:/ProgramData/conda/.condarc",
-          "C:/ProgramData/conda/condarc",
-          "C:/ProgramData/conda/condarc.d",
+          "C:/Users/<your_info>/.condarc",
+          "C:/Users/<your_info/AppData/Local/<name_of_Anaconda_distribution>/.condarc",
       )
   else:
       SEARCH_PATH = (


### PR DESCRIPTION
Windows 10+ operating systems no longer have a "ProgramData" folder on the C:\ drive, so that is an obsolete reference. Also, miniconda (the free distribution of Anaconda, no license fees required and thus the most popular moving forward indefinitely) always installs for the local user in the "AppData/Local" subfolder of the user's profile.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
