### PR TITLE
Remove no-op `context.use_only_tar_bz2` logic

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -969,18 +969,10 @@ class Context(Configuration):
         #    is only called when use_only_tar_bz2 is first called.
         import conda_package_handling.api
 
-        use_only_tar_bz2 = False
-        if self._use_only_tar_bz2 is None:
-            if self._argparse_args and "use_only_tar_bz2" in self._argparse_args:
-                use_only_tar_bz2 &= self._argparse_args["use_only_tar_bz2"]
         return (
-            (
-                hasattr(conda_package_handling.api, "libarchive_enabled")
-                and not conda_package_handling.api.libarchive_enabled
-            )
-            or self._use_only_tar_bz2
-            or use_only_tar_bz2
-        )
+            hasattr(conda_package_handling.api, "libarchive_enabled")
+            and not conda_package_handling.api.libarchive_enabled
+        ) or self._use_only_tar_bz2
 
     @property
     def binstar_upload(self):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -970,8 +970,7 @@ class Context(Configuration):
         import conda_package_handling.api
 
         return (
-            hasattr(conda_package_handling.api, "libarchive_enabled")
-            and not conda_package_handling.api.libarchive_enabled
+            not conda_package_handling.api.libarchive_enabled
         ) or self._use_only_tar_bz2
 
     @property


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The following code block will always evaluate to `use_only_tar_bz2 = False` so we can remove it (plus none of our subcommands supports providing a `--use-only-tar-bz2` flag anyhow):

https://github.com/conda/conda/blob/8ba894077c7ddfbcc4e258dc4cefcd1fae5a460d/conda/base/context.py#L972-L975

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
