### PR TITLE
Add session scoped fixture variants for `capsys`, `conda_cli`, and `tmp_env`

### DIFF
--- a/conda/testing/__init__.py
+++ b/conda/testing/__init__.py
@@ -14,37 +14,28 @@
 # CONDA_PREFIX too in some instances and that really needs fixing.
 from __future__ import annotations
 
-import json
 import os
 import sys
-import uuid
 import warnings
-from contextlib import contextmanager, nullcontext
-from dataclasses import dataclass
 from logging import getLogger
 from os.path import join
 from pathlib import Path
-from shutil import copyfile
-from typing import TYPE_CHECKING, overload
 
-import pytest
-
-from ..auxlib.entity import EntityEncoder
-from ..base.constants import PACKAGE_CACHE_MAGIC_FILE
-from ..base.context import context, reset_context
-from ..cli.main import main_subshell
 from ..common.compat import on_win
-from ..common.url import path_to_url
-from ..core.package_cache_data import PackageCacheData
 from ..deprecations import deprecated
-from ..exceptions import CondaExitZero
-from ..models.records import PackageRecord
-
-if TYPE_CHECKING:
-    from typing import Iterator
-
-    from pytest import CaptureFixture, ExceptionInfo, MonkeyPatch
-    from pytest_mock import MockerFixture
+from .fixtures import (
+    CondaCLIFixture,
+    PathFactoryFixture,
+    TmpChannelFixture,
+    TmpEnvFixture,
+    conda_cli,
+    context_aware_monkeypatch,
+    path_factory,
+    tmp_channel,
+    tmp_env,
+    tmp_envs_dir,
+    tmp_pkgs_dir,
+)
 
 log = getLogger(__name__)
 
@@ -127,234 +118,91 @@ def conda_move_to_front_of_PATH():
         os.environ["PATH"] = os.pathsep.join(p)
 
 
