### PR TITLE
Users may specify which environment spec plugin to use with the `--format` flag

### DIFF
--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -617,6 +617,7 @@ def add_parser_environment_specifier(p: ArgumentParser) -> None:
     p.add_argument(
         "--environment-specifier",
         "--env-spec",  # for brevity
+        "--format",    # for consistency with the export command
         action=LazyChoicesAction,
         choices_func=context.plugin_manager.get_environment_specifiers,
         default=NULL,

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -617,7 +617,7 @@ def add_parser_environment_specifier(p: ArgumentParser) -> None:
     p.add_argument(
         "--environment-specifier",
         "--env-spec",  # for brevity
-        "--format",    # for consistency with the export command
+        "--format",  # for consistency with the export command
         action=LazyChoicesAction,
         choices_func=context.plugin_manager.get_environment_specifiers,
         default=NULL,

--- a/news/15134-add-format-cli-arg-to-specify-env-spec-plugin
+++ b/news/15134-add-format-cli-arg-to-specify-env-spec-plugin
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Users may specify which environment spec plugin to use with the --format flag. (#15134)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_all_commands.py
+++ b/tests/cli/test_all_commands.py
@@ -51,7 +51,7 @@ def test_denylist_channels(
     (
         (
             ("env", "create", "--environment-specifier", "idontexist"),
-            "error: argument --environment-specifier/--env-spec: invalid choice: 'idontexist'",
+            "error: argument --environment-specifier/--env-spec/--format: invalid choice: 'idontexist'",
         ),
         (
             ("install", "--solver", "idontexist"),

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -183,7 +183,11 @@ def test_create_valid_env(path_factory: PathFactoryFixture, conda_cli: CondaCLIF
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "specifying_flag",
-    ("--environment-specifier", "--env-spec", "--format",)
+    (
+        "--environment-specifier",
+        "--env-spec",
+        "--format",
+    ),
 )
 def test_create_specify_plugin_type(
     path_factory: PathFactoryFixture,

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -181,6 +181,32 @@ def test_create_valid_env(path_factory: PathFactoryFixture, conda_cli: CondaCLIF
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    "specifying_flag",
+    ("--environment-specifier", "--env-spec", "--format",)
+)
+def test_create_specify_plugin_type(
+    path_factory: PathFactoryFixture,
+    conda_cli: CondaCLIFixture,
+    specifying_flag: str,
+):
+    """
+    Creates an environment.yml. Then, try to create an environment using different
+    ways to specify the plugin. Use --dry-run argument to speed up tests.
+    """
+    create_env(ENVIRONMENT_CA_CERTIFICATES)
+    prefix = path_factory()
+    conda_cli(
+        "env",
+        "create",
+        f"--prefix={prefix}",
+        "--dry-run",
+        f"{specifying_flag}=environment.yml",
+        # "--file=environment.yml",  # this is the implied default
+    )
+
+
+@pytest.mark.integration
 def test_create_unsolvable_env(
     path_factory: PathFactoryFixture, conda_cli: CondaCLIFixture
 ):


### PR DESCRIPTION

### Description

This PR adds the `--format` alias for the  `--environment-specifier` cli argument.  Now users may specify which environment spec plugin they want to use like:

```
$ conda env create -n myenv --file env.yml --format environment.yml
```
OR
```
$ conda env create -n myenv --file env.yml --environment-specifier environment.yml
```
OR
```
$ conda env create -n myenv --file env.yml --env-spec environment.yml
```

This is reflected in the `--help`

```
$ conda env create -h     [14:05:20]
usage: conda env create [-h] [-f FILE] [-n ENVIRONMENT | -p PATH] [-C] [-k] [--offline]
                        [--environment-specifier {binstar,environment.yml,explicit,requirements.txt}]
                        [--no-default-packages] [--json] [--console CONSOLE] [-v] [-q] [-d] [-y]
                        [--solver {classic,libmamba}] [--subdir SUBDIR]
                        [remote_definition]

Create an environment based on an environment definition file.

. . .

  --environment-specifier {binstar,environment.yml,explicit,requirements.txt}, --env-spec {binstar,environment.yml,explicit,requirements.txt}, --format {binstar,environment.yml,explicit,requirements.txt}
                        (EXPERIMENTAL) Specify the environment specifier plugin to use.

. . .
```


Note, that this PR does not change the context setting name for environment specifiers. So, users can set `CONDA_ENVIRONMENT_SPECIFIER`/`CONDA_ENV_SPEC` to select the env spec plugin they wish to use. But they **can not** use `CONDA_FORMAT`. This name is too ambiguous and may collide with other names in the future. 

Fixes: https://github.com/conda/conda-environments-project-mgmt/issues/101

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
