### PR TITLE
`conda install` should raise an error if incompatible arguments are provided

### DIFF
--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -144,12 +144,19 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     # Validate that input files are of the same format type
     validate_environment_files_consistency(args.file)
 
+    # Ensure that users do not provide incompatible arguments.
+    # revision and packages can not be specified together
+    if args.revision and (args.file or args.packages):
+        raise CondaValueError(
+            "too many arguments, must supply one of command line packages, --file or --revision"
+        )
+
     # Ensure provided combination of command line arguments are valid
     if args.revision:
         get_revision(args.revision, json=context.json)
     elif not (args.file or args.packages):
         raise CondaValueError(
-            "too few arguments, must supply command line packages, --file or --revision"
+            "too few arguments, must supply one of command line packages, --file or --revision"
         )
 
     if args.revision:

--- a/news/15003-raise-error-for-incompatible-install-args
+++ b/news/15003-raise-error-for-incompatible-install-args
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_install.py
+++ b/tests/cli/test_main_install.py
@@ -10,7 +10,7 @@ import pytest
 from conda.base.context import context, reset_context
 from conda.common.compat import on_win
 from conda.core.prefix_data import PrefixData
-from conda.exceptions import PackagesNotFoundError
+from conda.exceptions import CondaValueError, PackagesNotFoundError
 from conda.testing.helpers import forward_to_subprocess, in_subprocess
 from conda.testing.integration import package_is_installed
 
@@ -136,3 +136,18 @@ def test_build_version_shows_as_changed(
         assert "The following packages will be UPDATED" in out
         assert "The following packages will be REVISED" in out
         assert "The following packages will be DOWNGRADED" not in out
+
+
+def test_too_many_arguments(
+    conda_cli: CondaCLIFixture,
+):
+    with pytest.raises(CondaValueError) as excinfo:
+        conda_cli(
+            "install",
+            "--revision",
+            "0",
+            "another_dependent",
+            "--freeze-installed",
+            "--yes",
+        )
+    assert "too many arguments" in excinfo.value.message


### PR DESCRIPTION

### Description

This PR updates `conda install` to raise an error if the `--revision` argument is passed along with packages or `--file` arguments. Previously, conda would short cirtuit to just run the install of the revision and ignore all other arguments. For example:

```
$ conda install --revision 1 pandas                                           
Collecting package metadata (current_repodata.json): done
Reverting to revision 1: / 
. . . 
```

With this change, conda will raise an error about the invalid command instead:

```
$ conda install --revision 1 pandas       

CondaValueError: too many arguments, must supply one of command line packages, --file or --revision
```

fixes: https://github.com/conda/conda-environments-project-mgmt/issues/70

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
