### PR TITLE
Fix tuple sizes for `conda.models.environment.EnvironmentConfig`

### DIFF
--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -41,27 +41,27 @@ class EnvironmentConfig:
     Data model for a conda environment config.
     """
 
-    aggressive_update_packages: tuple[str] = field(default_factory=tuple)
+    aggressive_update_packages: tuple[str, ...] = field(default_factory=tuple)
 
     channel_priority: ChannelPriority | None = None
 
-    channels: tuple[str] = field(default_factory=tuple)
+    channels: tuple[str, ...] = field(default_factory=tuple)
 
-    channel_settings: tuple[dict[str, str]] = field(default_factory=tuple)
+    channel_settings: tuple[dict[str, str], ...] = field(default_factory=tuple)
 
     deps_modifier: DepsModifier | None = None
 
-    disallowed_packages: tuple[str] = field(default_factory=tuple)
+    disallowed_packages: tuple[str, ...] = field(default_factory=tuple)
 
-    pinned_packages: tuple[str] = field(default_factory=tuple)
+    pinned_packages: tuple[str, ...] = field(default_factory=tuple)
 
-    repodata_fns: tuple[str] = field(default_factory=tuple)
+    repodata_fns: tuple[str, ...] = field(default_factory=tuple)
 
     sat_solver: SatSolverChoice | None = None
 
     solver: str | None = None
 
-    track_features: tuple[str] = field(default_factory=tuple)
+    track_features: tuple[str, ...] = field(default_factory=tuple)
 
     update_modifier: UpdateModifier | None = None
 
@@ -73,8 +73,8 @@ class EnvironmentConfig:
         return tuple(dict.fromkeys(item for item in chain(first, second)))
 
     def _merge_channel_settings(
-        self, first: tuple[dict[str, str]], second: tuple[dict[str, str]]
-    ) -> tuple[dict[str, str]]:
+        self, first: tuple[dict[str, str], ...], second: tuple[dict[str, str], ...]
+    ) -> tuple[dict[str, str], ...]:
         """Merge channel settings.
 
         An individual channel setting is a dict that may have the key "channels". Settings


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Correct the `EnvironmentConfig` attribute types to allow undefined tuple sizes.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
