### PR TITLE
Enhance `ProxyError` to accept custom messages and add tests for default and custom error messages

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -474,15 +474,16 @@ class CondaOSError(CondaError, OSError):
 
 
 class ProxyError(CondaError):
-    def __init__(self):
-        message = dals(
+    def __init__(self, message: str | None = None):
+        if message is None:
+            message = dals(
+                """
+            Conda cannot proceed due to an error in your proxy configuration.
+            Check for typos and other configuration errors in any '.netrc' file in your home directory,
+            any environment variables ending in '_PROXY', and any other system-wide proxy
+            configuration settings.
             """
-        Conda cannot proceed due to an error in your proxy configuration.
-        Check for typos and other configuration errors in any '.netrc' file in your home directory,
-        any environment variables ending in '_PROXY', and any other system-wide proxy
-        configuration settings.
-        """
-        )
+            )
         super().__init__(message)
 
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -478,11 +478,11 @@ class ProxyError(CondaError):
         if message is None:
             message = dals(
                 """
-            Conda cannot proceed due to an error in your proxy configuration.
-            Check for typos and other configuration errors in any '.netrc' file in your home directory,
-            any environment variables ending in '_PROXY', and any other system-wide proxy
-            configuration settings.
-            """
+                Conda cannot proceed due to an error in your proxy configuration.
+                Check for typos and other configuration errors in any '.netrc' file in your home directory,
+                any environment variables ending in '_PROXY', and any other system-wide proxy
+                configuration settings.
+                """
             )
         super().__init__(message)
 

--- a/news/proxyerror-optional-message
+++ b/news/proxyerror-optional-message
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* `ProxyError` now accepts an optional custom message parameter to provide more specific error details. (#14945)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -815,6 +815,7 @@ def test_proxy_error_default_message() -> None:
     assert ".netrc" in default_message
     assert "_PROXY" in default_message
 
+
 def test_proxy_error_custom_message() -> None:
     """Test ProxyError with custom message."""
     custom_message = "Could not find a proxy for 'https'. Custom error message."

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -811,7 +811,7 @@ def test_proxy_error_default_message() -> None:
     # Test default message
     exc_default = ProxyError()
     default_message = str(exc_default)
-    assert "proxy configuration" in default_message.lower()
+    assert "proxy configuration" in default_message
     assert ".netrc" in default_message
     assert "_PROXY" in default_message
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -25,6 +25,7 @@ from conda.exceptions import (
     KnownPackageClobberError,
     PackagesNotFoundError,
     PathNotFoundError,
+    ProxyError,
     SharedLinkPathClobberError,
     TooManyArgumentsError,
     UnknownPackageClobberError,
@@ -803,3 +804,21 @@ def test_PackagesNotFoundError_use_only_tar_bz2(
             packages=["does-not-exist"],
             channel_urls=["https://repo.anaconda.org/pkgs/main"],
         )
+
+
+def test_proxy_error_default_message() -> None:
+    """Test ProxyError with default and custom messages."""
+    # Test default message
+    exc_default = ProxyError()
+    default_message = str(exc_default)
+    assert "proxy configuration" in default_message.lower()
+    assert ".netrc" in default_message
+    assert "_PROXY" in default_message
+
+def test_proxy_error_custom_message() -> None:
+    """Test ProxyError with custom message."""
+    custom_message = "Could not find a proxy for 'https'. Custom error message."
+    exc_custom = ProxyError(custom_message)
+    assert str(exc_custom) == custom_message
+
+    assert str(ProxyError()) != str(exc_custom)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

While looking at some proxy related issue reports from users, I noticed that one case of `ProxyError` was being instantiated with an argument, that it doesn't actual support. Here's the call in `session.py`: https://github.com/conda/conda/blob/fbeec0b3ebc756e1cfc1339bfa0c2343079fac15/conda/gateways/connection/session.py#L324-L334

Refs #12013?

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
