### PR TITLE
Remove deprecated code in `conda.context`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -211,24 +211,6 @@ def ssl_verify_validation(value: str) -> str | Literal[True]:
     return True
 
 
-def _warn_defaults_deprecation() -> None:
-    deprecated.topic(
-        "24.9",
-        "25.9",
-        topic=f"Adding '{DEFAULTS_CHANNEL_NAME}' to channel list implicitly",
-        addendum=(
-            "\n\n"
-            "To remove this warning, please choose a default channel explicitly "
-            "with conda's regular configuration system, e.g. "
-            f"by adding '{DEFAULTS_CHANNEL_NAME}' to the list of channels:\n\n"
-            f"  conda config --add channels {DEFAULTS_CHANNEL_NAME}"
-            "\n\n"
-            "For more information see https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/use-condarc.html\n"
-        ),
-        deprecation_type=FutureWarning,
-    )
-
-
 class Context(Configuration):
     add_pip_as_python_dependency = ParameterLoader(PrimitiveParameter(True))
     allow_conda_downgrades = ParameterLoader(PrimitiveParameter(False))
@@ -448,10 +430,6 @@ class Context(Configuration):
     denylist_channels = ParameterLoader(
         SequenceParameter(PrimitiveParameter("", element_type=str)),
         expandvars=True,
-    )
-    _restore_free_channel = ParameterLoader(
-        PrimitiveParameter(False),
-        aliases=("restore_free_channel",),
     )
     repodata_fns = ParameterLoader(
         SequenceParameter(
@@ -931,17 +909,6 @@ class Context(Configuration):
         #   - are meant to be prepended with channel_alias
         return self.custom_multichannels[DEFAULTS_CHANNEL_NAME]
 
-    @property
-    @deprecated(
-        "24.9",
-        "25.9",
-        addendum="See "
-        "https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/free-channel.html "
-        "for more details.",
-    )
-    def restore_free_channel(self) -> bool:
-        return self._restore_free_channel
-
     @memoizedproperty
     def custom_multichannels(self) -> dict[str, tuple[Channel, ...]]:
         from ..models.channel import Channel
@@ -954,18 +921,6 @@ class Context(Configuration):
             default_channels = list(DEFAULT_CHANNELS_WIN)
         else:
             default_channels = list(self._default_channels)
-
-        if self._restore_free_channel:
-            deprecated.topic(
-                "24.9",
-                "25.9",
-                topic="Adding the 'free' channel using `restore_free_channel` config",
-                addendum="See "
-                "https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/free-channel.html "
-                "for more details.",
-                deprecation_type=FutureWarning,
-            )
-            default_channels.insert(1, "https://repo.anaconda.com/pkgs/free")
 
         reserved_multichannel_urls = {
             DEFAULTS_CHANNEL_NAME: default_channels,
@@ -1031,28 +986,7 @@ class Context(Configuration):
                     "--override-channels."
                 )
 
-        # add 'defaults' channel when necessary if --channel is given via the command line
-        if cli_channels:
-            # Add condition to make sure that we add the 'defaults'
-            # channel only when no channels are defined in condarc
-            # We need to get the config_files and then check that they
-            # don't define channels
-            channel_in_config_files = any(
-                "channels" in context.raw_data[rc_file] for rc_file in self.config_files
-            )
-            if cli_channels and not channel_in_config_files:
-                _warn_defaults_deprecation()
-                return validate_channels(
-                    (*local_channels, *cli_channels, DEFAULTS_CHANNEL_NAME)
-                )
-
-        if self._channels:
-            channels = self._channels
-        else:
-            _warn_defaults_deprecation()
-            channels = [DEFAULTS_CHANNEL_NAME]
-
-        return validate_channels((*local_channels, *channels))
+        return validate_channels((*local_channels, *self._channels))
 
     @property
     def config_files(self) -> tuple[PathType, ...]:
@@ -1338,7 +1272,6 @@ class Context(Configuration):
                 "migrated_custom_channels",
                 "add_anaconda_token",
                 "allow_non_channel_urls",
-                "restore_free_channel",
                 "repodata_fns",
                 "use_only_tar_bz2",
                 "repodata_threads",
@@ -1889,12 +1822,6 @@ class Context(Configuration):
                 Opt in, or opt out, of automatic error reporting to core maintainers. Error
                 reports are anonymous, with only the error stack trace and information given
                 by `conda info` being sent.
-                """
-            ),
-            restore_free_channel=dals(
-                """"
-                Add the "free" channel back into defaults, behind "main" in priority. The "free"
-                channel was removed from the collection of default channels in conda 4.7.0.
                 """
             ),
             rollback_enabled=dals(

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -635,7 +635,6 @@ def set_keys(*args: tuple[str, Any], path: str | os.PathLike | Path) -> None:
 def execute_config(args, parser):
     from .. import CondaError
     from ..base.context import (
-        _warn_defaults_deprecation,
         context,
         sys_rc_path,
         user_rc_path,
@@ -908,15 +907,6 @@ def execute_config(args, parser):
         for key, item in arg:
             key, subkey = key.split(".", 1) if "." in key else (key, None)
 
-            channels_is_unpopulated = key == "channels" and key not in rc_config
-
-            if channels_is_unpopulated:
-                # don't warn if users are literally trying to remove the warning
-                # by explicitly adding the defaults channel to the channels list
-                if item != DEFAULTS_CHANNEL_NAME:
-                    _warn_defaults_deprecation()
-                rc_config[key] = [DEFAULTS_CHANNEL_NAME]
-
             if key in sequence_parameters:
                 arglist = rc_config.setdefault(key, [])
             elif key == "plugins" and subkey in plugin_sequence_parameters:
@@ -937,9 +927,6 @@ def execute_config(args, parser):
                 raise CouldntParseError(f"key {key!r} should be a list, not {bad}.")
 
             if item in arglist:
-                # don't warn if users are literally trying to remove the warning
-                if channels_is_unpopulated and item == DEFAULTS_CHANNEL_NAME:
-                    continue
                 message_key = key + "." + subkey if subkey is not None else key
                 # Right now, all list keys should not contain duplicates
                 location = "top" if prepend else "bottom"

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -214,17 +214,6 @@ def test_custom_multichannels(context_testdata: None):
     )
 
 
-def test_restore_free_channel(monkeypatch: MonkeyPatch) -> None:
-    free_channel = "https://repo.anaconda.com/pkgs/free"
-    assert free_channel not in context.default_channels
-
-    monkeypatch.setenv("CONDA_RESTORE_FREE_CHANNEL", "true")
-    reset_context()
-    assert context.restore_free_channel
-
-    assert context.default_channels[1] == free_channel
-
-
 def test_proxy_servers(context_testdata: None):
     assert context.proxy_servers["http"] == "http://user:pass@corp.com:8080"
     assert context.proxy_servers["https"] is None
@@ -391,8 +380,7 @@ def test_threads(monkeypatch: MonkeyPatch) -> None:
 def test_channels_empty(context_testdata: None):
     """Test when no channels provided in cli and no condarc config is present."""
     reset_context(())
-    with pytest.warns((PendingDeprecationWarning, FutureWarning)):
-        assert context.channels == ("defaults",)
+    assert context.channels == ()
 
 
 def test_channels_defaults_condarc(context_testdata: None):
@@ -420,8 +408,7 @@ def test_specify_channels_cli_not_adding_defaults_no_condarc(context_testdata: N
     See https://github.com/conda/conda/issues/14217 for context.
     """
     reset_context((), argparse_args=AttrDict(channel=["conda-forge"]))
-    with pytest.warns((PendingDeprecationWarning, FutureWarning)):
-        assert context.channels == ("conda-forge", "defaults")
+    assert context.channels == ("conda-forge",)
 
 
 def test_specify_channels_cli_condarc(context_testdata: None):

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -119,8 +119,7 @@ def test_channels_add_empty(conda_cli: CondaCLIFixture):
             *("--add", "channels", "test"),
         )
         assert stdout == stderr == ""
-        # TODO: Update in 25.3
-        assert _read_test_condarc(rc) == _channels_as_yaml("test", "defaults")
+        assert _read_test_condarc(rc) == _channels_as_yaml("test")
 
 
 def test_channels_add_empty_with_defaults(conda_cli: CondaCLIFixture):
@@ -133,11 +132,6 @@ def test_channels_add_empty_with_defaults(conda_cli: CondaCLIFixture):
             *("--add", "channels", "defaults"),
         )
         assert stdout == ""
