### PR TITLE
Replace `get_index` and `get_reduced_index` usage

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -27,9 +27,8 @@ from ..base.context import context
 from ..common.constants import NULL
 from ..common.path import is_package_file
 from ..core.index import (
-    _supplement_index_with_prefix,
+    Index,
     calculate_channel_urls,
-    get_index,
 )
 from ..core.link import PrefixSetup, UnlinkLinkTransaction
 from ..core.prefix_data import PrefixData
@@ -493,13 +492,16 @@ def install_revision(args, parser):
     for repodata_fn in Repodatas(repodata_fns, index_args):
         with repodata_fn as repodata:
             with get_spinner(f"Collecting package metadata ({repodata})"):
-                index = get_index(
-                    channel_urls=index_args["channel_urls"],
+                index = Index(
+                    channels=index_args["channel_urls"],
                     prepend=index_args["prepend"],  # --override-channels
                     platform=None,
-                    use_local=index_args["use_local"],  # --use-local
+                    # these options were commented out in the version of this
+                    # code bit that used the now-deprecated `get_index` function
+                    # we have left them here so that this information is not lost
                     # use_cache=index_args["use_cache"],  # --use-index-cache
                     # unknown=index_args["unknown"],  # --unknown
+                    use_local=index_args["use_local"],
                     prefix=prefix,
                     repodata_fn=repodata,
                 )
@@ -510,7 +512,7 @@ def install_revision(args, parser):
     handle_txn(unlink_link_transaction, prefix, args, newenv=False)
 
 
-def revert_actions(prefix, revision=-1, index=None):
+def revert_actions(prefix, revision=-1, index: Index | None = None):
     # TODO: If revision raise a revision error, should always go back to a safe revision
     h = History(prefix)
     # TODO: need a History method to get user-requested specs for revision number
@@ -526,7 +528,8 @@ def revert_actions(prefix, revision=-1, index=None):
     except IndexError:
         raise CondaIndexError("no such revision: %d" % revision)
 
-    _supplement_index_with_prefix(index, prefix)
+    if index is not None:
+        index.reload(prefix=True)
 
     not_found_in_index_specs = set()
     link_precs = set()

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -210,7 +210,7 @@ def get_info_dict() -> dict[str, Any]:
     )
     from ..common.compat import on_win
     from ..common.url import mask_anaconda_token
-    from ..core.index import _supplement_index_with_system
+    from ..core.index import Index
     from ..models.channel import all_channel_urls, offline_keep
 
     try:
@@ -223,8 +223,7 @@ def get_info_dict() -> dict[str, Any]:
         log.error("Error importing conda-build: %s", err)
         conda_build_version = "error"
 
-    virtual_pkg_index = {}
-    _supplement_index_with_system(virtual_pkg_index)
+    virtual_pkg_index = Index().system_packages
     virtual_pkgs = [[p.name, p.version, p.build] for p in virtual_pkg_index.values()]
 
     channels = list(all_channel_urls(context.channels))

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -37,7 +37,7 @@ from ..models.prefix_graph import PrefixGraph
 from ..models.version import VersionOrder
 from ..reporters import get_spinner
 from ..resolve import Resolve
-from .index import _supplement_index_with_system, get_reduced_index
+from .index import Index, ReducedIndex
 from .link import PrefixSetup, UnlinkLinkTransaction
 from .prefix_data import PrefixData
 from .subdir_data import SubdirData
