### PR TITLE
Use `default=NULL` for `--override-frozen`

### DIFF
--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -239,9 +239,12 @@ def add_output_and_prompt_options(p: ArgumentParser) -> _ArgumentGroup:
 
 
 def add_parser_frozen_env(p: ArgumentParser):
+    from ..common.constants import NULL
+
     p.add_argument(
         "--override-frozen",
         action="store_false",
+        default=NULL,
         help="DANGEROUS. Use at your own risk. Ignore protections if the environment is frozen.",
         dest="protect_frozen_envs",
     )

--- a/news/15162-override-frozen-env-var
+++ b/news/15162-override-frozen-env-var
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Respect `CONDA_PROTECT_FROZEN_ENVS` environment variable in the absence of `--override-frozen`. (#15162)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -130,7 +130,7 @@ def test_emscripten_forge(
         assert package_is_installed(prefix, "pyjs")
 
 
-def test_frozen_env_cep22(tmp_env, conda_cli):
+def test_frozen_env_cep22(tmp_env, conda_cli, monkeypatch):
     with tmp_env("ca-certificates") as prefix:
         prefix_data = PrefixData(prefix)
         prefix_data._frozen_file.touch()
@@ -145,7 +145,7 @@ def test_frozen_env_cep22(tmp_env, conda_cli):
             "update", "-p", prefix, "ca-certificates", raises=EnvironmentIsFrozenError
         )
 
-        # Bypass protection
+        # Bypass protection with CLI flag
         conda_cli(
             "install",
             "-p",
@@ -173,6 +173,34 @@ def test_frozen_env_cep22(tmp_env, conda_cli):
             "--override-frozen",
         )
         assert rc == 0
+
+        # Bypass protection with env var
+        with monkeypatch.context() as monkeyctx:
+            monkeyctx.setenv("CONDA_PROTECT_FROZEN_ENVS", "0")
+            conda_cli(
+                "install",
+                "-p",
+                prefix,
+                "zlib",
+                "--dry-run",
+                raises=DryRunExit,
+            )
+            conda_cli(
+                "remove",
+                "-p",
+                prefix,
+                "ca-certificates",
+                "--dry-run",
+                raises=DryRunExit,
+            )
+            out, err, rc = conda_cli(
+                "update",
+                "-p",
+                prefix,
+                "ca-certificates",
+                "--dry-run",
+            )
+            assert rc == 0
 
         # With message
         prefix_data._frozen_file.write_text('{"message": "EnvOnTheRocks"}')


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

@marcoesters reported this while debugging the new protected base installers. Turns out the `CONDA_PROTECT_FROZEN_ENVS` env var had no effect on the config because `--override-frozen` had `action="store_false"`, whose default value is `True`. Since the CLI layer has precedence over the env vars to populate the context, this implicit default was overriding the env var config, _even_ if there was no explicit CLI flag passed!

The fix, as seen in other bits of the CLI config, is to use an explicit `default=NULL`, which is special cased in `configuration.py`. This might be hitting other booleans `store_{true,false}` in the CLI config. Took a while to understand what was going on 😬 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
