### PR TITLE
Remove unused import of deprecated `DumpEncoder`

### DIFF
--- a/conda/auxlib/entity.py
+++ b/conda/auxlib/entity.py
@@ -252,7 +252,6 @@ from .compat import isiterable, odict
 from .collection import AttrDict
 from .exceptions import Raise, ValidationError
 from .ish import find_or_raise
-from .logz import DumpEncoder
 from .type_coercion import maybecall
 from ..common.serialize import json
 from ..deprecations import deprecated

--- a/news/15015-remove-unused-deprecated-import-dumpencoder
+++ b/news/15015-remove-unused-deprecated-import-dumpencoder
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Remove unused import of deprecated `DumpEncoder`. (#15015)


### PR DESCRIPTION

### Description

This is causing [test failures in conda-build](https://github.com/conda/conda-build/actions/runs/16329396754/job/46127863285?pr=5750)

```
ImportError while loading conftest '/home/runner/work/conda-build/conda-build/tests/conftest.py'.
tests/conftest.py:16: in <module>
    import conda_build
conda_build/__init__.py:43: in <module>
    reset_context()
/usr/share/miniconda/envs/test/lib/python3.[13](https://github.com/conda/conda-build/actions/runs/16329396754/job/46127863285?pr=5750#step:10:14)/site-packages/conda/base/context.py:2040: in reset_context
    from ..plugins.config import PluginConfig
/usr/share/miniconda/envs/test/lib/python3.13/site-packages/conda/plugins/__init__.py:28: in <module>
    from .types import (  # noqa: F401
/usr/share/miniconda/envs/test/lib/python3.13/site-packages/conda/plugins/types.py:[19](https://github.com/conda/conda-build/actions/runs/16329396754/job/46127863285?pr=5750#step:10:20): in <module>
    from ..models.records import PackageRecord
/usr/share/miniconda/envs/test/lib/python3.13/site-packages/conda/models/records.py:22: in <module>
    from ..auxlib.entity import (
/usr/share/miniconda/envs/test/lib/python3.13/site-packages/conda/auxlib/entity.py:255: in <module>
    from .logz import DumpEncoder
/usr/share/miniconda/envs/test/lib/python3.13/site-packages/conda/deprecations.py:329: in __getattr__
    return super_getattr(name)
           ^^^^^^^^^^^^^^^^^^^
/usr/share/miniconda/envs/test/lib/python3.13/site-packages/conda/deprecations.py:329: in __getattr__
    return super_getattr(name)
           ^^^^^^^^^^^^^^^^^^^
/usr/share/miniconda/envs/test/lib/python3.13/site-packages/conda/deprecations.py:3[25](https://github.com/conda/conda-build/actions/runs/16329396754/job/46127863285?pr=5750#step:10:26): in __getattr__
    warnings.warn(message, category, stacklevel=3 + stack)
E   PendingDeprecationWarning: conda.auxlib.logz.DumpEncoder is pending deprecation and will be removed in [26](https://github.com/conda/conda-build/actions/runs/16329396754/job/46127863285?pr=5750#step:10:27).9. Use `conda.common.serialize.json.CondaJSONEncoder` instead.
```
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
