### PR TITLE
Cleanup: `DepsModifier` does not have an attribute `UPDATE_SPECS`

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -21,7 +21,6 @@ from .. import CondaError
 from ..base.constants import (
     REPODATA_FN,
     ROOT_ENV_NAME,
-    DepsModifier,
     UpdateModifier,
 )
 from ..base.context import context
@@ -421,8 +420,6 @@ def install(args, parser, command="install"):
     if (isinstall or isremove) and args.update_modifier == NULL:
         update_modifier = UpdateModifier.FREEZE_INSTALLED
     deps_modifier = context.deps_modifier
-    if isupdate:
-        deps_modifier = context.deps_modifier or DepsModifier.UPDATE_SPECS
 
     for repodata_fn in Repodatas(
         repodata_fns,

--- a/news/14087-depsmodifier-does-not-hav-update-specs
+++ b/news/14087-depsmodifier-does-not-hav-update-specs
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Cleanup refrences to `DepsModifier.UPDATE_SPECS`. (#14807)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION


### Description

This PR cleans up a small line in `cli/install.py`. The `DepsModifier` class does not have an attribute `UPTATE_SPECS`, it is defined as:

```
class DepsModifier(Enum):
    """Flags to enable alternate handling of dependencies."""

    NOT_SET = "not_set"  # default
    NO_DEPS = "no_deps"
    ONLY_DEPS = "only_deps"

    def __str__(self):
        return self.value
```
ref: https://github.com/conda/conda/blob/main/conda/base/constants.py#L201

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
