### PR TITLE
Deprecate `conda.common.url.hex_octal_to_int`

### DIFF
--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -19,10 +19,12 @@ from urllib.parse import (  # noqa: F401
 from urllib.parse import urlparse as _urlparse
 from urllib.parse import urlunparse as _urlunparse  # noqa: F401
 
+from ..deprecations import deprecated
 from .compat import on_win
 from .path import split_filename, strip_pkg_extension
 
 
+@deprecated("25.9", "26.3", addendum="Use int(..., 16) instead.")
 def hex_octal_to_int(ho):
     ho = ord(ho.upper())
     o0 = ord("0")
@@ -67,8 +69,8 @@ def percent_decode(path):
 
                     emit = struct.pack(
                         "B",
-                        hex_octal_to_int(path[i + 1]) * 16
-                        + hex_octal_to_int(path[i + 2]),
+                        int(path[i + 1], 16) * 16
+                        + int(path[i + 2], 16),
                     )
                     skips = 2
                     break

--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -5,6 +5,7 @@
 import codecs
 import re
 import socket
+import struct
 from collections import namedtuple
 from functools import cache
 from getpass import getpass
@@ -65,12 +66,7 @@ def percent_decode(path):
         if c == b"%":
             for r in ranges:
                 if i == r[0]:
-                    import struct
-
-                    emit = struct.pack(
-                        "B",
-                        int(path[i + 1], 16) * 16 + int(path[i + 2], 16),
-                    )
+                    emit = struct.pack("B", int(path[i + 1 : i + 3], 16))
                     skips = 2
                     break
         if emit:

--- a/conda/common/url.py
+++ b/conda/common/url.py
@@ -69,8 +69,7 @@ def percent_decode(path):
 
                     emit = struct.pack(
                         "B",
-                        int(path[i + 1], 16) * 16
-                        + int(path[i + 2], 16),
+                        int(path[i + 1], 16) * 16 + int(path[i + 2], 16),
                     )
                     skips = 2
                     break

--- a/news/14840-hex-octal
+++ b/news/14840-hex-octal
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.common.url.hex_octal_to_int` as pending deprecation. Use `int(..., 16)` instead. It will be permanently removed in 26.3. (#14750)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Comes from https://github.com/conda/conda/pull/14817#discussion_r2087408445. cc @dholth 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
