### PR TITLE
Report package variant installation as a "REVISED" package (opposed to "DOWNGRADED")

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1403,8 +1403,8 @@ class UnlinkLinkTransaction:
         # updated means a version increase, or a build number increase
         # downgraded means a version decrease, or build number decrease, but channel canonical_name
         #   has to be the same
-        # changed means the version and channel canonical_name is the same, but the build variant
-        #   is different
+        # revised means the version and channel canonical_name is the same, but the build variant
+        #   is different. The build variant is the build string and build number.
         # superseded then should be everything else left over (eg. changed channel)
         updated_precs = {}
         downgraded_precs = {}

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1334,6 +1334,16 @@ class UnlinkLinkTransaction:
                 left_str = left_str[:37] + "~"
             builder.append("  %-18s %38s --> %s" % (display_key, left_str, right_str))
 
+        def summarize_double(change_report_precs, key):
+            for namekey in sorted(change_report_precs, key=key):
+                unlink_prec, link_prec = change_report_precs[namekey]
+                left_str, right_str = diff_strs(unlink_prec, link_prec)
+                add_double(
+                    strip_global(namekey),
+                    left_str,
+                    f"{right_str} {' '.join(link_prec.metadata)}",
+                )
+
         if change_report.new_precs:
             builder.append("\nThe following NEW packages will be INSTALLED:\n")
             for namekey in sorted(change_report.new_precs, key=convert_namekey):
@@ -1353,50 +1363,22 @@ class UnlinkLinkTransaction:
 
         if change_report.updated_precs:
             builder.append("\nThe following packages will be UPDATED:\n")
-            for namekey in sorted(change_report.updated_precs, key=convert_namekey):
-                unlink_prec, link_prec = change_report.updated_precs[namekey]
-                left_str, right_str = diff_strs(unlink_prec, link_prec)
-                add_double(
-                    strip_global(namekey),
-                    left_str,
-                    f"{right_str} {' '.join(link_prec.metadata)}",
-                )
+            summarize_double(change_report.updated_precs, convert_namekey)
 
         if change_report.superseded_precs:
             builder.append(
                 "\nThe following packages will be SUPERSEDED "
                 "by a higher-priority channel:\n"
             )
-            for namekey in sorted(change_report.superseded_precs, key=convert_namekey):
-                unlink_prec, link_prec = change_report.superseded_precs[namekey]
-                left_str, right_str = diff_strs(unlink_prec, link_prec)
-                add_double(
-                    strip_global(namekey),
-                    left_str,
-                    f"{right_str} {' '.join(link_prec.metadata)}",
-                )
+            summarize_double(change_report.superseded_precs, convert_namekey)
 
         if change_report.downgraded_precs:
             builder.append("\nThe following packages will be DOWNGRADED:\n")
-            for namekey in sorted(change_report.downgraded_precs, key=convert_namekey):
-                unlink_prec, link_prec = change_report.downgraded_precs[namekey]
-                left_str, right_str = diff_strs(unlink_prec, link_prec)
-                add_double(
-                    strip_global(namekey),
-                    left_str,
-                    f"{right_str} {' '.join(link_prec.metadata)}",
-                )
+            summarize_double(change_report.downgraded_precs, convert_namekey)
 
         if change_report.revised_precs:
             builder.append("\nThe following packages will be REVISED:\n")
-            for namekey in sorted(change_report.revised_precs, key=convert_namekey):
-                unlink_prec, link_prec = change_report.revised_precs[namekey]
-                left_str, right_str = diff_strs(unlink_prec, link_prec)
-                add_double(
-                    strip_global(namekey),
-                    left_str,
-                    f"{right_str} {' '.join(link_prec.metadata)}",
-                )
+            summarize_double(change_report.revised_precs, convert_namekey)
 
         builder.append("")
         builder.append("")

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -206,7 +206,7 @@ class ChangeReport(NamedTuple):
     downgraded_precs: Iterable[PackageRecord]
     superseded_precs: Iterable[PackageRecord]
     fetch_precs: Iterable[PackageRecord]
-    changed_precs: Iterable[PackageRecord]
+    revised_precs: Iterable[PackageRecord]
 
 
 class UnlinkLinkTransaction:
@@ -1387,10 +1387,10 @@ class UnlinkLinkTransaction:
                     f"{right_str} {' '.join(link_prec.metadata)}",
                 )
 
