### PR TITLE
Don't install explicit packages if invoked with `conda update`

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -347,7 +347,6 @@ def install(args, parser, command="install"):
         add_default_packages=command == "create" and not args.no_default_packages,
     )
 
-
     # for 'conda update' make sure:
     # 1) there are no explicit_packages specified
     # 2) the requested specs actually exist in the prefix

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1452,3 +1452,11 @@ class InvalidInstaller(Exception):
 
 class OfflineError(CondaError, RuntimeError):
     pass
+
+
+class CondaUpdatePackageError(CondaError):
+    def __init__(self, spec: str | list[str]):
+        spec_format = dashlist(spec, 4) if isinstance(spec, list) else spec
+        msg = (f"`conda update` only supports name-only spec, but received: {spec_format}\n"
+            f"Use `conda install` to install a specific version of a package.")
+        super().__init__(msg)

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1457,6 +1457,8 @@ class OfflineError(CondaError, RuntimeError):
 class CondaUpdatePackageError(CondaError):
     def __init__(self, spec: str | list[str]):
         spec_format = dashlist(spec, 4) if isinstance(spec, list) else spec
-        msg = (f"`conda update` only supports name-only spec, but received: {spec_format}\n"
-            f"Use `conda install` to install a specific version of a package.")
+        msg = (
+            f"`conda update` only supports name-only spec, but received: {spec_format}\n"
+            f"Use `conda install` to install a specific version of a package."
+        )
         super().__init__(msg)

--- a/news/15044-dont-update-explicit-package
+++ b/news/15044-dont-update-explicit-package
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Don't install explicit packages if invoked with `conda update`. (#15044)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_update.py
+++ b/tests/cli/test_main_update.py
@@ -49,4 +49,4 @@ def test_dont_update_packages_with_version_constraints(
             "update",
             "python=3.10",
         )
-    assert "'conda update' only supports name-only spec" in excinfo.value.message
+    assert "`conda update` only supports name-only spec" in excinfo.value.message

--- a/tests/cli/test_main_update.py
+++ b/tests/cli/test_main_update.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import pytest
+from typing import TYPE_CHECKING
+
+from conda.exceptions import CondaUpdatePackageError
+from conda.testing.integration import package_is_installed
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+
+
+def test_update(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture,):
+    with tmp_env("python==3.10") as prefix:
+        assert package_is_installed(prefix, "python==3.10")
+        conda_cli(
+            "update",
+            "python",
+            "--prefix",
+            prefix,
+            "--yes"
+        )
+        assert package_is_installed(prefix, "python>3.10")
+
+
+def test_dont_update_explicit_packages(
+    test_recipes_channel: Path,
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+):
+    with tmp_env(test_recipes_channel / "noarch" / "dependent-1.0-0.tar.bz2") as prefix:
+        with pytest.raises(CondaUpdatePackageError) as excinfo:
+            conda_cli(
+                "update",
+                test_recipes_channel / "noarch" / "dependent-1.0-0.tar.bz2",
+                "--prefix",
+                prefix,
+            )
+        assert "`conda update` only supports name-only spec" in excinfo.value.message
+
+
+def test_dont_update_packages_with_version_constraints(
+    conda_cli: CondaCLIFixture,
+):
+    with pytest.raises(CondaUpdatePackageError) as excinfo:
+        conda_cli(
+            "update",
+            "python=3.10",
+        )
+    assert "'conda update' only supports name-only spec" in excinfo.value.message

--- a/tests/cli/test_main_update.py
+++ b/tests/cli/test_main_update.py
@@ -2,28 +2,26 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import pytest
 from typing import TYPE_CHECKING
+
+import pytest
 
 from conda.exceptions import CondaUpdatePackageError
 from conda.testing.integration import package_is_installed
 
-
 if TYPE_CHECKING:
     from pathlib import Path
+
     from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 
-def test_update(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture,):
+def test_update(
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+):
     with tmp_env("python==3.10") as prefix:
         assert package_is_installed(prefix, "python==3.10")
-        conda_cli(
-            "update",
-            "python",
-            "--prefix",
-            prefix,
-            "--yes"
-        )
+        conda_cli("update", "python", "--prefix", prefix, "--yes")
         assert package_is_installed(prefix, "python>3.10")
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR introduces a new exception `CondaUpdatePackageError` to represent an error with the package specification when running `conda update`. A user must pass a name only spec to the `conda update` command. Explicit packages, or packages with a version constraint is not allowed.

For example the following are NOT valid:
```
$ conda update  ~/miniconda3/pkgs/flask-2.2.5-pyhd8ed1ab_0.conda

$ conda update https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.conda

$ conda update python=3.10
``` 

fixes: https://github.com/conda/conda-environments-project-mgmt/issues/75


Note, this check is still a little bit clunky. For example, you can see that for an explicit package, conda will first try to download and extract the package, then produce an error:
```
$ conda update  ~/miniconda3/pkgs/flask-2.2.5-pyhd8ed1ab_0.conda

Downloading and Extracting Packages:
                                                                                              

CondaUpdatePackageError: `conda update` only supports name-only spec, but received: 
    - <unknown>/noarch::flask==2.2.5=pyhd8ed1ab_0
Use `conda install` to install a specific version of a package.
```
 This issues is captured (and will be fixed) by https://github.com/conda/conda-environments-project-mgmt/issues/76


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
