### PR TITLE
Replace custom `--subdir`/`--platform` definition with `add_parser_platform` helper function

### DIFF
--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -598,10 +598,17 @@ def add_parser_default_packages(p: ArgumentParser) -> None:
     )
 
 
-def add_parser_platform(parser):
+def add_parser_platform(parser: ArgumentParser, *, help: str | None = None) -> None:
     from ..base.constants import KNOWN_SUBDIRS
     from ..common.constants import NULL
 
+    help = (
+        help
+        or (
+            "Use packages built for this platform. "
+            "The new environment will be configured to remember this choice. "
+        )
+    ).strip()
     parser.add_argument(
         "--subdir",
         "--platform",
@@ -609,10 +616,11 @@ def add_parser_platform(parser):
         dest="subdir",
         choices=[s for s in KNOWN_SUBDIRS if s != "noarch"],
         metavar="SUBDIR",
-        help="Use packages built for this platform. "
-        "The new environment will be configured to remember this choice. "
-        "Should be formatted like 'osx-64', 'linux-32', 'win-64', and so on. "
-        "Defaults to the current (native) platform.",
+        help=(
+            f"{help}{' ' if help else ''}"
+            f"Should be formatted like 'osx-64', 'linux-32', 'win-64', and so on. "
+            f"Defaults to the current (native) platform."
+        ),
     )
 
 

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -598,8 +598,13 @@ def add_parser_default_packages(p: ArgumentParser) -> None:
     )
 
 
-def add_parser_platform(parser: ArgumentParser, *, help: str | None = None) -> None:
-    from ..base.constants import KNOWN_SUBDIRS
+def add_parser_platform(
+    parser: ArgumentParser | _ArgumentGroup,
+    *,
+    help: str | None = None,
+    known_subdirs_only: bool = True,
+) -> None:
+    from ..base.context import context
     from ..common.constants import NULL
 
     help = (
@@ -614,7 +619,9 @@ def add_parser_platform(parser: ArgumentParser, *, help: str | None = None) -> N
         "--platform",
         default=NULL,
         dest="subdir",
-        choices=[s for s in KNOWN_SUBDIRS if s != "noarch"],
+        choices=(
+            sorted(context.known_subdirs - {"noarch"}) if known_subdirs_only else None
+        ),
         metavar="SUBDIR",
         help=(
             f"{help}{' ' if help else ''}"

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -22,12 +22,12 @@ if TYPE_CHECKING:
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from ..common.constants import NULL
     from .helpers import (
         add_parser_channels,
         add_parser_json,
         add_parser_known,
         add_parser_networking,
+        add_parser_platform,
     )
 
     summary = "Search for packages and display associated information using the MatchSpec format."
@@ -105,15 +105,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         action="store_true",
         help="Provide detailed information about each package.",
     )
-    p.add_argument(
-        "--subdir",
-        "--platform",
-        action="store",
-        dest="subdir",
-        help="Search the given subdir. Should be formatted like 'osx-64', 'linux-32', "
-        "'win-64', and so on. The default is to search the current platform.",
-        default=NULL,
-    )
+    add_parser_platform(p, help="Specify which platform to search.")
     p.add_argument(
         "--skip-flexible-search",
         action="store_true",

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -105,7 +105,11 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         action="store_true",
         help="Provide detailed information about each package.",
     )
-    add_parser_platform(p, help="Specify which platform to search.")
+    add_parser_platform(
+        p,
+        help="Specify which platform to search.",
+        known_subdirs_only=False,
+    )
     p.add_argument(
         "--skip-flexible-search",
         action="store_true",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 
 import conda
 from conda import plugins
-from conda.base.constants import APP_NAME
+from conda.base.constants import APP_NAME, KNOWN_SUBDIRS
 from conda.base.context import context, reset_context
 from conda.common.configuration import (
     Configuration,
@@ -317,6 +317,7 @@ def plugin_config(mocker) -> tuple[type[Configuration], str]:
             self.plugin_manager = mocker.MagicMock()
             self.repodata_fns = ["repodata.json", "current_repodata.json"]
             self.subdir = mocker.MagicMock()
+            self.known_subdirs = frozenset(KNOWN_SUBDIRS)
             self.preview = ()
 
         @property

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2664,7 +2664,7 @@ def test_create_env_different_platform(
     platform = f"{context.subdir.split('-')[0]}-fake"
 
     # the platform must match the defined known platforms, patch to use fake subdir
-    monkeypatch.setattr("conda.base.constants.KNOWN_SUBDIRS", [platform])
+    monkeypatch.setattr("conda.base.context.KNOWN_SUBDIRS", [platform])
     monkeypatch.setattr("conda.models.environment.PLATFORMS", [platform])
 
     # either set CONDA_SUBDIR or pass --platform


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Instead of having a custom definition of `--subdir`/`--platform` improve helper function so we can use it in both `conda create`/`conda env create` and `conda search`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
