### PR TITLE
Transition to new conda-maintainers team.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Syntax for this file at https://help.github.com/articles/about-codeowners/
 
-*       @conda/conda-core
+*       @conda/conda-maintainers


### PR DESCRIPTION
### Description

This moves the repo to the new smaller scope "conda-maintainers" team. See #13526 for more details.
