### PR TITLE
Bump `canary-release`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -645,11 +645,11 @@ jobs:
     if: >-
       !cancelled()
       && !github.event.repository.fork
-    #   && (
-    #     github.ref_name == 'main'
-    #     || startsWith(github.ref_name, 'feature/')
-    #     || endsWith(github.ref_name, '.x')
-    #   )
+      && (
+        github.ref_name == 'main'
+        || startsWith(github.ref_name, 'feature/')
+        || endsWith(github.ref_name, '.x')
+      )
     strategy:
       matrix:
         include:
@@ -713,7 +713,7 @@ jobs:
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 
       - name: Create & Upload
-        uses: conda/actions/canary-release@upload-dot-conda
+        uses: conda/actions/canary-release@8ff3faa82ad80f5c05d91c22bcd37d897f80ca46 # v25.1.1
         env:
           # Run conda-build in isolated activation to properly package conda
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -645,11 +645,11 @@ jobs:
     if: >-
       !cancelled()
       && !github.event.repository.fork
-      && (
-        github.ref_name == 'main'
-        || startsWith(github.ref_name, 'feature/')
-        || endsWith(github.ref_name, '.x')
-      )
+    #   && (
+    #     github.ref_name == 'main'
+    #     || startsWith(github.ref_name, 'feature/')
+    #     || endsWith(github.ref_name, '.x')
+    #   )
     strategy:
       matrix:
         include:
@@ -713,7 +713,7 @@ jobs:
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 
       - name: Create & Upload
-        uses: conda/actions/canary-release@606d3b22aaf8737d2b9fc170b38a8887195f59b4 # v25.1.0
+        uses: conda/actions/canary-release@upload-dot-conda
         env:
           # Run conda-build in isolated activation to properly package conda
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1


### PR DESCRIPTION
### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda-build` is changing the default package format from `.tar.bz2` to `.conda`. The old `canary-release` action did not account for `.conda` packages and needs updating to handle this format for uploads.

Xref https://github.com/conda/actions/pull/250
Xref https://github.com/conda/actions/pull/251

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