-        if change_report.changed_precs:
-            builder.append("\nThe following packages will be CHANGED:\n")
-            for namekey in sorted(change_report.changed_precs, key=convert_namekey):
-                unlink_prec, link_prec = change_report.changed_precs[namekey]
+        if change_report.revised_precs:
+            builder.append("\nThe following packages will be REVISED:\n")
+            for namekey in sorted(change_report.revised_precs, key=convert_namekey):
+                unlink_prec, link_prec = change_report.revised_precs[namekey]
                 left_str, right_str = diff_strs(unlink_prec, link_prec)
                 add_double(
                     strip_global(namekey),
@@ -1426,7 +1426,7 @@ class UnlinkLinkTransaction:
         # superseded then should be everything else left over (eg. changed channel)
         updated_precs = {}
         downgraded_precs = {}
-        changed_precs = {}
+        revised_precs = {}
         superseded_precs = {}
 
         common_namekeys = link_namekeys & unlink_namekeys
@@ -1447,7 +1447,7 @@ class UnlinkLinkTransaction:
                     # just leave them out of the package report
                     continue
                 if link_vo == unlink_vo and link_prec.build != unlink_prec.build:
-                    changed_precs[namekey] = (unlink_prec, link_prec)
+                    revised_precs[namekey] = (unlink_prec, link_prec)
                 else:
                     downgraded_precs[namekey] = (unlink_prec, link_prec)
             else:
@@ -1464,7 +1464,7 @@ class UnlinkLinkTransaction:
             downgraded_precs,
             superseded_precs,
             fetch_precs,
-            changed_precs,
+            revised_precs,
         )
         return change_report
 

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1386,6 +1386,18 @@ class UnlinkLinkTransaction:
                     left_str,
                     f"{right_str} {' '.join(link_prec.metadata)}",
                 )
+
+        if change_report.changed_precs:
+            builder.append("\nThe following packages will be CHANGED:\n")
+            for namekey in sorted(change_report.changed_precs, key=convert_namekey):
+                unlink_prec, link_prec = change_report.changed_precs[namekey]
+                left_str, right_str = diff_strs(unlink_prec, link_prec)
+                add_double(
+                    strip_global(namekey),
+                    left_str,
+                    f"{right_str} {' '.join(link_prec.metadata)}",
+                )
+
         builder.append("")
         builder.append("")
         return "\n".join(builder)

