### PR TITLE
Fix failing tests in main

### DIFF
--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -137,6 +137,6 @@ def test_sorted_commands_in_error(capsys):
     except (ArgumentError, SystemExit):
         stderr = capsys.readouterr().err
         # ...but the suggestions here are sorted
-        assert "invalid choice: 'd' (choose from 'a', 'b', 'c')" in stderr
+        assert "invalid choice: 'd' (choose from" in stderr
     else:
         pytest.fail("Did not raise")

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import re
+from argparse import ArgumentError
 from inspect import isclass, isfunction
 from logging import getLogger
 from typing import TYPE_CHECKING
@@ -133,7 +134,7 @@ def test_sorted_commands_in_error(capsys):
     sp.add_parser("b")
     try:
         p.parse_args(["d"])
-    except SystemExit:
+    except (ArgumentError, SystemExit):
         stderr = capsys.readouterr().err
         # ...but the suggestions here are sorted
         assert "invalid choice: 'd' (choose from 'a', 'b', 'c')" in stderr

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -134,9 +134,15 @@ def test_sorted_commands_in_error(capsys):
     sp.add_parser("b")
     try:
         p.parse_args(["d"])
-    except (ArgumentError, SystemExit):
+    # Python < 3.12
+    except SystemExit:
         stderr = capsys.readouterr().err
         # ...but the suggestions here are sorted
-        assert "invalid choice: 'd' (choose from" in stderr
+        assert "invalid choice: 'd' (choose from 'a', 'b', 'c')" in stderr
+    # Python >= 3.12
+    except ArgumentError:
+        stderr = capsys.readouterr().err
+        # ...but the suggestions here are sorted
+        assert "invalid choice: 'd' (choose from a, b, c)" in stderr
     else:
         pytest.fail("Did not raise")

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 import re
-from argparse import ArgumentError
+import sys
 from inspect import isclass, isfunction
 from logging import getLogger
 from typing import TYPE_CHECKING
@@ -134,15 +134,13 @@ def test_sorted_commands_in_error(capsys):
     sp.add_parser("b")
     try:
         p.parse_args(["d"])
-    # Python < 3.12
     except SystemExit:
         stderr = capsys.readouterr().err
         # ...but the suggestions here are sorted
-        assert "invalid choice: 'd' (choose from 'a', 'b', 'c')" in stderr
-    # Python >= 3.12
-    except ArgumentError:
-        stderr = capsys.readouterr().err
-        # ...but the suggestions here are sorted
-        assert "invalid choice: 'd' (choose from a, b, c)" in stderr
+        if sys.version_info < (3, 12):
+            # FUTURE: Python 3.12+: remove this test case
+            assert "invalid choice: 'd' (choose from 'a', 'b', 'c')" in stderr
+        else:
+            assert "invalid choice: 'd' (choose from a, b, c)" in stderr
     else:
         pytest.fail("Did not raise")

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2296,10 +2296,10 @@ def test_force_remove(
 ):
     with tmp_env("libarchive") as prefix:
         assert package_is_installed(prefix, "libarchive")
-        assert package_is_installed(prefix, "xz")
+        assert package_is_installed(prefix, "bzip2")
 
-        conda_cli("remove", f"--prefix={prefix}", "xz", "--force", "--yes")
-        assert not package_is_installed(prefix, "xz")
+        conda_cli("remove", f"--prefix={prefix}", "bzip2", "--force", "--yes")
+        assert not package_is_installed(prefix, "bzip2")
         assert package_is_installed(prefix, "libarchive")
 
         conda_cli("remove", f"--prefix={prefix}", "libarchive", "--yes")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

- Fix subcommand sorting test introduced for compatibility with Python 3.12. This was introduced in #14402.
- Fix dependency drift in integration test. Previously discovered and fixed in 24.11.x in #14431.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
