### PR TITLE
EnvironmentConfig lists of values should be `tuples`

### DIFF
--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -64,7 +64,7 @@ class EnvironmentConfig:
     use_only_tar_bz2: bool | None = None
 
     def _append_without_duplicates(self, first: tuple, second: tuple) -> tuple:
-        return tuple(dict.fromkeys(item for item in first+second))
+        return tuple(dict.fromkeys(item for item in first + second))
 
     def _merge_channel_settings(
         self, first: tuple[dict[str, str]], second: tuple[dict[str, str]]

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -37,39 +37,38 @@ class EnvironmentConfig:
     Data model for a conda environment config.
     """
 
-    aggressive_update_packages: list[str] = field(default_factory=list)
+    aggressive_update_packages: tuple[str] = field(default_factory=tuple)
 
     channel_priority: ChannelPriority | None = None
 
-    channels: list[str] = field(default_factory=list)
+    channels: tuple[str] = field(default_factory=tuple)
 
-    channel_settings: list[dict[str, str]] = field(default_factory=list)
+    channel_settings: tuple[dict[str, str]] = field(default_factory=tuple)
 
     deps_modifier: DepsModifier | None = None
 
-    disallowed_packages: list[str] = field(default_factory=list)
+    disallowed_packages: tuple[str] = field(default_factory=tuple)
 
-    pinned_packages: list[str] = field(default_factory=list)
+    pinned_packages: tuple[str] = field(default_factory=tuple)
 
-    repodata_fns: list[str] = field(default_factory=list)
+    repodata_fns: tuple[str] = field(default_factory=tuple)
 
     sat_solver: SatSolverChoice | None = None
 
     solver: str | None = None
 
-    track_features: list[str] = field(default_factory=list)
+    track_features: tuple[str] = field(default_factory=tuple)
 
     update_modifier: UpdateModifier | None = None
 
     use_only_tar_bz2: bool | None = None
 
-    def _append_without_duplicates(self, first: list, second: list) -> list:
-        first.extend(second)
-        return list(dict.fromkeys(item for item in first))
+    def _append_without_duplicates(self, first: tuple, second: tuple) -> tuple:
+        return tuple(dict.fromkeys(item for item in first+second))
 
     def _merge_channel_settings(
-        self, first: list[dict[str, str]], second: list[dict[str, str]]
-    ) -> list[dict[str, str]]:
+        self, first: tuple[dict[str, str]], second: tuple[dict[str, str]]
+    ) -> tuple[dict[str, str]]:
         """Merge channel settings.
 
         An individual channel setting is a dict that may have the key "channels". Settings
@@ -80,10 +79,10 @@ class EnvironmentConfig:
             lambda x: x.get("channel"), chain(first, second)
         )
 
