### PR TITLE
Replace hard-coded `C:\ProgramData` for `.condarc` search paths

### DIFF
--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -37,7 +37,7 @@ APP_NAME: Final = "conda"
 
 SEARCH_PATH: tuple[str, ...] = ()
 
-if on_win and (PROGRAMDATA := environ.get("PROGRAMDATA")):  # pragma: no cover
+if on_win and (PROGRAMDATA := environ.get("ProgramData")):  # pragma: no cover
     PROGRAMDATA = PureWindowsPath(PROGRAMDATA).as_posix()
     SEARCH_PATH += (
         f"{PROGRAMDATA}/conda/.condarc",

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import struct
 from enum import Enum, EnumMeta
+from os import environ
 from os.path import join
+from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
 
 from ..common.compat import on_win
@@ -33,16 +35,17 @@ machine_bits: Final = 8 * struct.calcsize("P")
 
 APP_NAME: Final = "conda"
 
-SEARCH_PATH: tuple[str, ...]
+SEARCH_PATH: tuple[str, ...] = ()
 
-if on_win:  # pragma: no cover
-    SEARCH_PATH = (
-        "C:/ProgramData/conda/.condarc",
-        "C:/ProgramData/conda/condarc",
-        "C:/ProgramData/conda/condarc.d",
+if on_win and (PROGRAMDATA := environ.get("PROGRAMDATA")):  # pragma: no cover
+    PROGRAMDATA = PureWindowsPath(PROGRAMDATA).as_posix()
+    SEARCH_PATH += (
+        f"{PROGRAMDATA}/conda/.condarc",
+        f"{PROGRAMDATA}/conda/condarc",
+        f"{PROGRAMDATA}/conda/condarc.d",
     )
 else:
-    SEARCH_PATH = (
+    SEARCH_PATH += (
         "/etc/conda/.condarc",
         "/etc/conda/condarc",
         "/etc/conda/condarc.d/",

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -35,17 +35,19 @@ machine_bits: Final = 8 * struct.calcsize("P")
 
 APP_NAME: Final = "conda"
 
-SEARCH_PATH: tuple[str, ...] = ()
+SEARCH_PATH: tuple[str, ...]
 
-if on_win and (PROGRAMDATA := environ.get("ProgramData")):  # pragma: no cover
-    PROGRAMDATA = PureWindowsPath(PROGRAMDATA).as_posix()
-    SEARCH_PATH += (
+if on_win:  # pragma: no cover
+    PROGRAMDATA = PureWindowsPath(
+        environ.get("ProgramData", r"C:\ProgramData")
+    ).as_posix()
+    SEARCH_PATH = (
         f"{PROGRAMDATA}/conda/.condarc",
         f"{PROGRAMDATA}/conda/condarc",
         f"{PROGRAMDATA}/conda/condarc.d",
     )
 else:
-    SEARCH_PATH += (
+    SEARCH_PATH = (
         "/etc/conda/.condarc",
         "/etc/conda/condarc",
         "/etc/conda/condarc.d/",

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 import struct
 from enum import Enum, EnumMeta
-from os import environ
 from os.path import join
-from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
 
 from ..common.compat import on_win
+
+if on_win:
+    from pathlib import PureWindowsPath
+    from platformdirs import site_config_dir
 
 if TYPE_CHECKING:
     from typing import Final
@@ -38,13 +40,13 @@ APP_NAME: Final = "conda"
 SEARCH_PATH: tuple[str, ...]
 
 if on_win:  # pragma: no cover
-    PROGRAMDATA = PureWindowsPath(
-        environ.get("ProgramData", r"C:\ProgramData")
+    CONDA_SITE_CONFIG_DIR = PureWindowsPath(
+        site_config_dir(appname="conda", appauthor=False)
     ).as_posix()
     SEARCH_PATH = (
-        f"{PROGRAMDATA}/conda/.condarc",
-        f"{PROGRAMDATA}/conda/condarc",
-        f"{PROGRAMDATA}/conda/condarc.d",
+        f"{CONDA_SITE_CONFIG_DIR}/.condarc",
+        f"{CONDA_SITE_CONFIG_DIR}/condarc",
+        f"{CONDA_SITE_CONFIG_DIR}/condarc.d",
     )
 else:
     SEARCH_PATH = (

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -19,6 +19,7 @@ from ..common.compat import on_win
 
 if on_win:
     from pathlib import PureWindowsPath
+
     from platformdirs import site_config_dir
 
 if TYPE_CHECKING:

--- a/docs/source/user-guide/configuration/use-condarc.rst
+++ b/docs/source/user-guide/configuration/use-condarc.rst
@@ -101,9 +101,9 @@ Conda looks in the following locations for a ``.condarc`` file:
 
   if on_win:
       SEARCH_PATH = (
-          "C:/ProgramData/conda/.condarc",
-          "C:/ProgramData/conda/condarc",
-          "C:/ProgramData/conda/condarc.d",
+          "$PROGRAMDATA/conda/.condarc",
+          "$PROGRAMDATA/conda/condarc",
+          "$PROGRAMDATA/conda/condarc.d",
       )
   else:
       SEARCH_PATH = (
@@ -141,6 +141,7 @@ to $HOME/.config should be used.
 ``CONDA_ROOT`` is the path for your base conda install.
 ``CONDA_PREFIX`` is the path to the current active environment.
 ``CONDARC`` must be a path to a file named ``.condarc``, ``condarc``, or end with a YAML suffix (``.yml`` or ``.yaml``).
+``PROGRAMDATA`` is the path to the ``ProgramData`` directory on Windows, typically ``C:\ProgramData``.
 
 .. note::
    Any condarc files that exist in any of these special search path

--- a/news/14902-use-programdata-envvar
+++ b/news/14902-use-programdata-envvar
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Use `%PROGRAMDATA%` environment variable instead of hard-coding `C:\ProgramData` for `.condarc` search paths. (#14902)
+* Use `%PROGRAMDATA%` environment variable instead of hard-coding `C:\ProgramData` for `.condarc` search paths. (#14912 via #14902)

--- a/news/14902-use-programdata-envvar
+++ b/news/14902-use-programdata-envvar
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Use `%PROGRAMDATA%` environment variable instead of hard-coding `C:\ProgramData` for `.condarc` search paths. (#14902)


### PR DESCRIPTION
### Description

The search paths for `.condarc` files contain hard-coded paths for `ProgramData`. While that path is correct for most systems, it is possible to redirect that directory to a different drive, e.g., because disk space in the system drive is full or dual boots. A more robust approach is using known folder IDs as implemented by `platformdirs`.

Closes #14912 

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [X] Add / update outdated documentation?
