### PR TITLE
Use `tmp_path` & `monkeypatch` for automatic cleanup

### DIFF
--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import sys
 from contextlib import contextmanager, nullcontext
@@ -15,13 +14,16 @@ from ruamel.yaml.scanner import ScannerError
 
 from conda import CondaError, CondaMultiError
 from conda.auxlib.compat import Utf8NamedTemporaryFile
-from conda.base.context import context, reset_context, sys_rc_path, user_rc_path
+from conda.base import context as context_module
+from conda.base.context import context, reset_context
 from conda.common.configuration import ConfigurationLoadError, CustomValidationError
 from conda.common.serialize import yaml_round_trip_dump, yaml_round_trip_load
 from conda.exceptions import CondaKeyError, CondaValueError
 from conda.gateways.disk.delete import rm_rf
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
@@ -586,48 +588,28 @@ def test_ssl_verify_set_filename(conda_cli: CondaCLIFixture):
         assert context.ssl_verify == tf.name
 
 
-def test_set_rc_without_user_rc(conda_cli: CondaCLIFixture):
-    if os.path.exists(sys_rc_path):
-        # Backup system rc_config
-        with open(sys_rc_path) as fh:
-            sys_rc_config_backup = yaml_round_trip_load(fh)
-        restore_sys_rc_config_backup = True
-    else:
-        restore_sys_rc_config_backup = False
+def test_set_rc_without_user_rc(
+    conda_cli: CondaCLIFixture,
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+):
+    sys_rc_path = tmp_path / "condarc"
+    user_rc_path = tmp_path / ".condarc"
 
-    if os.path.exists(user_rc_path):
-        # Backup user rc_config
-        with open(user_rc_path) as fh:
-            user_rc_config_backup = yaml_round_trip_load(fh)
-        # Remove user rc_path
-        os.remove(user_rc_path)
-        restore_user_rc_config_backup = True
-    else:
-        restore_user_rc_config_backup = False
+    with sys_rc_path.open("w") as fh:
+        yaml_round_trip_dump({"channels": ["conda-forge"]}, fh)
 
-    try:
-        # Write custom system sys_rc_config
-        with open(sys_rc_path, "w") as rc:
-            rc.write(yaml_round_trip_dump({"channels": ["conda-forge"]}))
-    except OSError:
-        # In case, we don't have writing right to the system rc config file
-        pytest.skip("No writing right to root prefix.")
+    monkeypatch.setattr(context_module, "sys_rc_path", str(sys_rc_path))
+    monkeypatch.setattr(context_module, "user_rc_path", str(user_rc_path))
 
     # This would create a user rc_config
-    stdout, stderr, return_code = conda_cli("config", "--add", "channels", "test")
-    assert stdout == stderr == ""
-    assert yaml_round_trip_load(_read_test_condarc(user_rc_path)) == {
+    stdout, stderr, error = conda_cli("config", "--add", "channels", "test")
+    assert not stdout
+    assert not stderr
+    assert not error
+    assert yaml_round_trip_load(user_rc_path.read_text()) == {
         "channels": ["test", "conda-forge"]
     }
-
-    if restore_user_rc_config_backup:
-        # Restore previous user rc_config
-        with open(user_rc_path, "w") as rc:
-            rc.write(yaml_round_trip_dump(user_rc_config_backup))
-    if restore_sys_rc_config_backup:
-        # Restore previous system rc_config
-        with open(sys_rc_path, "w") as rc:
-            rc.write(yaml_round_trip_dump(sys_rc_config_backup))
 
 
 def test_custom_multichannels_append(conda_cli: CondaCLIFixture):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Spin off from #15176

Replace overwriting `sys_rc_path` and `user_rc_path` for testing and subsequently requiring restoring/cleanup.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
