### PR TITLE
Deprecate `AttrDict` in favor of `SimpleNamespace`

### DIFF
--- a/conda/auxlib/collection.py
+++ b/conda/auxlib/collection.py
@@ -32,6 +32,7 @@ def make_immutable(value):
 
 
 # http://stackoverflow.com/a/14620633/2127762
+@deprecated("25.3", "25.9", addendum="Use `types.SimpleNamespace` instead.")
 class AttrDict(dict):
     """Sub-classes dict, and further allows attribute-like access to dictionary items.
 

--- a/conda/auxlib/ish.py
+++ b/conda/auxlib/ish.py
@@ -1,6 +1,8 @@
 from logging import getLogger
 from textwrap import dedent
 
+from ..deprecations import deprecated
+
 log = getLogger(__name__)
 
 
@@ -9,6 +11,7 @@ def dals(string):
     return dedent(string).lstrip()
 
 
+@deprecated("25.3", "25.9")
 def _get_attr(obj, attr_name, aliases=()):
     try:
         return getattr(obj, attr_name)
@@ -22,6 +25,7 @@ def _get_attr(obj, attr_name, aliases=()):
             raise
 
 
+@deprecated("25.3", "25.9")
 def find_or_none(key, search_maps, aliases=(), _map_index=0):
     """Return the value of the first key found in the list of search_maps,
     otherwise return None.
@@ -53,6 +57,7 @@ def find_or_none(key, search_maps, aliases=(), _map_index=0):
         return None
 
 
+@deprecated("25.3", "25.9")
 def find_or_raise(key, search_maps, aliases=(), _map_index=0):
     try:
         attr = _get_attr(search_maps[_map_index], key, aliases)

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -288,7 +288,7 @@ class ArgParseRawParameter(RawParameter):
     @classmethod
     def make_raw_parameters(cls, args_from_argparse):
         return super().make_raw_parameters(
-            ArgParseRawParameter.source, args_from_argparse
+            ArgParseRawParameter.source, vars(args_from_argparse)
         )
 
 

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -29,6 +29,7 @@ from os.path import expandvars
 from pathlib import Path
 from re import IGNORECASE, VERBOSE, compile
 from string import Template
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 from boltons.setutils import IndexedSet
@@ -37,7 +38,7 @@ from ruamel.yaml.reader import ReaderError
 from ruamel.yaml.scanner import ScannerError
 
 from .. import CondaError, CondaMultiError
-from ..auxlib.collection import AttrDict, first, last
+from ..auxlib.collection import first, last
 from ..auxlib.exceptions import ThisShouldNeverHappenError
 from ..auxlib.type_coercion import TypeCoercionError, typify, typify_data_structure
 from ..common.iterators import unique
@@ -1451,8 +1452,8 @@ class Configuration(metaclass=ConfigurationType):
             #   already having been processed by this method before
             items = argparse_args.items()
 
