### PR TITLE
bugfix: [0] returns the letter "h" of https...

### DIFF
--- a/conda/plugins/subcommands/doctor/health_checks.py
+++ b/conda/plugins/subcommands/doctor/health_checks.py
@@ -154,7 +154,7 @@ def env_txt_check(prefix: str, verbose: bool) -> None:
 def requests_ca_bundle_check(prefix: str, verbose: bool) -> None:
     # Use a channel aliases url since users may be on an intranet and
     # have customized their conda setup to point to an internal mirror.
-    ca_bundle_test_url = context.channel_alias.url()[0]
+    ca_bundle_test_url = context.channel_alias.urls()[0]
 
     requests_ca_bundle = os.getenv("REQUESTS_CA_BUNDLE")
     if not requests_ca_bundle:


### PR DESCRIPTION
### Description

Hello,

On my system, `REQUESTS_CA_BUNDLE` is a (valid) local path that makes `conda doctor` complain:

```console
$ echo $REQUESTS_CA_BUNDLE 
/etc/ssl/certs/ca-certificates.crt
$ conda doctor
(...)
❌ The following error occured while verifying `REQUESTS_CA_BUNDLE`: Invalid URL 'h': No scheme supplied. Perhaps you meant https://h?
```

After a false start in #14341, I've now understood that the problem is that the `ca_bundle_test_url` variable was only getting the first letter of the channel URL, i.e. `h` instead of `https://...`.


### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?