--- a/news/144727-variant-install-report
+++ b/news/144727-variant-install-report
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Report package variant installation as "REVISED" opposed to "DOWNGRADED". (#13797 via #14727)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_install.py
+++ b/tests/cli/test_main_install.py
@@ -119,13 +119,13 @@ def test_build_version_shows_as_changed(
     tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
 ):
     """
-    Test to make sure the changes in build version show up as "CHANGED" in install plan.
+    Test to make sure the changes in build version show up as "REVISED" in install plan.
     To check this, start with an environment that has python and one other python package.
     Then, the test should install another version python into the environment, forcing the
-    build variant of the other python package to be "CHANGED".
+    build variant of the other python package to be "REVISED".
     """
     with tmp_env("python=3.11", "numpy") as prefix:
         out, err, _ = conda_cli("install", f"--prefix={prefix}", "python=3.12", "--yes")
         assert "The following packages will be UPDATED" in out
-        assert "The following packages will be CHANGED" in out
+        assert "The following packages will be REVISED" in out
         assert "The following packages will be DOWNGRADED" not in out

--- a/tests/cli/test_main_install.py
+++ b/tests/cli/test_main_install.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import re
 from json import loads as json_loads
 from typing import TYPE_CHECKING
 
@@ -112,3 +113,19 @@ def test_install_from_extracted_package(
         # appeared again, we decided to re-download the package for some reason.
         conda_cli("install", f"--prefix={prefix}", "openssl", "--offline", "--yes")
         assert not pkgs_dir_has_tarball("openssl-")
+
+
+def test_build_version_shows_as_changed(
+    tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
+):
+    """
+    Test to make sure the changes in build version show up as "CHANGED" in install plan.
+    To check this, start with an environment that has python and one other python package.
+    Then, the test should install another version python into the environment, forcing the
+    build variant of the other python package to be "CHANGED".
+    """
+    with tmp_env("python=3.11", "numpy") as prefix:
+        out, err, _ = conda_cli("install", f"--prefix={prefix}", "python=3.12", "--yes")
+        assert "The following packages will be UPDATED" in out
+        assert "The following packages will be CHANGED" in out
+        assert "The following packages will be DOWNGRADED" not in out

--- a/tests/cli/test_main_install.py
+++ b/tests/cli/test_main_install.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import re
 from json import loads as json_loads
 from typing import TYPE_CHECKING
 

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -5,10 +5,10 @@ from conda.core import link
 from conda.models.records import PackageRecord
 
 
-def test_calculate_change_report_changed_variant():
+def test_calculate_change_report_revised_variant():
     """
     Test to ensure that the change report will categorize a change in variant as
-    a "CHANGED" package.
+    a "REVISED" package.
     """
     unlink_precs = [
         PackageRecord(
@@ -39,7 +39,7 @@ def test_calculate_change_report_changed_variant():
         "notarealprefix", unlink_precs, link_precs, (), (), ()
     )
 
-    assert change_report.changed_precs.get("global:mypackage") is not None
+    assert change_report.revised_precs.get("global:mypackage") is not None
 
 
 def test_calculate_change_report_downgrade():

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+from conda.core import link
+from conda.models.records import PackageRecord
+
+
+def test_calculate_change_report_changed_variant():
+    """
+    Test to ensure that the change report will categorize a change in variant as
+    a "CHANGED" package.
+    """
+    unlink_precs = [
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage",
+            "version": "2.3.9",
+            "build": "py35_0",
+            # notice the build number decrease between the unlink and link precs
+            "build_number": 1,
+        }),
+    ]
+
+    link_precs = [
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage",
+            "version": "2.3.9",
+            "build": "py36_0",
+            "build_number": 0,
+        }),
+    ]
+
+    change_report = link.UnlinkLinkTransaction._calculate_change_report(
+        "notarealprefix", unlink_precs, link_precs, (), (), ()
+    )
+
+    assert change_report.changed_precs.get("global:mypackage") is not None
+
+
+def test_calculate_change_report_downgrade():
+    """
+    Test to ensure that the change report will categorize a downgrade of a package
+    """
+    unlink_precs = [
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage_downgrade_version",
+            "version": "2.3.9",
+            "build": "py36_0",
+            "build_number": 0,
+        }),
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage_downgrade_build",
+            "version": "2.3.9",
+            "build": "py36_0",
+            "build_number": 1,
+        }),
+    ]
+
+    link_precs = [
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage_downgrade_version",
+            "version": "2.3.8",
+            "build": "py36_0",
+            "build_number": 0,
+        }),
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage_downgrade_build",
+            "version": "2.3.9",
+            "build": "py36_0",
+            "build_number": 0,
+        }),
+    ]
+
+    change_report = link.UnlinkLinkTransaction._calculate_change_report(
+        "notarealprefix", unlink_precs, link_precs, (), (), ()
+    )
+
+    # ensure downgrade version gets added to the downgrade section
+    assert change_report.downgraded_precs.get("global:mypackage_downgrade_version") is not None
+    
+    # ensure downgrade build number gets added to the downgrade section
+    assert change_report.downgraded_precs.get("global:mypackage_downgrade_build") is not None
+
+
+def test_calculate_change_report_update():
+    """
+    Test to ensure that the change report will categorize an upgrade of a package
+    """
+    unlink_precs = [
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage",
+            "version": "2.3.9",
+            "build": "py35_0",
+            "build_number": 0,
+        }),
+    ]
+
+    link_precs = [
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage",
+            "version": "2.4.9",
+            "build": "py36_0",
+            "build_number": 0,
+        }),
+    ]
+
+    change_report = link.UnlinkLinkTransaction._calculate_change_report(
+        "notarealprefix", unlink_precs, link_precs, (), (), ()
+    )
+
+    assert change_report.updated_precs.get("global:mypackage") is not None
+
+
+def test_calculate_change_report_superseded():
+    """
+    Test to ensure that the change report will categorize a superseded package
+    """
+    unlink_precs = [
+        PackageRecord(**{
+            "channel": "pkgs/main/linux-64",
+            "name": "mypackage",
+            "version": "2.3.9",
+            "build": "py35_0",
+            "build_number": 0,
+        }),
+    ]
+
+    link_precs = [
+        PackageRecord(**{
+            "channel": "conda-forge/linux-64",
+            "name": "mypackage",
+            "version": "2.3.9",
+            "build": "py36_0",
+            "build_number": 0,
+        }),
+    ]
+
+    change_report = link.UnlinkLinkTransaction._calculate_change_report(
+        "notarealprefix", unlink_precs, link_precs, (), (), ()
+    )
+
+    assert change_report.superseded_precs.get("global:mypackage") is not None

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -11,24 +11,28 @@ def test_calculate_change_report_changed_variant():
     a "CHANGED" package.
     """
     unlink_precs = [
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage",
-            "version": "2.3.9",
-            "build": "py35_0",
-            # notice the build number decrease between the unlink and link precs
-            "build_number": 1,
-        }),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage",
+                "version": "2.3.9",
+                "build": "py35_0",
+                # notice the build number decrease between the unlink and link precs
+                "build_number": 1,
+            }
+        ),
     ]
 
     link_precs = [
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage",
-            "version": "2.3.9",
-            "build": "py36_0",
-            "build_number": 0,
-        }),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage",
+                "version": "2.3.9",
+                "build": "py36_0",
+                "build_number": 0,
+            }
+        ),
     ]
 
     change_report = link.UnlinkLinkTransaction._calculate_change_report(
@@ -43,37 +47,45 @@ def test_calculate_change_report_downgrade():
     Test to ensure that the change report will categorize a downgrade of a package
     """
     unlink_precs = [
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage_downgrade_version",
-            "version": "2.3.9",
-            "build": "py36_0",
-            "build_number": 0,
-        }),
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage_downgrade_build",
-            "version": "2.3.9",
-            "build": "py36_0",
-            "build_number": 1,
-        }),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage_downgrade_version",
+                "version": "2.3.9",
+                "build": "py36_0",
+                "build_number": 0,
+            }
+        ),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage_downgrade_build",
+                "version": "2.3.9",
+                "build": "py36_0",
+                "build_number": 1,
+            }
+        ),
     ]
 
     link_precs = [
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage_downgrade_version",
-            "version": "2.3.8",
-            "build": "py36_0",
-            "build_number": 0,
-        }),
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage_downgrade_build",
-            "version": "2.3.9",
-            "build": "py36_0",
-            "build_number": 0,
-        }),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage_downgrade_version",
+                "version": "2.3.8",
+                "build": "py36_0",
+                "build_number": 0,
+            }
+        ),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage_downgrade_build",
+                "version": "2.3.9",
+                "build": "py36_0",
+                "build_number": 0,
+            }
+        ),
     ]
 
     change_report = link.UnlinkLinkTransaction._calculate_change_report(
@@ -81,10 +93,16 @@ def test_calculate_change_report_downgrade():
     )
 
     # ensure downgrade version gets added to the downgrade section
