### PR TITLE
Ensure `conda run` is tested with `--dev`

### DIFF
--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -207,16 +207,19 @@ class CondaCLIFixture:
     @overload
     def __call__(
         self,
-        *argv: str | os.PathLike | Path,
+        *argv: str | os.PathLike[str] | Path,
         raises: type[Exception] | tuple[type[Exception], ...],
     ) -> tuple[str, str, ExceptionInfo]: ...
 
     @overload
-    def __call__(self, *argv: str | os.PathLike | Path) -> tuple[str, str, int]: ...
+    def __call__(
+        self,
+        *argv: str | os.PathLike[str] | Path,
+    ) -> tuple[str, str, int]: ...
 
     def __call__(
         self,
-        *argv: str | os.PathLike | Path,
+        *argv: str | os.PathLike[str] | Path,
         raises: type[Exception] | tuple[type[Exception], ...] | None = None,
     ) -> tuple[str | None, str | None, int | ExceptionInfo]:
         """Test conda CLI. Mimic what is done in `conda.cli.main.main`.
@@ -232,13 +235,10 @@ class CondaCLIFixture:
         if self.capsys:
             self.capsys.readouterr()
 
-        # ensure arguments are string
-        argv = tuple(map(str, argv))
-
         # run command
         code = None
         with pytest.raises(raises) if raises else nullcontext() as exception:
-            code = main_subshell(*argv)
+            code = main_subshell(*self._cast_args(argv))
         # capture output
         if self.capsys:
             out, err = self.capsys.readouterr()
@@ -249,6 +249,29 @@ class CondaCLIFixture:
         reset_context()
 
         return out, err, exception if raises else code
+
+    @staticmethod
+    def _cast_args(argv: tuple[str | os.PathLike[str] | Path, ...]) -> Iterable[str]:
+        """Cast args to string and inspect for `conda run`.
+
+        `conda run` is a unique case that requires `--dev` to use the src shell scripts
+        and not the shell scripts provided by the installer.
+        """
+        # TODO: Refactor this so we don't expose testing infrastructure to the user
+        # (i.e., deprecate `conda run --dev`).
+        argv = map(str, argv)
+        for arg in argv:
+            yield arg
+
+            # detect if arg is the command (the first positional)
+            if arg[0] != "-":
+                # this is the first positional, return remaining arguments
+
+                # if this happens to be the `conda run` command, add --dev
+                if arg == "run":
+                    yield "--dev"  # use src, not installer's shell scripts
+
+                yield from argv
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While working on https://github.com/conda/conda/pull/14607 we discovered that `conda run` was using the installer's shell scripts for testing and not the source code's shell scripts. We correct this by injecting the `--dev` argument anytime we are calling `conda run`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
