### PR TITLE
Remove unreachable code path

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -727,9 +727,7 @@ class CondaPluginManager(pluggy.PluginManager):
             if basename in exporter_config.default_filenames:
                 matches.append(exporter_config)
 
-        if len(matches) == 1:
-            return matches[0]
-        elif len(matches) == 0:
+        if not matches:
             # Collect all available formats and supported filenames for the error message
             all_exporters = list(self.get_environment_exporters())
             available_formats = [exporter.name for exporter in all_exporters]
@@ -749,8 +747,7 @@ class CondaPluginManager(pluggy.PluginManager):
                 f"\n"
                 f"Please make sure that you don't have any conflicting exporter plugins installed."
             )
-
-        return None
+        return matches[0]
 
     def get_environment_exporter_by_format(
         self, format_name: str


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`CondaPluginManager.detect_environment_exporter` is only expected to return a plugin (not `None`) so theres no point in including an unreachable fallback `return None`.

Found via `mypy`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
