### PR TITLE
`test_context`: Replace `env_var`/`env_vars` with `monkeypatch.setenv`

### DIFF
--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -259,16 +259,15 @@ def test_custom_multichannels(testdata: None):
     )
 
 
-def test_restore_free_channel(testdata: None):
-    assert "https://repo.anaconda.com/pkgs/free" not in context.default_channels
-    with env_var(
-        "CONDA_RESTORE_FREE_CHANNEL",
-        "true",
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        assert (
-            context.default_channels.index("https://repo.anaconda.com/pkgs/free") == 1
-        )
+def test_restore_free_channel(monkeypatch: MonkeyPatch) -> None:
+    free_channel = "https://repo.anaconda.com/pkgs/free"
+    assert free_channel not in context.default_channels
+
+    monkeypatch.setenv("CONDA_RESTORE_FREE_CHANNEL", "true")
+    reset_context()
+    assert context.restore_free_channel
+
+    assert context.default_channels[1] == free_channel
 
 
 def test_proxy_servers(testdata: None):

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -21,14 +21,12 @@ from conda.base.constants import (
     PathConflict,
 )
 from conda.base.context import (
-    conda_tests_ctxt_mgmt_def_pol,
     context,
     get_plugin_config_data,
     reset_context,
     validate_prefix_name,
 )
 from conda.common.configuration import Configuration, ValidationError, YamlRawParameter
-from conda.common.io import env_var
 from conda.common.path import expand, win_path_backout
 from conda.common.serialize import yaml_round_trip_load
 from conda.common.url import join_url, path_to_url
@@ -604,16 +602,13 @@ def test_channel_settings(testdata: None):
     )
 
 
-def test_subdirs():
+def test_subdirs(monkeypatch: MonkeyPatch) -> None:
     assert context.subdirs == (context.subdir, "noarch")
 
     subdirs = ("linux-highest", "linux-64", "noarch")
-    with env_var(
-        "CONDA_SUBDIRS",
-        ",".join(subdirs),
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        assert context.subdirs == subdirs
+    monkeypatch.setenv("CONDA_SUBDIRS", ",".join(subdirs))
+    reset_context()
+    assert context.subdirs == subdirs
 
 
 def test_local_build_root_default_rc():

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -28,7 +28,7 @@ from conda.base.context import (
     validate_prefix_name,
 )
 from conda.common.configuration import Configuration, ValidationError, YamlRawParameter
-from conda.common.io import env_var, env_vars
+from conda.common.io import env_var
 from conda.common.path import expand, win_path_backout
 from conda.common.serialize import yaml_round_trip_load
 from conda.common.url import join_url, path_to_url
@@ -386,49 +386,49 @@ def test_channel_priority(testdata: None):
     assert context.channel_priority == ChannelPriority.DISABLED
 
 
-def test_threads(testdata: None):
+def test_threads(monkeypatch: MonkeyPatch) -> None:
     default_value = None
     assert context.default_threads == default_value
     assert context.repodata_threads == default_value
     assert context.verify_threads == 1
     assert context.execute_threads == 1
 
-    with env_var(
-        "CONDA_DEFAULT_THREADS", "3", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
+    with monkeypatch.context() as m:
+        m.setenv("CONDA_DEFAULT_THREADS", "3")
+        reset_context()
         assert context.default_threads == 3
         assert context.verify_threads == 3
         assert context.repodata_threads == 3
         assert context.execute_threads == 3
 
-    with env_var(
-        "CONDA_VERIFY_THREADS", "3", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
+    with monkeypatch.context() as m:
+        m.setenv("CONDA_VERIFY_THREADS", "3")
+        reset_context()
         assert context.default_threads == default_value
         assert context.verify_threads == 3
         assert context.repodata_threads == default_value
         assert context.execute_threads == 1
 
-    with env_var(
-        "CONDA_REPODATA_THREADS", "3", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
+    with monkeypatch.context() as m:
+        m.setenv("CONDA_REPODATA_THREADS", "3")
+        reset_context()
         assert context.default_threads == default_value
         assert context.verify_threads == 1
         assert context.repodata_threads == 3
         assert context.execute_threads == 1
 
-    with env_var(
-        "CONDA_EXECUTE_THREADS", "3", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
+    with monkeypatch.context() as m:
+        m.setenv("CONDA_EXECUTE_THREADS", "3")
+        reset_context()
         assert context.default_threads == default_value
         assert context.verify_threads == 1
         assert context.repodata_threads == default_value
         assert context.execute_threads == 3
 
-    with env_vars(
-        {"CONDA_EXECUTE_THREADS": "3", "CONDA_DEFAULT_THREADS": "1"},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
+    with monkeypatch.context() as m:
+        m.setenv("CONDA_EXECUTE_THREADS", "3")
+        m.setenv("CONDA_DEFAULT_THREADS", "1")
+        reset_context()
         assert context.default_threads == 1
         assert context.verify_threads == 1
         assert context.repodata_threads == 1

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -283,13 +283,11 @@ def test_conda_build_root_dir(testdata: None):
     assert context.conda_build["root-dir"] == "/some/test/path"
 
 
-def test_clobber_enum(testdata: None):
-    with env_var(
-        "CONDA_PATH_CONFLICT",
-        "prevent",
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        assert context.path_conflict == PathConflict.prevent
+@pytest.mark.parametrize("path_conflict", PathConflict.__members__)
+def test_clobber_enum(monkeypatch: MonkeyPatch, path_conflict: str) -> None:
+    monkeypatch.setenv("CONDA_PATH_CONFLICT", path_conflict)
+    reset_context()
+    assert context.path_conflict == PathConflict(path_conflict)
 
 
 def test_context_parameter_map(testdata: None):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Replace `env_var` usage in `tests/base/test_context.py with `monkeypatch.setenv`.

Xref https://github.com/conda/conda/issues/14095

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
