### PR TITLE
Deprecate unused `arg2spec` and `specs_from_args` `json` arg

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -4,6 +4,7 @@
 
 import re
 import sys
+from collections.abc import Iterable
 from logging import getLogger
 from os.path import (
     dirname,
@@ -117,7 +118,8 @@ def is_active_prefix(prefix: str) -> bool:
     )
 
 
-def arg2spec(arg, json=False, update=False):
+@deprecated.argument("26.3", "26.9", "json")
+def arg2spec(arg: str, json: bool = False, update: bool = False) -> str:
     try:
         spec = MatchSpec(arg)
     except:
@@ -138,8 +140,9 @@ def arg2spec(arg, json=False, update=False):
     return str(spec)
 
 
-def specs_from_args(args, json=False):
-    return [arg2spec(arg, json=json) for arg in args]
+@deprecated.argument("26.3", "26.9", "json")
+def specs_from_args(args: Iterable[str], json: bool = False) -> list[str]:
+    return [arg2spec(arg) for arg in args]
 
 
 spec_pat = re.compile(

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Common utilities for conda command line tools."""
 
+from __future__ import annotations
+
 import re
 import sys
-from collections.abc import Iterable
 from logging import getLogger
 from os.path import (
     dirname,
@@ -14,6 +15,7 @@ from os.path import (
     join,
     normcase,
 )
+from typing import TYPE_CHECKING
 
 from ..auxlib.ish import dals
 from ..base.constants import PREFIX_MAGIC_FILE
@@ -35,6 +37,9 @@ from ..gateways.connection.session import CONDA_SESSION_SCHEMES
 from ..gateways.disk.test import file_path_is_writable
 from ..models.match_spec import MatchSpec
 from ..reporters import render
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 log = getLogger(__name__)
 

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -123,7 +123,11 @@ def is_active_prefix(prefix: str) -> bool:
     )
 
 
-@deprecated("26.3", "26.9", addendum="Use `spec = str(MatchSpec(arg))` instead",)
+@deprecated(
+    "26.3",
+    "26.9",
+    addendum="Use `spec = str(MatchSpec(arg))` instead",
+)
 def arg2spec(arg: str, update: bool = False) -> str:
     try:
         spec = MatchSpec(arg)

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -119,7 +119,7 @@ def is_active_prefix(prefix: str) -> bool:
 
 
 @deprecated.argument("26.3", "26.9", "json")
-def arg2spec(arg: str, json: bool = False, update: bool = False) -> str:
+def arg2spec(arg: str, update: bool = False) -> str:
     try:
         spec = MatchSpec(arg)
     except:
@@ -141,7 +141,7 @@ def arg2spec(arg: str, json: bool = False, update: bool = False) -> str:
 
 
 @deprecated.argument("26.3", "26.9", "json")
-def specs_from_args(args: Iterable[str], json: bool = False) -> list[str]:
+def specs_from_args(args: Iterable[str]) -> list[str]:
     return [arg2spec(arg) for arg in args]
 
 

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -123,7 +123,7 @@ def is_active_prefix(prefix: str) -> bool:
     )
 
 
-@deprecated.argument("26.3", "26.9", "json")
+@deprecated("26.3", "26.9", addendum="Use `spec = str(MatchSpec(arg))` instead",)
 def arg2spec(arg: str, update: bool = False) -> str:
     try:
         spec = MatchSpec(arg)
@@ -147,7 +147,7 @@ def arg2spec(arg: str, update: bool = False) -> str:
 
 @deprecated.argument("26.3", "26.9", "json")
 def specs_from_args(args: Iterable[str]) -> list[str]:
-    return [arg2spec(arg) for arg in args]
+    return [str(MatchSpec(arg)) for arg in args]
 
 
 spec_pat = re.compile(

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -385,7 +385,7 @@ def install(args, parser, command="install"):
             # short circuit to installing explicit if explicit specs are provided
             explicit(specs, prefix, verbose=not context.quiet)
             return
-    specs.extend(common.specs_from_args(args_packages, json=context.json))
+    specs.extend(common.specs_from_args(args_packages))
 
     # for 'conda update', make sure the requested specs actually exist in the prefix
     # and that they are name-only specs

--- a/conda/env/env.py
+++ b/conda/env/env.py
@@ -194,7 +194,7 @@ class Dependencies(dict):
             if isinstance(line, dict):
                 self.update(line)
             else:
-                self["conda"].append(common.arg2spec(line))
+                self["conda"].append(str(MatchSpec(line)))
 
         if "pip" in self:
             if not self["pip"]:

--- a/news/15028-deprecate-json-arg
+++ b/news/15028-deprecate-json-arg
@@ -8,7 +8,8 @@
 
 ### Deprecations
 
-* Deprecate unused `arg2spec` and `specs_from_args` `json` argument. (#15028)
+* Mark `conda.cli.common.arg2spec` keyword argument `json` as pending deprecation, to be removed in 26.9. (#15028)
+* Mark `conda.cli.common.specs_from_args` keyword argument `json` as pending deprecation, to be removed in 26.9. (#15028)
 
 ### Docs
 

--- a/news/15028-deprecate-json-arg
+++ b/news/15028-deprecate-json-arg
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Mark `conda.cli.common.arg2spec` keyword argument `json` as pending deprecation, to be removed in 26.9. (#15028)
+* Mark `conda.cli.common.arg2spec` as pending deprecation, to be removed in 26.9. (#15028)
 * Mark `conda.cli.common.specs_from_args` keyword argument `json` as pending deprecation, to be removed in 26.9. (#15028)
 
 ### Docs

--- a/news/15028-deprecate-json-arg
+++ b/news/15028-deprecate-json-arg
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Deprecate unused `arg2spec` and `specs_from_args` `json` argument. (#15028)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -611,6 +611,7 @@ def test_license_match():
     assert MatchSpec("*[license='*gpl*']").match(record)
     assert MatchSpec("*[license='*v3+']").match(record)
 
+
 @pytest.mark.parametrize(
     "spec,expected_result",
     [
@@ -621,7 +622,7 @@ def test_license_match():
         ("ipython=0.13.0", "ipython=0.13.0"),
         ("ipython==0.13.0", "ipython==0.13.0"),
         ("foo=1.3.0=3", "foo==1.3.0=3"),
-    ]
+    ],
 )
 def test_simple(spec, expected_result):
     assert str(MatchSpec(spec)) == expected_result
@@ -633,7 +634,7 @@ def test_simple(spec, expected_result):
         ("foo>=1.3", "foo[version='>=1.3']"),
         ("zope.int>=1.3,<3.0", "zope.int[version='>=1.3,<3.0']"),
         ("numpy >=1.9", "numpy[version='>=1.9']"),
-    ]
+    ],
 )
 def test_pip_style(spec, expected_result):
     assert str(MatchSpec(spec)) == expected_result


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
The `json` argument in the `arg2spec` and `specs_from_args` functions are unused. This PR cleans this up by deprecating this argument.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