-        return [
+        return tuple(
             {k: v for config in configs for k, v in config.items()}
             for channel, configs in grouped_channel_settings.items()
-        ]
+        )
 
     def _merge(self, other: EnvironmentConfig) -> EnvironmentConfig:
         """
@@ -162,7 +161,7 @@ class EnvironmentConfig:
         field_names = {field.name for field in fields(cls)}
 
         environment_settings = {
-            key: list(value) if isinstance(value, tuple) else value
+            key: value
             for key, value in context.environment_settings.items()
             if key in field_names
         }

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -162,7 +162,7 @@ class EnvironmentConfig:
         field_names = {field.name for field in fields(cls)}
 
         environment_settings = {
-            key: value
+            key: list(value) if isinstance(value, tuple) else value
             for key, value in context.environment_settings.items()
             if key in field_names
         }

--- a/news/15000-environmentconfig-types
+++ b/news/15000-environmentconfig-types
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* EnvironmentConfig lists of values should be tuples. (#15000)

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
+from dataclasses import fields
+
 import pytest
 
 from conda.base.constants import ChannelPriority
@@ -260,8 +262,16 @@ def test_merge_configs_deduplicate_values():
 
 def test_environment_config_from_context(context_testdata):
     config = EnvironmentConfig.from_context()
+
     # Check that some of the config values have been populated from the context
     assert config.channel_priority == ChannelPriority.DISABLED
+
+    # Check that the types are matching up with the default type
+    for field in fields(EnvironmentConfig):
+        if field.default:
+            assert isinstance(getattr(config, field.name), field.default_factory), (
+                f"{field.name} expected to be a {field.default_factory} but is a {type(getattr(config, field.name))}"
+            )
 
 
 def test_merge_channel_settings():

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -105,9 +105,18 @@ def test_environments_merge():
     assert merged.prefix == "/path/to/env1"
     assert merged.platform == "linux-64"
     assert merged.config == EnvironmentConfig(
-        aggressive_update_packages=("abc", "two",),
-        channels=("defaults", "conda-forge",),
-        channel_settings=({"channel": "one", "a": 1}, {"channel": "two", "b": 2},),
+        aggressive_update_packages=(
+            "abc",
+            "two",
+        ),
+        channels=(
+            "defaults",
+            "conda-forge",
+        ),
+        channel_settings=(
+            {"channel": "one", "a": 1},
+            {"channel": "two", "b": 2},
+        ),
         repodata_fns=("repodata2.json",),
     )
     assert merged.external_packages == {
@@ -235,25 +244,39 @@ def test_merge_configs_primitive_none_values_order():
 
 def test_merge_configs_deduplicate_values():
     config1 = EnvironmentConfig(
-        channels=("defaults", "conda-forge",),
+        channels=(
+            "defaults",
+            "conda-forge",
+        ),
         disallowed_packages=("a",),
         pinned_packages=("b",),
         repodata_fns=("repodata.json",),
         track_features=("track",),
     )
     config2 = EnvironmentConfig(
-        channels=("defaults", "my-channel",),
+        channels=(
+            "defaults",
+            "my-channel",
+        ),
         disallowed_packages=("a",),
         pinned_packages=("b",),
         repodata_fns=("repodata.json",),
         track_features=("track",),
     )
     config3 = EnvironmentConfig(
-        channels=("conda-forge", "b-channel",),
+        channels=(
+            "conda-forge",
+            "b-channel",
+        ),
     )
 
     result = EnvironmentConfig.merge(config1, config2, config3)
-    assert result.channels == ("defaults", "conda-forge", "my-channel", "b-channel",)
+    assert result.channels == (
+        "defaults",
+        "conda-forge",
+        "my-channel",
+        "b-channel",
+    )
     assert result.disallowed_packages == ("a",)
     assert result.pinned_packages == ("b",)
     assert result.repodata_fns == ("repodata.json",)
@@ -290,11 +313,7 @@ def test_merge_channel_settings():
             {"channel": "three", "param_three": "val_three"},
         )
     )
-    config3 = EnvironmentConfig(
-        channel_settings=(
-            {"some": "stuff"},
-        )
-    )
+    config3 = EnvironmentConfig(channel_settings=({"some": "stuff"},))
     result = EnvironmentConfig.merge(config1, config2, config3)
     expected = EnvironmentConfig(
         channel_settings=(

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -73,9 +73,9 @@ def test_environments_merge():
         prefix="/path/to/env1",
         platform="linux-64",
         config=EnvironmentConfig(
-            aggressive_update_packages=["abc"],
-            channels=["defaults"],
-            channel_settings=[{"channel": "one", "a": 1}],
+            aggressive_update_packages=("abc",),
+            channels=("defaults",),
+            channel_settings=({"channel": "one", "a": 1},),
         ),
         external_packages={
             "pip": ["one", "two", {"special": "type"}],
@@ -90,10 +90,10 @@ def test_environments_merge():
         prefix="/path/to/env1",
         platform="linux-64",
         config=EnvironmentConfig(
-            aggressive_update_packages=["two"],
-            channels=["conda-forge"],
-            channel_settings=[{"channel": "two", "b": 2}],
-            repodata_fns=["repodata2.json"],
+            aggressive_update_packages=("two",),
+            channels=("conda-forge",),
+            channel_settings=({"channel": "two", "b": 2},),
+            repodata_fns=("repodata2.json",),
         ),
         external_packages={"pip": ["two", "flask"], "a": ["nother"]},
         explicit_packages=[],
@@ -105,10 +105,10 @@ def test_environments_merge():
     assert merged.prefix == "/path/to/env1"
     assert merged.platform == "linux-64"
     assert merged.config == EnvironmentConfig(
-        aggressive_update_packages=["abc", "two"],
-        channels=["defaults", "conda-forge"],
-        channel_settings=[{"channel": "one", "a": 1}, {"channel": "two", "b": 2}],
-        repodata_fns=["repodata2.json"],
+        aggressive_update_packages=("abc", "two",),
+        channels=("defaults", "conda-forge",),
+        channel_settings=({"channel": "one", "a": 1}, {"channel": "two", "b": 2},),
+        repodata_fns=("repodata2.json",),
     )
     assert merged.external_packages == {
         "pip": ["one", "two", {"special": "type"}, "flask"],
@@ -235,29 +235,29 @@ def test_merge_configs_primitive_none_values_order():
 
 def test_merge_configs_deduplicate_values():
     config1 = EnvironmentConfig(
-        channels=["defaults", "conda-forge"],
-        disallowed_packages=["a"],
-        pinned_packages=["b"],
-        repodata_fns=["repodata.json"],
-        track_features=["track"],
+        channels=("defaults", "conda-forge",),
+        disallowed_packages=("a",),
+        pinned_packages=("b",),
+        repodata_fns=("repodata.json",),
+        track_features=("track",),
     )
     config2 = EnvironmentConfig(
-        channels=["defaults", "my-channel"],
-        disallowed_packages=["a"],
-        pinned_packages=["b"],
-        repodata_fns=["repodata.json"],
-        track_features=["track"],
+        channels=("defaults", "my-channel",),
+        disallowed_packages=("a",),
+        pinned_packages=("b",),
+        repodata_fns=("repodata.json",),
+        track_features=("track",),
     )
     config3 = EnvironmentConfig(
-        channels=["conda-forge", "b-channel"],
+        channels=("conda-forge", "b-channel",),
     )
 
     result = EnvironmentConfig.merge(config1, config2, config3)
-    assert result.channels == ["defaults", "conda-forge", "my-channel", "b-channel"]
-    assert result.disallowed_packages == ["a"]
-    assert result.pinned_packages == ["b"]
-    assert result.repodata_fns == ["repodata.json"]
-    assert result.track_features == ["track"]
+    assert result.channels == ("defaults", "conda-forge", "my-channel", "b-channel",)
+    assert result.disallowed_packages == ("a",)
+    assert result.pinned_packages == ("b",)
+    assert result.repodata_fns == ("repodata.json",)
+    assert result.track_features == ("track",)
 
 
 def test_environment_config_from_context(context_testdata):
@@ -276,28 +276,28 @@ def test_environment_config_from_context(context_testdata):
 
 def test_merge_channel_settings():
     config1 = EnvironmentConfig(
-        channel_settings=[
+        channel_settings=(
             {"channel": "one", "param_one": "val_one", "param_two": "val_two"},
             {"channel": "two", "param_three": "val_three"},
-        ],
+        ),
     )
     config2 = EnvironmentConfig(
-        channel_settings=[
+        channel_settings=(
             {
                 "channel": "one",
                 "other_val": "yes",
             },
             {"channel": "three", "param_three": "val_three"},
-        ]
+        )
     )
     config3 = EnvironmentConfig(
-        channel_settings=[
+        channel_settings=(
             {"some": "stuff"},
-        ]
+        )
     )
     result = EnvironmentConfig.merge(config1, config2, config3)
     expected = EnvironmentConfig(
-        channel_settings=[
+        channel_settings=(
             {
                 "channel": "one",
                 "param_one": "val_one",
@@ -307,6 +307,6 @@ def test_merge_channel_settings():
             {"channel": "two", "param_three": "val_three"},
             {"channel": "three", "param_three": "val_three"},
             {"some": "stuff"},
-        ],
+        ),
     )
     assert result == expected


### PR DESCRIPTION
### Description

Iterable values coming from the context objects are usually returned as `tuples`. This PR changes the `EnvironmentConfig` types to more closely match the context.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