-    assert change_report.downgraded_precs.get("global:mypackage_downgrade_version") is not None
-    
+    assert (
+        change_report.downgraded_precs.get("global:mypackage_downgrade_version")
+        is not None
+    )
+
     # ensure downgrade build number gets added to the downgrade section
-    assert change_report.downgraded_precs.get("global:mypackage_downgrade_build") is not None
+    assert (
+        change_report.downgraded_precs.get("global:mypackage_downgrade_build")
+        is not None
+    )
 
 
 def test_calculate_change_report_update():
@@ -92,23 +110,27 @@ def test_calculate_change_report_update():
     Test to ensure that the change report will categorize an upgrade of a package
     """
     unlink_precs = [
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage",
-            "version": "2.3.9",
-            "build": "py35_0",
-            "build_number": 0,
-        }),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage",
+                "version": "2.3.9",
+                "build": "py35_0",
+                "build_number": 0,
+            }
+        ),
     ]
 
     link_precs = [
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage",
-            "version": "2.4.9",
-            "build": "py36_0",
-            "build_number": 0,
-        }),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage",
+                "version": "2.4.9",
+                "build": "py36_0",
+                "build_number": 0,
+            }
+        ),
     ]
 
     change_report = link.UnlinkLinkTransaction._calculate_change_report(
@@ -123,23 +145,27 @@ def test_calculate_change_report_superseded():
     Test to ensure that the change report will categorize a superseded package
     """
     unlink_precs = [
-        PackageRecord(**{
-            "channel": "pkgs/main/linux-64",
-            "name": "mypackage",
-            "version": "2.3.9",
-            "build": "py35_0",
-            "build_number": 0,
-        }),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage",
+                "version": "2.3.9",
+                "build": "py35_0",
+                "build_number": 0,
+            }
+        ),
     ]
 
     link_precs = [
-        PackageRecord(**{
-            "channel": "conda-forge/linux-64",
-            "name": "mypackage",
-            "version": "2.3.9",
-            "build": "py36_0",
-            "build_number": 0,
-        }),
+        PackageRecord(
+            **{
+                "channel": "conda-forge/linux-64",
+                "name": "mypackage",
+                "version": "2.3.9",
+                "build": "py36_0",
+                "build_number": 0,
+            }
+        ),
     ]
 
     change_report = link.UnlinkLinkTransaction._calculate_change_report(

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -14,16 +14,35 @@ def test_calculate_change_report_revised_variant():
         PackageRecord(
             **{
                 "channel": "pkgs/main/linux-64",
-                "name": "mypackage",
+                "name": "mypackage_decrease_build",
                 "version": "2.3.9",
                 "build": "py35_0",
                 # notice the build number decrease between the unlink and link precs
-                "build_number": 1,
+                "build_number": 200,
+            }
+        ),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage",
+                "version": "2.3.9",
+                "build": "py35_0",
+                # notice the build number stay the same between the unlink and link precs
+                "build_number": 0,
             }
         ),
     ]
 
     link_precs = [
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage_decrease_build",
+                "version": "2.3.9",
+                "build": "py36_0",
+                "build_number": 100,
+            }
+        ),
         PackageRecord(
             **{
                 "channel": "pkgs/main/linux-64",
@@ -39,6 +58,9 @@ def test_calculate_change_report_revised_variant():
         "notarealprefix", unlink_precs, link_precs, (), (), ()
     )
 
+    assert (
+        change_report.revised_precs.get("global:mypackage_decrease_build") is not None
+    )
     assert change_report.revised_precs.get("global:mypackage") is not None
 
 
@@ -119,6 +141,15 @@ def test_calculate_change_report_update():
                 "build_number": 0,
             }
         ),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage_upgrade_build",
