### PR TITLE
Specs originating from files should also override `create_default_packages` setting

### DIFF
--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -492,12 +492,6 @@ class Environment:
         :return: An Environment object representing the cli
         """
         specs = [package.strip("\"'") for package in args.packages]
-        if add_default_packages:
-            names = {MatchSpec(spec).name for spec in specs}
-            for default_package in context.create_default_packages:
-                if MatchSpec(default_package).name not in names:
-                    specs.append(default_package)
-
         requested_packages = []
         fetch_explicit_packages = []
 
@@ -516,6 +510,15 @@ class Environment:
                     "Error reading file, file should be a text file containing packages\n"
                     "See `conda create --help` for details."
                 )
+
+        # Add default packages if required. If the default package is already
+        # present in the list of specs, don't add it (this will override any
+        # version constraint from the default package).
+        if add_default_packages:
+            names = {MatchSpec(spec).name for spec in specs}
+            for default_package in context.create_default_packages:
+                if MatchSpec(default_package).name not in names:
+                    specs.append(default_package)
 
         for spec in specs:
             if is_package_file(spec):

--- a/news/15041-specs-from-files-override-default-packages
+++ b/news/15041-specs-from-files-override-default-packages
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Specs originating from files should also override `create_default_packages` setting. (#15041)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION

### Description

Fixes https://github.com/conda/conda-environments-project-mgmt/issues/86

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
