### PR TITLE
Rename requirements_txt export format to specs

### DIFF
--- a/conda/plugins/environment_exporters/__init__.py
+++ b/conda/plugins/environment_exporters/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Built-in conda environment exporter plugins."""
 
-from . import environment_yml, explicit, requirements_txt
+from . import environment_yml, explicit, specs
 
 #: The list of environment exporter plugins for easier registration with pluggy
-plugins = [environment_yml, explicit, requirements_txt]
+plugins = [environment_yml, explicit, specs]

--- a/conda/plugins/environment_exporters/specs.py
+++ b/conda/plugins/environment_exporters/specs.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""Built-in conda requirements environment exporter plugin.
+"""Built-in conda specs environment exporter plugin.
 
-This module implements the requirements format defined in CEP 23:
+This module implements the specs format defined in CEP 23:
 Files with MatchSpec strings (no @EXPLICIT marker) for flexible package specifications.
 """
 
@@ -21,27 +21,27 @@ if TYPE_CHECKING:
     from ...models.environment import Environment
 
 
-#: The name of the requirements format
-REQUIREMENTS_FORMAT: Final = "requirements"
+#: The name of the specs format
+SPECS_FORMAT: Final = "specs"
 
 
-def export_requirements(env: Environment) -> str:
-    """Export Environment to requirements format with MatchSpecs (CEP 23 compliant)."""
+def export_specs(env: Environment) -> str:
+    """Export Environment to specs file with MatchSpecs (CEP 23 compliant)."""
     lines = ["# This file may be used to create an environment using:"]
     lines.append("# $ conda create --name <env> --file <this file>")
     lines.append(f"# platform: {env.platform}")
     lines.append(f"# created-by: conda {__version__}")
 
-    # Only create requirements files if we have requested packages
+    # Only create specs file if we have requested packages
     if not env.requested_packages:
         raise CondaValueError(
-            "Cannot export requirements format: no requested packages found. "
+            "Cannot export specs format: no requested packages found. "
             "Use 'explicit' format for environments with installed packages, "
             "or ensure the environment has package specifications."
         )
 
-    # Create CEP 23 compliant non-explicit requirements file (no @EXPLICIT)
-    lines.append("# Note: This is a conda requirements file (MatchSpec format)")
+    # Create CEP 23 compliant non-explicit specs file (no @EXPLICIT)
+    lines.append("# Note: This is a conda specs file (MatchSpec format)")
     lines.append("# Contains conda package specifications, not pip requirements")
     lines.append("")
 
@@ -54,10 +54,10 @@ def export_requirements(env: Environment) -> str:
 
 @hookimpl
 def conda_environment_exporters():
-    """Environment exporter plugin for requirements format."""
+    """Environment exporter plugin for specs format."""
     yield CondaEnvironmentExporter(
-        name=REQUIREMENTS_FORMAT,
-        aliases=("reqs", "txt"),
-        export=export_requirements,
-        default_filenames=("requirements.txt", "spec.txt"),
+        name=SPECS_FORMAT,
+        aliases=("txt",),
+        export=export_specs,
+        default_filenames=("specs.txt",),
     )

--- a/tests/cli/test_main_export.py
+++ b/tests/cli/test_main_export.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Test conda export."""
 
+from __future__ import annotations
+
 import json
 import uuid
-from pathlib import Path
 from subprocess import check_call
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -17,8 +19,14 @@ from conda.exceptions import (
     CondaValueError,
     EnvironmentExporterNotDetected,
 )
-from conda.testing.fixtures import CondaCLIFixture
+from conda.plugins.environment_exporters.explicit import EXPLICIT_FORMAT
+from conda.plugins.environment_exporters.specs import SPECS_FORMAT
 from conda.testing.integration import PYTHON_BINARY
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture
 
 
 def test_export(conda_cli: CondaCLIFixture) -> None:
@@ -136,10 +144,9 @@ def test_export_structured_file_extension_detection(
 @pytest.mark.parametrize(
     "format_name,expected_error_fragment",
     [
-        ("explicit", "Cannot export explicit format"),
-        ("requirements", "Cannot export requirements format"),
-        ("reqs", "Cannot export requirements format"),  # Test alias
-        ("txt", "Cannot export requirements format"),  # Test alias
+        (EXPLICIT_FORMAT, "Cannot export explicit format"),
+        (SPECS_FORMAT, "Cannot export specs format"),
+        ("txt", "Cannot export specs format"),  # alias
     ],
 )
 def test_export_text_formats_fail_on_empty_environments(
@@ -157,8 +164,7 @@ def test_export_text_formats_fail_on_empty_environments(
     "filename,expected_error_fragment",
     [
         ("explicit.txt", "Cannot export explicit format"),
-        ("requirements.txt", "Cannot export requirements format"),
-        ("spec.txt", "Cannot export requirements format"),
+        ("specs.txt", "Cannot export specs format"),
     ],
 )
 def test_export_text_file_extensions_fail_on_empty_environments(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Looking to avoid conflating pip's `requirements.txt` with conda so let's rename this exporter format a more generic "specs" format since it is composed of `MatchSpec`s.

Depends on #15058 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
