### PR TITLE
Replace `curl` with `small-executable` in shell stacking tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,3 +9,7 @@ initialize_logging()
 from conda.testing import conda_move_to_front_of_PATH
 
 conda_move_to_front_of_PATH()
+
+from pathlib import Path
+
+TEST_RECIPES_CHANNEL = Path(__file__).parent / "test-recipes"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from conda.plugins.hookspec import CondaSpecs
 from conda.plugins.manager import CondaPluginManager
 from conda.plugins.reporter_backends import plugins as reporter_backend_plugins
 
-from . import http_test_server
+from . import TEST_RECIPES_CHANNEL, http_test_server
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -38,17 +38,15 @@ def pytest_report_header(config: pytest.Config):
 
 @pytest.fixture
 def test_recipes_channel(mocker: MockerFixture) -> Path:
-    channel = Path(__file__).parent / "test-recipes"
-
     mocker.patch(
         "conda.base.context.Context.channels",
         new_callable=mocker.PropertyMock,
-        return_value=(channel_str := str(channel),),
+        return_value=(channel_str := str(TEST_RECIPES_CHANNEL),),
     )
     reset_context()
     assert context.channels == (channel_str,)
 
-    return channel
+    return TEST_RECIPES_CHANNEL
 
 
 @pytest.fixture

--- a/tests/shell/conftest.py
+++ b/tests/shell/conftest.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+from conda.common.compat import on_win
 from conda.testing.integration import SPACER_CHARACTER
 
 from . import Shell
@@ -21,7 +22,12 @@ if TYPE_CHECKING:
 
 @pytest.fixture(scope="module")
 def shell(request: FixtureRequest) -> Shell:
-    return Shell.resolve(request.param)
+    try:
+        shell = request.param
+    except AttributeError:
+        # AttributeError: 'FixtureRequest' object has no attribute 'param'
+        shell = "cmd.exe" if on_win else "bash"
+    return Shell.resolve(shell)
 
 
 @pytest.fixture

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -3,22 +3,22 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from subprocess import check_output
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
 
-from conda.base.context import context
 from conda.common.compat import on_linux, on_mac, on_win
 from conda.testing.integration import SPACER_CHARACTER
 
+from .. import TEST_RECIPES_CHANNEL
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from typing import Any
 
-    from pytest import TempPathFactory
+    from pytest import FixtureRequest, TempPathFactory
 
     from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
