### PR TITLE
Remove uses of `env_var` contexts in `tests/core/test_envs_manager.py`, `tests/models/test_dist.py`, `tests/models/test_prefix_graph.py`, and `tests/plugins/test_virtual_packages.py`

### DIFF
--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -105,10 +105,7 @@ def test_cuda_override(
     monkeypatch.setenv("CONDA_OVERRIDE_CUDA", override_value)
     reset_context()
 
-    if override_value:
-        version = cuda.cached_cuda_version()
-    else:
-        version = cuda.cuda_version()
+    version = cuda.cuda_version()
     assert version == expected
 
 

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -6,13 +6,13 @@ import platform
 from typing import TYPE_CHECKING
 
 import pytest
+from pytest import MonkeyPatch
 
 import conda.core.index
 from conda import __version__, plugins
 from conda.base.context import context, reset_context
 from conda.common._os.osx import mac_ver
 from conda.common.compat import on_linux, on_mac, on_win
-from conda.common.io import env_var
 from conda.exceptions import PluginError
 from conda.plugins.types import CondaVirtualPackage
 from conda.plugins.virtual_packages import cuda
@@ -92,16 +92,24 @@ def test_cuda_detection(clear_cuda_version):
     assert version is None or isinstance(version, str)
 
 
-def test_cuda_override(clear_cuda_version):
-    with env_var("CONDA_OVERRIDE_CUDA", "4.5"):
+@pytest.mark.parametrize(
+    "override_value,expected",
+    [
+        pytest.param("4.5", "4.5", id="override-set"),
+        pytest.param("", None, id="override-empty"),
+    ],
+)
+def test_cuda_override(
+    clear_cuda_version, override_value, expected, monkeypatch: MonkeyPatch
+):
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", override_value)
+    reset_context()
+
+    if override_value:
         version = cuda.cached_cuda_version()
-        assert version == "4.5"
-
-
-def test_cuda_override_none(clear_cuda_version):
-    with env_var("CONDA_OVERRIDE_CUDA", ""):
+    else:
         version = cuda.cuda_version()
-        assert version is None
+    assert version == expected
 
 
 def get_virtual_precs() -> Iterable[PackageRecord]:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Similar to #15202, this PR replaces the `env_var` context manager in these test files: `tests/core/test_envs_manager.py`, `tests/models/test_dist.py`, `tests/models/test_prefix_graph.py`, and `tests/plugins/test_virtual_packages.py`.

(I've decided to split the diff by opening separate PRs.)

xref #14095

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
