### PR TITLE
Add LazyChoicesAction enhancements with caching

### DIFF
--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -44,8 +44,10 @@ class LazyChoicesAction(Action):
         valid_choices = self.choices
         if values not in valid_choices:
             choices_string = ", ".join(f"'{val}'" for val in valid_choices)
+            # Use the same format as argparse for consistency
+            option_display = "/".join(self.option_strings)
             parser.error(
-                f"argument '{option_string}': invalid choice: {values!r} (choose from {choices_string})"
+                f"argument {option_display}: invalid choice: {values!r} (choose from {choices_string})"
             )
         setattr(namespace, self.dest, values)
 

--- a/news/lazy-choices-action-enhancements
+++ b/news/lazy-choices-action-enhancements
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Enhanced `LazyChoicesAction` with dynamic choices property and caching for improved CLI argument validation and help text generation. (#15046)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_all_commands.py
+++ b/tests/cli/test_all_commands.py
@@ -51,11 +51,11 @@ def test_denylist_channels(
     (
         (
             ("env", "create", "--environment-specifier", "idontexist"),
-            "error: argument '--environment-specifier': invalid choice: 'idontexist'",
+            "error: argument --environment-specifier/--env-spec: invalid choice: 'idontexist'",
         ),
         (
             ("install", "--solver", "idontexist"),
-            "error: argument '--solver': invalid choice: 'idontexist'",
+            "error: argument --solver: invalid choice: 'idontexist'",
         ),
     ),
 )

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -19,9 +19,9 @@ def simple_choices():
 
 
 @pytest.fixture
-def export_format_choices():
+def food_choices():
     """Fixture providing realistic export format choices."""
-    return ["environment-json", "environment-yaml", "explicit", "json", "yaml"]
+    return ["spam", "eggs", "bacon", "spam"]
 
 
 @pytest.fixture
@@ -139,13 +139,13 @@ def test_invalid_choice_handling(lazy_action, mock_parser_namespace):
     assert "choose from 'red', 'green', 'blue'" in parser.error_message
 
 
-def test_argumentparser_help_integration(export_format_choices):
+def test_argumentparser_help_integration(simple_choices):
     """Test that LazyChoicesAction works with ArgumentParser help generation."""
     parser = ArgumentParser(prog="test")
     parser.add_argument(
         "--format",
         action=LazyChoicesAction,
-        choices_func=lambda: export_format_choices,
+        choices_func=lambda: simple_choices,
         help="Choose a format",
     )
 
@@ -153,7 +153,7 @@ def test_argumentparser_help_integration(export_format_choices):
     help_output = parser.format_help()
 
     # Should show choices in help
-    assert "{environment-json,environment-yaml,explicit,json,yaml}" in help_output
+    assert "{red,green,blue}" in help_output
     assert "Choose a format" in help_output
 
 
@@ -293,25 +293,24 @@ def test_multiple_option_strings(mock_parser_namespace):
     assert namespace.format == "long"
 
 
-def test_conda_export_format_integration(export_format_choices):
-    """Test LazyChoicesAction with realistic conda export format choices."""
-    parser = ArgumentParser(prog="conda export")
+def test_conda_food_choices(food_choices):
+    """Test LazyChoicesAction with realistic conda food choices."""
+    parser = ArgumentParser(prog="conda food")
     parser.add_argument(
-        "--format",
+        "--food",
         action=LazyChoicesAction,
-        choices_func=lambda: export_format_choices,
-        help="Export format",
+        choices_func=lambda: food_choices,
+        help="Food",
     )
 
     # Test valid parsing
-    args = parser.parse_args(["--format", "yaml"])
-    assert args.format == "yaml"
+    args = parser.parse_args(["--food", "bacon"])
+    assert args.food == "bacon"
 
     # Test help includes choices
     help_text = parser.format_help()
-    assert "environment-json" in help_text
-    assert "environment-yaml" in help_text
-    assert "explicit" in help_text
+    assert "{spam,eggs,bacon,spam}" in help_text
+    assert "Food" in help_text
 
 
 def test_conda_solver_integration(solver_choices):

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -1,0 +1,333 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Tests for conda.cli.helpers module."""
+
+from __future__ import annotations
+
+import argparse
+from argparse import ArgumentParser, Namespace
+
+import pytest
+
+from conda.cli.helpers import LazyChoicesAction
+
+
+@pytest.fixture
+def simple_choices():
+    """Fixture providing simple test choices."""
+    return ["red", "green", "blue"]
+
+
+@pytest.fixture
+def export_format_choices():
+    """Fixture providing realistic export format choices."""
+    return ["environment-json", "environment-yaml", "explicit", "json", "yaml"]
+
+
+@pytest.fixture
+def solver_choices():
+    """Fixture providing realistic solver choices."""
+    return ["classic", "libmamba"]
+
+
+@pytest.fixture
+def choices_func_counter():
+    """Fixture providing a choices function that counts calls."""
+    call_count = {"count": 0}
+
+    def func():
+        call_count["count"] += 1
+        return ["option1", "option2", "option3"]
+
+    func.call_count = lambda: call_count["count"]
+    return func
+
+
+@pytest.fixture
+def lazy_action(simple_choices):
+    """Fixture providing a basic LazyChoicesAction."""
+    return LazyChoicesAction(
+        option_strings=["--test"],
+        dest="test",
+        choices_func=lambda: simple_choices,
+    )
+
+
+@pytest.fixture
+def mock_parser_namespace():
+    """Fixture providing mock parser and namespace objects."""
+
+    class MockParser:
+        def __init__(self):
+            self.error_called = False
+            self.error_message = None
+
+        def error(self, message):
+            self.error_called = True
+            self.error_message = message
+
+    parser = MockParser()
+    namespace = Namespace()
+    return parser, namespace
+
+
+def test_lazy_choices_action_initialization(simple_choices):
+    """Test basic initialization of LazyChoicesAction."""
+    choices_func = lambda: simple_choices
+    action = LazyChoicesAction(
+        option_strings=["--test"],
+        dest="test",
+        choices_func=choices_func,
+    )
+    assert action.choices_func == choices_func
+    assert action.dest == "test"
+
+
+def test_choices_property_evaluation(choices_func_counter):
+    """Test that choices property dynamically evaluates choices_func."""
+    action = LazyChoicesAction(
+        option_strings=["--test"],
+        dest="test",
+        choices_func=choices_func_counter,
+    )
+
+    # First access
+    choices1 = action.choices
+    assert choices1 == ["option1", "option2", "option3"]
+    assert choices_func_counter.call_count() == 1
+
+    # Second access - should use cached result (with caching)
+    choices2 = action.choices
+    assert choices2 == ["option1", "option2", "option3"]
+    assert choices_func_counter.call_count() == 1  # Same count due to caching
+
+
+def test_choices_setter_ignores_values():
+    """Test that choices setter ignores attempts to set static choices."""
+    choices_func = lambda: ["dynamic1", "dynamic2"]
+    action = LazyChoicesAction(
+        option_strings=["--test"],
+        dest="test",
+        choices_func=choices_func,
+    )
+
+    # Try to set choices (this happens during argparse init)
+    action.choices = ["static1", "static2"]
+
+    # Should still return dynamic choices
+    assert action.choices == ["dynamic1", "dynamic2"]
+
+
+def test_valid_choice_handling(lazy_action, mock_parser_namespace):
+    """Test action call with valid choice."""
+    parser, namespace = mock_parser_namespace
+
+    # Valid choice should set attribute without error
+    lazy_action(parser, namespace, "red", "--test")
+    assert namespace.test == "red"
+    assert not parser.error_called
+
+
+def test_invalid_choice_handling(lazy_action, mock_parser_namespace):
+    """Test action call with invalid choice raises error."""
+    parser, namespace = mock_parser_namespace
+
+    # Invalid choice should call parser.error
+    lazy_action(parser, namespace, "purple", "--test")
+    assert parser.error_called
+    assert "invalid choice: 'purple'" in parser.error_message
+    assert "choose from 'red', 'green', 'blue'" in parser.error_message
+
+
+def test_argumentparser_help_integration(export_format_choices):
+    """Test that LazyChoicesAction works with ArgumentParser help generation."""
+    parser = ArgumentParser(prog="test")
+    parser.add_argument(
+        "--format",
+        action=LazyChoicesAction,
+        choices_func=lambda: export_format_choices,
+        help="Choose a format",
+    )
+
+    # Get help text
+    help_output = parser.format_help()
+
+    # Should show choices in help
+    assert "{environment-json,environment-yaml,explicit,json,yaml}" in help_output
+    assert "Choose a format" in help_output
+
+
+def test_argumentparser_error_handling():
+    """Test that LazyChoicesAction error handling works with ArgumentParser."""
+    choices_func = lambda: ["alpha", "beta", "gamma"]
+
+    parser = ArgumentParser(prog="test")
+    parser.add_argument(
+        "--choice",
+        action=LazyChoicesAction,
+        choices_func=choices_func,
+    )
+
+    # Should raise SystemExit for invalid choice
+    with pytest.raises((SystemExit, argparse.ArgumentError)):
+        parser.parse_args(["--choice", "invalid"])
+
+
+def test_argumentparser_valid_parsing():
+    """Test that LazyChoicesAction works correctly with valid parsing."""
+    choices_func = lambda: ["one", "two", "three"]
+
+    parser = ArgumentParser(prog="test")
+    parser.add_argument(
+        "--number",
+        action=LazyChoicesAction,
+        choices_func=choices_func,
+    )
+
+    # Valid choice should parse correctly
+    args = parser.parse_args(["--number", "two"])
+    assert args.number == "two"
+
+
+def test_choices_func_exception_propagation():
+    """Test that exceptions in choices_func are propagated."""
+
+    def failing_choices_func():
+        raise ValueError("Choices function failed")
+
+    action = LazyChoicesAction(
+        option_strings=["--test"],
+        dest="test",
+        choices_func=failing_choices_func,
+    )
+
+    # Exception should be propagated when accessing choices
+    with pytest.raises(ValueError, match="Choices function failed"):
+        _ = action.choices
+
+
+def test_empty_choices_behavior(mock_parser_namespace):
+    """Test behavior with empty choices list."""
+    action = LazyChoicesAction(
+        option_strings=["--test"],
+        dest="test",
+        choices_func=lambda: [],
+    )
+
+    parser, namespace = mock_parser_namespace
+
+    # Any value should be invalid with empty choices
+    action(parser, namespace, "anything", "--test")
+    assert parser.error_called
+    assert "invalid choice: 'anything'" in parser.error_message
+
+
+def test_non_list_iterable_choices(mock_parser_namespace):
+    """Test that choices_func can return any iterable."""
+    action = LazyChoicesAction(
+        option_strings=["--test"],
+        dest="test",
+        choices_func=lambda: {"set", "of", "choices"},  # set instead of list
+    )
+
+    parser, namespace = mock_parser_namespace
+
+    # Valid choice from set should work
+    action(parser, namespace, "set", "--test")
+    assert namespace.test == "set"
+    assert not parser.error_called
+
+
+@pytest.mark.parametrize("valid_choice", ["yaml", "json", "explicit"])
+def test_parametrized_valid_choices(valid_choice, mock_parser_namespace):
+    """Test multiple valid choices using parametrization."""
+    action = LazyChoicesAction(
+        option_strings=["--format"],
+        dest="format",
+        choices_func=lambda: ["yaml", "json", "explicit"],
+    )
+
+    parser, namespace = mock_parser_namespace
+
+    action(parser, namespace, valid_choice, "--format")
+    assert getattr(namespace, "format") == valid_choice
+    assert not parser.error_called
+
+
+@pytest.mark.parametrize("invalid_choice", ["xml", "csv", "invalid"])
+def test_parametrized_invalid_choices(invalid_choice, mock_parser_namespace):
+    """Test multiple invalid choices using parametrization."""
+    action = LazyChoicesAction(
+        option_strings=["--format"],
+        dest="format",
+        choices_func=lambda: ["yaml", "json", "explicit"],
+    )
+
+    parser, namespace = mock_parser_namespace
+
+    action(parser, namespace, invalid_choice, "--format")
+    assert parser.error_called
+    assert f"invalid choice: '{invalid_choice}'" in parser.error_message
+
+
+def test_multiple_option_strings(mock_parser_namespace):
+    """Test LazyChoicesAction with multiple option strings."""
+    action = LazyChoicesAction(
+        option_strings=["-f", "--format"],
+        dest="format",
+        choices_func=lambda: ["short", "long"],
+    )
+
+    parser, namespace = mock_parser_namespace
+
+    # Test with long option
+    action(parser, namespace, "short", "--format")
+    assert namespace.format == "short"
+
+    # Reset namespace
+    namespace.format = None
+    parser.error_called = False
+
+    # Test with short option
+    action(parser, namespace, "long", "-f")
+    assert namespace.format == "long"
+
+
+def test_conda_export_format_integration(export_format_choices):
+    """Test LazyChoicesAction with realistic conda export format choices."""
+    parser = ArgumentParser(prog="conda export")
+    parser.add_argument(
+        "--format",
+        action=LazyChoicesAction,
+        choices_func=lambda: export_format_choices,
+        help="Export format",
+    )
+
+    # Test valid parsing
+    args = parser.parse_args(["--format", "yaml"])
+    assert args.format == "yaml"
+
+    # Test help includes choices
+    help_text = parser.format_help()
+    assert "environment-json" in help_text
+    assert "environment-yaml" in help_text
+    assert "explicit" in help_text
+
+
+def test_conda_solver_integration(solver_choices):
+    """Test LazyChoicesAction with realistic conda solver choices."""
+    parser = ArgumentParser(prog="conda install")
+    parser.add_argument(
+        "--solver",
+        action=LazyChoicesAction,
+        choices_func=lambda: solver_choices,
+        help="Solver backend",
+    )
+
+    # Test valid parsing
+    args = parser.parse_args(["--solver", "libmamba"])
+    assert args.solver == "libmamba"
+
+    # Test help includes choices
+    help_text = parser.format_help()
+    assert "{classic,libmamba}" in help_text

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -20,7 +20,7 @@ def simple_choices():
 
 @pytest.fixture
 def food_choices():
-    """Fixture providing realistic export format choices."""
+    """Fixture providing realistic food choices."""
     return ["spam", "eggs", "bacon", "spam"]
 
 
@@ -143,10 +143,10 @@ def test_argumentparser_help_integration(simple_choices):
     """Test that LazyChoicesAction works with ArgumentParser help generation."""
     parser = ArgumentParser(prog="test")
     parser.add_argument(
-        "--format",
+        "--color",
         action=LazyChoicesAction,
         choices_func=lambda: simple_choices,
-        help="Choose a format",
+        help="Choose a color",
     )
 
     # Get help text
@@ -154,7 +154,7 @@ def test_argumentparser_help_integration(simple_choices):
 
     # Should show choices in help
     assert "{red,green,blue}" in help_output
-    assert "Choose a format" in help_output
+    assert "Choose a color" in help_output
 
 
 def test_argumentparser_error_handling():
@@ -238,19 +238,19 @@ def test_non_list_iterable_choices(mock_parser_namespace):
     assert not parser.error_called
 
 
-@pytest.mark.parametrize("valid_choice", ["yaml", "json", "explicit"])
+@pytest.mark.parametrize("valid_choice", ["spam", "eggs", "bacon"])
 def test_parametrized_valid_choices(valid_choice, mock_parser_namespace):
     """Test multiple valid choices using parametrization."""
     action = LazyChoicesAction(
-        option_strings=["--format"],
-        dest="format",
-        choices_func=lambda: ["yaml", "json", "explicit"],
+        option_strings=["--food"],
+        dest="food",
+        choices_func=lambda: ["spam", "eggs", "bacon"],
     )
 
     parser, namespace = mock_parser_namespace
 
-    action(parser, namespace, valid_choice, "--format")
-    assert getattr(namespace, "format") == valid_choice
+    action(parser, namespace, valid_choice, "--food")
+    assert getattr(namespace, "food") == valid_choice
     assert not parser.error_called
 
 
@@ -258,14 +258,14 @@ def test_parametrized_valid_choices(valid_choice, mock_parser_namespace):
 def test_parametrized_invalid_choices(invalid_choice, mock_parser_namespace):
     """Test multiple invalid choices using parametrization."""
     action = LazyChoicesAction(
-        option_strings=["--format"],
-        dest="format",
-        choices_func=lambda: ["yaml", "json", "explicit"],
+        option_strings=["--food"],
+        dest="food",
+        choices_func=lambda: ["spam", "eggs", "bacon"],
     )
 
     parser, namespace = mock_parser_namespace
 
-    action(parser, namespace, invalid_choice, "--format")
+    action(parser, namespace, invalid_choice, "--food")
     assert parser.error_called
     assert f"invalid choice: '{invalid_choice}'" in parser.error_message
 
@@ -273,24 +273,24 @@ def test_parametrized_invalid_choices(invalid_choice, mock_parser_namespace):
 def test_multiple_option_strings(mock_parser_namespace):
     """Test LazyChoicesAction with multiple option strings."""
     action = LazyChoicesAction(
-        option_strings=["-f", "--format"],
-        dest="format",
+        option_strings=["-f", "--food"],
+        dest="food",
         choices_func=lambda: ["short", "long"],
     )
 
     parser, namespace = mock_parser_namespace
 
     # Test with long option
-    action(parser, namespace, "short", "--format")
-    assert namespace.format == "short"
+    action(parser, namespace, "short", "--food")
+    assert namespace.food == "short"
 
     # Reset namespace
-    namespace.format = None
+    namespace.food = None
     parser.error_called = False
 
     # Test with short option
     action(parser, namespace, "long", "-f")
-    assert namespace.format == "long"
+    assert namespace.food == "long"
 
 
 def test_conda_food_choices(food_choices):


### PR DESCRIPTION
- Add choices property for dynamic evaluation
- Add choices setter to ignore argparse initialization
- Implement caching to avoid repeated calls to choices_func
- Add comprehensive test suite for LazyChoicesAction

This is a clean port of commits 75a6e36 and 541b679 from env-exporter-hook branch,
focusing only on the LazyChoicesAction improvements without dependencies on other features.

Refs #14886.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
