### PR TITLE
Deprecate `-f` as alias of `--force` in favor of `--file`

### DIFF
--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -70,6 +70,7 @@ def add_parser_create_install_update(p, prefix_required=False):
     # Add the file kwarg. We don't use {action="store", nargs='*'} as we don't
     # want to gobble up all arguments after --file.
     p.add_argument(
+        # "-f",  # FUTURE: 25.7: Enable this after deprecating alias in --force
         "--file",
         default=[],
         action="append",
@@ -449,7 +450,7 @@ def add_parser_package_install_options(p: ArgumentParser) -> _ArgumentGroup:
         "Package Linking and Install-time Options"
     )
     package_install_options.add_argument(
-        "-f",
+        "-f",  # FUTURE: 25.7: Remove here and add as alias to --file
         "--force",
         action="store_true",
         default=NULL,

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -11,6 +11,7 @@ conda.cli.main_remove for the entry points into this module.
 from __future__ import annotations
 
 import os
+import sys
 from logging import getLogger
 from os.path import abspath, basename, exists, isdir, isfile, join
 from pathlib import Path
@@ -31,6 +32,7 @@ from ..core.index import (
 from ..core.link import PrefixSetup, UnlinkLinkTransaction
 from ..core.prefix_data import PrefixData
 from ..core.solve import diff_for_unlink_link_precs
+from ..deprecations import deprecated
 from ..exceptions import (
     CondaEnvException,
     CondaExitZero,
@@ -191,6 +193,14 @@ def install(args, parser, command="install"):
     prefix = context.target_prefix
     if context.force_32bit and prefix == context.root_prefix:
         raise CondaValueError("cannot use CONDA_FORCE_32BIT=1 in base env")
+    if getattr(args, "force", None) and "-f" in sys.argv:
+        deprecated.topic(
+            "25.1.0",
+            "25.7.0",
+            topic="Deprecated -f flag will be repurposed as a --file alias.",
+            addendum="The -f alias for --force has not been used for long. In the future, "
+            "it will be repurposed as an alias for --file.",
+        )
     if isupdate and not (
         args.file
         or args.packages


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

In the future, we will fold `conda env create` under `conda create`. `conda env create` uses `-f` for file paths, but `conda create` only had `--file` because `-f` was being used for the suppressed / deprecated `--force` flag. If it's true that the `env` folding is not ready yet, we can already start the flag migration process here to have it ready when time comes.

Part of https://github.com/conda/conda/issues/13015

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