+                "version": "2.3.9",
+                "build": "py36_0",
+                "build_number": 1,
+            }
+        ),
     ]
 
     link_precs = [
@@ -131,6 +162,15 @@ def test_calculate_change_report_update():
                 "build_number": 0,
             }
         ),
+        PackageRecord(
+            **{
+                "channel": "pkgs/main/linux-64",
+                "name": "mypackage_upgrade_build",
+                "version": "2.3.9",
+                "build": "py36_0",
+                "build_number": 2,
+            }
+        ),
     ]
 
     change_report = link.UnlinkLinkTransaction._calculate_change_report(
@@ -138,6 +178,7 @@ def test_calculate_change_report_update():
     )
 
     assert change_report.updated_precs.get("global:mypackage") is not None
+    assert change_report.updated_precs.get("global:mypackage_upgrade_build") is not None
 
 
 def test_calculate_change_report_superseded():


### PR DESCRIPTION
### Description

Fixes https://github.com/conda/conda/issues/13797

This PR adds a "REVISED" section the cli change report. A "REVISED" package is one where the version and channel and build number is the same, but the build variant has changed. 

For example, this might happen when updating the python version for an environment.

Previously, this would produce the result
```
$ conda create -n test-13797 python=3.10 numpy --yes
. . .

$ conda install -n test-13797 python=3.12
. . .
The following packages will be UPDATED:

  python                         3.10.16-he725a3c_1_cpython --> 3.12.9-h9e4cc4f_1_cpython 
  python_abi                                   3.10-6_cp310 --> 3.12-6_cp312 

The following packages will be DOWNGRADED:

  numpy                               2.2.4-py310hefbff90_0 --> 2.2.4-py312h72c5963_0 
```

Notice, that numpy is being incorrectly categoriized as DOWNGRADED.

This PR changes this behaviour, so the output is:
```
$ conda install -n test-13797 python=3.12
. . .
The following packages will be UPDATED:

  python                         3.10.16-he725a3c_1_cpython --> 3.12.9-h9e4cc4f_1_cpython 
  python_abi                                   3.10-6_cp310 --> 3.12-6_cp312 

The following packages will be REVISED:

  numpy                               2.2.4-py310hefbff90_0 --> 2.2.4-py312h72c5963_0 

```

Note, that a package will still be categorized as "DOWNGRADED" for a downgraded version number or build number. For example:

``` 
$ conda install -n test-13797  numpy=2.1   
. . .
The following packages will be DOWNGRADED:

  numpy                               2.2.4-py310hefbff90_0 --> 2.1.3-py310hd6e36ab_0 

```




### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
