### PR TITLE
Leave `context.channels` empty by default

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -90,7 +90,8 @@ KNOWN_SUBDIRS = PLATFORM_DIRECTORIES = (
 
 RECOGNIZED_URL_SCHEMES = ("http", "https", "ftp", "s3", "file")
 
-
+# TODO: Deprecate these hardcoded repo.anaconda.com URLs
+# Let distributions specify their 'defaults'
 DEFAULT_CHANNELS_UNIX = (
     "https://repo.anaconda.com/pkgs/main",
     "https://repo.anaconda.com/pkgs/r",

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -90,8 +90,6 @@ KNOWN_SUBDIRS = PLATFORM_DIRECTORIES = (
 
 RECOGNIZED_URL_SCHEMES = ("http", "https", "ftp", "s3", "file")
 
-# TODO: Deprecate these hardcoded repo.anaconda.com URLs
-# Let distributions specify their 'defaults'
 DEFAULT_CHANNELS_UNIX = (
     "https://repo.anaconda.com/pkgs/main",
     "https://repo.anaconda.com/pkgs/r",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -934,6 +934,11 @@ class Context(Configuration):
             else:
                 return tuple(IndexedSet((*local_add, *self._argparse_args["channel"])))
 
+        addendum = (
+            "To remove this warning, please choose a default channel explicitly "
+            "via 'conda config --add channels <name>'. In the future, the implicit "
+            "default channel configuration will be removed."
+        )
         # add 'defaults' channel when necessary if --channel is given via the command line
         if self._argparse_args and "channel" in self._argparse_args:
             # TODO: it's args.channel right now, not channels
@@ -949,11 +954,9 @@ class Context(Configuration):
             if argparse_channels and not channel_in_config_files:
                 deprecated.topic(
                     "24.9",
-                    "25.1",
+                    "25.3",
                     topic=f"Adding '{DEFAULTS_CHANNEL_NAME}' to channel list implicitly.",
-                    addendum="To remove this warning, please choose a default channel explicitly "
-                    "via 'conda config --add channels <name>'. In the future, the implicit "
-                    "default channel configuration will be removed.",
+                    addendum=addendum,
                     deprecation_type=FutureWarning,
                 )
                 return tuple(
@@ -964,11 +967,9 @@ class Context(Configuration):
         else:
             deprecated.topic(
                 "24.9",
-                "25.1",
+                "25.3",
                 topic=f"Adding '{DEFAULTS_CHANNEL_NAME}' to channel list implicitly.",
-                addendum="To remove this warning, please choose a default channel explicitly "
-                "via 'conda config --add channels <name>'. In the future, the implicit "
-                "default channel configuration will be removed.",
+                addendum=addendum,
                 deprecation_type=FutureWarning,
             )
             _channels = [DEFAULTS_CHANNEL_NAME]

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -13,7 +13,6 @@ import os
 import platform
 import struct
 import sys
-import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from errno import ENOENT
@@ -948,12 +947,14 @@ class Context(Configuration):
                 for rc_file in self.config_files
             )
             if argparse_channels and not channel_in_config_files:
-                warnings.warn(
-                    f"Adding '{DEFAULTS_CHANNEL_NAME}' to channel list implicitly. "
-                    "To remove this warning, please choose a default channel explicitly via "
-                    "'conda config --add channels <name>'. In the future, the implicit default "
-                    "channel configuration will be removed.",
-                    FutureWarning,
+                deprecated.topic(
+                    "24.9",
+                    "25.1",
+                    topic=f"Adding '{DEFAULTS_CHANNEL_NAME}' to channel list implicitly.",
+                    addendum="To remove this warning, please choose a default channel explicitly "
+                    "via 'conda config --add channels <name>'. In the future, the implicit "
+                    "default channel configuration will be removed.",
+                    deprecation_type=FutureWarning,
                 )
                 return tuple(
                     IndexedSet((*local_add, *argparse_channels, DEFAULTS_CHANNEL_NAME))
@@ -961,12 +962,14 @@ class Context(Configuration):
         if self._channels:
             _channels = self._channels
         else:
-            warnings.warn(
-                f"Adding '{DEFAULTS_CHANNEL_NAME}' to channel list implicitly. "
-                "To remove this warning, please choose a default channel explicitly via "
-                "'conda config --add channels <name>'. In the future, the implicit default "
-                "channel configuration will be removed.",
-                FutureWarning,
+            deprecated.topic(
+                "24.9",
+                "25.1",
+                topic=f"Adding '{DEFAULTS_CHANNEL_NAME}' to channel list implicitly.",
+                addendum="To remove this warning, please choose a default channel explicitly "
+                "via 'conda config --add channels <name>'. In the future, the implicit "
+                "default channel configuration will be removed.",
+                deprecation_type=FutureWarning,
             )
             _channels = [DEFAULTS_CHANNEL_NAME]
         return tuple(IndexedSet((*local_add, *_channels)))

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -522,10 +522,11 @@ class Context(Configuration):
             errors.append(error)
         if not self.channels:
             from conda.core.prefix_data import PrefixData
+            from conda.models.channel import Channel
 
             conda_meta_info = next(PrefixData(self.root_prefix).query("conda"), None)
             if conda_meta_info:
-                conda_channel = conda_meta_info.channel
+                conda_channel = Channel(conda_meta_info.channel).canonical_name
             else:
                 conda_channel = "[desired channel]"
             log.warning(

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -353,9 +353,7 @@ class Context(Configuration):
     )
     channel_priority = ParameterLoader(PrimitiveParameter(ChannelPriority.FLEXIBLE))
     _channels = ParameterLoader(
-        SequenceParameter(
-            PrimitiveParameter("", element_type=str), default=(),
-        ),
+        SequenceParameter(PrimitiveParameter("", element_type=str), default=()),
         aliases=(
             "channels",
             "channel",

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -270,9 +270,10 @@ def install(args, parser, command="install"):
             if MatchSpec(default_package).name not in names:
                 args_packages.append(default_package)
 
+    context_channels = context.channels
     index_args = {
         "use_cache": args.use_index_cache,
-        "channel_urls": context.channels,
+        "channel_urls": context_channels,
         "unknown": args.unknown,
         "prepend": not args.override_channels,
         "use_local": args.use_local,
@@ -398,7 +399,7 @@ def install(args, parser, command="install"):
                 solver_backend = context.plugin_manager.get_cached_solver_backend()
                 solver = solver_backend(
                     prefix,
-                    context.channels,
+                    context_channels,
                     context.subdirs,
                     specs_to_add=specs,
                     repodata_fn=repodata_fn,

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -19,6 +19,9 @@ from pathlib import Path
 from textwrap import wrap
 from typing import TYPE_CHECKING
 
+from ..base.constants import DEFAULTS_CHANNEL_NAME
+from ..deprecations import deprecated
+
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace, _SubParsersAction
     from typing import Any
@@ -731,6 +734,17 @@ def execute_config(args, parser):
     for arg, prepend in zip((args.prepend, args.append), (True, False)):
         for key, item in arg:
             key, subkey = key.split(".", 1) if "." in key else (key, None)
+            if key == "channels" and key not in rc_config:
+                deprecated.topic(
+                    "24.9",
+                    "25.3",
+                    topic=f"Adding '{DEFAULTS_CHANNEL_NAME}' to channel list implicitly.",
+                    addendum=f"In the future, {DEFAULTS_CHANNEL_NAME} won't be added when "
+                    "'conda config --add/--append channels' is used. If you depend on that "
+                    "behavior, run 'conda config --append channels defaults'.",
+                    deprecation_type=FutureWarning,
+                )
+                rc_config[key] = [DEFAULTS_CHANNEL_NAME]
             if key in sequence_parameters:
                 arglist = rc_config.setdefault(key, [])
             elif key in map_parameters:

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -731,8 +731,6 @@ def execute_config(args, parser):
     for arg, prepend in zip((args.prepend, args.append), (True, False)):
         for key, item in arg:
             key, subkey = key.split(".", 1) if "." in key else (key, None)
-            if key == "channels" and key not in rc_config:
-                rc_config[key] = ["defaults"]
             if key in sequence_parameters:
                 arglist = rc_config.setdefault(key, [])
             elif key in map_parameters:

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -113,6 +113,7 @@ class SubdirData(metaclass=SubdirDataType):
         create_cache_dir()
         if channels is None:
             channels = context.channels
+            # TODO: Raise if 'channels' is empty?
         if subdirs is None:
             subdirs = context.subdirs
         channel_urls = all_channel_urls(channels, subdirs=subdirs)

--- a/conda/testing/notices/fixtures.py
+++ b/conda/testing/notices/fixtures.py
@@ -36,7 +36,7 @@ def notices_mock_fetch_get_session():
 @pytest.fixture(scope="function")
 def conda_notices_args_n_parser():
     parser = generate_parser()
-    args = parser.parse_args(["notices", "-c", DEFAULTS_CHANNEL_NAME])
+    args = parser.parse_args(["notices", f"--channel={DEFAULTS_CHANNEL_NAME}"])
     reset_context((), args)
 
     return args, parser

--- a/conda/testing/notices/fixtures.py
+++ b/conda/testing/notices/fixtures.py
@@ -7,7 +7,8 @@ from unittest import mock
 
 import pytest
 
-from ...base.constants import NOTICES_CACHE_SUBDIR
+from ...base.constants import DEFAULTS_CHANNEL_NAME, NOTICES_CACHE_SUBDIR
+from ...base.context import reset_context
 from ...cli.conda_argparse import generate_parser
 
 
@@ -35,6 +36,7 @@ def notices_mock_fetch_get_session():
 @pytest.fixture(scope="function")
 def conda_notices_args_n_parser():
     parser = generate_parser()
-    args = parser.parse_args(["notices"])
+    args = parser.parse_args(["notices", "-c", DEFAULTS_CHANNEL_NAME])
+    reset_context((), args)
 
     return args, parser

--- a/news/14227-nodefaults
+++ b/news/14227-nodefaults
@@ -10,12 +10,15 @@
 
 * The `defaults` multichannel will stop being the (implicit) default value for `channels`. Users
   relying on this behaviour are encouraged to run `conda config --add channels defaults`.
-  This is now deprecated, and will become an error in 25.3. (#14178 via #14227)
-* `conda config --add/--append channels ...` will warn when `defaults` is being added implicitly.
-  By 25.3, this behaviour will be removed and users should run `conda config --add/--append channels defaults` explicitly if needed. (#12356 via #14227)
-* Without an explicit `channels` configuration (`condarc`, environment variables, CLI flags),
-  `context.channels` will warn about emitting `defaults` implicitly. In 25.3, an empty list will be
-  returned. If this behavior is desired, the `context.channels or [Channel("defaults")]` idiom is recommended. (#14227)
+  This is now pending deprecation, and will be fully deprecated in 25.3. (#14178 via #14227)
+* Running `conda config --add/--append channels ...` will warn when `defaults` is being
+  added implicitly. By 25.3, this behaviour will be removed and users should run
+  `conda config --add/--append channels defaults` explicitly if needed. Conda
+  distribution installers like miniforge or miniconda will pre-
+  configure conda channels during installation. (#12356 via #14227)
+* Without an explicit `channels` configuration (via `condarc` files, environment
+  variables, or CLI flags), conda will warn about using `defaults` implicitly.
+  In 25.3, an empty list will be used. (#14227)
 
 ### Docs
 

--- a/news/14227-nodefaults
+++ b/news/14227-nodefaults
@@ -9,13 +9,13 @@
 ### Deprecations
 
 * The `defaults` multichannel will stop being the (implicit) default value for `channels`. Users
-  relying on this behaviour are encouraged to run `conda config --add channels defaults`. (#14178 via #14227)
-* `conda config --add/--append channels ...` will no longer inject `defaults` implicitly.
-  Users are encouraged to run `conda config --add/--append channels defaults` explicitly.
-  (#12356 via #14227)
+  relying on this behaviour are encouraged to run `conda config --add channels defaults`.
+  This is now deprecated, and will become an error in 25.3. (#14178 via #14227)
+* `conda config --add/--append channels ...` will warn when `defaults` is being added implicitly.
+  By 25.3, this behaviour will be removed and users should run `conda config --add/--append channels defaults` explicitly if needed. (#12356 via #14227)
 * Without an explicit `channels` configuration (`condarc`, environment variables, CLI flags),
-  `context.channels` will return an empty list. Users relying on this behaviour are encouraged to
-  use the `context.channels or [Channel("defaults")]` idiom instead. (#14227)
+  `context.channels` will warn about emitting `defaults` implicitly. In 25.3, an empty list will be
+  returned. If this behavior is desired, the `context.channels or [Channel("defaults")]` idiom is recommended. (#14227)
 
 ### Docs
 

--- a/news/14227-nodefaults
+++ b/news/14227-nodefaults
@@ -1,0 +1,26 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* The `defaults` multichannel will stop being the (implicit) default value for `channels`. Users
+  relying on this behaviour are encouraged to run `conda config --add channels defaults`. (#14178 via #14227)
+* `conda config --add/--append channels ...` will no longer inject `defaults` implicitly.
+  Users are encouraged to run `conda config --add/--append channels defaults` explicitly.
+  (#12356 via #14227)
+* Without an explicit `channels` configuration (`condarc`, environment variables, CLI flags),
+  `context.channels` will return an empty list. Users relying on this behaviour are encouraged to
+  use the `context.channels or [Channel("defaults")]` idiom instead. (#14227)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -447,7 +447,8 @@ def test_threads(testdata: None):
 def test_channels_empty(testdata: None):
     """Test when no channels provided in cli and no condarc config is present."""
     reset_context(())
-    assert context.channels == ()
+    with pytest.warns((PendingDeprecationWarning, FutureWarning)):
+        assert context.channels == ("defaults",)
 
 
 def test_channels_defaults_condarc(testdata: None):
@@ -475,7 +476,8 @@ def test_specify_channels_cli_not_adding_defaults_no_condarc(testdata: None):
     See https://github.com/conda/conda/issues/14217 for context.
     """
     reset_context((), argparse_args=AttrDict(channel=["conda-forge"]))
-    assert context.channels == ("conda-forge",)
+    with pytest.warns((PendingDeprecationWarning, FutureWarning)):
+        assert context.channels == ("conda-forge", "defaults")
 
 
 def test_specify_channels_cli_condarc(testdata: None):

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -444,10 +444,10 @@ def test_threads(testdata: None):
         assert context.execute_threads == 3
 
 
-def test_channels_defaults(testdata: None):
-    """Test when no channels provided in cli."""
+def test_channels_empty(testdata: None):
+    """Test when no channels provided in cli and no condarc config is present."""
     reset_context(())
-    assert context.channels == ("defaults",)
+    assert context.channels == ()
 
 
 def test_channels_defaults_condarc(testdata: None):
@@ -467,13 +467,15 @@ def test_channels_defaults_condarc(testdata: None):
     assert context.channels == ("defaults", "conda-forge")
 
 
-def test_specify_channels_cli_adding_defaults_no_condarc(testdata: None):
+def test_specify_channels_cli_not_adding_defaults_no_condarc(testdata: None):
     """
     When the channel haven't been specified in condarc, 'defaults'
-    should be present when specifying channel in the cli
+    should NOT be present when specifying channel in the cli.
+
+    See https://github.com/conda/conda/issues/14217 for context.
     """
     reset_context((), argparse_args=AttrDict(channel=["conda-forge"]))
-    assert context.channels == ("conda-forge", "defaults")
+    assert context.channels == ("conda-forge",)
 
 
 def test_specify_channels_cli_condarc(testdata: None):

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -115,7 +115,6 @@ def test_channels_add_empty(conda_cli: CondaCLIFixture):
 
 
 def test_channels_add_empty_with_defaults(conda_cli: CondaCLIFixture):
-    # When defaults is explicitly given, it should not be added
     with make_temp_condarc() as rc:
         stdout, stderr, _ = conda_cli(
             "config",
@@ -124,10 +123,6 @@ def test_channels_add_empty_with_defaults(conda_cli: CondaCLIFixture):
             *("--add", "channels", "defaults"),
         )
         assert stdout == ""
-        assert (
-            stderr.strip()
-            == "Warning: 'defaults' already in 'channels' list, moving to the top"
-        )
         assert _read_test_condarc(rc) == _channels_as_yaml("defaults", "test")
 
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -111,10 +111,12 @@ def test_channels_add_empty(conda_cli: CondaCLIFixture):
             *("--add", "channels", "test"),
         )
         assert stdout == stderr == ""
-        assert _read_test_condarc(rc) == _channels_as_yaml("test")
+        # TODO: Update in 25.3
+        assert _read_test_condarc(rc) == _channels_as_yaml("test", "defaults")
 
 
 def test_channels_add_empty_with_defaults(conda_cli: CondaCLIFixture):
+    # When defaults is explicitly given, it should not be added
     with make_temp_condarc() as rc:
         stdout, stderr, _ = conda_cli(
             "config",
@@ -123,6 +125,11 @@ def test_channels_add_empty_with_defaults(conda_cli: CondaCLIFixture):
             *("--add", "channels", "defaults"),
         )
         assert stdout == ""
+        # TODO: Update in 25.3
+        assert (
+            stderr.strip()
+            == "Warning: 'defaults' already in 'channels' list, moving to the top"
+        )
         assert _read_test_condarc(rc) == _channels_as_yaml("defaults", "test")
 
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -111,7 +111,7 @@ def test_channels_add_empty(conda_cli: CondaCLIFixture):
             *("--add", "channels", "test"),
         )
         assert stdout == stderr == ""
-        assert _read_test_condarc(rc) == _channels_as_yaml("test", "defaults")
+        assert _read_test_condarc(rc) == _channels_as_yaml("test")
 
 
 def test_channels_add_empty_with_defaults(conda_cli: CondaCLIFixture):

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -98,8 +98,8 @@ def test_get_index_no_platform_with_offline_cache(platform=OVERRIDE_PLATFORM):
         local_channel = Channel(join(CHANNEL_DIR_V1, platform))
         sd = SubdirData(channel=local_channel)
         assert len(sd.query_all("zlib", channels=[local_channel])) > 0
-        assert len(sd.query_all("zlib")) == 0
-    assert len(sd.query_all("zlib")) > 1
+        assert len(sd.query_all("zlib", channels=context.channels or ["defaults"])) == 0
+    assert len(sd.query_all("zlib", channels=context.channels or ["defaults"])) > 1
 
     # test load from cache
     with env_vars(

--- a/tests/notices/test_core.py
+++ b/tests/notices/test_core.py
@@ -3,6 +3,7 @@
 import pytest
 
 from conda.base.constants import NOTICES_DECORATOR_DISPLAY_INTERVAL
+from conda.base.context import reset_context
 from conda.notices import core as notices
 from conda.testing.notices.helpers import (
     DummyArgs,
@@ -15,12 +16,18 @@ from conda.testing.notices.helpers import (
 
 @pytest.mark.parametrize("status_code", (200, 404, 500))
 def test_display_notices_happy_path(
-    status_code, capsys, notices_cache_dir, notices_mock_fetch_get_session
+    status_code,
+    capsys,
+    notices_cache_dir,
+    notices_mock_fetch_get_session,
+    monkeypatch,
 ):
     """
     Happy path for displaying notices. We test two error codes to make sure we get
     display that we assume
     """
+    monkeypatch.setenv("CONDA_CHANNELS", "defaults")
+    reset_context()
     messages = ("Test One", "Test Two")
     messages_json = get_test_notices(messages)
     add_resp_to_mock(notices_mock_fetch_get_session, status_code, messages_json)
@@ -48,11 +55,15 @@ def test_display_notices_happy_path(
         assert message not in captured.out
 
 
-def test_notices_decorator(capsys, notices_cache_dir, notices_mock_fetch_get_session):
+def test_notices_decorator(
+    capsys, notices_cache_dir, notices_mock_fetch_get_session, monkeypatch
+):
     """
     Create a dummy function to wrap with our notices decorator and test it with
     two test messages.
     """
+    monkeypatch.setenv("CONDA_CHANNELS", "defaults")
+    reset_context()
     messages = ("Test One", "Test Two")
     messages_json = get_test_notices(messages)
     add_resp_to_mock(notices_mock_fetch_get_session, 200, messages_json)
@@ -77,12 +88,17 @@ def test_notices_decorator(capsys, notices_cache_dir, notices_mock_fetch_get_ses
 
 
 def test__conda_user_story__only_see_once(
-    capsys, notices_cache_dir, notices_mock_fetch_get_session
+    capsys,
+    notices_cache_dir,
+    notices_mock_fetch_get_session,
+    monkeypatch,
 ):
     """
     As a conda user, I only want to see a channel notice once while running
     commands like, 'install', 'update', or 'create'.
     """
+    monkeypatch.setenv("CONDA_CHANNELS", "defaults")
+    reset_context()
     messages = ("Test One",)
     dummy_mesg = "Dummy Mesg"
     messages_json = get_test_notices(messages)
@@ -114,12 +130,15 @@ def test__conda_user_story__disable_notices(
     notices_cache_dir,
     notices_mock_fetch_get_session,
     disable_channel_notices,
+    monkeypatch,
 ):
     """
     As a conda user, if I disable channel notifications in my .condarc file,
     I do not want to see notifications while running commands like,  "install",
     "update" or "create".
     """
+    monkeypatch.setenv("CONDA_CHANNELS", "defaults")
+    reset_context()
     messages = ("Test One", "Test Two")
     dummy_mesg = "Dummy Mesg"
     messages_json = get_test_notices(messages)
@@ -139,12 +158,17 @@ def test__conda_user_story__disable_notices(
 
 
 def test__conda_user_story__more_notices_message(
-    capsys, notices_cache_dir, notices_mock_fetch_get_session
+    capsys,
+    notices_cache_dir,
+    notices_mock_fetch_get_session,
+    monkeypatch,
 ):
     """
     As a conda user, I want to see a message telling me there are more notices
     if there are more to display.
     """
+    monkeypatch.setenv("CONDA_CHANNELS", "defaults")
+    reset_context()
     messages = tuple(f"Test {idx}" for idx in range(1, 11, 1))
     messages_json = get_test_notices(messages)
     add_resp_to_mock(notices_mock_fetch_get_session, 200, messages_json)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

- Closes https://github.com/conda/conda/issues/14178
- Closes https://github.com/conda/conda/issues/12356

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
