### PR TITLE
Inline `ruamel.yaml` imports

### DIFF
--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -556,6 +556,8 @@ def _read_rc(path: str | os.PathLike | Path) -> dict:
 
 
 def _write_rc(path: str | os.PathLike | Path, config: dict) -> None:
+    from ruamel.yaml.representer import RoundTripRepresenter
+
     from .. import CondaError
     from ..base.constants import (
         ChannelPriority,
@@ -565,7 +567,7 @@ def _write_rc(path: str | os.PathLike | Path, config: dict) -> None:
         SatSolverChoice,
         UpdateModifier,
     )
-    from ..common.serialize import yaml, yaml_round_trip_dump
+    from ..common.serialize import yaml_round_trip_dump
 
     # Add representers for enums.
     # Because a representer cannot be added for the base Enum class (it must be added for
@@ -574,24 +576,12 @@ def _write_rc(path: str | os.PathLike | Path, config: dict) -> None:
     def enum_representer(dumper, data):
         return dumper.represent_str(str(data))
 
-    yaml.representer.RoundTripRepresenter.add_representer(
-        SafetyChecks, enum_representer
-    )
-    yaml.representer.RoundTripRepresenter.add_representer(
-        PathConflict, enum_representer
-    )
-    yaml.representer.RoundTripRepresenter.add_representer(
-        DepsModifier, enum_representer
-    )
-    yaml.representer.RoundTripRepresenter.add_representer(
-        UpdateModifier, enum_representer
-    )
-    yaml.representer.RoundTripRepresenter.add_representer(
-        ChannelPriority, enum_representer
-    )
-    yaml.representer.RoundTripRepresenter.add_representer(
-        SatSolverChoice, enum_representer
-    )
+    RoundTripRepresenter.add_representer(SafetyChecks, enum_representer)
+    RoundTripRepresenter.add_representer(PathConflict, enum_representer)
+    RoundTripRepresenter.add_representer(DepsModifier, enum_representer)
+    RoundTripRepresenter.add_representer(UpdateModifier, enum_representer)
+    RoundTripRepresenter.add_representer(ChannelPriority, enum_representer)
+    RoundTripRepresenter.add_representer(SatSolverChoice, enum_representer)
 
     try:
         Path(path).write_text(yaml_round_trip_dump(config))

--- a/conda/common/serialize/__init__.py
+++ b/conda/common/serialize/__init__.py
@@ -6,8 +6,6 @@ import functools
 from io import StringIO
 from logging import getLogger
 
-import ruamel.yaml as yaml
-
 from ...deprecations import deprecated
 from .json import CondaJSONEncoder, loads
 
@@ -16,14 +14,18 @@ log = getLogger(__name__)
 
 @functools.cache
 def _yaml_round_trip():
-    parser = yaml.YAML(typ="rt")
+    from ruamel.yaml import YAML
+
+    parser = YAML(typ="rt")
     parser.indent(mapping=2, offset=2, sequence=4)
     return parser
 
 
 @functools.cache
 def _yaml_safe():
-    parser = yaml.YAML(typ="safe", pure=True)
+    from ruamel.yaml import YAML
+
+    parser = YAML(typ="safe", pure=True)
     parser.indent(mapping=2, offset=2, sequence=4)
     parser.default_flow_style = False
     parser.sort_base_mapping_type_on_output = False

--- a/tests/cli/test_main_config.py
+++ b/tests/cli/test_main_config.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import conda.exceptions
+from conda.base.constants import SafetyChecks
 from conda.base.context import context, reset_context
 from conda.cli.main_config import (
     _get_key,
@@ -237,8 +238,17 @@ def test_config_read_rc(tmp_path: Path) -> None:
 def test_config_write_rc(tmp_path: Path) -> None:
     condarc = tmp_path / ".condarc"
 
-    _write_rc(condarc, {"changeps1": False, "auto_stack": 5})
-    assert condarc.read_text() == "changeps1: false\nauto_stack: 5\n"
+    _write_rc(
+        condarc,
+        {
+            "changeps1": False,
+            "auto_stack": 5,
+            "safety_checks": SafetyChecks.disabled,
+        },
+    )
+    assert condarc.read_text() == (
+        "changeps1: false\nauto_stack: 5\nsafety_checks: disabled\n"
+    )
 
 
 def test_config_set_keys(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Split from https://github.com/conda/conda/pull/15176

Inlining `ruamel.yaml` imports and removing the `conda.common.serialize.yaml` re-export so the namespace can be used in the https://github.com/conda/conda/pull/15176 refactor instead.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
