### PR TITLE
Add references to miniforge in Readme and update links to miniforge in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ the amazing members of the conda community. Some of them can be found
 
 ## Installation
 
-Conda is a part of the [Anaconda Distribution](https://repo.anaconda.com).
-Use [Miniconda](https://docs.anaconda.com/free/miniconda/) to bootstrap a minimal installation
-that only includes conda and its dependencies.
+To bootstrap a minimal distribution, use a minimal installer such as [Miniconda](https://docs.anaconda.com/free/miniconda/) or [Miniforge](https://conda-forge.org/download/).
 
+Conda is also included  in the [Anaconda Distribution](https://repo.anaconda.com).
 
 ## Updating conda
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the amazing members of the conda community. Some of them can be found
 
 To bootstrap a minimal distribution, use a minimal installer such as [Miniconda](https://docs.anaconda.com/free/miniconda/) or [Miniforge](https://conda-forge.org/download/).
 
-Conda is also included  in the [Anaconda Distribution](https://repo.anaconda.com).
+Conda is also included in the [Anaconda Distribution](https://repo.anaconda.com).
 
 ## Updating conda
 

--- a/docs/source/user-guide/concepts/environments.rst
+++ b/docs/source/user-guide/concepts/environments.rst
@@ -21,7 +21,7 @@ Conda directory structure
 
 ``ROOT_DIR``
 ------------
-The directory that Anaconda or Miniconda was installed into.
+The directory where the conda distribution was installed into.
 
 EXAMPLES:
 

--- a/docs/source/user-guide/getting-started.rst
+++ b/docs/source/user-guide/getting-started.rst
@@ -15,7 +15,9 @@ This guide to getting started with conda goes over the basics of starting up and
 Before you start
 ================
 
-You should have already installed conda before beginning this getting started guide. Conda can be found in many distributions, like `Anaconda Distribution <https://docs.anaconda.com/free/anaconda/install/>`_, `Miniconda <https://docs.anaconda.com/free/miniconda/>`_ or `Miniforge <https://github.com/conda-forge/miniforge>`_.
+To bootstrap a conda installation, use a minimal installer such as `Miniconda <https://docs.anaconda.com/free/miniconda/>`_ or `Miniforge <https://conda-forge.org/download>`_.
+
+Conda is also included in the `Anaconda Distribution <https://docs.anaconda.com/free/anaconda/install/>`_.
 
 Starting conda
 ==============

--- a/docs/source/user-guide/install/index.rst
+++ b/docs/source/user-guide/install/index.rst
@@ -16,7 +16,7 @@ The following are the most popular installers currently available:
         of packages for data science, as well as Anaconda Navigator, a GUI application
         for working with conda environments.
 
-    `Miniforge <https://github.com/conda-forge/miniforge>`_
+    `Miniforge <https://conda-forge.org/download>`_
         Miniforge is an installer maintained by the conda-forge community that comes
         preconfigured for use with the conda-forge channel. To learn more about conda-forge,
         visit `their website <https://conda-forge.org>`_.

--- a/docs/source/user-guide/install/linux.rst
+++ b/docs/source/user-guide/install/linux.rst
@@ -8,7 +8,7 @@ Installing on Linux
 
    * `Anaconda Distribution installer for Linux <https://www.anaconda.com/download/>`_.
 
-   * `Miniforge installer for Linux <https://github.com/conda-forge/miniforge/>`_.
+   * `Miniforge installer for Linux <https://conda-forge.org/download/>`_.
 
 #. :ref:`Verify your installer hashes <hash-verification>`.
 

--- a/docs/source/user-guide/install/macos.rst
+++ b/docs/source/user-guide/install/macos.rst
@@ -14,7 +14,7 @@ Installing on macOS
 
    * `Anaconda installer for macOS <https://www.anaconda.com/download/>`_.
 
-   * `Miniforge installer for macOS <https://github.com/conda-forge/miniforge/>`_.
+   * `Miniforge installer for macOS <https://conda-forge.org/download/>`_.
 
 #. :ref:`Verify your installer hashes <hash-verification>`.
 

--- a/docs/source/user-guide/install/windows.rst
+++ b/docs/source/user-guide/install/windows.rst
@@ -10,7 +10,7 @@ Installing on Windows
    * `Anaconda Distribution installer for
      Windows <https://www.anaconda.com/download/>`_
 
-   * `Miniforge installer for Windows <https://github.com/conda-forge/miniforge>`_
+   * `Miniforge installer for Windows <https://conda-forge.org/download>`_
 
 #. :ref:`Verify your installer hashes <hash-verification>`.
 


### PR DESCRIPTION
### Description

The main changes is the update of the link for miniforge, now pointing to the relevant part of the conda-forge website rather than the GitHub repository.

I am also adding a reference to miniforge in the Readme.
