### PR TITLE
Add example to environment specs plugin docs

### DIFF
--- a/docs/source/dev-guide/plugins/environment_specifiers.rst
+++ b/docs/source/dev-guide/plugins/environment_specifiers.rst
@@ -39,8 +39,8 @@ of its abstract methods:
 
 Be sure to be very specific when implementing the ``can_handle`` method. It should only
 return a ``True`` if the file can be parsed by the plugin. Making the ``can_handle``
-method too permissive in the types of files it handles may lead to conflicts with other 
-plugins. If multiple installed plugins are able to ``can_handle`` the same file type, 
+method too permissive in the types of files it handles may lead to conflicts with other
+plugins. If multiple installed plugins are able to ``can_handle`` the same file type,
 conda will return an error to the user.
 
 Registering the plugin hook
@@ -72,7 +72,7 @@ using the plugin defined above:
 
 Another example plugin
 -----------------------
-In this example, we want to build a more realistic environemnt spec plugin. This 
+In this example, we want to build a more realistic environemnt spec plugin. This
 plugin has a scheme which expresses what it expects a valid environment file to
 contain. In this example, a valid environment file is a ``.json`` file that defines:
 
@@ -90,60 +90,61 @@ contain. In this example, a valid environment file is a ``.json`` file that defi
 
 
    class MySimpleEnvironment(BaseModel):
-      """An model representing an environment file."""
-      # required
-      name: str
+       """An model representing an environment file."""
 
-      # optional
-      conda_deps: list[str] = []
+       # required
+       name: str
+
+       # optional
+       conda_deps: list[str] = []
 
 
    class MySimpleSpec(EnvironmentSpecBase):
-      def __init__(self, filename=None):
-         self.filename = filename
+       def __init__(self, filename=None):
+           self.filename = filename
 
-      def _parse_data(self) -> MySimpleEnvironment:
-         """"Validate and convert the provided file into a MySimpleEnvironment"""
-         with open(self.filename, "rb") as fp:
+       def _parse_data(self) -> MySimpleEnvironment:
+           """ "Validate and convert the provided file into a MySimpleEnvironment"""
+           with open(self.filename, "rb") as fp:
                json_data = fp.read()
-         
-         return MySimpleEnvironment.model_validate_json(json_data)
 
-      def can_handle(self) -> bool:
-         """
-         Validates loader can process environment definition.
-         This can handle if:
-               * the file exists
-               * the file can be read
-               * the data can be parsed as JSON into a MySimpleEnvironment object
+           return MySimpleEnvironment.model_validate_json(json_data)
 
-         :return: True if the file can be parsed and handled, False otherwise
-         """
-         if not os.path.exists(self.filename):
+       def can_handle(self) -> bool:
+           """
+           Validates loader can process environment definition.
+           This can handle if:
+                 * the file exists
+                 * the file can be read
+                 * the data can be parsed as JSON into a MySimpleEnvironment object
+
+           :return: True if the file can be parsed and handled, False otherwise
+           """
+           if not os.path.exists(self.filename):
                return False
-         try:
+           try:
                self._parse_data()
            except Exception:
                return False
-         
-         return True
 
-      @property
-      def environment(self) -> Environment:
-         """Returns the Environment representation of the environment spec file"""
-         data = self._parse_data()
-         return Environment(
+           return True
+
+       @property
+       def environment(self) -> Environment:
+           """Returns the Environment representation of the environment spec file"""
+           data = self._parse_data()
+           return Environment(
                name=data.name,
                dependencies=data.conda_deps,
-         )
+           )
 
 
    @hookimpl
    def conda_environment_specifiers():
-      yield CondaEnvironmentSpecifier(
-         name="mysimple",
-         environment_spec=MySimpleSpec,
-      )
+       yield CondaEnvironmentSpecifier(
+           name="mysimple",
+           environment_spec=MySimpleSpec,
+       )
 
 We can test this out by trying to create a conda environment with a new file
 that is compatible with the definied spec. Create a file ``testenv.json``
@@ -160,4 +161,3 @@ Then, create the environment
 .. code-block:: bash
 
    $ conda env create --file testenv.json
- 

--- a/docs/source/dev-guide/plugins/environment_specifiers.rst
+++ b/docs/source/dev-guide/plugins/environment_specifiers.rst
@@ -27,8 +27,8 @@ hook.
 
 .. autoapifunction:: conda.plugins.hookspec.CondaSpecs.conda_environment_specifiers
 
