### PR TITLE
Update `check_output()` call in `tests.yml`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -706,7 +706,7 @@ jobs:
               # to override the version with a derivative of the branch name
 
               # override the version if `git describe --tag` does not start with the branch version
-              last_release = check_output(["git", "describe", "--tag"])
+              last_release = check_output(["git", "describe", "--tag"], text=True).strip()
               prefix = "${{ github.ref_name }}"[:-1]  # without x suffix
               if not last_release.startswith(prefix):
                   envs["VERSION_OVERRIDE"] = "${{ github.ref_name }}"


### PR DESCRIPTION
A follow-up PR related to https://github.com/conda/conda/pull/14387
Xref https://github.com/conda/conda-build/pull/5537

Builds are failing (see example [here](https://github.com/conda/conda-build/actions/runs/11842587199/job/33001566121#step:4:44)) due to [`check_output()`](https://docs.python.org/3/library/subprocess.html#subprocess.check_output) returning a bytes object instead of a string; per discussion with @kenodegard , I've added `text=True` so that a `str` will be returned, and also a `.strip()` to avoid any potential extra whitespace.