### PR TITLE
Change how arguments are passed in in `Invoke-Conda` function

### DIFF
--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -125,6 +125,11 @@ function Exit-CondaEnvironment {
         conda install toolz
 #>
 function Invoke-Conda() {
+    # To mitigate breaking change in .NET 9
+    # see github issue: https://github.com/PowerShell/PowerShell/issues/24268
+    if ($Env:_CE_M -eq "") { $Env:_CE_M = $null }
+    if ($Env:_CE_CONDA -eq "") { $Env:_CE_CONDA = $null }
+    
     # Don't use any explicit args here, we'll use $args and tab completion
     # so that we can capture everything, INCLUDING short options (e.g. -n).
     if ($Args.Count -eq 0) {

--- a/news/14239-convert-envvar-empty-string-to-null
+++ b/news/14239-convert-envvar-empty-string-to-null
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Convert environment variables with empty string as value to `$null`, to mitigate breaking chnage in .NET 9. (#14239)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Due to breaking change in core .NET libraries, where passing `string.Empty` to `Environment.SetEnvironmentVariable` no longer deletes the environment variable, see [dotnet breaking chnage](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/empty-env-variable) and [this GitHub issue](https://github.com/PowerShell/PowerShell/issues/24268)

This solution should mitigate this issue PowerShell version above 7.5.0-preview.4. (This is just a workaround, further fixing how empty env vars are handled might be needed.)

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
