### PR TITLE
Updated sentence for formatting issue and clarity

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -97,8 +97,8 @@ class MatchSpec(metaclass=MatchSpecType):
     :class:`MatchSpec` can also be composed using a single positional argument, with optional
     keyword arguments.  Keyword arguments also override any conflicting information provided in
     the positional argument.  The positional argument can be either an existing :class:`MatchSpec`
-    instance or a string.  Conda has historically supported more than one string representation 
-    for equivalent :class:`MatchSpec` queries.  This :class:`MatchSpec` should accept any existing 
+    instance or a string.  Conda has historically supported more than one string representation
+    for equivalent :class:`MatchSpec` queries.  This :class:`MatchSpec` should accept any existing
     valid spec string, and correctly compose a :class:`MatchSpec` instance.
 
     A series of rules are now followed for creating the canonical string representation of a

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -97,9 +97,9 @@ class MatchSpec(metaclass=MatchSpecType):
     :class:`MatchSpec` can also be composed using a single positional argument, with optional
     keyword arguments.  Keyword arguments also override any conflicting information provided in
     the positional argument.  The positional argument can be either an existing :class:`MatchSpec`
-    instance or a string.  Conda has historically had several string representations for equivalent
-    :class:`MatchSpec`s.  This :class:`MatchSpec` should accept any existing valid spec string, and
-    correctly compose a :class:`MatchSpec` instance.
+    instance or a string.  Conda has historically supported more than one string representation 
+    for equivalent :class:`MatchSpec` queries.  This :class:`MatchSpec` should accept any existing 
+    valid spec string, and correctly compose a :class:`MatchSpec` instance.
 
     A series of rules are now followed for creating the canonical string representation of a
     :class:`MatchSpec` instance.  The canonical string representation can generically be


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes https://github.com/conda/conda/issues/14328.

This presence of the "s" right next to "`class:`MatchSpec`" caused a formatting issue in the automated docs. Plus, the sentence was a little difficult to parse. This change removes the plural and hopefully makes things a bit more clear.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