@@ -96,66 +96,65 @@ def test_activate_deactivate_modify_path(
     assert original_path == os.environ.get("PATH")
 
 
+@dataclass
+class Env:
+    name: str
+    prefix: Path | None = None
+    paths: tuple[Path, ...] | None = None
+
+    def __post_init__(self):
+        if self.paths is None:
+            paths = [
+                self.prefix / "Scripts" / "small.bat" if on_win else None,
+                self.prefix / "bin" / "small",
+            ]
+            self.paths = filter(Path.exists, filter(None, paths))
+
+
+@pytest.fixture(scope="module")
+def stacking_envs(session_tmp_env: TmpEnvFixture) -> dict[str, Env]:
+    # create envs using full path to avoid solver
+    path = TEST_RECIPES_CHANNEL / "noarch" / "small-executable-1.0.0-0.tar.bz2"
+    with (
+        session_tmp_env(path) as base_env,
+        session_tmp_env(path) as has_env,
+        # use --offline for empty env to avoid HTTP hit
+        session_tmp_env("--offline") as not_env,
+    ):
+        return {
+            "sys": Env("sys", paths=()),
+            "base": Env("base", prefix=base_env),
+            "has": Env("has", prefix=has_env),
+            "not": Env("not", prefix=not_env),
+        }
+
+
 @pytest.fixture
-def create_stackable_envs(
-    tmp_env: TmpEnvFixture,
-) -> Iterator[tuple[str, dict[str, Any]]]:
-    # generate stackable environments, two with curl and one without curl
-    which = f"{'where' if on_win else 'which -a'} curl"
-
-    class Env:
-        def __init__(self, prefix=None, paths=None):
-            self.prefix = Path(prefix) if prefix else None
-
-            if not paths:
-                if on_win:
-                    path = self.prefix / "Library" / "bin" / "curl.exe"
-                else:
-                    path = self.prefix / "bin" / "curl"
-
-                paths = (path,) if path.exists() else ()
-            self.paths = paths
-
-    sys = _run_command(which)
-
-    with tmp_env("curl") as base, tmp_env("curl") as haspkg, tmp_env() as notpkg:
-        yield (
-            which,
-            {
-                "sys": Env(paths=sys),
-                "base": Env(prefix=base),
-                "has": Env(prefix=haspkg),
-                "not": Env(prefix=notpkg),
-            },
-        )
+def stack(request: FixtureRequest, stacking_envs: dict[str, Env]) -> tuple[Env, ...]:
+    envs = request.param.split(",") if request.param else ()
+    return tuple(stacking_envs[env] for env in envs)
 
 
-def _run_command(*lines):
-    # create a custom run command since this is specific to the shell integration
-    if on_win:
-        join = " && ".join
-        source = f"{Path(context.root_prefix, 'condabin', 'conda_hook.bat')}"
-    else:
-        join = "\n".join
-        source = f". {Path(context.root_prefix, 'etc', 'profile.d', 'conda.sh')}"
-
-    marker = uuid4().hex
-    script = join((source, *(["conda deactivate"] * 5), f"echo {marker}", *lines))
-    output = check_output(script, shell=True).decode().splitlines()
-    output = list(map(str.strip, output))
-    output = output[output.index(marker) + 1 :]  # trim setup output
-
-    return [Path(path) for path in filter(None, output)]
+@pytest.fixture
+def run(request: FixtureRequest, stacking_envs: dict[str, Env]) -> Env:
+    return stacking_envs[request.param]
 
 
+@pytest.fixture
+def expected(request: FixtureRequest, stacking_envs: dict[str, Env]) -> tuple[Env, ...]:
+    envs = request.param.split(",") if request.param else ()
+    return tuple(stacking_envs[env] for env in envs)
+
+
+# TODO: test stacking on all shells
 # see https://github.com/conda/conda/pull/11257#issuecomment-1050531320
 @pytest.mark.parametrize(
-    ("auto_stack", "stack", "run", "expected"),
+    "auto_stack,stack,run,expected",
     [
         # no environments activated
-        (0, "", "base", "base,sys"),
-        (0, "", "has", "has,sys"),
-        (0, "", "not", "sys"),
+        (0, None, "base", "base,sys"),
+        (0, None, "has", "has,sys"),
+        (0, None, "not", "sys"),
         # one environment activated, no stacking
         (0, "base", "base", "base,sys"),
         (0, "base", "has", "has,sys"),
@@ -184,24 +183,25 @@ def _run_command(*lines):
         (5, "base,not", "has", "has,base,sys"),
         (5, "base,not", "not", "base,sys"),
     ],
+    indirect=["stack", "run", "expected"],
 )
 def test_stacking(
-    create_stackable_envs: tuple[str, dict[str, Any]],
     auto_stack: int,
-    stack: str,
-    run: str,
-    expected: str,
+    stack: tuple[Env, ...],
+    run: Env,
+    expected: tuple[Env, ...],
+    shell: Shell,
 ) -> None:
-    which, envs = create_stackable_envs
-    assert _run_command(
-        f"conda config --set auto_stack {auto_stack}",
-        *(
-            f'conda activate "{envs[env.strip()].prefix}"'
-            for env in filter(None, stack.split(","))
-        ),
-        f'conda run -p "{envs[run.strip()].prefix}" {which}',
-    ) == [
-        path
-        for env in filter(None, expected.split(","))
-        for path in envs[env.strip()].paths
-    ]
+    which = f"{'where' if on_win else 'which -a'} small"
+    with shell.interactive() as sh:
+        sh.sendline(sh.activator.set_var_tmpl % ("CONDA_AUTO_STACK", auto_stack))
+        for env in stack:
+            sh.sendline(f'conda activate "{env.prefix}"')
+
+        sh.sendline(f'conda run --prefix="{run.prefix}" {which}')
+        if not expected:
+            sh.expect_exact(f"'conda run {which}' failed")
+        else:
+            for env in expected:
+                for path in env.paths:
+                    sh.expect_exact(str(path))

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -116,10 +116,7 @@ def create_stackable_envs(
                 paths = (path,) if path.exists() else ()
             self.paths = paths
 
-    sys = _run_command(
-        "conda config --set auto_activate_base false",
-        which,
-    )
+    sys = _run_command(which)
 
     with tmp_env("curl") as base, tmp_env("curl") as haspkg, tmp_env() as notpkg:
         yield (

--- a/tests/testing/test_fixtures.py
+++ b/tests/testing/test_fixtures.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
 
 from conda.base.context import context, reset_context
@@ -11,7 +10,6 @@ from conda.gateways.disk.test import is_conda_environment
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from _pytest.capture import MultiCapture
     from pytest import MonkeyPatch, Pytester
 
     from conda.testing.fixtures import (
@@ -22,14 +20,6 @@ if TYPE_CHECKING:
     )
 
 pytest_plugins = ["conda.testing.fixtures", "pytester"]
-
-
-def test_session_capsys(session_capsys: MultiCapture) -> None:
-    print("stdout")
-    print("stderr", file=sys.stderr)
-    out, err = session_capsys.readouterr()
-    assert out == "stdout\n"
-    assert err == "stderr\n"
 
 
 def test_conda_cli(conda_cli: CondaCLIFixture) -> None:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The shell integration tests for environment stacking are pretty slow given the cost of creating the test environments. The stacking itself isn't the slow part. Previously the environments were (re-)created per test and installing `curl` which while being a comparatively cheaper package to install, it is still an HTTP request hit.

The change here updates the fixture(s) used for environment stacking to be session scoped fixtures and to use `small-executable` instead of `curl`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
