### PR TITLE
Allow env spec plugins to enable/disable autodetection

### DIFF
--- a/conda/env/specs/binstar.py
+++ b/conda/env/specs/binstar.py
@@ -24,7 +24,6 @@ deprecated.module("24.7", "25.9")
 deprecated.constant("24.7", "25.9", "ENVIRONMENT_TYPE", "env")
 
 
-@deprecated("24.7", "25.9")
 class BinstarSpec(EnvironmentSpecBase):
     """
     spec = BinstarSpec('darth/deathstar')
@@ -36,6 +35,7 @@ class BinstarSpec(EnvironmentSpecBase):
 
     msg = None
 
+    @deprecated("24.7", "25.9")
     def __init__(self, name=None):
         self.name = name
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1301,7 +1301,7 @@ class EnvironmentSpecPluginNotDetected(SpecNotFound):
         self,
         name: str,
         plugin_names: Iterable[str],
-        autodetect_disabled_plugins: Iterable[str] = [],
+        autodetect_disabled_plugins: Iterable[str] = (),
         *args,
         **kwargs,
     ):

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1310,11 +1310,18 @@ class EnvironmentSpecPluginNotDetected(SpecNotFound):
             f"""
             Environment at {name} is not readable by any installed environment specifier plugins.
 
-Available plugins: {dashlist(plugin_names, 4)}
+            Available plugins: {dashlist(plugin_names, 16)}
+
             """
         )
         if len(autodetect_disabled_plugins) > 0:
-            msg += f"\nAvailable plugins with autodetection disabled. Request conda to use these plugins by providing the cli argument `--environment-spec PLUGIN_NAME`: {dashlist(autodetect_disabled_plugins, 4)}"
+            msg += dals(
+                f"""
+                Found compatible plugins but they must be explicitly selected.
+                Request conda to use these plugins by providing
+                the cli argument `--environment-spec PLUGIN_NAME`:
+                """
+            ) + dashlist(autodetect_disabled_plugins, 4)
         super().__init__(msg, *args, **kwargs)
 
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1297,16 +1297,18 @@ class SpecNotFound(CondaError):
 
 
 class EnvironmentSpecPluginNotDetected(SpecNotFound):
-    def __init__(self, name: str, plugin_names: Iterable[str], *args, **kwargs):
+    def __init__(
+            self, name: str, plugin_names: Iterable[str], autodetect_disabled_plugins: Iterable[str] = [], *args, **kwargs):
         self.name = name
         msg = dals(
             f"""
-            Environment at {name} is not readable by any installed
-            environment specifier plugins.
+            Environment at {name} is not readable by any installed environment specifier plugins.
 
