### PR TITLE
Update `deprecated.action()` to account for positional arguments with no value specified

### DIFF
--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -226,11 +226,12 @@ class DeprecationHandler:
                 option_string: str | None = None,
             ) -> None:
                 # alert user that it's time to remove something
-                warnings.warn(
-                    inner_self.help,
-                    inner_self.category,
-                    stacklevel=7 + stack,
-                )
+                if values:
+                    warnings.warn(
+                        inner_self.help,
+                        inner_self.category,
+                        stacklevel=7 + stack,
+                    )
 
                 super().__call__(parser, namespace, values, option_string)
 

--- a/news/14359-update-deprecated.action
+++ b/news/14359-update-deprecated.action
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Update `deprecated.action()` function to account for positional arguments that have no value specified. (#14359)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from argparse import ArgumentParser, _StoreAction
+from argparse import ArgumentParser, _StoreAction, _StoreTrueAction
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
@@ -139,11 +139,15 @@ def test_action(
         parser = ArgumentParser()
         parser.add_argument(
             "--foo",
+            action=deprecated.action("2.0", "3.0", _StoreTrueAction),
+        )
+        parser.add_argument(
+            "bar",
             action=deprecated.action("2.0", "3.0", _StoreAction),
         )
 
         with pytest.warns(warning, match=message):
-            parser.parse_args(["--foo", "some_value"])
+            parser.parse_args(["--foo", "bar"])
 
 
 @parametrize_dev

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from argparse import ArgumentParser, _StoreTrueAction
+from argparse import ArgumentParser, _StoreAction
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
@@ -139,11 +139,11 @@ def test_action(
         parser = ArgumentParser()
         parser.add_argument(
             "--foo",
-            action=deprecated.action("2.0", "3.0", _StoreTrueAction),
+            action=deprecated.action("2.0", "3.0", _StoreAction),
         )
 
         with pytest.warns(warning, match=message):
-            parser.parse_args(["--foo"])
+            parser.parse_args(["--foo", "some_value"])
 
 
 @parametrize_dev

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -147,7 +147,10 @@ def test_action(
         )
 
         with pytest.warns(warning, match=message):
-            parser.parse_args(["--foo", "bar"])
+            parser.parse_args(["--foo", "some_value"])
+
+        with pytest.warns(warning, match=message):
+            parser.parse_args(["bar"])
 
 
 @parametrize_dev


### PR DESCRIPTION
Resolves https://github.com/conda/conda/issues/14355

Every positional argument in the conda CLI is either required or defaults to `None` or `[]`, so [checking to see if `values` exists](https://github.com/conda/conda/pull/14359/files#diff-55373dab266c863a6f3a85e6ed1700a8e532ca7c027f6650093e18fd0cb66c4dR229) avoids the activation of an unnecessary deprecation warning.