### PR TITLE
Fix: Conda print False terminal prompt when no environment activated on Windows Powershell #14768

### DIFF
--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -241,10 +241,10 @@ if ($CondaModuleArgs.ChangePs1) {
     }
 
     function global:prompt() {
-        if ($Env:CONDA_PROMPT_MODIFIER) {
-            $Env:CONDA_PROMPT_MODIFIER | Write-Host -NoNewline
+        if ($Env:CONDA_PROMPT_MODIFIER -match '^\(.*\)\s*$') {
+            Write-Host $Env:CONDA_PROMPT_MODIFIER -NoNewline
         }
-        CondaPromptBackup;
+        CondaPromptBackup
     }
 }
 

--- a/news/14768-suspend-prompt-print-False-when-no-env-activated.md
+++ b/news/14768-suspend-prompt-print-False-when-no-env-activated.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Suspend prompt print annoying `False` as env name when no environment activate`
+
+### Bug fixes
+
+* [#14768](https://github.com/conda/conda/issues/14768)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
Fix: Conda print False terminal prompt when no environment activated on Windows Powershell #14768

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Fix https://github.com/conda/conda/issues/14768

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
