### PR TITLE
Add configuration support for multiple platforms

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -746,7 +746,9 @@ class Context(Configuration):
             platforms = argparse_args.get("export_platforms") or ()
         else:
             platforms = self._export_platforms
-        return tuple(dict.fromkeys((self.subdir, *platforms)))
+        all_platforms = (self.subdir, *platforms)
+        unique_platforms = tuple(dict.fromkeys(all_platforms))
+        return unique_platforms[1:]  # remove the current platform
 
     @property
     def bits(self) -> int:
@@ -1741,7 +1743,8 @@ class Context(Configuration):
             ),
             export_platforms=dals(
                 """
-                Target platform(s)/subdir(s) for export (e.g., linux-64, osx-64, win-64).
+                Additional platform(s)/subdir(s) for export (e.g., linux-64, osx-64, win-64), current
+                platform is always included.
                 """
             ),
             fetch_threads=dals(

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -354,6 +354,10 @@ class Context(Configuration):
     _subdirs = ParameterLoader(
         SequenceParameter(PrimitiveParameter("", str)), aliases=("subdirs",)
     )
+    export_platforms = ParameterLoader(
+        SequenceParameter(PrimitiveParameter("", str)),
+        aliases=("extra_platforms",),
+    )
 
     local_repodata_ttl = ParameterLoader(
         PrimitiveParameter(1, element_type=(bool, int))
@@ -1417,6 +1421,7 @@ class Context(Configuration):
                 "unsatisfiable_hints_check_depth",
                 "number_channel_notices",
                 "envvars_force_uppercase",
+                "export_platforms",
             ),
             "CLI-only": (
                 "deps_modifier",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1739,6 +1739,11 @@ class Context(Configuration):
                 see much benefit here.
                 """
             ),
+            export_platforms=dals(
+                """
+                Target platform(s)/subdir(s) for export (e.g., linux-64, osx-64, win-64).
+                """
+            ),
             fetch_threads=dals(
                 """
                 Threads to use when downloading packages.  When not set,

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -354,9 +354,9 @@ class Context(Configuration):
     _subdirs = ParameterLoader(
         SequenceParameter(PrimitiveParameter("", str)), aliases=("subdirs",)
     )
-    export_platforms = ParameterLoader(
+    _export_platforms = ParameterLoader(
         SequenceParameter(PrimitiveParameter("", str)),
-        aliases=("extra_platforms",),
+        aliases=("export_platforms", "extra_platforms"),
     )
 
     local_repodata_ttl = ParameterLoader(
@@ -736,8 +736,17 @@ class Context(Configuration):
         return self._subdirs or (self.subdir, "noarch")
 
     @memoizedproperty
-    def known_subdirs(self) -> set[str]:
+    def known_subdirs(self) -> frozenset[str]:
         return frozenset((*KNOWN_SUBDIRS, *self.subdirs))
+
+    @property
+    def export_platforms(self) -> tuple[str, ...]:
+        argparse_args = dict(getattr(self, "_argparse_args", {}) or {})
+        if argparse_args.get("override_platforms"):
+            platforms = argparse_args.get("export_platforms") or ()
+        else:
+            platforms = self._export_platforms
+        return tuple(dict.fromkeys((self.subdir, *platforms)))
 
     @property
     def bits(self) -> int:

--- a/conda/cli/main_export.py
+++ b/conda/cli/main_export.py
@@ -68,8 +68,13 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         "--platform",
         "--subdir",
         action="append",
-        dest="platforms",
+        dest="export_platforms",
         help="Target platform(s)/subdir(s) for export (e.g., linux-64, osx-64, win-64)",
+    )
+    p.add_argument(
+        "--override-platforms",
+        action="store_true",
+        help="Override the platforms specified in the condarc",
     )
     add_parser_prefix(p)
 
@@ -134,17 +139,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from .common import stdout_json
 
     # Determine target platforms for export
-    target_platforms = []
-    if args.platforms:
-        # Use platforms specified on command line
-        target_platforms = args.platforms
-    elif context.export_platforms:
-        # Use platforms from condarc configuration
-        target_platforms = list(context.export_platforms)
-
-    # If no platforms specified, use current platform only
-    if not target_platforms:
-        target_platforms = [context.subdir]
+    target_platforms = context.export_platforms
 
     # TODO: Check if platform targets are valid
 
@@ -190,7 +185,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     env = Environment.from_prefix(
         prefix=prefix,
         name=env_name(prefix),
-        platform=context.subdir,
+        platform=target_platforms[0],
         from_history=args.from_history,
         no_builds=args.no_builds,
         ignore_channels=args.ignore_channels,

--- a/conda/cli/main_export.py
+++ b/conda/cli/main_export.py
@@ -66,8 +66,9 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     # for the current environment.  We may want to change the helper.
     p.add_argument(
         "--platform",
+        "--subdir",
         action="append",
-        help="Target platform(s) for export (e.g., linux-64, osx-64, win-64)",
+        help="Target platform(s)/subdir(s) for export (e.g., linux-64, osx-64, win-64)",
     )
     add_parser_prefix(p)
 

--- a/conda/cli/main_export.py
+++ b/conda/cli/main_export.py
@@ -138,9 +138,6 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..base.context import env_name
     from .common import stdout_json
 
-    # Determine target platforms for export
-    target_platforms = context.export_platforms
-
     # TODO: Check if platform targets are valid
 
     # Early format validation - fail fast if format is unsupported
@@ -180,12 +177,12 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     #       we need to specify the source platform and then export to
     #       the target platform?  If so, is this done in the
     #       environment_exporter?
-    # target_platform = target_platforms[0] if target_platforms else context.subdir
+    # target_platforms = context.export_platforms
 
     env = Environment.from_prefix(
         prefix=prefix,
         name=env_name(prefix),
-        platform=target_platforms[0],
+        platform=context.subdir,
         from_history=args.from_history,
         no_builds=args.no_builds,
         ignore_channels=args.ignore_channels,

--- a/conda/cli/main_export.py
+++ b/conda/cli/main_export.py
@@ -180,14 +180,16 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     prefix = context.target_prefix
 
     # Create models.Environment directly
-    # TODO: In the future, this will support generating exports for multiple platforms
-    # For now, we use the first target platform
-    target_platform = target_platforms[0] if target_platforms else context.subdir
+    # TODO: Figure out how to handle source and target platforms.  Do we
+    #       we need to specify the source platform and then export to
+    #       the target platform?  If so, is this done in the
+    #       environment_exporter?
+    # target_platform = target_platforms[0] if target_platforms else context.subdir
 
     env = Environment.from_prefix(
         prefix=prefix,
         name=env_name(prefix),
-        platform=target_platform,
+        platform=context.subdir,
         from_history=args.from_history,
         no_builds=args.no_builds,
         ignore_channels=args.ignore_channels,

--- a/conda/cli/main_export.py
+++ b/conda/cli/main_export.py
@@ -68,6 +68,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         "--platform",
         "--subdir",
         action="append",
+        dest="platforms",
         help="Target platform(s)/subdir(s) for export (e.g., linux-64, osx-64, win-64)",
     )
     add_parser_prefix(p)
@@ -134,9 +135,9 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
 
     # Determine target platforms for export
     target_platforms = []
-    if args.platform:
+    if args.platforms:
         # Use platforms specified on command line
-        target_platforms = args.platform
+        target_platforms = args.platforms
     elif context.export_platforms:
         # Use platforms from condarc configuration
         target_platforms = list(context.export_platforms)

--- a/docs/source/commands/export.rst
+++ b/docs/source/commands/export.rst
@@ -321,6 +321,29 @@ When **not** to use ``--from-history``:
   - With ``requirements`` format (always uses all packages)
   - When you need exact dependency reproduction
 
+Platform-Specific Exports
+==========================
+
+You can specify target platforms for export using the ``--platform`` option or by configuring
+``export_platforms`` in your condarc file:
+
+.. code-block:: bash
+
+   # Export for specific platforms
+   conda export --platform linux-64 --platform osx-64 --format=environment-yaml
+
+   # Export using condarc configuration
+   conda export --format=environment-yaml
+
+With condarc configuration:
+
+.. code-block:: yaml
+
+   export_platforms:
+     - linux-64
+     - osx-64
+     - win-64
+
 File Format Detection
 =====================
 
@@ -410,6 +433,12 @@ Advanced Usage
 
    # Export with custom channels
    conda export --channel conda-forge --format=environment-yaml
+
+   # Export for multiple platforms
+   conda export --platform linux-64 --platform osx-64 --format=environment-yaml
+
+   # Export for specific platform only
+   conda export --platform win-64 --format=explicit --file=explicit-win-64.txt
 
 Error Handling
 ==============

--- a/docs/source/commands/export.rst
+++ b/docs/source/commands/export.rst
@@ -331,6 +331,8 @@ You can specify target platforms for export using the ``--platform`` option or b
 
    # Export for specific platforms
    conda export --platform linux-64 --platform osx-64 --format=environment-yaml
+   # or
+   conda export --subdir linux-64 --subdir osx-64 --format=environment-yaml
 
    # Export using condarc configuration
    conda export --format=environment-yaml
@@ -436,9 +438,11 @@ Advanced Usage
 
    # Export for multiple platforms
    conda export --platform linux-64 --platform osx-64 --format=environment-yaml
+   conda export --subdir linux-64 --subdir osx-64 --format=environment-yaml
 
    # Export for specific platform only
    conda export --platform win-64 --format=explicit --file=explicit-win-64.txt
+   conda export --subdir win-64 --format=explicit --file=explicit-win-64.txt
 
 Error Handling
 ==============

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+from argparse import Namespace
 from itertools import chain
 from os.path import abspath, join
 from pathlib import Path
@@ -838,3 +839,24 @@ def test_create_default_packages_will_warn_for_explicit_packages(
     ):
         # Ensure only valid packages are returned
         assert context.create_default_packages == (PYTHON_SPEC,)
+
+
+def test_export_platforms(monkeypatch: MonkeyPatch):
+    reset_context([])
+    assert not context.export_platforms
+
+    monkeypatch.setenv("CONDA_EXPORT_PLATFORMS", "linux-64,osx-64")
+    reset_context()
+    assert context.export_platforms == ("linux-64", "osx-64")
+
+    monkeypatch.setenv("CONDA_EXPORT_PLATFORMS", "linux-64,osx-64,win-64")
+    reset_context()
+    assert context.export_platforms == ("linux-64", "osx-64", "win-64")
+
+    reset_context(argparse_args=Namespace(export_platforms=["linux-32"]))
+    assert context.export_platforms == ("linux-32", "linux-64", "osx-64", "win-64")
+
+    reset_context(
+        argparse_args=Namespace(export_platforms=["linux-32"], override_platforms=True)
+    )
+    assert context.export_platforms == ("linux-32",)

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -842,21 +842,32 @@ def test_create_default_packages_will_warn_for_explicit_packages(
 
 
 def test_export_platforms(monkeypatch: MonkeyPatch):
+    def remove_subdir(*platforms) -> tuple[str, ...]:
+        return tuple(platform for platform in platforms if platform != context.subdir)
+
     reset_context([])
     assert not context.export_platforms
 
     monkeypatch.setenv("CONDA_EXPORT_PLATFORMS", "linux-64,osx-64")
     reset_context()
-    assert context.export_platforms == ("linux-64", "osx-64")
+    assert context.export_platforms == remove_subdir("linux-64", "osx-64")
 
     monkeypatch.setenv("CONDA_EXPORT_PLATFORMS", "linux-64,osx-64,win-64")
     reset_context()
-    assert context.export_platforms == ("linux-64", "osx-64", "win-64")
+    assert context.export_platforms == remove_subdir("linux-64", "osx-64", "win-64")
 
     reset_context(argparse_args=Namespace(export_platforms=["linux-32"]))
-    assert context.export_platforms == ("linux-32", "linux-64", "osx-64", "win-64")
+    assert context.export_platforms == remove_subdir(
+        "linux-32",
+        "linux-64",
+        "osx-64",
+        "win-64",
+    )
 
     reset_context(
-        argparse_args=Namespace(export_platforms=["linux-32"], override_platforms=True)
+        argparse_args=Namespace(
+            export_platforms=["linux-32"],
+            override_platforms=True,
+        )
     )
-    assert context.export_platforms == ("linux-32",)
+    assert context.export_platforms == remove_subdir("linux-32")

--- a/tests/cli/test_main_export.py
+++ b/tests/cli/test_main_export.py
@@ -819,8 +819,7 @@ def test_export_platform_argument(conda_cli: CondaCLIFixture) -> None:
     stdout, stderr, code = conda_cli(
         "export",
         f"--name={name}",
-        "--platform",
-        "linux-64",
+        "--platform=linux-64",
         "--format=environment-yaml",
     )
     assert not stderr
@@ -838,10 +837,8 @@ def test_export_multiple_platforms(conda_cli: CondaCLIFixture) -> None:
     stdout, stderr, code = conda_cli(
         "export",
         f"--name={name}",
-        "--platform",
-        "linux-64",
-        "--platform",
-        "osx-64",
+        "--platform=linux-64",
+        "--platform=osx-64",
         "--format=environment-yaml",
     )
     assert not stderr

--- a/tests/cli/test_main_export.py
+++ b/tests/cli/test_main_export.py
@@ -811,3 +811,43 @@ def test_export_explicit_format_validation_errors(
         error_msg = str(exc_info.value)
         assert "Cannot export explicit format" in error_msg
         assert "external packages" in error_msg
+
+
+def test_export_platform_argument(conda_cli: CondaCLIFixture) -> None:
+    """Test export with platform argument."""
+    name = uuid.uuid4().hex
+    stdout, stderr, code = conda_cli(
+        "export",
+        f"--name={name}",
+        "--platform",
+        "linux-64",
+        "--format=environment-yaml",
+    )
+    assert not stderr
+    assert not code
+    assert stdout
+
+    # Verify the output is valid YAML
+    yaml_data = yaml_safe_load(stdout)
+    assert yaml_data["name"] == name
+
+
+def test_export_multiple_platforms(conda_cli: CondaCLIFixture) -> None:
+    """Test export with multiple platform arguments."""
+    name = uuid.uuid4().hex
+    stdout, stderr, code = conda_cli(
+        "export",
+        f"--name={name}",
+        "--platform",
+        "linux-64",
+        "--platform",
+        "osx-64",
+        "--format=environment-yaml",
+    )
+    assert not stderr
+    assert not code
+    assert stdout
+
+    # Verify the output is valid YAML
+    yaml_data = yaml_safe_load(stdout)
+    assert yaml_data["name"] == name


### PR DESCRIPTION
### Description

This PR implements the configuration option and command line flag for the conda export command for multiplatform export outputs.

Closes #15158

Changes made:
- Added export_platforms configuration parameter to conda/base/context.py with alias extra_platforms
- Added --platform command line argument to conda export command (supports multiple platforms)
- Updated documentation with platform-specific export examples and condarc configuration
- Added comprehensive tests for both single and multiple platform scenarios

Key features:
- Users can specify target platforms via --platform linux-64 --platform osx-64
- Configuration can be set in condarc: export_platforms: [linux-64, osx-64, win-64]
- Falls back to current platform if no platforms specified
- This provides the foundation for future multi-platform export functionality while maintaining backward compatibility.
  - NOTE: Right now, the code only accepts the first platform for exporting
  
Checklist - did you ...
- [ ] Add a file to the news directory 1 for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
