### PR TITLE
Replace _logger_lock with logging._lock

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -279,14 +279,14 @@ def disable_logger(logger_name):
     logr = getLogger(logger_name)
     _lvl, _dsbld, _prpgt = logr.level, logr.disabled, logr.propagate
     null_handler = NullHandler()
-    with _logger_lock():
+    with logging._lock:
         logr.addHandler(null_handler)
         logr.setLevel(CRITICAL + 1)
         logr.disabled, logr.propagate = True, False
     try:
         yield
     finally:
-        with _logger_lock():
+        with logging._lock:
             logr.removeHandler(null_handler)  # restore list logr.handlers
             logr.level, logr.disabled = _lvl, _dsbld
             logr.propagate = _prpgt
@@ -305,7 +305,7 @@ def stderr_log_level(level, logger_name=None):
     handler.name = "stderr"
     handler.setLevel(level)
     handler.setFormatter(_FORMATTER)
-    with _logger_lock():
+    with logging._lock:
         logr.setLevel(level)
         logr.handlers, logr.disabled, logr.propagate = [], False, False
         logr.addHandler(handler)
@@ -313,7 +313,7 @@ def stderr_log_level(level, logger_name=None):
     try:
         yield
     finally:
-        with _logger_lock():
+        with logging._lock:
             logr.handlers, logr.level, logr.disabled = _hndlrs, _lvl, _dsbld
             logr.propagate = _prpgt
 
@@ -354,7 +354,7 @@ def attach_stderr_handler(
         new_stderr_handler.addFilter(filter_)
 
     # do the switch
-    with _logger_lock():
+    with logging._lock:
         if old_stderr_handler:
             logr.removeHandler(old_stderr_handler)
         logr.addHandler(new_stderr_handler)

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -265,6 +265,7 @@ def argv(args_list):
         sys.argv = saved_args
 
 
+@deprecated("25.9", "26.3", addendum="Use `with logging._lock` instead")
 @contextmanager
 def _logger_lock():
     logging._acquireLock()


### PR DESCRIPTION
### Description

* Replace use of `_logger_lock()` as a context manager in the common/io module with `logging._lock`.
* Mark the `_logger_lock` function for deprecation.

This use of `logging._lock` is supported since Python 3.7. 

This syntax is supported by Python 3.13.  The use of `logging._aquireLock` used in the `_logger_lock` function is problematic as the function was removed in Python 3.13 (python/cpython#109462)

This is inspired by a similar change in pastescript, pasteorg/pastescript#15

This would make #14117 unnecessary unless an update to the function marked for deprecation is needed.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
