### PR TITLE
Remove uses of `env_vars` in `tests/gateways/test_repodata_gateway.py`

### DIFF
--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -17,8 +17,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.base.constants import REPODATA_FN
-from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context
-from conda.common.io import env_vars
+from conda.base.context import context, reset_context
 from conda.exceptions import (
     CondaDependencyError,
     CondaHTTPError,
@@ -47,6 +46,8 @@ from conda.models.channel import Channel
 
 if TYPE_CHECKING:
     from socket import socket
+
+    from pytest import MonkeyPatch
 
 
 def test_save(tmp_path):
@@ -201,7 +202,7 @@ def test_repodata_state_has_format():
     assert "has_zst" in state
 
 
-def test_coverage_conda_http_errors():
+def test_coverage_conda_http_errors(monkeypatch: MonkeyPatch):
     class Response:
         def __init__(self, status_code):
             self.status_code = status_code
@@ -237,12 +238,10 @@ def test_coverage_conda_http_errors():
     ):
         raise HTTPError(response=Response(404))
 
+    monkeypatch.setenv("CONDA_ALLOW_NON_CHANNEL_URLS", "1")
+    reset_context()
     with (
         pytest.raises(RepodataIsEmpty),
-        env_vars(
-            {"CONDA_ALLOW_NON_CHANNEL_URLS": "1"},
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ),
         conda_http_errors("https://conda.anaconda.org/noarch", "repodata.json"),
     ):
         raise HTTPError(response=Response(404))
@@ -264,17 +263,17 @@ def test_coverage_conda_http_errors():
     ):
         raise HTTPError(response=Response(401))
 
-    # env_vars plus a harmless option to reset context on exit
+    # monkeypatch plus reset context to restore state
+    monkeypatch.setenv("CONDA_ALLOW_NON_CHANNEL_URLS", "1")
+    reset_context()
     with (
         pytest.raises(CondaHTTPError, match="The credentials"),
-        env_vars(
-            {"CONDA_ALLOW_NON_CHANNEL_URLS": "1"},
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ),
         conda_http_errors("https://conda.anaconda.org/noarch", "repodata.json"),
     ):
         context.channel_alias.location = "xyzzy"
         raise HTTPError(response=Response(401))
+
+    reset_context()
 
     # was the context reset properly?
     assert context.channel_alias.location != "xyzzy"
@@ -366,7 +365,11 @@ def test_repodata_fetch_formats(
 @pytest.mark.parametrize("use_network", [False, True])
 @pytest.mark.parametrize("use_index", ["false", "true"])
 def test_repodata_fetch_cached(
-    use_index: str, use_network: bool, package_server, tmp_path
+    use_index: str,
+    use_network: bool,
+    package_server,
+    tmp_path,
+    monkeypatch: MonkeyPatch,
 ):
     """
     An empty cache should return an empty result instead of an error, when
@@ -380,26 +383,27 @@ def test_repodata_fetch_cached(
     else:
         channel_url = "file:///path/does/not/exist"
 
-    with env_vars({"CONDA_USE_INDEX": use_index}):
-        # we always check for *and create* a writable cache dir before fetch
-        cache_path_base = tmp_path / "fetch_cached"
-        cache_path_base.parent.mkdir(exist_ok=True)
+    monkeypatch.setenv("CONDA_USE_INDEX", use_index)
 
-        # due to the way we handle file:/// urls, this test will pass whether or
-        # not use_index is true or false. Will it exercise different code paths?
-        channel = Channel(channel_url)
+    # we always check for *and create* a writable cache dir before fetch
+    cache_path_base = tmp_path / "fetch_cached"
+    cache_path_base.parent.mkdir(exist_ok=True)
 
-        fetch = RepodataFetch(
-            cache_path_base, channel, REPODATA_FN, repo_interface_cls=CondaRepoInterface
-        )
+    # due to the way we handle file:/// urls, this test will pass whether or
+    # not use_index is true or false. Will it exercise different code paths?
+    channel = Channel(channel_url)
 
-        # strangely never throws unavailable exception?
-        repodata, state = fetch.fetch_latest_parsed()
+    fetch = RepodataFetch(
+        cache_path_base, channel, REPODATA_FN, repo_interface_cls=CondaRepoInterface
+    )
 
-        assert repodata == {}
-        for key in "mtime_ns", "size", "refresh_ns":
-            state.pop(key)
-        assert state == {}
+    # strangely never throws unavailable exception?
+    repodata, state = fetch.fetch_latest_parsed()
+
+    assert repodata == {}
+    for key in "mtime_ns", "size", "refresh_ns":
+        state.pop(key)
+    assert state == {}
 
 
 def test_repodata_fetch_jsondecodeerror(tmp_path):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Contributes towards #14095; this PR removes all uses of `env_vars` from `tests/gateways/test_repodata_gateway.py`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
