### PR TITLE
Remove `logging.Logger.trace`, `context.restore_free_channel`, and postpone `context.conda_exe`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -789,7 +789,7 @@ class Context(Configuration):
     @property
     @deprecated(
         "23.9",
-        "25.3",
+        "26.3",
         addendum="Please use `conda.base.context.context.conda_exe_vars_dict` instead",
     )
     def conda_exe(self):

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -412,7 +412,6 @@ class Context(Configuration):
         SequenceParameter(PrimitiveParameter("", element_type=str)),
         expandvars=True,
     )
-    restore_free_channel = ParameterLoader(PrimitiveParameter(False))
     repodata_fns = ParameterLoader(
         SequenceParameter(
             PrimitiveParameter("", element_type=str),
@@ -882,18 +881,6 @@ class Context(Configuration):
         else:
             default_channels = list(self._default_channels)
 
-        if self.restore_free_channel:
-            deprecated.topic(
-                "24.9",
-                "25.3",
-                topic="Adding the 'free' channel as it existed prior to conda 4.7.",
-                addendum="See "
-                "https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/free-channel.html "
-                "for more details.",
-                deprecation_type=FutureWarning,
-            )
-            default_channels.insert(1, "https://repo.anaconda.com/pkgs/free")
-
         reserved_multichannel_urls = {
             DEFAULTS_CHANNEL_NAME: default_channels,
             "local": self.conda_build_local_urls,
@@ -1190,7 +1177,6 @@ class Context(Configuration):
                 "migrated_custom_channels",
                 "add_anaconda_token",
                 "allow_non_channel_urls",
-                "restore_free_channel",
                 "repodata_fns",
                 "use_only_tar_bz2",
                 "repodata_threads",
@@ -1715,12 +1701,6 @@ class Context(Configuration):
                 Opt in, or opt out, of automatic error reporting to core maintainers. Error
                 reports are anonymous, with only the error stack trace and information given
                 by `conda info` being sent.
-                """
-            ),
-            restore_free_channel=dals(
-                """"
-                Add the "free" channel back into defaults, behind "main" in priority. The "free"
-                channel was removed from the collection of default channels in conda 4.7.0.
                 """
             ),
             rollback_enabled=dals(

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -23,7 +23,6 @@ from ..common.io import _FORMATTER, attach_stderr_handler
 from ..deprecations import deprecated
 
 log = getLogger(__name__)
-
 _VERBOSITY_LEVELS = {
     0: WARN,  # standard output
     1: WARN,  # -v, detailed output
@@ -31,6 +30,9 @@ _VERBOSITY_LEVELS = {
     3: DEBUG,  # -vvv, debug logging
     4: TRACE,  # -vvvv, trace logging
 }
+
+# Labels log messages with log level TRACE (5) as "TRACE"
+logging.addLevelName(TRACE, "TRACE")
 
 
 class TokenURLFilter(Filter):
@@ -219,17 +221,3 @@ def set_file_logging(logger_name=None, level=DEBUG, path=None):
 def set_log_level(log_level: int):
     set_all_logger_level(log_level)
     log.debug("log_level set to %d", log_level)
-
-
-@deprecated(
-    "24.9",
-    "25.3",
-    addendum="Use `logging.getLogger(__name__)(conda.common.constants.TRACE, ...)` instead.",
-)
-def trace(self, message, *args, **kwargs):
-    if self.isEnabledFor(TRACE):
-        self._log(TRACE, message, args, **kwargs)
-
-
-logging.addLevelName(TRACE, "TRACE")
-logging.Logger.trace = trace  # type: ignore[attr-defined]

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -263,17 +263,6 @@ def test_custom_multichannels(testdata: None):
     )
 
 
-def test_restore_free_channel(monkeypatch: MonkeyPatch) -> None:
-    free_channel = "https://repo.anaconda.com/pkgs/free"
-    assert free_channel not in context.default_channels
-
-    monkeypatch.setenv("CONDA_RESTORE_FREE_CHANNEL", "true")
-    reset_context()
-    assert context.restore_free_channel
-
-    assert context.default_channels[1] == free_channel
-
-
 def test_proxy_servers(testdata: None):
     assert context.proxy_servers["http"] == "http://user:pass@corp.com:8080"
     assert context.proxy_servers["https"] is None

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -454,7 +454,7 @@ def test_set_map_key(key, from_val, to_val, conda_cli: CondaCLIFixture):
 
 
 def test_set_unconfigured_key(conda_cli: CondaCLIFixture):
-    key, to_val = "restore_free_channel", "true"
+    key, to_val = "clobber", "true"
     with make_temp_condarc(CONDARC_BASE) as rc:
         stdout, stderr, _ = conda_cli("config", "--file", rc, "--set", key, to_val)
         assert stdout == stderr == ""
@@ -514,12 +514,9 @@ def test_remove_key_duplicate(conda_cli: CondaCLIFixture):
 
 
 def test_remove_unconfigured_key(conda_cli: CondaCLIFixture):
-    key = "restore_free_channel"
+    key = "clobber"
     with make_temp_condarc(CONDARC_BASE) as rc:
-        with pytest.raises(
-            CondaKeyError,
-            match=r"'restore_free_channel': undefined in config",
-        ):
+        with pytest.raises(CondaKeyError, match=rf"{key!r}: undefined in config"):
             conda_cli("config", "--file", rc, "--remove-key", key)
 
         assert _read_test_condarc(rc) == CONDARC_BASE
@@ -548,7 +545,7 @@ def test_set_check_types(key, str_value, py_value, conda_cli: CondaCLIFixture):
 
 
 def test_set_and_get_bool(conda_cli: CondaCLIFixture):
-    key = "restore_free_channel"
+    key = "clobger"
     with make_temp_condarc() as rc:
         stdout, stderr, _ = conda_cli("config", "--file", rc, "--set", key, "yes")
         stdout, stderr, _ = conda_cli("config", "--file", rc, "--get", key)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Postpone:
- `conda.base.context.Context.conda_exe` (reason: have not had time to remove dependency on this value from `conda.activate`)

Remove:
- `logging.Logger.trace` monkeypatch
- `conda.base.context.Context.restore_free_channel`

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
