### PR TITLE
Improve GitHub Actions security and variable handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,10 +131,8 @@ jobs:
           --file tests\requirements-${{ runner.os }}.txt
           --file tests\requirements-ci.txt
           --file tests\requirements-s3.txt
-          ${REQUIREMENTS_TRUSTSTORE}
+          ${{ env.REQUIREMENTS_TRUSTSTORE }}
           python=${{ matrix.python-version }}
-        env:
-          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -172,11 +170,8 @@ jobs:
           --basetemp=${{ runner.temp }}
           --durations-path=durations\${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${PYTEST_SPLITS}
-          -m "${PYTEST_MARKER}"
-        env:
-          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
-          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
+          --splits=${{ env.PYTEST_SPLITS }}
+          -m "${{ env.PYTEST_MARKER }}"
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -271,10 +266,8 @@ jobs:
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          ${REQUIREMENTS_TRUSTSTORE}
+          ${{ env.REQUIREMENTS_TRUSTSTORE }}
           python=${{ matrix.python-version }}
-        env:
-          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -297,11 +290,8 @@ jobs:
           --cov=conda
           --durations-path=durations/${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${PYTEST_SPLITS}
-          -m "${PYTEST_MARKER}"
-        env:
-          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
-          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
+          --splits=${{ env.PYTEST_SPLITS }}
+          -m "${{ env.PYTEST_MARKER }}"
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -370,10 +360,8 @@ jobs:
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
           --file tests/requirements-benchmarks.txt
-          ${REQUIREMENTS_TRUSTSTORE}
+          ${{ env.REQUIREMENTS_TRUSTSTORE }}
           python=${{ matrix.python-version }}
-        env:
-          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -440,10 +428,8 @@ jobs:
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
           --file tests/requirements-typing.txt
-          ${REQUIREMENTS_TRUSTSTORE}
+          ${{ env.REQUIREMENTS_TRUSTSTORE }}
           python=${{ matrix.python-version }}
-        env:
-          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -684,10 +670,8 @@ jobs:
           --file tests/requirements.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          ${REQUIREMENTS_TRUSTSTORE}
+          ${{ env.REQUIREMENTS_TRUSTSTORE }}
           python=${{ matrix.python-version }}
-        env:
-          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -710,11 +694,8 @@ jobs:
           --cov=conda
           --durations-path=durations/${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${PYTEST_SPLITS}
-          -m "${PYTEST_MARKER}"
-        env:
-          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
-          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
+          --splits=${{ env.PYTEST_SPLITS }}
+          -m "${{ env.PYTEST_MARKER }}"
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,8 @@ jobs:
         # dorny/paths-filter needs git clone for non-PR events
         # https://github.com/dorny/paths-filter#supported-workflows
         if: github.event_name != 'pull_request'
+        with:
+          persist-credentials: false
 
       - name: Filter Changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -95,6 +97,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Hash + Timestamp
         shell: bash  # use bash to run date command
@@ -124,8 +127,10 @@ jobs:
           --file tests\requirements-${{ runner.os }}.txt
           --file tests\requirements-ci.txt
           --file tests\requirements-s3.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -163,8 +168,11 @@ jobs:
           --basetemp=${{ runner.temp }}
           --durations-path=durations\${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          -m "${{ env.PYTEST_MARKER }}"
+          --splits=${PYTEST_SPLITS}
+          -m "${PYTEST_MARKER}"
+        env:
+          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
+          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -234,6 +242,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Hash + Timestamp
         run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
@@ -258,8 +267,10 @@ jobs:
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -282,8 +293,11 @@ jobs:
           --cov=conda
           --durations-path=durations/${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          -m "${{ env.PYTEST_MARKER }}"
+          --splits=${PYTEST_SPLITS}
+          -m "${PYTEST_MARKER}"
+        env:
+          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
+          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -326,6 +340,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Hash + Timestamp
         run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-benchmark-$(date -u "+%Y%m")" >> $GITHUB_ENV
@@ -351,8 +366,10 @@ jobs:
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
           --file tests/requirements-benchmarks.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -393,6 +410,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Hash + Timestamp
         run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-benchmark-$(date -u "+%Y%m")" >> $GITHUB_ENV
@@ -418,8 +436,10 @@ jobs:
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
           --file tests/requirements-typing.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -488,6 +508,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -543,6 +564,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Hash + Timestamp
         run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-memray-$(date -u "+%Y%m")" >> $GITHUB_ENV
@@ -630,6 +652,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Hash + Timestamp
         run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ matrix.test-type }}-${{ matrix.test-group }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
@@ -657,8 +680,10 @@ jobs:
           --file tests/requirements.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -681,8 +706,11 @@ jobs:
           --cov=conda
           --durations-path=durations/${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          -m "${{ env.PYTEST_MARKER }}"
+          --splits=${PYTEST_SPLITS}
+          -m "${PYTEST_MARKER}"
+        env:
+          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
+          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -750,6 +778,8 @@ jobs:
       - name: Checkout our source
         if: always() && github.event_name == 'schedule' && steps.alls-green.outputs.result == 'failure'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Report failures
         if: always() && github.event_name == 'schedule' && steps.alls-green.outputs.result == 'failure'
@@ -798,8 +828,7 @@ jobs:
           ref: ${{ github.ref }}
           clean: true
           fetch-depth: 0
-
-      # Explicitly use Python 3.11 since each of the OSes has a different default Python
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -817,14 +846,14 @@ jobs:
           # e.g., `main` branch commits
           envs = {"ANACONDA_ORG_LABEL": "dev"}
 
-          if "${{ github.ref_name }}".startswith("feature/"):
+          if "${GITHUB_REF_NAME}".startswith("feature/"):
               # feature branch commits are uploaded to a custom label
-              envs["ANACONDA_ORG_LABEL"] = "${{ github.ref_name }}"
-          elif re.match(r"\d+(\.\d+)+\.x", "${{ github.ref_name }}"):
+              envs["ANACONDA_ORG_LABEL"] = "${GITHUB_REF_NAME}"
+          elif re.match(r"\d+(\.\d+)+\.x", "${GITHUB_REF_NAME}"):
               # release branch commits are added to the rc label
               # see https://github.com/conda/infrastructure/issues/760
               _, name = "${{ github.repository }}".split("/")
-              envs["ANACONDA_ORG_LABEL"] = f"rc-{name}-${{ github.ref_name }}"
+              envs["ANACONDA_ORG_LABEL"] = f"rc-{name}-${GITHUB_REF_NAME}"
 
               # if no releases have occurred on this branch yet then `git describe --tag`
               # will misleadingly produce a version number relative to the last release
@@ -833,7 +862,7 @@ jobs:
 
               # override the version if `git describe --tag` does not start with the branch version
               last_release = check_output(["git", "describe", "--tag"], text=True).strip()
-              prefix = "${{ github.ref_name }}"[:-1]  # without x suffix
+              prefix = "${GITHUB_REF_NAME}"[:-1]  # without x suffix
               if not last_release.startswith(prefix):
                   envs["VERSION_OVERRIDE"] = f"{prefix}0"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,8 +131,10 @@ jobs:
           --file tests\requirements-${{ runner.os }}.txt
           --file tests\requirements-ci.txt
           --file tests\requirements-s3.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          $env:REQUIREMENTS_TRUSTSTORE
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -170,8 +172,11 @@ jobs:
           --basetemp=${{ runner.temp }}
           --durations-path=durations\${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          -m "${{ env.PYTEST_MARKER }}"
+          --splits=$env:PYTEST_SPLITS
+          -m "$env:PYTEST_MARKER"
+        env:
+          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
+          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -266,8 +271,10 @@ jobs:
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -290,8 +297,11 @@ jobs:
           --cov=conda
           --durations-path=durations/${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          -m "${{ env.PYTEST_MARKER }}"
+          --splits=${PYTEST_SPLITS}
+          -m "${PYTEST_MARKER}"
+        env:
+          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
+          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -360,8 +370,10 @@ jobs:
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
           --file tests/requirements-benchmarks.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -428,8 +440,10 @@ jobs:
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
           --file tests/requirements-typing.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -670,8 +684,10 @@ jobs:
           --file tests/requirements.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          ${REQUIREMENTS_TRUSTSTORE}
           python=${{ matrix.python-version }}
+        env:
+          REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -694,8 +710,11 @@ jobs:
           --cov=conda
           --durations-path=durations/${{ runner.os }}.json
           --group=${{ matrix.test-group }}
-          --splits=${{ env.PYTEST_SPLITS }}
-          -m "${{ env.PYTEST_MARKER }}"
+          --splits=${PYTEST_SPLITS}
+          -m "${PYTEST_MARKER}"
+        env:
+          PYTEST_SPLITS: ${{ env.PYTEST_SPLITS }}
+          PYTEST_MARKER: ${{ env.PYTEST_MARKER }}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,10 @@ env:
   # https://conda.github.io/conda-libmamba-solver/user-guide/configuration/#advanced-options
   CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED: true
 
+# Set minimal default permissions for security
+permissions:
+  contents: read
+
 jobs:
   # detect whether any code changes are included in this PR
   changes:
@@ -766,6 +770,9 @@ jobs:
     if: '!cancelled()'
 
     runs-on: ubuntu-latest
+    permissions:
+      # needed to create issues on test failures
+      issues: write
     steps:
       - name: Determine Success
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration' || 'integration' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       REQUIREMENTS_TRUSTSTORE: ${{ contains('3.10|3.11|3.12|3.13', matrix.python-version) && '--file tests\requirements-truststore.txt' || '' }}
+      REQUIREMENTS_S3: ${{ matrix.default-channel == 'conda-forge' && '--file tests\requirements-s3.txt' || '' }}
       CONDA_TEST_SOLVERS: ${{ github.event_name == 'pull_request' && 'libmamba' || 'libmamba,classic' }}
 
     steps:
@@ -122,6 +123,7 @@ jobs:
           run-post: false  # skip post cleanup
           pkgs-dirs: D:\conda_pkgs_dir
           installation-dir: D:\conda
+          conda-remove-defaults: ${{ matrix.default-channel == 'conda-forge' }}
 
       - name: Conda Install
         run: >
@@ -130,11 +132,12 @@ jobs:
           --file tests\requirements.txt
           --file tests\requirements-${{ runner.os }}.txt
           --file tests\requirements-ci.txt
-          --file tests\requirements-s3.txt
+          $env:REQUIREMENTS_S3
           $env:REQUIREMENTS_TRUSTSTORE
           python=${{ matrix.python-version }}
         env:
           REQUIREMENTS_TRUSTSTORE: ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          REQUIREMENTS_S3: ${{ env.REQUIREMENTS_S3 }}
 
       - name: Conda Info
         # view test env info (not base)
@@ -262,6 +265,7 @@ jobs:
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
+          conda-remove-defaults: ${{ matrix.default-channel == 'conda-forge' }}
 
       - name: Conda Install
         run: >
@@ -676,6 +680,7 @@ jobs:
           miniconda-version: ${{ (matrix.default-channel == 'defaults' && matrix.arch == 'osx-arm64') && 'latest' || null }}
           miniforge-version: ${{ (matrix.default-channel == 'conda-forge' && matrix.arch == 'osx-arm64') && 'latest' || null }}
           architecture: ${{ runner.arch }}
+          conda-remove-defaults: ${{ matrix.default-channel == 'conda-forge' }}
 
       - name: Conda Install
         run: >


### PR DESCRIPTION
- Add persist-credentials: false to all checkout actions for security
- Fix environment variable syntax in shell commands (use ${VAR} instead of ${{ env.VAR }})
- Add explicit env blocks for proper variable scoping in pytest runs
- Remove duplicate comment about Python version selection

These changes address security recommendations from static analysis tools.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
