### PR TITLE
Exclude Sphinx version 8.1.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Pillow==10.1.0
-Sphinx<9, !=8.1.3
+Sphinx<9, !=8.1.2, !=8.1.3
 boltons==23.1.1
 conda-sphinx-theme==0.2.1
 linkify-it-py==2.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Pillow==10.1.0
-Sphinx<9
+Sphinx<9, !=8.1.3
 boltons==23.1.1
 conda-sphinx-theme==0.2.1
 linkify-it-py==2.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Pillow==10.1.0
-Sphinx<9, !=8.1.2, !=8.1.3
+Sphinx<=8.1.1
 boltons==23.1.1
 conda-sphinx-theme==0.2.1
 linkify-it-py==2.0.2


### PR DESCRIPTION
The newest version of Sphinx seems to be breaking conda docs ([example](https://readthedocs.com/projects/continuumio-conda/builds/2564942/)); this PR excludes the [most recently released version](https://github.com/sphinx-doc/sphinx/releases/tag/v8.1.3) in the docs requirements file.