### PR TITLE
Deprecate `conda.cli.main_info.get_info_components`

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -509,15 +509,13 @@ class InfoRenderer:
 @deprecated(
     "25.9",
     "26.3",
-    addendum="Use `conda.cli.main_info.get_info_components_iterable` instead.",
+    addendum="Use `conda.cli.main_info.iter_info_components` instead.",
 )
 def get_info_components(args: Namespace, context: Context) -> set[InfoComponents]:
-    return set(get_info_components_iterable(args, context))
+    return set(iter_info_components(args, context))
 
 
-def get_info_components_iterable(
-    args: Namespace, context: Context
-) -> Iterable[InfoComponents]:
+def iter_info_components(args: Namespace, context: Context) -> Iterable[InfoComponents]:
     """
     Determine which components to display.
 
@@ -563,7 +561,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
 
     from ..base.context import context
 
-    components = get_info_components_iterable(args, context)
+    components = iter_info_components(args, context)
     renderer = InfoRenderer(context)
     renderer.render(components)
 

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -506,7 +506,18 @@ class InfoRenderer:
         return self._info_dict
 
 
-def get_info_components(args: Namespace, context: Context) -> Iterable[InfoComponents]:
+@deprecated(
+    "25.9",
+    "26.3",
+    addendum="Use `conda.cli.main_info.get_info_components_iterable` instead.",
+)
+def get_info_components(args: Namespace, context: Context) -> set[InfoComponents]:
+    return set(get_info_components_iterable(args, context))
+
+
+def get_info_components_iterable(
+    args: Namespace, context: Context
+) -> Iterable[InfoComponents]:
     """
     Determine which components to display.
 
@@ -552,7 +563,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
 
     from ..base.context import context
 
-    components = get_info_components(args, context)
+    components = get_info_components_iterable(args, context)
     renderer = InfoRenderer(context)
     renderer.render(components)
 

--- a/news/14837-deprecate-get_info_components
+++ b/news/14837-deprecate-get_info_components
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Mark `conda.cli.main_info.get_info_components` as pending deprecation to be removed in 26.3. Use `conda.cli.main_info.get_info_components_iterable` instead. (#14837)
+* Mark `conda.cli.main_info.get_info_components` as pending deprecation to be removed in 26.3. Use `conda.cli.main_info.iter_info_components` instead. (#14837)
 
 ### Docs
 

--- a/news/14837-deprecate-get_info_components
+++ b/news/14837-deprecate-get_info_components
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.cli.main_info.get_info_components` as pending deprecation to be removed in 26.3. Use `conda.cli.main_info.get_info_components_iterable` instead. (#14837)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
 
 from conda.base.context import context
+from conda.cli.main_info import get_info_components, get_info_components_iterable
 from conda.common.path import paths_equal
 from conda.core.envs_manager import list_all_known_prefixes
 from conda.plugins.reporter_backends.console import ConsoleReporterRenderer
@@ -192,3 +195,34 @@ def test_info_license(conda_cli: CondaCLIFixture):
 def test_info_root(conda_cli: CondaCLIFixture):
     with pytest.deprecated_call():
         conda_cli("info", "--root")
+
+
+def test_get_info_components_iterable() -> None:
+    components = get_info_components_iterable(
+        args=SimpleNamespace(
+            base=True,
+            unsafe_channels=True,
+            all=True,
+            envs=True,
+            system=True,
+        ),
+        context=SimpleNamespace(json=False),
+    )
+    assert isinstance(components, Iterable)
+    assert tuple(components) == ("base", "channels", "envs", "system")
+
+
+def test_get_info_components() -> None:
+    with pytest.deprecated_call():
+        components = get_info_components(
+            args=SimpleNamespace(
+                base=True,
+                unsafe_channels=True,
+                all=True,
+                envs=True,
+                system=True,
+            ),
+            context=SimpleNamespace(json=False),
+        )
+    assert isinstance(components, set)
+    assert components == {"base", "channels", "envs", "system"}

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.base.context import context
-from conda.cli.main_info import get_info_components, get_info_components_iterable
+from conda.cli.main_info import get_info_components, iter_info_components
 from conda.common.path import paths_equal
 from conda.core.envs_manager import list_all_known_prefixes
 from conda.plugins.reporter_backends.console import ConsoleReporterRenderer
@@ -197,8 +197,8 @@ def test_info_root(conda_cli: CondaCLIFixture):
         conda_cli("info", "--root")
 
 
-def test_get_info_components_iterable() -> None:
-    components = get_info_components_iterable(
+def test_iter_info_components() -> None:
+    components = iter_info_components(
         args=SimpleNamespace(
             base=True,
             unsafe_channels=True,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Followup to #14831 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
