### PR TITLE
Deprecate `get_index_args`

### DIFF
--- a/conda/misc.py
+++ b/conda/misc.py
@@ -280,7 +280,8 @@ def touch_nonadmin(prefix):
             fo.write("")
 
 
-def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
+@deprecated.argument("26.3", "26.9", "index_args")
+def clone_env(prefix1, prefix2, verbose=True, quiet=False):
     """Clone existing prefix1 into new prefix2."""
     untracked_files = untracked(prefix1)
     drecs = {prec for prec in PrefixData(prefix1).iter_records()}
@@ -290,9 +291,7 @@ def clone_env(prefix1, prefix2, verbose=True, quiet=False, index_args=None):
     unknowns = [prec for prec in drecs if not prec.get("url")]
     notfound = []
     if unknowns:
-        index_args = index_args or {}
-        index_args["channels"] = index_args.pop("channel_urls")
-        index = Index(**index_args)
+        index = Index()
 
         for prec in unknowns:
             spec = MatchSpec(name=prec.name, version=prec.version, build=prec.build)

--- a/news/15187-get_index_args
+++ b/news/15187-get_index_args
@@ -1,0 +1,23 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.cli.install.clone(index_args)` as pending deprecation to be removed in 26.9. Use `conda.base.context.context.channels` instead. (#15187)
+* Mark `conda.cli.install.get_index_args` as pending deprecation to be removed in 26.9. Use `conda.base.context.context.channels` instead. (#15187)
+* Mark `conda.cli.install.TryRepodata(index_args)` as pending deprecation to be removed in 26.9. Use `conda.base.context.context.channels` instead. (#15187)
+* Mark `conda.cli.install.Repodatas(index_args)` as pending deprecation to be removed in 26.9. Use `conda.base.context.context.channels` instead. (#15187)
+* Mark `conda.misc.clone_env(index_args)` as pending deprecation to be removed in 26.9. Use `conda.base.context.context.channels` instead. (#15187)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Continuing with the premise in #15173 that we don't need to pass around `index_args` since `context.channels` is already correctly stacked we can completely deprecate `get_index_args`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
