### PR TITLE
Introduce dataclass to represent an environment config

### DIFF
--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -12,8 +12,6 @@ from ..base.constants import PLATFORMS
 from ..exceptions import CondaValueError
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from ..base.constants import (
         DepsModifier,
         ChannelPriority,
@@ -38,9 +36,9 @@ class EnvironmentConfig:
 
     aggressive_update_packages: bool | None = None
 
-    channel_priority:  ChannelPriority | None = None
+    channel_priority: ChannelPriority | None = None
 
-    channels: list[str]  = field(default_factory=list)
+    channels: list[str] = field(default_factory=list)
 
     channel_settings: dict[str, str] = field(default_factory=dict)
 
@@ -77,7 +75,9 @@ class EnvironmentConfig:
 
         # Ensure that we are merging another EnvironmentConfig
         if not isinstance(other, self.__class__):
-            raise CondaValueError("Cannot merge EnvironmentConfig with non-EnvironmentConfig")
+            raise CondaValueError(
+                "Cannot merge EnvironmentConfig with non-EnvironmentConfig"
+            )
 
         self.aggressive_update_packages = other.aggressive_update_packages
         self.channel_priority = other.channel_priority

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -14,11 +14,61 @@ from ..exceptions import CondaValueError
 if TYPE_CHECKING:
     from typing import Any
 
+    from ..base.constants import (
+        DepsModifier,
+        ChannelPriority,
+        SatSolverChoice,
+        UpdateModifier,
+    )
+
     from .match_spec import MatchSpec
     from .records import PackageRecord
 
 
 log = getLogger(__name__)
+
+
+@dataclass
+class EnvironmentConfig:
+    """
+    **Experimental** While experimental, expect both major and minor changes across minor releases.
+
+    Data model for a conda environment config.
+    """
+
+    aggressive_update_packages: bool
+
+    channel_priority:  ChannelPriority
+
+    channels: list[str]
+
+    channel_settings: dict[str, str]
+
+    deps_modifier: DepsModifier
+
+    disallowed_packages: list[str]
+
+    pinned_packages: list[str]
+
+    repodata_fns: list[str]
+
+    sat_solver: SatSolverChoice | None = None
+
+    solver: str | None = None
+
+    track_features: list[str]
+
+    update_modifier: UpdateModifier
+
+    use_only_tar_bz2: bool
+
+    @classmethod
+    def merge(cls, *config):
+        """
+        **Experimental** While experimental, expect both major and minor changes across minor releases.
+
+        Merges multiple EnvironemntConfigs
+        """
 
 
 @dataclass
@@ -38,7 +88,7 @@ class Environment:
     #: Environment level configuration, eg. channels, solver options, etc.
     #: TODO: may need to think more about the type of this field and how
     #:       conda should be merging configs between environments
-    config: dict[str, Any] = field(default_factory=dict)
+    config: EnvironmentConfig
 
     #: Map of other package types that conda can install. For example pypi packages.
     external_packages: dict[str, list[str]] = field(default_factory=dict)

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -13,12 +13,11 @@ from ..exceptions import CondaValueError
 
 if TYPE_CHECKING:
     from ..base.constants import (
-        DepsModifier,
         ChannelPriority,
+        DepsModifier,
         SatSolverChoice,
         UpdateModifier,
     )
-
     from .match_spec import MatchSpec
     from .records import PackageRecord
 
@@ -62,12 +61,7 @@ class EnvironmentConfig:
 
     def _append_without_duplicates(self, first: list, second: list) -> list:
         first.extend(second)
-        return list(
-            dict.fromkeys(
-                item
-                for item in first
-            )
-        )
+        return list(dict.fromkeys(item for item in first))
 
     def _merge(self, other: EnvironmentConfig) -> EnvironmentConfig:
         """
@@ -101,11 +95,17 @@ class EnvironmentConfig:
         if other.deps_modifier is not None:
             self.deps_modifier = other.deps_modifier
 
-        self.disallowed_packages = self._append_without_duplicates(self.disallowed_packages, other.disallowed_packages)
+        self.disallowed_packages = self._append_without_duplicates(
+            self.disallowed_packages, other.disallowed_packages
+        )
 
-        self.pinned_packages = self._append_without_duplicates(self.pinned_packages, other.pinned_packages)
+        self.pinned_packages = self._append_without_duplicates(
+            self.pinned_packages, other.pinned_packages
+        )
 
-        self.repodata_fns = self._append_without_duplicates(self.repodata_fns, other.repodata_fns)
+        self.repodata_fns = self._append_without_duplicates(
+            self.repodata_fns, other.repodata_fns
+        )
 
         if other.sat_solver is not None:
             self.sat_solver = other.sat_solver
@@ -113,7 +113,9 @@ class EnvironmentConfig:
         if other.solver is not None:
             self.solver = other.solver
 
-        self.track_features = self._append_without_duplicates(self.track_features, other.track_features)
+        self.track_features = self._append_without_duplicates(
+            self.track_features, other.track_features
+        )
 
         if other.update_modifier is not None:
             self.update_modifier = other.update_modifier
@@ -281,7 +283,9 @@ class Environment:
                 elif isinstance(v, list):
                     external_packages[k] = v
 
-        config = EnvironmentConfig.merge(*[env.config for env in environments if env.config is not None])
+        config = EnvironmentConfig.merge(
+            *[env.config for env in environments if env.config is not None]
+        )
 
         return cls(
             config=config,

--- a/news/14913-environment-model-config
+++ b/news/14913-environment-model-config
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Introduce dataclass to represent an environment config. (#14913)
+* Introduce new dataclass `conda.models.environment.EnvironmentConfig` to represent `Environment` settings, a subset of `context` settings that impact environment creation and management. (#14913)
 
 ### Bug fixes
 

--- a/news/14913-environment-model-config
+++ b/news/14913-environment-model-config
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Introduce dataclass to represent an environment config. (#14913)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -70,7 +70,9 @@ def test_environments_merge():
         prefix="/path/to/env1",
         platform="linux-64",
         config=EnvironmentConfig(
-            aggressive_update_packages=True, channels=["defaults"], channel_settings={"a":1},
+            aggressive_update_packages=True,
+            channels=["defaults"],
+            channel_settings={"a": 1},
         ),
         external_packages={
             "pip": ["one", "two", {"special": "type"}],
@@ -84,7 +86,10 @@ def test_environments_merge():
         prefix="/path/to/env1",
         platform="linux-64",
         config=EnvironmentConfig(
-            aggressive_update_packages=False, channels=["conda-forge"], channel_settings={"b":2}, repodata_fns=["repodata2.json"],
+            aggressive_update_packages=False,
+            channels=["conda-forge"],
+            channel_settings={"b": 2},
+            repodata_fns=["repodata2.json"],
         ),
         external_packages={"pip": ["two", "flask"], "a": ["nother"]},
         explicit_packages=[],
@@ -97,7 +102,7 @@ def test_environments_merge():
     assert merged.config == EnvironmentConfig(
         aggressive_update_packages=False,
         channels=["defaults", "conda-forge"],
-        channel_settings={"a":1, "b":2},
+        channel_settings={"a": 1, "b": 2},
         repodata_fns=["repodata2.json"],
     )
     assert merged.external_packages == {

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -4,7 +4,7 @@
 import pytest
 
 from conda.exceptions import CondaValueError
-from conda.models.environment import Environment
+from conda.models.environment import Environment, EnvironmentConfig
 from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord
 
@@ -69,7 +69,9 @@ def test_environments_merge():
     env1 = Environment(
         prefix="/path/to/env1",
         platform="linux-64",
-        config={"primitive_one": "yes", "list_one": [1, 2, 4], "map": {"a": 1}},
+        config=EnvironmentConfig(
+            aggressive_update_packages=True, channels=["defaults"], channel_settings={"a":1},
+        ),
         external_packages={
             "pip": ["one", "two", {"special": "type"}],
             "other": ["three"],
@@ -81,12 +83,9 @@ def test_environments_merge():
     env2 = Environment(
         prefix="/path/to/env1",
         platform="linux-64",
-        config={
-            "primitive_one": "no",
-            "primitive_two": "yes",
-            "list_one": [3],
-            "map": {"b": 1},
-        },
+        config=EnvironmentConfig(
+            aggressive_update_packages=False, channels=["conda-forge"], channel_settings={"b":2}, repodata_fns=["repodata2.json"],
+        ),
         external_packages={"pip": ["two", "flask"], "a": ["nother"]},
         explicit_packages=[],
         requested_packages=[MatchSpec("numpy"), MatchSpec("flask")],
@@ -95,12 +94,12 @@ def test_environments_merge():
     merged = Environment.merge(env1, env2)
     assert merged.prefix == "/path/to/env1"
     assert merged.platform == "linux-64"
-    assert merged.config == {
-        "primitive_one": "no",
-        "primitive_two": "yes",
-        "list_one": [1, 2, 4, 3],
-        "map": {"a": 1, "b": 1},
-    }
+    assert merged.config == EnvironmentConfig(
+        aggressive_update_packages=False,
+        channels=["defaults", "conda-forge"],
+        channel_settings={"a":1, "b":2},
+        repodata_fns=["repodata2.json"],
+    )
     assert merged.external_packages == {
         "pip": ["one", "two", {"special": "type"}, "flask"],
         "other": ["three"],


### PR DESCRIPTION
### Description

This PR suggests adding some rigidity to the Environment's model notion of config. Previously, Environment config was just stored as a plain dict. This is ok, but leaves some abiguity around what type of data ought to present in the config.

Providing this dataclass will give plugin authors a more concrete understanding of:
* the limits of what configuration they can control, and
* what information they _should_ be passing into conda

Further, providing this dataclass will give downstream consumers of the Environment model some assurances about what environment configuratio information should be available to them. For example, consider how the Environment model will be used to generate a set of transactions for conda to execute for package installation/update/removal (https://github.com/conda/conda/pull/14911).

This PR provides the ability to merge multiple environment configs together. It is important to note that this simple approach to merging config is not a substitute for the merging of config sources that happens in the context object. 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

