### PR TITLE
Don't say repodata.json.bz2 is a required part of a conda channel

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -566,10 +566,9 @@ class UnavailableInvalidChannel(ChannelError):
             url = join_url(channel.location, channel.name)
             message += dedent(
                 f"""
-                As of conda 4.3, a valid channel must contain a `noarch/repodata.json` and
-                associated `noarch/repodata.json.bz2` file, even if `noarch/repodata.json` is
+                As of conda 4.3, a valid channel must contain a
+                `noarch/repodata.json` even if `noarch/repodata.json` is
                 empty. Use `conda index {url}`, or create `noarch/repodata.json`
-                and associated `noarch/repodata.json.bz2`.
                 """
             )
 

--- a/news/14965-repodata-json-bz2
+++ b/news/14965-repodata-json-bz2
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* No longer claim that `noarch/repodata.json.bz2` is required. Conda has not
+  used `repodata.json.bz2` for years. (#14965)
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

conda channels don't require `noarch/repodata.json.bz2`

Probably needs to be updated in other documentation.

Fix #14965 

[A PR about the old behavior](https://github.com/conda/conda/pull/3739/files) from 2017

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
