### PR TITLE
Install `pytest-split` and `pytest-xprocess` from defaults.

### DIFF
--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -1,6 +1,6 @@
 anaconda-client
-conda-forge::pytest-split
-conda-forge::pytest-xprocess
+pytest-split
+pytest-xprocess
 coverage
 flask >=2.2  # jlap pytest fixture
 git

--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -1,6 +1,4 @@
 anaconda-client
-pytest-split
-pytest-xprocess
 coverage
 flask >=2.2  # jlap pytest fixture
 git
@@ -11,7 +9,9 @@ pytest
 pytest-cov
 pytest-mock
 pytest-rerunfailures
+pytest-split
 pytest-timeout
+pytest-xprocess
 responses
 tomli  # for coverage pyproject.toml, only necessary for Python <= 3.11.0a6
 werkzeug >=2.2  # jlap pytest fixture


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

We have these packages in defaults now as well. The test matrix will correctly select to either install from defaults or conda-forge, which hopefully should prevent further bleeding over of branches.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
