### PR TITLE
Env vars should override cli args for primitives

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -563,8 +563,8 @@ class Context(Configuration):
             # for proper search_path templating when --name/--prefix is used
             CONDA_PREFIX=determine_target_prefix(self, argparse_args),
         )
-        self._set_env_vars(APP_NAME)
         self._set_argparse_args(argparse_args)
+        self._set_env_vars(APP_NAME)
 
     def post_build_validation(self) -> list[ValidationError]:
         errors = []


### PR DESCRIPTION


### Description

This PR tries out switching the config precedence between env vars and cli args. With this change, env vars get precedence over all other source of config, as specified in the docs.

For example, `CONDA_JSON=False conda info --json ` no longer returns a json response with this change.


addresses https://github.com/conda/conda/issues/15033
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
