### PR TITLE
Install `importlib_resources` for Python < 3.12

### DIFF
--- a/tests/data/pkg_cache/__init__.py
+++ b/tests/data/pkg_cache/__init__.py
@@ -1,9 +1,14 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import json
-from importlib.resources import files
+import sys
 
 from conda.core.package_cache_data import PackageCacheRecord
+
+if sys.version_info < (3, 12):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 
 
 def load_data_file(filename):

--- a/tests/data/pkg_cache/__init__.py
+++ b/tests/data/pkg_cache/__init__.py
@@ -1,14 +1,9 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import json
-import sys
+from importlib.resources import files
 
 from conda.core.package_cache_data import PackageCacheRecord
-
-if sys.version_info < (3, 12):
-    from importlib_resources import files
-else:
-    from importlib.resources import files
 
 
 def load_data_file(filename):

--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -4,6 +4,7 @@ conda-forge::pytest-xprocess
 coverage
 flask >=2.2  # jlap pytest fixture
 git
+importlib_resources >= 5.10  # only necessary for Python < 3.12
 pexpect
 pip
 pytest


### PR DESCRIPTION
### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`setuptools 75.4.0` dropped their vendored `importlib_resources` in favor of the stdlib `importlib.resources` which is available since Python 3.9.

This change only impacts the test suite and has no impact on older conda versions so we opt to not include a news snippet.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
