### PR TITLE
Deprecate `calculate_channel_urls`

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -24,10 +24,7 @@ from ..base.constants import (
 )
 from ..base.context import context
 from ..common.constants import NULL
-from ..core.index import (
-    Index,
-    calculate_channel_urls,
-)
+from ..core.index import Index
 from ..core.link import PrefixSetup, UnlinkLinkTransaction
 from ..core.prefix_data import PrefixData
 from ..core.solve import diff_for_unlink_link_precs
@@ -56,6 +53,7 @@ from ..misc import (
     clone_env,
     install_explicit_packages,
 )
+from ..models.channel import all_channel_urls
 from ..models.environment import Environment
 from ..models.match_spec import MatchSpec
 from ..models.prefix_graph import PrefixGraph
@@ -228,17 +226,11 @@ class TryRepodata:
         ):
             return True
         elif isinstance(exc_value, ResolvePackageNotFound):
-            # transform a ResolvePackageNotFound into PackagesNotFoundError
-            channels_urls = tuple(
-                calculate_channel_urls(
-                    channel_urls=self.index_args["channel_urls"],
-                    prepend=self.index_args["prepend"],
-                    platform=None,
-                    use_local=self.index_args["use_local"],
-                )
-            )
             # convert the ResolvePackageNotFound into PackagesNotFoundError
-            raise PackagesNotFoundError(exc_value._formatted_chains, channels_urls)
+            raise PackagesNotFoundError(
+                exc_value._formatted_chains,
+                all_channel_urls(context.channels),
+            )
 
 
 class Repodatas:

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -167,7 +167,6 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..base.context import context
     from ..cli.common import stdout_json
     from ..core.envs_manager import query_all_prefixes
-    from ..core.index import calculate_channel_urls
     from ..core.subdir_data import SubdirData
     from ..models.match_spec import MatchSpec
     from ..models.records import PackageRecord
@@ -248,17 +247,10 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         )
 
     if not matches:
-        channels_urls = tuple(
-            calculate_channel_urls(
-                channel_urls=context.channels,
-                prepend=not args.override_channels,
-                platform=subdirs[0],
-                use_local=args.use_local,
-            )
-        )
         from ..exceptions import PackagesNotFoundError
+        from ..models.channel import all_channel_urls
 
-        raise PackagesNotFoundError((str(spec),), channels_urls)
+        raise PackagesNotFoundError([spec], all_channel_urls(context.channels, subdirs))
 
     if context.json:
         json_obj = defaultdict(list)

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -834,6 +834,11 @@ def get_archspec_name() -> str | None:
         return str(archspec.cpu.host())
 
 
+@deprecated(
+    "26.3",
+    "26.9",
+    addendum="Use `conda.models.channel.all_channel_urls(context.channels)` instead.",
+)
 def calculate_channel_urls(
     channel_urls: tuple[str] = (),
     prepend: bool = True,

--- a/news/15173-deprecate-calculate_channel_urls
+++ b/news/15173-deprecate-calculate_channel_urls
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.core.index.calculate_channel_urls` as pending deprecation in 26.9. Use `conda.models.channel.all_channel_urls(conda.base.context.context.channels)` instead. (#15173)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import platform
+from contextlib import nullcontext
 from logging import getLogger
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,7 @@ import pytest
 import conda
 from conda.base.context import context, non_x86_machines
 from conda.common.compat import on_linux, on_mac, on_win
+from conda.core import index
 from conda.core.index import (
     Index,
     _make_virtual_package,
@@ -555,3 +557,15 @@ def test_check_allowlist_deprecation_warning():
     """
     with pytest.deprecated_call():
         check_allowlist(("defaults",))
+
+
+@pytest.mark.parametrize(
+    "function,raises",
+    [
+        ("calculate_channel_urls", None),
+    ],
+)
+def test_deprecations(function: str, raises: type[Exception] | None) -> None:
+    raises_context = pytest.raises(raises) if raises else nullcontext()
+    with pytest.deprecated_call(), raises_context:
+        getattr(index, function)()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Since `context.channels` already performs channel stacking we don't need helper functions that also perform the stacking.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