-        self._argparse_args = argparse_args = AttrDict(
-            {k: v for k, v in items if v is not NULL}
+        self._argparse_args = argparse_args = SimpleNamespace(
+            **{k: v for k, v in items if v is not NULL}
         )
 
         # remove existing source so "insert" order is correct

--- a/news/14234-deprecate-AttrDict
+++ b/news/14234-deprecate-AttrDict
@@ -1,0 +1,22 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.auxlib.collection.AttrDict` as pending deprecation. Use `types.SimpleNamespace` instead. (#14234)
+* Mark `conda.auxlib.ish._get_attr` as pending deprecation. (#14234)
+* Mark `conda.auxlib.ish.find_or_none` as pending deprecation. (#14234)
+* Mark `conda.auxlib.ish.find_or_raise` as pending deprecation. (#14234)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -10,7 +10,6 @@ from unittest import mock
 
 import pytest
 
-from conda.auxlib.collection import AttrDict
 from conda.auxlib.ish import dals
 from conda.base.constants import ChannelPriority, PathConflict
 from conda.base.context import (
@@ -363,20 +362,20 @@ def test_target_prefix(testdata: None):
             stack_callback=conda_tests_ctxt_mgmt_def_pol,
         ):
             # with both dirs writable, choose first
-            reset_context((), argparse_args=AttrDict(name="blarg", func="create"))
+            reset_context((), argparse_args=SimpleNamespace(name="blarg"))
             assert context.target_prefix == join(envs_dirs[0], "blarg")
 
             # with first dir read-only, choose second
             PackageCacheData._cache_.clear()
             make_read_only(join(envs_dirs[0], ".conda_envs_dir_test"))
-            reset_context((), argparse_args=AttrDict(name="blarg", func="create"))
+            reset_context((), argparse_args=SimpleNamespace(name="blarg"))
             assert context.target_prefix == join(envs_dirs[1], "blarg")
 
             # if first dir is read-only but environment exists, choose first
             PackageCacheData._cache_.clear()
             mkdir_p(join(envs_dirs[0], "blarg"))
             touch(join(envs_dirs[0], "blarg", "history"))
-            reset_context((), argparse_args=AttrDict(name="blarg", func="create"))
+            reset_context((), argparse_args=SimpleNamespace(name="blarg"))
             assert context.target_prefix == join(envs_dirs[0], "blarg")
 
 
@@ -472,7 +471,7 @@ def test_specify_channels_cli_adding_defaults_no_condarc(testdata: None):
     When the channel haven't been specified in condarc, 'defaults'
     should be present when specifying channel in the cli
     """
-    reset_context((), argparse_args=AttrDict(channel=["conda-forge"]))
+    reset_context((), argparse_args=SimpleNamespace(channel=["conda-forge"]))
     assert context.channels == ("conda-forge", "defaults")
 
 
@@ -481,7 +480,7 @@ def test_specify_channels_cli_condarc(testdata: None):
     When the channel have been specified in condarc, these channels
     should be used along with the one specified
     """
-    reset_context((), argparse_args=AttrDict(channel=["conda-forge"]))
+    reset_context((), argparse_args=SimpleNamespace(channel=["conda-forge"]))
     string = dals(
         """
         channels: ['defaults', 'conda-forge']
@@ -503,7 +502,7 @@ def test_specify_different_channels_cli_condarc(testdata: None):
     In this test, the given channel in cli is different from condarc
     'defaults' should not be added
     """
-    reset_context((), argparse_args=AttrDict(channel=["other"]))
+    reset_context((), argparse_args=SimpleNamespace(channel=["other"]))
     string = dals(
         """
         channels: ['conda-forge']
@@ -527,7 +526,7 @@ def test_specify_same_channels_cli_as_in_condarc(testdata: None):
     'defaults' should not be added
     See https://github.com/conda/conda/issues/10732
     """
-    reset_context((), argparse_args=AttrDict(channel=["conda-forge"]))
+    reset_context((), argparse_args=SimpleNamespace(channel=["conda-forge"]))
     string = dals(
         """
         channels: ['conda-forge']

--- a/tests/core/test_envs_manager.py
+++ b/tests/core/test_envs_manager.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 
 import pytest
 
-from conda.auxlib.collection import AttrDict
 from conda.base.constants import PREFIX_MAGIC_FILE
 from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context, reset_context
 from conda.common.compat import on_win
@@ -91,7 +90,7 @@ def test_prefix_cli_flag(tmp_path: Path):
         stack_callback=conda_tests_ctxt_mgmt_def_pol,
     ):
         # even if prefix doesn't exist, it can be a target prefix
-        reset_context((), argparse_args=AttrDict(prefix="./blarg", func="create"))
+        reset_context((), argparse_args=SimpleNamespace(prefix="./blarg"))
         target_prefix = join(os.getcwd(), "blarg")
         assert context.target_prefix == target_prefix
         assert not isdir(target_prefix)

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -6,11 +6,11 @@ import sys
 from logging import getLogger
 from os.path import basename, dirname, getsize, isdir, isfile, join, lexists
 from pathlib import Path
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
-from conda.auxlib.collection import AttrDict
 from conda.auxlib.ish import dals
 from conda.base.context import context
 from conda.common.compat import on_win
@@ -76,15 +76,17 @@ def pkgs_dir(path_factory: PathFactoryFixture) -> Path:
 
 
 def test_CompileMultiPycAction_generic(prefix: Path):
-    package_info = AttrDict(
-        package_metadata=AttrDict(noarch=AttrDict(type=NoarchType.generic))
+    package_info = SimpleNamespace(
+        package_metadata=SimpleNamespace(
+            noarch=SimpleNamespace(type=NoarchType.generic)
+        )
     )
     noarch = package_info.package_metadata and package_info.package_metadata.noarch
     assert noarch.type == NoarchType.generic
     axns = CompileMultiPycAction.create_actions({}, package_info, prefix, None, ())
     assert axns == ()
 
-    package_info = AttrDict(package_metadata=None)
+    package_info = SimpleNamespace(package_metadata=None)
     axns = CompileMultiPycAction.create_actions({}, package_info, prefix, None, ())
     assert axns == ()
 
@@ -99,29 +101,29 @@ def test_CompileMultiPycAction_noarch_python(prefix: Path):
         "target_python_version": target_python_version,
         "target_site_packages_short_path": sp_dir,
     }
-    package_info = AttrDict(
-        package_metadata=AttrDict(noarch=AttrDict(type=NoarchType.python))
+    package_info = SimpleNamespace(
+        package_metadata=SimpleNamespace(noarch=SimpleNamespace(type=NoarchType.python))
     )
 
     file_link_actions = [
-        AttrDict(
+        SimpleNamespace(
             source_short_path="site-packages/something.py",
             target_short_path=get_python_noarch_target_path(
                 "site-packages/something.py", sp_dir
             ),
         ),
-        AttrDict(
+        SimpleNamespace(
             source_short_path="site-packages/another.py",
             target_short_path=get_python_noarch_target_path(
                 "site-packages/another.py", sp_dir
             ),
         ),
-        AttrDict(
+        SimpleNamespace(
             # this one shouldn't get compiled
             source_short_path="something.py",
             target_short_path=get_python_noarch_target_path("something.py", sp_dir),
         ),
-        AttrDict(
+        SimpleNamespace(
             # this one shouldn't get compiled
             source_short_path="another.py",
             target_short_path=get_python_noarch_target_path("another.py", sp_dir),
@@ -204,7 +206,7 @@ def test_CompileMultiPycAction_noarch_python(prefix: Path):
 
 
 def test_CreatePythonEntryPointAction_generic(prefix: Path):
-    package_info = AttrDict(package_metadata=None)
+    package_info = SimpleNamespace(package_metadata=None)
     axns = CreatePythonEntryPointAction.create_actions({}, package_info, prefix, None)
     assert axns == ()
 
@@ -214,9 +216,9 @@ def test_CreatePythonEntryPointAction_noarch_python(prefix: Path):
     transaction_context = {
         "target_python_version": target_python_version,
     }
-    package_info = AttrDict(
-        package_metadata=AttrDict(
-            noarch=AttrDict(
+    package_info = SimpleNamespace(
+        package_metadata=SimpleNamespace(
+            noarch=SimpleNamespace(
                 type=NoarchType.python,
                 entry_points=(
                     "command1=some.module:main",

--- a/tests/test_auxlib.py
+++ b/tests/test_auxlib.py
@@ -2,17 +2,18 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+from contextlib import nullcontext
 from enum import Enum
 from typing import TYPE_CHECKING
 
 import pytest
 from frozendict import deepfreeze
 
-from conda.auxlib.collection import make_immutable
+from conda.auxlib import collection, ish
 from conda.base.constants import UpdateModifier
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, ModuleType
 
 
 IMMUTABLE = (
@@ -41,4 +42,23 @@ MUTABLE = ([1, 1, 2], {1, 1, 2}, {1: 1, 2: 2})
     ],
 )
 def test_deepfreeze(unfrozen: Any) -> None:
-    assert make_immutable(unfrozen) == deepfreeze(unfrozen, {Enum: lambda x: x})
+    assert collection.make_immutable(unfrozen) == deepfreeze(
+        unfrozen, {Enum: lambda x: x}
+    )
+
+
+@pytest.mark.parametrize(
+    "module,function,raises",
+    [
+        (collection, "AttrDict", None),
+        (ish, "_get_attr", TypeError),
+        (ish, "find_or_none", TypeError),
+        (ish, "find_or_raise", TypeError),
+    ],
+)
+def test_deprecations(
+    module: ModuleType, function: str, raises: type[Exception] | None
+) -> None:
+    raises_context = pytest.raises(raises) if raises else nullcontext()
+    with pytest.deprecated_call(), raises_context:
+        getattr(module, function)()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,13 +3,13 @@
 import getpass
 import json
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
 from pytest_mock import MockerFixture
 
-from conda.auxlib.collection import AttrDict
 from conda.base.constants import PathConflict
 from conda.base.context import context, reset_context
 from conda.common.io import captured
@@ -521,12 +521,12 @@ def test_print_unexpected_error_message_upload_1(
     post_mock = mocker.patch(
         "requests.post",
         side_effect=(
-            AttrDict(
-                headers=AttrDict(Location="somewhere.else"),
+            SimpleNamespace(
+                headers=SimpleNamespace(Location="somewhere.else"),
                 status_code=302,
                 raise_for_status=lambda: None,
             ),
-            AttrDict(raise_for_status=lambda: None),
+            SimpleNamespace(raise_for_status=lambda: None),
         ),
     )
 
@@ -559,17 +559,17 @@ def test_print_unexpected_error_message_upload_2(
     post_mock = mocker.patch(
         "requests.post",
         side_effect=(
-            AttrDict(
-                headers=AttrDict(Location="somewhere.else"),
+            SimpleNamespace(
+                headers=SimpleNamespace(Location="somewhere.else"),
                 status_code=302,
                 raise_for_status=lambda: None,
             ),
-            AttrDict(
-                headers=AttrDict(Location="somewhere.again"),
+            SimpleNamespace(
+                headers=SimpleNamespace(Location="somewhere.again"),
                 status_code=301,
                 raise_for_status=lambda: None,
             ),
-            AttrDict(raise_for_status=lambda: None),
+            SimpleNamespace(raise_for_status=lambda: None),
         ),
     )
 
@@ -602,12 +602,12 @@ def test_print_unexpected_error_message_upload_3(
     post_mock = mocker.patch(
         "requests.post",
         side_effect=(
-            AttrDict(
-                headers=AttrDict(Location="somewhere.else"),
+            SimpleNamespace(
+                headers=SimpleNamespace(Location="somewhere.else"),
                 status_code=302,
                 raise_for_status=lambda: None,
             ),
-            AttrDict(raise_for_status=lambda: None),
+            SimpleNamespace(raise_for_status=lambda: None),
         ),
     )
     input_mock = mocker.patch("builtins.input", return_value="y")
@@ -635,12 +635,12 @@ def test_print_unexpected_error_message_upload_3(
 @patch(
     "requests.post",
     side_effect=(
-        AttrDict(
-            headers=AttrDict(Location="somewhere.else"),
+        SimpleNamespace(
+            headers=SimpleNamespace(Location="somewhere.else"),
             status_code=302,
             raise_for_status=lambda: None,
         ),
-        AttrDict(raise_for_status=lambda: None),
+        SimpleNamespace(raise_for_status=lambda: None),
     ),
 )
 @patch("getpass.getuser", return_value="some name")
@@ -667,12 +667,12 @@ def test_print_unexpected_error_message_upload_username_with_spaces(
 @patch(
     "requests.post",
     side_effect=(
-        AttrDict(
-            headers=AttrDict(Location="somewhere.else"),
+        SimpleNamespace(
+            headers=SimpleNamespace(Location="somewhere.else"),
             status_code=302,
             raise_for_status=lambda: None,
         ),
-        AttrDict(raise_for_status=lambda: None),
+        SimpleNamespace(raise_for_status=lambda: None),
     ),
 )
 @patch("getpass.getuser", return_value="my√nameΩ")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
