### PR TITLE
Add a data model for an environment

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -76,8 +76,7 @@ CONDA_HOMEPAGE_URL: Final = "https://conda.io"
 ERROR_UPLOAD_URL: Final = "https://conda.io/conda-post/unexpected-error"
 DEFAULTS_CHANNEL_NAME: Final = "defaults"
 
-KNOWN_SUBDIRS: Final = (
-    "noarch",
+PLATFORMS: Final = (
     "emscripten-wasm32",
     "wasi-wasm32",
     "freebsd-64",
@@ -97,6 +96,10 @@ KNOWN_SUBDIRS: Final = (
     "win-arm64",
     "zos-z",
 )
+KNOWN_SUBDIRS: Final = (
+    "noarch",
+) 
+KNOWN_SUBDIRS += PLATFORMS
 PLATFORM_DIRECTORIES = KNOWN_SUBDIRS
 
 RECOGNIZED_URL_SCHEMES: Final = ("http", "https", "ftp", "s3", "file")

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -96,9 +96,7 @@ PLATFORMS: Final = (
     "win-arm64",
     "zos-z",
 )
-KNOWN_SUBDIRS: Final = (
-    "noarch",
-) 
+KNOWN_SUBDIRS: Final = ("noarch",)
 KNOWN_SUBDIRS += PLATFORMS
 PLATFORM_DIRECTORIES = KNOWN_SUBDIRS
 

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -96,8 +96,7 @@ PLATFORMS: Final = (
     "win-arm64",
     "zos-z",
 )
-KNOWN_SUBDIRS: Final = ("noarch",)
-KNOWN_SUBDIRS += PLATFORMS
+KNOWN_SUBDIRS: Final = ("noarch", *PLATFORMS)
 PLATFORM_DIRECTORIES = KNOWN_SUBDIRS
 
 RECOGNIZED_URL_SCHEMES: Final = ("http", "https", "ftp", "s3", "file")

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Conda environment data model"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from ..exceptions import CondaValueError
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from .match_spec import MatchSpec
+    from .records import PackageRecord
+
+
+log = getLogger(__name__)
+
+
+@dataclass
+class Environment:
+    # Prefix the environment is installed into (required).
+    prefix: str
+
+    # The platform this environment may be installed on (required)
+    platform: str
+
+    # Environment level configuration, eg. channels, solver options, etc.
+    config: dict[str, Any] = field(default_factory=dict)
+
+    # Map of other package types that conda can install. For example pypi packages.
+    external_packages: dict[str, list]  = field(default_factory=dict)
+
+    # The complete list of specs for the environment.
+    # eg. after a solve, or from an explicit environemnt spec
+    explicit_specs: list[PackageRecord] = field(default_factory=list)
+
+    # Environment name
+    name: str |  None = None
+
+    # User requested specs for this environment.
+    requested_specs: list[MatchSpec] = field(default_factory=list)
+
+    # Environment variables to be applied to the environment.
+    variables: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+        # an environment must have a name of prefix
+        if not self.prefix:
+            raise CondaValueError("'Environment' needs a 'prefix'.")
+
+    @classmethod
+    def merge(cls, *environments):
+        """
+        Keeps first name and/or prefix.
+        Concatenates and deduplicates requirements.
+        Reduces configuration and variables (last key wins).
+        """
+        name = None
+        prefix = None
+        platform = None
+        names = [env.name for env in environments if env.name]
+        prefixes = [env.prefix for env in environments if env.prefix]
+        
+        if names:
+            name = names[0]
+            if len(names) > 1:
+                log.debug("Several names passed %s. Picking first one %s", names, name)
+        
+        if prefixes:
+            prefix = prefixes[0]
+            if len(prefixes) > 1:
+                log.debug(
+                    "Several prefixes passed %s. Picking first one %s", prefixes, prefix
+                )
+        
+        platforms = [env.platform for env in environments if env.platform]
+        # Ensure that all environments have the same platform
+        if len(set(platforms)) == 1:
+            platform = platforms[0]
+        else:
+            raise CondaValueError(f"Conda can not merge environments of different platforms. Recieved environments with plafroms {platforms}")
+
+        requested_specs = list(
+            dict.fromkeys(
+                requirement for env in environments for requirement in env.requested_specs
+            )
+        )
+
+        explicit_specs = list(
+            dict.fromkeys(
+                requirement for env in environments for requirement in env.explicit_specs
+            )
+        )
+
+        variables = {k: v for env in environments for (k, v) in env.variables.items()}
+
+        config = {}
+        external_packages = {}
+        for env in environments:
+            # Config items can be any type, merge them so that lists get 
+            # concatenated, dicts get merged, and primitive types get clobbered.
+            for k, v in env.config.items():
+                if k not in config:
+                    config[k] = v
+                elif isinstance(config[k], list) and isinstance(v, list):
+                    config[k].extend(v)
+                elif isinstance(config[k], dict) and isinstance(v, dict):
+                    config[k].update(v)
+                else:
+                    log.debug("merging configs, clobbering value %s with value %s")
+                    config[k] = v
+
+            # External packages map values are always lists of strings. So,
+            # we'll want to concatentate each list.
+            for k, v in env.external_packages.items():
+                if k in external_packages:
+                    for val in v:
+                        if val not in external_packages[k]:
+                            external_packages[k].append(val)
+                elif isinstance(v, list):
+                    external_packages[k] = v
+
+        return cls(
+            config=config,
+            external_packages= external_packages,
+            explicit_specs=explicit_specs,
+            name=name,
+            platform=platform,
+            prefix=prefix,
+            requested_specs=requested_specs,
+            variables=variables,
+        )

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""Conda environment data model"""
+"""EXPERIMENTAL Conda environment data model"""
 
 from __future__ import annotations
 
@@ -22,6 +22,12 @@ log = getLogger(__name__)
 
 @dataclass
 class Environment:
+    """
+    **Experimental** While experimental, expect both major and minor changes across minor releases.
+
+    Data model for a conda environment.
+    """
+
     #: Prefix the environment is installed into (required).
     prefix: str
 
@@ -55,9 +61,12 @@ class Environment:
     @classmethod
     def merge(cls, *environments):
         """
-        Keeps first name and/or prefix.
-        Concatenates and deduplicates requirements.
-        Reduces configuration and variables (last key wins).
+        **Experimental** While experimental, expect both major and minor changes across minor releases.
+
+        Merges multiple environments into a single environment following the rules:
+        * Keeps first name and/or prefix.
+        * Concatenates and deduplicates requirements.
+        * Reduces configuration and variables (last key wins).
         """
         name = None
         prefix = None

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -32,14 +32,14 @@ class Environment:
     config: dict[str, Any] = field(default_factory=dict)
 
     # Map of other package types that conda can install. For example pypi packages.
-    external_packages: dict[str, list]  = field(default_factory=dict)
+    external_packages: dict[str, list] = field(default_factory=dict)
 
     # The complete list of specs for the environment.
     # eg. after a solve, or from an explicit environemnt spec
     explicit_specs: list[PackageRecord] = field(default_factory=list)
 
     # Environment name
-    name: str |  None = None
+    name: str | None = None
 
     # User requested specs for this environment.
     requested_specs: list[MatchSpec] = field(default_factory=list)
@@ -64,35 +64,41 @@ class Environment:
         platform = None
         names = [env.name for env in environments if env.name]
         prefixes = [env.prefix for env in environments if env.prefix]
-        
+
         if names:
             name = names[0]
             if len(names) > 1:
                 log.debug("Several names passed %s. Picking first one %s", names, name)
-        
+
         if prefixes:
             prefix = prefixes[0]
             if len(prefixes) > 1:
                 log.debug(
                     "Several prefixes passed %s. Picking first one %s", prefixes, prefix
                 )
-        
+
         platforms = [env.platform for env in environments if env.platform]
         # Ensure that all environments have the same platform
         if len(set(platforms)) == 1:
             platform = platforms[0]
         else:
-            raise CondaValueError(f"Conda can not merge environments of different platforms. Recieved environments with plafroms {platforms}")
+            raise CondaValueError(
+                f"Conda can not merge environments of different platforms. Recieved environments with plafroms {platforms}"
+            )
 
         requested_specs = list(
             dict.fromkeys(
-                requirement for env in environments for requirement in env.requested_specs
+                requirement
+                for env in environments
+                for requirement in env.requested_specs
             )
         )
 
         explicit_specs = list(
             dict.fromkeys(
-                requirement for env in environments for requirement in env.explicit_specs
+                requirement
+                for env in environments
+                for requirement in env.explicit_specs
             )
         )
 
@@ -101,7 +107,7 @@ class Environment:
         config = {}
         external_packages = {}
         for env in environments:
-            # Config items can be any type, merge them so that lists get 
+            # Config items can be any type, merge them so that lists get
             # concatenated, dicts get merged, and primitive types get clobbered.
             for k, v in env.config.items():
                 if k not in config:
@@ -126,7 +132,7 @@ class Environment:
 
         return cls(
             config=config,
-            external_packages= external_packages,
+            external_packages=external_packages,
             explicit_specs=explicit_specs,
             name=name,
             platform=platform,

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -38,7 +38,7 @@ class Environment:
     config: dict[str, Any] = field(default_factory=dict)
 
     #: Map of other package types that conda can install. For example pypi packages.
-    external_packages: dict[str, list[Any]] = field(default_factory=dict)
+    external_packages: dict[str, list[str]] = field(default_factory=dict)
 
     #: The complete list of specs for the environment.
     #: eg. after a solve, or from an explicit environemnt spec
@@ -92,7 +92,8 @@ class Environment:
             platform = platforms[0]
         else:
             raise CondaValueError(
-                f"Conda can not merge environments of different platforms. Recieved environments with plafroms {platforms}"
+                "Conda can not merge environments of different platforms. "
+                f"Received environments with platforms: {platforms}"
             )
 
         requested_packages = list(
@@ -130,7 +131,7 @@ class Environment:
                     config[k] = v
 
             # External packages map values are always lists of strings. So,
-            # we'll want to concatentate each list.
+            # we'll want to concatenate each list.
             for k, v in env.external_packages.items():
                 if k in external_packages:
                     for val in v:

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -32,7 +32,7 @@ class Environment:
     config: dict[str, Any] = field(default_factory=dict)
 
     # Map of other package types that conda can install. For example pypi packages.
-    external_packages: dict[str, list] = field(default_factory=dict)
+    external_packages: dict[str, list[Any]] = field(default_factory=dict)
 
     # The complete list of specs for the environment.
     # eg. after a solve, or from an explicit environemnt spec

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -64,22 +64,27 @@ class Environment:
         # an environment must have a platform
         if not self.platform:
             raise CondaValueError("'Environment' needs a 'platform'.")
-        
+
         # ensure the platform is valid
         if self.platform not in PLATFORMS:
-            raise CondaValueError(f"Invalid platform '{self.platform}'. Valid platforms are {PLATFORMS}.")
+            raise CondaValueError(
+                f"Invalid platform '{self.platform}'. Valid platforms are {PLATFORMS}."
+            )
 
         # ensure there are no duplicate packages in explicit_packages
-        if len(self.explicit_packages) > 1 and len(set(pkg.name for pkg in self.explicit_packages)) != len(self.explicit_packages):
+        if len(self.explicit_packages) > 1 and len(
+            set(pkg.name for pkg in self.explicit_packages)
+        ) != len(self.explicit_packages):
             raise CondaValueError("Duplicate packages found in 'explicit_packages'.")
-        
+
         # ensure requested_packages matches one (and only one) explicit package
         if len(self.requested_packages) > 0 and len(self.explicit_packages) > 0:
             explicit_package_names = set(pkg.name for pkg in self.explicit_packages)
             for requested_package in self.requested_packages:
                 if requested_package.name not in explicit_package_names:
-                    raise CondaValueError(f"Requested package '{requested_package}' is not found in 'explicit_packages'.")
-
+                    raise CondaValueError(
+                        f"Requested package '{requested_package}' is not found in 'explicit_packages'."
+                    )
 
     @classmethod
     def merge(cls, *environments):

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -22,29 +22,29 @@ log = getLogger(__name__)
 
 @dataclass
 class Environment:
-    # Prefix the environment is installed into (required).
+    #: Prefix the environment is installed into (required).
     prefix: str
 
-    # The platform this environment may be installed on (required)
+    #: The platform this environment may be installed on (required)
     platform: str
 
-    # Environment level configuration, eg. channels, solver options, etc.
+    #: Environment level configuration, eg. channels, solver options, etc.
     config: dict[str, Any] = field(default_factory=dict)
 
-    # Map of other package types that conda can install. For example pypi packages.
+    #: Map of other package types that conda can install. For example pypi packages.
     external_packages: dict[str, list[Any]] = field(default_factory=dict)
 
-    # The complete list of specs for the environment.
-    # eg. after a solve, or from an explicit environemnt spec
-    explicit_specs: list[PackageRecord] = field(default_factory=list)
+    #: The complete list of specs for the environment.
+    #: eg. after a solve, or from an explicit environemnt spec
+    explicit_packages: list[PackageRecord] = field(default_factory=list)
 
-    # Environment name
+    #: Environment name
     name: str | None = None
 
-    # User requested specs for this environment.
-    requested_specs: list[MatchSpec] = field(default_factory=list)
+    #: User requested specs for this environment.
+    requested_packages: list[MatchSpec] = field(default_factory=list)
 
-    # Environment variables to be applied to the environment.
+    #: Environment variables to be applied to the environment.
     variables: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -86,19 +86,19 @@ class Environment:
                 f"Conda can not merge environments of different platforms. Recieved environments with plafroms {platforms}"
             )
 
-        requested_specs = list(
+        requested_packages = list(
             dict.fromkeys(
                 requirement
                 for env in environments
-                for requirement in env.requested_specs
+                for requirement in env.requested_packages
             )
         )
 
-        explicit_specs = list(
+        explicit_packages = list(
             dict.fromkeys(
                 requirement
                 for env in environments
-                for requirement in env.explicit_specs
+                for requirement in env.explicit_packages
             )
         )
 
@@ -133,10 +133,10 @@ class Environment:
         return cls(
             config=config,
             external_packages=external_packages,
-            explicit_specs=explicit_specs,
+            explicit_packages=explicit_packages,
             name=name,
             platform=platform,
             prefix=prefix,
-            requested_specs=requested_specs,
+            requested_packages=requested_packages,
             variables=variables,
         )

--- a/news/14870-add-environment-data-model
+++ b/news/14870-add-environment-data-model
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add a data model to represent an environment. (#14870)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/14870-add-environment-data-model
+++ b/news/14870-add-environment-data-model
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add a data model to represent an environment. (#14870)
+* Add an experimental data model to represent an environment. (#14870)
 
 ### Bug fixes
 

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -81,7 +81,12 @@ def test_environments_merge():
     env2 = Environment(
         prefix="/path/to/env1",
         platform="linux-64",
-        config={"primitive_one": "no", "primitive_two": "yes", "list_one": [3], "map": {"b": 1}},
+        config={
+            "primitive_one": "no",
+            "primitive_two": "yes",
+            "list_one": [3],
+            "map": {"b": 1},
+        },
         external_packages={"pip": ["two", "flask"], "a": ["nother"]},
         explicit_packages=[],
         requested_packages=[MatchSpec("numpy"), MatchSpec("flask")],
@@ -94,7 +99,7 @@ def test_environments_merge():
         "primitive_one": "no",
         "primitive_two": "yes",
         "list_one": [1, 2, 4, 3],
-        "map": {"a":1, "b": 1},
+        "map": {"a": 1, "b": 1},
     }
     assert merged.external_packages == {
         "pip": ["one", "two", {"special": "type"}, "flask"],

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from conda.models.environment import Environment
+from conda.models.match_spec import MatchSpec
+from conda.exceptions import CondaValueError
+
+
+def test_create_environment_no_prefix():
+    with pytest.raises(CondaValueError):
+        Environment(platform="platform", prefix=None)
+
+
+def test_environments_merge():
+    env1 = Environment(
+        prefix="/path/to/env1",
+        platform="one",
+        config={"primitive_one": "yes", "list_one": [1,2,4]},
+        external_packages={"pip": ["one", "two"], "other": ["three"]},
+        explicit_specs=[MatchSpec("somepackage.conda")],
+        requested_specs=[MatchSpec("numpy"), MatchSpec("pandas")],
+        variables={"PATH": "/usr/bin"}
+    )
+    env2 = Environment(
+        prefix="/path/to/env1",
+        platform="one",
+        config={"primitive_one": "no", "primitive_two": "yes", "list_one": [3]},
+        external_packages={"pip": ["two", "flask"], "a": ["nother"]},
+        explicit_specs=[MatchSpec("somepackageother.conda")],
+        requested_specs=[MatchSpec("numpy"), MatchSpec("flask")],
+        variables={"VAR": "IABLE"}
+    )
+    merged = Environment.merge(env1, env2)
+    assert merged.prefix == "/path/to/env1"
+    assert merged.platform == "one"
+    assert merged.config == {"primitive_one": "no", "primitive_two": "yes", "list_one": [1,2,4,3]}
+    assert merged.external_packages == {"pip": ["one", "two", "flask"], "other": ["three"], "a": ["nother"]}
+    assert set(merged.requested_specs) == set([MatchSpec("pandas"), MatchSpec("flask"), MatchSpec("numpy")])
+    assert set(merged.explicit_specs) == set([MatchSpec("somepackageother.conda"), MatchSpec("somepackage.conda")])
+    assert merged.variables == {"PATH": "/usr/bin", "VAR": "IABLE"}
+
+
+def test_environments_merge_colliding_platform():
+    env1 = Environment(prefix="/path/to/env1", platform="one")
+    env2 = Environment(prefix="/path/to/env2", platform="two")
+    
+    with pytest.raises(CondaValueError):
+        Environment.merge(env1, env2)

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -69,7 +69,7 @@ def test_environments_merge():
     env1 = Environment(
         prefix="/path/to/env1",
         platform="linux-64",
-        config={"primitive_one": "yes", "list_one": [1, 2, 4]},
+        config={"primitive_one": "yes", "list_one": [1, 2, 4], "map": {"a": 1}},
         external_packages={
             "pip": ["one", "two", {"special": "type"}],
             "other": ["three"],
@@ -81,7 +81,7 @@ def test_environments_merge():
     env2 = Environment(
         prefix="/path/to/env1",
         platform="linux-64",
-        config={"primitive_one": "no", "primitive_two": "yes", "list_one": [3]},
+        config={"primitive_one": "no", "primitive_two": "yes", "list_one": [3], "map": {"b": 1}},
         external_packages={"pip": ["two", "flask"], "a": ["nother"]},
         explicit_packages=[],
         requested_packages=[MatchSpec("numpy"), MatchSpec("flask")],
@@ -94,6 +94,7 @@ def test_environments_merge():
         "primitive_one": "no",
         "primitive_two": "yes",
         "list_one": [1, 2, 4, 3],
+        "map": {"a":1, "b": 1},
     }
     assert merged.external_packages == {
         "pip": ["one", "two", {"special": "type"}, "flask"],

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -18,7 +18,10 @@ def test_environments_merge():
         prefix="/path/to/env1",
         platform="one",
         config={"primitive_one": "yes", "list_one": [1, 2, 4]},
-        external_packages={"pip": ["one", "two"], "other": ["three"]},
+        external_packages={
+            "pip": ["one", "two", {"special": "type"}], 
+            "other": ["three"],
+        },
         explicit_specs=[MatchSpec("somepackage.conda")],
         requested_specs=[MatchSpec("numpy"), MatchSpec("pandas")],
         variables={"PATH": "/usr/bin"},
@@ -41,7 +44,7 @@ def test_environments_merge():
         "list_one": [1, 2, 4, 3],
     }
     assert merged.external_packages == {
-        "pip": ["one", "two", "flask"],
+        "pip": ["one", "two", {"special": "type"}, "flask"],
         "other": ["three"],
         "a": ["nother"],
     }

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -22,8 +22,8 @@ def test_environments_merge():
             "pip": ["one", "two", {"special": "type"}], 
             "other": ["three"],
         },
-        explicit_specs=[MatchSpec("somepackage.conda")],
-        requested_specs=[MatchSpec("numpy"), MatchSpec("pandas")],
+        explicit_packages=[MatchSpec("somepackage.conda")],
+        requested_packages=[MatchSpec("numpy"), MatchSpec("pandas")],
         variables={"PATH": "/usr/bin"},
     )
     env2 = Environment(
@@ -31,8 +31,8 @@ def test_environments_merge():
         platform="one",
         config={"primitive_one": "no", "primitive_two": "yes", "list_one": [3]},
         external_packages={"pip": ["two", "flask"], "a": ["nother"]},
-        explicit_specs=[MatchSpec("somepackageother.conda")],
-        requested_specs=[MatchSpec("numpy"), MatchSpec("flask")],
+        explicit_packages=[MatchSpec("somepackageother.conda")],
+        requested_packages=[MatchSpec("numpy"), MatchSpec("flask")],
         variables={"VAR": "IABLE"},
     )
     merged = Environment.merge(env1, env2)
@@ -48,10 +48,10 @@ def test_environments_merge():
         "other": ["three"],
         "a": ["nother"],
     }
-    assert set(merged.requested_specs) == set(
+    assert set(merged.requested_packages) == set(
         [MatchSpec("pandas"), MatchSpec("flask"), MatchSpec("numpy")]
     )
-    assert set(merged.explicit_specs) == set(
+    assert set(merged.explicit_packages) == set(
         [MatchSpec("somepackageother.conda"), MatchSpec("somepackage.conda")]
     )
     assert merged.variables == {"PATH": "/usr/bin", "VAR": "IABLE"}

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -12,7 +12,7 @@ from conda.models.records import PackageRecord
 def test_create_environment_missing_required_fields():
     with pytest.raises(CondaValueError):
         Environment(platform="linux-64", prefix=None)
-    
+
     with pytest.raises(CondaValueError):
         Environment(platform=None, prefix="/path/to/env")
 
@@ -41,9 +41,9 @@ def test_ensure_no_duplicate_named_explicit_packages():
     )
     with pytest.raises(CondaValueError):
         Environment(
-            platform="linux-64", 
-            prefix="/path/to/env", 
-            explicit_packages=[test_record_one, test_record_two]
+            platform="linux-64",
+            prefix="/path/to/env",
+            explicit_packages=[test_record_one, test_record_two],
         )
 
 
@@ -58,8 +58,8 @@ def test_create_missing_explicit_package():
     )
     with pytest.raises(CondaValueError):
         Environment(
-            platform="linux-64", 
-            prefix="/path/to/env", 
+            platform="linux-64",
+            prefix="/path/to/env",
             explicit_packages=[test_record_one],
             requested_packages=[MatchSpec("test"), MatchSpec("pandas")],
         )

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -19,7 +19,7 @@ def test_environments_merge():
         platform="one",
         config={"primitive_one": "yes", "list_one": [1, 2, 4]},
         external_packages={
-            "pip": ["one", "two", {"special": "type"}], 
+            "pip": ["one", "two", {"special": "type"}],
             "other": ["three"],
         },
         explicit_packages=[MatchSpec("somepackage.conda")],

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -6,38 +6,90 @@ import pytest
 from conda.exceptions import CondaValueError
 from conda.models.environment import Environment
 from conda.models.match_spec import MatchSpec
+from conda.models.records import PackageRecord
 
 
-def test_create_environment_no_prefix():
+def test_create_environment_missing_required_fields():
     with pytest.raises(CondaValueError):
-        Environment(platform="platform", prefix=None)
+        Environment(platform="linux-64", prefix=None)
+    
+    with pytest.raises(CondaValueError):
+        Environment(platform=None, prefix="/path/to/env")
+
+
+def test_create_invalid_platform():
+    with pytest.raises(CondaValueError):
+        Environment(platform="idontexist", prefix="/path/to/env")
+
+
+def test_ensure_no_duplicate_named_explicit_packages():
+    test_record_one = PackageRecord(
+        name="test",
+        version="1.0",
+        build="1",
+        channel="defaults",
+        subdir="noarch",
+        build_number=1,
+    )
+    test_record_two = PackageRecord(
+        name="test",
+        version="2.0",
+        build="1",
+        channel="defaults",
+        subdir="noarch",
+        build_number=1,
+    )
+    with pytest.raises(CondaValueError):
+        Environment(
+            platform="linux-64", 
+            prefix="/path/to/env", 
+            explicit_packages=[test_record_one, test_record_two]
+        )
+
+
+def test_create_missing_explicit_package():
+    test_record_one = PackageRecord(
+        name="test",
+        version="1.0",
+        build="1",
+        channel="defaults",
+        subdir="noarch",
+        build_number=1,
+    )
+    with pytest.raises(CondaValueError):
+        Environment(
+            platform="linux-64", 
+            prefix="/path/to/env", 
+            explicit_packages=[test_record_one],
+            requested_packages=[MatchSpec("test"), MatchSpec("pandas")],
+        )
 
 
 def test_environments_merge():
     env1 = Environment(
         prefix="/path/to/env1",
-        platform="one",
+        platform="linux-64",
         config={"primitive_one": "yes", "list_one": [1, 2, 4]},
         external_packages={
             "pip": ["one", "two", {"special": "type"}],
             "other": ["three"],
         },
-        explicit_packages=[MatchSpec("somepackage.conda")],
+        explicit_packages=[],
         requested_packages=[MatchSpec("numpy"), MatchSpec("pandas")],
         variables={"PATH": "/usr/bin"},
     )
     env2 = Environment(
         prefix="/path/to/env1",
-        platform="one",
+        platform="linux-64",
         config={"primitive_one": "no", "primitive_two": "yes", "list_one": [3]},
         external_packages={"pip": ["two", "flask"], "a": ["nother"]},
-        explicit_packages=[MatchSpec("somepackageother.conda")],
+        explicit_packages=[],
         requested_packages=[MatchSpec("numpy"), MatchSpec("flask")],
         variables={"VAR": "IABLE"},
     )
     merged = Environment.merge(env1, env2)
     assert merged.prefix == "/path/to/env1"
-    assert merged.platform == "one"
+    assert merged.platform == "linux-64"
     assert merged.config == {
         "primitive_one": "no",
         "primitive_two": "yes",
@@ -51,15 +103,76 @@ def test_environments_merge():
     assert set(merged.requested_packages) == set(
         [MatchSpec("pandas"), MatchSpec("flask"), MatchSpec("numpy")]
     )
-    assert set(merged.explicit_packages) == set(
-        [MatchSpec("somepackageother.conda"), MatchSpec("somepackage.conda")]
-    )
     assert merged.variables == {"PATH": "/usr/bin", "VAR": "IABLE"}
 
 
+def test_environments_merge_explicit_packages():
+    somepackage = PackageRecord(
+        name="somepackage",
+        version="1.0",
+        build="1",
+        channel="defaults",
+        subdir="noarch",
+        build_number=1,
+    )
+    somepackageother = PackageRecord(
+        name="somepackageother",
+        version="1.0",
+        build="1",
+        channel="defaults",
+        subdir="noarch",
+        build_number=1,
+    )
+    env1 = Environment(
+        prefix="/path/to/env1",
+        platform="linux-64",
+        explicit_packages=[somepackage],
+    )
+    env2 = Environment(
+        prefix="/path/to/env1",
+        platform="linux-64",
+        explicit_packages=[somepackage, somepackageother],
+    )
+    merged = Environment.merge(env1, env2)
+    assert merged.prefix == "/path/to/env1"
+    assert merged.platform == "linux-64"
+    assert merged.explicit_packages == [somepackage, somepackageother]
+
+
 def test_environments_merge_colliding_platform():
-    env1 = Environment(prefix="/path/to/env1", platform="one")
-    env2 = Environment(prefix="/path/to/env2", platform="two")
+    env1 = Environment(prefix="/path/to/env1", platform="linux-64")
+    env2 = Environment(prefix="/path/to/env2", platform="osx-64")
 
     with pytest.raises(CondaValueError):
         Environment.merge(env1, env2)
+
+
+def test_environments_merge_colliding_name():
+    env1 = Environment(
+        prefix="/path/to/env1",
+        platform="linux-64",
+        name="one",
+    )
+    env2 = Environment(
+        prefix="/path/to/env1",
+        platform="linux-64",
+        name="two",
+    )
+    merged = Environment.merge(env1, env2)
+    assert merged.prefix == "/path/to/env1"
+    assert merged.platform == "linux-64"
+    assert merged.name == "one"
+
+
+def test_environments_merge_colliding_prefix():
+    env1 = Environment(
+        prefix="/path/to/env1",
+        platform="linux-64",
+    )
+    env2 = Environment(
+        prefix="/path/to/env2",
+        platform="linux-64",
+    )
+    merged = Environment.merge(env1, env2)
+    assert merged.prefix == "/path/to/env1"
+    assert merged.platform == "linux-64"

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -3,9 +3,9 @@
 
 import pytest
 
+from conda.exceptions import CondaValueError
 from conda.models.environment import Environment
 from conda.models.match_spec import MatchSpec
-from conda.exceptions import CondaValueError
 
 
 def test_create_environment_no_prefix():
@@ -17,11 +17,11 @@ def test_environments_merge():
     env1 = Environment(
         prefix="/path/to/env1",
         platform="one",
-        config={"primitive_one": "yes", "list_one": [1,2,4]},
+        config={"primitive_one": "yes", "list_one": [1, 2, 4]},
         external_packages={"pip": ["one", "two"], "other": ["three"]},
         explicit_specs=[MatchSpec("somepackage.conda")],
         requested_specs=[MatchSpec("numpy"), MatchSpec("pandas")],
-        variables={"PATH": "/usr/bin"}
+        variables={"PATH": "/usr/bin"},
     )
     env2 = Environment(
         prefix="/path/to/env1",
@@ -30,21 +30,33 @@ def test_environments_merge():
         external_packages={"pip": ["two", "flask"], "a": ["nother"]},
         explicit_specs=[MatchSpec("somepackageother.conda")],
         requested_specs=[MatchSpec("numpy"), MatchSpec("flask")],
-        variables={"VAR": "IABLE"}
+        variables={"VAR": "IABLE"},
     )
     merged = Environment.merge(env1, env2)
     assert merged.prefix == "/path/to/env1"
     assert merged.platform == "one"
-    assert merged.config == {"primitive_one": "no", "primitive_two": "yes", "list_one": [1,2,4,3]}
-    assert merged.external_packages == {"pip": ["one", "two", "flask"], "other": ["three"], "a": ["nother"]}
-    assert set(merged.requested_specs) == set([MatchSpec("pandas"), MatchSpec("flask"), MatchSpec("numpy")])
-    assert set(merged.explicit_specs) == set([MatchSpec("somepackageother.conda"), MatchSpec("somepackage.conda")])
+    assert merged.config == {
+        "primitive_one": "no",
+        "primitive_two": "yes",
+        "list_one": [1, 2, 4, 3],
+    }
+    assert merged.external_packages == {
+        "pip": ["one", "two", "flask"],
+        "other": ["three"],
+        "a": ["nother"],
+    }
+    assert set(merged.requested_specs) == set(
+        [MatchSpec("pandas"), MatchSpec("flask"), MatchSpec("numpy")]
+    )
+    assert set(merged.explicit_specs) == set(
+        [MatchSpec("somepackageother.conda"), MatchSpec("somepackage.conda")]
+    )
     assert merged.variables == {"PATH": "/usr/bin", "VAR": "IABLE"}
 
 
 def test_environments_merge_colliding_platform():
     env1 = Environment(prefix="/path/to/env1", platform="one")
     env2 = Environment(prefix="/path/to/env2", platform="two")
-    
+
     with pytest.raises(CondaValueError):
         Environment.merge(env1, env2)


### PR DESCRIPTION
### Description

This PR adds a data model for a conda Environment. In follow up PRs this data model will be used to:
* refactor the `cli.install` module
* update the environment_spec interface to use this Environment model (opposed to the environment.yaml specific model)
* save declarative environment state

### Checklist - did you ...


- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