-Defining ``Defining ``EnvironmentSpecBase``
--------------------------------------------
+Defining ``EnvironmentSpecBase``
+--------------------------------
 
 The first class we define is a subclass of :class:`~conda.plugins.types.EnvironmentSpecBase`. The
 base class is an abstract base class which requires us to define our own implementations
@@ -37,11 +37,11 @@ of its abstract methods:
 * ``can_handle`` Determines if the defined plugin can read and operate on the provided file.
 * ``environment`` Expresses the provided environment file as a conda environment object.
 
-.. hint::
-
-   Be sure to be very specific when implementing the ``can_handle`` method. It should only
-   return a ``True`` if the file can be parsed by the plugin. Making the ``can_handle``
-   method too permissive in the types of files it handles may lead to conflicts with other plugins.
+Be sure to be very specific when implementing the ``can_handle`` method. It should only
+return a ``True`` if the file can be parsed by the plugin. Making the ``can_handle``
+method too permissive in the types of files it handles may lead to conflicts with other 
+plugins. If multiple installed plugins are able to ``can_handle`` the same file type, 
+conda will return an error to the user.
 
 Registering the plugin hook
 ---------------------------
@@ -69,4 +69,95 @@ using the plugin defined above:
 
    conda env create --file /doesnt/matter/any/way.random
 
-.. _`Managing environments`:: https://pluggy.readthedocs.io/en/stable/
+
+Another example plugin
+-----------------------
+In this example, we want to build a more realistic environemnt spec plugin. This 
+plugin has a scheme which expresses what it expects a valid environment file to
+contain. In this example, a valid environment file is a ``.json`` file that defines:
+
+* an environment name (required)
+* a list of conda dependencies
+
+.. code-block:: python
+
+   import os
+   from pydantic import BaseModel
+
+   from conda.plugins import CondaEnvironmentSpecifier, hookimpl
+   from conda.plugins.types import EnvironmentSpecBase
+   from conda.env.env import Environment
+
+
+   class MySimpleEnvironment(BaseModel):
+      """An model representing an environment file."""
+      # required
+      name: str
+
+      # optional
+      conda_deps: list[str] = []
+
+
+   class MySimpleSpec(EnvironmentSpecBase):
+      def __init__(self, filename=None):
+         self.filename = filename
+
+      def _parse_data(self) -> MySimpleEnvironment:
+         """"Validate and convert the provided file into a MySimpleEnvironment"""
+         with open(self.filename, "rb") as fp:
+               json_data = fp.read()
+         
+         return MySimpleEnvironment.model_validate_json(json_data)
+
+      def can_handle(self) -> bool:
+         """
+         Validates loader can process environment definition.
+         This can handle if:
+               * the file exists
+               * the file can be read
+               * the data can be parsed as JSON into a MySimpleEnvironment object
+
+         :return: True if the file can be parsed and handled, False otherwise
+         """
+         if not os.path.exists(self.filename):
+               return False
+         try:
+               self._parse_data()
+           except Exception:
+               return False
+         
+         return True
+
+      @property
+      def environment(self) -> Environment:
+         """Returns the Environment representation of the environment spec file"""
+         data = self._parse_data()
+         return Environment(
+               name=data.name,
+               dependencies=data.conda_deps,
+         )
+
+
+   @hookimpl
+   def conda_environment_specifiers():
+      yield CondaEnvironmentSpecifier(
+         name="mysimple",
+         environment_spec=MySimpleSpec,
+      )
+
+We can test this out by trying to create a conda environment with a new file
+that is compatible with the definied spec. Create a file ``testenv.json``
+
+.. code-block::
+
+   {
+      "name": "mysimpletest",
+      "conda_deps": ["numpy", "pandas"]
+   }
+
+Then, create the environment
+
+.. code-block:: bash
+
+   $ conda env create --file testenv.json
+ 

--- a/news/14814-environment-spec-plugin-docs
+++ b/news/14814-environment-spec-plugin-docs
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Add examples to environment specs plugin docs (#14814)
+
+### Other
+
+* <news item>

--- a/news/14814-environment-spec-plugin-docs
+++ b/news/14814-environment-spec-plugin-docs
@@ -12,7 +12,7 @@
 
 ### Docs
 
-* Add examples to environment specs plugin docs (#14814)
+* Add examples to environment specs plugin docs. (#14814)
 
 ### Other
 


### PR DESCRIPTION
### Description

This PR updates the developer documentation for environment specs plugins. It adds a more realistic example of a plugin author defining a new schema for an environment file.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
