### PR TITLE
Environment spec plugin detection improvements

### DIFF
--- a/conda/env/specs/binstar.py
+++ b/conda/env/specs/binstar.py
@@ -39,22 +39,22 @@ class BinstarSpec(EnvironmentSpecBase):
     def __init__(self, name=None):
         self.name = name
 
-    def can_handle(self) -> bool:
+    def validate_source_name(self) -> bool:
+        return self.valid_name()
+
+    def validate_schema(self) -> bool:
         """
         Validates loader can process environment definition.
         :return: True or False
         """
-        # TODO: log information about trying to find the package in binstar.org
-        if self.valid_name():
-            if not self.binstar:
-                self.msg = (
-                    "Anaconda Client is required to interact with anaconda.org or an "
-                    "Anaconda API. Please run `conda install anaconda-client -n base`."
-                )
-                return False
+        if not self.binstar:
+            self.msg = (
+                "Anaconda Client is required to interact with anaconda.org or an "
+                "Anaconda API. Please run `conda install anaconda-client -n base`."
+            )
+            return False
 
-            return self.package is not None and self.valid_package()
-        return False
+        return self.package is not None and self.valid_package()
 
     def valid_name(self) -> bool:
         """

--- a/conda/env/specs/requirements.py
+++ b/conda/env/specs/requirements.py
@@ -49,9 +49,9 @@ class RequirementsSpec(EnvironmentSpecBase):
         else:
             return True
 
-    def can_handle(self) -> bool:
+    def validate_source_name(self) -> bool:
         """
-        Validates loader can process environment definition.
+        Validates loader can process the spec with the provided filename. 
         This can handle if:
             * the provided file ends in the supported file extensions (.txt)
             * the file exists
@@ -70,6 +70,10 @@ class RequirementsSpec(EnvironmentSpecBase):
             spec_ext == file_ext and os.path.exists(self.filename)
             for spec_ext in RequirementsSpec.extensions
         )
+    
+    def validate_schema(self) -> bool:
+        # no-op
+        return True
 
     @property
     def environment(self):

--- a/conda/env/specs/yaml_file.py
+++ b/conda/env/specs/yaml_file.py
@@ -19,14 +19,12 @@ class YamlFileSpec(EnvironmentSpecBase):
         self.filename = filename
         self.msg = None
 
-    def can_handle(self):
+    def validate_source_name(self) -> bool:
         """
-        Validates loader can process environment definition.
-        This can handle if:
+        Validates loader can process the spec with the provided filename. 
+        Valid if:
             * the provided file exists
             * the provided file ends in the supported file extensions (.yaml or .yml)
-            * the env file can be interpreted and transformed into
-              a `conda.env.env.Environment`
 
         :return: True or False
         """
@@ -36,7 +34,18 @@ class YamlFileSpec(EnvironmentSpecBase):
         # Check if the file has a supported extension and exists
         if not any(spec_ext == file_ext for spec_ext in YamlFileSpec.extensions):
             return False
+        
+        return True
 
+    def validate_schema(self) -> bool:
+        """
+        Validates loader can process the spec with the provided filename. 
+        Valid if:
+            * the env file can be interpreted and transformed into
+              a `conda.env.env.Environment`
+
+        :return: True or False
+        """
         try:
             self._environment = env.from_file(self.filename)
             return True
@@ -49,5 +58,5 @@ class YamlFileSpec(EnvironmentSpecBase):
     @property
     def environment(self):
         if not self._environment:
-            self.can_handle()
+            self._environment = env.from_file(self.filename)
         return self._environment

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -519,9 +519,9 @@ class CondaPluginManager(pluggy.PluginManager):
         found = []
         for hook in hooks:
             log.debug("EnvironmentSpec hook: checking %s", hook.name)
