### PR TITLE
Stop using deprecated `json_load`/`json_dump`

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -19,7 +19,7 @@ from ...base.context import context
 from ...common.compat import on_linux, on_win
 from ...common.constants import TRACE
 from ...common.path import ensure_pad, expand, win_path_double_escape, win_path_ok
-from ...common.serialize import json_dump
+from ...common.serialize import json
 from ...exceptions import (
     BasicClobberError,
     CondaOSError,
@@ -118,8 +118,7 @@ if __name__ == '__main__':
 def write_as_json_to_file(file_path, obj):
     log.log(TRACE, "writing json to file %s", file_path)
     with codecs.open(file_path, mode="wb", encoding="utf-8") as fo:
-        json_str = json_dump(obj)
-        fo.write(json_str)
+        json.dump(obj, fo)
 
 
 def create_python_entry_point(target_full_path, python_full_path, module, func):

--- a/conda/plugins/reporter_backends/json.py
+++ b/conda/plugins/reporter_backends/json.py
@@ -4,7 +4,7 @@
 Defines a JSON reporter backend
 
 This reporter backend is used to provide JSON strings for output rendering. It is
-essentially just a wrapper around ``conda.common.serialize.json_dump``.
+essentially just a wrapper around ``conda.common.serialize.json.dumps``.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from ...base.constants import DEFAULT_JSON_REPORTER_BACKEND
 from ...common.io import swallow_broken_pipe
-from ...common.serialize import json_dump
+from ...common.serialize import json
 from .. import CondaReporterBackend, hookimpl
 from ..types import ProgressBarBase, ReporterRendererBase, SpinnerBase
 
@@ -72,13 +72,13 @@ class JSONReporterRenderer(ReporterRendererBase):
     """
 
     def render(self, data: Any, **kwargs) -> str:
-        return json_dump(data)
+        return json.dumps(data)
 
     def detail_view(self, data: dict[str, str | int | bool], **kwargs) -> str:
-        return json_dump(data)
+        return json.dumps(data)
 
     def envs_list(self, data, **kwargs) -> str:
-        return json_dump({"envs": data})
+        return json.dumps({"envs": data})
 
     def progress_bar(
         self,

--- a/tests/cli/test_main_export.py
+++ b/tests/cli/test_main_export.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.base.context import context, reset_context
-from conda.common.serialize import json_load, yaml_safe_load
+from conda.common.serialize import json, yaml_safe_load
 from conda.exceptions import CondaValueError
 
 if TYPE_CHECKING:
@@ -120,7 +120,7 @@ def test_export_with_json(
     assert not stderr
     assert not code
 
-    data = json_load(stdout)
+    data = json.loads(stdout)
     assert data["name"] == name
 
     assert path.exists()

--- a/tests/gateways/disk/test_read.py
+++ b/tests/gateways/disk/test_read.py
@@ -7,7 +7,7 @@ from pprint import pprint
 
 from conda.common.compat import on_win
 from conda.common.path import get_python_site_packages_short_path
-from conda.common.serialize import json_dump, json_load
+from conda.common.serialize import json
 from conda.gateways.disk.read import read_python_record
 
 ENV_METADATA_DIR = Path(__file__).parent.parent.parent / "data" / "env_metadata"
@@ -18,10 +18,10 @@ def test_scrapy_py36_osx_whl():
     prefix_path = str(ENV_METADATA_DIR / "py36-osx-whl")
     prefix_rec = read_python_record(prefix_path, anchor_file, "3.6")
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     files = dumped_rec.pop("files")
     paths_data = dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     assert dumped_rec == {
         "build": "pypi_0",
         "build_number": 0,
@@ -46,8 +46,8 @@ def test_scrapy_py36_osx_whl():
         "subdir": "pypi",
         "version": "1.5.1",
     }
-    print(json_dump(files))
-    print(json_dump(paths_data["paths"]))
+    print(json.dumps(files))
+    print(json.dumps(paths_data["paths"]))
     sp_dir = get_python_site_packages_short_path("3.6")
     assert sp_dir + "/scrapy/core/scraper.py" in files
     assert sp_dir + "/scrapy/core/__pycache__/scraper.cpython-36.pyc" in files
@@ -81,10 +81,10 @@ def test_twilio_py36_osx_whl():
     pprint(prefix_rec.depends)
     pprint(prefix_rec.constrains)
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     files = dumped_rec.pop("files")
     paths_data = dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     assert dumped_rec == {
         "build": "pypi_0",
         "build_number": 0,
@@ -104,8 +104,8 @@ def test_twilio_py36_osx_whl():
         "subdir": "pypi",
         "version": "6.16.1",
     }
-    print(json_dump(files))
-    print(json_dump(paths_data["paths"]))
+    print(json.dumps(files))
+    print(json.dumps(paths_data["paths"]))
     sp_dir = get_python_site_packages_short_path("3.6")
     assert sp_dir + "/twilio/compat.py" in files
     assert sp_dir + "/twilio/__pycache__/compat.cpython-36.pyc" in files
@@ -130,10 +130,10 @@ def test_pyjwt_py36_osx_whl():
     prefix_path = str(ENV_METADATA_DIR / "py36-osx-whl")
     prefix_rec = read_python_record(prefix_path, anchor_file, "3.6")
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     files = dumped_rec.pop("files")
     paths_data = dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     assert dumped_rec == {
         "build": "pypi_0",
         "build_number": 0,
@@ -146,8 +146,8 @@ def test_pyjwt_py36_osx_whl():
         "subdir": "pypi",
         "version": "1.6.4",
     }
-    print(json_dump(files))
-    print(json_dump(paths_data["paths"]))
+    print(json.dumps(files))
+    print(json.dumps(paths_data["paths"]))
     sp_dir = get_python_site_packages_short_path("3.6")
     assert ("../bin/pyjwt" if on_win else "bin/pyjwt") in files
     assert sp_dir + "/jwt/__pycache__/__init__.cpython-36.pyc" in files
@@ -172,10 +172,10 @@ def test_cherrypy_py36_osx_whl():
     prefix_path = str(ENV_METADATA_DIR / "py36-osx-whl")
     prefix_rec = read_python_record(prefix_path, anchor_file, "3.6")
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     dumped_rec.pop("files")
     dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     constrains = dumped_rec.pop("constrains")
     depends = dumped_rec.pop("depends")
     assert dumped_rec == {
@@ -221,10 +221,10 @@ def test_scrapy_py27_osx_no_binary():
     prefix_path = str(ENV_METADATA_DIR / "py27-osx-no-binary")
     prefix_rec = read_python_record(prefix_path, anchor_file, "2.7")
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     files = dumped_rec.pop("files")
     paths_data = dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     assert dumped_rec == {
         "build": "pypi_0",
         "build_number": 0,
@@ -249,8 +249,8 @@ def test_scrapy_py27_osx_no_binary():
         "subdir": "pypi",
         "version": "1.5.1",
     }
-    print(json_dump(files))
-    print(json_dump(paths_data["paths"]))
+    print(json.dumps(files))
+    print(json.dumps(paths_data["paths"]))
     sp_dir = get_python_site_packages_short_path("2.7")
     assert sp_dir + "/scrapy/contrib/downloadermiddleware/decompression.py" in files
     assert sp_dir + "/scrapy/downloadermiddlewares/decompression.pyc" in files
@@ -279,10 +279,10 @@ def test_twilio_py27_osx_no_binary():
     pprint(prefix_rec.depends)
     pprint(prefix_rec.constrains)
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     files = dumped_rec.pop("files")
     paths_data = dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     assert dumped_rec == {
         "build": "pypi_0",
         "build_number": 0,
@@ -295,8 +295,8 @@ def test_twilio_py27_osx_no_binary():
         "subdir": "pypi",
         "version": "6.16.1",
     }
-    print(json_dump(files))
-    print(json_dump(paths_data["paths"]))
+    print(json.dumps(files))
+    print(json.dumps(paths_data["paths"]))
     sp_dir = get_python_site_packages_short_path("2.7")
     assert sp_dir + "/twilio/compat.py" in files
     assert sp_dir + "/twilio/compat.pyc" in files
@@ -311,10 +311,10 @@ def test_pyjwt_py27_osx_no_binary():
     prefix_path = str(ENV_METADATA_DIR / "py27-osx-no-binary")
     prefix_rec = read_python_record(prefix_path, anchor_file, "2.7")
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     files = dumped_rec.pop("files")
     paths_data = dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     assert dumped_rec == {
         "build": "pypi_0",
         "build_number": 0,
@@ -327,8 +327,8 @@ def test_pyjwt_py27_osx_no_binary():
         "subdir": "pypi",
         "version": "1.6.4",
     }
-    print(json_dump(files))
-    print(json_dump(paths_data["paths"]))
+    print(json.dumps(files))
+    print(json.dumps(paths_data["paths"]))
     sp_dir = get_python_site_packages_short_path("2.7")
     assert ("../bin/pyjwt" if on_win else "bin/pyjwt") in files
     assert sp_dir + "/jwt/__init__.pyc" in files
@@ -343,10 +343,10 @@ def test_cherrypy_py27_osx_no_binary():
     prefix_path = str(ENV_METADATA_DIR / "py27-osx-no-binary")
     prefix_rec = read_python_record(prefix_path, anchor_file, "2.7")
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     dumped_rec.pop("files")
     dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     constrains = dumped_rec.pop("constrains")
     depends = dumped_rec.pop("depends")
     assert dumped_rec == {
@@ -390,10 +390,10 @@ def test_six_py27_osx_no_binary_unmanageable():
     prefix_path = str(ENV_METADATA_DIR / "py27-osx-no-binary")
     prefix_rec = read_python_record(prefix_path, anchor_file, "2.7")
 
-    dumped_rec = json_load(json_dump(prefix_rec.dump()))
+    dumped_rec = json.loads(json.dumps(prefix_rec.dump()))
     files = dumped_rec.pop("files")
     dumped_rec.pop("paths_data")
-    print(json_dump(dumped_rec))
+    print(json.dumps(dumped_rec))
     assert dumped_rec == {
         "build": "pypi_0",
         "build_number": 0,

--- a/tests/plugins/reporter_backends/test_json.py
+++ b/tests/plugins/reporter_backends/test_json.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import json
-
-from conda.common.serialize import json_dump
+from conda.common.serialize import json
 from conda.plugins.reporter_backends.json import (
     JSONProgressBar,
     JSONReporterRenderer,
@@ -19,8 +17,8 @@ def test_json_handler():
     test_str = "a string value"
     json_handler_object = JSONReporterRenderer()
 
-    assert json_handler_object.detail_view(test_data) == json_dump(test_data)
-    assert json_handler_object.envs_list(test_envs) == json_dump({"envs": test_envs})
+    assert json_handler_object.detail_view(test_data) == json.dumps(test_data)
+    assert json_handler_object.envs_list(test_envs) == json.dumps({"envs": test_envs})
     assert json_handler_object.render(test_str) == json.dumps(test_str)
 
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import json
 import platform
 import re
 import sys
@@ -38,7 +37,7 @@ from conda.common.path import (
     get_python_site_packages_short_path,
     pyc_path,
 )
-from conda.common.serialize import json_dump, yaml_round_trip_load
+from conda.common.serialize import json, yaml_round_trip_load
 from conda.core.index import ReducedIndex
 from conda.core.package_cache_data import PackageCacheData
 from conda.core.prefix_data import PrefixData, get_python_version_for_prefix
@@ -1779,7 +1778,7 @@ def test_conda_pip_interop_pip_clobbers_conda(
         )
         assert any(pkg.strip() == "six==1.10.0" for pkg in stdout.splitlines())
 
-        assert json.loads(json_dump(PrefixData(prefix).get("six"))) == {
+        assert json.loads(json.dumps(PrefixData(prefix).get("six"))) == {
             "build": "pypi_0",
             "build_number": 0,
             "channel": "https://conda.anaconda.org/pypi",
@@ -1957,7 +1956,7 @@ def test_conda_pip_interop_conda_editable_package(
         prec_dump = PrefixData(prefix).get("urllib3").dump()
         prec_dump.pop("files")
         prec_dump.pop("paths_data")
-        assert json.loads(json_dump(prec_dump)) == {
+        assert json.loads(json.dumps(prec_dump)) == {
             "build": "dev_0",
             "build_number": 0,
             "channel": "https://conda.anaconda.org/<develop>",
@@ -2007,7 +2006,7 @@ def test_conda_pip_interop_conda_editable_package(
         prec_dump = PrefixData(prefix).get("urllib3").dump()
         prec_dump.pop("files")
         prec_dump.pop("paths_data")
-        assert json.loads(json_dump(prec_dump)) == {
+        assert json.loads(json.dumps(prec_dump)) == {
             "build": "pypi_0",
             "build_number": 0,
             "channel": "https://conda.anaconda.org/pypi",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Noticed while working on https://github.com/conda/conda/pull/12771

Remove usage of deprecated `json_load` and `json_dump` from testing.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
