### PR TITLE
Deprecate `conda shell.posix commands` in favor of `conda commands`

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -251,7 +251,10 @@ class _Activator(metaclass=abc.ABCMeta):
         # Hidden commands to provide metadata to shells.
         return "\n".join(
             sorted(
-                find_builtin_commands(generate_parser()) + tuple(find_commands(True))
+                {
+                    *find_builtin_commands(generate_parser()),
+                    *find_commands(True),
+                }
             )
         )
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -229,6 +229,14 @@ class _Activator(metaclass=abc.ABCMeta):
         context.plugin_manager.invoke_post_commands(self.command)
         return response
 
+    @deprecated(
+        "25.3",
+        "25.9",
+        addendum="Use `conda commands` instead.",
+        # these commands are already pretty hidden in their implementation and access (`conda shell.posix commands`)
+        # so we opt to not warn end users that this is going away, we only need to notify tab-completion devs
+        # deprecation_type=FutureWarning,
+    )
     def commands(self):
         """
         Returns a list of possible subcommands that are valid

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -46,6 +46,7 @@ from .helpers import (  # noqa: F401
     add_parser_verbose,
 )
 from .main_clean import configure_parser as configure_parser_clean
+from .main_commands import configure_parser as configure_parser_commands
 from .main_compare import configure_parser as configure_parser_compare
 from .main_config import configure_parser as configure_parser_config
 from .main_create import configure_parser as configure_parser_create
@@ -74,6 +75,7 @@ escaped_sys_rc_path = sys_rc_path.replace("%", "%%")
 BUILTIN_COMMANDS = {
     "activate",  # Mock entry for shell command
     "clean",
+    "commands",
     "compare",
     "config",
     "create",
@@ -140,6 +142,7 @@ def generate_parser(**kwargs) -> ArgumentParser:
 
     configure_parser_activate(sub_parsers)
     configure_parser_clean(sub_parsers)
+    configure_parser_commands(sub_parsers)
     configure_parser_compare(sub_parsers)
     configure_parser_config(sub_parsers)
     configure_parser_create(sub_parsers)

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -92,7 +92,9 @@ BUILTIN_COMMANDS = {
     "run",
     "search",
     "update",
-    "upgrade",
+    "upgrade",  # update alias
+    "uninstall",  # remove alias
+    "env",
 }
 
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -80,6 +80,7 @@ BUILTIN_COMMANDS = {
     "config",
     "create",
     "deactivate",  # Mock entry for shell command
+    "env",
     "export",
     "info",
     "init",
@@ -91,10 +92,9 @@ BUILTIN_COMMANDS = {
     "rename",
     "run",
     "search",
+    "uninstall",  # remove alias
     "update",
     "upgrade",  # update alias
-    "uninstall",  # remove alias
-    "env",
 }
 
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -83,6 +83,7 @@ BUILTIN_COMMANDS = {
     "init",
     "install",
     "list",
+    "notices",
     "package",
     "remove",
     "rename",
@@ -90,7 +91,6 @@ BUILTIN_COMMANDS = {
     "search",
     "update",
     "upgrade",
-    "notices",
 }
 
 
@@ -152,12 +152,12 @@ def generate_parser(**kwargs) -> ArgumentParser:
     configure_parser_list(sub_parsers)
     configure_parser_notices(sub_parsers)
     configure_parser_package(sub_parsers)
+    configure_parser_plugins(sub_parsers)
     configure_parser_remove(sub_parsers, aliases=["uninstall"])
     configure_parser_rename(sub_parsers)
     configure_parser_run(sub_parsers)
     configure_parser_search(sub_parsers)
     configure_parser_update(sub_parsers, aliases=["upgrade"])
-    configure_parser_plugins(sub_parsers)
 
     return parser
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -55,8 +55,8 @@ from .main_info import configure_parser as configure_parser_info
 from .main_init import configure_parser as configure_parser_init
 from .main_install import configure_parser as configure_parser_install
 from .main_list import configure_parser as configure_parser_list
-from .main_mock_activate import configure_parser as configure_parser_mock_activate
-from .main_mock_deactivate import configure_parser as configure_parser_mock_deactivate
+from .main_mock_activate import configure_parser as configure_parser_activate
+from .main_mock_deactivate import configure_parser as configure_parser_deactivate
 from .main_notices import configure_parser as configure_parser_notices
 from .main_package import configure_parser as configure_parser_package
 from .main_remove import configure_parser as configure_parser_remove
@@ -138,12 +138,12 @@ def generate_parser(**kwargs) -> ArgumentParser:
         required=True,
     )
 
-    configure_parser_mock_activate(sub_parsers)
-    configure_parser_mock_deactivate(sub_parsers)
+    configure_parser_activate(sub_parsers)
     configure_parser_clean(sub_parsers)
     configure_parser_compare(sub_parsers)
     configure_parser_config(sub_parsers)
     configure_parser_create(sub_parsers)
+    configure_parser_deactivate(sub_parsers)
     configure_parser_env(sub_parsers)
     configure_parser_export(sub_parsers)
     configure_parser_info(sub_parsers)

--- a/conda/cli/main_commands.py
+++ b/conda/cli/main_commands.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Mock CLI implementation for `conda activate`.
+
+A mock implementation of the activate shell command for better UX.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
+
+
+def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
+    p = sub_parsers.add_parser(
+        "commands",
+        help=(
+            "List all available conda subcommands (including those from plugins). "
+            "Generally only used by tab-completion."
+        ),
+        **kwargs,
+    )
+    p.set_defaults(func="conda.cli.main_commands.execute")
+
+    return p
+
+
+def execute(args: Namespace, parser: ArgumentParser) -> int:
+    from .conda_argparse import find_builtin_commands
+    from .find_commands import find_commands
+
+    print(
+        *sorted(
+            (
+                *find_builtin_commands(parser),
+                *find_commands(True),
+            )
+        ),
+        sep="\n",
+        end="",
+    )
+    return 0

--- a/conda/cli/main_commands.py
+++ b/conda/cli/main_commands.py
@@ -33,10 +33,10 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
 
     print(
         *sorted(
-            (
+            {
                 *find_builtin_commands(parser),
                 *find_commands(True),
-            )
+            }
         ),
         sep="\n",
         end="",

--- a/conda/cli/main_mock_activate.py
+++ b/conda/cli/main_mock_activate.py
@@ -5,19 +5,28 @@
 A mock implementation of the activate shell command for better UX.
 """
 
