### PR TITLE
Remove deprecated error submission system from conda

### DIFF
--- a/conda/exception_handler.py
+++ b/conda/exception_handler.py
@@ -86,7 +86,6 @@ class ExceptionHandler:
     def handle_unexpected_exception(self, exc_val, exc_tb):
         error_report = self.get_error_report(exc_val, exc_tb)
         self.print_unexpected_error_report(error_report)
-        self._upload(error_report)
         rc = getattr(exc_val, "return_code", None)
         return rc if rc is not None else 1
 
@@ -97,7 +96,6 @@ class ExceptionHandler:
         if context.json:
             error_report.update(exc_val.dump_map())
         self.print_expected_error_report(error_report)
-        self._upload(error_report)
         return exc_val.return_code
 
     def get_error_report(self, exc_val, exc_tb):
@@ -238,147 +236,6 @@ class ExceptionHandler:
         except Exception as e:
             log.debug("%r", e)
             return True
-
-    def _upload(self, error_report) -> None:
-        """Determine whether or not to upload the error report."""
-        from .base.context import context
-
-        post_upload = False
-        if context.report_errors is False:
-            # no prompt and no submission
-            do_upload = False
-        elif context.report_errors is True or context.always_yes:
-            # no prompt and submit
-            do_upload = True
-        elif context.json or context.quiet or not self._isatty:
-            # never prompt under these conditions, submit iff always_yes
-            do_upload = bool(not context.offline and context.always_yes)
-        else:
-            # prompt whether to submit
-            do_upload = self._ask_upload()
-            post_upload = True
-
-        # the upload state is one of the following:
-        #   - True: upload error report
-        #   - False: do not upload error report
-        #   - None: while prompting a timeout occurred
-
-        if do_upload:
-            # user wants report to be submitted
-            self._execute_upload(error_report)
-
-        if post_upload:
-            # post submission text
-            self._post_upload(do_upload)
-
-    def _ask_upload(self):
-        from .auxlib.type_coercion import boolify
-        from .common.io import timeout
-
-        try:
-            do_upload = timeout(
-                40,
-                partial(
-                    input,
-                    "If submitted, this report will be used by core maintainers to improve\n"
-                    "future releases of conda.\n"
-                    "Would you like conda to send this report to the core maintainers? "
-                    "[y/N]: ",
-                ),
-            )
-            return do_upload and boolify(do_upload)
-        except Exception as e:
-            log.debug("%r", e)
-            return False
-
-    def _execute_upload(self, error_report):
-        import getpass
-        import json
-
-        from .auxlib.entity import EntityEncoder
-
-        headers = {
-            "User-Agent": self.user_agent,
-        }
-        _timeout = self.http_timeout
-        username = getpass.getuser()
-        error_report["is_ascii"] = (
-            True if all(ord(c) < 128 for c in username) else False
-        )
-        error_report["has_spaces"] = True if " " in str(username) else False
-        data = json.dumps(error_report, sort_keys=True, cls=EntityEncoder) + "\n"
-        data = data.replace(str(username), "USERNAME_REMOVED")
-        response = None
-        try:
-            # requests does not follow HTTP standards for redirects of non-GET methods
-            # That is, when following a 301 or 302, it turns a POST into a GET.
-            # And no way to disable.  WTF
-            import requests
-
-            redirect_counter = 0
-            url = self.error_upload_url
-            response = requests.post(
-                url, headers=headers, timeout=_timeout, data=data, allow_redirects=False
-            )
-            response.raise_for_status()
-            while response.status_code in (301, 302) and response.headers.get(
-                "Location"
-            ):
-                url = response.headers["Location"]
-                response = requests.post(
-                    url,
-                    headers=headers,
-                    timeout=_timeout,
-                    data=data,
-                    allow_redirects=False,
-                )
-                response.raise_for_status()
-                redirect_counter += 1
-                if redirect_counter > 15:
-                    from . import CondaError
-
-                    raise CondaError("Redirect limit exceeded")
-            log.debug("upload response status: %s", response and response.status_code)
-        except Exception as e:  # pragma: no cover
-            log.info("%r", e)
-        try:
-            if response and response.ok:
-                self.write_out("Upload successful.")
-            else:
-                self.write_out("Upload did not complete.")
-                if response and response.status_code:
-                    self.write_out(f" HTTP {response.status_code}")
-        except Exception as e:
-            log.debug(f"{e!r}")
-
-    def _post_upload(self, do_upload):
-        if do_upload is True:
-            # report was submitted
-            self.write_out(
-                "",
-                "Thank you for helping to improve conda.",
-                "Opt-in to always sending reports (and not see this message again)",
-                "by running",
-                "",
-                "    $ conda config --set report_errors true",
-                "",
-            )
-        elif do_upload is None:
-            # timeout was reached while prompting user
-            self.write_out(
-                "",
-                "Timeout reached. No report sent.",
-                "",
-            )
-        else:
-            # no report submitted
-            self.write_out(
-                "",
-                "No report sent. To permanently opt-out, use",
-                "",
-                "    $ conda config --set report_errors false",
-                "",
-            )
 
 
 def conda_exception_handler(func, *args, **kwargs):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -516,19 +516,9 @@ def test_print_unexpected_error_message_upload_1(
     capsys: CaptureFixture,
 ):
     """
-    Test that error reports are auto submitted when CONDA_REPORT_ERRORS=true.
+    Test that error reports are no longer submitted since the functionality was removed.
     """