-        # TODO: Update in 25.3
-        assert (
-            stderr.strip()
-            == "Warning: 'defaults' already in 'channels' list, moving to the top"
-        )
         assert _read_test_condarc(rc) == _channels_as_yaml("defaults", "test")
 
 
@@ -456,7 +450,7 @@ def test_set_map_key(key, from_val, to_val, conda_cli: CondaCLIFixture):
 
 
 def test_set_unconfigured_key(conda_cli: CondaCLIFixture):
-    key, to_val = "restore_free_channel", "true"
+    key, to_val = "use_only_tar_bz2", "true"
     with make_temp_condarc(CONDARC_BASE) as rc:
         stdout, stderr, _ = conda_cli("config", "--file", rc, "--set", key, to_val)
         assert stdout == stderr == ""
@@ -516,11 +510,11 @@ def test_remove_key_duplicate(conda_cli: CondaCLIFixture):
 
 
 def test_remove_unconfigured_key(conda_cli: CondaCLIFixture):
-    key = "restore_free_channel"
+    key = "use_only_tar_bz2"
     with make_temp_condarc(CONDARC_BASE) as rc:
         with pytest.raises(
             CondaKeyError,
-            match=r"'restore_free_channel': undefined in config",
+            match=r"'use_only_tar_bz2': undefined in config",
         ):
             conda_cli("config", "--file", rc, "--remove-key", key)
 
@@ -550,7 +544,7 @@ def test_set_check_types(key, str_value, py_value, conda_cli: CondaCLIFixture):
 
 
 def test_set_and_get_bool(conda_cli: CondaCLIFixture):
-    key = "restore_free_channel"
+    key = "use_only_tar_bz2"
     with make_temp_condarc() as rc:
         stdout, stderr, _ = conda_cli("config", "--file", rc, "--set", key, "yes")
         stdout, stderr, _ = conda_cli("config", "--file", rc, "--get", key)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Remove deprecated methods, arguments and constants from `cli.context`. This includes:
- removing the context arg for restoring the free channel
- not injecting the defaults channel

xref: https://github.com/conda/conda/issues/15116
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
