### PR TITLE
Create constant for all reserved base environment names

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -37,8 +37,9 @@ from .base.constants import (
     CONDA_ENV_VARS_UNSET_VAR,
     PACKAGE_ENV_VARS_DIR,
     PREFIX_STATE_FILE,
+    RESERVED_ENV_NAMES,
 )
-from .base.context import ROOT_ENV_NAME, context, locate_prefix_by_name
+from .base.context import context, locate_prefix_by_name
 from .common.compat import on_win
 from .common.path import _cygpath, paths_equal, unix_path_to_win, win_path_to_unix
 from .common.path import path_identity as _path_identity
@@ -355,7 +356,7 @@ class _Activator(metaclass=abc.ABCMeta):
                 from .exceptions import EnvironmentLocationNotFound
 
                 raise EnvironmentLocationNotFound(prefix)
-        elif env_name_or_prefix in (ROOT_ENV_NAME, "root"):
+        elif env_name_or_prefix in (RESERVED_ENV_NAMES):
             prefix = context.root_prefix
         else:
             prefix = locate_prefix_by_name(env_name_or_prefix)

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -120,6 +120,10 @@ DEFAULT_CUSTOM_CHANNELS: Final = {
 DEFAULT_CHANNELS: Final = DEFAULT_CHANNELS_WIN if on_win else DEFAULT_CHANNELS_UNIX
 
 ROOT_ENV_NAME: Final = "base"
+RESERVED_ENV_NAMES: Final = (
+    ROOT_ENV_NAME,
+    "root",
+)
 UNUSED_ENV_NAME: Final = "unused-env-name"
 
 ROOT_NO_RM: Final = (

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -67,6 +67,7 @@ from .constants import (
     PREFIX_MAGIC_FILE,
     PREFIX_NAME_DISALLOWED_CHARS,
     REPODATA_FN,
+    RESERVED_ENV_NAMES,
     ROOT_ENV_NAME,
     SEARCH_PATH,
     ChannelPriority,
@@ -794,7 +795,7 @@ class Context(Configuration):
         if self.active_prefix:
             return self.active_prefix
         _default_env = os.getenv("CONDA_DEFAULT_ENV")
-        if _default_env in (None, ROOT_ENV_NAME, "root"):
+        if _default_env in (None, *RESERVED_ENV_NAMES):
             return self.root_prefix
         elif os.sep in _default_env:
             return abspath(_default_env)
@@ -2220,7 +2221,7 @@ def locate_prefix_by_name(name: str, envs_dirs: PathsType | None = None) -> Path
     error is raised.
     """
     assert name
-    if name in (ROOT_ENV_NAME, "root"):
+    if name in RESERVED_ENV_NAMES:
         return context.root_prefix
     if envs_dirs is None:
         envs_dirs = context.envs_dirs
@@ -2290,7 +2291,7 @@ def validate_prefix_name(
             )
         )
 
-    if prefix_name in (ROOT_ENV_NAME, "root"):
+    if prefix_name in RESERVED_ENV_NAMES:
         if allow_base:
             return ctx.root_prefix
         else:

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -19,7 +19,7 @@ from boltons.setutils import IndexedSet
 
 from ..base.constants import (
     REPODATA_FN,
-    ROOT_ENV_NAME,
+    RESERVED_ENV_NAMES,
     UpdateModifier,
 )
 from ..base.context import context
@@ -112,7 +112,7 @@ def check_prefix(prefix: str, json=False):
         )
     name = basename(prefix)
     error = None
-    if name == ROOT_ENV_NAME:
+    if name in RESERVED_ENV_NAMES:
         error = f"'{name}' is a reserved environment name"
     if exists(prefix):
         if isdir(prefix) and "conda-meta" not in tuple(

--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -19,6 +19,7 @@ from ..base.constants import (
     PREFIX_NAME_DISALLOWED_CHARS,
     PREFIX_PINNED_FILE,
     PREFIX_STATE_FILE,
+    RESERVED_ENV_NAMES,
     ROOT_ENV_NAME,
 )
 from ..base.context import context, locate_prefix_by_name
@@ -338,7 +339,7 @@ class PrefixData(metaclass=PrefixDataType):
         :raises CondaValueError: If the name is protected, or if it contains disallowed characters
             (`/`, ` `, `:`, `#`).
         """
-        if not allow_base and self.name in (ROOT_ENV_NAME, "root"):
+        if not allow_base and self.name in RESERVED_ENV_NAMES:
             raise CondaValueError(f"'{self.name}' is a reserved environment name")
 
         if PREFIX_NAME_DISALLOWED_CHARS.intersection(self.prefix_path.name):


### PR DESCRIPTION
### Description

This PR adds a new constant `RESERVED_ENV_NAMES` that is a list of all the environment names that are reserved by conda. This includes "base" and "root". Conda code can refer to this new constant when doing environment name validations.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
