### PR TITLE
Use subprocess for `test_build_version_shows_as_changed` on Windows

### DIFF
--- a/tests/cli/test_main_install.py
+++ b/tests/cli/test_main_install.py
@@ -8,8 +8,10 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.base.context import context, reset_context
+from conda.common.compat import on_win
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import PackagesNotFoundError
+from conda.testing.helpers import forward_to_subprocess, in_subprocess
 from conda.testing.integration import package_is_installed
 
 if TYPE_CHECKING:
@@ -114,8 +116,11 @@ def test_install_from_extracted_package(
         assert not pkgs_dir_has_tarball("openssl-")
 
 
+@pytest.mark.flaky(reruns=2, condition=on_win and not in_subprocess())
 def test_build_version_shows_as_changed(
-    tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+    request: pytest.FixtureRequest,
 ):
     """
     Test to make sure the changes in build version show up as "REVISED" in install plan.
@@ -123,6 +128,9 @@ def test_build_version_shows_as_changed(
     Then, the test should install another version python into the environment, forcing the
     build variant of the other python package to be "REVISED".
     """
+    if context.solver == "libmamba" and on_win and forward_to_subprocess(request):
+        return
+
     with tmp_env("python=3.11", "numpy") as prefix:
         out, err, _ = conda_cli("install", f"--prefix={prefix}", "python=3.12", "--yes")
         assert "The following packages will be UPDATED" in out


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Saw another segfault in https://github.com/conda/conda/actions/runs/14648378797/job/41108265954?pr=14776

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
