### PR TITLE
Handle exceptions coming from environment spec plugins

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -542,13 +542,10 @@ class CondaPluginManager(pluggy.PluginManager):
                 f"{', '.join([hook.name for hook in hooks])}"
             )
         if len(found) == 1:
+            # Try to load the plugin and check if it can handle the environment spec
             try:
                 if found[0].environment_spec(source).can_handle():
                     return found[0]
-                else:
-                    raise PluginError(
-                        f"Requested plugin '{name}' is unable to handle environment spec '{source}'"
-                    )
             except Exception as e:
                 raise PluginError(
                     dals(
@@ -558,6 +555,11 @@ class CondaPluginManager(pluggy.PluginManager):
                         {type(e).__name__}: {e}
                         """
                     )
+                )
+            else:
+                # If the plugin was not able to handle the environment spec, raise an error
+                raise PluginError(
+                    f"Requested plugin '{name}' is unable to handle environment spec '{source}'"
                 )
         elif len(found) > 1:
             raise PluginError(

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -595,7 +595,12 @@ class CondaPluginManager(pluggy.PluginManager):
                             hook.name,
                         )
                 except Exception as e:
-                    log.error("EnvironmentSpec hook: an error occurred when handling '%s' with plugin '%s'. %s", source, hook.name, e)
+                    log.error(
+                        "EnvironmentSpec hook: an error occurred when handling '%s' with plugin '%s'. %s",
+                        source,
+                        hook.name,
+                        e,
+                    )
             else:
                 log.debug(
                     "EnvironmentSpec hook: %s can NOT be handled by %s",

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -603,6 +603,7 @@ class CondaPluginManager(pluggy.PluginManager):
                         hook.name,
                         e,
                     )
+                    log.debug("%r", e, exc_info=e)
             else:
                 log.debug(
                     "EnvironmentSpec hook: %s can NOT be handled by %s",

--- a/news/14916-handle-exceptions-from-env-spec-plugins
+++ b/news/14916-handle-exceptions-from-env-spec-plugins
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Handle exceptions coming from environment spec plugins can_handle functions. (#14916)
+* Handle exceptions coming from environment spec plugins `can_handle` functions. (#14916)
 
 ### Bug fixes
 

--- a/news/14916-handle-exceptions-from-env-spec-plugins
+++ b/news/14916-handle-exceptions-from-env-spec-plugins
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Handle exceptions coming from environment spec plugins can_handle functions. (#14916)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -12,6 +12,25 @@ from conda.exceptions import (
 from conda.plugins.types import CondaEnvironmentSpecifier, EnvironmentSpecBase
 
 
+class NaughtySpec(EnvironmentSpecBase):
+    def __init__(self, source: str):
+        self.source = source
+
+    def can_handle(self):
+        raise TypeError("This is a naughty spec")
+
+    def environment(self):
+        raise TypeError("This is a naughty spec")
+
+
+class NaughtySpecPlugin:
+    @plugins.hookimpl
+    def conda_environment_specifiers(self):
+        yield CondaEnvironmentSpecifier(
+            name="naughty",
+            environment_spec=NaughtySpec,
+        )
+
 class RandomSpec(EnvironmentSpecBase):
     extensions = {".random"}
 
@@ -79,6 +98,13 @@ def dummy_random_spec_plugin2(plugin_manager):
 def dummy_random_spec_plugin_no_autodetect(plugin_manager):
     random_spec_plugin = RandomSpecPluginNoAutodetect()
     plugin_manager.register(random_spec_plugin)
+
+    return plugin_manager
+
+@pytest.fixture()
+def naughty_spec_plugin(plugin_manager):
+    plg = NaughtySpecPlugin()
+    plugin_manager.register(plg)
 
     return plugin_manager
 
@@ -167,3 +193,33 @@ def test_explicitly_select_a_non_autodetect_plugin(
     )
     assert env_spec.name == "rand-spec-no-autodetect"
     assert env_spec.environment_spec.detection_supported is False
+
+
+def test_naught_plugin_does_not_cause_unhandled_errors(
+    plugin_manager,
+    dummy_random_spec_plugin,
+    dummy_random_spec_plugin_no_autodetect,
+    naughty_spec_plugin
+):
+    """
+    Ensures that explicitly selecting a plugin that has errors is handled appropriately
+    """
+    filename = "test.random"
+    with pytest.raises(PluginError) as e:
+        plugin_manager.get_environment_specifier_by_name(filename, "naughty")
+        assert "An error occured when handling '{filename}' with plugin 'naughty'." in str(e)
+
+
+def test_naught_plugin_does_not_cause_unhandled_errors_during_detection(
+    plugin_manager,
+    dummy_random_spec_plugin,
+    dummy_random_spec_plugin_no_autodetect,
+    naughty_spec_plugin,
+):
+    """
+    Ensure that plugins that cause errors does not break plugin detection
+    """
+    filename = "test.random"
+    env_spec_backend = plugin_manager.detect_environment_specifier(filename)
+    assert env_spec_backend.name == "rand-spec"
+    assert env_spec_backend.environment_spec(filename).environment is not None

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -31,6 +31,7 @@ class NaughtySpecPlugin:
             environment_spec=NaughtySpec,
         )
 
+
 class RandomSpec(EnvironmentSpecBase):
     extensions = {".random"}
 
@@ -100,6 +101,7 @@ def dummy_random_spec_plugin_no_autodetect(plugin_manager):
     plugin_manager.register(random_spec_plugin)
 
     return plugin_manager
+
 
 @pytest.fixture()
 def naughty_spec_plugin(plugin_manager):
@@ -199,7 +201,7 @@ def test_naught_plugin_does_not_cause_unhandled_errors(
     plugin_manager,
     dummy_random_spec_plugin,
     dummy_random_spec_plugin_no_autodetect,
-    naughty_spec_plugin
+    naughty_spec_plugin,
 ):
     """
     Ensures that explicitly selecting a plugin that has errors is handled appropriately
@@ -207,7 +209,10 @@ def test_naught_plugin_does_not_cause_unhandled_errors(
     filename = "test.random"
     with pytest.raises(PluginError) as e:
         plugin_manager.get_environment_specifier_by_name(filename, "naughty")
-        assert "An error occured when handling '{filename}' with plugin 'naughty'." in str(e)
+        assert (
+            "An error occured when handling '{filename}' with plugin 'naughty'."
+            in str(e)
+        )
 
 
 def test_naught_plugin_does_not_cause_unhandled_errors_during_detection(

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -157,9 +157,13 @@ def test_raises_an_error_if_named_plugin_can_not_be_handled(
     """
     Ensures that an error is raised if the user requests a plugin exists, but can't be handled
     """
-    with pytest.raises(PluginError):
+    with pytest.raises(PluginError) as e:
         dummy_random_spec_plugin.get_environment_specifier_by_name(
             name="rand-spec", source="test.random-not-so-much"
+        )
+        assert (
+            "Requested plugin 'rand-spec' is unable to handle environment spec"
+            in str(e)
         )
 
 

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -157,13 +157,12 @@ def test_raises_an_error_if_named_plugin_can_not_be_handled(
     """
     Ensures that an error is raised if the user requests a plugin exists, but can't be handled
     """
-    with pytest.raises(PluginError) as e:
+    with pytest.raises(
+        PluginError,
+        match=r"Requested plugin 'rand-spec' is unable to handle environment spec",
+    ):
         dummy_random_spec_plugin.get_environment_specifier_by_name(
             name="rand-spec", source="test.random-not-so-much"
-        )
-        assert (
-            "Requested plugin 'rand-spec' is unable to handle environment spec"
-            in str(e)
         )
 
 
@@ -211,12 +210,11 @@ def test_naught_plugin_does_not_cause_unhandled_errors(
     Ensures that explicitly selecting a plugin that has errors is handled appropriately
     """
     filename = "test.random"
-    with pytest.raises(PluginError) as e:
+    with pytest.raises(
+        PluginError,
+        match=rf"An error occured when handling '{filename}' with plugin 'naughty'.",
+    ):
         plugin_manager.get_environment_specifier_by_name(filename, "naughty")
-        assert (
-            "An error occured when handling '{filename}' with plugin 'naughty'."
-            in str(e)
-        )
 
 
 def test_naught_plugin_does_not_cause_unhandled_errors_during_detection(


### PR DESCRIPTION
### Description

This PR introduces some more error handling into the environemnt_spec plugin detection process. Now,
if a plugin has an unhandled exception in their `can_handle` function:
* detecting plugins (`detect_environment_specifier`) will capture + log errors coming from plugins, instead of erroring out
* explicitly requesting a plugin (`get_environment_specifier_by_name`) with unhandled exceptions will wrap the error up in a conda exception and provide information about the error to the user

See the attached tests for examples of how this works.

This PR is just handling exceptions during the plugin detection phase, so that would be in the plugin implementation of the `can_handle` function. This PR does not introduce any error handling for retrieving an environment from the plugin.

depends on the changes to the plugin manager introduced in https://github.com/conda/conda/pull/14877 and https://github.com/conda/conda/pull/14914

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
