### PR TITLE
Remove `xdoctest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,6 @@ addopts = [
   "--store-durations",
   "--strict-markers",
   "--tb=native",
-  "--xdoctest-modules",
-  "--xdoctest-style=google",
   "-vv",
 ]
 doctest_optionflags = [

--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -1,7 +1,6 @@
 anaconda-client
 conda-forge::pytest-split
 conda-forge::pytest-xprocess
-conda-forge::xdoctest
 coverage
 flask >=2.2  # jlap pytest fixture
 git


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While debugging an ABI issue in `conda-build`'s test suite we found that `xdoctest` hasn't actually been testing anything for us since `pytest` by default only crawls the `tests` directory and not the source code itself.

Since it hasn't been doing anything for us we might as well just remove it and evaluate adding it back in a future effort.

Xref https://github.com/conda/conda-build/pull/5471

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
