### PR TITLE
Cleanup and replace `hdf5` with `small-executable`

### DIFF
--- a/tests/shell/test_cmd_exe.py
+++ b/tests/shell/test_cmd_exe.py
@@ -26,48 +26,48 @@ def test_cmd_exe_basic_integration(shell_wrapper_integration: tuple[str, str, st
     prefix, charizard, _ = shell_wrapper_integration
     conda_bat = str(Path(CONDA_PACKAGE_ROOT, "shell", "condabin", "conda.bat"))
 
-    with InteractiveShell("cmd.exe") as shell:
-        shell.assert_env_var("_CE_CONDA", "conda")
-        shell.assert_env_var("_CE_M", "-m")
-        shell.assert_env_var("CONDA_EXE", escape(sys.executable))
+    with InteractiveShell("cmd.exe") as sh:
+        sh.assert_env_var("_CE_CONDA", "conda")
+        sh.assert_env_var("_CE_M", "-m")
+        sh.assert_env_var("CONDA_EXE", escape(sys.executable))
 
         # We use 'PowerShell' here because 'where conda' returns all of them and
         # shell.expect_exact does not do what you would think it does given its name.
-        shell.sendline('powershell -NoProfile -c "(Get-Command conda).Source"')
-        shell.expect_exact(conda_bat)
+        sh.sendline('powershell -NoProfile -c "(Get-Command conda).Source"')
+        sh.expect_exact(conda_bat)
 
-        shell.sendline("chcp")
-        shell.clear()
+        sh.sendline("chcp")
+        sh.clear()
 
-        PATH0 = shell.get_env_var("PATH", "").split(os.pathsep)
+        PATH0 = sh.get_env_var("PATH", "").split(os.pathsep)
         log.debug(f"{PATH0=}")
-        shell.sendline(f'conda {activate} "{charizard}"')
+        sh.sendline(f'conda {activate} "{charizard}"')
 
-        shell.sendline("chcp")
-        shell.clear()
-        shell.assert_env_var("CONDA_SHLVL", "1")
+        sh.sendline("chcp")
+        sh.clear()
+        sh.assert_env_var("CONDA_SHLVL", "1")
 
-        PATH1 = shell.get_env_var("PATH", "").split(os.pathsep)
+        PATH1 = sh.get_env_var("PATH", "").split(os.pathsep)
         log.debug(f"{PATH1=}")
-        shell.sendline('powershell -NoProfile -c "(Get-Command conda).Source"')
-        shell.expect_exact(conda_bat)
+        sh.sendline('powershell -NoProfile -c "(Get-Command conda).Source"')
+        sh.expect_exact(conda_bat)
 
-        shell.assert_env_var("_CE_CONDA", "conda")
-        shell.assert_env_var("_CE_M", "-m")
-        shell.assert_env_var("CONDA_EXE", escape(sys.executable))
-        shell.assert_env_var("CONDA_PREFIX", charizard, True)
-        PATH2 = shell.get_env_var("PATH", "").split(os.pathsep)
+        sh.assert_env_var("_CE_CONDA", "conda")
+        sh.assert_env_var("_CE_M", "-m")
+        sh.assert_env_var("CONDA_EXE", escape(sys.executable))
+        sh.assert_env_var("CONDA_PREFIX", charizard, True)
+        PATH2 = sh.get_env_var("PATH", "").split(os.pathsep)
         log.debug(f"{PATH2=}")
 
-        shell.sendline('powershell -NoProfile -c "(Get-Command conda -All).Source"')
-        shell.expect_exact(conda_bat)
+        sh.sendline('powershell -NoProfile -c "(Get-Command conda -All).Source"')
+        sh.expect_exact(conda_bat)
 
-        shell.sendline(f'conda {activate} "{prefix}"')
-        shell.assert_env_var("_CE_CONDA", "conda")
-        shell.assert_env_var("_CE_M", "-m")
-        shell.assert_env_var("CONDA_EXE", escape(sys.executable))
-        shell.assert_env_var("CONDA_SHLVL", "2")
-        shell.assert_env_var("CONDA_PREFIX", prefix, True)
+        sh.sendline(f'conda {activate} "{prefix}"')
+        sh.assert_env_var("_CE_CONDA", "conda")
+        sh.assert_env_var("_CE_M", "-m")
+        sh.assert_env_var("CONDA_EXE", escape(sys.executable))
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        sh.assert_env_var("CONDA_PREFIX", prefix, True)
 
         # TODO: Make a dummy package and release it (somewhere?)
         #       should be a relatively light package, but also
@@ -76,41 +76,41 @@ def test_cmd_exe_basic_integration(shell_wrapper_integration: tuple[str, str, st
         #       not require an old or incompatible version of any
         #       library critical to the correct functioning of
         #       Python (e.g. OpenSSL).
-        shell.sendline(f"conda install --yes --quiet hdf5={HDF5_VERSION}")
-        shell.expect(r"Executing transaction: ...working... done.*\n", timeout=100)
-        shell.assert_env_var("errorlevel", "0", True)
+        sh.sendline(f"conda install --yes --quiet hdf5={HDF5_VERSION}")
+        sh.expect(r"Executing transaction: ...working... done.*\n", timeout=100)
+        sh.assert_env_var("errorlevel", "0", True)
         # TODO: assert that reactivate worked correctly
 
-        shell.sendline("h5stat --version")
-        shell.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
+        sh.sendline("h5stat --version")
+        sh.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
 
         # conda run integration test
-        shell.sendline(f"conda run {dev_arg} h5stat --version")
-        shell.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
+        sh.sendline(f"conda run {dev_arg} h5stat --version")
+        sh.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
 
-        shell.sendline(f"conda {deactivate}")
-        shell.assert_env_var("CONDA_SHLVL", "1")
-        shell.sendline(f"conda {deactivate}")
-        shell.assert_env_var("CONDA_SHLVL", "0")
-        shell.sendline(f"conda {deactivate}")
-        shell.assert_env_var("CONDA_SHLVL", "0")
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "0")
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "0")
 
 
 @pytest.mark.skipif(not which("cmd.exe"), reason="cmd.exe not installed")
 def test_cmd_exe_activate_error(shell_wrapper_integration: tuple[str, str, str]):
     context.dev = True
-    with InteractiveShell("cmd.exe") as shell:
-        shell.sendline("set")
-        shell.expect(".*")
-        shell.sendline(f"conda {activate} environment-not-found-doesnt-exist")
-        shell.expect(
+    with InteractiveShell("cmd.exe") as sh:
+        sh.sendline("set")
+        sh.expect(".*")
+        sh.sendline(f"conda {activate} environment-not-found-doesnt-exist")
+        sh.expect(
             "Could not find conda environment: environment-not-found-doesnt-exist"
         )
-        shell.expect(".*")
-        shell.assert_env_var("errorlevel", "1")
+        sh.expect(".*")
+        sh.assert_env_var("errorlevel", "1")
 
-        shell.sendline("conda activate -h blah blah")
-        shell.expect("usage: conda activate")
+        sh.sendline("conda activate -h blah blah")
+        sh.expect("usage: conda activate")
 
 
 @pytest.mark.skipif(not which("cmd.exe"), reason="cmd.exe not installed")
@@ -119,39 +119,39 @@ def test_legacy_activate_deactivate_cmd_exe(
 ):
     prefix, prefix2, prefix3 = shell_wrapper_integration
 
-    with InteractiveShell("cmd.exe") as shell:
-        shell.sendline("echo off")
+    with InteractiveShell("cmd.exe") as sh:
+        sh.sendline("echo off")
 
-        conda__ce_conda = shell.get_env_var("_CE_CONDA")
+        conda__ce_conda = sh.get_env_var("_CE_CONDA")
         assert conda__ce_conda == "conda"
 
         PATH = f"{CONDA_PACKAGE_ROOT}\\shell\\Scripts;%PATH%"
 
-        shell.sendline("SET PATH=" + PATH)
+        sh.sendline("SET PATH=" + PATH)
 
-        shell.sendline(f'activate --dev "{prefix2}"')
-        shell.clear()
+        sh.sendline(f'activate --dev "{prefix2}"')
+        sh.clear()
 
-        conda_shlvl = shell.get_env_var("CONDA_SHLVL")
+        conda_shlvl = sh.get_env_var("CONDA_SHLVL")
         assert conda_shlvl == "1", conda_shlvl
 
-        PATH = shell.get_env_var("PATH")
+        PATH = sh.get_env_var("PATH")
         assert "charizard" in PATH
 
-        conda__ce_conda = shell.get_env_var("_CE_CONDA")
+        conda__ce_conda = sh.get_env_var("_CE_CONDA")
         assert conda__ce_conda == "conda"
 
-        shell.sendline("conda --version")
-        shell.expect_exact("conda " + conda_version)
+        sh.sendline("conda --version")
+        sh.expect_exact("conda " + conda_version)
 
-        shell.sendline(f'activate.bat --dev "{prefix3}"')
-        PATH = shell.get_env_var("PATH")
+        sh.sendline(f'activate.bat --dev "{prefix3}"')
+        PATH = sh.get_env_var("PATH")
         assert "venusaur" in PATH
 
-        shell.sendline("deactivate.bat --dev")
-        PATH = shell.get_env_var("PATH")
+        sh.sendline("deactivate.bat --dev")
+        PATH = sh.get_env_var("PATH")
         assert "charizard" in PATH
 
-        shell.sendline("deactivate --dev")
-        conda_shlvl = shell.get_env_var("CONDA_SHLVL")
+        sh.sendline("deactivate --dev")
+        conda_shlvl = sh.get_env_var("CONDA_SHLVL")
         assert conda_shlvl == "0", conda_shlvl

--- a/tests/shell/test_csh.py
+++ b/tests/shell/test_csh.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from shutil import which
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -11,39 +10,14 @@ from conda import __version__ as conda_version
 
 from . import InteractiveShell
 
-if TYPE_CHECKING:
-    from typing import Callable
-
 pytestmark = pytest.mark.integration
 
 
-def basic_csh(shell, prefix, prefix2, prefix3):
-    shell.sendline("conda --version")
-    shell.expect_exact("conda " + conda_version)
-    shell.assert_env_var("CONDA_SHLVL", "0")
-    shell.sendline("conda activate base")
-    shell.assert_env_var("prompt", "(base).*")
-    shell.assert_env_var("CONDA_SHLVL", "1")
-    shell.sendline(f'conda activate "{prefix}"')
-    shell.assert_env_var("CONDA_SHLVL", "2")
-    shell.assert_env_var("CONDA_PREFIX", prefix, True)
-    shell.sendline("conda deactivate")
-    shell.assert_env_var("CONDA_SHLVL", "1")
-    shell.sendline("conda deactivate")
-    shell.assert_env_var("CONDA_SHLVL", "0")
-
-    assert "CONDA_PROMPT_MODIFIER" not in str(shell.p.after)
-
-    shell.sendline("conda deactivate")
-    shell.assert_env_var("CONDA_SHLVL", "0")
-
-
 @pytest.mark.parametrize(
-    "shell_name,script",
+    "shell_name",
     [
         pytest.param(
             "csh",
-            basic_csh,
             marks=[
                 pytest.mark.skipif(not which("csh"), reason="csh not installed"),
                 pytest.mark.xfail(
@@ -53,7 +27,6 @@ def basic_csh(shell, prefix, prefix2, prefix3):
         ),
         pytest.param(
             "tcsh",
-            basic_csh,
             marks=[
                 pytest.mark.skipif(not which("tcsh"), reason="tcsh not installed"),
                 pytest.mark.xfail(
@@ -66,7 +39,24 @@ def basic_csh(shell, prefix, prefix2, prefix3):
 def test_basic_integration(
     shell_wrapper_integration: tuple[str, str, str],
     shell_name: str,
-    script: Callable[[InteractiveShell, str, str, str], None],
 ):
-    with InteractiveShell(shell_name) as shell:
-        script(shell, *shell_wrapper_integration)
+    prefix, _, _ = shell_wrapper_integration
+    with InteractiveShell(shell_name) as sh:
+        sh.sendline("conda --version")
+        sh.expect_exact("conda " + conda_version)
+        sh.assert_env_var("CONDA_SHLVL", "0")
+        sh.sendline("conda activate base")
+        sh.assert_env_var("prompt", "(base).*")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        sh.sendline(f'conda activate "{prefix}"')
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        sh.assert_env_var("CONDA_PREFIX", prefix, True)
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "0")
+
+        assert "CONDA_PROMPT_MODIFIER" not in str(sh.p.after)
+
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "0")

--- a/tests/shell/test_fish.py
+++ b/tests/shell/test_fish.py
@@ -16,25 +16,25 @@ pytestmark = pytest.mark.integration
 def test_fish_basic_integration(shell_wrapper_integration: tuple[str, str, str]):
     prefix, _, _ = shell_wrapper_integration
 
-    with InteractiveShell("fish") as shell:
-        shell.sendline("env | sort")
+    with InteractiveShell("fish") as sh:
+        sh.sendline("env | sort")
         # We should be seeing environment variable output to terminal with this line, but
         # we aren't.  Haven't experienced this problem yet with any other shell...
 
-        shell.assert_env_var("CONDA_SHLVL", "0")
-        shell.sendline("conda activate base")
-        shell.assert_env_var("CONDA_SHLVL", "1")
-        shell.sendline(f'conda activate "{prefix}"')
-        shell.assert_env_var("CONDA_SHLVL", "2")
-        shell.assert_env_var("CONDA_PREFIX", prefix, True)
-        shell.sendline("conda deactivate")
-        shell.assert_env_var("CONDA_SHLVL", "1")
-        shell.sendline("conda deactivate")
-        shell.assert_env_var("CONDA_SHLVL", "0")
+        sh.assert_env_var("CONDA_SHLVL", "0")
+        sh.sendline("conda activate base")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        sh.sendline(f'conda activate "{prefix}"')
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        sh.assert_env_var("CONDA_PREFIX", prefix, True)
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "0")
 
-        shell.sendline(shell.print_env_var % "PS1")
-        shell.clear()
-        assert "CONDA_PROMPT_MODIFIER" not in str(shell.p.after)
+        sh.sendline(sh.print_env_var % "PS1")
+        sh.clear()
+        assert "CONDA_PROMPT_MODIFIER" not in str(sh.p.after)
 
-        shell.sendline("conda deactivate")
-        shell.assert_env_var("CONDA_SHLVL", "0")
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "0")

--- a/tests/shell/test_posix.py
+++ b/tests/shell/test_posix.py
@@ -7,7 +7,6 @@ from functools import cache
 from logging import getLogger
 from shutil import which
 from subprocess import CalledProcessError, check_output
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -17,9 +16,6 @@ from conda.base.context import context
 from conda.common.compat import on_win
 
 from . import HDF5_VERSION, InteractiveShell, activate, deactivate, dev_arg, install
-
-if TYPE_CHECKING:
-    from typing import Callable
 
 log = getLogger(__name__)
 pytestmark = pytest.mark.integration
@@ -50,217 +46,11 @@ skip_unsupported_bash = pytest.mark.skipif(
 )
 
 
-def basic_posix(shell, prefix, prefix2, prefix3):
-    if shell.shell_name in ("zsh", "dash"):
-        conda_is_a_function = "conda is a shell function"
-    else:
-        conda_is_a_function = "conda is a function"
-
-    case = str.lower if on_win else str
-
-    num_paths_added = len(tuple(shell.activator._get_path_dirs(prefix)))
-    prefix_p = shell.path_conversion(prefix)
-    prefix2_p = shell.path_conversion(prefix2)
-    shell.path_conversion(prefix3)
-
-    PATH0 = shell.get_env_var("PATH", "")
-    assert any(path.endswith("condabin") for path in PATH0.split(":"))
-
-    shell.assert_env_var("CONDA_SHLVL", "0")
-    # Remove sys.prefix from PATH. It interferes with path entry count tests.
-    # We can no longer check this since we'll replace e.g. between 1 and N path
-    # entries with N of them in _replace_prefix_in_path() now. It is debatable
-    # whether it should be here at all too.
-    if PATH0.startswith(shell.path_conversion(sys.prefix) + ":"):
-        PATH0 = PATH0[len(shell.path_conversion(sys.prefix)) + 1 :]
-        shell.sendline(f'export PATH="{PATH0}"')
-        PATH0 = shell.get_env_var("PATH", "")
-    shell.sendline("type conda")
-    shell.expect(conda_is_a_function)
-
-    _CE_M = shell.get_env_var("_CE_M")
-    _CE_CONDA = shell.get_env_var("_CE_CONDA")
-
-    shell.sendline("conda --version")
-    shell.expect_exact("conda " + conda_version)
-
-    shell.sendline(f"conda {activate} base")
-
-    shell.sendline("type conda")
-    shell.expect(conda_is_a_function)
-
-    CONDA_EXE2 = case(shell.get_env_var("CONDA_EXE"))
-    _CE_M2 = shell.get_env_var("_CE_M")
-
-    shell.assert_env_var("PS1", "(base).*")
-    shell.assert_env_var("CONDA_SHLVL", "1")
-    PATH1 = shell.get_env_var("PATH", "")
-    assert len(PATH0.split(":")) + num_paths_added == len(PATH1.split(":"))
-
-    CONDA_EXE = case(shell.get_env_var("CONDA_EXE"))
-    _CE_M = shell.get_env_var("_CE_M")
-    _CE_CONDA = shell.get_env_var("_CE_CONDA")
-
-    log.debug("activating ..")
-    shell.sendline(f'conda {activate} "{prefix_p}"')
-
-    shell.sendline("type conda")
-    shell.expect(conda_is_a_function)
-
-    CONDA_EXE2 = case(shell.get_env_var("CONDA_EXE"))
-    _CE_M2 = shell.get_env_var("_CE_M")
-    _CE_CONDA2 = shell.get_env_var("_CE_CONDA")
-    assert CONDA_EXE == CONDA_EXE2
-    assert _CE_M == _CE_M2
-    assert _CE_CONDA == _CE_CONDA2
-
-    shell.sendline("env | sort")
-    # When CONDA_SHLVL==2 fails it usually means that conda activate failed. We that fails it is
-    # usually because you forgot to pass `--dev` to the *previous* activate so CONDA_EXE changed
-    # from python to conda, which is then found on PATH instead of using the dev sources. When it
-    # goes to use this old conda to generate the activation script for the newly activated env.
-    # it is running the old code (or at best, a mix of new code and old scripts).
-    shell.assert_env_var("CONDA_SHLVL", "2")
-    CONDA_PREFIX = shell.get_env_var("CONDA_PREFIX", "")
-    # We get C: vs c: differences on Windows.
-    # Also, self.prefix instead of prefix_p is deliberate (maybe unfortunate?)
-    assert CONDA_PREFIX.lower() == prefix.lower()
-    PATH2 = shell.get_env_var("PATH", "")
-    assert len(PATH0.split(":")) + num_paths_added == len(PATH2.split(":"))
-
-    shell.sendline("env | sort | grep CONDA")
-    shell.expect("CONDA_")
-    shell.sendline('echo "PATH=$PATH"')
-    shell.expect("PATH=")
-    shell.sendline(f'conda {activate} "{prefix2_p}"')
-    shell.sendline("env | sort | grep CONDA")
-    shell.expect("CONDA_")
-    shell.sendline('echo "PATH=$PATH"')
-    shell.expect("PATH=")
-    shell.assert_env_var("PS1", "(charizard).*")
-    shell.assert_env_var("CONDA_SHLVL", "3")
-    PATH3 = shell.get_env_var("PATH")
-    assert len(PATH0.split(":")) + num_paths_added == len(PATH3.split(":"))
-
-    CONDA_EXE2 = case(shell.get_env_var("CONDA_EXE"))
-    _CE_M2 = shell.get_env_var("_CE_M")
-    _CE_CONDA2 = shell.get_env_var("_CE_CONDA")
-    assert CONDA_EXE == CONDA_EXE2
-    assert _CE_M == _CE_M2
-    assert _CE_CONDA == _CE_CONDA2
-
-    shell.sendline(f"conda {install} -yq hdf5={HDF5_VERSION}")
-    shell.expect(r"Executing transaction: ...working... done.*\n", timeout=180)
-    shell.assert_env_var("?", "0", use_exact=True)
-
-    shell.sendline("h5stat --version")
-    shell.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
-
-    # TODO: assert that reactivate worked correctly
-
-    shell.sendline("type conda")
-    shell.expect(conda_is_a_function)
-
-    shell.sendline(f"conda run {dev_arg} h5stat --version")
-    shell.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
-
-    # regression test for #6840
-    shell.sendline(f"conda {install} --blah")
-    shell.assert_env_var("?", "2", use_exact=True)
-    shell.sendline("conda list --blah")
-    shell.assert_env_var("?", "2", use_exact=True)
-
-    shell.sendline(f"conda {deactivate}")
-    shell.assert_env_var("CONDA_SHLVL", "2")
-    PATH = shell.get_env_var("PATH")
-    assert len(PATH0.split(":")) + num_paths_added == len(PATH.split(":"))
-
-    shell.sendline(f"conda {deactivate}")
-    shell.assert_env_var("CONDA_SHLVL", "1")
-    PATH = shell.get_env_var("PATH")
-    assert len(PATH0.split(":")) + num_paths_added == len(PATH.split(":"))
-
-    shell.sendline(f"conda {deactivate}")
-    shell.assert_env_var("CONDA_SHLVL", "0")
-    PATH = shell.get_env_var("PATH")
-    assert len(PATH0.split(":")) == len(PATH.split(":"))
-    # assert PATH0 == PATH  # cygpath may "resolve" paths
-
-    shell.sendline(shell.print_env_var % "PS1")
-    shell.clear()
-    assert "CONDA_PROMPT_MODIFIER" not in str(shell.p.after)
-
-    shell.sendline(f"conda {deactivate}")
-    shell.assert_env_var("CONDA_SHLVL", "0")
-
-    # When fully deactivated, CONDA_EXE, _CE_M and _CE_CONDA must be retained
-    # because the conda shell scripts use them and if they are unset activation
-    # is not possible.
-    CONDA_EXED = case(shell.get_env_var("CONDA_EXE"))
-    assert CONDA_EXED, (
-        "A fully deactivated conda shell must retain CONDA_EXE (and _CE_M and _CE_CONDA in dev)\n"
-        "  as the shell scripts refer to them."
-    )
-
-    PATH0 = shell.get_env_var("PATH")
-
-    shell.sendline(f'conda {activate} "{prefix2_p}"')
-    shell.assert_env_var("CONDA_SHLVL", "1")
-    PATH1 = shell.get_env_var("PATH")
-    assert len(PATH0.split(":")) + num_paths_added == len(PATH1.split(":"))
-
-    shell.sendline(f'conda {activate} "{prefix3}" --stack')
-    shell.assert_env_var("CONDA_SHLVL", "2")
-    PATH2 = shell.get_env_var("PATH")
-    assert "charizard" in PATH2
-    assert "venusaur" in PATH2
-    assert len(PATH0.split(":")) + num_paths_added * 2 == len(PATH2.split(":"))
-
-    shell.sendline(f'conda {activate} "{prefix_p}"')
-    shell.assert_env_var("CONDA_SHLVL", "3")
-    PATH3 = shell.get_env_var("PATH")
-    assert "charizard" in PATH3
-    assert "venusaur" not in PATH3
-    assert len(PATH0.split(":")) + num_paths_added * 2 == len(PATH3.split(":"))
-
-    shell.sendline(f"conda {deactivate}")
-    shell.assert_env_var("CONDA_SHLVL", "2")
-    PATH4 = shell.get_env_var("PATH")
-    assert "charizard" in PATH4
-    assert "venusaur" in PATH4
-    assert len(PATH4.split(":")) == len(PATH2.split(":"))
-    # assert PATH4 == PATH2  # cygpath may "resolve" paths
-
-    shell.sendline(f"conda {deactivate}")
-    shell.assert_env_var("CONDA_SHLVL", "1")
-    PATH5 = shell.get_env_var("PATH")
-    assert len(PATH1.split(":")) == len(PATH5.split(":"))
-    # assert PATH1 == PATH5  # cygpath may "resolve" paths
-
-    # Test auto_stack
-    shell.sendline(shell.activator.export_var_tmpl % ("CONDA_AUTO_STACK", "1"))
-
-    shell.sendline(f'conda {activate} "{prefix3}"')
-    shell.assert_env_var("CONDA_SHLVL", "2")
-    PATH2 = shell.get_env_var("PATH")
-    assert "charizard" in PATH2
-    assert "venusaur" in PATH2
-    assert len(PATH0.split(":")) + num_paths_added * 2 == len(PATH2.split(":"))
-
-    shell.sendline(f'conda {activate} "{prefix_p}"')
-    shell.assert_env_var("CONDA_SHLVL", "3")
-    PATH3 = shell.get_env_var("PATH")
-    assert "charizard" in PATH3
-    assert "venusaur" not in PATH3
-    assert len(PATH0.split(":")) + num_paths_added * 2 == len(PATH3.split(":"))
-
-
 @pytest.mark.parametrize(
-    "shell_name,script",
+    "shell_name",
     [
         pytest.param(
             "bash",
-            basic_posix,
             marks=[
                 skip_unsupported_bash,
                 pytest.mark.skipif(
@@ -270,7 +60,6 @@ def basic_posix(shell, prefix, prefix2, prefix3):
         ),
         pytest.param(
             "dash",
-            basic_posix,
             marks=[
                 pytest.mark.skipif(
                     not which("dash") or on_win, reason="dash not installed"
@@ -279,7 +68,6 @@ def basic_posix(shell, prefix, prefix2, prefix3):
         ),
         pytest.param(
             "zsh",
-            basic_posix,
             marks=[pytest.mark.skipif(not which("zsh"), reason="zsh not installed")],
         ),
     ],
@@ -287,29 +75,231 @@ def basic_posix(shell, prefix, prefix2, prefix3):
 def test_basic_integration(
     shell_wrapper_integration: tuple[str, str, str],
     shell_name: str,
-    script: Callable[[InteractiveShell, str, str, str], None],
 ):
-    with InteractiveShell(shell_name) as shell:
-        script(shell, *shell_wrapper_integration)
+    prefix, prefix2, prefix3 = shell_wrapper_integration
+
+    with InteractiveShell(shell_name) as sh:
+        if sh.shell_name in ("zsh", "dash"):
+            conda_is_a_function = "conda is a shell function"
+        else:
+            conda_is_a_function = "conda is a function"
+
+        case = str.lower if on_win else str
+
+        num_paths_added = len(tuple(sh.activator._get_path_dirs(prefix)))
+        prefix_p = sh.path_conversion(prefix)
+        prefix2_p = sh.path_conversion(prefix2)
+        sh.path_conversion(prefix3)
+
+        PATH0 = sh.get_env_var("PATH", "")
+        assert any(path.endswith("condabin") for path in PATH0.split(":"))
+
+        sh.assert_env_var("CONDA_SHLVL", "0")
+        # Remove sys.prefix from PATH. It interferes with path entry count tests.
+        # We can no longer check this since we'll replace e.g. between 1 and N path
+        # entries with N of them in _replace_prefix_in_path() now. It is debatable
+        # whether it should be here at all too.
+        if PATH0.startswith(sh.path_conversion(sys.prefix) + ":"):
+            PATH0 = PATH0[len(sh.path_conversion(sys.prefix)) + 1 :]
+            sh.sendline(f'export PATH="{PATH0}"')
+            PATH0 = sh.get_env_var("PATH", "")
+        sh.sendline("type conda")
+        sh.expect(conda_is_a_function)
+
+        _CE_M = sh.get_env_var("_CE_M")
+        _CE_CONDA = sh.get_env_var("_CE_CONDA")
+
+        sh.sendline("conda --version")
+        sh.expect_exact("conda " + conda_version)
+
+        sh.sendline(f"conda {activate} base")
+
+        sh.sendline("type conda")
+        sh.expect(conda_is_a_function)
+
+        CONDA_EXE2 = case(sh.get_env_var("CONDA_EXE"))
+        _CE_M2 = sh.get_env_var("_CE_M")
+
+        sh.assert_env_var("PS1", "(base).*")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        PATH1 = sh.get_env_var("PATH", "")
+        assert len(PATH0.split(":")) + num_paths_added == len(PATH1.split(":"))
+
+        CONDA_EXE = case(sh.get_env_var("CONDA_EXE"))
+        _CE_M = sh.get_env_var("_CE_M")
+        _CE_CONDA = sh.get_env_var("_CE_CONDA")
+
+        log.debug("activating ..")
+        sh.sendline(f'conda {activate} "{prefix_p}"')
+
+        sh.sendline("type conda")
+        sh.expect(conda_is_a_function)
+
+        CONDA_EXE2 = case(sh.get_env_var("CONDA_EXE"))
+        _CE_M2 = sh.get_env_var("_CE_M")
+        _CE_CONDA2 = sh.get_env_var("_CE_CONDA")
+        assert CONDA_EXE == CONDA_EXE2
+        assert _CE_M == _CE_M2
+        assert _CE_CONDA == _CE_CONDA2
+
+        sh.sendline("env | sort")
+        # When CONDA_SHLVL==2 fails it usually means that conda activate failed. We that fails it is
+        # usually because you forgot to pass `--dev` to the *previous* activate so CONDA_EXE changed
+        # from python to conda, which is then found on PATH instead of using the dev sources. When it
+        # goes to use this old conda to generate the activation script for the newly activated env.
+        # it is running the old code (or at best, a mix of new code and old scripts).
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        CONDA_PREFIX = sh.get_env_var("CONDA_PREFIX", "")
+        # We get C: vs c: differences on Windows.
+        # Also, self.prefix instead of prefix_p is deliberate (maybe unfortunate?)
+        assert CONDA_PREFIX.lower() == prefix.lower()
+        PATH2 = sh.get_env_var("PATH", "")
+        assert len(PATH0.split(":")) + num_paths_added == len(PATH2.split(":"))
+
+        sh.sendline("env | sort | grep CONDA")
+        sh.expect("CONDA_")
+        sh.sendline('echo "PATH=$PATH"')
+        sh.expect("PATH=")
+        sh.sendline(f'conda {activate} "{prefix2_p}"')
+        sh.sendline("env | sort | grep CONDA")
+        sh.expect("CONDA_")
+        sh.sendline('echo "PATH=$PATH"')
+        sh.expect("PATH=")
+        sh.assert_env_var("PS1", "(charizard).*")
+        sh.assert_env_var("CONDA_SHLVL", "3")
+        PATH3 = sh.get_env_var("PATH")
+        assert len(PATH0.split(":")) + num_paths_added == len(PATH3.split(":"))
+
+        CONDA_EXE2 = case(sh.get_env_var("CONDA_EXE"))
+        _CE_M2 = sh.get_env_var("_CE_M")
+        _CE_CONDA2 = sh.get_env_var("_CE_CONDA")
+        assert CONDA_EXE == CONDA_EXE2
+        assert _CE_M == _CE_M2
+        assert _CE_CONDA == _CE_CONDA2
+
+        sh.sendline(f"conda {install} -yq hdf5={HDF5_VERSION}")
+        sh.expect(r"Executing transaction: ...working... done.*\n", timeout=180)
+        sh.assert_env_var("?", "0", use_exact=True)
+
+        sh.sendline("h5stat --version")
+        sh.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
+
+        # TODO: assert that reactivate worked correctly
+
+        sh.sendline("type conda")
+        sh.expect(conda_is_a_function)
+
+        sh.sendline(f"conda run {dev_arg} h5stat --version")
+        sh.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
+
+        # regression test for #6840
+        sh.sendline(f"conda {install} --blah")
+        sh.assert_env_var("?", "2", use_exact=True)
+        sh.sendline("conda list --blah")
+        sh.assert_env_var("?", "2", use_exact=True)
+
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        PATH = sh.get_env_var("PATH")
+        assert len(PATH0.split(":")) + num_paths_added == len(PATH.split(":"))
+
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        PATH = sh.get_env_var("PATH")
+        assert len(PATH0.split(":")) + num_paths_added == len(PATH.split(":"))
+
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "0")
+        PATH = sh.get_env_var("PATH")
+        assert len(PATH0.split(":")) == len(PATH.split(":"))
+        # assert PATH0 == PATH  # cygpath may "resolve" paths
+
+        sh.sendline(sh.print_env_var % "PS1")
+        sh.clear()
+        assert "CONDA_PROMPT_MODIFIER" not in str(sh.p.after)
+
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "0")
+
+        # When fully deactivated, CONDA_EXE, _CE_M and _CE_CONDA must be retained
+        # because the conda shell scripts use them and if they are unset activation
+        # is not possible.
+        CONDA_EXED = case(sh.get_env_var("CONDA_EXE"))
+        assert CONDA_EXED, (
+            "A fully deactivated conda shell must retain CONDA_EXE (and _CE_M and _CE_CONDA in dev)\n"
+            "  as the shell scripts refer to them."
+        )
+
+        PATH0 = sh.get_env_var("PATH")
+
+        sh.sendline(f'conda {activate} "{prefix2_p}"')
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        PATH1 = sh.get_env_var("PATH")
+        assert len(PATH0.split(":")) + num_paths_added == len(PATH1.split(":"))
+
+        sh.sendline(f'conda {activate} "{prefix3}" --stack')
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        PATH2 = sh.get_env_var("PATH")
+        assert "charizard" in PATH2
+        assert "venusaur" in PATH2
+        assert len(PATH0.split(":")) + num_paths_added * 2 == len(PATH2.split(":"))
+
+        sh.sendline(f'conda {activate} "{prefix_p}"')
+        sh.assert_env_var("CONDA_SHLVL", "3")
+        PATH3 = sh.get_env_var("PATH")
+        assert "charizard" in PATH3
+        assert "venusaur" not in PATH3
+        assert len(PATH0.split(":")) + num_paths_added * 2 == len(PATH3.split(":"))
+
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        PATH4 = sh.get_env_var("PATH")
+        assert "charizard" in PATH4
+        assert "venusaur" in PATH4
+        assert len(PATH4.split(":")) == len(PATH2.split(":"))
+        # assert PATH4 == PATH2  # cygpath may "resolve" paths
+
+        sh.sendline(f"conda {deactivate}")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        PATH5 = sh.get_env_var("PATH")
+        assert len(PATH1.split(":")) == len(PATH5.split(":"))
+        # assert PATH1 == PATH5  # cygpath may "resolve" paths
+
+        # Test auto_stack
+        sh.sendline(sh.activator.export_var_tmpl % ("CONDA_AUTO_STACK", "1"))
+
+        sh.sendline(f'conda {activate} "{prefix3}"')
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        PATH2 = sh.get_env_var("PATH")
+        assert "charizard" in PATH2
+        assert "venusaur" in PATH2
+        assert len(PATH0.split(":")) + num_paths_added * 2 == len(PATH2.split(":"))
+
+        sh.sendline(f'conda {activate} "{prefix_p}"')
+        sh.assert_env_var("CONDA_SHLVL", "3")
+        PATH3 = sh.get_env_var("PATH")
+        assert "charizard" in PATH3
+        assert "venusaur" not in PATH3
+        assert len(PATH0.split(":")) + num_paths_added * 2 == len(PATH3.split(":"))
 
 
 @skip_unsupported_bash
 @pytest.mark.skipif(on_win, reason="Temporary skip, larger refactor necessary")
 def test_bash_activate_error(shell_wrapper_integration: tuple[str, str, str]):
     context.dev = True
-    with InteractiveShell("bash") as shell:
-        shell.sendline("export CONDA_SHLVL=unaffected")
+    with InteractiveShell("bash") as sh:
+        sh.sendline("export CONDA_SHLVL=unaffected")
         if on_win:
-            shell.sendline("uname -o")
-            shell.expect("(Msys|Cygwin)")
-        shell.sendline("conda activate environment-not-found-doesnt-exist")
-        shell.expect(
+            sh.sendline("uname -o")
+            sh.expect("(Msys|Cygwin)")
+        sh.sendline("conda activate environment-not-found-doesnt-exist")
+        sh.expect(
             "Could not find conda environment: environment-not-found-doesnt-exist"
         )
-        shell.assert_env_var("CONDA_SHLVL", "unaffected")
+        sh.assert_env_var("CONDA_SHLVL", "unaffected")
 
-        shell.sendline("conda activate -h blah blah")
-        shell.expect("usage: conda activate")
+        sh.sendline("conda activate -h blah blah")
+        sh.expect("usage: conda activate")
 
 
 @skip_unsupported_bash
@@ -318,33 +308,29 @@ def test_legacy_activate_deactivate_bash(
 ):
     prefix, prefix2, prefix3 = shell_wrapper_integration
 
-    with InteractiveShell("bash") as shell:
-        CONDA_PACKAGE_ROOT_p = shell.path_conversion(CONDA_PACKAGE_ROOT)
-        prefix2_p = shell.path_conversion(prefix2)
-        prefix3_p = shell.path_conversion(prefix3)
-        shell.sendline(f"export _CONDA_ROOT='{CONDA_PACKAGE_ROOT_p}/shell'")
-        shell.sendline(
-            f'source "${{_CONDA_ROOT}}/bin/activate" {dev_arg} "{prefix2_p}"'
-        )
-        PATH0 = shell.get_env_var("PATH")
+    with InteractiveShell("bash") as sh:
+        CONDA_PACKAGE_ROOT_p = sh.path_conversion(CONDA_PACKAGE_ROOT)
+        prefix2_p = sh.path_conversion(prefix2)
+        prefix3_p = sh.path_conversion(prefix3)
+        sh.sendline(f"export _CONDA_ROOT='{CONDA_PACKAGE_ROOT_p}/shell'")
+        sh.sendline(f'source "${{_CONDA_ROOT}}/bin/activate" {dev_arg} "{prefix2_p}"')
+        PATH0 = sh.get_env_var("PATH")
         assert "charizard" in PATH0
 
-        shell.sendline("type conda")
-        shell.expect("conda is a function")
+        sh.sendline("type conda")
+        sh.expect("conda is a function")
 
-        shell.sendline("conda --version")
-        shell.expect_exact("conda " + conda_version)
+        sh.sendline("conda --version")
+        sh.expect_exact("conda " + conda_version)
 
-        shell.sendline(
-            f'source "${{_CONDA_ROOT}}/bin/activate" {dev_arg} "{prefix3_p}"'
-        )
+        sh.sendline(f'source "${{_CONDA_ROOT}}/bin/activate" {dev_arg} "{prefix3_p}"')
 
-        PATH1 = shell.get_env_var("PATH")
+        PATH1 = sh.get_env_var("PATH")
         assert "venusaur" in PATH1
 
-        shell.sendline('source "${_CONDA_ROOT}/bin/deactivate"')
-        PATH2 = shell.get_env_var("PATH")
+        sh.sendline('source "${_CONDA_ROOT}/bin/deactivate"')
+        PATH2 = sh.get_env_var("PATH")
         assert "charizard" in PATH2
 
-        shell.sendline('source "${_CONDA_ROOT}/bin/deactivate"')
-        shell.assert_env_var("CONDA_SHLVL", "0")
+        sh.sendline('source "${_CONDA_ROOT}/bin/deactivate"')
+        sh.assert_env_var("CONDA_SHLVL", "0")

--- a/tests/shell/test_powershell.py
+++ b/tests/shell/test_powershell.py
@@ -74,56 +74,56 @@ def test_powershell_basic_integration(
     prefix, charizard, venusaur = shell_wrapper_integration
 
     log.debug(f"## [PowerShell integration] Using {pwsh_path}.")
-    with InteractiveShell(pwsh_name, shell_path=pwsh_path) as shell:
+    with InteractiveShell(pwsh_name, shell_path=pwsh_path) as sh:
         log.debug("## [PowerShell integration] Starting test.")
-        shell.sendline("(Get-Command conda).CommandType")
-        shell.expect_exact("Alias")
-        shell.sendline("(Get-Command conda).Definition")
-        shell.expect_exact("Invoke-Conda")
-        shell.sendline("(Get-Command Invoke-Conda).Definition")
+        sh.sendline("(Get-Command conda).CommandType")
+        sh.expect_exact("Alias")
+        sh.sendline("(Get-Command conda).Definition")
+        sh.expect_exact("Invoke-Conda")
+        sh.sendline("(Get-Command Invoke-Conda).Definition")
 
         log.debug("## [PowerShell integration] Activating.")
-        shell.sendline(f'conda activate "{charizard}"')
-        shell.assert_env_var("CONDA_SHLVL", "1")
-        PATH = shell.get_env_var("PATH")
+        sh.sendline(f'conda activate "{charizard}"')
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        PATH = sh.get_env_var("PATH")
         assert "charizard" in PATH
-        shell.sendline("conda --version")
-        shell.expect_exact("conda " + conda_version)
-        shell.sendline(f'conda activate "{prefix}"')
-        shell.assert_env_var("CONDA_SHLVL", "2")
-        shell.assert_env_var("CONDA_PREFIX", prefix, True)
+        sh.sendline("conda --version")
+        sh.expect_exact("conda " + conda_version)
+        sh.sendline(f'conda activate "{prefix}"')
+        sh.assert_env_var("CONDA_SHLVL", "2")
+        sh.assert_env_var("CONDA_PREFIX", prefix, True)
 
-        shell.sendline("conda deactivate")
-        PATH = shell.get_env_var("PATH")
+        sh.sendline("conda deactivate")
+        PATH = sh.get_env_var("PATH")
         assert "charizard" in PATH
-        shell.sendline(f'conda activate -stack "{venusaur}"')
-        PATH = shell.get_env_var("PATH")
+        sh.sendline(f'conda activate -stack "{venusaur}"')
+        PATH = sh.get_env_var("PATH")
         assert "venusaur" in PATH
         assert "charizard" in PATH
 
         log.debug("## [PowerShell integration] Installing.")
-        shell.sendline(f"conda install -yq hdf5={HDF5_VERSION}")
-        shell.expect(r"Executing transaction: ...working... done.*\n", timeout=100)
-        shell.sendline("$LASTEXITCODE")
-        shell.expect("0")
+        sh.sendline(f"conda install -yq hdf5={HDF5_VERSION}")
+        sh.expect(r"Executing transaction: ...working... done.*\n", timeout=100)
+        sh.sendline("$LASTEXITCODE")
+        sh.expect("0")
         # TODO: assert that reactivate worked correctly
 
         log.debug("## [PowerShell integration] Checking installed version.")
-        shell.sendline("h5stat --version")
-        shell.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
+        sh.sendline("h5stat --version")
+        sh.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
 
         # conda run integration test
         log.debug("## [PowerShell integration] Checking conda run.")
-        shell.sendline(f"conda run {dev_arg} h5stat --version")
-        shell.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
+        sh.sendline(f"conda run {dev_arg} h5stat --version")
+        sh.expect(rf".*h5stat: Version {HDF5_VERSION}.*")
 
         log.debug("## [PowerShell integration] Deactivating")
-        shell.sendline("conda deactivate")
-        shell.assert_env_var("CONDA_SHLVL", "1")
-        shell.sendline("conda deactivate")
-        shell.assert_env_var("CONDA_SHLVL", "0")
-        shell.sendline("conda deactivate")
-        shell.assert_env_var("CONDA_SHLVL", "0")
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "0")
+        sh.sendline("conda deactivate")
+        sh.assert_env_var("CONDA_SHLVL", "0")
 
 
 @pytest.mark.skipif(
@@ -139,22 +139,22 @@ def test_powershell_PATH_management(
     prefix, _, _ = shell_wrapper_integration
 
     print(f"## [PowerShell activation PATH management] Using {pwsh_path}.")
-    with InteractiveShell(pwsh_name, shell_path=pwsh_path) as shell:
+    with InteractiveShell(pwsh_name, shell_path=pwsh_path) as sh:
         prefix = join(prefix, "envs", "test")
         print("## [PowerShell activation PATH management] Starting test.")
-        shell.sendline("(Get-Command conda).CommandType")
-        shell.expect_exact("Alias")
-        shell.sendline("(Get-Command conda).Definition")
-        shell.expect_exact("Invoke-Conda")
-        shell.sendline("(Get-Command Invoke-Conda).Definition")
-        shell.clear()
+        sh.sendline("(Get-Command conda).CommandType")
+        sh.expect_exact("Alias")
+        sh.sendline("(Get-Command conda).Definition")
+        sh.expect_exact("Invoke-Conda")
+        sh.sendline("(Get-Command Invoke-Conda).Definition")
+        sh.clear()
 
-        shell.sendline("conda deactivate")
-        shell.sendline("conda deactivate")
+        sh.sendline("conda deactivate")
+        sh.sendline("conda deactivate")
 
-        PATH0 = shell.get_env_var("PATH", "")
+        PATH0 = sh.get_env_var("PATH", "")
         print(f"PATH is {PATH0.split(os.pathsep)}")
-        shell.sendline("(Get-Command conda).CommandType")
-        shell.expect_exact("Alias")
-        shell.sendline(f'conda create -yqp "{prefix}" bzip2')
-        shell.expect(r"Executing transaction: ...working... done.*\n")
+        sh.sendline("(Get-Command conda).CommandType")
+        sh.expect_exact("Alias")
+        sh.sendline(f'conda create -yqp "{prefix}" bzip2')
+        sh.expect(r"Executing transaction: ...working... done.*\n")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Extracted from #13673

Changes include:
- Replace all `shell` variables with `sh` in preparation for introducing the `shell` fixture in #13673
- Inline both `basic_csh` and `basic_sh` helper functions
- Replace `hdf5` with local `small-executable`

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
