### PR TITLE
Update test_sorted_commands_in_error for linux-Python-3.12.3

### DIFF
--- a/news/15171-test-sorted-commands-in-error
+++ b/news/15171-test-sorted-commands-in-error
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Update test to accept quotes in Python 3.12 argparse errors. (#15172)

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -116,10 +116,18 @@ def test_sorted_commands_in_error(capsys):
     except SystemExit:
         stderr = capsys.readouterr().err
         # ...but the suggestions here are sorted
+
+        # Linux Python 3.12.3 and possibly other 3.12 builds appear to use the
+        # quoted style:
+        old_style = "invalid choice: 'd' (choose from 'a', 'b', 'c')"
+        new_style = "invalid choice: 'd' (choose from a, b, c)"
+
         if sys.version_info < (3, 12):
             # FUTURE: Python 3.12+: remove this test case
-            assert "invalid choice: 'd' (choose from 'a', 'b', 'c')" in stderr
+            assert old_style in stderr
+        elif sys.version_info[:2] == (3, 12):
+            assert old_style in stderr or new_style in stderr
         else:
-            assert "invalid choice: 'd' (choose from a, b, c)" in stderr
+            assert new_style in stderr
     else:
         pytest.fail("Did not raise")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This is intended to fix a test failure under Linux Python 3.12.3 in the [conda-libmamba-solver test suite](https://github.com/conda/conda-libmamba-solver/actions/runs/17439308833/job/49677569312?pr=695#step:13:1718).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
