### PR TITLE
Add missing re-export into `conda.plugins`

### DIFF
--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -27,6 +27,7 @@ as well as conda's internal implementations of plugins.
 from .hookspec import hookimpl  # noqa: F401
 from .types import (  # noqa: F401
     CondaAuthHandler,
+    CondaEnvironmentExporter,
     CondaEnvironmentSpecifier,
     CondaHealthCheck,
     CondaPostCommand,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We missed importing `conda.plugins.types.CondaEnvironmentExporter` into `conda.plugins`.

Alternative to #15103
Closes #15103

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
