### PR TITLE
Rename `env.env.Environment` to `env.env.EnvironmentYaml`

### DIFF
--- a/conda/env/installers/conda.py
+++ b/conda/env/installers/conda.py
@@ -13,7 +13,7 @@ from boltons.setutils import IndexedSet
 from ...base.constants import UpdateModifier
 from ...base.context import context
 from ...common.constants import NULL
-from ...env.env import Environment as EnvironmentYaml
+from ...env.env import EnvironmentYaml
 from ...exceptions import CondaValueError, UnsatisfiableError
 from ...models.channel import Channel, prioritize_channels
 

--- a/conda/env/specs/requirements.py
+++ b/conda/env/specs/requirements.py
@@ -16,7 +16,7 @@ from ...gateways.disk.read import yield_lines
 from ...models.environment import Environment
 from ...models.match_spec import MatchSpec
 from ...plugins.types import EnvironmentSpecBase
-from ..env import Environment as EnvironmentYaml
+from ..env import EnvironmentYaml
 
 
 class RequirementsSpec(EnvironmentSpecBase):

--- a/conda/env/specs/yaml_file.py
+++ b/conda/env/specs/yaml_file.py
@@ -9,7 +9,7 @@ from ...deprecations import deprecated
 from ...models.environment import Environment
 from ...plugins.types import EnvironmentSpecBase
 from .. import env
-from ..env import Environment as EnvironmentYaml
+from ..env import EnvironmentYaml
 
 log = getLogger(__name__)
 

