### PR TITLE
Strict environment yaml validation

### DIFF
--- a/conda/env/specs/yaml_file.py
+++ b/conda/env/specs/yaml_file.py
@@ -50,6 +50,8 @@ class YamlFileSpec(EnvironmentSpecBase):
         except Exception:
             log.debug("Failed to load %s as a YAML.", self.filename, exc_info=True)
             return False
+        except Exception as e:
+            return False
 
     @property
     @deprecated("26.3", "26.9", addendum="This method is not used anymore, use 'env'")

--- a/conda/env/specs/yaml_file.py
+++ b/conda/env/specs/yaml_file.py
@@ -45,7 +45,7 @@ class YamlFileSpec(EnvironmentSpecBase):
             return False
 
         try:
-            self._environment = env.from_file(self.filename)
+            self._environment = env.from_file(self.filename, strict=True)
             return True
         except Exception:
             log.debug("Failed to load %s as a YAML.", self.filename, exc_info=True)

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1368,6 +1368,12 @@ class SpecNotFoundInPackageCache(CondaError):
         super().__init__(msg, *args, **kwargs)
 
 
+class EnvironmentSectionNotValid(CondaError):
+    def __init__(self, filename: str, sections: list[str],plural: str, verb: str, *args, **kwargs):
+        msg = f"The following section{plural} on '{filename}' {verb} invalid and will be ignored: {dashlist(sections)}"
+        super().__init__(msg, *args, **kwargs)
+
+
 def maybe_raise(error: BaseException, context: Context):
     if isinstance(error, CondaMultiError):
         groups = groupby(lambda e: isinstance(e, ClobberError), error.errors)

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -19,7 +19,7 @@ from conda.env.env import (
     from_environment,
     from_file,
 )
-from conda.exceptions import CondaHTTPError
+from conda.exceptions import CondaHTTPError, EnvironmentSectionNotValid
 from conda.models.match_spec import MatchSpec
 from conda.testing.integration import package_is_installed
 
@@ -309,6 +309,12 @@ def test_invalid_keys():
     e_dict = e.to_dict()
     assert "name" in e_dict
     assert len(e_dict) == 1
+
+
+def test_strict_invalid_keys():
+    file = support_file("invalid_keys.yml")
+    with pytest.raises(EnvironmentSectionNotValid):
+        from_file(file, strict=True)
 
 
 def test_creates_file_on_save(tmp_path: Path):


### PR DESCRIPTION
### Description

Currently, the `YamlFileSpec` plugin, which provides functionality for reading `environment.yaml` files is very permissive in the files that is can handle. It validates that the provided file has a given set of keys, but if there is extra data, it will strip it out and continue to work perfectly ok. This flexibility is really great for forwards/backwards compatibility. However, environment_spec plugins must not be so permissive in handling environment files, so as not to interfer with other plugins. 

For example, given the current `YamlFileSpec.cam_handle` implementation, the `YamlFileSpec` plugin will be selected for all the following files even if it shouldn't:

valid environment.yaml
```
name: nlp
dependencies:
  - nltk
```

not a valid environment.yaml - actually an empty json files
```
{ }
```

not a valid environment.yaml - actually a json file
```
{
   "name": "mysimpletest",
   "conda_deps": ["numpy", "pandas"]
}
```

not a valid environment.yaml - a made up yaml format
```
env_version: 2.0
name: nlp
deps:
  - nltk
```

This PR suggests resolving this issue by introducing a `strict` mode to the environment.yaml key validation step. When strict mode is enabled, reading a file will return an error if an invalid key is encountered.

#### Warning

This approach will be a breaking change for users that have `environment.yaml` files with keys outside of ("name", "dependencies", "prefix", "channels", "variables"). `environment.yaml` files that use additional keys will no longer be detected as valid and conda will return a `EnvironmentSpecPluginNotDetected` error.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

