### PR TITLE
Fix issues with pip-interop package detection that occur in free-threading Python

### DIFF
--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -296,9 +296,11 @@ class PrefixData(metaclass=PrefixDataType):
         if not python_pkg_record:
             return {}
 
-        site_packages_dir = get_python_site_packages_short_path(
-            python_pkg_record.version
-        )
+        site_packages_dir = python_pkg_record.python_site_packages_path
+        if site_packages_dir is None:
+            site_packages_dir = get_python_site_packages_short_path(
+                python_pkg_record.version
+            )
         site_packages_path = self.prefix_path / win_path_ok(site_packages_dir)
 
         if not site_packages_path.is_dir():


### PR DESCRIPTION
### Description

Address issues that occur when detecting non-conda install Python packages when the environment contains a free-threading version of `python`. Specifically look for packages in the path specified by the `python_site_packages_path` repodata entry when specified and resolve symlinks in the site-packages path when present.

closes #14673 
closes #14153 

Note that #14673 is only addressed if the environment is created with the classic solver as additional work is needed for libmamba to pass the `python_site_packages_path` entry (conda/conda-libmamba-solver#560).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?