### PR TITLE
`conda create --clone` should not allow users to specify a `--file`

### DIFF
--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -112,14 +112,24 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
                 "one of the arguments -n/--name -p/--prefix is required"
             )
 
-    # Only one of the arguments --clone and packages is allowed
-    if args.clone and args.packages:
-        raise TooManyArgumentsError(
-            0,
-            len(args.packages),
-            list(args.packages),
-            "did not expect any arguments for --clone",
-        )
+    # If the --clone argument is provided, users must not provide any other
+    # package specification. That includes providing the --file argument or
+    # a list of packages
+    if args.clone:
+        if args.packages:
+            raise TooManyArgumentsError(
+                0,
+                len(args.packages),
+                list(args.packages),
+                "did not expect any new packages or arguments for --clone",
+            )
+        elif args.file:
+            raise TooManyArgumentsError(
+                0,
+                len(args.file),
+                list(args.file),
+                "--file and --clone arguments are mutually exclusive",
+            )
     prefix_data = PrefixData.from_context(validate=True)
 
     if prefix_data.is_environment():

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -121,14 +121,14 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
                 0,
                 len(args.packages),
                 list(args.packages),
-                "did not expect any new packages or arguments for --clone",
+                "Did not expect any new packages or arguments for `--clone`.",
             )
         elif args.file:
             raise TooManyArgumentsError(
                 0,
                 len(args.file),
                 list(args.file),
-                "--file and --clone arguments are mutually exclusive",
+                "`--file` and `--clone` arguments are mutually exclusive.",
             )
     prefix_data = PrefixData.from_context(validate=True)
 

--- a/news/15073-clone-and-file-args-are-mutually-exclusive
+++ b/news/15073-clone-and-file-args-are-mutually-exclusive
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* `conda create --clone` should not allow users to specify a `--file`. (#15702 via #15073)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2680,7 +2680,7 @@ def test_create_without_prefix_raises_argument_error(conda_cli: CondaCLIFixture)
     conda_cli("create", "--json", "ca-certificates", raises=ArgumentError)
 
 
-def test_create_without_clone_and_packages_raises_argument_error(
+def test_create_with_clone_and_packages_raises_argument_error(
     conda_cli: CondaCLIFixture,
 ):
     conda_cli(
@@ -2690,6 +2690,21 @@ def test_create_without_clone_and_packages_raises_argument_error(
         "--clone",
         "idontexist",
         "ca-certificates",
+        raises=TooManyArgumentsError,
+    )
+
+
+def test_create_with_clone_and_file_raises_argument_error(
+    conda_cli: CondaCLIFixture,
+):
+    conda_cli(
+        "create",
+        "--prefix",
+        "/tmp/idontexist",
+        "--clone",
+        "idontexist",
+        "--file",
+        "/pretend/this/file/exists",
         raises=TooManyArgumentsError,
     )
 


### PR DESCRIPTION


### Description
With this change, conda will not allow users to specify extra packages using the `--file` arg when cloning an environment.  This makes the `conda create --clone` command more consistent in the arguments that are allowed.

```
$ conda create  --clone existing -n testenv2 python                                                                                                                               

TooManyArgumentsError: did not expect any arguments for --clone Got 1 argument (python) but expected 0.

$ conda create  --clone existing -n testenv2 --file tests/env/support/requirements.txt                                                                                         

TooManyArgumentsError: --file and --clone arguments are mutually exclusive Got 1 argument (tests/env/support/requirements.txt) but expected 0.
```

fixes https://github.com/conda/conda/issues/15072

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
