### PR TITLE
Make Spinner configurable via reporter backends plugin hook

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -22,7 +22,6 @@ from ..auxlib.ish import dals
 from ..base.constants import REPODATA_FN, ROOT_ENV_NAME, DepsModifier, UpdateModifier
 from ..base.context import context, locate_prefix_by_name
 from ..common.constants import NULL
-from ..common.io import Spinner
 from ..common.path import is_package_file, paths_equal
 from ..core.index import (
     _supplement_index_with_prefix,
@@ -59,6 +58,7 @@ from ..history import History
 from ..misc import _get_best_prec_match, clone_env, explicit, touch_nonadmin
 from ..models.match_spec import MatchSpec
 from ..models.prefix_graph import PrefixGraph
+from ..reporters import get_spinner
 from . import common
 from .common import check_non_admin
 from .main_config import set_keys
@@ -370,11 +370,7 @@ def install(args, parser, command="install"):
     for repodata_fn in repodata_fns:
         try:
             if isinstall and args.revision:
-                with Spinner(
-                    f"Collecting package metadata ({repodata_fn})",
-                    not context.verbose and not context.quiet,
-                    context.json,
-                ):
+                with get_spinner(f"Collecting package metadata ({repodata_fn})"):
                     index = get_index(
                         channel_urls=index_args["channel_urls"],
                         prepend=index_args["prepend"],
@@ -386,11 +382,7 @@ def install(args, parser, command="install"):
                         repodata_fn=repodata_fn,
                     )
                 revision_idx = get_revision(args.revision)
-                with Spinner(
-                    f"Reverting to revision {revision_idx}",
-                    not context.verbose and not context.quiet,
-                    context.json,
-                ):
+                with get_spinner(f"Reverting to revision {revision_idx}"):
                     unlink_link_transaction = revert_actions(
                         prefix, revision_idx, index
                     )

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -163,13 +163,13 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     """
     from ..base.context import context
     from ..cli.common import stdout_json
-    from ..common.io import Spinner
     from ..core.envs_manager import query_all_prefixes
     from ..core.index import calculate_channel_urls
     from ..core.subdir_data import SubdirData
     from ..models.match_spec import MatchSpec
     from ..models.records import PackageRecord
     from ..models.version import VersionOrder
+    from ..reporters import get_spinner
 
     spec = MatchSpec(args.match_spec)
     if spec.get_exact_value("subdir"):
@@ -178,11 +178,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         subdirs = context.subdirs
 
     if args.envs:
-        with Spinner(
-            f"Searching environments for {spec}",
-            not context.verbose and not context.quiet,
-            context.json,
-        ):
+        with get_spinner(f"Searching environments for {spec}"):
             prefix_matches = query_all_prefixes(spec)
             ordered_result = tuple(
                 {
@@ -231,11 +227,9 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
             print("\n".join(builder))
         return 0
 
-    with Spinner(
-        "Loading channels",
-        not context.verbose and not context.quiet,
-        context.json,
-    ):
+    spinner = get_spinner("Loading channels")
+
+    with spinner:
         spec_channel = spec.get_exact_value("channel")
         channel_urls = (spec_channel,) if spec_channel else context.channels
 

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -24,6 +24,7 @@ from time import sleep, time
 from ..auxlib.decorators import memoizemethod
 from ..auxlib.logz import NullHandler
 from ..auxlib.type_coercion import boolify
+from ..deprecations import deprecated
 from .compat import encode_environment, on_win
 from .constants import NULL
 from .path import expand
@@ -392,6 +393,11 @@ def timeout(timeout_secs, func, *args, default_return=None, **kwargs):
             return default_return
 
 
+@deprecated(
+    "25.3",
+    "25.9",
+    addendum="Use `conda.reporters.get_spinner` instead.",
+)
 class Spinner:
     """
     Args:
@@ -463,6 +469,11 @@ class Spinner:
                 sys.stdout.flush()
 
 
+@deprecated(
+    "25.3",
+    "25.9",
+    addendum="Use `conda.reporters.get_progress_bar` instead.",
+)
 class ProgressBar:
     @classmethod
     def get_lock(cls):

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -26,7 +26,6 @@ from ..cli.common import confirm_yn
 from ..common.compat import ensure_text_type, on_win
 from ..common.io import (
     DummyExecutor,
-    Spinner,
     ThreadLimitedThreadPoolExecutor,
     dashlist,
     time_recorder,
@@ -60,6 +59,7 @@ from ..gateways.disk.test import (
 from ..gateways.subprocess import subprocess_call
 from ..models.enums import LinkType
 from ..models.version import VersionOrder
+from ..reporters import get_spinner
 from ..resolve import MatchSpec
 from ..utils import get_comspec, human_bytes, wrap_subprocess_call
 from .package_cache_data import PackageCacheData
@@ -266,11 +266,7 @@ class UnlinkLinkTransaction:
 
         self.transaction_context = {}
 
-        with Spinner(
-            "Preparing transaction",
-            not context.verbose and not context.quiet,
-            context.json,
-        ):
+        with get_spinner("Preparing transaction"):
             for stp in self.prefix_setups.values():
                 grps = self._prepare(
                     self.transaction_context,
@@ -296,11 +292,7 @@ class UnlinkLinkTransaction:
             self._verified = True
             return
 
-        with Spinner(
-            "Verifying transaction",
-            not context.verbose and not context.quiet,
-            context.json,
-        ):
+        with get_spinner("Verifying transaction"):
             exceptions = self._verify(self.prefix_setups, self.prefix_action_groups)
             if exceptions:
                 try:
@@ -847,11 +839,7 @@ class UnlinkLinkTransaction:
 
         with signal_handler(conda_signal_handler), time_recorder("unlink_link_execute"):
             exceptions = []
-            with Spinner(
-                "Executing transaction",
-                not context.verbose and not context.quiet,
-                context.json,
-            ):
+            with get_spinner("Executing transaction"):
                 # Execute unlink actions
                 for group, register_group, install_side in (
                     (unlink_actions, "unregister", False),
@@ -957,11 +945,7 @@ class UnlinkLinkTransaction:
                 # reverse all executed packages except the one that failed
                 rollback_excs = []
                 if context.rollback_enabled:
-                    with Spinner(
-                        "Rolling back transaction",
-                        not context.verbose and not context.quiet,
-                        context.json,
-                    ):
+                    with get_spinner("Rolling back transaction"):
                         reverse_actions = reversed(tuple(all_action_groups))
                         for axngroup in reverse_actions:
                             excs = UnlinkLinkTransaction._reverse_actions(axngroup)

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -21,7 +21,7 @@ from ..auxlib.ish import dals
 from ..base.constants import REPODATA_FN, UNKNOWN_CHANNEL, DepsModifier, UpdateModifier
 from ..base.context import context
 from ..common.constants import NULL, TRACE
-from ..common.io import Spinner, dashlist, time_recorder
+from ..common.io import dashlist, time_recorder
 from ..common.iterators import groupby_to_dict as groupby
 from ..common.path import get_major_minor_version, paths_equal
 from ..exceptions import (
@@ -35,6 +35,7 @@ from ..models.enums import NoarchType
 from ..models.match_spec import MatchSpec
 from ..models.prefix_graph import PrefixGraph
 from ..models.version import VersionOrder
+from ..reporters import get_spinner
 from ..resolve import Resolve
 from .index import _supplement_index_with_system, get_reduced_index
 from .link import PrefixSetup, UnlinkLinkTransaction
@@ -357,11 +358,7 @@ class Solver:
                 return IndexedSet(PrefixGraph(ssc.solution_precs).graph)
 
         if not ssc.r:
-            with Spinner(
-                f"Collecting package metadata ({self._repodata_fn})",
-                not context.verbose and not context.quiet and not retrying,
-                context.json,
-            ):
+            with get_spinner(f"Collecting package metadata ({self._repodata_fn})"):
                 ssc = self._collect_all_metadata(ssc)
 
         if should_retry_solve and update_modifier == UpdateModifier.FREEZE_INSTALLED:
@@ -377,12 +374,7 @@ class Solver:
         else:
             fail_message = "failed\n"
 
-        with Spinner(
-            "Solving environment",
-            not context.verbose and not context.quiet,
-            context.json,
-            fail_message=fail_message,
-        ):
+        with get_spinner("Solving environment", fail_message=fail_message):
             ssc = self._remove_specs(ssc)
             ssc = self._add_specs(ssc)
             solution_precs = copy.copy(ssc.solution_precs)

--- a/conda/env/installers/pip.py
+++ b/conda/env/installers/pip.py
@@ -7,10 +7,9 @@ import os.path as op
 from logging import getLogger
 
 from ...auxlib.compat import Utf8NamedTemporaryFile
-from ...base.context import context
-from ...common.io import Spinner
 from ...env.pip_util import get_pip_installed_packages, pip_subprocess
 from ...gateways.connection.session import CONDA_SESSION_SCHEMES
+from ...reporters import get_spinner
 
 log = getLogger(__name__)
 
@@ -69,9 +68,5 @@ def _pip_install_via_requirements(prefix, specs, args, *_, **kwargs):
 
 
 def install(*args, **kwargs):
-    with Spinner(
-        "Installing pip dependencies",
-        not context.verbose and not context.quiet,
-        context.json,
-    ):
+    with get_spinner("Installing pip dependencies"):
         return _pip_install_via_requirements(*args, **kwargs)

--- a/conda/notices/fetch.py
+++ b/conda/notices/fetch.py
@@ -10,9 +10,8 @@ from typing import TYPE_CHECKING
 
 import requests
 
-from ..base.context import context
-from ..common.io import Spinner
 from ..gateways.connection.session import get_session
+from ..reporters import get_spinner
 from .cache import cached_response
 from .types import ChannelNoticeResponse
 
@@ -40,7 +39,7 @@ def get_notice_responses(
     """
     executor = ThreadPoolExecutor(max_workers=max_workers)
 
-    with Spinner("Retrieving notices", enabled=not silent, json=context.json):
+    with get_spinner("Retrieving notices"):
         return tuple(
             filter(
                 None,

--- a/conda/plugins/reporter_backends/console.py
+++ b/conda/plugins/reporter_backends/console.py
@@ -153,7 +153,7 @@ class QuietSpinner(SpinnerBase):
         sys.stdout.write(f"{self.message}: ")
         sys.stdout.flush()
 
-        sys.stdout.write("...working...")
+        sys.stdout.write("...working... ")
         sys.stdout.flush()
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/conda/plugins/reporter_backends/console.py
+++ b/conda/plugins/reporter_backends/console.py
@@ -10,14 +10,17 @@ from __future__ import annotations
 
 import sys
 from errno import EPIPE, ESHUTDOWN
+from itertools import cycle
 from os.path import basename, dirname
+from threading import Event, Thread
+from time import sleep
 
 from ...base.constants import DEFAULT_CONSOLE_REPORTER_BACKEND, ROOT_ENV_NAME
 from ...base.context import context
 from ...common.io import swallow_broken_pipe
 from ...common.path import paths_equal
 from .. import CondaReporterBackend, hookimpl
-from ..types import ProgressBarBase, ReporterRendererBase
+from ..types import ProgressBarBase, ReporterRendererBase, SpinnerBase
 
 
 class QuietProgressBar(ProgressBarBase):
@@ -96,6 +99,72 @@ class TQDMProgressBar(ProgressBarBase):
         return tqdm(*args, **kwargs)
 
 
+class Spinner(SpinnerBase):
+    spinner_cycle = cycle("/-\\|")
+
+    def __init__(self, message, fail_message="failed\n"):
+        super().__init__(message, fail_message)
+
+        self.show_spin: bool = True
+        self._stop_running = Event()
+        self._spinner_thread = Thread(target=self._start_spinning)
+        self._indicator_length = len(next(self.spinner_cycle)) + 1
+        self.fh = sys.stdout
+
+    def start(self):
+        self._spinner_thread.start()
+
+    def stop(self):
+        self._stop_running.set()
+        self._spinner_thread.join()
+        self.show_spin = False
+
+    def _start_spinning(self):
+        try:
+            while not self._stop_running.is_set():
+                self.fh.write(next(self.spinner_cycle) + " ")
+                self.fh.flush()
+                sleep(0.10)
+                self.fh.write("\b" * self._indicator_length)
+        except OSError as e:
+            if e.errno in (EPIPE, ESHUTDOWN):
+                self.stop()
+            else:
+                raise
+
+    @swallow_broken_pipe
+    def __enter__(self):
+        sys.stdout.write(f"{self.message}: ")
+        sys.stdout.flush()
+        self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        with swallow_broken_pipe:
+            if exc_type or exc_val:
+                sys.stdout.write(self.fail_message)
+            else:
+                sys.stdout.write("done\n")
+            sys.stdout.flush()
+
+
+class QuietSpinner(SpinnerBase):
+    def __enter__(self):
+        sys.stdout.write(f"{self.message}: ")
+        sys.stdout.flush()
+
+        sys.stdout.write("...working...")
+        sys.stdout.flush()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        with swallow_broken_pipe:
+            if exc_type or exc_val:
+                sys.stdout.write(self.fail_message)
+            else:
+                sys.stdout.write("done\n")
+            sys.stdout.flush()
+
+
 class ConsoleReporterRenderer(ReporterRendererBase):
     """
     Default implementation for console reporting in conda
@@ -149,6 +218,15 @@ class ConsoleReporterRenderer(ReporterRendererBase):
             return QuietProgressBar(description, **kwargs)
         else:
             return TQDMProgressBar(description, **kwargs)
+
+    def spinner(self, message: str, fail_message: str = "failed\n") -> SpinnerBase:
+        """
+        Determines whether to return a Spinner or QuietSpinner
+        """
+        if context.quiet:
+            return QuietSpinner(message, fail_message)
+        else:
+            return Spinner(message, fail_message)
 
 
 @hookimpl(

--- a/conda/plugins/reporter_backends/json.py
+++ b/conda/plugins/reporter_backends/json.py
@@ -17,7 +17,7 @@ from ...base.constants import DEFAULT_JSON_REPORTER_BACKEND
 from ...common.io import swallow_broken_pipe
 from ...common.serialize import json_dump
 from .. import CondaReporterBackend, hookimpl
-from ..types import ProgressBarBase, ReporterRendererBase
+from ..types import ProgressBarBase, ReporterRendererBase, SpinnerBase
 
 if TYPE_CHECKING:
     from typing import Any
@@ -86,6 +86,21 @@ class JSONReporterRenderer(ReporterRendererBase):
         **kwargs,
     ) -> ProgressBarBase:
         return JSONProgressBar(description, **kwargs)
+
+    def spinner(self, message: str, fail_message: str = "failed\n") -> SpinnerBase:
+        return JSONSpinner(message, fail_message)
+
+
+class JSONSpinner(SpinnerBase):
+    """
+    This class for a JSONSpinner does nothing because we do not want to include this output.
+    """
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
 
 @hookimpl(

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -239,6 +239,18 @@ class ProgressBarBase(ABC):
         pass
 
 
+class SpinnerBase(ABC):
+    def __init__(self, message: str, fail_message: str = "failed\n"):
+        self.message = message
+        self.fail_message = fail_message
+
+    @abstractmethod
+    def __enter__(self): ...
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_val, exc_tb): ...
+
+
 class ReporterRendererBase(ABC):
     """
     Base class for all reporter renderers.
@@ -275,6 +287,13 @@ class ReporterRendererBase(ABC):
         Returns a null context by default but allows plugins to define their own if necessary
         """
         return nullcontext()
+
+    @abstractmethod
+    def spinner(self, message, failed_message) -> SpinnerBase:
+        """
+        Return a :class:`~conda.plugins.types.SpinnerBase~` object to use as a spinner (i.e.
+        loading dialog)
+        """
 
 
 @dataclass

--- a/conda/reporters.py
+++ b/conda/reporters.py
@@ -19,7 +19,7 @@ from .base.context import context
 if TYPE_CHECKING:
     from typing import Callable
 
-    from .plugins.types import ProgressBarBase
+    from .plugins.types import ProgressBarBase, SpinnerBase
 
 logger = logging.getLogger(__name__)
 
@@ -69,3 +69,10 @@ def get_progress_bar_context_manager() -> ContextManager:
     Retrieve progress bar context manager to use with registered reporter
     """
     return _get_render_func("progress_bar_context_manager")()
+
+
+def get_spinner(message: str, fail_message: str = "failed\n") -> SpinnerBase:
+    """
+    Retrieve spinner to use with registered reporter
+    """
+    return _get_render_func("spinner")(message, fail_message)

--- a/news/14206-spinner-support-reporter-backends
+++ b/news/14206-spinner-support-reporter-backends
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Adds support for defining spinners for the reporter backends plugin hook (#14206)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_search.py
+++ b/tests/cli/test_main_search.py
@@ -198,6 +198,7 @@ def test_rpy_search(monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture, subdir
     with pytest.raises(PackagesNotFoundError):
         conda_cli("search", "--override-channels", "--channel=main", "rpy2")
 
+    reset_context()
     # assert conda search can now find rpy2
     stdout, stderr, _ = conda_cli(
         "search",
@@ -206,6 +207,7 @@ def test_rpy_search(monkeypatch: MonkeyPatch, conda_cli: CondaCLIFixture, subdir
         "rpy2",
         "--json",
     )
+
     assert "rpy2" in json.loads(stdout)
 
 
@@ -280,6 +282,7 @@ def test_anaconda_token_with_private_package(
     capsys.readouterr()
 
     # Step 2. Now with the token make sure we can see the package
+    reset_context()
     channel_url = "https://conda-web.anaconda.org/t/co-de3376bc-5463-41fe-8d14-878c7e6a8253/conda-test"
     stdout, _, _ = conda_cli(
         "search",

--- a/tests/plugins/reporter_backends/test_json.py
+++ b/tests/plugins/reporter_backends/test_json.py
@@ -3,7 +3,11 @@
 import json
 
 from conda.common.serialize import json_dump
-from conda.plugins.reporter_backends.json import JSONProgressBar, JSONReporterRenderer
+from conda.plugins.reporter_backends.json import (
+    JSONProgressBar,
+    JSONReporterRenderer,
+    JSONSpinner,
+)
 
 
 def test_json_handler():
@@ -53,3 +57,15 @@ def test_json_progress_bar_not_enabled(mocker):
     progress_bar.close()
 
     assert mock_stdout.write.mock_calls == []
+
+
+def test_json_spinner(capsys):
+    """
+    Ensure that the JSONSpinner does not print anything to stdout
+    """
+    with JSONSpinner("Test"):
+        pass
+
+    capture = capsys.readouterr()
+
+    assert capture.out == ""

--- a/tests/plugins/test_post_solves.py
+++ b/tests/plugins/test_post_solves.py
@@ -25,15 +25,15 @@ class PostSolvePlugin:
 @pytest.fixture
 def post_solve_plugin(
     mocker: MockerFixture,
-    plugin_manager: CondaPluginManager,
+    plugin_manager_with_reporter_backends: CondaPluginManager,
 ) -> PostSolvePlugin:
     mocker.patch.object(PostSolvePlugin, "post_solve_action")
 
     post_solve_plugin = PostSolvePlugin()
-    plugin_manager.register(post_solve_plugin)
+    plugin_manager_with_reporter_backends.register(post_solve_plugin)
 
     # register solvers
-    plugin_manager.load_plugins(solvers)
+    plugin_manager_with_reporter_backends.load_plugins(solvers)
 
     return post_solve_plugin
 

--- a/tests/plugins/test_pre_solves.py
+++ b/tests/plugins/test_pre_solves.py
@@ -25,15 +25,15 @@ class PreSolvePlugin:
 @pytest.fixture
 def pre_solve_plugin(
     mocker: MockerFixture,
-    plugin_manager: CondaPluginManager,
+    plugin_manager_with_reporter_backends: CondaPluginManager,
 ) -> PreSolvePlugin:
     mocker.patch.object(PreSolvePlugin, "pre_solve_action")
 
     pre_solve_plugin = PreSolvePlugin()
-    plugin_manager.register(pre_solve_plugin)
+    plugin_manager_with_reporter_backends.register(pre_solve_plugin)
 
     # register solvers
-    plugin_manager.load_plugins(solvers)
+    plugin_manager_with_reporter_backends.load_plugins(solvers)
 
     return pre_solve_plugin
 


### PR DESCRIPTION
### Description

xref: #13775 

This pull request makes it so that the "Spinner" component can be switched out via the `reporter_backends` plugin hook.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
