### PR TITLE
Handle 'null' for noarch values

### DIFF
--- a/conda/models/enums.py
+++ b/conda/models/enums.py
@@ -161,7 +161,7 @@ class NoarchType(Enum):
                 val = NoarchType.generic
             else:
                 try:
-                    val = NoarchType.generic if boolify(val) else None
+                    val = NoarchType.generic if boolify(val, nullable=True) else None
                 except TypeCoercionError:
                     raise CondaUpgradeError(
                         dals(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

We recently had an artifactory issue where it was deserialising empty noarch on meta.yaml for some of our internally built packages to `noarch: null` on repodata.json and this broke the entire conda workflows that are using our internal channels with the below error.

While we are getting artifactory to fix the repodata, I figured that NoarchType enum handle null values too like in this PR.

If the earlier usage is intentional and a hard check not to handle null values on NoarchType, feel free to close this PR.

```
Traceback (most recent call last):
  File "/<>/conda/conda/models/enums.py", line 164, in coerce
    val = NoarchType.generic if boolify(val) else None
  File "/<>/conda/conda/auxlib/type_coercion.py", line 170, in boolify
    raise TypeCoercionError(value, "The value %r cannot be boolified." % value)
conda.auxlib.type_coercion.TypeCoercionError: The value 'null' cannot be boolified.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/<>/conda/conda/models/enums.py", line 166, in coerce
    raise CondaUpgradeError(
conda.exceptions.CondaUpgradeError: The noarch type for this package is set to 'null'.
The current version of conda is too old to install this package.
Please update conda.
```

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