+from __future__ import annotations
+
 from argparse import SUPPRESS
+from typing import TYPE_CHECKING
 
 from .. import CondaError
 
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
-def configure_parser(sub_parsers):
+
+def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     p = sub_parsers.add_parser(
         "activate",
         help="Activate a conda environment.",
+        **kwargs,
     )
     p.set_defaults(func="conda.cli.main_mock_activate.execute")
     p.add_argument("args", action="store", nargs="*", help=SUPPRESS)
 
+    return p
 
-def execute(args, parser):
+
+def execute(args: Namespace, parser: ArgumentParser) -> int:
     raise CondaError("Run 'conda init' before 'conda activate'")

--- a/conda/cli/main_mock_deactivate.py
+++ b/conda/cli/main_mock_deactivate.py
@@ -5,16 +5,26 @@
 A mock implementation of the deactivate shell command for better UX.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .. import CondaError
 
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
-def configure_parser(sub_parsers):
+
+def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     p = sub_parsers.add_parser(
         "deactivate",
         help="Deactivate the current active conda environment.",
+        **kwargs,
     )
     p.set_defaults(func="conda.cli.main_mock_deactivate.execute")
 
+    return p
 
-def execute(args, parser):
+
+def execute(args: Namespace, parser: ArgumentParser) -> int:
     raise CondaError("Run 'conda init' before 'conda deactivate'")

--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -191,13 +191,8 @@ function Expand-CondaSubcommands() {
         $Filter
     );
 
-    $ValidCommands = Invoke-Conda shell.powershell commands;
-
-    # Add in the commands defined within this wrapper, filter, sort, and return.
-    $ValidCommands + @('activate', 'deactivate') `
-        | Where-Object { $_ -like "$Filter*" } `
-        | Sort-Object `
-        | Write-Output;
+    # Filter and output applicable subcommands
+    Invoke-Conda commands | Where-Object { $_ -like "$Filter*" } | Write-Output;
 
 }
 

--- a/conda/shell/etc/fish/conf.d/conda.fish
+++ b/conda/shell/etc/fish/conf.d/conda.fish
@@ -85,16 +85,8 @@ end
 # Autocompletions below
 
 
-# Faster but less tested (?)
 function __fish_conda_commands
-    string replace -r '.*_([a-z]+)\.py$' '$1' $_CONDA_ROOT/lib/python*/site-packages/conda/cli/main_*.py
-    for f in $_CONDA_ROOT/bin/conda-*
-        if test -x "$f" -a ! -d "$f"
-            string replace -r '^.*/conda-' '' "$f"
-        end
-    end
-    echo activate
-    echo deactivate
+    conda commands
 end
 
 function __fish_conda_env_commands

--- a/docs/source/commands/commands.rst
+++ b/docs/source/commands/commands.rst
@@ -1,0 +1,10 @@
+``conda commands``
+*****************
+
+.. argparse::
+   :module: conda.cli.conda_argparse
+   :func: generate_parser
+   :prog: conda
+   :path: commands
+   :nodefault:
+   :nodefaultconst:

--- a/news/14215-move-commands-subcommand
+++ b/news/14215-move-commands-subcommand
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `conda commands` subcommand. (#14215)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda shell.SHELL commands` as pending deprecation. Use `conda commands` instead. (#14215)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_find_commands.py
+++ b/tests/cli/test_find_commands.py
@@ -58,11 +58,15 @@ def faux_path(tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
     (exe / "conda-exe.exe").touch()
     monkeypatch.setenv("PATH", str(exe), prepend=os.pathsep)
 
+    find_commands.cache_clear()
+
     yield tmp_path
 
     if not on_win:
         # undo read-only for clean removal
         permission.chmod(permission.stat().st_mode | 0o444)
+
+    find_commands.cache_clear()
 
 
 def test_find_executable(faux_path: Path):
@@ -77,7 +81,6 @@ def test_find_executable(faux_path: Path):
 
 
 def test_find_commands(faux_path: Path):
-    find_commands.cache_clear()
     if on_win:
         assert {"bin", "bat", "exe"}.issubset(find_commands())
     else:

--- a/tests/cli/test_main_commands.py
+++ b/tests/cli/test_main_commands.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+from conda.cli.conda_argparse import BUILTIN_COMMANDS
+from conda.testing import CondaCLIFixture
+
+
+def test_commands(conda_cli: CondaCLIFixture):
+    stdout, stderr, code = conda_cli("commands")
+
+    assert stdout == "\n".join(
+        sorted(
+            {
+                *BUILTIN_COMMANDS,
+                "content-trust",  # from conda-content-trust
+                "doctor",  # builtin plugin
+                "repoquery",  # from conda-libmamba-solver
+                "server",  # from anaconda-client
+            }
+        )
+    )
+    assert not stderr
+    assert not code


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The `commands` subcommand is a tab-completion helper function and has long been hidden within the activation code as `conda shell.posix commands`. There is no need for this as the command produces entirely OS and shell agnostic output (a newline delimited list of available subcommands).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