-            Available plugins: {dashlist(plugin_names, 4)}
+Available plugins: {dashlist(plugin_names, 4)}
             """
         )
+        if len(autodetect_disabled_plugins) > 0:
+            msg += f"\nAvailable plugins with autodetection disabled. Request conda to use these plugins by providing the cli argument `--environment-spec PLUGIN_NAME`: {dashlist(autodetect_disabled_plugins, 4)}"
         super().__init__(msg, *args, **kwargs)
 
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1298,7 +1298,13 @@ class SpecNotFound(CondaError):
 
 class EnvironmentSpecPluginNotDetected(SpecNotFound):
     def __init__(
-            self, name: str, plugin_names: Iterable[str], autodetect_disabled_plugins: Iterable[str] = [], *args, **kwargs):
+        self,
+        name: str,
+        plugin_names: Iterable[str],
+        autodetect_disabled_plugins: Iterable[str] = [],
+        *args,
+        **kwargs,
+    ):
         self.name = name
         msg = dals(
             f"""

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1316,7 +1316,7 @@ class EnvironmentSpecPluginNotDetected(SpecNotFound):
         )
         if len(autodetect_disabled_plugins) > 0:
             msg += dals(
-                f"""
+                """
                 Found compatible plugins but they must be explicitly selected.
                 Request conda to use these plugins by providing
                 the cli argument `--environment-spec PLUGIN_NAME`:

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -565,24 +565,23 @@ class CondaPluginManager(pluggy.PluginManager):
         hooks = self.get_hook_results("environment_specifiers")
         found = []
         for hook in hooks:
-            if hook.enable_autodetection:
-                log.debug("EnvironmentSpec hook: checking %s", hook.name)
-                if hook.environment_spec(source).can_handle():
-                    log.debug(
-                        "EnvironmentSpec hook: %s can be %s",
-                        source,
-                        hook.name,
-                    )
-                    found.append(hook)
-                else:
-                    log.debug(
-                        "EnvironmentSpec hook: %s can NOT be handled by %s",
-                        source,
-                        hook.name,
-                    )
-            else:
+            log.debug("EnvironmentSpec hook: checking %s", hook.name)
+            if not hook.environment_spec.detection_supported():
                 log.debug(
                     "EnvironmentSpec hook '%s' does not support autodetection, skipping",
+                    hook.name,
+                )
+            elif hook.environment_spec(source).can_handle():
+                log.debug(
+                    "EnvironmentSpec hook: %s can be %s",
+                    source,
+                    hook.name,
+                )
+                found.append(hook)
+            else:
+                log.debug(
+                    "EnvironmentSpec hook: %s can NOT be handled by %s",
+                    source,
                     hook.name,
                 )
 

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -568,7 +568,7 @@ class CondaPluginManager(pluggy.PluginManager):
         autodetect_disabled_plugins = []
         for hook in hooks:
             log.debug("EnvironmentSpec hook: checking %s", hook.name)
-            if not hook.environment_spec.detection_supported():
+            if not hook.environment_spec.detection_supported:
                 log.debug(
                     "EnvironmentSpec hook '%s' does not support autodetection, skipping",
                     hook.name,

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -565,18 +565,24 @@ class CondaPluginManager(pluggy.PluginManager):
         hooks = self.get_hook_results("environment_specifiers")
         found = []
         for hook in hooks:
-            log.debug("EnvironmentSpec hook: checking %s", hook.name)
-            if hook.environment_spec(source).can_handle():
-                log.debug(
-                    "EnvironmentSpec hook: %s can be %s",
-                    source,
-                    hook.name,
-                )
-                found.append(hook)
+            if hook.enable_autodetection:
+                log.debug("EnvironmentSpec hook: checking %s", hook.name)
+                if hook.environment_spec(source).can_handle():
+                    log.debug(
+                        "EnvironmentSpec hook: %s can be %s",
+                        source,
+                        hook.name,
+                    )
+                    found.append(hook)
+                else:
+                    log.debug(
+                        "EnvironmentSpec hook: %s can NOT be handled by %s",
+                        source,
+                        hook.name,
+                    )
             else:
                 log.debug(
-                    "EnvironmentSpec hook: %s can NOT be handled by %s",
-                    source,
+                    "EnvironmentSpec hook '%s' does not support autodetection, skipping",
                     hook.name,
                 )
 

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -595,7 +595,9 @@ class CondaPluginManager(pluggy.PluginManager):
             raise EnvironmentSpecPluginNotDetected(
                 name=source,
                 plugin_names=[hook.name for hook in available_hooks],
-                autodetect_disabled_plugins=[hook.name for hook in autodetect_disabled_plugins],
+                autodetect_disabled_plugins=[
+                    hook.name for hook in autodetect_disabled_plugins
+                ],
             )
         elif len(found) == 1:
             # return the plugin if only one is found

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -420,6 +420,21 @@ class EnvironmentSpecBase(ABC):
     Base class for all env specs.
     """
 
+    @classmethod
+    def detection_supported(cls) -> bool:
+        """
+        Determines if the EnvSpec plugin should be included in the set
+        of available plugins checked during environment_spec plugin detection.
+        If set to False, the only way to use the plugin will be through explicitly
+        requesting it as a cli argument or setting in .condarc. By default,
+        autodetection is enabled.
+
+        :returns bool: returns True if the plugin should be included in
+                       autodetection. Default value is True, unless overridden
+                       in the subclass.
+        """
+        return True
+
     @abstractmethod
     def can_handle(self) -> bool:
         """
@@ -452,13 +467,7 @@ class CondaEnvironmentSpecifier:
 
     :param name: name of the spec (e.g., ``environment_yaml``)
     :param environment_spec: EnvironmentSpecBase subclass handler
-    :param enable_autodetection: whether to include the plugin in the list of available plugins
-                                 during plugin detection. If set to False, the only way to use
-                                 the plugin will be through explicitly requesting it as a cli
-                                 argument or setting in .condarc. By default, autodetection is
-                                 enabled.
     """
 
     name: str
     environment_spec: type[EnvironmentSpecBase]
-    enable_autodetection: bool = True

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -420,20 +420,12 @@ class EnvironmentSpecBase(ABC):
     Base class for all env specs.
     """
 
-    @classmethod
-    def detection_supported(cls) -> bool:
-        """
-        Determines if the EnvSpec plugin should be included in the set
-        of available plugins checked during environment_spec plugin detection.
-        If set to False, the only way to use the plugin will be through explicitly
-        requesting it as a cli argument or setting in .condarc. By default,
-        autodetection is enabled.
-
-        :returns bool: returns True if the plugin should be included in
-                       autodetection. Default value is True, unless overridden
-                       in the subclass.
-        """
-        return True
+    # Determines if the EnvSpec plugin should be included in the set
+    # of available plugins checked during environment_spec plugin detection.
+    # If set to False, the only way to use the plugin will be through explicitly
+    # requesting it as a cli argument or setting in .condarc. By default,
+    # autodetection is enabled.
+    detection_supported: bool = True
 
     @abstractmethod
     def can_handle(self) -> bool:

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -21,7 +21,7 @@ from ..models.records import PackageRecord
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from contextlib import AbstractContextManager
-    from typing import Any, Callable, TypeAlias
+    from typing import Any, Callable, ClassVar, TypeAlias
 
     from ..common.configuration import Parameter
     from ..common.path import PathType
@@ -425,7 +425,7 @@ class EnvironmentSpecBase(ABC):
     # If set to False, the only way to use the plugin will be through explicitly
     # requesting it as a cli argument or setting in .condarc. By default,
     # autodetection is enabled.
-    detection_supported: bool = True
+    detection_supported: ClassVar[bool] = True
 
     @abstractmethod
     def can_handle(self) -> bool:

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -452,7 +452,13 @@ class CondaEnvironmentSpecifier:
 
     :param name: name of the spec (e.g., ``environment_yaml``)
     :param environment_spec: EnvironmentSpecBase subclass handler
+    :param enable_autodetection: whether to include the plugin in the list of available plugins
+                                 during plugin detection. If set to False, the only way to use
+                                 the plugin will be through explicitly requesting it as a cli
+                                 argument or setting in .condarc. By default, autodetection is
+                                 enabled.
     """
 
     name: str
     environment_spec: type[EnvironmentSpecBase]
+    enable_autodetection: bool = True

--- a/news/14914-env-spec-plugins-can-opt-out-of-autodetection
+++ b/news/14914-env-spec-plugins-can-opt-out-of-autodetection
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Allow env spec plugins to enable/disable auto detection. (#14914)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/14914-env-spec-plugins-can-opt-out-of-autodetection
+++ b/news/14914-env-spec-plugins-can-opt-out-of-autodetection
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Allow env spec plugins to enable/disable auto detection. (#14914)
+* Allow env spec plugins to opt-out of auto detection. (#14914)
 
 ### Bug fixes
 

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -28,6 +28,12 @@ class RandomSpec(EnvironmentSpecBase):
         return Environment(name="random-environment", dependencies=["python", "numpy"])
 
 
+class RandomSpecNoAutoDetect(RandomSpec):
+    @classmethod
+    def detection_supported(cls):
+        return False
+
+
 class RandomSpecPlugin:
     @plugins.hookimpl
     def conda_environment_specifiers(self):
@@ -51,8 +57,7 @@ class RandomSpecPluginNoAutodetect:
     def conda_environment_specifiers(self):
         yield CondaEnvironmentSpecifier(
             name="rand-spec-no-autodetect",
-            environment_spec=RandomSpec,
-            enable_autodetection=False,
+            environment_spec=RandomSpecNoAutoDetect,
         )
 
 
@@ -163,4 +168,4 @@ def test_explicitly_select_a_non_autodetect_plugin(
         "test.random", name="rand-spec-no-autodetect"
     )
     assert env_spec.name == "rand-spec-no-autodetect"
-    assert env_spec.enable_autodetection is False
+    assert env_spec.environment_spec.detection_supported() is False

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -29,9 +29,7 @@ class RandomSpec(EnvironmentSpecBase):
 
 
 class RandomSpecNoAutoDetect(RandomSpec):
-    @classmethod
-    def detection_supported(cls):
-        return False
+    detection_supported = False
 
 
 class RandomSpecPlugin:
@@ -168,4 +166,4 @@ def test_explicitly_select_a_non_autodetect_plugin(
         "test.random", name="rand-spec-no-autodetect"
     )
     assert env_spec.name == "rand-spec-no-autodetect"
-    assert env_spec.environment_spec.detection_supported() is False
+    assert env_spec.environment_spec.detection_supported is False

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -14,13 +14,10 @@ from conda.common.url import urlparse
 from conda.core import solve
 from conda.exceptions import (
     CondaValueError,
-    EnvironmentSpecPluginNotDetected,
     PluginError,
 )
 from conda.plugins import virtual_packages
 from conda.plugins.manager import CondaPluginManager
-from conda.plugins.types import EnvironmentSpecBase
-
 
 log = logging.getLogger(__name__)
 this_module = sys.modules[__name__]

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -19,6 +19,8 @@ from conda.exceptions import (
 )
 from conda.plugins import virtual_packages
 from conda.plugins.manager import CondaPluginManager
+from conda.plugins.types import EnvironmentSpecBase
+
 
 log = logging.getLogger(__name__)
 this_module = sys.modules[__name__]
@@ -238,55 +240,3 @@ def test_get_request_headers(plugin_manager: CondaPluginManager):
     """
     url = urlparse("https://example.com")
     assert plugin_manager.get_request_headers(host=url.netloc, path=url.path) == {}
-
-
-class DummyEnvironmentSpecifier:
-    def __init__(self, name, can_handle_result=True):
-        self.name = name
-        self._can_handle_result = can_handle_result
-
-    def can_handle(self):
-        return self._can_handle_result
-
-
-class EnvironmentSpecifierPlugin:
-    def __init__(self, name="test-env-spec", can_handle_result=True):
-        self.specifier_name = name
-        self.can_handle_result = can_handle_result
-
-    @plugins.hookimpl
-    def conda_environment_specifiers(self):
-        yield plugins.CondaEnvironmentSpecifier(
-            name=self.specifier_name,
-            environment_spec=lambda filename: DummyEnvironmentSpecifier(
-                self.specifier_name, self.can_handle_result
-            ),
-        )
-
-
-def test_get_environment_specifier_success(plugin_manager: CondaPluginManager):
-    """
-    Test that get_environment_specifier returns the name of the environment
-    specifier plugin that can handle the given file.
-    """
-    # Load a test environment specifier plugin
-    plugin = EnvironmentSpecifierPlugin(name="test-env-spec", can_handle_result=True)
-    assert plugin_manager.load_plugins(plugin) == 1
-
-    # Test successful case
-    specifier_name = plugin_manager.get_environment_specifier("environment.yml")
-    assert specifier_name.name == "test-env-spec"
-
-
-def test_get_environment_specifier_not_found(plugin_manager: CondaPluginManager):
-    """
-    Test that get_environment_specifier returns an error string when no plugin
-    can handle the given file.
-    """
-    # Load a test environment specifier plugin that can't handle any files
-    plugin = EnvironmentSpecifierPlugin(name="test-env-spec", can_handle_result=False)
-    assert plugin_manager.load_plugins(plugin) == 1
-
-    # Test error case
-    with pytest.raises(EnvironmentSpecPluginNotDetected):
-        plugin_manager.get_environment_specifier("environment.yml")


### PR DESCRIPTION
### Description

This PR introduces a way for environment spec plugins to declare that they should not be automatically detected. So, these plugins would only be accessible to users if they explicitly request the plugin by cli arg or configuration.

For example, consider the [environment.yml spec plugin](https://github.com/conda/conda/blob/main/conda/env/specs/yaml_file.py). One could implement a new plugin based on it, with autodetection for their new plugin disabled:
```
class YamlNoAutoDetect(YamlFileSpec):
   detection_supported = False

@hookimpl
def conda_environment_specifiers():
    yield CondaEnvironmentSpecifier(
        name="secret-environment.yml",
        environment_spec=YamlNoAutoDetect,
    )
```

This plugin will never be selected if not explicitly requested. In order to use the `YamlNoAutoDetect` plugin, users must run a command like:

```
$ conda env create --file special.yml --env-spec secret-environment.yml
```

When no plugin is detected, conda will produce an error calling out plugins with autodetection disabled:

```
$ conda env create --file tests/env/support/simple.yml             

EnvironmentSpecPluginNotDetected: Environment at tests/env/support/simple.yml is not readable by any installed environment specifier plugins.

Available plugins: 
    - binstar
    - requirements.txt

Found compatible plugins but they must be explicitly selected.
Request conda to use these plugins by providing
the cli argument `--environment-spec PLUGIN_NAME`:

    - secret-environment.yml
 ```

depends on the changes to the plugin manager introduced in https://github.com/conda/conda/pull/14877

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

