### PR TITLE
Remove `.pyc` and `.pyo` files from altered files

### DIFF
--- a/conda/plugins/subcommands/doctor/health_checks.py
+++ b/conda/plugins/subcommands/doctor/health_checks.py
@@ -97,6 +97,9 @@ def find_altered_packages(prefix: str | Path) -> dict[str, list[str]]:
 
         for path in paths:
             _path = path.get("_path")
+            if excluded_files_check(_path):
+                continue
+
             old_sha256 = path.get("sha256_in_prefix")
             if _path is None or old_sha256 is None:
                 continue

--- a/tests/plugins/subcommands/doctor/test_health_checks.py
+++ b/tests/plugins/subcommands/doctor/test_health_checks.py
@@ -104,10 +104,12 @@ def env_altered_files(
     env_ok: tuple[Path, str, str, str, str],
 ) -> tuple[Path, str, str, str, str]:
     """Fixture that returns a testing environment with altered files"""
-    prefix, _, lib_doctor, _, _ = env_ok
+    prefix, _, lib_doctor, ignored_doctor, _ = env_ok
     # Altering the lib_doctor.py file so that it's sha256 checksum will change
     with open(prefix / lib_doctor, "w") as f:
         f.write("print('Hello, World!')")
+    with open(prefix / ignored_doctor, "w") as f:
+        f.write("nonsense")
 
     return env_ok
 
@@ -192,11 +194,12 @@ def test_no_missing_files_action(
 def test_altered_files_action(
     env_altered_files: tuple[Path, str, str, str, str], capsys, verbose
 ):
-    prefix, _, lib_doctor, _, package = env_altered_files
+    prefix, _, lib_doctor, ignored_doctor, package = env_altered_files
     altered_files(prefix, verbose=verbose)
     captured = capsys.readouterr()
     if verbose:
         assert str(lib_doctor) in captured.out
+        assert str(ignored_doctor) not in captured.out
     else:
         assert f"{package}: 1" in captured.out
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
resolves #14873 

This PR removes `.pyc` and `.pyo` files from the list of altered files in `conda doctor` health report. 
Tests have been updated accordingly

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
