### PR TITLE
When deprecating a class wrap `__init__`

### DIFF
--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -96,12 +96,12 @@ class DeprecationHandler:
         :param stack: Optional stacklevel increment.
         """
 
-        def deprecated_decorator(func: Callable[P, T]) -> Callable[P, T]:
+        def deprecated_decorator(obj: Callable[P, T]) -> Callable[P, T]:
             # detect function name and generate message
             category, message = self._generate_message(
                 deprecate_in=deprecate_in,
                 remove_in=remove_in,
-                prefix=f"{func.__module__}.{func.__qualname__}",
+                prefix=f"{obj.__module__}.{obj.__qualname__}",
                 addendum=addendum,
                 deprecation_type=deprecation_type,
             )
@@ -110,14 +110,31 @@ class DeprecationHandler:
             if not category:
                 raise DeprecatedError(message)
 
+            # if func is a class, wrap the constructor
+            isclass = False
+            func: Callable[P, T]
+            if isinstance(obj, type):
+                try:
+                    func = obj.__init__  # type: ignore[misc]
+                except AttributeError:
+                    func = obj
+                else:
+                    isclass = True
+            else:
+                func = obj
+
             # alert user that it's time to remove something
-            @wraps(func)
+            @wraps(func)  # type: ignore[reportArgumentType]
             def inner(*args: P.args, **kwargs: P.kwargs) -> T:
                 warnings.warn(message, category, stacklevel=2 + stack)
 
                 return func(*args, **kwargs)
 
-            return inner
+            if isclass:
+                obj.__init__ = inner  # type: ignore[misc]
+                return obj
+            else:
+                return inner
 
         return deprecated_decorator
 

--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -117,6 +117,7 @@ class DeprecationHandler:
                 try:
                     func = obj.__init__  # type: ignore[misc]
                 except AttributeError:
+                    # AttributeError: obj has no __init__
                     func = obj
                 else:
                     isclass = True

--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -110,7 +110,7 @@ class DeprecationHandler:
             if not category:
                 raise DeprecatedError(message)
 
-            # if func is a class, wrap the constructor
+            # if obj is a class, wrap the __init__
             isclass = False
             func: Callable[P, T]
             if isinstance(obj, type):

--- a/conda/env/specs/binstar.py
+++ b/conda/env/specs/binstar.py
@@ -25,6 +25,7 @@ deprecated.module("24.7", "25.9")
 deprecated.constant("24.7", "25.9", "ENVIRONMENT_TYPE", "env")
 
 
+@deprecated("24.7", "25.9")
 class BinstarSpec(EnvironmentSpecBase):
     """
     spec = BinstarSpec('darth/deathstar')
@@ -37,7 +38,6 @@ class BinstarSpec(EnvironmentSpecBase):
 
     msg = None
 
-    @deprecated("24.7", "25.9")
     def __init__(self, name=None):
         self.name = name
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We were previously treating all class deprecations the same as a function/method. This worked great until we tried to access class attributes which wasn't possible when the deprecation wrapper is a function.

Instead we now detect if a deprecation is for a class in which case we attempt to wrap the `__init__` constructor instead.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
