### PR TITLE
Deprecate unused private env helper functions

### DIFF
--- a/conda/common/path.py
+++ b/conda/common/path.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from .. import CondaError
+from ..deprecations import deprecated
 from .compat import on_win
 
 if TYPE_CHECKING:
@@ -271,6 +272,7 @@ def ensure_pad(name, pad="_"):
         return f"{pad}{name}{pad}"
 
 
+@deprecated("25.3", "25.9")
 def is_private_env_name(env_name):
     """
 
@@ -284,6 +286,7 @@ def is_private_env_name(env_name):
     return env_name and env_name[0] == env_name[-1] == "_"
 
 
+@deprecated("25.3", "25.9")
 def is_private_env_path(env_path):
     """
 

--- a/news/14189-deprecate-private-environment
+++ b/news/14189-deprecate-private-environment
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.common.path.is_private_env_name` as pending deprecation. (#14189)
+* Mark `conda.common.path.is_private_env_path` as pending deprecation. (#14189)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Found two more private conda environment references that are not in use. Marking as deprecated.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
