### PR TITLE
Ignore flaky stderr checks

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -358,41 +358,38 @@ def test_safety_checks_disabled(
 
 
 def test_json_create_install_update_remove(
-    path_factory: PathFactoryFixture,
+    tmp_path: Path,
     conda_cli: CondaCLIFixture,
-    capsys: CaptureFixture,
 ):
     # regression test for #5384
 
-    def assert_json_parsable(content):
-        string = None
-        try:
-            for string in content and content.split("\0") or ():
+    def is_json_parsable(content: str) -> bool:
+        for string in content and content.split("\0") or ():
+            try:
                 json.loads(string)
-        except Exception as e:
-            log.warning(
-                "Problem parsing json output.\n"
-                "  content: %s\n"
-                "  string: %s\n"
-                "  error: %r",
-                content,
-                string,
-                e,
-            )
-            raise
+            except Exception as err:
+                log.warning(
+                    "Problem parsing json output.\n"
+                    "  content: %s\n"
+                    "  string: %s\n"
+                    "  error: %r",
+                    content,
+                    string,
+                    err,
+                )
+                return False
+            else:
+                return True
 
-    prefix = path_factory()
-
-    with pytest.raises(DryRunExit):
-        conda_cli(
-            "create",
-            f"--prefix={prefix}",
-            "zlib",
-            "--json",
-            "--dry-run",
-        )
-    stdout, stderr = capsys.readouterr()
-    assert_json_parsable(stdout)
+    stdout, _, _ = conda_cli(
+        "create",
+        f"--prefix={tmp_path}",
+        "zlib",
+        "--json",
+        "--dry-run",
+        raises=DryRunExit,
+    )
+    assert is_json_parsable(stdout)
 
     # regression test for #5825
     # contents of LINK and UNLINK is expected to have dist format
@@ -400,69 +397,64 @@ def test_json_create_install_update_remove(
     dist_dump = json_obj["actions"]["LINK"][0]
     assert "dist_name" in dist_dump
 
-    stdout, stderr, _ = conda_cli(
+    stdout, _, _ = conda_cli(
         "create",
-        f"--prefix={prefix}",
+        f"--prefix={tmp_path}",
         "zlib",
         "--json",
         "--yes",
     )
-    assert_json_parsable(stdout)
-    assert not stderr
+    assert is_json_parsable(stdout)
 
     json_obj = json.loads(stdout)
     dist_dump = json_obj["actions"]["LINK"][0]
     assert "dist_name" in dist_dump
 
-    stdout, stderr, _ = conda_cli(
+    stdout, _, _ = conda_cli(
         "install",
-        f"--prefix={prefix}",
+        f"--prefix={tmp_path}",
         "ca-certificates<2023",
         "--json",
         "--yes",
     )
-    assert_json_parsable(stdout)
-    assert not stderr
-    assert package_is_installed(prefix, "ca-certificates<2023")
-    assert package_is_installed(prefix, "zlib")
+    assert is_json_parsable(stdout)
+    assert package_is_installed(tmp_path, "ca-certificates<2023")
+    assert package_is_installed(tmp_path, "zlib")
 
     # Test force reinstall
-    stdout, stderr, _ = conda_cli(
+    stdout, _, _ = conda_cli(
         "install",
-        f"--prefix={prefix}",
+        f"--prefix={tmp_path}",
         "--force-reinstall",
         "ca-certificates<2023",
         "--json",
         "--yes",
     )
-    assert_json_parsable(stdout)
-    assert not stderr
-    assert package_is_installed(prefix, "ca-certificates<2023")
-    assert package_is_installed(prefix, "zlib")
+    assert is_json_parsable(stdout)
+    assert package_is_installed(tmp_path, "ca-certificates<2023")
+    assert package_is_installed(tmp_path, "zlib")
 
-    stdout, stderr, _ = conda_cli(
+    stdout, _, _ = conda_cli(
         "update",
-        f"--prefix={prefix}",
+        f"--prefix={tmp_path}",
         "ca-certificates",
         "--json",
         "--yes",
     )
-    assert_json_parsable(stdout)
-    assert not stderr
-    assert package_is_installed(prefix, "ca-certificates>=2023")
-    assert package_is_installed(prefix, "zlib")
+    assert is_json_parsable(stdout)
+    assert package_is_installed(tmp_path, "ca-certificates>=2023")
+    assert package_is_installed(tmp_path, "zlib")
 
-    stdout, stderr, _ = conda_cli(
+    stdout, _, _ = conda_cli(
         "remove",
-        f"--prefix={prefix}",
+        f"--prefix={tmp_path}",
         "ca-certificates",
         "--json",
         "--yes",
     )
-    assert_json_parsable(stdout)
-    assert not stderr
-    assert not package_is_installed(prefix, "ca-certificates")
-    assert package_is_installed(prefix, "zlib")
+    assert is_json_parsable(stdout)
+    assert not package_is_installed(tmp_path, "ca-certificates")
+    assert package_is_installed(tmp_path, "zlib")
 
     # regression test for #5825
     # contents of LINK and UNLINK is expected to have Dist format
@@ -470,23 +462,21 @@ def test_json_create_install_update_remove(
     dist_dump = json_obj["actions"]["UNLINK"][0]
     assert "dist_name" in dist_dump
 
-    stdout, stderr, _ = conda_cli("list", f"--prefix={prefix}", "--revisions", "--json")
-    assert not stderr
+    stdout, _, _ = conda_cli("list", f"--prefix={tmp_path}", "--revisions", "--json")
     json_obj = json.loads(stdout)
     assert len(json_obj) == 5
     assert json_obj[4]["rev"] == 4
 
-    stdout, stderr, _ = conda_cli(
+    stdout, _, _ = conda_cli(
         "install",
-        f"--prefix={prefix}",
+        f"--prefix={tmp_path}",
         "--revision=0",
         "--json",
         "--yes",
     )
-    assert_json_parsable(stdout)
-    assert not stderr
-    assert not package_is_installed(prefix, "ca-certificates")
-    assert package_is_installed(prefix, "zlib")
+    assert is_json_parsable(stdout)
+    assert not package_is_installed(tmp_path, "ca-certificates")
+    assert package_is_installed(tmp_path, "zlib")
 
 
 def test_not_writable_env_raises_EnvironmentNotWritableError(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -378,8 +378,7 @@ def test_json_create_install_update_remove(
                     err,
                 )
                 return False
-            else:
-                return True
+        return True
 
     stdout, _, _ = conda_cli(
         "create",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Recent testing has shown the `tests/test_create.py::test_json_create_install_update_remove` test to be very flaky on Linux ARM and results in the test failing something like 90% of the time. The failure occurs when under network connection retries which are printed to stderr. So the proposed change is to stop testing for `assert not stderr`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