--- a/news/14981-rename-environment-to-environmentyaml
+++ b/news/14981-rename-environment-to-environmentyaml
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.env.env.Environment` as pending deprecation in 26.9. Use `conda.env.env.EnvironmentYaml` instead. (#14981)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -14,6 +14,7 @@ from conda.common.serialize import yaml_round_trip_load
 from conda.core.prefix_data import PrefixData
 from conda.env.env import (
     VALID_KEYS,
+    EnvironmentYaml,
     Environment,
     from_environment,
     from_file,
@@ -58,7 +59,7 @@ def get_invalid_keys_environment():
 
 def test_returns_Environment():
     e = get_simple_environment()
-    assert isinstance(e, Environment)
+    assert isinstance(e, EnvironmentYaml)
 
 
 def test_retains_full_filename():
@@ -120,30 +121,30 @@ def test_envvars():
 
 
 def test_has_empty_filename_by_default():
-    e = Environment()
+    e = EnvironmentYaml()
     assert e.filename is None
 
 
 def test_has_filename_if_provided():
     r = random.randint(100, 200)
     random_filename = f"/path/to/random/environment-{r}.yml"
-    e = Environment(filename=random_filename)
+    e = EnvironmentYaml(filename=random_filename)
     assert e.filename == random_filename
 
 
 def test_has_empty_name_by_default():
-    e = Environment()
+    e = EnvironmentYaml()
     assert e.name is None
 
 
 def test_has_name_if_provided():
     random_name = f"random-{random.randint(100, 200)}"
-    e = Environment(name=random_name)
+    e = EnvironmentYaml(name=random_name)
     assert e.name == random_name
 
 
 def test_dependencies_are_empty_by_default():
-    e = Environment()
+    e = EnvironmentYaml()
     assert not e.dependencies
 
 
@@ -155,19 +156,19 @@ def test_parses_dependencies_from_raw_file():
 
 def test_builds_spec_from_line_raw_dependency():
     # TODO Refactor this inside conda to not be a raw string
-    e = Environment(dependencies=["nltk=3.0.0=np18py27_0"])
+    e = EnvironmentYaml(dependencies=["nltk=3.0.0=np18py27_0"])
     expected = {"conda": ["nltk==3.0.0=np18py27_0"]}
     assert e.dependencies == expected
 
 
 def test_args_are_wildcarded():
-    e = Environment(dependencies=["python=2.7"])
+    e = EnvironmentYaml(dependencies=["python=2.7"])
     expected = {"conda": ["python=2.7"]}
     assert e.dependencies == expected
 
 
 def test_other_tips_of_dependencies_are_supported():
-    e = Environment(dependencies=["nltk", {"pip": ["foo", "bar"]}])
+    e = EnvironmentYaml(dependencies=["nltk", {"pip": ["foo", "bar"]}])
     expected = {
         "conda": ["nltk", "pip"],
         "pip": ["foo", "bar"],
@@ -176,32 +177,32 @@ def test_other_tips_of_dependencies_are_supported():
 
 
 def test_channels_default_to_empty_list():
-    e = Environment()
+    e = EnvironmentYaml()
     assert isinstance(e.channels, list)
     assert not e.channels
 
 
 def test_add_channels():
-    e = Environment()
+    e = EnvironmentYaml()
     e.add_channels(["dup", "dup", "unique"])
     assert e.channels == ["dup", "unique"]
 
 
 def test_remove_channels():
-    e = Environment(channels=["channel"])
+    e = EnvironmentYaml(channels=["channel"])
     e.remove_channels()
     assert not e.channels
 
 
 def test_channels_are_provided_by_kwarg():
     random_channels = (random.randint(100, 200), random)
-    e = Environment(channels=random_channels)
+    e = EnvironmentYaml(channels=random_channels)
     assert e.channels == random_channels
 
 
 def test_to_dict_returns_dictionary_of_data():
     random_name = f"random{random.randint(100, 200)}"
-    e = Environment(name=random_name, channels=["javascript"], dependencies=["nodejs"])
+    e = EnvironmentYaml(name=random_name, channels=["javascript"], dependencies=["nodejs"])
 
     expected = {
         "name": random_name,
@@ -212,14 +213,14 @@ def test_to_dict_returns_dictionary_of_data():
 
 
 def test_to_dict_returns_just_name_if_only_thing_present():
-    e = Environment(name="simple")
+    e = EnvironmentYaml(name="simple")
     expected = {"name": "simple"}
     assert e.to_dict() == expected
 
 
 def test_to_yaml_returns_yaml_parseable_string():
     random_name = f"random{random.randint(100, 200)}"
-    e = Environment(name=random_name, channels=["javascript"], dependencies=["nodejs"])
+    e = EnvironmentYaml(name=random_name, channels=["javascript"], dependencies=["nodejs"])
 
     expected = {
         "name": random_name,
@@ -233,7 +234,7 @@ def test_to_yaml_returns_yaml_parseable_string():
 
 def test_to_yaml_returns_proper_yaml():
     random_name = f"random{random.randint(100, 200)}"
-    e = Environment(name=random_name, channels=["javascript"], dependencies=["nodejs"])
+    e = EnvironmentYaml(name=random_name, channels=["javascript"], dependencies=["nodejs"])
 
     expected = "\n".join(
         [
@@ -252,7 +253,7 @@ def test_to_yaml_returns_proper_yaml():
 
 def test_to_yaml_takes_stream():
     random_name = f"random{random.randint(100, 200)}"
-    e = Environment(name=random_name, channels=["javascript"], dependencies=["nodejs"])
+    e = EnvironmentYaml(name=random_name, channels=["javascript"], dependencies=["nodejs"])
 
     s = FakeStream()
     e.to_yaml(stream=s)
@@ -307,7 +308,7 @@ def test_creates_file_on_save(tmp_path: Path):
 
     assert not tmp.exists()
 
-    env = Environment(filename=tmp, name="simple")
+    env = EnvironmentYaml(filename=tmp, name="simple")
     env.save()
 
     assert tmp.exists()
@@ -351,3 +352,8 @@ def test_from_history():
         assert len(out.to_dict()["dependencies"]) == 4
 
         m.assert_called()
+
+
+def test_environment_deprecated() -> None:
+    with pytest.deprecated_call():
+        Environment(filename="idontexist", name="simple")

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -14,8 +14,8 @@ from conda.common.serialize import yaml_round_trip_load
 from conda.core.prefix_data import PrefixData
 from conda.env.env import (
     VALID_KEYS,
-    EnvironmentYaml,
     Environment,
+    EnvironmentYaml,
     from_environment,
     from_file,
 )
@@ -202,7 +202,9 @@ def test_channels_are_provided_by_kwarg():
 
 def test_to_dict_returns_dictionary_of_data():
     random_name = f"random{random.randint(100, 200)}"
-    e = EnvironmentYaml(name=random_name, channels=["javascript"], dependencies=["nodejs"])
+    e = EnvironmentYaml(
+        name=random_name, channels=["javascript"], dependencies=["nodejs"]
+    )
 
     expected = {
         "name": random_name,
@@ -220,7 +222,9 @@ def test_to_dict_returns_just_name_if_only_thing_present():
 
 def test_to_yaml_returns_yaml_parseable_string():
     random_name = f"random{random.randint(100, 200)}"
-    e = EnvironmentYaml(name=random_name, channels=["javascript"], dependencies=["nodejs"])
+    e = EnvironmentYaml(
+        name=random_name, channels=["javascript"], dependencies=["nodejs"]
+    )
 
     expected = {
         "name": random_name,
@@ -234,7 +238,9 @@ def test_to_yaml_returns_yaml_parseable_string():
 
 def test_to_yaml_returns_proper_yaml():
     random_name = f"random{random.randint(100, 200)}"
-    e = EnvironmentYaml(name=random_name, channels=["javascript"], dependencies=["nodejs"])
+    e = EnvironmentYaml(
+        name=random_name, channels=["javascript"], dependencies=["nodejs"]
+    )
 
     expected = "\n".join(
         [
@@ -253,7 +259,9 @@ def test_to_yaml_returns_proper_yaml():
 
 def test_to_yaml_takes_stream():
     random_name = f"random{random.randint(100, 200)}"
-    e = EnvironmentYaml(name=random_name, channels=["javascript"], dependencies=["nodejs"])
+    e = EnvironmentYaml(
+        name=random_name, channels=["javascript"], dependencies=["nodejs"]
+    )
 
     s = FakeStream()
     e.to_yaml(stream=s)

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -3,7 +3,7 @@
 import pytest
 
 from conda import plugins
-from conda.env.env import Environment
+from conda.models.environment import Environment
 from conda.exceptions import (
     CondaValueError,
     EnvironmentSpecPluginNotDetected,
@@ -45,7 +45,7 @@ class RandomSpec(EnvironmentSpecBase):
         return False
 
     def env(self):
-        return Environment(name="random-environment", dependencies=["python", "numpy"])
+        return Environment(prefix="/somewhere", platform=["linux-64"])
 
 
 class RandomSpecNoAutoDetect(RandomSpec):

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -3,12 +3,12 @@
 import pytest
 
 from conda import plugins
-from conda.models.environment import Environment
 from conda.exceptions import (
     CondaValueError,
     EnvironmentSpecPluginNotDetected,
     PluginError,
 )
+from conda.models.environment import Environment
 from conda.plugins.types import CondaEnvironmentSpecifier, EnvironmentSpecBase
 
 


### PR DESCRIPTION
### Description

Follow up to https://github.com/conda/conda/pull/14937.

The new `conda.model.environment.Environment` class has a very similar name to the `conda.env.env.Environment` class. These classes often intermingle, and their similar names makes working with them confusing.

`conda.model.environment.Environment` represents a conda environment.
`conda.env.env.Environment`  represents an `environment.yaml` file.

This PR proposes renaming `conda.env.env.Environment` -> `conda.env.env.EnvironmentYaml`, by deprecating `conda.env.env.Environment` and introducing a new class `conda.env.env.EnvironmentYaml`.

### Checklist - did you ...


- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

