### PR TITLE
Fixing broken test assertion for `tests.plugins.test_subcommands:test_help` (24.9.x)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -272,7 +272,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -68,7 +69,7 @@ def test_help(plugin_manager, conda_cli: CondaCLIFixture, capsys: CaptureFixture
     stdout, stderr = capsys.readouterr()
 
     # assertions; make sure our command appears with the help blurb
-    assert "custom            Summary." in stdout
+    assert re.search(r"custom\s+Summary.", stdout) is not None
     assert not stderr
 
 


### PR DESCRIPTION
### Description

Fixes a broken test assertion that is currently make builds on the main branch fail.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
