### PR TITLE
`conda.gateways.disk.lock` raises `LockError` instead of `OSError`

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -65,7 +65,7 @@ class ResolvePackageNotFound(CondaError):
 NoPackagesFound = NoPackagesFoundError = ResolvePackageNotFound
 
 
-class LockError(CondaError):
+class LockError(CondaError, OSError):
     def __init__(self, message: str):
         msg = str(message)
         super().__init__(msg)

--- a/conda/gateways/disk/lock.py
+++ b/conda/gateways/disk/lock.py
@@ -43,6 +43,9 @@ try:  # pragma: no cover
         except OSError as e:
             if e.errno in (errno.EACCES, errno.EAGAIN):
                 raise LockError("Failed to acquire lock.") from e
+            else:
+                raise
+
 
 except ImportError:
     try:
@@ -71,6 +74,8 @@ except ImportError:
                         if e.errno in (errno.EACCES, errno.EAGAIN):
                             if attempt > LOCK_ATTEMPTS - 2:
                                 raise LockError("Failed to acquire lock.") from e
+                        else:
+                            raise
                         time.sleep(LOCK_SLEEP)
 
             def __exit__(self, *exc):

--- a/conda/gateways/disk/lock.py
+++ b/conda/gateways/disk/lock.py
@@ -39,8 +39,8 @@ try:  # pragma: no cover
             finally:
                 fd.seek(LOCK_BYTE)
                 msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore
-        except OSError as e:
-            raise LockError("Failed to acquire lock.") from e
+        except LockError as e:
+            print("Failed to acquire lock.", e)
 
 except ImportError:
     try:
@@ -65,9 +65,9 @@ except ImportError:
                             self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB, 1, LOCK_BYTE
                         )
                         break
-                    except OSError as e:
+                    except LockError as e:
                         if attempt > LOCK_ATTEMPTS - 2:
-                            raise LockError("Failed to acquire lock.") from e
+                            print("Failed to acquire lock.", e)
                         time.sleep(LOCK_SLEEP)
 
             def __exit__(self, *exc):

--- a/conda/gateways/disk/lock.py
+++ b/conda/gateways/disk/lock.py
@@ -14,6 +14,7 @@ from ...base.context import context
 from ...exceptions import LockError
 
 LOCK_BYTE = 21  # mamba interop
+LOCK_ATTEMPTS = 10
 LOCK_SLEEP = 1
 
 
@@ -82,7 +83,7 @@ except ImportError:
                     raise LockError("Failed to release lock.")
 
 
-def lock(fd, lock_attempts=10):
+def lock(fd, *, lock_attempts=LOCK_ATTEMPTS):
     if not context.no_lock:
         # locking required for jlap, now default for all
         return _lock_impl(fd, lock_attempts)

--- a/conda/gateways/disk/lock.py
+++ b/conda/gateways/disk/lock.py
@@ -79,7 +79,7 @@ except ImportError:
                 try:
                     fcntl.lockf(self.fd, fcntl.LOCK_UN, 1, LOCK_BYTE)
                 except OSError as e:
-                    raise LockError("Failed to acquire lock.") from e
+                    raise LockError("Failed to release lock.") from e
 
 
 def lock(fd):

--- a/conda/gateways/disk/lock.py
+++ b/conda/gateways/disk/lock.py
@@ -70,16 +70,16 @@ except ImportError:
                             self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB, 1, LOCK_BYTE
                         )
                         break
-                    except OSError as e:
+                    except OSError:
                         if attempt > LOCK_ATTEMPTS - 2:
-                            raise LockError("Failed to acquire lock.") from e
+                            raise LockError("Failed to acquire lock.")
                         time.sleep(LOCK_SLEEP)
 
             def __exit__(self, *exc):
                 try:
                     fcntl.lockf(self.fd, fcntl.LOCK_UN, 1, LOCK_BYTE)
-                except OSError as e:
-                    raise LockError("Failed to release lock.") from e
+                except OSError:
+                    raise LockError("Failed to release lock.")
 
 
 def lock(fd):

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
-import builtins
-import sys
 
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
@@ -14,23 +12,6 @@ from conda.gateways.disk.lock import (
     _lock_impl,
     lock,
 )
