### PR TITLE
Remove CreateNonAdminAction

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -66,7 +66,6 @@ from .package_cache_data import PackageCacheData
 from .path_actions import (
     AggregateCompileMultiPycAction,
     CompileMultiPycAction,
-    CreateNonadminAction,
     CreatePrefixRecordAction,
     CreatePythonEntryPointAction,
     LinkPathAction,
@@ -635,8 +634,6 @@ class UnlinkLinkTransaction:
             for link_path_action in axn.all_link_path_actions:
                 if isinstance(link_path_action, CompileMultiPycAction):
                     target_short_paths = link_path_action.target_short_paths
-                elif isinstance(link_path_action, CreateNonadminAction):
-                    continue
                 else:
                     target_short_paths = (
                         (link_path_action.target_short_path,)
@@ -1140,13 +1137,11 @@ class UnlinkLinkTransaction:
         create_directory_actions = LinkPathAction.create_directory_actions(
             *required_quad, file_link_actions=file_link_actions
         )
-        create_nonadmin_actions = CreateNonadminAction.create_actions(*required_quad)
 
         # the ordering here is significant
         return (
             *create_directory_actions,
             *file_link_actions,
-            *create_nonadmin_actions,
         )
 
     @staticmethod

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -593,32 +593,6 @@ class MakeMenuAction(CreateInPrefixPathAction):
             make_menu(self.target_prefix, self.target_short_path, remove=True)
 
 
-class CreateNonadminAction(CreateInPrefixPathAction):
-    @classmethod
-    def create_actions(
-        cls, transaction_context, package_info, target_prefix, requested_link_type
-    ):
-        if on_win and lexists(join(context.root_prefix, ".nonadmin")):
-            return (cls(transaction_context, package_info, target_prefix),)
-        else:
-            return ()
-
-    def __init__(self, transaction_context, package_info, target_prefix):
-        super().__init__(
-            transaction_context, package_info, None, None, target_prefix, ".nonadmin"
-        )
-        self._file_created = False
-
-    def execute(self):
-        log.log(TRACE, "touching nonadmin %s", self.target_full_path)
-        self._file_created = touch(self.target_full_path)
-
-    def reverse(self):
-        if self._file_created:
-            log.log(TRACE, "removing nonadmin file %s", self.target_full_path)
-            rm_rf(self.target_full_path)
-
-
 class CompileMultiPycAction(MultiPathAction):
     @classmethod
     def create_actions(

--- a/docs/source/dev-guide/deep-dives/install.md
+++ b/docs/source/dev-guide/deep-dives/install.md
@@ -458,7 +458,6 @@ PathAction
       LinkPathAction
         PrefixReplaceLinkAction
       MakeMenuAction
-      CreateNonadminAction
       CreatePythonEntryPointAction
       CreatePrefixRecordAction
       UpdateHistoryAction

--- a/news/14271-remove-createnonadmin-action
+++ b/news/14271-remove-createnonadmin-action
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Remove CreateNonAdminAction to prevent conda remove from deleting .nonadmin files. (#14271)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2666,3 +2666,20 @@ def test_create_dry_run_without_prefix(
 
 def test_create_without_prefix_raises_argument_error(conda_cli: CondaCLIFixture):
     conda_cli("create", "--json", "ca-certificates", raises=ArgumentError)
+
+
+def test_nonadmin_file_untouched(
+    conda_cli: CondaCLIFixture,
+    tmp_env: TmpEnvFixture,
+):
+    channel = Path(__file__).parent / "test-recipes" / "noarch"
+    with tmp_env() as prefix:
+        nonadmin_file = prefix / ".nonadmin"
+        nonadmin_file.touch()
+        assert nonadmin_file.is_file()
+        conda_cli(
+            "install", "--yes", "--prefix", prefix, "--channel", channel, "dependency"
+        )
+        assert nonadmin_file.is_file(), ".nonadmin file removed after installation"
+        conda_cli("remove", "--yes", "--prefix", prefix, "dependency")
+        assert nonadmin_file.is_file(), ".nonadmin file removed after uninstallation"


### PR DESCRIPTION
### Description

The .nonadmin file is created by constructor-based installers to indicate that the installed application does not require admin privileges. This is used by the Windows uninstaller for constructor-based installers (e.g., Miniconda, Miniforge) and menuinst.

When removing a package via `conda remove`, the .nonadmin file is removed. This will require users to have admin rights for subsequent calls of menuinst or when running the uninstaller. If a user does not have those privileges, those calls will fail.

The culprit is the [`CreateNonadminAction`](https://github.com/conda/conda/blob/main/conda/core/path_actions.py#L596-L619) which is added to the linking transaction: https://github.com/conda/conda/blob/main/conda/core/link.py#L1144-L1151

This adds the .nonadmin file to the paths list for each package and is removed during `conda remove`. Since it is an environment-level file, however, the .nonadmin file should not be touched by the installation transactions. https://github.com/conda/conda/pull/13940 has recently added all necessary `touch_nonadmin` commands to environment creations, so this action is obsolete.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?