-@dataclass
-class CondaCLIFixture:
-    capsys: CaptureFixture
-
-    @overload
-    def __call__(
-        self,
-        *argv: str | os.PathLike | Path,
-        raises: type[Exception] | tuple[type[Exception], ...],
-    ) -> tuple[str, str, ExceptionInfo]: ...
-
-    @overload
-    def __call__(self, *argv: str | os.PathLike | Path) -> tuple[str, str, int]: ...
-
-    def __call__(
-        self,
-        *argv: str | os.PathLike | Path,
-        raises: type[Exception] | tuple[type[Exception], ...] | None = None,
-    ) -> tuple[str, str, int | ExceptionInfo]:
-        """Test conda CLI. Mimic what is done in `conda.cli.main.main`.
-
-        `conda ...` == `conda_cli(...)`
-
-        :param argv: Arguments to parse.
-        :param raises: Expected exception to intercept. If provided, the raised exception
-            will be returned instead of exit code (see pytest.raises and pytest.ExceptionInfo).
-        :return: Command results (stdout, stderr, exit code or pytest.ExceptionInfo).
-        """
-        # clear output
-        self.capsys.readouterr()
-
-        # ensure arguments are string
-        argv = tuple(map(str, argv))
-
-        # run command
-        code = None
-        with pytest.raises(raises) if raises else nullcontext() as exception:
-            code = main_subshell(*argv)
-        # capture output
-        out, err = self.capsys.readouterr()
-
-        # restore to prior state
-        reset_context()
-
-        return out, err, exception if raises else code
-
-
-@pytest.fixture
-def conda_cli(capsys: CaptureFixture) -> Iterator[CondaCLIFixture]:
-    """Fixture returning CondaCLIFixture instance."""
-    yield CondaCLIFixture(capsys)
-
-
-@dataclass
-class PathFactoryFixture:
-    tmp_path: Path
-
-    def __call__(
-        self,
-        name: str | None = None,
-        prefix: str | None = None,
-        suffix: str | None = None,
-    ) -> Path:
-        """Unique, non-existent path factory.
-
-        Extends pytest's `tmp_path` fixture with a new unique, non-existent path for usage in cases
-        where we need a temporary path that doesn't exist yet.
-
-        :param name: Path name to append to `tmp_path`
-        :param prefix: Prefix to prepend to unique name generated
-        :param suffix: Suffix to append to unique name generated
-        :return: A new unique path
-        """
-        prefix = prefix or ""
-        name = name or uuid.uuid4().hex
-        suffix = suffix or ""
-        return self.tmp_path / (prefix + name + suffix)
-
-
-@pytest.fixture
-def path_factory(tmp_path: Path) -> Iterator[PathFactoryFixture]:
-    """Fixture returning PathFactoryFixture instance."""
-    yield PathFactoryFixture(tmp_path)
-
-
-@dataclass
-class TmpEnvFixture:
-    path_factory: PathFactoryFixture
-    conda_cli: CondaCLIFixture
-
-    @contextmanager
-    def __call__(
-        self,
-        *packages: str,
-        prefix: str | os.PathLike | None = None,
-    ) -> Iterator[Path]:
-        """Generate a conda environment with the provided packages.
-
-        :param packages: The packages to install into environment
-        :param prefix: The prefix at which to install the conda environment
-        :return: The conda environment's prefix
-        """
-        prefix = Path(prefix or self.path_factory())
-
-        self.conda_cli("create", "--prefix", prefix, *packages, "--yes", "--quiet")
-        yield prefix
-
-        # no need to remove prefix since it is in a temporary directory
-
-
-@pytest.fixture
-def tmp_env(
-    path_factory: PathFactoryFixture,
-    conda_cli: CondaCLIFixture,
-) -> Iterator[TmpEnvFixture]:
-    """Fixture returning TmpEnvFixture instance."""
-    yield TmpEnvFixture(path_factory, conda_cli)
-
-
-@dataclass
-class TmpChannelFixture:
-    path_factory: PathFactoryFixture
-    conda_cli: CondaCLIFixture
-
-    @contextmanager
-    def __call__(self, *packages: str) -> Iterator[tuple[Path, str]]:
-        # download packages
-        self.conda_cli(
-            "create",
-            f"--prefix={self.path_factory()}",
-            *packages,
-            "--yes",
-            "--quiet",
-            "--download-only",
-            raises=CondaExitZero,
-        )
-
-        pkgs_dir = Path(PackageCacheData.first_writable().pkgs_dir)
-        pkgs_cache = PackageCacheData(pkgs_dir)
-
-        channel = self.path_factory()
-        subdir = channel / context.subdir
-        subdir.mkdir(parents=True)
-        noarch = channel / "noarch"
-        noarch.mkdir(parents=True)
-
-        repodata = {"info": {}, "packages": {}}
-        for package in packages:
-            for pkg_data in pkgs_cache.query(package):
-                fname = pkg_data["fn"]
-
-                copyfile(pkgs_dir / fname, subdir / fname)
-
-                repodata["packages"][fname] = PackageRecord(
-                    **{
-                        field: value
-                        for field, value in pkg_data.dump().items()
-                        if field not in ("url", "channel", "schannel")
-                    }
-                )
-
-        (subdir / "repodata.json").write_text(json.dumps(repodata, cls=EntityEncoder))
-        (noarch / "repodata.json").write_text(json.dumps({}, cls=EntityEncoder))
-
-        for package in packages:
-            assert any(PackageCacheData.query_all(package))
-
-        yield channel, path_to_url(str(channel))
-
-
-@pytest.fixture
-def tmp_channel(
-    path_factory: PathFactoryFixture,
-    conda_cli: CondaCLIFixture,
-) -> Iterator[TmpChannelFixture]:
-    """Fixture returning TmpChannelFixture instance."""
-    yield TmpChannelFixture(path_factory, conda_cli)
-
-
-@pytest.fixture(name="monkeypatch")
-def context_aware_monkeypatch(monkeypatch: MonkeyPatch) -> MonkeyPatch:
-    """A monkeypatch fixture that resets context after each test"""
-    yield monkeypatch
-
-    # reset context if any CONDA_ variables were set/unset
-    if conda_vars := [
-        name
-        for obj, name, _ in monkeypatch._setitem
-        if obj is os.environ and name.startswith("CONDA_")
-    ]:
-        log.debug(f"monkeypatch cleanup: undo & reset context: {', '.join(conda_vars)}")
-        monkeypatch.undo()
-        # reload context without search paths
-        reset_context([])
-
-
-@pytest.fixture
-def tmp_pkgs_dir(
-    path_factory: PathFactoryFixture, mocker: MockerFixture
-) -> Iterator[Path]:
-    pkgs_dir = path_factory() / "pkgs"
-    pkgs_dir.mkdir(parents=True)
-    (pkgs_dir / PACKAGE_CACHE_MAGIC_FILE).touch()
-
-    mocker.patch(
-        "conda.base.context.Context.pkgs_dirs",
-        new_callable=mocker.PropertyMock,
-        return_value=(pkgs_dir_str := str(pkgs_dir),),
-    )
-    assert context.pkgs_dirs == (pkgs_dir_str,)
-
-    yield pkgs_dir
-
-    PackageCacheData._cache_.pop(pkgs_dir_str, None)
-
-
-@pytest.fixture
-def tmp_envs_dir(
-    path_factory: PathFactoryFixture, mocker: MockerFixture
-) -> Iterator[Path]:
-    envs_dir = path_factory() / "envs"
-    envs_dir.mkdir(parents=True)
-
-    mocker.patch(
-        "conda.base.context.Context.envs_dirs",
-        new_callable=mocker.PropertyMock,
-        return_value=(envs_dir_str := str(envs_dir),),
-    )
-    assert context.envs_dirs == (envs_dir_str,)
-
-    yield envs_dir
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "CondaCLIFixture",
+    CondaCLIFixture,
+    addendum="Use `conda.testing.fixtures.CondaCLIFixture` instead.",
+)
+del CondaCLIFixture
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "conda_cli",
+    conda_cli,
+    addendum="Use `conda.testing.fixtures.conda_cli` instead.",
+)
+del conda_cli
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "PathFactoryFixture",
+    PathFactoryFixture,
+    addendum="Use `conda.testing.fixtures.PathFactoryFixture` instead.",
+)
+del PathFactoryFixture
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "path_factory",
+    path_factory,
+    addendum="Use `conda.testing.fixtures.path_factory` instead.",
+)
+del path_factory
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "TmpEnvFixture",
+    TmpEnvFixture,
+    addendum="Use `conda.testing.fixtures.TmpEnvFixture` instead.",
+)
+del TmpEnvFixture
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "tmp_env",
+    tmp_env,
+    addendum="Use `conda.testing.fixtures.tmp_env` instead.",
+)
+del tmp_env
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "TmpChannelFixture",
+    TmpChannelFixture,
+    addendum="Use `conda.testing.fixtures.TmpChannelFixture` instead.",
+)
+del TmpChannelFixture
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "tmp_channel",
+    tmp_channel,
+    addendum="Use `conda.testing.fixtures.tmp_channel` instead.",
+)
+del tmp_channel
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "context_aware_monkeypatch",
+    context_aware_monkeypatch,
+    addendum="Use `conda.testing.fixtures.context_aware_monkeypatch` instead.",
+)
+del context_aware_monkeypatch
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "tmp_pkgs_dir",
+    tmp_pkgs_dir,
+    addendum="Use `conda.testing.fixtures.tmp_pkgs_dir` instead.",
+)
+del tmp_pkgs_dir
+deprecated.constant(
+    "25.3",
+    "25.9",
+    "tmp_envs_dir",
+    tmp_envs_dir,
+    addendum="Use `conda.testing.fixtures.tmp_envs_dir` instead.",
+)
+del tmp_envs_dir

