### PR TITLE
Explicitly selected env spec plugin

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1389,7 +1389,7 @@ class Context(Configuration):
                 # prevent modifications to envs marked with conda-meta/frozen
             ),
             "Plugin Configuration": ("no_plugins",),
-            "Environment Managment Configuration": ("environment_specifier",),
+            "Experimental": ("environment_specifier",),
         }
 
     def get_descriptions(self) -> dict[str, str]:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -245,6 +245,12 @@ class Context(Configuration):
     clobber = ParameterLoader(PrimitiveParameter(False))
     changeps1 = ParameterLoader(PrimitiveParameter(True))
     env_prompt = ParameterLoader(PrimitiveParameter("({default_env}) "))
+
+    # environment_specifier is an EXPERIMENTAL config parameter
+    environment_specifier = ParameterLoader(
+        PrimitiveParameter(None, element_type=(str, NoneType)), aliases=("env_spec",)
+    )
+
     create_default_packages = ParameterLoader(
         SequenceParameter(PrimitiveParameter("", element_type=str))
     )
@@ -1383,6 +1389,7 @@ class Context(Configuration):
                 # prevent modifications to envs marked with conda-meta/frozen
             ),
             "Plugin Configuration": ("no_plugins",),
+            "Environment Managment Configuration": ("environment_specifier",),
         }
 
     def get_descriptions(self) -> dict[str, str]:
@@ -1634,6 +1641,14 @@ class Context(Configuration):
                 of '{name}' if the active environment is a conda named environment ('-n'
                 flag), or otherwise holds the value of '{prefix}'. Templating uses python's
                 str.format() method.
+                """
+            ),
+            environment_specifier=dals(
+                """
+                **EXPERIMENTAL** While experimental, expect both major and minor changes across minor releases.
+
+                The name of the environment specifier plugin that should be used for this context.
+                If not specified, the plugin manager will try to detect the plugin to use.
                 """
             ),
             execute_threads=dals(

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -376,7 +376,7 @@ def validate_environment_files_consistency(files: list[str]) -> None:
 
     # Get types for all files using the plugin manager
     file_types = {
-        file: context.plugin_manager.get_environment_specifier_name(file)
+        file: context.plugin_manager.get_environment_specifier(file).name
         for file in files
     }
     # If there's more than one unique type, raise an error

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -576,6 +576,19 @@ def add_parser_verbose(parser: ArgumentParser | _ArgumentGroup) -> None:
     )
 
 
+def add_parser_environment_specifier(p: ArgumentParser) -> None:
+    from ..base.context import context
+    from ..common.constants import NULL
+
+    p.add_argument(
+        "--environment-specifier",
+        "--env-spec",  # for brevity
+        choices=context.plugin_manager.get_environment_specifiers(),
+        default=NULL,
+        help="(EXPERIMENTAL) Specify the environment specifier plugin to use.",
+    )
+
+
 def comma_separated_stripped(value: str) -> list[str]:
     """
     Custom type for argparse to handle comma-separated strings with stripping

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -102,7 +102,6 @@ def compare_packages(active_pkgs, specification_pkgs) -> tuple[int, list[str]]:
 def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..base.context import context
     from ..core.prefix_data import PrefixData
-    from ..env import specs
     from ..exceptions import SpecNotFound
     from ..gateways.connection.session import CONDA_SESSION_SCHEMES
     from .common import stdout_json
@@ -118,7 +117,11 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         else:
             filename = abspath(expanduser(expandvars(args.file)))
 
-        spec = specs.detect(name=args.name, filename=filename, directory=os.getcwd())
+        spec_hook = context.plugin_manager.get_environment_specifier(
+            source=filename,
+            name=context.environment_specifier,
+        )
+        spec = spec_hook.environment_spec(filename)
         env = spec.environment
 
         if args.prefix is None and args.name is None:

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -24,6 +24,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_default_packages,
+        add_parser_environment_specifier,
         add_parser_networking,
         add_parser_platform,
         add_parser_prefix,
@@ -82,6 +83,9 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     # Add networking args
     add_parser_networking(p)
 
