### PR TITLE
Lazily evaluate cli options originating from the plugin manager

### DIFF
--- a/news/14925-lazily-load-cli-choices
+++ b/news/14925-lazily-load-cli-choices
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Lazily evaluate cli options originating from the plugin manager. (#14925)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_all_commands.py
+++ b/tests/cli/test_all_commands.py
@@ -44,3 +44,31 @@ def test_denylist_channels(
         monkeypatch.setenv("CONDA_CHANNEL", denylist_channel)
     with pytest.raises(ChannelDenied):
         conda_cli(*command)
+
+
+@pytest.mark.parametrize(
+    ("command", "err_message"),
+    (
+        (
+            ("env", "create", "--environment-specifier", "idontexist"),
+            "error: argument '--environment-specifier': invalid choice: 'idontexist'",
+        ),
+        (
+            ("install", "--solver", "idontexist"),
+            "error: argument '--solver': invalid choice: 'idontexist'",
+        ),
+    ),
+)
+def test_commands_with_plugin_backed_options(
+    conda_cli: CondaCLIFixture,
+    command: tuple[str, ...],
+    err_message: str,
+    capsys,
+):
+    """Ensure that conda raises an error when a plugin-backed option
+    is used with an invalid value.
+    """
+    with pytest.raises(SystemExit):
+        conda_cli(*command)
+    captured = capsys.readouterr()
+    assert err_message in captured.err


### PR DESCRIPTION

### Description
Follow up to https://github.com/conda/conda/pull/14877

This PR lazily evaluates `choices` for cli arguments that require information from the plugin manager. This will ensure that the plugin manager and context are fully initialized before calling on them.

The message returned to the user when selecting an invalid plugin is unchanged:

```

$ conda env create --env-spec idontexist         [9:59:00]
usage: conda env create [-h] [-f FILE] [-n ENVIRONMENT | -p PATH] [-C] [-k] [--offline]
                        [--environment-specifier ENVIRONMENT_SPECIFIER] [--no-default-packages]
                        [--json] [--console CONSOLE] [-v] [-q] [-d] [-y] [--solver SOLVER]
                        [--subdir SUBDIR]
                        [remote_definition]
conda env create: error: argument '--env-spec': invalid choice: 'idontexist' (choose from 'binstar', 'environment.yml', 'requirements.txt')
```

```
$ conda install --solver  idontexist            [10:00:20]
usage: conda install [-h] [--revision REVISION] [--override-frozen] [-n ENVIRONMENT | -p PATH]
                     [-c CHANNEL] [--use-local] [--override-channels] [--repodata-fn REPODATA_FNS]
                     [--experimental {jlap,lock}] [--no-lock]
                     [--repodata-use-zst | --no-repodata-use-zst] [--strict-channel-priority]
                     [--no-channel-priority] [--no-deps | --only-deps] [--no-pin] [--copy]
                     [--no-shortcuts] [--shortcuts-only SHORTCUTS_ONLY] [-C] [-k] [--offline]
                     [--json] [--console CONSOLE] [-v] [-q] [-d] [-y] [--download-only]
                     [--show-channel-urls] [--file FILE] [--solver SOLVER] [--force-reinstall]
                     [--freeze-installed | --update-deps | -S | --update-all | --update-specs]
                     [--clobber] [--dev]
                     [package_spec ...]
conda install: error: argument '--solver': invalid choice: 'idontexist' (choose from 'classic', 'libmamba')
```
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
