### PR TITLE
Remove nested if-clauses in `Activator.get_export_unset_vars`

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -122,38 +122,27 @@ class _Activator(metaclass=abc.ABCMeta):
         # split provided environment variables into exports vs unsets
         for name, value in kwargs.items():
             if value is None:
-                if context.envvars_force_uppercase:
-                    unset_vars.append(name.upper())
-                else:
-                    unset_vars.append(name)
-
+                unset_vars.append(name)
             else:
-                if context.envvars_force_uppercase:
-                    export_vars[name.upper()] = value
-                else:
-                    export_vars[name] = value
+                export_vars[name] = value
 
         if export_metavars:
             # split meta variables into exports vs unsets
             for name, value in context.conda_exe_vars_dict.items():
                 if value is None:
-                    if context.envvars_force_uppercase:
-                        unset_vars.append(name.upper())
-                    else:
-                        unset_vars.append(name)
+                    unset_vars.append(name)
                 elif "/" in value or "\\" in value:
-                    if context.envvars_force_uppercase:
-                        export_vars[name.upper()] = self.path_conversion(value)
-                    else:
-                        export_vars[name] = self.path_conversion(value)
+                    export_vars[name] = self.path_conversion(value)
                 else:
-                    if context.envvars_force_uppercase:
-                        export_vars[name.upper()] = value
-                    else:
-                        export_vars[name] = value
+                    export_vars[name] = value
         else:
             # unset all meta variables
             unset_vars.extend(context.conda_exe_vars_dict)
+
+        # normalize case if requested
+        if context.envvars_force_uppercase:
+            export_vars = {k.upper(): v for k, v in export_vars.items()}
+            unset_vars = [k.upper() for k in unset_vars]
 
         return export_vars, unset_vars
 

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -141,8 +141,8 @@ class _Activator(metaclass=abc.ABCMeta):
 
         # normalize case if requested
         if context.envvars_force_uppercase:
-            export_vars = {k.upper(): v for k, v in export_vars.items()}
-            unset_vars = [k.upper() for k in unset_vars]
+            export_vars = {name.upper(): value for name, value in export_vars.items()}
+            unset_vars = [name.upper() for name in unset_vars]
 
         return export_vars, unset_vars
 

--- a/news/14960-nested-if-clauses
+++ b/news/14960-nested-if-clauses
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Apply case normalization to all activation environment variables. (#14960)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While reviewing #14942 discovered we weren't force uppercasing for `export_metavars=False`:

https://github.com/conda/conda/blob/a6a02ac676eae47861e640db89e17eb33f8101ac/conda/activate.py#L154-L156

Flatten nested if-clauses for readability

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