+    # Add environment spec plugin args
+    add_parser_environment_specifier(p)
+
     p.add_argument(
         "remote_definition",
         help="Remote environment definition / IPython notebook",
@@ -111,7 +115,6 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..core.prefix_data import PrefixData
     from ..env.env import print_result
     from ..env.installers.base import get_installer
-    from ..env.specs import detect
     from ..exceptions import CondaEnvException, InvalidInstaller
     from ..gateways.disk.delete import rm_rf
     from .common import validate_file_exists
@@ -120,7 +123,11 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     validate_file_exists(args.file)
 
     # detect the file format and get the env representation
-    spec = detect(filename=args.file)
+    spec_hook = context.plugin_manager.get_environment_specifier(
+        source=args.file,
+        name=context.environment_specifier,
+    )
+    spec = spec_hook.environment_spec(args.file)
     env = spec.environment
 
     # FIXME conda code currently requires args to have a name or prefix

--- a/conda/cli/main_env_update.py
+++ b/conda/cli/main_env_update.py
@@ -21,6 +21,7 @@ from ..notices import notices
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from .helpers import (
+        add_parser_environment_specifier,
         add_parser_frozen_env,
         add_parser_json,
         add_parser_prefix,
@@ -49,6 +50,10 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         epilog=epilog,
         **kwargs,
     )
+
+    # Add environment spec plugin args
+    add_parser_environment_specifier(p)
+
     add_parser_frozen_env(p)
     add_parser_prefix(p)
     p.add_argument(
@@ -88,7 +93,6 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..auxlib.ish import dals
     from ..base.context import context, determine_target_prefix
     from ..core.prefix_data import PrefixData
-    from ..env import specs as install_specs
     from ..env.env import print_result
     from ..env.installers.base import get_installer
     from ..exceptions import CondaEnvException, InvalidInstaller
@@ -98,7 +102,11 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     validate_file_exists(args.file)
 
     # detect the file format and get the env representation
-    spec = install_specs.detect(filename=args.file)
+    spec_hook = context.plugin_manager.get_environment_specifier(
+        source=args.file,
+        name=context.environment_specifier,
+    )
+    spec = spec_hook.environment_spec(args.file)
     env = spec.environment
 
     if not (args.name or args.prefix):

--- a/conda/env/specs/__init__.py
+++ b/conda/env/specs/__init__.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 @deprecated(
     "25.9",
     "26.3",
-    addendum="Use conda.base.context.plugin_manager.get_environment_specifiers.",
+    addendum="Use conda.base.context.plugin_manager.detect_environment_specifier.",
 )
 def get_spec_class_from_file(filename: str) -> FileSpecTypes:
     """
@@ -71,8 +71,8 @@ def detect(
     :raises SpecNotFound: Raised if no suitable spec class could be found given the input
     """
     try:
-        spec_hook = context.plugin_manager.get_environment_specifiers(
-            filename=filename,
+        spec_hook = context.plugin_manager.detect_environment_specifier(
+            source=filename,
         )
     except EnvironmentSpecPluginNotDetected as e:
         raise SpecNotFound(e.message)

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1297,7 +1297,7 @@ class SpecNotFound(CondaError):
 
 
 class EnvironmentSpecPluginNotDetected(SpecNotFound):
-    def __init__(self, name, plugin_names, *args, **kwargs):
+    def __init__(self, name: str, plugin_names: Iterable[str], *args, **kwargs):
         self.name = name
         msg = dals(
             f"""

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1287,7 +1287,16 @@ class EnvironmentFileNotDownloaded(CondaError):
         super().__init__(msg, *args, **kwargs)
 
 
-class EnvironmentSpecPluginNotDetected(CondaError):
+class PluginError(CondaError):
+    pass
+
+
+class SpecNotFound(CondaError):
+    def __init__(self, msg: str, *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+
+
+class EnvironmentSpecPluginNotDetected(SpecNotFound):
     def __init__(self, name, plugin_names, *args, **kwargs):
         self.name = name
         msg = dals(
@@ -1299,15 +1308,6 @@ class EnvironmentSpecPluginNotDetected(CondaError):
             """
         )
         super().__init__(msg, *args, **kwargs)
-
-
-class SpecNotFound(CondaError):
-    def __init__(self, msg: str, *args, **kwargs):
-        super().__init__(msg, *args, **kwargs)
-
-
-class PluginError(CondaError):
-    pass
 
 
 def maybe_raise(error: BaseException, context: Context):

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -550,7 +550,7 @@ class CondaPluginManager(pluggy.PluginManager):
                 )
         elif len(found) > 1:
             raise PluginError(
-                f"More than one environment_spec plugin named {name} found"
+                f"More than one environment_spec plugin named {name} found: {found}"
             )
 
     def detect_environment_specifier(self, source: str) -> CondaEnvironmentSpecifier:

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -621,24 +621,6 @@ class CondaPluginManager(pluggy.PluginManager):
         else:
             return self.get_environment_specifier_by_name(source=source, name=name)
 
-    def get_environment_specifier_name(self, filename: str) -> str:
-        """
-        Returns the name of the environment specifier plugin that can handle the given file.
-
-        Unlike get_environment_specifiers, this method doesn't raise exceptions but
-        returns a string with the specifier name or an error description.
-
-        :param filename: Path to the environment file
-        :type filename: str
-        :return: The name of the environment specifier that can handle the file,
-                 or a descriptive error string
-        :rtype: str
-        """
-        try:
-            return self.get_environment_specifiers(filename).name
-        except (EnvironmentSpecPluginNotDetected, PluginError, Exception) as e:
-            return f"unknown ({type(e).__name__})"
-
     def get_pre_transaction_actions(
         self,
         transaction_context: dict[str, str] | None = None,

--- a/news/14877-option-to-choose-environment-spec-plugin
+++ b/news/14877-option-to-choose-environment-spec-plugin
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add config option and cli argument to allow users to select which environment specifier plugin to use. (#14877)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/14877-option-to-choose-environment-spec-plugin
+++ b/news/14877-option-to-choose-environment-spec-plugin
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add config option and cli argument to allow users to select which environment specifier plugin to use. (#14877)
+* Add config option `environment_specifier` and CLI argument (`--environment-specifier, --env-spec`) to allow users to select which environment specifier plugin to use. (#14877)
 
 ### Bug fixes
 

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -302,3 +302,27 @@ def test_protected_dirs_error_for_env_create(
                 "--file",
                 support_file("example/environment_pinned.yml"),
             )
+
+
+def test_create_env_from_non_existent_plugin(
+    conda_cli: CondaCLIFixture,
+    tmp_env: TmpEnvFixture,
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setenv("CONDA_ENVIRONMENT_SPECIFIER", "nonexistent_plugin")
+    with tmp_env() as prefix:
+        with pytest.raises(
+            CondaValueError,
+        ) as excinfo:
+            conda_cli(
+                "env",
+                "create",
+                f"--prefix={prefix}/envs",
+                "--file",
+                support_file("example/environment_pinned.yml"),
+            )
+
+        assert (
+            "You have chosen an unrecognized environment specifier type (nonexistent_plugin)"
+            in str(excinfo.value)
+        )

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -12,7 +12,11 @@ from pytest_mock import MockerFixture
 from conda import plugins
 from conda.common.url import urlparse
 from conda.core import solve
-from conda.exceptions import CondaValueError, EnvironmentSpecPluginNotDetected, PluginError
+from conda.exceptions import (
+    CondaValueError,
+    EnvironmentSpecPluginNotDetected,
+    PluginError,
+)
 from conda.plugins import virtual_packages
 from conda.plugins.manager import CondaPluginManager
 


### PR DESCRIPTION
### Description

This PR:
* adds a cli arg `--env-spec`/`--environment-specifier` to `conda env` commands to users can explicitly select the environment spec plugin they want to use when creating/updating an environment using an environment file
* removes references to the function `env.specs.detect`
* does not substitue improving the environment spec plugin detection process

This PR suggests that environment spec plugin selection works as follows:
* If no plugin is selected, conda should try to detect what environment spec plugin should be used against the file
* If the user requests a specific plugin with the `--env-spec` cli arg or `env_spec` config parameter, conda will try to use the plugin with that name
  * if a environment spec plugin with that name is not registered, return an error
  * if the requested environment spec plugin can not handle the input file, return an error

Here are some examples of this change:

The environment spec plugin is automatically detected if no argument is provided
```
$ conda env create --file tests/env/support/simple.yml
Channels:
 - conda-forge
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done
#
# To activate this environment, use
#
#     $ conda activate nlp
#
# To deactivate an active environment, use
#
#     $ conda deactivate
```

Return an error to the user if an unregistered plugin is requested
```
$ conda env create --file tests/env/support/simple.yml --env-spec idontextis

usage: conda env create [-h] [-f FILE] [-n ENVIRONMENT | -p PATH] [-C] [-k] [--offline]
                        [--env-spec-plugin {binstar,environment.yml,requirements.txt}] [--no-default-packages] [--json]
                        [--console CONSOLE] [-v] [-q] [-d] [-y] [--solver {classic,libmamba}] [--subdir SUBDIR]
                        [remote_definition]
conda env create: error: argument --env-spec-plugin: invalid choice: 'idontextis' (choose from 'binstar', 'environment.yml', 'requirements.txt')
```

Return an error to the user if a plugin that won't work is requested
```
$ conda env create --file tests/env/support/simple.yml --env-spec binstar

PluginError: Requested plugin 'binstar' is unable to handle environment spec 'tests/env/support/simple.yml'
```

Set the environment spec using env vars
```
$ CONDA_ENV_SPEC=idontexist conda env create --file tests/env/support/simple.yml

CondaValueError: You have chosen an unrecognized environment specifier type (idontexist). Choose one of: binstar, environment.yml, requirements.txt
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