-            if hook.environment_spec(filename).can_handle():
+            if hook.environment_spec(filename).validate_source_name() and hook.environment_spec(filename).validate_schema():
                 log.debug(
-                    "EnvironmentSpec hook: %s can be %s",
+                    "EnvironmentSpec hook: %s can be handled by %s",
                     filename,
                     hook.name,
                 )

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -419,12 +419,24 @@ class EnvironmentSpecBase(ABC):
     """
 
     @abstractmethod
-    def can_handle(self) -> bool:
+    def validate_source_name(self) -> bool:
         """
-        Determines if the EnvSpec plugin can read and operate on the
-        environment described by the `filename`.
+        Determine if the EnvironmentSpec plugin can parse the target
+        source name. If the source spec is a filename, this check
+        may be used to ensure the file has the right extension and format.
 
-        :returns bool: returns True, if the plugin can interpret the file.
+        :returns bool: returns True, if the plugin can interpret the source
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def validate_schema(self) -> bool:
+        """
+        Determine if the EnvironmentSpec plugin can parse the contents of
+        the source spec. This check may be used to ensure that the provided
+        spec has all the correct fields for parsing to an Environment.
+
+        :returns bool: returns True, if the plugin can interpret the source
         """
         raise NotImplementedError()
 

--- a/tests/env/specs/test_binstar.py
+++ b/tests/env/specs/test_binstar.py
@@ -28,7 +28,7 @@ def test_cannot_handle_file_path():
     assert spec.valid_name() is False
 
 
-def test_can_handle_binstar_name():
+def test_valid_name_binstar_name():
     spec = binstar.BinstarSpec("conda-test/test")
     assert spec.valid_name()
 

--- a/tests/env/specs/test_requirements.py
+++ b/tests/env/specs/test_requirements.py
@@ -9,18 +9,20 @@ from .. import support_file
 
 def test_no_environment_file():
     spec = RequirementsSpec(name=None, filename="not-a-file")
-    assert not spec.can_handle()
+    assert not spec.validate_source_name()
 
 
 def test_no_name():
     spec = RequirementsSpec(filename=support_file("requirements.txt"))
-    assert spec.can_handle()
+    assert spec.validate_source_name()
+    assert spec.validate_schema()
     assert spec.name is None  # this is caught in the application layer
 
 
 def test_req_file_and_name():
     spec = RequirementsSpec(filename=support_file("requirements.txt"), name="env")
-    assert spec.can_handle()
+    assert spec.validate_source_name()
+    assert spec.validate_schema()
 
 
 def test_environment():

--- a/tests/env/specs/test_yaml_file.py
+++ b/tests/env/specs/test_yaml_file.py
@@ -10,17 +10,18 @@ from .. import support_file
 
 def test_no_environment_file():
     spec = YamlFileSpec(name=None, filename="not-a-file")
-    assert not spec.can_handle()
+    assert not spec.validate_source_name()
 
 
 def test_environment_file_exist():
     spec = YamlFileSpec(name=None, filename=support_file("simple.yml"))
-    assert spec.can_handle()
+    assert spec.validate_source_name()
+    assert spec.validate_schema()
 
 
 def test_environment_file_not_yaml():
     spec = YamlFileSpec(name=None, filename=support_file("requirements.txt"))
-    assert not spec.can_handle()
+    assert not spec.validate_source_name()
 
 
 def test_get_environment():

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -14,11 +14,14 @@ class RandomSpec(EnvironmentSpecBase):
     def __init__(self, filename: str):
         self.filename = filename
 
-    def can_handle(self):
+    def validate_source_name(self):
         for ext in RandomSpec.extensions:
             if self.filename.endswith(ext):
                 return True
         return False
+    
+    def validate_schema(self):
+        return True
 
     def environment(self):
         return Environment(name="random-environment", dependencies=["python", "numpy"])


### PR DESCRIPTION
### Description

This PR suggests some improvements to conda's environment spec detection system. conda expands the environment spec plugin interface to have a more opinionated set of validations for determining an environment spec plugin. So, instead of `can_handle`, a plugin must implement `validate_filename`, `validate_schema`. 

ref: https://docs.google.com/document/d/1LtB2QKuF72FsnuBzWYsw4wOL2w_boyvYys5taiOE2zE/edit?tab=t.0

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

