### PR TITLE
Limit anaconda_upload config value to bool

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -535,7 +535,7 @@ class Context(Configuration):
     # conda_build
     bld_path = ParameterLoader(PrimitiveParameter(""))
     anaconda_upload = ParameterLoader(
-        PrimitiveParameter(None, element_type=(bool, NoneType)),
+        PrimitiveParameter(False, element_type=bool),
         aliases=("binstar_upload",),
     )
     _croot = ParameterLoader(PrimitiveParameter(""), aliases=("croot",))
@@ -1068,7 +1068,7 @@ class Context(Configuration):
         ) or self._use_only_tar_bz2
 
     @property
-    def binstar_upload(self) -> bool | None:
+    def binstar_upload(self) -> bool:
         # backward compatibility for conda-build
         return self.anaconda_upload
 


### PR DESCRIPTION
Docs at https://docs.conda.io/projects/conda/en/stable/configuration.html say

```
# # anaconda_upload (NoneType, bool)
```

I was wondering what the meaning of the default value None means. When inspecting the code, it turns out that conda-build only ever uses the value in a boolean context, i.e. None is equivalent to False.

https://github.com/search?q=repo%3Aconda%2Fconda-build%20anaconda_upload&type=code
https://github.com/search?q=repo%3Aconda%2Fconda-build+binstar_upload&type=code (binstar_upload is an alias)

By removing support for None, code and semantics become clearer.


### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->

  Is this worth a news entry? If so, which category should this be in?
- [ ] <s>Add / update necessary tests?</s>
- [ ] <s>Add / update outdated documentation?</s> - AFAICS the relevant config documentation is autogenerated.
