### PR TITLE
Silence the error when unset variable in fish

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -1056,7 +1056,7 @@ class FishActivator(_Activator):
     tempfile_extension = None  # output to stdout
     command_join = ";\n"
 
-    unset_var_tmpl = "set -e %s"
+    unset_var_tmpl = "set -e %s || true"
     export_var_tmpl = 'set -gx %s "%s"'
     set_var_tmpl = 'set -g %s "%s"'
     run_script_tmpl = 'source "%s"'

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1884,9 +1884,9 @@ def test_fish_basic(
     assert deactivate_data == (
         f'set -gx PATH "{new_path}";\n'
         f'source "{deactivate1}";\n'
-        f"set -e CONDA_PREFIX;\n"
-        f"set -e CONDA_DEFAULT_ENV;\n"
-        f"set -e CONDA_PROMPT_MODIFIER;\n"
+        f"set -e CONDA_PREFIX || true;\n"
+        f"set -e CONDA_DEFAULT_ENV || true;\n"
+        f"set -e CONDA_PROMPT_MODIFIER || true;\n"
         f"{unset_vars};\n"
         f'set -gx CONDA_SHLVL "0";\n'
         f"{conda_exe_export};\n"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fix https://github.com/conda/conda/issues/14659, avoid failure when unset a variable in fish

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

~- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
~- [ ] Add / update necessary tests?~
~- [ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
