### PR TITLE
Remove `conda.cli.main_env.configure_parser(sub_parsers=None)`

### DIFF
--- a/conda/cli/main_env.py
+++ b/conda/cli/main_env.py
@@ -4,17 +4,15 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser
 from typing import TYPE_CHECKING
 
-from ..deprecations import deprecated
 from . import main_export
 
 if TYPE_CHECKING:
-    from argparse import Namespace, _SubParsersAction
+    from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 
-def configure_parser(sub_parsers: _SubParsersAction | None, **kwargs) -> ArgumentParser:
+def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from . import (
         main_env_config,
         main_env_create,
@@ -23,20 +21,10 @@ def configure_parser(sub_parsers: _SubParsersAction | None, **kwargs) -> Argumen
         main_env_update,
     )
 
-    # This is a backport for the deprecated `conda_env`, see `conda_env.cli.main`
-    if sub_parsers is None:
-        deprecated.topic(
-            "24.9",
-            "25.3",
-            topic="'conda_env'",
-        )
-        p = ArgumentParser()
-
-    else:
-        p = sub_parsers.add_parser(
-            "env",
-            **kwargs,
-        )
+    p = sub_parsers.add_parser(
+        "env",
+        **kwargs,
+    )
 
     env_parsers = p.add_subparsers(
         metavar="command",

--- a/news/14600-remove-configure_parser-None
+++ b/news/14600-remove-configure_parser-None
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove `conda.cli.main_env.configure_parser(sub_parsers=None)`. (#14600)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Remove `conda.cli.main_env.configure_parser`'s support for passing in `sub_parsers=None` as used in `conda_env.cli.main` which has now been removed, see https://github.com/conda/conda/pull/14564.

Xref https://github.com/conda/conda/issues/14560

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
