### PR TITLE
Deprecate `get_bin_directory_short_path()` in favor of `BIN_DIRECTORY`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -44,7 +44,7 @@ from ..common.configuration import (
 )
 from ..common.constants import TRACE
 from ..common.iterators import unique
-from ..common.path import expand, paths_equal
+from ..common.path import BIN_DIRECTORY, expand, paths_equal
 from ..common.url import has_scheme, path_to_url, split_scheme_auth_token
 from ..deprecations import deprecated
 from .constants import (
@@ -776,9 +776,8 @@ class Context(Configuration):
         addendum="Please use `conda.base.context.context.conda_exe_vars_dict` instead",
     )
     def conda_exe(self):
-        bin_dir = "Scripts" if on_win else "bin"
         exe = "conda.exe" if on_win else "conda"
-        return join(self.conda_prefix, bin_dir, exe)
+        return join(self.conda_prefix, BIN_DIRECTORY, exe)
 
     @property
     def av_data_dir(self):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -811,12 +811,11 @@ class Context(Configuration):
                 "CONDA_PYTHON_EXE": sys.executable,
             }
         else:
-            bin_dir = "Scripts" if on_win else "bin"
             exe = "conda.exe" if on_win else "conda"
             # I was going to use None to indicate a variable to unset, but that gets tricky with
             # error-on-undefined.
             return {
-                "CONDA_EXE": os.path.join(sys.prefix, bin_dir, exe),
+                "CONDA_EXE": os.path.join(sys.prefix, BIN_DIRECTORY, exe),
                 "_CE_M": "",
                 "_CE_CONDA": "",
                 "CONDA_PYTHON_EXE": sys.executable,

--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from .. import CondaError
+from ..deprecations import deprecated
 from .compat import on_win
 
 if TYPE_CHECKING:
@@ -234,8 +235,12 @@ def get_major_minor_version(string, with_dot=True):
     return ".".join(maj_min) if with_dot else "".join(maj_min)
 
 
+BIN_DIRECTORY = "Scripts" if on_win else "bin"
+
+
+@deprecated("25.3", "25.9", addendum="Use `conda.common.path.BIN_DIRECTORY` instead.")
 def get_bin_directory_short_path():
-    return "Scripts" if on_win else "bin"
+    return BIN_DIRECTORY
 
 
 def win_path_ok(path):
@@ -316,8 +321,7 @@ def get_python_noarch_target_path(source_short_path, target_site_packages_short_
         sp_dir = target_site_packages_short_path
         return source_short_path.replace("site-packages", sp_dir, 1)
     elif source_short_path.startswith("python-scripts/"):
-        bin_dir = get_bin_directory_short_path()
-        return source_short_path.replace("python-scripts", bin_dir, 1)
+        return source_short_path.replace("python-scripts", BIN_DIRECTORY, 1)
     else:
         return source_short_path
 

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -1174,12 +1174,11 @@ def install_conda_csh(target_path, conda_prefix):
 
 
 def _config_fish_content(conda_prefix):
+    conda_exe = join(conda_prefix, BIN_DIRECTORY, "conda.exe" if on_win else "conda")
     if on_win:
         from ..activate import native_path_to_unix
 
-        conda_exe = native_path_to_unix(join(conda_prefix, "Scripts", "conda.exe"))
-    else:
-        conda_exe = join(conda_prefix, "bin", "conda")
+        conda_exe = native_path_to_unix(conda_exe)
     conda_initialize_content = dals(
         """
         # >>> conda initialize >>>
@@ -1288,12 +1287,11 @@ def init_fish_user(target_path, conda_prefix, reverse):
 
 
 def _config_xonsh_content(conda_prefix):
+    conda_exe = join(conda_prefix, BIN_DIRECTORY, "conda.exe" if on_win else "conda")
     if on_win:
         from ..activate import native_path_to_unix
 
-        conda_exe = native_path_to_unix(join(conda_prefix, "Scripts", "conda.exe"))
-    else:
-        conda_exe = join(conda_prefix, "bin", "conda")
+        conda_exe = native_path_to_unix(conda_exe)
     conda_initialize_content = dals(
         """
     # >>> conda initialize >>>
@@ -1377,10 +1375,11 @@ def init_xonsh_user(target_path, conda_prefix, reverse):
 
 
 def _bashrc_content(conda_prefix, shell):
+    conda_exe = join(conda_prefix, BIN_DIRECTORY, "conda.exe" if on_win else "conda")
     if on_win:
         from ..activate import native_path_to_unix
 
-        conda_exe = native_path_to_unix(join(conda_prefix, "Scripts", "conda.exe"))
+        conda_exe = native_path_to_unix(conda_exe)
         conda_initialize_content = dals(
             """
         # >>> conda initialize >>>
@@ -1395,7 +1394,6 @@ def _bashrc_content(conda_prefix, shell):
             "shell": shell,
         }
     else:
-        conda_exe = join(conda_prefix, "bin", "conda")
         if shell in ("csh", "tcsh"):
             conda_initialize_content = dals(
                 """
@@ -1707,10 +1705,7 @@ def init_long_path(target_path):
 
 
 def _powershell_profile_content(conda_prefix):
-    if on_win:
-        conda_exe = join(conda_prefix, "Scripts", "conda.exe")
-    else:
-        conda_exe = join(conda_prefix, "bin", "conda")
+    conda_exe = join(conda_prefix, BIN_DIRECTORY, "conda.exe" if on_win else "conda")
 
     conda_powershell_module = dals(
         f"""

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -64,8 +64,8 @@ from ..common.compat import (
     open_utf8,
 )
 from ..common.path import (
+    BIN_DIRECTORY,
     expand,
-    get_bin_directory_short_path,
     get_python_short_path,
     get_python_site_packages_short_path,
     win_path_ok,
@@ -456,9 +456,7 @@ def make_install_plan(conda_prefix):
         {
             "function": install_activate.__name__,
             "kwargs": {
-                "target_path": join(
-                    conda_prefix, get_bin_directory_short_path(), "activate"
-                ),
+                "target_path": join(conda_prefix, BIN_DIRECTORY, "activate"),
                 "conda_prefix": conda_prefix,
             },
         }
@@ -467,9 +465,7 @@ def make_install_plan(conda_prefix):
         {
             "function": install_deactivate.__name__,
             "kwargs": {
-                "target_path": join(
-                    conda_prefix, get_bin_directory_short_path(), "deactivate"
-                ),
+                "target_path": join(conda_prefix, BIN_DIRECTORY, "deactivate"),
                 "conda_prefix": conda_prefix,
             },
         }
@@ -1074,7 +1070,7 @@ def install_deactivate_bat(target_path, conda_prefix):
 
 
 def install_activate(target_path, conda_prefix):
-    # target_path: join(conda_prefix, get_bin_directory_short_path(), 'activate')
+    # target_path: join(conda_prefix, BIN_DIRECTORY, 'activate')
     src_path = join(CONDA_PACKAGE_ROOT, "shell", "bin", "activate")
     file_content = f'#!/bin/sh\n_CONDA_ROOT="{conda_prefix}"\n'
     with open_utf8(src_path) as fsrc:
@@ -1083,7 +1079,7 @@ def install_activate(target_path, conda_prefix):
 
 
 def install_deactivate(target_path, conda_prefix):
-    # target_path: join(conda_prefix, get_bin_directory_short_path(), 'deactivate')
+    # target_path: join(conda_prefix, BIN_DIRECTORY, 'deactivate')
     src_path = join(CONDA_PACKAGE_ROOT, "shell", "bin", "deactivate")
     file_content = f'#!/bin/sh\n_CONDA_ROOT="{conda_prefix}"\n'
     with open_utf8(src_path) as fsrc:

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -32,6 +32,7 @@ from ..common.io import (
     time_recorder,
 )
 from ..common.path import (
+    BIN_DIRECTORY,
     explode_directories,
     get_all_directories,
     get_major_minor_version,
@@ -1470,7 +1471,7 @@ def run_script(
     """
     path = join(
         prefix,
-        "Scripts" if on_win else "bin",
+        BIN_DIRECTORY,
         ".{}-{}.{}".format(prec.name, action, "bat" if on_win else "sh"),
     )
     if not isfile(path):

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -18,7 +18,7 @@ from ..base.context import context
 from ..common.compat import on_win
 from ..common.constants import TRACE
 from ..common.path import (
-    get_bin_directory_short_path,
+    BIN_DIRECTORY,
     get_leaf_directories,
     get_python_noarch_target_path,
     get_python_short_path,
@@ -765,7 +765,7 @@ class CreatePythonEntryPointAction(CreateInPrefixPathAction):
 
             def this_triplet(entry_point_def):
                 command, module, func = parse_entry_point_def(entry_point_def)
-                target_short_path = f"{get_bin_directory_short_path()}/{command}"
+                target_short_path = f"{BIN_DIRECTORY}/{command}"
                 if on_win:
                     target_short_path += "-script.py"
                 return target_short_path, module, func

--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -40,6 +40,7 @@ from ..common.io import (
     env_var,
     stderr_log_level,
 )
+from ..common.path import BIN_DIRECTORY
 from ..common.url import path_to_url
 from ..core.package_cache_data import PackageCacheData
 from ..core.prefix_data import PrefixData
@@ -61,7 +62,14 @@ if TYPE_CHECKING:
 
 TEST_LOG_LEVEL = DEBUG
 PYTHON_BINARY = "python.exe" if on_win else "bin/python"
-BIN_DIRECTORY = "Scripts" if on_win else "bin"
+deprecated.constant(
+    "25.3",
+    "23.9",
+    "BIN_DIRECTORY",
+    BIN_DIRECTORY,
+    addendum="Use `conda.common.path.BIN_DIRECTORY` instead.",
+)
+del BIN_DIRECTORY
 UNICODE_CHARACTERS = "ōγђ家固한áêñßôç"
 # UNICODE_CHARACTERS_RESTRICTED = u"áêñßôç"
 UNICODE_CHARACTERS_RESTRICTED = "abcdef"

--- a/news/14188-BIN_DIRECTORY
+++ b/news/14188-BIN_DIRECTORY
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.testing.integration.BIN_DIRECTORY` as pending deprecation. Use `conda.common.path.BIN_DIRECTORY` instead. (#14188)
+* Mark `conda.common.path.get_bin_directory_short_path()` as pending deprecation. Use `conda.common.path.BIN_DIRECTORY` instead. (#14188)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -14,7 +14,12 @@ from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context, reset_con
 from conda.cli.common import stdout_json
 from conda.common.compat import on_win, open_utf8
 from conda.common.io import captured, env_var, env_vars
-from conda.common.path import get_python_short_path, win_path_backout, win_path_ok
+from conda.common.path import (
+    BIN_DIRECTORY,
+    get_python_short_path,
+    win_path_backout,
+    win_path_ok,
+)
 from conda.core.initialize import (
     Result,
     _get_python_info,
@@ -37,7 +42,6 @@ from conda.gateways.disk.create import create_link, mkdir_p
 from conda.models.enums import LinkType
 from conda.testing import CondaCLIFixture
 from conda.testing.helpers import tempdir
-from conda.testing.integration import BIN_DIRECTORY
 
 CONDA_EXE = "conda.exe" if on_win else "conda"
 

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -366,10 +366,11 @@ def test_make_initialize_plan_cmd_exe(verbose):
 def test_make_entry_point(verbose):
     with tempdir() as conda_temp_prefix:
         conda_prefix = abspath(sys.prefix)
-        if on_win:
-            conda_exe_path = join(conda_temp_prefix, "Scripts", "conda-script.py")
-        else:
-            conda_exe_path = join(conda_temp_prefix, "bin", "conda")
+        conda_exe_path = join(
+            conda_temp_prefix,
+            BIN_DIRECTORY,
+            "conda-script.py" if on_win else "conda",
+        )
         result = make_entry_point(
             conda_exe_path, conda_prefix, "conda.entry.point", "run"
         )

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -16,7 +16,7 @@ from conda.base.context import context
 from conda.common.compat import on_win
 from conda.common.iterators import groupby_to_dict as groupby
 from conda.common.path import (
-    get_bin_directory_short_path,
+    BIN_DIRECTORY,
     get_python_noarch_target_path,
     get_python_short_path,
     get_python_site_packages_short_path,
@@ -240,9 +240,9 @@ def test_CreatePythonEntryPointAction_noarch_python(prefix: Path):
     command, module, func = parse_entry_point_def("command1=some.module:main")
     assert command == "command1"
     if on_win:
-        target_short_path = f"{get_bin_directory_short_path()}\\{command}-script.py"
+        target_short_path = f"{BIN_DIRECTORY}\\{command}-script.py"
     else:
-        target_short_path = f"{get_bin_directory_short_path()}/{command}"
+        target_short_path = f"{BIN_DIRECTORY}/{command}"
     assert py_ep_axn.target_full_path == join(prefix, target_short_path)
     assert py_ep_axn.module == module == "some.module"
     assert py_ep_axn.func == func == "main"
@@ -277,7 +277,7 @@ def test_CreatePythonEntryPointAction_noarch_python(prefix: Path):
 
     if on_win:
         windows_exe_axn = windows_exe_axns[0]
-        target_short_path = f"{get_bin_directory_short_path()}\\{command}.exe"
+        target_short_path = f"{BIN_DIRECTORY}\\{command}.exe"
         assert windows_exe_axn.target_full_path == join(prefix, target_short_path)
 
         mkdir_p(dirname(windows_exe_axn.target_full_path))

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -33,7 +33,7 @@ from conda.common.compat import on_linux, on_mac, on_win
 from conda.common.io import stderr_log_level
 from conda.common.iterators import groupby_to_dict as groupby
 from conda.common.path import (
-    get_bin_directory_short_path,
+    BIN_DIRECTORY,
     get_python_site_packages_short_path,
     pyc_path,
 )
@@ -69,7 +69,6 @@ from conda.models.match_spec import MatchSpec
 from conda.resolve import Resolve
 from conda.testing.helpers import CHANNEL_DIR_V2
 from conda.testing.integration import (
-    BIN_DIRECTORY,
     PYTHON_BINARY,
     TEST_LOG_LEVEL,
     get_shortcut_dir,
@@ -549,9 +548,7 @@ def test_noarch_python_package_with_entry_points(
         assert (prefix / py_file).is_file()
         assert (prefix / pyc_file).is_file()
         exe_path = (
-            prefix
-            / get_bin_directory_short_path()
-            / ("pygmentize.exe" if on_win else "pygmentize")
+            prefix / BIN_DIRECTORY / ("pygmentize.exe" if on_win else "pygmentize")
         )
         assert exe_path.is_file()
         output = check_output([exe_path, "--help"], text=True)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We previously offered a `get_bin_directory_short_path()` which evaluated to `Scripts` on Windows and `bin` on Unix. This is better suited as a constant. We opt to move `conda.testing.integration.BIN_DIRECTORY` to `conda.common.path.BIN_DIRECTORY` and deprecate `conda.common.path.get_bin_directory_short_path` in favor of this constant.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
