### PR TITLE
Aggressive update packages is a list of strings, not a bool

### DIFF
--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -33,7 +33,7 @@ class EnvironmentConfig:
     Data model for a conda environment config.
     """
 
-    aggressive_update_packages: bool | None = None
+    aggressive_update_packages: list[str] = field(default_factory=list)
 
     channel_priority: ChannelPriority | None = None
 
@@ -82,8 +82,9 @@ class EnvironmentConfig:
                 "Cannot merge EnvironmentConfig with non-EnvironmentConfig"
             )
 
-        if other.aggressive_update_packages is not None:
-            self.aggressive_update_packages = other.aggressive_update_packages
+        self.aggressive_update_packages = self._append_without_duplicates(
+            self.aggressive_update_packages, other.aggressive_update_packages
+        )
 
         if other.channel_priority is not None:
             self.channel_priority = other.channel_priority

--- a/news/14982-fix-environmentconfig-types
+++ b/news/14982-fix-environmentconfig-types
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `EnvironmentConfig.aggressive_update_packages` type. It is a list of strings, not a bool. (#14982)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -70,7 +70,7 @@ def test_environments_merge():
         prefix="/path/to/env1",
         platform="linux-64",
         config=EnvironmentConfig(
-            aggressive_update_packages=True,
+            aggressive_update_packages=["abc"],
             channels=["defaults"],
             channel_settings={"a": 1},
         ),
@@ -86,7 +86,7 @@ def test_environments_merge():
         prefix="/path/to/env1",
         platform="linux-64",
         config=EnvironmentConfig(
-            aggressive_update_packages=False,
+            aggressive_update_packages=["two"],
             channels=["conda-forge"],
             channel_settings={"b": 2},
             repodata_fns=["repodata2.json"],
@@ -100,7 +100,7 @@ def test_environments_merge():
     assert merged.prefix == "/path/to/env1"
     assert merged.platform == "linux-64"
     assert merged.config == EnvironmentConfig(
-        aggressive_update_packages=False,
+        aggressive_update_packages=["abc", "two"],
         channels=["defaults", "conda-forge"],
         channel_settings={"a": 1, "b": 2},
         repodata_fns=["repodata2.json"],
@@ -190,30 +190,30 @@ def test_environments_merge_colliding_prefix():
 
 def test_merge_configs_primitive_values_order():
     config1 = EnvironmentConfig(
-        aggressive_update_packages=True,
+        use_only_tar_bz2=True,
     )
     config2 = EnvironmentConfig(
-        aggressive_update_packages=False,
+        use_only_tar_bz2=False,
     )
 
     result = EnvironmentConfig.merge(config1, config2)
-    assert result.aggressive_update_packages is False
+    assert result.use_only_tar_bz2 is False
 
     result = EnvironmentConfig.merge(config2, config1)
-    assert result.aggressive_update_packages is True
+    assert result.use_only_tar_bz2 is True
 
 
 def test_merge_configs_primitive_none_values_order():
     config1 = EnvironmentConfig(
-        aggressive_update_packages=True,
+        use_only_tar_bz2=True,
     )
     config2 = EnvironmentConfig()
 
     result = EnvironmentConfig.merge(config1, config2)
-    assert result.aggressive_update_packages is True
+    assert result.use_only_tar_bz2 is True
 
     result = EnvironmentConfig.merge(config2, config1)
-    assert result.aggressive_update_packages is True
+    assert result.use_only_tar_bz2 is True
 
 
 def test_merge_configs_deduplicate_values():


### PR DESCRIPTION
### Description

This PR fixes the `EnvironmentConfig` model so that the `aggressive_update_packages` fiels is to be a list of strings opposed to a bool field.

In the [`Context` object](https://github.com/conda/conda/blob/main/conda/base/context.py#L300), it is defined as a list of strings:
```
_aggressive_update_packages = ParameterLoader(
        SequenceParameter(
            PrimitiveParameter("", element_type=str), DEFAULT_AGGRESSIVE_UPDATE_PACKAGES
        ),
        aliases=("aggressive_update_packages",),
    )
```
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