@@ -64,6 +64,9 @@ class Solver:
       * :meth:`solve_for_diff`
       * :meth:`solve_for_transaction`
     """
+
+    _index: ReducedIndex | None
+    _r: Resolve | None
 
     def __init__(
         self,
@@ -536,8 +539,7 @@ class Solver:
                     ssc.specs_map[pkg_name] = MatchSpec(pkg_name)
 
             # Add virtual packages so they are taken into account by the solver
-            virtual_pkg_index = {}
-            _supplement_index_with_system(virtual_pkg_index)
+            virtual_pkg_index = Index().system_packages
             virtual_pkgs = [p.name for p in virtual_pkg_index.keys()]
             for virtual_pkgs_name in virtual_pkgs:
                 if virtual_pkgs_name not in ssc.specs_map:
@@ -1261,7 +1263,7 @@ class Solver:
                     file=sys.stderr,
                 )
 
-    def _prepare(self, prepared_specs):
+    def _prepare(self, prepared_specs) -> tuple[ReducedIndex, Resolve]:
         # All of this _prepare() method is hidden away down here. Someday we may want to further
         # abstract away the use of `index` or the Resolve object.
 
@@ -1271,7 +1273,6 @@ class Solver:
         if hasattr(self, "_index") and self._index:
             # added in install_actions for conda-build back-compat
             self._prepared_specs = prepared_specs
-            _supplement_index_with_system(self._index)
             self._r = Resolve(self._index, channels=self.channels)
         else:
             # add in required channels that aren't explicitly given in the channels list
@@ -1288,17 +1289,18 @@ class Solver:
 
             self.channels.update(additional_channels)
 
-            reduced_index = get_reduced_index(
-                self.prefix,
-                self.channels,
-                self.subdirs,
-                prepared_specs,
-                self._repodata_fn,
-            )
-            _supplement_index_with_system(reduced_index)
-
             self._prepared_specs = prepared_specs
-            self._index = reduced_index
+            self._index = reduced_index = ReducedIndex(
+                prepared_specs,
+                channels=self.channels,
+                prepend=False,
+                subdirs=self.subdirs,
+                use_local=False,
+                use_cache=False,
+                prefix=self.prefix,
+                repodata_fn=self._repodata_fn,
+                use_system=True,
+            )
             self._r = Resolve(reduced_index, channels=self.channels)
 
         self._prepared = True

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -16,7 +16,7 @@ from .common.compat import on_mac, on_win, open_utf8
 from .common.io import dashlist
 from .common.path import expand
 from .common.url import is_url, join_url, path_to_url
-from .core.index import get_index
+from .core.index import Index
 from .core.link import PrefixSetup, UnlinkLinkTransaction
 from .core.package_cache_data import PackageCacheData, ProgressiveFetchExtract
 from .core.prefix_data import PrefixData
@@ -285,7 +285,8 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
     notfound = []
     if unknowns:
         index_args = index_args or {}
-        index = get_index(**index_args)
+        index_args["channels"] = index_args.pop("channel_urls")
+        index = Index(**index_args)
 
         for prec in unknowns:
             spec = MatchSpec(name=prec.name, version=prec.version, build=prec.build)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def support_file_server_port(
 
 
 @pytest.fixture
-def clear_cuda_version():
+def clear_cuda_version() -> None:
     from conda.plugins.virtual_packages import cuda
 
     cuda.cached_cuda_version.cache_clear()

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -12,7 +12,6 @@ import pytest
 import conda
 from conda.base.context import context, non_x86_machines
 from conda.common.compat import on_linux, on_mac, on_win
-from conda.common.io import env_vars
 from conda.core.index import (
     Index,
     _make_virtual_package,
@@ -23,7 +22,6 @@ from conda.core.index import (
     check_allowlist,
     dist_str_in_index,
     fetch_index,
-    get_index,
     get_reduced_index,
 )
 from conda.core.prefix_data import PrefixData
@@ -40,7 +38,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
 
-    from pytest import FixtureRequest
+    from pytest import FixtureRequest, MonkeyPatch
 
     from conda.core.index import ReducedIndex
 
@@ -147,9 +145,15 @@ def patch_pkg_cache(mocker, pkg_cache_entries):
     mocker.patch("conda.base.context.context.track_features", ("test_feature",))
 
 
-def test_supplement_index_with_system():
-    index = {}
-    _supplement_index_with_system(index)
+def test_deprecated_supplement_index_with_system() -> None:
+    index: dict[PackageRecord, PackageRecord] = {}
+    with pytest.deprecated_call():
+        _supplement_index_with_system(index)
+    assert index == Index().system_packages
+
+
+def test_supplement_index_with_system() -> None:
+    index = Index().system_packages
 
     has_virtual_pkgs = {
         rec.name for rec in index if rec.package_type == PackageType.VIRTUAL_SYSTEM
@@ -166,19 +170,19 @@ def test_supplement_index_with_system():
     context.subdir.split("-", 1)[1] not in {"32", "64", *non_x86_machines},
     reason=f"archspec not available for subdir {context.subdir}",
 )
-def test_supplement_index_with_system_archspec():
-    index = {}
-    _supplement_index_with_system(index)
+def test_supplement_index_with_system_archspec() -> None:
+    index = Index().system_packages
     assert any(
         rec.package_type == PackageType.VIRTUAL_SYSTEM and rec.name == "__archspec"
         for rec in index
     )
 
 
-def test_supplement_index_with_system_cuda(clear_cuda_version):
-    index = {}
-    with env_vars({"CONDA_OVERRIDE_CUDA": "3.2"}):
-        _supplement_index_with_system(index)
+def test_supplement_index_with_system_cuda(
+    clear_cuda_version: None, monkeypatch: MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "3.2")
+    index = Index().system_packages
 
     cuda_pkg = next(iter(_ for _ in index if _.name == "__cuda"))
     assert cuda_pkg.version == "3.2"
@@ -186,10 +190,9 @@ def test_supplement_index_with_system_cuda(clear_cuda_version):
 
 
 @pytest.mark.skipif(not on_mac, reason="osx-only test")
-def test_supplement_index_with_system_osx():
-    index = {}
-    with env_vars({"CONDA_OVERRIDE_OSX": "0.15"}):
-        _supplement_index_with_system(index)
+def test_supplement_index_with_system_osx(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("CONDA_OVERRIDE_OSX", "0.15")
+    index = Index().system_packages
 
     osx_pkg = next(iter(_ for _ in index if _.name == "__osx"))
     assert osx_pkg.version == "0.15"
@@ -211,10 +214,11 @@ def test_supplement_index_with_system_osx():
         ("9.a.1", "0"),
     ],
 )
-def test_supplement_index_with_system_linux(release_str, version):
-    index = {}
-    with env_vars({"CONDA_OVERRIDE_LINUX": release_str}):
-        _supplement_index_with_system(index)
+def test_supplement_index_with_system_linux(
+    release_str: str, version: str, monkeypatch: MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CONDA_OVERRIDE_LINUX", release_str)
+    index = Index().system_packages
 
     linux_pkg = next(iter(_ for _ in index if _.name == "__linux"))
     assert linux_pkg.version == version
@@ -222,10 +226,9 @@ def test_supplement_index_with_system_linux(release_str, version):
 
 
 @pytest.mark.skipif(on_win or on_mac, reason="linux-only test")
-def test_supplement_index_with_system_glibc():
-    index = {}
-    with env_vars({"CONDA_OVERRIDE_GLIBC": "2.10"}):
-        _supplement_index_with_system(index)
+def test_supplement_index_with_system_glibc(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.10")
+    index = Index().system_packages
 
     glibc_pkg = next(iter(_ for _ in index if _.name == "__glibc"))
     assert glibc_pkg.version == "2.10"
@@ -233,43 +236,32 @@ def test_supplement_index_with_system_glibc():
 
 
 @pytest.mark.integration
-def test_get_index_linux64_platform():
-    linux64 = "linux-64"
-    index = get_index(platform=linux64)
+@pytest.mark.parametrize("platform", ["linux-64", "osx-64", "win-64"])
+def test_get_index_platform(platform: str) -> None:
+    index = Index(platform=platform)
     for dist, record in index.items():
-        assert platform_in_record(linux64, record), (linux64, record.url)
-
-
-@pytest.mark.integration
-def test_get_index_osx64_platform():
-    osx64 = "osx-64"
-    index = get_index(platform=osx64)
-    for dist, record in index.items():
-        assert platform_in_record(osx64, record), (osx64, record.url)
-
-
-@pytest.mark.integration
-def test_get_index_win64_platform():
-    win64 = "win-64"
-    index = get_index(platform=win64)
-    for dist, record in index.items():
-        assert platform_in_record(win64, record), (win64, record.url)
+        assert platform_in_record(platform, record), (platform, record.url)
 
 
 @pytest.mark.integration
 def test_basic_get_reduced_index():
-    get_reduced_index(
-        None,
-        (Channel("defaults"), Channel("conda-test")),
-        context.subdirs,
-        (MatchSpec("flask"),),
-        "repodata.json",
-    )
+    """
+    TODO: test should be removed when `get_reduced_index` is removed.
+    """
+    with pytest.deprecated_call():
+        get_reduced_index(
+            None,
+            (Channel("defaults"), Channel("conda-test")),
+            context.subdirs,
+            (MatchSpec("flask"),),
+            "repodata.json",
+        )
 
 
 def test_fetch_index(test_recipes_channel: Path) -> None:
-    idx = fetch_index(Channel(str(test_recipes_channel)).urls())
-    assert len(idx) == 25
+    with pytest.deprecated_call():
+        idx = fetch_index(Channel(str(test_recipes_channel)).urls())
+        assert len(idx) == 25
 
 
 def test_dist_str_in_index(test_recipes_channel: Path) -> None:
@@ -293,10 +285,13 @@ def test__supplement_index_with_prefix(
     )
     pkg_spec = "dependent=2.0"
     index = {ref: ref}
-    with tmp_env(pkg_spec) as prefix:
-        _supplement_index_with_prefix(index, prefix)
-    with tmp_env(pkg_spec) as prefix:
-        _supplement_index_with_prefix(index, PrefixData(prefix))
+
+    with pytest.deprecated_call():
+        with tmp_env(pkg_spec) as prefix:
+            _supplement_index_with_prefix(index, prefix)
+        with tmp_env(pkg_spec) as prefix:
+            _supplement_index_with_prefix(index, PrefixData(prefix))
+
     pkg = index[ref]
     assert type(ref) is PackageRecord
     assert type(pkg) is PrefixRecord
@@ -318,12 +313,13 @@ def test__supplement_index_with_prefix_index_class(
     )
     index = Index()
     pkg_spec = "dependent=2.0"
-    with tmp_env(pkg_spec) as prefix:
-        with pytest.raises(OperationNotAllowed):
+    with pytest.deprecated_call():
+        with tmp_env(pkg_spec) as prefix:
+            with pytest.raises(OperationNotAllowed):
+                _supplement_index_with_prefix(index, prefix)
+        with tmp_env(pkg_spec) as prefix:
+            index = Index(prefix=prefix)
             _supplement_index_with_prefix(index, prefix)
-    with tmp_env(pkg_spec) as prefix:
-        index = Index(prefix=prefix)
-        _supplement_index_with_prefix(index, prefix)
     pkg = index[ref]
     assert type(ref) is PackageRecord
     assert type(pkg) is PrefixRecord
@@ -332,11 +328,14 @@ def test__supplement_index_with_prefix_index_class(
 
 def test__supplement_index_with_cache():
     idx = {}
-    _supplement_index_with_cache(idx)
+    with pytest.deprecated_call():
+        _supplement_index_with_cache(idx)
+        _supplement_index_with_cache(idx)
     tzdata = [p for p in idx.values() if p.name == "tzdata"][0]
     tzdata = PackageRecord.from_objects(tzdata)
     idx = {tzdata: tzdata}
-    _supplement_index_with_cache(idx)
+    with pytest.deprecated_call():
+        _supplement_index_with_cache(idx)
     augmented_tzdata = idx[tzdata]
     assert type(tzdata) is PackageRecord
     assert type(augmented_tzdata) is PackageCacheRecord
@@ -344,7 +343,13 @@ def test__supplement_index_with_cache():
 
 
 def test__make_virtual_package():
-    virtual_package = _make_virtual_package("name", "1.0", "0")
+    """
+    Ensures that the deprecated call and the new call are equivalent.
+
+    TODO: Remove this test when the deprecated call is removed.
+    """
+    with pytest.deprecated_call():
+        virtual_package = _make_virtual_package("name", "1.0", "0")
     ref = PackageRecord.virtual_package("name", "1.0", "0")
     assert virtual_package == ref
 
@@ -359,7 +364,7 @@ def test_calculate_channel_urls():
 @pytest.mark.integration
 def test_get_index_lazy():
     subdir = PLATFORMS[(platform.system(), platform.machine())]
-    index = get_index(channel_urls=["conda-forge"], platform=subdir)
+    index = Index(channels=["conda-forge"], platform=subdir)
     main_prec = PackageRecord(**DEFAULTS_SAMPLE_PACKAGES[subdir])
     conda_forge_prec = PackageRecord(**CONDAFORGE_SAMPLE_PACKAGES[subdir])
 

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -13,7 +13,7 @@ from conda.base.constants import PACKAGE_CACHE_MAGIC_FILE
 from conda.base.context import context, reset_context
 from conda.common.compat import on_win
 from conda.core import package_cache_data
-from conda.core.index import get_index
+from conda.core.index import Index
 from conda.core.package_cache_data import (
     PackageCacheData,
     PackageCacheRecord,
@@ -86,7 +86,7 @@ def test_ProgressiveFetchExtract_prefers_conda_v2_format(monkeypatch: MonkeyPatc
     assert not context.use_only_tar_bz2
     assert context.subdir == "linux-64"
 
-    index = get_index([CONDA_PKG_REPO], prepend=False)
+    index = Index(channels=[CONDA_PKG_REPO], prepend=False)
     rec = next(iter(index))
     for rec in index:
         # zlib is the one package in the test index that has a .conda file record

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -55,12 +55,12 @@ def plugin(plugin_manager):
 
 
 def test_invoked(plugin):
-    index = conda.core.index.get_reduced_index(
-        context.default_prefix,
-        context.default_channels,
-        context.subdirs,
-        (),
-        context.repodata_fns[0],
+    index = conda.core.index.ReducedIndex(
+        prefix=context.default_prefix,
+        channels=context.default_channels,
+        subdirs=context.subdirs,
+        specs=(),
+        repodata_fn=context.repodata_fns[0],
     )
 
     packages = package_dict(index)
@@ -78,12 +78,12 @@ def test_duplicated(plugin_manager):
     with pytest.raises(
         PluginError, match=re.escape("Conflicting `virtual_packages` plugins found")
     ):
-        conda.core.index.get_reduced_index(
-            context.default_prefix,
-            context.default_channels,
-            context.subdirs,
-            (),
-            context.repodata_fns[0],
+        conda.core.index.ReducedIndex(
+            prefix=context.default_prefix,
+            channels=context.default_channels,
+            subdirs=context.subdirs,
+            specs=(),
+            repodata_fn=context.repodata_fns[0],
         )
 
 
@@ -106,15 +106,17 @@ def test_cuda_override_none(clear_cuda_version):
 
 
 def get_virtual_precs() -> Iterable[PackageRecord]:
+    index = conda.core.index.ReducedIndex(
+        prefix=context.default_prefix,
+        channels=context.default_channels,
+        subdirs=context.subdirs,
+        specs=(),
+        repodata_fn=context.repodata_fns[0],
+    )
+
     yield from (
         prec
-        for prec in conda.core.index.get_reduced_index(
-            context.default_prefix,
-            context.default_channels,
-            context.subdirs,
-            (),
-            context.repodata_fns[0],
-        )
+        for prec in index
         if prec.channel.name == "@" and prec.name.startswith("__")
     )
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -39,7 +39,7 @@ from conda.common.path import (
     pyc_path,
 )
 from conda.common.serialize import json_dump, yaml_round_trip_load
-from conda.core.index import get_reduced_index
+from conda.core.index import ReducedIndex
 from conda.core.package_cache_data import PackageCacheData
 from conda.core.prefix_data import PrefixData, get_python_version_for_prefix
 from conda.exceptions import (
@@ -791,7 +791,17 @@ def test_strict_channel_priority(
 def test_strict_resolve_get_reduced_index(monkeypatch: MonkeyPatch):
     channels = (Channel("defaults"),)
     specs = (MatchSpec("anaconda"),)
-    index = get_reduced_index(None, channels, context.subdirs, specs, "repodata.json")
+    index = ReducedIndex(
+        specs,
+        channels=channels,
+        prepend=False,
+        subdirs=context.subdirs,
+        use_local=False,
+        use_cache=None,
+        prefix=None,
+        repodata_fn="repodata.json",
+        use_system=True,
+    )
     r = Resolve(index, channels=channels)
 
     monkeypatch.setenv("CONDA_CHANNEL_PRIORITY", "strict")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Followup to https://github.com/conda/conda/pull/13880

Stop using deprecated `conda.core.index.get_index` and `conda.core.index.get_reduced_index`.

Extracted from https://github.com/conda/conda/pull/12771

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
