### PR TITLE
Ensure file types can not be mixed in the conda install command

### DIFF
--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -128,6 +128,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
 def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..base.context import context
     from ..exceptions import CondaValueError
+    from .common import validate_environment_files_consistency
     from .install import get_revision, install, install_revision
 
     if context.force:
@@ -139,6 +140,9 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
             "\n",
             file=sys.stderr,
         )
+
+    # Validate that input files are of the same format type
+    validate_environment_files_consistency(args.file)
 
     # Ensure provided combination of command line arguments are valid
     if args.revision:

--- a/news/14999-ensure-filetypes-are-not-mixed-install
+++ b/news/14999-ensure-filetypes-are-not-mixed-install
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ensure file types can not be mixed in the conda install command. (#14999)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2772,9 +2772,7 @@ def test_python_site_packages_path(
         "update",
     ],
 )
-def test_dont_allow_mixed_file_arguments(
-    conda_cli: CondaCLIFixture, cmd
-):
+def test_dont_allow_mixed_file_arguments(conda_cli: CondaCLIFixture, cmd):
     """
     Test that conda will return an error when multiple --file arguments of different
     types are specified

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2764,34 +2764,24 @@ def test_python_site_packages_path(
         assert (prefix / sp_dir / "sample.py").is_file()
 
 
-def test_dont_allow_mixed_file_arguments_create(
-    conda_cli: CondaCLIFixture,
-):
-    """
-    Test that conda will return an error when multiple --file arguments of different
-    types are specified
-    """
-    _, _, exc = conda_cli(
+@pytest.mark.parametrize(
+    "cmd",
+    [
         "create",
-        *("--name", uuid4().hex[:8]),
-        *("--file", support_file("requirements.txt")),
-        *("--file", support_file("simple.yml")),
-        "--yes",
-        raises=EnvironmentFileTypeMismatchError,
-    )
-
-    assert exc.match("Cannot mix environment file formats")
-
-
-def test_dont_allow_mixed_file_arguments_install(
-    conda_cli: CondaCLIFixture,
+        "install",
+        "update",
+    ],
+)
+def test_dont_allow_mixed_file_arguments(
+    conda_cli: CondaCLIFixture, cmd
 ):
     """
     Test that conda will return an error when multiple --file arguments of different
     types are specified
     """
     _, _, exc = conda_cli(
-        "install",
+        cmd,
+        *("--name", uuid4().hex[:8]),
         *("--file", support_file("requirements.txt")),
         *("--file", support_file("simple.yml")),
         "--yes",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2764,7 +2764,7 @@ def test_python_site_packages_path(
         assert (prefix / sp_dir / "sample.py").is_file()
 
 
-def test_dont_allow_mixed_file_arguments(
+def test_dont_allow_mixed_file_arguments_create(
     conda_cli: CondaCLIFixture,
 ):
     """
@@ -2774,6 +2774,24 @@ def test_dont_allow_mixed_file_arguments(
     _, _, exc = conda_cli(
         "create",
         *("--name", uuid4().hex[:8]),
+        *("--file", support_file("requirements.txt")),
+        *("--file", support_file("simple.yml")),
+        "--yes",
+        raises=EnvironmentFileTypeMismatchError,
+    )
+
+    assert exc.match("Cannot mix environment file formats")
+
+
+def test_dont_allow_mixed_file_arguments_install(
+    conda_cli: CondaCLIFixture,
+):
+    """
+    Test that conda will return an error when multiple --file arguments of different
+    types are specified
+    """
+    _, _, exc = conda_cli(
+        "install",
         *("--file", support_file("requirements.txt")),
         *("--file", support_file("simple.yml")),
         "--yes",


### PR DESCRIPTION
### Description

https://github.com/conda/conda/issues/14684 added a check to ensure that `conda create/update` commands do not allow users to mix file types provided with the `--file` command.
 
This makes `conda install` consistent with the create and update commands.

For example:
```
$ conda install --file tests/env/support/explicit.txt --file tests/env/support/add-pip.yml                      

EnvironmentFileTypeMismatchError: Cannot mix environment file formats.

'tests/env/support/explicit.txt' is a explicit format file
'tests/env/support/add-pip.yml' is a environment.yml format file
```


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
