### PR TITLE
Mark environment spec hooks and types as experimental

### DIFF
--- a/conda/plugins/environment_specifiers/binstar.py
+++ b/conda/plugins/environment_specifiers/binstar.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 """
-**EXPERIMENTAL** 
+**EXPERIMENTAL**
 Register the conda env spec for binstar specs.
 """
 

--- a/conda/plugins/environment_specifiers/binstar.py
+++ b/conda/plugins/environment_specifiers/binstar.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""Register the conda env spec for requirements.txt files."""
+"""
+**EXPERIMENTAL** 
+Register the conda env spec for binstar specs.
+"""
 
 from .. import CondaEnvironmentSpecifier, hookimpl
 

--- a/conda/plugins/environment_specifiers/environment_yml.py
+++ b/conda/plugins/environment_specifiers/environment_yml.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""Register the conda env spec for environment.yml files."""
+"""
+**EXPERIMENTAL**
+Register the conda env spec for environment.yml files.
+"""
 
 from .. import CondaEnvironmentSpecifier, hookimpl
 

--- a/conda/plugins/environment_specifiers/requirements_txt.py
+++ b/conda/plugins/environment_specifiers/requirements_txt.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""Register the conda env spec for requirements.txt files."""
+"""
+**EXPERIMENTAL**
+Register the conda env spec for requirements.txt files.
+"""
 
 from .. import CondaEnvironmentSpecifier, hookimpl
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -614,6 +614,7 @@ class CondaSpecs:
     @_hookspec
     def conda_environment_specifiers(self) -> Iterable[CondaEnvironmentSpecifier]:
         """
+        **EXPERIMENTAL**
         Register new conda env spec type
 
         The example below defines a type of conda env file called "random". It

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -444,7 +444,7 @@ class EnvironmentSpecBase(ABC):
 class CondaEnvironmentSpecifier:
     """
     **EXPERIMENTAL**
-    
+
     Return type to use when defining a conda env spec plugin hook.
 
     For details on how this is used, see

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -415,6 +415,8 @@ class CondaPrefixDataLoader:
 
 class EnvironmentSpecBase(ABC):
     """
+    **EXPERIMENTAL**
+
     Base class for all env specs.
     """
 
@@ -441,6 +443,8 @@ class EnvironmentSpecBase(ABC):
 @dataclass
 class CondaEnvironmentSpecifier:
     """
+    **EXPERIMENTAL**
+    
     Return type to use when defining a conda env spec plugin hook.
 
     For details on how this is used, see

--- a/news/14900-mark-environment-spec-experimental
+++ b/news/14900-mark-environment-spec-experimental
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Mark environment spec hooks and types as experimental (#14900)
+
+### Other
+
+* <news item>


### PR DESCRIPTION

### Description

Marks the environment_spec hooks and related interfaces as experimental. 

While there is still discussion around [how conda ought to handle this going forward](https://github.com/conda/conda/issues/14895), this simply notes that these interfaces are experimental in the docstrings. 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
