### PR TITLE
Remove `git` & `bash` from CI dependencies

### DIFF
--- a/dev/start.bat
+++ b/dev/start.bat
@@ -116,8 +116,6 @@
     @ECHO Error: failed to install development environment 1>&2
     @EXIT /B 1
 )
-:: Windows doesn't ship with git so ensure installed into base otherwise auxlib will act up
-@CALL :CONDA "%_BASEEXE%" install --yes --quiet --name=base "defaults::git<2.45" > NUL
 :INSTALLED
 
 :: create empty env if it doesn't exist
@@ -216,9 +214,8 @@
 @GOTO :EOF
 
 :CONDA *args
-:: include OpenSSL & git on %PATH%
-@SET "_PATH=%PATH%"
-@SET "PATH=%1\..\..\Library\bin;%PATH%"
+:: include OpenSSL %PATH%
+@SET "_PATH=%PATH%"@SET "PATH=%1\..\..\Library\bin;%PATH%"
 
 @CALL %*
 @IF NOT %ErrorLevel%==0 @EXIT /B %ErrorLevel%

--- a/tests/requirements-Windows.txt
+++ b/tests/requirements-Windows.txt
@@ -1,1 +1,2 @@
+msys2-msys2-runtime  # cygpath
 pywin32

--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -3,7 +3,6 @@ conda-forge::pytest-split
 conda-forge::pytest-xprocess
 coverage
 flask >=2.2  # jlap pytest fixture
-git
 importlib_resources >= 5.10  # only necessary for Python < 3.12
 pexpect
 pip


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We may not need `git` as an explicit CI dependency anymore. Per comments and `git blame`, `git` was necessary for `auxlib` to work. The relevant parts that depended on `git` appear to have been removed so we're gonna try to remove `git`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
