### PR TITLE
Mark trust module as (pending) deprecated and prepare for migration to conda-content-trust.

### DIFF
--- a/conda/trust/__init__.py
+++ b/conda/trust/__init__.py
@@ -1,2 +1,12 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+
+from ..deprecations import deprecated
+
+# Mark the entire module for deprecation. For more information see
+# https://github.com/conda/conda-content-trust and #14797
+deprecated.module(
+    "25.9.0",  # deprecate_in version
+    "26.3.0",  # remove_in version
+    addendum="This module will be moved to conda-content-trust.",
+)

--- a/conda/trust/__init__.py
+++ b/conda/trust/__init__.py
@@ -5,8 +5,4 @@ from ..deprecations import deprecated
 
 # Mark the entire module for deprecation. For more information see
 # https://github.com/conda/conda-content-trust and #14797
-deprecated.module(
-    "25.9.0",  # deprecate_in version
-    "26.3.0",  # remove_in version
-    addendum="This module will be moved to conda-content-trust.",
-)
+deprecated.module("25.9", "26.3")

--- a/conda/trust/constants.py
+++ b/conda/trust/constants.py
@@ -19,8 +19,8 @@ from ..deprecations import deprecated
 # Mark the entire module for deprecation. For more information see
 # https://github.com/conda/conda-content-trust and #14797
 deprecated.module(
-    "25.9.0",  # deprecate_in version
-    "26.3.0",  # remove_in version
+    "25.9",  # deprecate_in version
+    "26.3",  # remove_in version
     addendum="This module will be moved to conda-anaconda-trust-root.",
 )
 

--- a/conda/trust/constants.py
+++ b/conda/trust/constants.py
@@ -13,6 +13,7 @@ The discrepancy can be detected when loading the root data, and we can
 decline to cache incorrect trust metadata that would make further root
 updates impossible.
 """
+
 from ..deprecations import deprecated
 
 # Mark the entire module for deprecation. For more information see
@@ -20,7 +21,7 @@ from ..deprecations import deprecated
 deprecated.module(
     "25.9.0",  # deprecate_in version
     "26.3.0",  # remove_in version
-    addendum="This module will be moved to conda-anaconda-trust-root."
+    addendum="This module will be moved to conda-anaconda-trust-root.",
 )
 
 INITIAL_TRUST_ROOT = {

--- a/conda/trust/constants.py
+++ b/conda/trust/constants.py
@@ -13,6 +13,15 @@ The discrepancy can be detected when loading the root data, and we can
 decline to cache incorrect trust metadata that would make further root
 updates impossible.
 """
+from ..deprecations import deprecated
+
+# Mark the entire module for deprecation. For more information see
+# https://github.com/conda/conda-content-trust and #14797
+deprecated.module(
+    "25.9.0",  # deprecate_in version
+    "26.3.0",  # remove_in version
+    addendum="This module will be moved to conda-anaconda-trust-root."
+)
 
 INITIAL_TRUST_ROOT = {
     "signatures": {

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -48,7 +48,7 @@ log = getLogger(__name__)
 deprecated.module(
     "25.9.0",  # deprecate_in version
     "26.3.0",  # remove_in version
-    addendum="This module will be moved to conda-content-trust."
+    addendum="This module will be moved to conda-content-trust.",
 )
 
 

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -32,7 +32,6 @@ from ..base.constants import CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION
 from ..base.context import context
 from ..common.url import join_url
 from ..core.subdir_data import SubdirData
-from ..deprecations import deprecated
 from ..gateways.connection import HTTPError, InsecureRequestWarning
 from ..gateways.connection.session import get_session
 from .constants import INITIAL_TRUST_ROOT, KEY_MGR_FILE
@@ -41,15 +40,6 @@ if TYPE_CHECKING:
     from ..models.records import PackageRecord
 
 log = getLogger(__name__)
-
-
-# Mark the entire module for deprecation. For more information see
-# https://github.com/conda/conda-content-trust and #14797
-deprecated.module(
-    "25.9.0",  # deprecate_in version
-    "26.3.0",  # remove_in version
-    addendum="This module will be moved to conda-content-trust.",
-)
 
 
 RE_ROOT_METADATA = re.compile(r"(?P<number>\d+)\.root\.json")

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -32,6 +32,7 @@ from ..base.constants import CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION
 from ..base.context import context
 from ..common.url import join_url
 from ..core.subdir_data import SubdirData
+from ..deprecations import deprecated
 from ..gateways.connection import HTTPError, InsecureRequestWarning
 from ..gateways.connection.session import get_session
 from .constants import INITIAL_TRUST_ROOT, KEY_MGR_FILE
@@ -40,6 +41,15 @@ if TYPE_CHECKING:
     from ..models.records import PackageRecord
 
 log = getLogger(__name__)
+
+
+# Mark the entire module for deprecation. For more information see
+# https://github.com/conda/conda-content-trust and #14797
+deprecated.module(
+    "25.9.0",  # deprecate_in version
+    "26.3.0",  # remove_in version
+    addendum="This module will be moved to conda-content-trust."
+)
 
 
 RE_ROOT_METADATA = re.compile(r"(?P<number>\d+)\.root\.json")

--- a/conda/trust/signature_verification.py
+++ b/conda/trust/signature_verification.py
@@ -32,12 +32,22 @@ from ..base.constants import CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION
 from ..base.context import context
 from ..common.url import join_url
 from ..core.subdir_data import SubdirData
+from ..deprecations import deprecated
 from ..gateways.connection import HTTPError, InsecureRequestWarning
 from ..gateways.connection.session import get_session
 from .constants import INITIAL_TRUST_ROOT, KEY_MGR_FILE
 
 if TYPE_CHECKING:
     from ..models.records import PackageRecord
+
+# Mark the entire module for deprecation. For more information see
+# https://github.com/conda/conda-content-trust and #14797
+deprecated.module(
+    "25.9",  # deprecate_in version
+    "26.3",  # remove_in version
+    addendum="This module will be moved to conda-content-trust.",
+)
+
 
 log = getLogger(__name__)
 

--- a/news/14849-deprecate-signature-verification
+++ b/news/14849-deprecate-signature-verification
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.trust.signature_verification` and `conda.trust.constants` modules for deprecation in version 25.9.0, to be removed in version 26.3.0. The functionality will be moved to `conda-content-trust` and `conda-anaconda-trust-root` packages respectively. (#14849)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/trust/test_trust.py
+++ b/tests/trust/test_trust.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+
+
+@pytest.mark.parametrize("module", ["conda.trust", "conda.trust.constants"])
+def test_deprecations(module: str) -> None:
+    with pytest.deprecated_call():
+        import_module(module)

--- a/tests/trust/test_trust.py
+++ b/tests/trust/test_trust.py
@@ -7,7 +7,10 @@ from importlib import import_module
 import pytest
 
 
-@pytest.mark.parametrize("module", ["conda.trust", "conda.trust.constants"])
+@pytest.mark.parametrize(
+    "module",
+    ["conda.trust", "conda.trust.constants", "conda.trust.signature_verification"],
+)
 def test_deprecations(module: str) -> None:
     with pytest.deprecated_call():
         import_module(module)

--- a/tests/trust/test_trust.py
+++ b/tests/trust/test_trust.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from importlib import import_module
+from importlib import import_module, reload
 
 import pytest
 
@@ -13,4 +13,4 @@ import pytest
 )
 def test_deprecations(module: str) -> None:
     with pytest.deprecated_call():
-        import_module(module)
+        reload(import_module(module))


### PR DESCRIPTION
Fix #14848.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