--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -190,6 +190,7 @@ def _solver_helper(
 
 @pytest.fixture(scope="session")
 def global_capsys(request) -> Iterator[MultiCapture]:
+    # https://github.com/pytest-dev/pytest/issues/2704#issuecomment-603387680
     capmanager = request.config.pluginmanager.getplugin("capturemanager")
     with capmanager.global_and_fixture_disabled():
         yield capmanager._global_capturing

--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -189,7 +189,7 @@ def _solver_helper(
 
 
 @pytest.fixture(scope="session")
-def global_capsys(request) -> Iterator[MultiCapture]:
+def session_capsys(request) -> Iterator[MultiCapture]:
     # https://github.com/pytest-dev/pytest/issues/2704#issuecomment-603387680
     capmanager = request.config.pluginmanager.getplugin("capturemanager")
     with capmanager.global_and_fixture_disabled():
@@ -254,13 +254,13 @@ def conda_cli(capsys: CaptureFixture) -> Iterator[CondaCLIFixture]:
 
 
 @pytest.fixture(scope="session")
-def global_conda_cli(global_capsys: MultiCapture) -> Iterator[CondaCLIFixture]:
+def session_conda_cli(session_capsys: MultiCapture) -> Iterator[CondaCLIFixture]:
     """A session scoped fixture returning CondaCLIFixture instance.
 
     Use this for any commands that are global to the test session (e.g., creating a
     conda environment shared across tests, `conda info`, etc.).
     """
-    yield CondaCLIFixture(global_capsys)
+    yield CondaCLIFixture(session_capsys)
 
 
 @dataclass
@@ -345,15 +345,15 @@ def tmp_env(
 
 
 @pytest.fixture(scope="session")
-def global_tmp_env(
+def session_tmp_env(
     tmp_path_factory: TempPathFactory,
-    global_conda_cli: CondaCLIFixture,
+    session_conda_cli: CondaCLIFixture,
 ) -> Iterator[TmpEnvFixture]:
     """A session scoped fixture returning TmpEnvFixture instance.
 
     Use this when creating a conda environment that is shared across tests.
     """
-    yield TmpEnvFixture(tmp_path_factory, global_conda_cli)
+    yield TmpEnvFixture(tmp_path_factory, session_conda_cli)
 
 
 @dataclass

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -11,7 +11,7 @@ these should serve as a good starting point.
 :::{note}
 The `conda_cli` fixture is a `scope="function"` fixture meaning it can only be used
 within tests or other `scope="function"` fixtures. For `"module"`, `"package"`, or
-`"session"` scoped fixtures use `global_conda_cli` instead.
+`"session"` scoped fixtures use `session_conda_cli` instead.
 :::
 
 CLI level tests are the highest level integration tests you can write. This means that the
@@ -93,7 +93,7 @@ unexpected race conditions.
 :::{note}
 The `tmp_env` fixture is a `scope="function"` fixture meaning it can only be used
 within tests or other `scope="function"` fixtures. For `"module"`, `"package"`, or
-`"session"` scoped fixtures use `global_tmp_env` instead.
+`"session"` scoped fixtures use `session_tmp_env` instead.
 :::
 
 The `tmp_env` fixture is a convenient way to create a temporary environment for use in

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -23,10 +23,17 @@ running `conda create`. A test like this would look like the following:
 :linenos:
 :name: test-conda-create-1
 :caption: Integration test for `conda create`
-import json
-from pathlib import Path
+from __future__ import annotations
 
-from conda.testing import CondaCLIFixture
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture
+
+pytest_plugins = "conda.testing.fixtures"
 
 
 def test_conda_create(conda_cli: CondaCLIFixture, tmp_path: Path):
@@ -96,7 +103,14 @@ tests:
 :linenos:
 :name: test-conda-environment-with-numpy
 :caption: Integration test for creating an environment with `numpy`
-from conda.testing import CondaCLIFixture, TmpEnvFixture
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+
+pytest_plugins = "conda.testing.fixtures"
 
 
 def test_environment_with_numpy(
@@ -120,11 +134,20 @@ paths. This makes it easier to generate new paths in tests:
 :linenos:
 :name: test-conda-rename
 :caption: Integration test for renaming an environment
-from conda.testing import (
-    CondaCLIFixture,
-    PathFactoryFixture,
-    TmpEnvFixture,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
+
+pytest_plugins = "conda.testing.fixtures"
 
 
 def test_conda_rename(
@@ -162,10 +185,17 @@ fixture:
 :linenos:
 :name: test-conda-create-2
 :caption: Integration test for `conda create`
-import json
-from pathlib import Path
+from __future__ import annotations
 
-from conda.testing import CondaCLIFixture
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+
+pytest_plugins = "conda.testing.fixtures"
 
 
 @pytest.fixture

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -8,6 +8,11 @@ these should serve as a good starting point.
 
 ## `conda_cli` Fixture: Running CLI level tests
 
+.. note::
+    The `conda_cli` fixture is a function scoped fixture meaning it can only be used
+    within tests or other function scoped fixtures. For module, package, or session
+    scoped fixtures use `global_conda_cli` instead.
+
 CLI level tests are the highest level integration tests you can write. This means that the
 code in the test is executed as if you were running it from the command line. For example,
 you may want to write a test to confirm that an environment is created after successfully
@@ -76,6 +81,11 @@ unexpected race conditions.
 :::
 
 ## `tmp_env` Fixture: Creating a temporary environment
+
+.. note::
+    The `tmp_env` fixture is a function scoped fixture meaning it can only be used
+    within tests or other function scoped fixtures. For module, package, or session
+    scoped fixtures use `global_tmp_env` instead.
 
 The `tmp_env` fixture is a convenient way to create a temporary environment for use in
 tests:

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -8,11 +8,11 @@ these should serve as a good starting point.
 
 ## `conda_cli` Fixture: Running CLI level tests
 
-```{note}
-The `conda_cli` fixture is a function scoped fixture meaning it can only be used
-within tests or other function scoped fixtures. For module, package, or session
-scoped fixtures use `global_conda_cli` instead.
-```
+:::{note}
+The `conda_cli` fixture is a `scope="function"` fixture meaning it can only be used
+within tests or other `scope="function"` fixtures. For `"module"`, `"package"`, or
+`"session"` scoped fixtures use `global_conda_cli` instead.
+:::
 
 CLI level tests are the highest level integration tests you can write. This means that the
 code in the test is executed as if you were running it from the command line. For example,
@@ -83,11 +83,11 @@ unexpected race conditions.
 
 ## `tmp_env` Fixture: Creating a temporary environment
 
-```{note}
-The `tmp_env` fixture is a function scoped fixture meaning it can only be used
-within tests or other function scoped fixtures. For module, package, or session
-scoped fixtures use `global_tmp_env` instead.
-```
+:::{note}
+The `tmp_env` fixture is a `scope="function"` fixture meaning it can only be used
+within tests or other `scope="function"` fixtures. For `"module"`, `"package"`, or
+`"session"` scoped fixtures use `global_tmp_env` instead.
+:::
 
 The `tmp_env` fixture is a convenient way to create a temporary environment for use in
 tests:

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -8,10 +8,11 @@ these should serve as a good starting point.
 
 ## `conda_cli` Fixture: Running CLI level tests
 
-.. note::
-    The `conda_cli` fixture is a function scoped fixture meaning it can only be used
-    within tests or other function scoped fixtures. For module, package, or session
-    scoped fixtures use `global_conda_cli` instead.
+```{note}
+The `conda_cli` fixture is a function scoped fixture meaning it can only be used
+within tests or other function scoped fixtures. For module, package, or session
+scoped fixtures use `global_conda_cli` instead.
+```
 
 CLI level tests are the highest level integration tests you can write. This means that the
 code in the test is executed as if you were running it from the command line. For example,
@@ -82,10 +83,11 @@ unexpected race conditions.
 
 ## `tmp_env` Fixture: Creating a temporary environment
 
-.. note::
-    The `tmp_env` fixture is a function scoped fixture meaning it can only be used
-    within tests or other function scoped fixtures. For module, package, or session
-    scoped fixtures use `global_tmp_env` instead.
+```{note}
+The `tmp_env` fixture is a function scoped fixture meaning it can only be used
+within tests or other function scoped fixtures. For module, package, or session
+scoped fixtures use `global_tmp_env` instead.
+```
 
 The `tmp_env` fixture is a convenient way to create a temporary environment for use in
 tests:

--- a/news/14243-session-fixtures
+++ b/news/14243-session-fixtures
@@ -1,0 +1,31 @@
+### Enhancements
+
+* Add `conda.testing.fixtures.global_capsys`. Use this to capture stdout and stderr within module, package, and session scoped fixtures. (#14243)
+* Add `conda.testing.fixtures.global_conda_cli`. Use this to invoke conda commands within module, package, and session scoped fixtures. (#14243)
+* Add `conda.testing.fixtures.global_tmp_env`. Use this to create a conda environment within module, package, and session scoped fixtures. (#14243)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.testing.CondaCLIFixture` as pending deprecation. Use `conda.testing.fixtures.CondaCLIFixture` instead. (#14243)
+* Mark `conda.testing.conda_cli` as pending deprecation. Use `conda.testing.fixtures.conda_cli` instead. (#14243)
+* Mark `conda.testing.PathFactoryFixture` as pending deprecation. Use `conda.testing.fixtures.PathFactoryFixture` instead. (#14243)
+* Mark `conda.testing.path_factory` as pending deprecation. Use `conda.testing.fixtures.path_factory` instead. (#14243)
+* Mark `conda.testing.TmpEnvFixture` as pending deprecation. Use `conda.testing.fixtures.TmpEnvFixture` instead. (#14243)
+* Mark `conda.testing.tmp_env` as pending deprecation. Use `conda.testing.fixtures.tmp_env` instead. (#14243)
+* Mark `conda.testing.TmpChannelFixture` as pending deprecation. Use `conda.testing.fixtures.TmpChannelFixture` instead. (#14243)
+* Mark `conda.testing.tmp_channel` as pending deprecation. Use `conda.testing.fixtures.tmp_channel` instead. (#14243)
+* Mark `conda.testing.context_aware_monkeypatch` as pending deprecation. Use `conda.testing.fixtures.context_aware_monkeypatch` instead. (#14243)
+* Mark `conda.testing.tmp_pkgs_dir` as pending deprecation. Use `conda.testing.fixtures.tmp_pkgs_dir` instead. (#14243)
+* Mark `conda.testing.tmp_envs_dir` as pending deprecation. Use `conda.testing.fixtures.tmp_envs_dir` instead. (#14243)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/14243-session-fixtures
+++ b/news/14243-session-fixtures
@@ -1,8 +1,8 @@
 ### Enhancements
 
-* Add `conda.testing.fixtures.global_capsys`. Use this to capture stdout and stderr within module, package, and session scoped fixtures. (#14243)
-* Add `conda.testing.fixtures.global_conda_cli`. Use this to invoke conda commands within module, package, and session scoped fixtures. (#14243)
-* Add `conda.testing.fixtures.global_tmp_env`. Use this to create a conda environment within module, package, and session scoped fixtures. (#14243)
+* Add `conda.testing.fixtures.session_capsys`. Use this to capture stdout and stderr within module, package, and session scoped fixtures. (#14243)
+* Add `conda.testing.fixtures.session_conda_cli`. Use this to invoke conda commands within module, package, and session scoped fixtures. (#14243)
+* Add `conda.testing.fixtures.session_tmp_env`. Use this to create a conda environment within module, package, and session scoped fixtures. (#14243)
 
 ### Bug fixes
 

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -1,16 +1,28 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
-from pytest_mock import MockerFixture
 
 from conda.base.context import context, reset_context
 from conda.exceptions import UnsatisfiableError
 from conda.models.match_spec import MatchSpec
-from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 from conda.testing.integration import package_is_installed
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import MonkeyPatch
+    from pytest_mock import MockerFixture
+
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
+
 
 pytestmark = pytest.mark.usefixtures("parametrized_solver_fixture")
 

--- a/tests/cli/test_compare.py
+++ b/tests/cli/test_compare.py
@@ -1,9 +1,15 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from conda.auxlib.ish import dals
-from conda.testing import CondaCLIFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 
 def test_compare_success(

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -1,16 +1,22 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import importlib
 import re
 from inspect import isclass, isfunction
 from logging import getLogger
-from typing import Any, Callable
+from typing import TYPE_CHECKING
 
 import pytest
 
 from conda.cli.conda_argparse import generate_parser
 from conda.exceptions import EnvironmentLocationNotFound
-from conda.testing import CondaCLIFixture
+
+if TYPE_CHECKING:
+    from typing import Any, Callable
+
+    from conda.testing.fixtures import CondaCLIFixture
 
 log = getLogger(__name__)
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,15 +1,16 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import json
 import os
 import re
 import sys
 from contextlib import contextmanager, nullcontext
 from textwrap import dedent
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
-from pytest_mock import MockerFixture
 from ruamel.yaml.scanner import ScannerError
 
 from conda import CondaError, CondaMultiError
@@ -19,7 +20,12 @@ from conda.common.configuration import ConfigurationLoadError, CustomValidationE
 from conda.common.serialize import yaml_round_trip_dump, yaml_round_trip_load
 from conda.exceptions import CondaKeyError, CondaValueError
 from conda.gateways.disk.delete import rm_rf
-from conda.testing import CondaCLIFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+    from pytest_mock import MockerFixture
+
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 # use condarc from source tree to run these tests against
 

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -27,7 +27,11 @@ if TYPE_CHECKING:
 
     from pytest import MonkeyPatch
 
-    from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
 
 pytestmark = pytest.mark.usefixtures("parametrized_solver_fixture")
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,8 +1,13 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
-from conda.testing import CondaCLIFixture
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture
 
 
 def test_main():

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-    from conda.testing import CondaCLIFixture, TmpEnvFixture
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 
 def _get_pkgs(pkgs_dir: str | Path) -> list[Path]:

--- a/tests/cli/test_main_compare.py
+++ b/tests/cli/test_main_compare.py
@@ -1,12 +1,19 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
 
 from conda.exceptions import EnvironmentLocationNotFound
-from conda.testing import CondaCLIFixture
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+    from conda.testing.fixtures import CondaCLIFixture
 
 
 def test_compare(mocker: MockerFixture, tmp_path: Path, conda_cli: CondaCLIFixture):

--- a/tests/cli/test_main_config.py
+++ b/tests/cli/test_main_config.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from pytest import MonkeyPatch
 
-    from conda.testing import CondaCLIFixture, PathFactoryFixture
+    from conda.testing.fixtures import CondaCLIFixture, PathFactoryFixture
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_main_export.py
+++ b/tests/cli/test_main_export.py
@@ -1,13 +1,19 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
 
 from conda.base.context import context, reset_context
 from conda.exceptions import CondaValueError
-from conda.testing import CondaCLIFixture
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+    from conda.testing.fixtures import CondaCLIFixture
 
 TEST_ENV_NAME = "test_env"
 

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -12,7 +12,7 @@ from conda.base.context import reset_context
 if TYPE_CHECKING:
     from pytest import MonkeyPatch
 
-    from conda.testing import CondaCLIFixture
+    from conda.testing.fixtures import CondaCLIFixture
 
 
 # conda info --root [--json]

--- a/tests/cli/test_main_install.py
+++ b/tests/cli/test_main_install.py
@@ -1,17 +1,24 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from json import loads as json_loads
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
 
 from conda.base.context import context, reset_context
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import DirectoryNotACondaEnvironmentError, PackagesNotFoundError
 from conda.gateways.disk.delete import path_is_clean, rm_rf
-from conda.testing import CondaCLIFixture, TmpEnvFixture
 from conda.testing.integration import package_is_installed
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import MonkeyPatch
+
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 
 def test_install_freezes_env_by_default(

--- a/tests/cli/test_main_list.py
+++ b/tests/cli/test_main_list.py
@@ -16,7 +16,11 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-    from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
 
 
 @pytest.fixture

--- a/tests/cli/test_main_notices.py
+++ b/tests/cli/test_main_notices.py
@@ -1,14 +1,15 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import datetime
 import glob
 import hashlib
 import json
 import os
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest import MonkeyPatch
-from pytest_mock import MockerFixture
 
 from conda.base.constants import NOTICES_DECORATOR_DISPLAY_INTERVAL
 from conda.base.context import context, reset_context
@@ -16,7 +17,6 @@ from conda.cli import conda_argparse
 from conda.cli import main_notices as notices
 from conda.exceptions import CondaError, PackagesNotFoundError
 from conda.notices import fetch
-from conda.testing import CondaCLIFixture, PathFactoryFixture
 from conda.testing.notices.helpers import (
     add_resp_to_mock,
     create_notice_cache_files,
@@ -24,6 +24,12 @@ from conda.testing.notices.helpers import (
     get_test_notices,
     offset_cache_file_mtime,
 )
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+    from pytest_mock import MockerFixture
+
+    from conda.testing.fixtures import CondaCLIFixture, PathFactoryFixture
 
 
 @pytest.fixture

--- a/tests/cli/test_main_remove.py
+++ b/tests/cli/test_main_remove.py
@@ -1,8 +1,11 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import json
 from importlib.metadata import version
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -10,12 +13,14 @@ from conda.base.context import context
 from conda.common.io import stderr_log_level
 from conda.exceptions import DryRunExit, PackagesNotFoundError
 from conda.gateways.disk.delete import path_is_clean
-from conda.testing import CondaCLIFixture, TmpEnvFixture
 from conda.testing.integration import (
     PYTHON_BINARY,
     TEST_LOG_LEVEL,
     package_is_installed,
 )
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 log = getLogger(__name__)
 stderr_log_level(TEST_LOG_LEVEL, "conda")

--- a/tests/cli/test_main_rename.py
+++ b/tests/cli/test_main_rename.py
@@ -24,7 +24,11 @@ if TYPE_CHECKING:
     from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
-    from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
 
 
 @pytest.fixture

--- a/tests/cli/test_main_run.py
+++ b/tests/cli/test_main_run.py
@@ -1,9 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import os
 import stat
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,8 +16,10 @@ from conda.exceptions import (
     DirectoryNotACondaEnvironmentError,
     EnvironmentLocationNotFound,
 )
-from conda.testing import CondaCLIFixture, TmpEnvFixture
 from conda.testing.integration import env_or_set, which_or_where
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 
 def test_run_returns_int(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture):

--- a/tests/cli/test_main_search.py
+++ b/tests/cli/test_main_search.py
@@ -1,17 +1,24 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import json
 import re
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 import requests
-from pytest import CaptureFixture, MonkeyPatch
 
 from conda.base.context import context, reset_context
 from conda.exceptions import PackagesNotFoundError
 from conda.gateways.anaconda_client import read_binstar_tokens
-from conda.testing import CondaCLIFixture
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import CaptureFixture, MonkeyPatch
+
+    from conda.testing.fixtures import CondaCLIFixture
 
 # all tests in this file are integration tests
 pytestmark = [pytest.mark.integration]

--- a/tests/cli/test_subcommands.py
+++ b/tests/cli/test_subcommands.py
@@ -12,7 +12,11 @@ from conda.common.compat import on_win
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
 
 pytestmark = pytest.mark.usefixtures("parametrized_solver_fixture")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 
 pytest_plugins = (
     # Add testing fixtures and internal pytest plugins here
-    "conda.testing",
     "conda.testing.gateways.fixtures",
     "conda.testing.notices.fixtures",
     "conda.testing.fixtures",

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -1,10 +1,13 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import ntpath
 import os
 import sys
 from os.path import abspath, dirname, isfile, join, realpath, samefile
 from sysconfig import get_path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -40,8 +43,10 @@ from conda.core.initialize import (
 from conda.exceptions import CondaValueError
 from conda.gateways.disk.create import create_link, mkdir_p
 from conda.models.enums import LinkType
-from conda.testing import CondaCLIFixture
 from conda.testing.helpers import tempdir
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture
 
 CONDA_EXE = "conda.exe" if on_win else "conda"
 

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -1,11 +1,13 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import importlib.util
 import os
 import sys
 from logging import getLogger
 from os.path import basename, dirname, getsize, isdir, isfile, join, lexists
-from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
@@ -39,7 +41,11 @@ from conda.models.channel import Channel
 from conda.models.enums import LinkType, NoarchType, PathType
 from conda.models.package_info import Noarch, PackageInfo, PackageMetadata
 from conda.models.records import PackageRecord, PathData, PathDataV1, PathsData
-from conda.testing import PathFactoryFixture
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import PathFactoryFixture
 
 log = getLogger(__name__)
 

--- a/tests/core/test_prefix_data.py
+++ b/tests/core/test_prefix_data.py
@@ -19,7 +19,7 @@ from conda.testing.helpers import record
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
-    from conda.testing import TmpEnvFixture
+    from conda.testing.fixtures import TmpEnvFixture
 
 
 ENV_METADATA_DIR = Path(__file__).parent.parent / "data" / "env_metadata"

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -1,20 +1,31 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
-from pytest import MonkeyPatch
 
 from conda.base.context import context, reset_context
 from conda.common.compat import on_win
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import CondaEnvException, CondaValueError
-from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
 from conda.testing.integration import package_is_installed
 
 from . import support_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import MonkeyPatch
+
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
 
 
 def get_env_vars(prefix):

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -1,13 +1,14 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import os
 import random
 from io import StringIO
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from pytest import MonkeyPatch
 
 from conda.common.serialize import yaml_round_trip_load
 from conda.core.prefix_data import PrefixData
@@ -19,10 +20,16 @@ from conda.env.env import (
 )
 from conda.exceptions import CondaHTTPError
 from conda.models.match_spec import MatchSpec
-from conda.testing import CondaCLIFixture, PathFactoryFixture
 from conda.testing.integration import package_is_installed
 
 from . import support_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import MonkeyPatch
+
+    from conda.testing.fixtures import CondaCLIFixture, PathFactoryFixture
 
 
 class FakeStream:

--- a/tests/gateways/test_connection.py
+++ b/tests/gateways/test_connection.py
@@ -31,7 +31,7 @@ from conda.testing.gateways.fixtures import MINIO_EXE
 if TYPE_CHECKING:
     from pytest import MonkeyPatch
 
-    from conda.testing import TmpEnvFixture
+    from conda.testing.fixtures import TmpEnvFixture
 
 log = getLogger(__name__)
 

--- a/tests/plugins/subcommands/doctor/test_cli.py
+++ b/tests/plugins/subcommands/doctor/test_cli.py
@@ -1,11 +1,16 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from conda.exceptions import EnvironmentLocationNotFound
-from conda.testing import CondaCLIFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 
 def test_conda_doctor_happy_path(conda_cli: CondaCLIFixture):

--- a/tests/plugins/test_post_solves.py
+++ b/tests/plugins/test_post_solves.py
@@ -1,13 +1,24 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_mock import MockerFixture
 
 from conda import plugins
 from conda.exceptions import DryRunExit
 from conda.plugins import solvers
-from conda.plugins.manager import CondaPluginManager
-from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda.plugins.manager import CondaPluginManager
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
 
 
 class PostSolvePlugin:

--- a/tests/plugins/test_pre_solves.py
+++ b/tests/plugins/test_pre_solves.py
@@ -1,13 +1,24 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_mock import MockerFixture
 
 from conda import plugins
 from conda.exceptions import DryRunExit
 from conda.plugins import solvers
-from conda.plugins.manager import CondaPluginManager
-from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda.plugins.manager import CondaPluginManager
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
 
 
 class PreSolvePlugin:

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from pytest import CaptureFixture
     from pytest_mock import MockerFixture
 
-    from conda.testing import CondaCLIFixture
+    from conda.testing.fixtures import CondaCLIFixture
 
 
 @dataclass(frozen=True)

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
     from conda.activate import _Activator
     from conda.plugins.manager import CondaPluginManager
-    from conda.testing import PathFactoryFixture, TmpEnvFixture
+    from conda.testing.fixtures import PathFactoryFixture, TmpEnvFixture
 
 
 log = getLogger(__name__)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -82,7 +82,7 @@ if TYPE_CHECKING:
     from pytest import CaptureFixture, FixtureRequest, MonkeyPatch
     from pytest_mock import MockerFixture
 
-    from conda.testing import (
+    from conda.testing.fixtures import (
         CondaCLIFixture,
         PathFactoryFixture,
         TmpChannelFixture,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,11 +1,17 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
 
-from conda.testing import CondaCLIFixture, TmpEnvFixture
 from conda.testing.integration import package_is_installed
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 # features not supported in libmamba
 pytestmark = pytest.mark.usefixtures("solver_classic")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,11 +1,14 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import random
 import subprocess
 import sys
 import tempfile
 from os import chdir, getcwd, makedirs
 from os.path import exists, join, relpath
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -17,7 +20,9 @@ from conda.gateways.connection.download import download
 from conda.gateways.disk.delete import move_path_to_trash
 from conda.gateways.disk.read import read_no_link, yield_lines
 from conda.models.enums import FileMode
-from conda.testing import PathFactoryFixture
+
+if TYPE_CHECKING:
+    from conda.testing.fixtures import PathFactoryFixture
 
 patch = mock.patch if mock else None
 

--- a/tests/test_link_order.py
+++ b/tests/test_link_order.py
@@ -1,10 +1,15 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
 
-from conda.testing import TmpEnvFixture
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import TmpEnvFixture
 
 
 @pytest.mark.integration

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-    from conda.testing import CondaCLIFixture
+    from conda.testing.fixtures import CondaCLIFixture
 
 
 def test_Utf8NamedTemporaryFile():

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
-    from conda.testing import CondaCLIFixture, TmpEnvFixture
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 index, r = get_index_r_1()
 index = index.copy()  # create a shallow copy so this module can mutate state

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -1,12 +1,19 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest import MonkeyPatch
 
 from conda.base.context import context
 from conda.common.compat import on_linux
 from conda.core.prefix_data import PrefixData
-from conda.testing import CondaCLIFixture, TmpEnvFixture
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 pytestmark = pytest.mark.usefixtures("parametrized_solver_fixture")
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -34,7 +34,11 @@ from conda.utils import quote_for_shell
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterable, Iterator
 
-    from conda.testing import CondaCLIFixture, PathFactoryFixture, TmpEnvFixture
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpEnvFixture,
+    )
 
 pytestmark = pytest.mark.integration
 

--- a/tests/testing/test_fixtures.py
+++ b/tests/testing/test_fixtures.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from conda.base.context import context, reset_context
+from conda.gateways.disk.test import is_conda_environment
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.capture import MultiCapture
+    from pytest import MonkeyPatch, Pytester
+
+    from conda.testing.fixtures import (
+        CondaCLIFixture,
+        PathFactoryFixture,
+        TmpChannelFixture,
+        TmpEnvFixture,
+    )
+
+pytest_plugins = ["conda.testing.fixtures", "pytester"]
+
+
+def test_global_capsys(global_capsys: MultiCapture) -> None:
+    print("stdout")
+    print("stderr", file=sys.stderr)
+    out, err = global_capsys.readouterr()
+    assert out == "stdout\n"
+    assert err == "stderr\n"
+
+
+def test_conda_cli(conda_cli: CondaCLIFixture) -> None:
+    stdout, stderr, err = conda_cli("info")
+    assert stdout
+    assert not stderr
+    assert not err
+
+
+def test_global_conda_cli(global_conda_cli: CondaCLIFixture) -> None:
+    stdout, stderr, err = global_conda_cli("info")
+    assert stdout
+    assert not stderr
+    assert not err
+
+
+def test_path_factory(path_factory: PathFactoryFixture) -> None:
+    path = path_factory()
+    assert not path.exists()
+    assert path.parent.is_dir()
+
+
+def test_tmp_env(tmp_env: TmpEnvFixture) -> None:
+    with tmp_env() as prefix:
+        is_conda_environment(prefix)
+
+
+def test_global_tmp_env(global_tmp_env: TmpEnvFixture) -> None:
+    with global_tmp_env() as prefix:
+        is_conda_environment(prefix)
+
+
+def test_env(pytester: Pytester) -> None:
+    """Assert all tests get the same conda environment."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        pytest_plugins = "conda.testing.fixtures"
+
+        @pytest.fixture
+        def env1(tmp_env):
+            with tmp_env() as prefix:
+                yield prefix
+
+        @pytest.fixture(scope="session")
+        def env2(global_tmp_env):
+            with global_tmp_env() as prefix:
+                yield prefix
+
+        @pytest.fixture(scope="session")
+        def env3(global_tmp_env):
+            with global_tmp_env() as prefix:
+                yield prefix
+
+        NAME = None
+
+        def test_env1(env1):
+            global NAME
+            NAME = env1.name
+            assert env1.name != "tmp_env-0"
+
+        def test_env2(env1):
+            assert env1.name != "tmp_env-0"
+            assert env1.name != NAME
+
+        def test_env3(env2):
+            assert env2.name == "tmp_env-0"
+
+        def test_env4(env2):
+            assert env2.name == "tmp_env-0"
+
+        def test_env5(env3):
+            assert env3.name == "tmp_env-1"
+
+        def test_env6(env3):
+            assert env3.name == "tmp_env-1"
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=6)
+
+
+def test_tmp_channel(tmp_channel: TmpChannelFixture) -> None:
+    with tmp_channel() as (channel, url):
+        assert channel.is_dir()
+
+
+def test_monkeypatch(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("CONDA_CLOBBER", "true")
+    reset_context()
+    assert context.clobber
+
+
+def test_tmp_pkgs_dir(tmp_pkgs_dir: Path) -> None:
+    assert tmp_pkgs_dir.is_dir()
+
+
+def test_tmp_envs_dir(tmp_envs_dir: Path) -> None:
+    assert tmp_envs_dir.is_dir()

--- a/tests/testing/test_fixtures.py
+++ b/tests/testing/test_fixtures.py
@@ -24,10 +24,10 @@ if TYPE_CHECKING:
 pytest_plugins = ["conda.testing.fixtures", "pytester"]
 
 
-def test_global_capsys(global_capsys: MultiCapture) -> None:
+def test_session_capsys(session_capsys: MultiCapture) -> None:
     print("stdout")
     print("stderr", file=sys.stderr)
-    out, err = global_capsys.readouterr()
+    out, err = session_capsys.readouterr()
     assert out == "stdout\n"
     assert err == "stderr\n"
 
@@ -39,8 +39,8 @@ def test_conda_cli(conda_cli: CondaCLIFixture) -> None:
     assert not err
 
 
-def test_global_conda_cli(global_conda_cli: CondaCLIFixture) -> None:
-    stdout, stderr, err = global_conda_cli("info")
+def test_session_conda_cli(session_conda_cli: CondaCLIFixture) -> None:
+    stdout, stderr, err = session_conda_cli("info")
     assert stdout
     assert not stderr
     assert not err
@@ -57,8 +57,8 @@ def test_tmp_env(tmp_env: TmpEnvFixture) -> None:
         is_conda_environment(prefix)
 
 
-def test_global_tmp_env(global_tmp_env: TmpEnvFixture) -> None:
-    with global_tmp_env() as prefix:
+def test_session_tmp_env(session_tmp_env: TmpEnvFixture) -> None:
+    with session_tmp_env() as prefix:
         is_conda_environment(prefix)
 
 
@@ -76,13 +76,13 @@ def test_env(pytester: Pytester) -> None:
                 yield prefix
 
         @pytest.fixture(scope="session")
-        def env2(global_tmp_env):
-            with global_tmp_env() as prefix:
+        def env2(session_tmp_env):
+            with session_tmp_env() as prefix:
                 yield prefix
 
         @pytest.fixture(scope="session")
-        def env3(global_tmp_env):
-            with global_tmp_env() as prefix:
+        def env3(session_tmp_env):
+            with session_tmp_env() as prefix:
                 yield prefix
 
         NAME = None

--- a/tests/testing/test_testing.py
+++ b/tests/testing/test_testing.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+
+from conda import testing
+
+
+@pytest.mark.parametrize(
+    "function,raises",
+    [
+        ("CondaCLIFixture", TypeError),
+        ("PathFactoryFixture", TypeError),
+        ("TmpEnvFixture", TypeError),
+        ("TmpChannelFixture", TypeError),
+    ],
+)
+def test_deprecations(function: str, raises: type[Exception] | None) -> None:
+    raises_context = pytest.raises(raises) if raises else nullcontext()
+    with pytest.deprecated_call(), raises_context:
+        getattr(testing, function)()

--- a/tests/trust/test_signature_verification.py
+++ b/tests/trust/test_signature_verification.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
-    from conda.testing import PathFactoryFixture
+    from conda.testing.fixtures import PathFactoryFixture
 
 
 TESTDATA = Path(__file__).parent / "testdata"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Occasionally we desire to generate conda environments that can be shared between several tests (e.g., https://github.com/conda/conda-libmamba-solver/pull/524). Previously this was not possible with `tmp_env` since it was a function scoped fixture. In order to support a session scoped fixture variant of `tmp_env` we also needed session scoped fixture variants for `conda_cli` and `capsys`.

We also opt to move all of the fixtures defined in `conda.testing` to the more appropriate `conda.testing.fixtures` module.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
