### PR TITLE
Make `conda doctor` accept `$REQUESTS_CA_BUNDLE` that point to a valid file

### DIFF
--- a/conda/plugins/subcommands/doctor/health_checks.py
+++ b/conda/plugins/subcommands/doctor/health_checks.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from logging import getLogger
 from pathlib import Path
 
 from requests.exceptions import RequestException
 
 from ....base.context import context
+from ....common.url import is_url
 from ....core.envs_manager import get_user_environments_txt_file
 from ....exceptions import CondaError
 from ....gateways.connection.session import get_session
@@ -160,13 +160,7 @@ def requests_ca_bundle_check(prefix: str, verbose: bool) -> None:
     requests_ca_bundle = os.getenv("REQUESTS_CA_BUNDLE")
     if not requests_ca_bundle:
         return
-    elif Path(requests_ca_bundle).exists():
-        print(f"{OK_MARK} `REQUESTS_CA_BUNDLE` was verified.\n")
-    elif re.match("^https?://", requests_ca_bundle) is None:
-        print(
-            f"{X_MARK} Env var `REQUESTS_CA_BUNDLE` is pointing to a non existent file.\n"
-        )
-    else:
+    if is_url(requests_ca_bundle):
         session = get_session(ca_bundle_test_url)
         try:
             response = session.get(ca_bundle_test_url)
@@ -176,6 +170,12 @@ def requests_ca_bundle_check(prefix: str, verbose: bool) -> None:
             print(
                 f"{X_MARK} The following error occured while verifying `REQUESTS_CA_BUNDLE`: {e}\n"
             )
+    elif Path(requests_ca_bundle).exists():
+        print(f"{OK_MARK} `REQUESTS_CA_BUNDLE` was verified.\n")
+    else:
+        print(
+            f"{X_MARK} Env var `REQUESTS_CA_BUNDLE` is pointing to a non existent file.\n"
+        )
 
 
 @hookimpl

--- a/conda/plugins/subcommands/doctor/health_checks.py
+++ b/conda/plugins/subcommands/doctor/health_checks.py
@@ -162,7 +162,7 @@ def requests_ca_bundle_check(prefix: str, verbose: bool) -> None:
         return
     elif Path(requests_ca_bundle).exists():
         print(f"{OK_MARK} `REQUESTS_CA_BUNDLE` was verified.\n")
-    elif re.match("^https://", requests_ca_bundle) is None:
+    elif re.match("^https?://", requests_ca_bundle) is None:
         print(
             f"{X_MARK} Env var `REQUESTS_CA_BUNDLE` is pointing to a non existent file.\n"
         )

--- a/conda/plugins/subcommands/doctor/health_checks.py
+++ b/conda/plugins/subcommands/doctor/health_checks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from logging import getLogger
 from pathlib import Path
 
@@ -159,7 +160,9 @@ def requests_ca_bundle_check(prefix: str, verbose: bool) -> None:
     requests_ca_bundle = os.getenv("REQUESTS_CA_BUNDLE")
     if not requests_ca_bundle:
         return
-    elif not Path(requests_ca_bundle).exists():
+    elif Path(requests_ca_bundle).exists():
+        print(f"{OK_MARK} `REQUESTS_CA_BUNDLE` was verified.\n")
+    elif re.match("^https://", requests_ca_bundle) is None:
         print(
             f"{X_MARK} Env var `REQUESTS_CA_BUNDLE` is pointing to a non existent file.\n"
         )

--- a/news/14341-conda-doctor_requests_ca_bundle_file
+++ b/news/14341-conda-doctor_requests_ca_bundle_file
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Make `conda doctor` accept `$REQUESTS_CA_BUNDLE` that point to a valid file
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/plugins/subcommands/doctor/test_health_checks.py
+++ b/tests/plugins/subcommands/doctor/test_health_checks.py
@@ -309,6 +309,25 @@ def test_requests_ca_bundle_check_action_fails(
     )
 
 
+def test_requests_ca_bundle_check_action_passes_http(
+    env_ok: tuple[Path, str, str, str, str],
+    capsys: CaptureFixture,
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+    mocker: MockerFixture,
+):
+    prefix, _, _, _, _ = env_ok
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "http://example.org/")
+    response = Response()
+    response.status_code = 200
+    mocker.patch(
+        "conda.gateways.connection.session.CondaSession.get", return_value=response
+    )
+    requests_ca_bundle_check(prefix, verbose=True)
+    captured = capsys.readouterr()
+    assert f"{OK_MARK} `REQUESTS_CA_BUNDLE` was verified.\n" in captured.out
+
+
 def test_json_keys_missing(env_ok: tuple[Path, str, str, str, str], capsys):
     """Test that runs for the case with empty json"""
     prefix, _, _, _, package = env_ok

--- a/tests/plugins/subcommands/doctor/test_health_checks.py
+++ b/tests/plugins/subcommands/doctor/test_health_checks.py
@@ -245,7 +245,7 @@ def test_not_env_txt_check_action(
     assert X_MARK in captured.out
 
 
-def test_requests_ca_bundle_check_action_passes(
+def test_requests_ca_bundle_check_action_existent_path(
     env_ok: tuple[Path, str, str, str, str],
     capsys: CaptureFixture,
     monkeypatch: MonkeyPatch,
@@ -254,11 +254,6 @@ def test_requests_ca_bundle_check_action_passes(
 ):
     prefix, _, _, _, _ = env_ok
     monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(tmp_path))
-    response = Response()
-    response.status_code = 200
-    mocker.patch(
-        "conda.gateways.connection.session.CondaSession.get", return_value=response
-    )
     requests_ca_bundle_check(prefix, verbose=True)
     captured = capsys.readouterr()
     assert f"{OK_MARK} `REQUESTS_CA_BUNDLE` was verified.\n" in captured.out
@@ -279,6 +274,25 @@ def test_requests_ca_bundle_check_action_non_existent_path(
     )
 
 
+def test_requests_ca_bundle_check_action_passes(
+    env_ok: tuple[Path, str, str, str, str],
+    capsys: CaptureFixture,
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+    mocker: MockerFixture,
+):
+    prefix, _, _, _, _ = env_ok
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "https://example.org/")
+    response = Response()
+    response.status_code = 200
+    mocker.patch(
+        "conda.gateways.connection.session.CondaSession.get", return_value=response
+    )
+    requests_ca_bundle_check(prefix, verbose=True)
+    captured = capsys.readouterr()
+    assert f"{OK_MARK} `REQUESTS_CA_BUNDLE` was verified.\n" in captured.out
+
+
 def test_requests_ca_bundle_check_action_fails(
     env_ok: tuple[Path, str, str, str, str],
     capsys: CaptureFixture,
@@ -286,7 +300,7 @@ def test_requests_ca_bundle_check_action_fails(
     tmp_path: Path,
 ):
     prefix, _, _, _, _ = env_ok
-    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(tmp_path))
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "https://example.org/file")
     requests_ca_bundle_check(prefix, verbose=True)
     captured = capsys.readouterr()
     assert (


### PR DESCRIPTION
### Description

Hello,

On my system, `REQUESTS_CA_BUNDLE` is a local path. It makes `conda doctor` complain:

```console
$ echo $REQUESTS_CA_BUNDLE 
/etc/ssl/certs/ca-certificates.crt
$ conda doctor
(...)
❌ The following error occured while verifying `REQUESTS_CA_BUNDLE`: Invalid URL 'h': No scheme supplied. Perhaps you meant https://h?
```

It looks like #14037 made `conda doctor` expects either an invalid path, or a URL. In this PR, I make it allow valid paths


### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~