### PR TITLE
Use plugin manager to get subcommands for `tests/cli/test_main_commands.py::test_commands`

### DIFF
--- a/tests/cli/test_main_commands.py
+++ b/tests/cli/test_main_commands.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from conda.base.context import context
 from conda.cli.conda_argparse import BUILTIN_COMMANDS
+from conda.cli.find_commands import find_commands
 
 if TYPE_CHECKING:
     from conda.testing import CondaCLIFixture
@@ -19,6 +20,7 @@ def test_commands(conda_cli: CondaCLIFixture) -> None:
             {
                 *BUILTIN_COMMANDS,
                 *context.plugin_manager.get_subcommands(),
+                *find_commands(True),
             }
         )
     )

--- a/tests/cli/test_main_commands.py
+++ b/tests/cli/test_main_commands.py
@@ -1,22 +1,24 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
+from conda.base.context import context
 from conda.cli.conda_argparse import BUILTIN_COMMANDS
-from conda.testing import CondaCLIFixture
+
+if TYPE_CHECKING:
+    from conda.testing import CondaCLIFixture
 
 
-def test_commands(conda_cli: CondaCLIFixture):
+def test_commands(conda_cli: CondaCLIFixture) -> None:
     stdout, stderr, code = conda_cli("commands")
 
     assert stdout == "\n".join(
         sorted(
             {
                 *BUILTIN_COMMANDS,
-                "content-trust",  # from conda-content-trust
-                "doctor",  # builtin plugin
-                "repoquery",  # from conda-libmamba-solver
-                "server",  # from anaconda-client
+                *context.plugin_manager.get_subcommands(),
             }
         )
     )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While working on CLS tests (https://github.com/conda/conda-libmamba-solver/pull/524, https://github.com/conda/conda-libmamba-solver/pull/529) I've found that the recently added `test_commands` test does a poor job of handling test environments with additional conda plugins installed (e.g. `conda-build`).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
