### PR TITLE
TOKEN_REPLACE is a staticmethod of TokenURLFilter

### DIFF
--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -45,7 +45,7 @@ class TokenURLFilter(Filter):
         r"(|:\d{1,5})?"  # \3  port
         r"/t/[a-z0-9A-Z-]+/"  # token
     )
-    TOKEN_REPLACE = partial(TOKEN_URL_PATTERN.sub, r"\1\2\3/t/<TOKEN>/")
+    TOKEN_REPLACE = staticmethod(partial(TOKEN_URL_PATTERN.sub, r"\1\2\3/t/<TOKEN>/"))
 
     def filter(self, record):
         """


### PR DESCRIPTION
### Description

TOKEN_REPLACE is a `staticmethod` of the TokenURLFilter.

It also works as a instance method in Python < 3.14 but will fail starting with Python 3.14 as functools.partial becomes a method descriptor.

The idiom used here is from the docs of staticmethod, https://docs.python.org/3/library/functions.html#staticmetho://docs.python.org/3/library/functions.html#staticmethod

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
