### PR TITLE
Create `EnvironmentConfig` from context

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1277,10 +1277,7 @@ class Context(Configuration):
     @property
     def environment_settings(self) -> dict[str, Any]:
         """Returns a dict of environment related settings"""
-        return {
-            key: getattr(self, key)
-            for key in self.environment_context_keys
-        }
+        return {key: getattr(self, key) for key in self.environment_context_keys}
 
     @property
     def category_map(self) -> dict[str, tuple[str, ...]]:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1255,6 +1255,34 @@ class Context(Configuration):
         return self._default_activation_env or ROOT_ENV_NAME
 
     @property
+    def environment_context_keys(self) -> list[str]:
+        return [
+            "aggressive_update_packages",
+            "channel_priority",
+            "channels",
+            "channel_settings",
+            "custom_channels",
+            "custom_multichannels",
+            "deps_modifier",
+            "disallowed_packages",
+            "pinned_packages",
+            "repodata_fns",
+            "sat_solver",
+            "solver",
+            "track_features",
+            "update_modifier",
+            "use_only_tar_bz2",
+        ]
+
+    @property
+    def environment_settings(self) -> dict[str, Any]:
+        """Returns a dict of environment related settings"""
+        return {
+            key: getattr(self, key)
+            for key in self.environment_context_keys
+        }
+
+    @property
     def category_map(self) -> dict[str, tuple[str, ...]]:
         return {
             "Channel Configuration": (

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -134,7 +134,8 @@ class EnvironmentConfig:
 
         Create an EnvironmentConfig from the current context
         """
-        field_names = [f.name for f in fields(cls)]
+        field_names = {field.name for field in fields(cls)}
+
         environment_settings = {
             key: value
             for key, value in context.environment_settings.items()

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -135,7 +135,11 @@ class EnvironmentConfig:
         Create an EnvironmentConfig from the current context
         """
         field_names = [f.name for f in fields(cls)]
-        environment_settings = {key: value for key, value in context.environment_settings.items() if key in field_names}
+        environment_settings = {
+            key: value
+            for key, value in context.environment_settings.items()
+            if key in field_names
+        }
         return cls(**environment_settings)
 
     @classmethod

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -4,11 +4,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from logging import getLogger
 from typing import TYPE_CHECKING
 
 from ..base.constants import PLATFORMS
+from ..base.context import context
 from ..exceptions import CondaValueError
 
 if TYPE_CHECKING:
@@ -125,6 +126,17 @@ class EnvironmentConfig:
             self.use_only_tar_bz2 = other.use_only_tar_bz2
 
         return self
+
+    @classmethod
+    def from_context(cls) -> EnvironmentConfig:
+        """
+        **Experimental** While experimental, expect both major and minor changes across minor releases.
+
+        Create an EnvironmentConfig from the current context
+        """
+        field_names = [f.name for f in fields(cls)]
+        environment_settings = {key: value for key, value in context.environment_settings.items() if key in field_names}
+        return cls(**environment_settings)
 
     @classmethod
     def merge(cls, *configs: EnvironmentConfig) -> EnvironmentConfig:

--- a/news/14986-create-environment-config-from-context
+++ b/news/14986-create-environment-config-from-context
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Create EnvironmentConfig from context. (#14986)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -50,58 +50,8 @@ if TYPE_CHECKING:
 
     from conda.testing import PathFactoryFixture
 
-TEST_CONDARC = dals(
-    """
-    custom_channels:
-      darwin: https://some.url.somewhere/stuff
-      chuck: http://another.url:8080/with/path
-    custom_multichannels:
-      michele:
-        - https://do.it.with/passion
-        - learn_from_every_thing
-      steve:
-        - more-downloads
-    channel_settings:
-      - channel: darwin
-        param_one: value_one
-        param_two: value_two
-      - channel: "http://localhost"
-        param_one: value_one
-        param_two: value_two
-    migrated_custom_channels:
-      darwin: s3://just/cant
-      chuck: file:///var/lib/repo/
-    migrated_channel_aliases:
-      - https://conda.anaconda.org
-    channel_alias: ftp://new.url:8082
-    conda-build:
-      root-dir: /some/test/path
-    proxy_servers:
-      http: http://user:pass@corp.com:8080
-      https: none
-      ftp:
-      sftp: ''
-      ftps: false
-      rsync: 'false'
-    aggressive_update_packages: []
-    channel_priority: false
-    """
-)
 
-
-@pytest.fixture
-def testdata() -> None:
-    reset_context()
-    context._set_raw_data(
-        {
-            "testdata": YamlRawParameter.make_raw_parameters(
-                "testdata", yaml_round_trip_load(TEST_CONDARC)
-            )
-        }
-    )
-
-
-def test_migrated_custom_channels(testdata: None):
+def test_migrated_custom_channels(context_testdata: None):
     assert (
         Channel(
             "https://some.url.somewhere/stuff/darwin/noarch/a-mighty-fine.tar.bz2"
@@ -117,7 +67,7 @@ def test_migrated_custom_channels(testdata: None):
     ]
 
 
-def test_old_channel_alias(testdata: None):
+def test_old_channel_alias(context_testdata: None):
     platform = context.subdir
 
     cf_urls = [
@@ -142,7 +92,7 @@ def test_old_channel_alias(testdata: None):
     ]
 
 
-def test_signing_metadata_url_base(testdata: None):
+def test_signing_metadata_url_base(context_testdata: None):
     SIGNING_URL_BASE = "https://conda.example.com/pkgs"
     string = f"signing_metadata_url_base: {SIGNING_URL_BASE}"
     reset_context()
@@ -155,7 +105,7 @@ def test_signing_metadata_url_base(testdata: None):
     assert context.signing_metadata_url_base == SIGNING_URL_BASE
 
 
-def test_signing_metadata_url_base_empty_default_channels(testdata: None):
+def test_signing_metadata_url_base_empty_default_channels(context_testdata: None):
     string = dals(
         """
         default_channels: []
@@ -172,7 +122,7 @@ def test_signing_metadata_url_base_empty_default_channels(testdata: None):
     assert context.signing_metadata_url_base is None
 
 
-def test_client_ssl_cert(testdata: None):
+def test_client_ssl_cert(context_testdata: None):
     string = dals(
         """
         client_ssl_cert_key: /some/key/path
@@ -188,7 +138,7 @@ def test_client_ssl_cert(testdata: None):
     pytest.raises(ValidationError, context.validate_configuration)
 
 
-def test_conda_envs_path(testdata: None):
+def test_conda_envs_path(context_testdata: None):
     saved_envs_path = os.environ.get("CONDA_ENVS_PATH")
     beginning = "C:" + os.sep if on_win else os.sep
     path1 = beginning + os.sep.join(["my", "envs", "dir", "1"])
@@ -256,7 +206,7 @@ def test_conda_bld_path(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     assert channel.canonical_name == "local"
 
 
-def test_custom_multichannels(testdata: None):
+def test_custom_multichannels(context_testdata: None):
     assert context.custom_multichannels["michele"] == (
         Channel("passion"),
         Channel("learn_from_every_thing"),
@@ -274,7 +224,7 @@ def test_restore_free_channel(monkeypatch: MonkeyPatch) -> None:
     assert context.default_channels[1] == free_channel
 
 
-def test_proxy_servers(testdata: None):
+def test_proxy_servers(context_testdata: None):
     assert context.proxy_servers["http"] == "http://user:pass@corp.com:8080"
     assert context.proxy_servers["https"] is None
     assert context.proxy_servers["ftp"] is None
@@ -283,7 +233,7 @@ def test_proxy_servers(testdata: None):
     assert context.proxy_servers["rsync"] == "false"
 
 
-def test_conda_build_root_dir(testdata: None):
+def test_conda_build_root_dir(context_testdata: None):
     assert context.conda_build["root-dir"] == "/some/test/path"
 
 
@@ -294,7 +244,7 @@ def test_clobber_enum(monkeypatch: MonkeyPatch, path_conflict: str) -> None:
     assert context.path_conflict == PathConflict(path_conflict)
 
 
-def test_context_parameter_map(testdata: None):
+def test_context_parameter_map(context_testdata: None):
     parameters = list(context.list_parameters())
     mapped = [name for names in context.category_map.values() for name in names]
 
@@ -308,7 +258,7 @@ def test_context_parameter_map(testdata: None):
     assert len(parameters) == len(mapped)
 
 
-def test_context_parameters_have_descriptions(testdata: None):
+def test_context_parameters_have_descriptions(context_testdata: None):
     skip_categories = ("CLI-only", "Hidden and Undocumented")
     documented_parameter_names = chain.from_iterable(
         (
@@ -326,7 +276,7 @@ def test_context_parameters_have_descriptions(testdata: None):
 
 
 def test_local_build_root_custom_rc(
-    testdata: None,
+    context_testdata: None,
     monkeypatch: MonkeyPatch,
     path_factory: PathFactoryFixture,
 ) -> None:
@@ -342,7 +292,7 @@ def test_local_build_root_custom_rc(
     assert context.local_build_root == croot
 
 
-def test_default_target_is_root_prefix(testdata: None):
+def test_default_target_is_root_prefix(context_testdata: None):
     assert context.target_prefix == context.root_prefix
 
 
@@ -384,7 +334,7 @@ def test_aggressive_update_packages(monkeypatch: MonkeyPatch) -> None:
     assert context.aggressive_update_packages == tuple(map(MatchSpec, specs))
 
 
-def test_channel_priority(testdata: None):
+def test_channel_priority(context_testdata: None):
     assert context.channel_priority == ChannelPriority.DISABLED
 
 
@@ -437,14 +387,14 @@ def test_threads(monkeypatch: MonkeyPatch) -> None:
         assert context.execute_threads == 3
 
 
-def test_channels_empty(testdata: None):
+def test_channels_empty(context_testdata: None):
     """Test when no channels provided in cli and no condarc config is present."""
     reset_context(())
     with pytest.warns((PendingDeprecationWarning, FutureWarning)):
         assert context.channels == ("defaults",)
 
 
-def test_channels_defaults_condarc(testdata: None):
+def test_channels_defaults_condarc(context_testdata: None):
     """Test when no channels provided in cli, but some in condarc."""
     reset_context(())
     string = dals(
@@ -461,7 +411,7 @@ def test_channels_defaults_condarc(testdata: None):
     assert context.channels == ("defaults", "conda-forge")
 
 
-def test_specify_channels_cli_not_adding_defaults_no_condarc(testdata: None):
+def test_specify_channels_cli_not_adding_defaults_no_condarc(context_testdata: None):
     """
     When the channel haven't been specified in condarc, 'defaults'
     should NOT be present when specifying channel in the cli.
@@ -473,7 +423,7 @@ def test_specify_channels_cli_not_adding_defaults_no_condarc(testdata: None):
         assert context.channels == ("conda-forge", "defaults")
 
 
-def test_specify_channels_cli_condarc(testdata: None):
+def test_specify_channels_cli_condarc(context_testdata: None):
     """
     When the channel have been specified in condarc, these channels
     should be used along with the one specified
@@ -493,7 +443,7 @@ def test_specify_channels_cli_condarc(testdata: None):
     assert context.channels == ("defaults", "conda-forge")
 
 
-def test_specify_different_channels_cli_condarc(testdata: None):
+def test_specify_different_channels_cli_condarc(context_testdata: None):
     """
     When the channel have been specified in condarc, these channels
     should be used along with the one specified
@@ -515,7 +465,7 @@ def test_specify_different_channels_cli_condarc(testdata: None):
     assert context.channels == ("conda-forge", "other")
 
 
-def test_specify_same_channels_cli_as_in_condarc(testdata: None):
+def test_specify_same_channels_cli_as_in_condarc(context_testdata: None):
     """
     When the channel have been specified in condarc, these channels
     should be used along with the one specified
@@ -539,7 +489,7 @@ def test_specify_same_channels_cli_as_in_condarc(testdata: None):
     assert context.channels == ("conda-forge",)
 
 
-def test_expandvars(testdata: None):
+def test_expandvars(context_testdata: None):
     """Environment variables should be expanded in settings that have expandvars=True."""
 
     def _get_expandvars_context(attr, config_expr, env_value):
@@ -599,7 +549,7 @@ def test_expandvars(testdata: None):
     assert any("foo" in d for d in pkgs_dirs)
 
 
-def test_channel_settings(testdata: None):
+def test_channel_settings(context_testdata: None):
     """Ensure "channel_settings" appears as we expect it to on the context object."""
     assert context.channel_settings == (
         {"channel": "darwin", "param_one": "value_one", "param_two": "value_two"},

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 from itertools import chain
-from frozendict import frozendict
 from os.path import abspath, join
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 from itertools import chain
+from frozendict import frozendict
 from os.path import abspath, join
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,15 +10,12 @@ from typing import TYPE_CHECKING
 import pytest
 
 import conda
-from conda.auxlib.ish import dals
 from conda.base.context import context, reset_context
 from conda.common.configuration import (
     Configuration,
     ParameterLoader,
     PrimitiveParameter,
-    YamlRawParameter
 )
-from conda.common.serialize import yaml_round_trip_load
 from conda.core.package_cache_data import PackageCacheData
 from conda.gateways.connection.session import CondaSession, get_session
 from conda.plugins.config import PluginConfig
@@ -41,56 +38,6 @@ pytest_plugins = (
     "conda.testing.fixtures",
     "tests.fixtures_jlap",
 )
-
-TEST_CONDARC = dals(
-    """
-    custom_channels:
-      darwin: https://some.url.somewhere/stuff
-      chuck: http://another.url:8080/with/path
-    custom_multichannels:
-      michele:
-        - https://do.it.with/passion
-        - learn_from_every_thing
-      steve:
-        - more-downloads
-    channel_settings:
-      - channel: darwin
-        param_one: value_one
-        param_two: value_two
-      - channel: "http://localhost"
-        param_one: value_one
-        param_two: value_two
-    migrated_custom_channels:
-      darwin: s3://just/cant
-      chuck: file:///var/lib/repo/
-    migrated_channel_aliases:
-      - https://conda.anaconda.org
-    channel_alias: ftp://new.url:8082
-    conda-build:
-      root-dir: /some/test/path
-    proxy_servers:
-      http: http://user:pass@corp.com:8080
-      https: none
-      ftp:
-      sftp: ''
-      ftps: false
-      rsync: 'false'
-    aggressive_update_packages: []
-    channel_priority: false
-    """
-)
-
-
-@pytest.fixture
-def context_testdata() -> None:
-    reset_context()
-    context._set_raw_data(
-        {
-            "testdata": YamlRawParameter.make_raw_parameters(
-                "testdata", yaml_round_trip_load(TEST_CONDARC)
-            )
-        }
-    )
 
 
 @pytest.hookimpl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,15 @@ from typing import TYPE_CHECKING
 import pytest
 
 import conda
+from conda.auxlib.ish import dals
 from conda.base.context import context, reset_context
 from conda.common.configuration import (
     Configuration,
     ParameterLoader,
     PrimitiveParameter,
+    YamlRawParameter
 )
+from conda.common.serialize import yaml_round_trip_load
 from conda.core.package_cache_data import PackageCacheData
 from conda.gateways.connection.session import CondaSession, get_session
 from conda.plugins.config import PluginConfig
@@ -38,6 +41,56 @@ pytest_plugins = (
     "conda.testing.fixtures",
     "tests.fixtures_jlap",
 )
+
+TEST_CONDARC = dals(
+    """
+    custom_channels:
+      darwin: https://some.url.somewhere/stuff
+      chuck: http://another.url:8080/with/path
+    custom_multichannels:
+      michele:
+        - https://do.it.with/passion
+        - learn_from_every_thing
+      steve:
+        - more-downloads
+    channel_settings:
+      - channel: darwin
+        param_one: value_one
+        param_two: value_two
+      - channel: "http://localhost"
+        param_one: value_one
+        param_two: value_two
+    migrated_custom_channels:
+      darwin: s3://just/cant
+      chuck: file:///var/lib/repo/
+    migrated_channel_aliases:
+      - https://conda.anaconda.org
+    channel_alias: ftp://new.url:8082
+    conda-build:
+      root-dir: /some/test/path
+    proxy_servers:
+      http: http://user:pass@corp.com:8080
+      https: none
+      ftp:
+      sftp: ''
+      ftps: false
+      rsync: 'false'
+    aggressive_update_packages: []
+    channel_priority: false
+    """
+)
+
+
+@pytest.fixture
+def context_testdata() -> None:
+    reset_context()
+    context._set_raw_data(
+        {
+            "testdata": YamlRawParameter.make_raw_parameters(
+                "testdata", yaml_round_trip_load(TEST_CONDARC)
+            )
+        }
+    )
 
 
 @pytest.hookimpl

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from conda.base.constants import ChannelPriority
 from conda.exceptions import CondaValueError
 from conda.models.environment import Environment, EnvironmentConfig
 from conda.models.match_spec import MatchSpec
@@ -241,3 +242,9 @@ def test_merge_configs_deduplicate_values():
     assert result.pinned_packages == ["b"]
     assert result.repodata_fns == ["repodata.json"]
     assert result.track_features == ["track"]
+
+
+def test_environment_config_from_context(context_testdata):
+    config = EnvironmentConfig.from_context()
+    # Check that some of the config values have been populated from the context 
+    assert config.channel_priority == ChannelPriority.DISABLED

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -246,5 +246,5 @@ def test_merge_configs_deduplicate_values():
 
 def test_environment_config_from_context(context_testdata):
     config = EnvironmentConfig.from_context()
-    # Check that some of the config values have been populated from the context 
+    # Check that some of the config values have been populated from the context
     assert config.channel_priority == ChannelPriority.DISABLED


### PR DESCRIPTION
### Description

This PR adds the ability to create an `EnvironmentConfig` object from the current running conda context. For example developers requiring the `EnvironmnentConfig` for the current context can use:

```
config = EnvironmentConfig.from_context()
```

This can be used for collecting information about the current command running environemtn, exporting the current environment, etc.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
