### PR TITLE
Remove deprecated code in `conda.cli.main_env_remove` and `conda.cli.main_rename`

### DIFF
--- a/conda/cli/main_env_remove.py
+++ b/conda/cli/main_env_remove.py
@@ -7,11 +7,8 @@ Removes the specified conda environment.
 
 from argparse import (
     ArgumentParser,
-    Namespace,
     _SubParsersAction,
 )
-
-from ..deprecations import deprecated
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
@@ -72,12 +69,3 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     )
 
     return p
-
-
-@deprecated("25.3", "25.9", addendum="Use `conda.cli.main_remove.execute` instead.")
-def execute(args: Namespace, parser: ArgumentParser) -> int:
-    from ..cli.main_remove import execute as remove
-
-    remove(args, parser)
-
-    return 0

--- a/conda/cli/main_rename.py
+++ b/conda/cli/main_rename.py
@@ -111,29 +111,6 @@ def validate_src() -> str:
     return str(prefix)
 
 
-@deprecated(
-    "25.3",
-    "25.9",
-    addendum="Use `conda.cli.install.validate_new_prefix` instead.",
-)
-def validate_destination(dest: str, force: bool = False) -> str:
-    """Ensure that our destination does not exist"""
-    from ..base.context import context, validate_prefix_name
-    from ..common.path import expand
-    from ..exceptions import CondaEnvException
-
-    if os.sep in dest:
-        dest = expand(dest)
-    else:
-        dest = validate_prefix_name(dest, ctx=context, allow_base=False)
-    if not force and os.path.exists(dest):
-        env_name = os.path.basename(os.path.normpath(dest))
-        raise CondaEnvException(
-            f"The environment '{env_name}' already exists. Override with --yes."
-        )
-    return dest
-
-
 def execute(args: Namespace, parser: ArgumentParser) -> int:
     """Executes the command for renaming an existing environment."""
     from ..base.constants import DRY_RUN_PREFIX

--- a/news/15182-remove-deprecated-code-cli
+++ b/news/15182-remove-deprecated-code-cli
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove `conda.cli.main_env_remove.execute`.Use `conda.cli.main_remove.execute` instead. (#15182)
+* Remove `conda.cli.install.validate_new_prefix`. Use `conda.cli.install.validate_new_prefix` instead. (#15182)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Remove deprecated methods, arguments and constants related to the cli `env remove` and `rename` commands.

xref: https://github.com/conda/conda/issues/15116

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
