### PR TITLE
Deprecate `conda.exports.plan`

### DIFF
--- a/conda/exports.py
+++ b/conda/exports.py
@@ -5,10 +5,11 @@
 import errno
 import functools
 import os
+import warnings
 from builtins import input  # noqa: F401, UP029
 from io import StringIO  # noqa: F401, for conda-build
 
-from . import CondaError, plan  # noqa: F401
+from . import CondaError  # noqa: F401
 from .auxlib.entity import EntityEncoder  # noqa: F401
 from .base.constants import (  # noqa: F401
     DEFAULT_CHANNELS,
@@ -101,6 +102,13 @@ PY3 = True
 string_types = str
 text_type = str
 
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", PendingDeprecationWarning)
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from . import plan
+
+    deprecated.constant("25.9", "26.3", "plan", plan)
+    del plan
 
 deprecated.constant(
     "25.3",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Now that conda.plan is deprecated we also need to deprecate `conda.exports.plan`.

Followup to https://github.com/conda/conda/pull/14603
Xref https://github.com/conda/conda-build/pull/4977

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
