### PR TITLE
include the conda package when cloning an environment

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -5,7 +5,6 @@
 import os
 import re
 import shutil
-import sys
 from collections import defaultdict
 from collections.abc import Iterable
 from logging import getLogger

--- a/conda/misc.py
+++ b/conda/misc.py
@@ -239,45 +239,7 @@ def touch_nonadmin(prefix):
 def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
     """Clone existing prefix1 into new prefix2."""
     untracked_files = untracked(prefix1)
-
-    # Discard conda, conda-env and any package that depends on them
-    filter = {}
-    found = True
-    while found:
-        found = False
-        for prec in PrefixData(prefix1).iter_records():
-            name = prec["name"]
-            if name in filter:
-                continue
-            if name == "conda":
-                filter["conda"] = prec
-                found = True
-                break
-            if name == "conda-env":
-                filter["conda-env"] = prec
-                found = True
-                break
-            for dep in prec.combined_depends:
-                if MatchSpec(dep).name in filter:
-                    filter[name] = prec
-                    found = True
-
-    if filter:
-        if not quiet:
-            fh = sys.stderr if context.json else sys.stdout
-            print(
-                "The following packages cannot be cloned out of the root environment:",
-                file=fh,
-            )
-            for prec in filter.values():
-                print(" - " + prec.dist_str(), file=fh)
-        drecs = {
-            prec
-            for prec in PrefixData(prefix1).iter_records()
-            if prec["name"] not in filter
-        }
-    else:
-        drecs = {prec for prec in PrefixData(prefix1).iter_records()}
+    drecs = {prec for prec in PrefixData(prefix1).iter_records()}
 
     # Resolve URLs for packages that do not have URLs
     index = {}

--- a/news/14919-allow-conda-to-be-cloned-between-environments
+++ b/news/14919-allow-conda-to-be-cloned-between-environments
@@ -1,0 +1,19 @@
+### Enhancements
+
+* The conda package is included when cloning an environment. (#14917 via #14919)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1052,6 +1052,14 @@ def test_allow_softlinks(
         assert (prefix / "fonts" / "Inconsolata-Bold.ttf").is_symlink()
 
 
+def test_clone_env_with_conda(tmp_env: TmpEnvFixture):
+    # Regression test for #14917
+    with tmp_env("--channel=conda-forge", "conda") as prefix:
+        assert package_is_installed(prefix, "conda-forge::conda")
+        with tmp_env(f"--clone={prefix}") as clone:
+            assert package_is_installed(clone, "conda-forge::conda")
+
+
 def test_channel_usage_replacing_python(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,


### PR DESCRIPTION
### Description

Include the `conda` package when cloning an environment.

The need to exclude conda was needed as conda was only allowed in the root/base environment. This exclusion is now longer needed.

closes #14917

### Checklist - did you ...


- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

