### PR TITLE
Remove some uses of `env_var` and `env_vars` contexts in `test_common.py`, `test_configuration.py`, and `test_reporters.py`

### DIFF
--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
-from conda.common.io import env_vars
+from conda.base.context import context, reset_context
 from conda.exceptions import CondaSystemExit, DryRunExit
 from conda.plugins.reporter_backends.console import TQDMProgressBar
 from conda.reporters import (
@@ -69,45 +68,34 @@ def test_get_progress_bar_context_managers():
     assert isinstance(progress_bar_context_manager, nullcontext)
 
 
-def test_confirm_yn_dry_run_exit():
-    with (
-        env_vars(
-            {"CONDA_DRY_RUN": "true"},
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ),
-        pytest.raises(DryRunExit),
-    ):
-        confirm_yn()
-
-
-def test_confirm_yn_always_yes():
-    with env_vars(
-        {
-            "CONDA_ALWAYS_YES": "true",
-            "CONDA_DRY_RUN": "false",
-        },
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        assert context.always_yes
-        assert not context.dry_run
+def test_confirm_yn_dry_run_exit(monkeypatch: MonkeyPatch):
+    with pytest.raises(DryRunExit):
+        monkeypatch.setenv("CONDA_DRY_RUN", "true")
+        reset_context()
 
         confirm_yn()
+
+
+def test_confirm_yn_always_yes(monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("CONDA_ALWAYS_YES", "true")
+    monkeypatch.setenv("CONDA_DRY_RUN", "false")
+    reset_context()
+    assert context.always_yes
+    assert not context.dry_run
+
+    confirm_yn()
 
 
 def test_confirm_yn_yes(monkeypatch: MonkeyPatch, capsys: CaptureFixture):
     monkeypatch.setattr("sys.stdin", StringIO("blah\ny\n"))
 
-    with env_vars(
-        {
-            "CONDA_ALWAYS_YES": "false",
-            "CONDA_DRY_RUN": "false",
-        },
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        assert not context.always_yes
-        assert not context.dry_run
+    monkeypatch.setenv("CONDA_ALWAYS_YES", "false")
+    monkeypatch.setenv("CONDA_DRY_RUN", "false")
+    reset_context()
+    assert not context.always_yes
+    assert not context.dry_run
 
-        assert confirm_yn()
+    assert confirm_yn()
 
     stdout, stderr = capsys.readouterr()
     assert "Invalid choice" in stdout
@@ -116,16 +104,11 @@ def test_confirm_yn_yes(monkeypatch: MonkeyPatch, capsys: CaptureFixture):
 def test_confirm_yn_no(monkeypatch: MonkeyPatch):
     monkeypatch.setattr("sys.stdin", StringIO("n\n"))
 
-    with (
-        env_vars(
-            {
-                "CONDA_ALWAYS_YES": "false",
-                "CONDA_DRY_RUN": "false",
-            },
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ),
-        pytest.raises(CondaSystemExit),
-    ):
+    with pytest.raises(CondaSystemExit):
+        monkeypatch.setenv("CONDA_ALWAYS_YES", "false")
+        monkeypatch.setenv("CONDA_DRY_RUN", "false")
+        reset_context()
+
         assert not context.always_yes
         assert not context.dry_run
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR updates `tests/cli/test_common.py`, `tests/common/test_configuration.py`, and `tests/test_reporters.py` to remove the use of the `env_var` and `env_vars` context managers.

xref #14095

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
