### PR TITLE
Only init the context with pre args once

### DIFF
--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -41,16 +41,18 @@ def main_subshell(*args, post_parse_hook=None, **kwargs):
         "verbosity": pre_args.verbosity,
     }
 
-    context.__init__(argparse_args=pre_args)
-    if context.no_plugins:
+    # disable plugins if requested
+    if pre_args.no_plugins:
         context.plugin_manager.disable_external_plugins()
 
-    # reinitialize in case any of the entrypoints modified the context
+    # initialize the context with the pre_args
     context.__init__(argparse_args=pre_args)
 
+    # generate the full parser
     parser = generate_parser(add_help=True)
     args = parser.parse_args(args, override_args=override_args, namespace=pre_args)
 
+    # reinitialize the context with the full parser information
     context.__init__(argparse_args=args)
     init_loggers()
 

--- a/news/15149-initialize-with-preargs-once
+++ b/news/15149-initialize-with-preargs-once
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Speed up the startup process by reducing the number of context re-initializations. (#15149)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Initializing the context object is costly. This issue surfaced in the work getting config from environment specs. See https://github.com/conda/conda/pull/15138 and https://github.com/conda/conda/pull/15138. In these PR's codspeed indicates that adding an extra context initialization call can add [up to 2 seconds to running a conda command](https://github.com/conda/conda/pull/15081#issuecomment-3161168592).

This PR aims to reduce the number of times context (re) initialization occurs during the application startup process.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
