### PR TITLE
Remove deprecated code in `conda.cli.common`

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -50,70 +50,6 @@ if TYPE_CHECKING:
 log = getLogger(__name__)
 
 
-@deprecated(
-    "25.3",
-    "25.9",
-    addendum="Use `conda.reporters.confirm_yn` instead.",
-)
-def confirm(message="Proceed", choices=("yes", "no"), default="yes", dry_run=NULL):
-    assert default in choices, default
-    if (dry_run is NULL and context.dry_run) or dry_run:
-        from ..exceptions import DryRunExit
-
-        raise DryRunExit()
-
-    options = []
-    for option in choices:
-        if option == default:
-            options.append(f"[{option[0]}]")
-        else:
-            options.append(option[0])
-    message = "{} ({})? ".format(message, "/".join(options))
-    choices = {alt: choice for choice in choices for alt in [choice, choice[0]]}
-    choices[""] = default
-    while True:
-        # raw_input has a bug and prints to stderr, not desirable
-        sys.stdout.write(message)
-        sys.stdout.flush()
-        try:
-            user_choice = sys.stdin.readline().strip().lower()
-        except OSError as e:
-            raise CondaError(f"cannot read from stdin: {e}")
-        if user_choice not in choices:
-            print(f"Invalid choice: {user_choice}")
-        else:
-            sys.stdout.write("\n")
-            sys.stdout.flush()
-            return choices[user_choice]
-
-
-@deprecated(
-    "25.3",
-    "25.9",
-    addendum="Use `conda.reporters.confirm_yn` instead.",
-)
-def confirm_yn(message="Proceed", default="yes", dry_run=NULL):
-    if (dry_run is NULL and context.dry_run) or dry_run:
-        from ..exceptions import DryRunExit
-
-        raise DryRunExit()
-    if context.always_yes:
-        return True
-    try:
-        choice = confirm(
-            message=message, choices=("yes", "no"), default=default, dry_run=dry_run
-        )
-    except KeyboardInterrupt:  # pragma: no cover
-        from ..exceptions import CondaSystemExit
-
-        raise CondaSystemExit("\nOperation aborted.  Exiting.")
-    if choice == "no":
-        from ..exceptions import CondaSystemExit
-
-        raise CondaSystemExit("Exiting.")
-    return True
-
-
 def is_active_prefix(prefix: str) -> bool:
     """
     Determines whether the args we pass in are pointing to the active prefix.
@@ -257,15 +193,6 @@ def stdout_json_success(success=True, **kwargs):
         result["actions"] = actions
     result.update(kwargs)
     stdout_json(result)
-
-
-@deprecated(
-    "25.3",
-    "25.9",
-    addendum="Use `conda.reporters.render(style='env_list')` instead.",
-)
-def print_envs_list(known_conda_prefixes, output=True):
-    render(known_conda_prefixes, style="envs_list", output=output)
 
 
 def check_non_admin():

--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import re
-import sys
 from logging import getLogger
 from os.path import (
     dirname,
@@ -26,12 +25,10 @@ from ..base.constants import (
     PREFIX_MAGIC_FILE,
 )
 from ..base.context import context, env_name
-from ..common.constants import NULL
 from ..common.io import swallow_broken_pipe
 from ..common.path import expand, paths_equal
 from ..deprecations import deprecated
 from ..exceptions import (
-    CondaError,
     DirectoryNotACondaEnvironmentError,
     EnvironmentFileNotFound,
     EnvironmentFileTypeMismatchError,

--- a/news/15180-remove-cli-common-deprecated-code
+++ b/news/15180-remove-cli-common-deprecated-code
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove `conda.cli.common.confirm`. Use `conda.reporters.confirm_yn` instead. (#15180)
+* Remove `conda.cli.common.confirm_yn`. Use `conda.reporters.confirm_yn` instead. (#15180)
+* Remove `conda.cli.common.print_envs_list`. Use `conda.reporters.render(style='env_list')` instead. (#15180)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -35,8 +35,6 @@ def test_pre_link_message(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
 ):
-    mocker.patch("conda.cli.common.confirm_yn", return_value=True)
-
     with tmp_env() as prefix:
         stdout, _, _ = conda_cli(
             "install",

--- a/tests/cli/test_common.py
+++ b/tests/cli/test_common.py
@@ -11,7 +11,6 @@ from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
 from conda.cli.common import (
     check_non_admin,
     is_active_prefix,
-    print_envs_list,
     validate_file_exists,
     validate_subdir_config,
 )
@@ -55,35 +54,6 @@ def test_is_active_prefix(prefix, active):
     if prefix == "active_prefix":
         prefix = context.active_prefix
     assert is_active_prefix(prefix) is active
-
-
-def test_print_envs_list(capsys):
-    """
-    Test the case for print_envs_list when output=True
-
-    TODO: this function is deprecated and this test should be remove when this function is removed
-    """
-    with pytest.deprecated_call():
-        print_envs_list(["test"])
-
-    capture = capsys.readouterr()
-
-    assert "test" in capture.out
-
-
-def test_print_envs_list_output_false(capsys):
-    """
-    Test the case for print_envs_list when output=False
-
-    TODO: this function is deprecated and this test should be remove when this function is removed
-    """
-
-    with pytest.deprecated_call():
-        print_envs_list(["test"], output=False)
-
-    capture = capsys.readouterr()
-
-    assert capture.out == ""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Remove deprecated methods, arguments and constants from `conda.cli.common`.

xref: https://github.com/conda/conda/issues/15116

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