-
-
-# A function mocking the signature of the real import method in the builtein module
-def monkey_import_ImportError(name, globals=None, locals=None, fromlist=(), level=0):
-    if name in ("msvcrt", "fcntl"):
-        raise ImportError("Mocked import error")
-
-
-def test_locking_not_supported(monkeypatch: MonkeyPatch, tmp_path):
-    tmp_file = tmp_path / "testfile"
-    tmp_file.write_bytes(b"test")
-    monkeypatch.delitem(sys.modules, "fcntl", raising=False)
-    monkeypatch.delitem(sys.modules, "msvcrt", raising=False)
-    monkeypatch.setattr(builtins, "__import__", monkey_import_ImportError)
-
-    with pytest.raises(ImportError):
-        lock(tmp_file)
 
 
 def test_LockError_raised(mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path):

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from pathlib import Path
+
 import pytest
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
@@ -14,7 +16,9 @@ from conda.gateways.disk.lock import (
 )
 
 
-def test_LockError_raised(mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path):
+def test_LockError_raised(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path: Path
+):
     tmp_file = tmp_path / "testfile"
     tmp_file.touch()
 
@@ -25,7 +29,7 @@ def test_LockError_raised(mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_p
                 pass
 
 
-def test_lock_acquired_success(mocker: MockerFixture, tmp_path):
+def test_lock_acquired_success(mocker: MockerFixture, tmp_path: Path):
     tmp_file = tmp_path / "testfile"
     tmp_file.touch()
 
@@ -33,6 +37,7 @@ def test_lock_acquired_success(mocker: MockerFixture, tmp_path):
 
     with tmp_file.open("r+b") as f:
         with lock(f):
+            # Because we are able to use lock(), that means lock acquisition succeeded.
             pass
 
 
@@ -48,7 +53,7 @@ def lock_wrapper(path):
         return "lock_error"
 
 
-def test_double_locking_fails(mocker: MockerFixture, tmp_path):
+def test_double_locking_fails(mocker: MockerFixture, tmp_path: Path):
     from multiprocessing import Pool
 
     tmp_file = tmp_path / "testfile"

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -63,7 +63,7 @@ def lock_wrapper(path):
     try:
         with path.open("r+b") as fd:
             with lock(fd, lock_attempts=1):
-                time.sleep(1)
+                time.sleep(2)
             return "success"
     except LockError:
         return "lock_error"

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -10,15 +10,10 @@ from pytest_mock import MockerFixture
 
 from conda.common.compat import on_win
 from conda.exceptions import LockError
-from conda.gateways.disk.lock import (
-    _lock_impl,
-    lock,
-)
+from conda.gateways.disk.lock import _lock_impl, lock
 
 
-def test_LockError_raised(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path: Path
-):
+def test_LockError_raised(mocker: MockerFixture, tmp_path: Path):
     tmp_file = tmp_path / "testfile"
     tmp_file.touch()
 

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -1,2 +1,52 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+
+import builtins
+import sys
+from tempfile import TemporaryFile
+
+import pytest
+from pytest import CaptureFixture, MonkeyPatch
+from pytest_mock import MockerFixture
+
+from conda.gateways.disk.lock import _lock_impl, _lock_noop, lock
+
+
+# A function mocking the signature of the real import method in the builtein module
+def monkey_import_ImportError(name, globals=None, locals=None, fromlist=(), level=0):
+    if name in ("msvcrt", "fcntl"):
+        raise ImportError("Mocked import error")
+
+
+def test_locking_not_supported(monkeypatch: MonkeyPatch):
+    tmp_file = TemporaryFile()
+    monkeypatch.delitem(sys.modules, "fcntl", raising=False)
+    monkeypatch.delitem(sys.modules, "msvcrt", raising=False)
+    monkeypatch.setattr(builtins, "__import__", monkey_import_ImportError)
+
+    with pytest.raises(ImportError):
+        lock(tmp_file)
+
+
+def test_lock_acquired(mocker: MockerFixture, capsys: CaptureFixture):
+    tmp_file = TemporaryFile()
+    print(tmp_file)
+    assert _lock_impl != _lock_noop
+    mocker.patch("conda.gateways.disk.lock.lock", return_value=_lock_impl)
+    with _lock_impl(tmp_file):
+        with _lock_impl(tmp_file):
+            pass
+    stdout, stderr = capsys.readouterr()
+    assert "Failed to acquire lock." in stdout
+
+
+def test_lock_not_acquired(): ...
+
+
+def test_lock_released(): ...
+
+
+def test_lock_not_released(): ...
+
+
+def test_lock_again(): ...

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -3,7 +3,6 @@
 
 import builtins
 import sys
-from tempfile import TemporaryFile
 
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
@@ -23,8 +22,9 @@ def monkey_import_ImportError(name, globals=None, locals=None, fromlist=(), leve
         raise ImportError("Mocked import error")
 
 
-def test_locking_not_supported(monkeypatch: MonkeyPatch):
-    tmp_file = TemporaryFile()
+def test_locking_not_supported(monkeypatch: MonkeyPatch, tmp_path):
+    tmp_file = tmp_path / "testfile"
+    tmp_file.write_bytes(b"test")
     monkeypatch.delitem(sys.modules, "fcntl", raising=False)
     monkeypatch.delitem(sys.modules, "msvcrt", raising=False)
     monkeypatch.setattr(builtins, "__import__", monkey_import_ImportError)
@@ -34,8 +34,11 @@ def test_locking_not_supported(monkeypatch: MonkeyPatch):
 
 
 @pytest.mark.skipif(not on_win, reason="windows-specific test")
-def test_LockError_raised_windows(mocker: MockerFixture, monkeypatch: MonkeyPatch):
-    tmp_file = TemporaryFile()
+def test_LockError_raised_windows(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path
+):
+    tmp_file = tmp_path / "testfile"
+    tmp_file.write_bytes(b"test")
     mocker.patch("msvcrt.locking", side_effect=OSError)
     monkeypatch.setattr("conda.gateways.disk.lock.LOCK_ATTEMPTS", 1)
     with pytest.raises(LockError):
@@ -44,8 +47,12 @@ def test_LockError_raised_windows(mocker: MockerFixture, monkeypatch: MonkeyPatc
 
 
 @pytest.mark.skipif(on_win, reason="non windows test")
-def test_LockError_raised_not_windows(mocker: MockerFixture, monkeypatch: MonkeyPatch):
-    tmp_file = TemporaryFile()
+def test_LockError_raised_not_windows(
+    mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path
+):
+    tmp_file = tmp_path / "testfile"
+    tmp_file.write_bytes(b"test")
+
     mocker.patch("fcntl.lockf", side_effect=OSError)
     monkeypatch.setattr("conda.gateways.disk.lock.LOCK_ATTEMPTS", 1)
     with pytest.raises(LockError):
@@ -53,16 +60,49 @@ def test_LockError_raised_not_windows(mocker: MockerFixture, monkeypatch: Monkey
             pass
 
 
-def test_lock_acquired_success(mocker: MockerFixture, capsys: CaptureFixture):
-    tmp_file = TemporaryFile()
+def test_lock_acquired_success(mocker: MockerFixture, capsys: CaptureFixture, tmp_path):
+    tmp_file = tmp_path / "testfile"
+    tmp_file.write_bytes(b"test")
+
     mocker.patch("conda.gateways.disk.lock.lock", return_value=_lock_impl)
-    with lock(tmp_file):
-        pass
-    stdout, stderr = capsys.readouterr()
+
+    with tmp_file.open("r+b") as f:
+        with lock(f):
+            pass
+    stdout, _ = capsys.readouterr()
     assert "Failed to acquire lock." not in stdout
 
 
-def test_lock_released(): ...
+def lock_wrapper(path, q):
+    import time
+
+    try:
+        with path.open("r+b") as fd:
+            with lock(fd):
+                # sleep needs to be long enough to keep p1 process running while p2 starts
+                time.sleep(12)
+            q.put("success")
+    except LockError:
+        q.put("lock_error")
 
 
-def test_lock_not_released(): ...
+def test_double_locking_fails(mocker: MockerFixture, capsys: CaptureFixture, tmp_path):
+    from multiprocessing import Process, Queue
+
+    tmp_file = tmp_path / "testfile"
+    tmp_file.write_bytes(b"test")
+
+    q = Queue()
+
+    p1 = Process(target=lock_wrapper, args=(tmp_file, q))
+    p2 = Process(target=lock_wrapper, args=(tmp_file, q))
+
+    p1.start()
+    p2.start()
+    p1.join()
+    p2.join()
+
+    result = [q.get() for _ in range(2)]
+
+    assert "success" in result
+    assert "lock_error" in result

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -43,7 +43,7 @@ def test_LockError_raised_windows(mocker: MockerFixture, monkeypatch: MonkeyPatc
             pass
 
 
-@pytest.mark.skipif(on_win, reason="windows-specific test")
+@pytest.mark.skipif(on_win, reason="non windows test")
 def test_LockError_raised_not_windows(mocker: MockerFixture, monkeypatch: MonkeyPatch):
     tmp_file = TemporaryFile()
     mocker.patch("fcntl.lockf", side_effect=OSError)

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -63,7 +63,7 @@ def lock_wrapper(path):
     try:
         with path.open("r+b") as fd:
             with lock(fd, lock_attempts=1):
-                time.sleep(3)
+                time.sleep(4)
             return "success"
     except LockError:
         return "lock_error"

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -5,12 +5,11 @@
 from pathlib import Path
 
 import pytest
-from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 
 from conda.common.compat import on_win
 from conda.exceptions import LockError
-from conda.gateways.disk.lock import _lock_impl, lock
+from conda.gateways.disk.lock import _lock_impl
 
 
 def test_LockError_raised(mocker: MockerFixture, tmp_path: Path):

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -63,7 +63,7 @@ def lock_wrapper(path):
     try:
         with path.open("r+b") as fd:
             with lock(fd, lock_attempts=1):
-                time.sleep(4)
+                time.sleep(5)
             return "success"
     except LockError:
         return "lock_error"

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -42,8 +42,9 @@ def test_LockError_raised_windows(
     mocker.patch("msvcrt.locking", side_effect=OSError)
     monkeypatch.setattr("conda.gateways.disk.lock.LOCK_ATTEMPTS", 1)
     with pytest.raises(LockError):
-        with lock(tmp_file):
-            pass
+        with tmp_file.open("r+b") as f:
+            with lock(f):
+                pass
 
 
 @pytest.mark.skipif(on_win, reason="non windows test")
@@ -56,8 +57,9 @@ def test_LockError_raised_not_windows(
     mocker.patch("fcntl.lockf", side_effect=OSError)
     monkeypatch.setattr("conda.gateways.disk.lock.LOCK_ATTEMPTS", 1)
     with pytest.raises(LockError):
-        with lock(tmp_file):
-            pass
+        with tmp_file.open("r+b") as f:
+            with lock(f):
+                pass
 
 
 def test_lock_acquired_success(mocker: MockerFixture, capsys: CaptureFixture, tmp_path):

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -75,9 +75,9 @@ def test_double_locking_fails(mocker: MockerFixture, tmp_path):
     from multiprocessing import Pool
 
     tmp_file = tmp_path / "testfile"
-    tmp_file.write_bytes(b"test")
+    tmp_file.touch()
 
-    p = Pool()
-    result = p.map(lock_wrapper, [tmp_file, tmp_file])
-    assert "success" in result
-    assert "lock_error" in result
+    with Pool(processes=2) as p:
+        result = p.map(lock_wrapper, [tmp_file, tmp_file])
+        assert "success" in result
+        assert "lock_error" in result

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -96,8 +96,20 @@ def test_double_locking_fails(mocker: MockerFixture, capsys: CaptureFixture, tmp
 
     q = Queue()
 
-    p1 = Process(target=lock_wrapper, args=(tmp_file, q))
-    p2 = Process(target=lock_wrapper, args=(tmp_file, q))
+    p1 = Process(
+        target=lock_wrapper,
+        args=(
+            tmp_file,
+            q,
+        ),
+    )
+    p2 = Process(
+        target=lock_wrapper,
+        args=(
+            tmp_file,
+            q,
+        ),
+    )
 
     p1.start()
     p2.start()

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -33,28 +33,11 @@ def test_locking_not_supported(monkeypatch: MonkeyPatch, tmp_path):
         lock(tmp_file)
 
 
-@pytest.mark.skipif(not on_win, reason="windows-specific test")
-def test_LockError_raised_windows(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path
-):
-    tmp_file = tmp_path / "testfile"
-    tmp_file.write_bytes(b"test")
-    mocker.patch("msvcrt.locking", side_effect=OSError)
-    monkeypatch.setattr("conda.gateways.disk.lock.LOCK_ATTEMPTS", 1)
-    with pytest.raises(LockError):
-        with tmp_file.open("r+b") as f:
-            with lock(f):
-                pass
-
-
-@pytest.mark.skipif(on_win, reason="non windows test")
-def test_LockError_raised_not_windows(
-    mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path
-):
+def test_LockError_raised(mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path):
     tmp_file = tmp_path / "testfile"
     tmp_file.write_bytes(b"test")
 
-    mocker.patch("fcntl.lockf", side_effect=OSError)
+    mocker.patch("msvcrt.locking" if on_win else "fcntl.lockf", side_effect=OSError)
     monkeypatch.setattr("conda.gateways.disk.lock.LOCK_ATTEMPTS", 1)
     with pytest.raises(LockError):
         with tmp_file.open("r+b") as f:

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -63,7 +63,7 @@ def lock_wrapper(path):
     try:
         with path.open("r+b") as fd:
             with lock(fd, lock_attempts=1):
-                time.sleep(5)
+                time.sleep(12 if on_win else 1)
             return "success"
     except LockError:
         return "lock_error"

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -3,7 +3,7 @@
 
 
 import pytest
-from pytest import CaptureFixture, MonkeyPatch
+from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 
 from conda.common.compat import on_win
@@ -16,7 +16,7 @@ from conda.gateways.disk.lock import (
 
 def test_LockError_raised(mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_path):
     tmp_file = tmp_path / "testfile"
-    tmp_file.write_bytes(b"test")
+    tmp_file.touch()
 
     mocker.patch("msvcrt.locking" if on_win else "fcntl.lockf", side_effect=OSError)
     with pytest.raises(LockError):
@@ -25,17 +25,15 @@ def test_LockError_raised(mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_p
                 pass
 
 
-def test_lock_acquired_success(mocker: MockerFixture, capsys: CaptureFixture, tmp_path):
+def test_lock_acquired_success(mocker: MockerFixture, tmp_path):
     tmp_file = tmp_path / "testfile"
-    tmp_file.write_bytes(b"test")
+    tmp_file.touch()
 
     mocker.patch("conda.gateways.disk.lock.lock", return_value=_lock_impl)
 
     with tmp_file.open("r+b") as f:
         with lock(f):
             pass
-    stdout, _ = capsys.readouterr()
-    assert "Failed to acquire lock." not in stdout
 
 
 def lock_wrapper(path):

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -38,10 +38,9 @@ def test_LockError_raised(mocker: MockerFixture, monkeypatch: MonkeyPatch, tmp_p
     tmp_file.write_bytes(b"test")
 
     mocker.patch("msvcrt.locking" if on_win else "fcntl.lockf", side_effect=OSError)
-    monkeypatch.setattr("conda.gateways.disk.lock.LOCK_ATTEMPTS", 1)
     with pytest.raises(LockError):
         with tmp_file.open("r+b") as f:
-            with lock(f):
+            with lock(f, lock_attempts=1):
                 pass
 
 
@@ -63,9 +62,8 @@ def lock_wrapper(path):
 
     try:
         with path.open("r+b") as fd:
-            with lock(fd):
-                # sleep needs to be long enough to keep p1 process running while p2 starts
-                time.sleep(12)
+            with lock(fd, lock_attempts=1):
+                time.sleep(1)
             return "success"
     except LockError:
         return "lock_error"

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -43,6 +43,7 @@ def test_LockError_raised_windows(mocker: MockerFixture, monkeypatch: MonkeyPatc
             pass
 
 
+@pytest.mark.skipif(on_win, reason="windows-specific test")
 def test_LockError_raised_not_windows(mocker: MockerFixture, monkeypatch: MonkeyPatch):
     tmp_file = TemporaryFile()
     mocker.patch("fcntl.lockf", side_effect=OSError)

--- a/tests/gateways/disk/test_lock.py
+++ b/tests/gateways/disk/test_lock.py
@@ -63,7 +63,7 @@ def lock_wrapper(path):
     try:
         with path.open("r+b") as fd:
             with lock(fd, lock_attempts=1):
-                time.sleep(2)
+                time.sleep(3)
             return "success"
     except LockError:
         return "lock_error"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

resolves #15077 

This PR:
1. Adds a tests file for `gateways/disk/lock.py`.
2. Uses `LockError` in the `lock.py` module.
3. Modifies the `lock()` function/class to accept "number of lock attempts" variable, default is set to 10 for backwards compatibility. 


Tests added:
1. That a LockError is displayed when the locking functions in either `msvcrt` or `fcntl` generate an OSError. 
4. Happy path case (locking works)
5. When a process tries to lock an already locked file (LockError generated, operation not allowed). 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