-    post_mock = mocker.patch(
-        "requests.post",
-        side_effect=(
-            AttrDict(
-                headers=AttrDict(Location="somewhere.else"),
-                status_code=302,
-                raise_for_status=lambda: None,
-            ),
-            AttrDict(raise_for_status=lambda: None),
-        ),
-    )
+    post_mock = mocker.patch("requests.post")
 
     monkeypatch.setenv("CONDA_REPORT_ERRORS", "true")
     monkeypatch.setenv("CONDA_ALWAYS_YES", "false")
@@ -541,8 +531,8 @@ def test_print_unexpected_error_message_upload_1(
     ExceptionHandler()(_raise_helper, AssertionError())
     stdout, stderr = capsys.readouterr()
 
-    assert username_not_in_post_mock(post_mock, getpass.getuser())
-    assert post_mock.call_count == 2
+    # Since error submission was removed, verify no HTTP requests are made
+    assert post_mock.call_count == 0
     assert not stdout
     assert "conda version" in stderr
 
@@ -553,25 +543,10 @@ def test_print_unexpected_error_message_upload_2(
     capsys: CaptureFixture,
 ):
     """
-    Test that error reports are auto submitted when CONDA_ALWAYS_YES=true. Also
-    test that we receive the error report in as a JSON when CONDA_JSON=true.
+    Test that error reports are no longer submitted even when CONDA_ALWAYS_YES=true.
+    Also test that we receive the error report as JSON when CONDA_JSON=true.
     """
-    post_mock = mocker.patch(
-        "requests.post",
-        side_effect=(
-            AttrDict(
-                headers=AttrDict(Location="somewhere.else"),
-                status_code=302,
-                raise_for_status=lambda: None,
-            ),
-            AttrDict(
-                headers=AttrDict(Location="somewhere.again"),
-                status_code=301,
-                raise_for_status=lambda: None,
-            ),
-            AttrDict(raise_for_status=lambda: None),
-        ),
-    )
+    post_mock = mocker.patch("requests.post")
 
     monkeypatch.setenv("CONDA_REPORT_ERRORS", "none")
     monkeypatch.setenv("CONDA_ALWAYS_YES", "true")
@@ -584,8 +559,8 @@ def test_print_unexpected_error_message_upload_2(
     ExceptionHandler()(_raise_helper, AssertionError())
     stdout, stderr = capsys.readouterr()
 
-    assert username_not_in_post_mock(post_mock, getpass.getuser())
-    assert post_mock.call_count == 3
+    # Since error submission was removed, verify no HTTP requests are made
+    assert post_mock.call_count == 0
     assert len(json.loads(stdout)["conda_info"]["channels"]) >= 2
     assert not stderr
 
@@ -596,22 +571,12 @@ def test_print_unexpected_error_message_upload_3(
     capsys: CaptureFixture,
 ):
     """
-    Test that we prompt for user confirmation before submitting error reports
-    when CONDA_REPORT_ERRORS=none, CONDA_ALWAYS_YES=false, and CONDA_JSON=false.
+    Test that we no longer prompt for user confirmation since error reporting
+    functionality has been removed.
     """
-    post_mock = mocker.patch(
-        "requests.post",
-        side_effect=(
-            AttrDict(
-                headers=AttrDict(Location="somewhere.else"),
-                status_code=302,
-                raise_for_status=lambda: None,
-            ),
-            AttrDict(raise_for_status=lambda: None),
-        ),
-    )
-    input_mock = mocker.patch("builtins.input", return_value="y")
-    isatty_mock = mocker.patch("os.isatty", return_value=True)
+    post_mock = mocker.patch("requests.post")
+    input_mock = mocker.patch("builtins.input")
+    isatty_mock = mocker.patch("os.isatty")
 
     monkeypatch.setenv("CONDA_REPORT_ERRORS", "none")
     monkeypatch.setenv("CONDA_ALWAYS_YES", "false")
@@ -624,31 +589,24 @@ def test_print_unexpected_error_message_upload_3(
     ExceptionHandler()(_raise_helper, AssertionError())
     stdout, stderr = capsys.readouterr()
 
-    assert username_not_in_post_mock(post_mock, username=getpass.getuser())
-    assert isatty_mock.call_count == 1
-    assert input_mock.call_count == 1
-    assert post_mock.call_count == 2
+    # Since error submission was removed, no prompts or HTTP requests should occur
+    assert isatty_mock.call_count == 0
+    assert input_mock.call_count == 0 
+    assert post_mock.call_count == 0
     assert not stdout
     assert "conda version" in stderr
 
 
-@patch(
-    "requests.post",
-    side_effect=(
-        AttrDict(
-            headers=AttrDict(Location="somewhere.else"),
-            status_code=302,
-            raise_for_status=lambda: None,
-        ),
-        AttrDict(raise_for_status=lambda: None),
-    ),
-)
-@patch("getpass.getuser", return_value="some name")
 def test_print_unexpected_error_message_upload_username_with_spaces(
-    pwuid,
-    post_mock,
+    mocker: MockerFixture,
     monkeypatch: MonkeyPatch,
 ) -> None:
+    """
+    Test that error reports are no longer submitted even with CONDA_REPORT_ERRORS=true.
+    """
+    post_mock = mocker.patch("requests.post")
+    mock_getuser = mocker.patch("getpass.getuser", return_value="some name")
+
     monkeypatch.setenv("CONDA_REPORT_ERRORS", "true")
     reset_context()
     assert context.report_errors
@@ -656,31 +614,22 @@ def test_print_unexpected_error_message_upload_username_with_spaces(
     with captured() as c:
         ExceptionHandler()(_raise_helper, AssertionError())
 
-    error_data = json.loads(post_mock.call_args[1].get("data"))
-    assert error_data.get("has_spaces") is True
-    assert error_data.get("is_ascii") is True
-    assert post_mock.call_count == 2
+    # Since error submission was removed, verify no HTTP requests are made
+    assert post_mock.call_count == 0
     assert c.stdout == ""
     assert "conda version" in c.stderr
 
 
-@patch(
-    "requests.post",
-    side_effect=(
-        AttrDict(
-            headers=AttrDict(Location="somewhere.else"),
-            status_code=302,
-            raise_for_status=lambda: None,
-        ),
-        AttrDict(raise_for_status=lambda: None),
-    ),
-)
-@patch("getpass.getuser", return_value="my√nameΩ")
 def test_print_unexpected_error_message_upload_username_with_unicode(
-    pwuid,
-    post_mock,
+    mocker: MockerFixture,
     monkeypatch: MonkeyPatch,
 ) -> None:
+    """
+    Test that error reports are no longer submitted even with CONDA_REPORT_ERRORS=true.
+    """
+    post_mock = mocker.patch("requests.post")
+    mock_getuser = mocker.patch("getpass.getuser", return_value="my√nameΩ")
+
     monkeypatch.setenv("CONDA_REPORT_ERRORS", "true")
     reset_context()
     assert context.report_errors
@@ -688,21 +637,20 @@ def test_print_unexpected_error_message_upload_username_with_unicode(
     with captured() as c:
         ExceptionHandler()(_raise_helper, AssertionError())
 
-    error_data = json.loads(post_mock.call_args[1].get("data"))
-    assert error_data.get("has_spaces") is False
-    assert error_data.get("is_ascii") is False
-    assert post_mock.call_count == 2
+    # Since error submission was removed, verify no HTTP requests are made
+    assert post_mock.call_count == 0
     assert c.stdout == ""
     assert "conda version" in c.stderr
 
 
-@patch("requests.post", return_value=None)
-@patch("builtins.input", return_value="n")
 def test_print_unexpected_error_message_opt_out_1(
-    input_mock,
-    post_mock,
+    mocker: MockerFixture,
     monkeypatch: MonkeyPatch,
 ) -> None:
+    """Test that error reports are not submitted when report_errors is false."""
+    input_mock = mocker.patch("builtins.input")
+    post_mock = mocker.patch("requests.post")
+    
     monkeypatch.setenv("CONDA_REPORT_ERRORS", "false")
     reset_context()
     assert not context.report_errors
@@ -717,14 +665,19 @@ def test_print_unexpected_error_message_opt_out_1(
     assert "conda version" in c.stderr
 
 
-@patch("requests.post", return_value=None)
-@patch("builtins.input", return_value="n")
-@patch("os.isatty", return_value=True)
-def test_print_unexpected_error_message_opt_out_2(isatty_mock, input_mock, post_mock):
+def test_print_unexpected_error_message_opt_out_2(
+    mocker: MockerFixture,
+) -> None:
+    """Test that we no longer prompt for confirmation since error reporting is removed."""
+    isatty_mock = mocker.patch("os.isatty")
+    input_mock = mocker.patch("builtins.input")
+    post_mock = mocker.patch("requests.post") 
+
     with captured() as c:
         ExceptionHandler()(_raise_helper, AssertionError())
 
-    assert input_mock.call_count == 1
+    # Since error submission was removed, no prompts should occur
+    assert input_mock.call_count == 0
     assert post_mock.call_count == 0
     assert c.stdout == ""
     assert "conda version" in c.stderr


### PR DESCRIPTION
### Description

This pull request **removes the error report upload functionality** from the `conda` codebase. Issue #13900 

**Why this change was made:**
- The functionality for uploading error reports is being deprecated.
- This change simplifies error handling and removes unused or unnecessary network behavior.
- Associated tests and methods relying on the upload logic were updated accordingly.

**Changes included:**

### Removal of error report upload functionality:
- [`conda/exception_handler.py`](diffhunk://#diff-2d7d8f57f6c5a6e7fc5bed7e7c24a83b572b6b26b79a760f465a342d35368ec6L242-L382): Removed the `_upload` method and all related logic used for submitting error reports and prompting users.
- [`conda/exception_handler.py`](diffhunk://#diff-2d7d8f57f6c5a6e7fc5bed7e7c24a83b572b6b26b79a760f465a342d35368ec6L89): Updated `handle_unexpected_exception` and `handle_reportable_application_exception` to no longer invoke `_upload`.

### Updates to tests:
- [`tests/test_exceptions.py`](diffhunk://#diff-f46006e3f43ffb1dd5d6862005427f6620f4dcfb1fa2f883d8482550069eeeccL519-R521): Updated or removed test logic and assertions that validated the upload process.
  - Removed checks for HTTP requests triggered by the now-removed error report submission feature.

---

### Deprecations

* Removed error report upload functionality, including the `_upload` method and associated prompt logic in `exception_handler.py`.

### Tests

* Removed or updated tests that validated the error report submission process to reflect the removal of this functionality.

---

Just as a reminder, everyone in all Conda org spaces (including PRs) must follow the Conda Org Code of Conduct.

If you have any feedback about the contribution process, feel free to share it with us!

**Helpful links:**
- Conda Org Code of Conduct: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md  
- Contributing Guide: https://github.com/conda/conda/blob/main/CONTRIBUTING.md