### PR TITLE
delay environment activation in dev setup

### DIFF
--- a/dev/start
+++ b/dev/start
@@ -273,7 +273,7 @@ fi
 
 # initialize conda command
 echo "Initializing shell integration..."
-eval "$("${_ENVEXE}" shell.bash hook)" > /dev/null
+eval "$(CONDA_AUTO_ACTIVATE=0 "${_ENVEXE}" shell.bash hook)" > /dev/null
 if ! [ $? = 0 ]; then
     echo "Error: failed to initialize shell integration" 1>&2
     return 1

--- a/dev/start.bat
+++ b/dev/start.bat
@@ -180,7 +180,7 @@
 
 :: initialize conda command
 @ECHO Initializing shell integration...
-@SET CONDA_AUTO_ACTIVATE=0
+@SET "CONDA_AUTO_ACTIVATE=0"
 @CALL "%_CONDAHOOK%"
 @SET CONDA_AUTO_ACTIVATE=
 @IF NOT %ErrorLevel%==0 (

--- a/dev/start.bat
+++ b/dev/start.bat
@@ -180,7 +180,9 @@
 
 :: initialize conda command
 @ECHO Initializing shell integration...
+@SET CONDA_AUTO_ACTIVATE=0
 @CALL "%_CONDAHOOK%"
+@SET CONDA_AUTO_ACTIVATE=
 @IF NOT %ErrorLevel%==0 (
     @ECHO Error: failed to initialize shell integration 1>&2
     @EXIT /B 1

--- a/news/14910-delay-environment-activation-in-dev-setup
+++ b/news/14910-delay-environment-activation-in-dev-setup
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Delay environment activation in dev setup to avoid issues when `default_activation_env` is set (#14910)


### PR DESCRIPTION
### Description

Do not activate an environment when initializing the shell integration in the dev script. This activation will use the `default_activation_env` environment name which may not exist in the bootstrap install causing the script to fail. The development base environment is explicitly activated in the next block.

Example behavior without this script with `default_activation_env: work` configured:

```
❯ . dev/start
Deactivating 1 environment(s)...
Update shell scripts...
Initializing shell integration...

EnvironmentNameNotFound: Could not find conda environment: work
You can list all discoverable environments with `conda info --envs`.


Error: failed to initialize shell integration
```

With this change:
```
❯ . dev/start
Deactivating 1 environment(s)...
Update shell scripts...
Initializing shell integration...
Activating devenv-3.10-c...
```

### Checklist - did you ...


- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
