### PR TITLE
Remove `conda.testing.integration.running_a_python_capable_of_unicode_subprocessing`

### DIFF
--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -10,14 +10,11 @@ from __future__ import annotations
 
 import os
 import sys
-from functools import cache
 from logging import getLogger
-from os.path import dirname, join
+from os.path import join
 from pathlib import Path
-from subprocess import check_output
 from typing import TYPE_CHECKING
 
-from ..auxlib.compat import Utf8NamedTemporaryFile
 from ..common.compat import on_win
 from ..common.io import dashlist
 from ..common.path import BIN_DIRECTORY
@@ -58,32 +55,6 @@ log = getLogger(__name__)
 
 def escape_for_winpath(p):
     return p.replace("\\", "\\\\")
-
-
-@cache
-@deprecated("24.9", "25.3")
-def running_a_python_capable_of_unicode_subprocessing():
-    name = None
-    # try:
-    # UNICODE_CHARACTERS + os.sep +
-    with Utf8NamedTemporaryFile(
-        mode="w", suffix=UNICODE_CHARACTERS + ".bat", delete=False
-    ) as batch_file:
-        batch_file.write("@echo Hello World\n")
-        batch_file.write("@exit 0\n")
-        name = batch_file.name
-    if name:
-        try:
-            out = check_output(name, cwd=dirname(name), stderr=None, shell=False)
-            out = out.decode("utf-8") if hasattr(out, "decode") else out
-            if out.startswith("Hello World"):
-                return True
-            return False
-        except Exception:
-            return False
-        finally:
-            os.unlink(name)
-    return False
 
 
 class Commands:

--- a/news/14669-remove-running_a_python_capable_of_unicode_subprocessing
+++ b/news/14669-remove-running_a_python_capable_of_unicode_subprocessing
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove `conda.testing.integration.running_a_python_capable_of_unicode_subprocessing`. (#14669)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Xref https://github.com/conda/conda/issues/14560

Last deprecation to remove for `conda 25.3`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
