### PR TITLE
`PrefixData(pip_interop_enabled=True)`: use Python name for non-conda packages

### DIFF
--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -307,7 +307,7 @@ def read_python_record(prefix_path, anchor_file, python_version):
 
     return PrefixRecord(
         package_type=package_type,
-        name=pydist.name,
+        name=pydist.norm_name,
         version=pydist.version,
         channel=channel,
         subdir="pypi",

--- a/conda/gateways/disk/read.py
+++ b/conda/gateways/disk/read.py
@@ -307,7 +307,7 @@ def read_python_record(prefix_path, anchor_file, python_version):
 
     return PrefixRecord(
         package_type=package_type,
-        name=pydist.conda_name,
+        name=pydist.name,
         version=pydist.version,
         channel=channel,
         subdir="pypi",

--- a/news/14317-pypi-names
+++ b/news/14317-pypi-names
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Do not map Python distribution names to conda names in `PrefixData(pip_interop_enabled=True)`. (#14310 via #14317)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes https://github.com/conda/conda/issues/14310

Not sure why we would want the conda name (or how that's obtained to begin with!) instead of the original Python name. This is causing the reproducibility problem seen in the linked issue.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
