### PR TITLE
Minor environment specifier fixes

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1314,7 +1314,7 @@ class EnvironmentSpecPluginNotDetected(SpecNotFound):
 
             """
         )
-        if len(autodetect_disabled_plugins) > 0:
+        if autodetect_disabled_plugins:
             msg += dals(
                 """
                 Found compatible plugins but they must be explicitly selected.

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -532,16 +532,16 @@ class CondaPluginManager(pluggy.PluginManager):
         :returns: an environment specifier plugin that matches the provided plugin name, or can handle the provided file
         """
         name = name.lower()
-        hooks = self.get_hook_results("environment_specifiers")
-        found = [hook for hook in hooks if hook.name == name]
+        hooks = self.get_environment_specifiers()
+        found = [hook for hook_name, hook in hooks.items() if hook_name == name]
 
-        if len(found) == 0:
+        if not found:
             raise CondaValueError(
                 f"You have chosen an unrecognized environment"
                 f" specifier type ({name}). Choose one of: "
-                f"{', '.join([hook.name for hook in hooks])}"
+                f"{', '.join(hooks)}"
             )
-        if len(found) == 1:
+        elif len(found) == 1:
             # Try to load the plugin and check if it can handle the environment spec
             try:
                 if found[0].environment_spec(source).can_handle():
@@ -561,7 +561,7 @@ class CondaPluginManager(pluggy.PluginManager):
                 raise PluginError(
                     f"Requested plugin '{name}' is unable to handle environment spec '{source}'"
                 )
-        elif len(found) > 1:
+        else:
             raise PluginError(
                 f"More than one environment_spec plugin named {name} found: {found}"
             )
@@ -575,32 +575,31 @@ class CondaPluginManager(pluggy.PluginManager):
         :param source: full path to the environment spec file or source
         :returns: an environment specifier plugin that can handle the provided file
         """
-        hooks = self.get_hook_results("environment_specifiers")
+        hooks = self.get_environment_specifiers()
         found = []
-        available_hooks = []
-        autodetect_disabled_plugins = []
-        for hook in hooks:
+        autodetect_disabled = []
+        for hook_name, hook in hooks.items():
             if hook.environment_spec.detection_supported:
-                log.debug("EnvironmentSpec hook: checking %s", hook.name)
+                log.debug("EnvironmentSpec hook: checking %s", hook_name)
                 try:
                     if hook.environment_spec(source).can_handle():
                         log.debug(
                             "EnvironmentSpec hook: %s can be %s",
                             source,
-                            hook.name,
+                            hook_name,
                         )
                         found.append(hook)
                     else:
                         log.debug(
                             "EnvironmentSpec hook: %s can NOT be handled by %s",
                             source,
-                            hook.name,
+                            hook_name,
                         )
                 except Exception as e:
                     log.error(
                         "EnvironmentSpec hook: an error occurred when handling '%s' with plugin '%s'. %s",
                         source,
-                        hook.name,
+                        hook_name,
                         e,
                     )
                     log.debug("%r", e, exc_info=e)
@@ -608,23 +607,21 @@ class CondaPluginManager(pluggy.PluginManager):
                 log.debug(
                     "EnvironmentSpec hook: %s can NOT be handled by %s",
                     source,
-                    hook.name,
+                    hook_name,
                 )
-                available_hooks.append(hook)
+                autodetect_disabled.append(hook_name)
 
-        if len(found) == 0:
+        if not found:
             # raise error if no plugins found that can read the environment file
             raise EnvironmentSpecPluginNotDetected(
                 name=source,
-                plugin_names=[hook.name for hook in available_hooks],
-                autodetect_disabled_plugins=[
-                    hook.name for hook in autodetect_disabled_plugins
-                ],
+                plugin_names=hooks,
+                autodetect_disabled_plugins=autodetect_disabled,
             )
         elif len(found) == 1:
             # return the plugin if only one is found
             return found[0]
-        elif len(found) > 1:
+        else:
             # raise an error if there is more than one plugin found
             raise PluginError(
                 dals(

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -577,7 +577,7 @@ class CondaPluginManager(pluggy.PluginManager):
         """
         hooks = self.get_environment_specifiers()
         found = []
-        autodetect_disabled = []
+        autodetect_disabled_plugins = []
         for hook_name, hook in hooks.items():
             if hook.environment_spec.detection_supported:
                 log.debug("EnvironmentSpec hook: checking %s", hook_name)
@@ -609,14 +609,14 @@ class CondaPluginManager(pluggy.PluginManager):
                     source,
                     hook_name,
                 )
-                autodetect_disabled.append(hook_name)
+                autodetect_disabled_plugins.append(hook_name)
 
         if not found:
             # raise error if no plugins found that can read the environment file
             raise EnvironmentSpecPluginNotDetected(
                 name=source,
                 plugin_names=hooks,
-                autodetect_disabled_plugins=autodetect_disabled,
+                autodetect_disabled_plugins=autodetect_disabled_plugins,
             )
         elif len(found) == 1:
             # return the plugin if only one is found


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Type checker was complaining about the return types so I've adjusted the if-clauses accordingly.

Switched to using `self.get_environment_specifiers()` instead of `self.get_hook_results("environment_specifiers")` since the former does plugin name normalization (lowercase).

Correct how we collect autodetect disabled plugins for error reporting.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
