### PR TITLE
Remove `env_var`/`env_vars` contexts from `tests/core/test_solve.py`

### DIFF
--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import os
 import re
 import sys
 from importlib.metadata import version
@@ -15,9 +14,8 @@ import pytest
 
 from conda.auxlib.ish import dals
 from conda.base.constants import PREFIX_PINNED_FILE
-from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context, reset_context
+from conda.base.context import context, reset_context
 from conda.common.compat import on_linux, on_mac, on_win
-from conda.common.io import env_var, env_vars
 from conda.core.solve import DepsModifier, UpdateModifier, get_pinned_specs
 from conda.exceptions import (
     PackagesNotFoundError,
@@ -204,7 +202,7 @@ def test_solve_2(tmpdir):
         assert len(prec_names) == len(set(prec_names))
 
 
-def test_virtual_package_solver(tmpdir, clear_cuda_version):
+def test_virtual_package_solver(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     if context.solver == "libmamba":
         pytest.skip(
             "conda-libmamba-solver does not use Solver.ssc (SolverStateContainer)"
@@ -212,69 +210,74 @@ def test_virtual_package_solver(tmpdir, clear_cuda_version):
 
     specs = (MatchSpec("cudatoolkit"),)
 
-    with env_var("CONDA_OVERRIDE_CUDA", "10.0"):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            _ = solver.solve_final_state()
-            ssc = solver.ssc
-            # Check the cuda virtual package is included in the solver
-            assert "__cuda" in ssc.specs_map.keys()
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "10.0")
 
-            # Check that the environment is consistent after installing a
-            # package which *depends* on a virtual package
-            for pkgs in ssc.solution_precs:
-                if pkgs.name == "cudatoolkit":
-                    # make sure this package depends on the __cuda virtual
-                    # package as a dependency since this is requirement of the
-                    # test the test
-                    assert "__cuda" in pkgs.depends[0]
-            assert ssc.r.bad_installed(ssc.solution_precs, ())[1] is None
+    with get_solver_cuda(tmpdir, specs) as solver:
+        _ = solver.solve_final_state()
+        ssc = solver.ssc
+        # Check the cuda virtual package is included in the solver
+        assert "__cuda" in ssc.specs_map.keys()
+
+        # Check that the environment is consistent after installing a
+        # package which *depends* on a virtual package
+        for pkgs in ssc.solution_precs:
+            if pkgs.name == "cudatoolkit":
+                # make sure this package depends on the __cuda virtual
+                # package as a dependency since this is requirement of the
+                # test the test
+                assert "__cuda" in pkgs.depends[0]
+        assert ssc.r.bad_installed(ssc.solution_precs, ())[1] is None
 
 
-def test_solve_msgs_exclude_vp(tmpdir, clear_cuda_version):
+def test_solve_msgs_exclude_vp(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     # Sovler hints should exclude virtual packages that are not dependencies
     specs = (
         MatchSpec("python =2.7.5"),
         MatchSpec("readline =5.0"),
     )
 
-    with env_var("CONDA_OVERRIDE_CUDA", "10.0"):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            with pytest.raises(UnsatisfiableError) as exc:
-                solver.solve_final_state()
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "10.0")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        with pytest.raises(UnsatisfiableError) as exc:
+            solver.solve_final_state()
 
     assert "__cuda==10.0" not in str(exc.value).strip()
 
 
-def test_cuda_1(tmpdir, clear_cuda_version):
+def test_cuda_1(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cudatoolkit"),)
 
-    with env_var("CONDA_OVERRIDE_CUDA", "9.2"):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            final_state = solver.solve_final_state()
-            # print(convert_to_dist_str(final_state))
-            order = add_subdir_to_iter(("channel-1::cudatoolkit-9.0-0",))
-            assert convert_to_dist_str(final_state) == order
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "9.2")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        final_state = solver.solve_final_state()
+        # print(convert_to_dist_str(final_state))
+        order = add_subdir_to_iter(("channel-1::cudatoolkit-9.0-0",))
+        assert convert_to_dist_str(final_state) == order
 
 
-def test_cuda_2(tmpdir, clear_cuda_version):
+def test_cuda_2(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cudatoolkit"),)
 
-    with env_var("CONDA_OVERRIDE_CUDA", "10.0"):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            final_state = solver.solve_final_state()
-            # print(convert_to_dist_str(final_state))
-            order = add_subdir_to_iter(("channel-1::cudatoolkit-10.0-0",))
-            assert convert_to_dist_str(final_state) == order
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "10.0")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        final_state = solver.solve_final_state()
+        # print(convert_to_dist_str(final_state))
+        order = add_subdir_to_iter(("channel-1::cudatoolkit-10.0-0",))
+        assert convert_to_dist_str(final_state) == order
 
 
-def test_cuda_fail_1(tmpdir, clear_cuda_version):
+def test_cuda_fail_1(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cudatoolkit"),)
 
     # No cudatoolkit in index for CUDA 8.0
-    with env_var("CONDA_OVERRIDE_CUDA", "8.0"):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            with pytest.raises(UnsatisfiableError) as exc:
-                solver.solve_final_state()
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "8.0")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        with pytest.raises(UnsatisfiableError) as exc:
+            solver.solve_final_state()
 
     if context.solver == "libmamba":
         # LIBMAMBA ADJUSTMENT
@@ -302,14 +305,16 @@ Your installed version is: 8.0"""
         )
 
 
-def test_cuda_fail_2(tmpdir, clear_cuda_version):
+def test_cuda_fail_2(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cudatoolkit"),)
 
     # No CUDA on system
-    with env_var("CONDA_OVERRIDE_CUDA", ""):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            with pytest.raises(UnsatisfiableError) as exc:
-                solver.solve_final_state()
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        with pytest.raises(UnsatisfiableError) as exc:
+            solver.solve_final_state()
+
     if context.solver == "libmamba":
         # LIBMAMBA ADJUSTMENT
         # We have a different (yet equivalent) error message
@@ -335,38 +340,41 @@ Your installed version is: not available"""
         )
 
 
-def test_cuda_constrain_absent(tmpdir, clear_cuda_version):
+def test_cuda_constrain_absent(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cuda-constrain"),)
 
-    with env_var("CONDA_OVERRIDE_CUDA", ""):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            final_state = solver.solve_final_state()
-            # print(convert_to_dist_str(final_state))
-            order = add_subdir_to_iter(("channel-1::cuda-constrain-11.0-0",))
-            assert convert_to_dist_str(final_state) == order
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        final_state = solver.solve_final_state()
+        # print(convert_to_dist_str(final_state))
+        order = add_subdir_to_iter(("channel-1::cuda-constrain-11.0-0",))
+        assert convert_to_dist_str(final_state) == order
 
 
 @pytest.mark.skip(reason="known broken; fix to be implemented")
-def test_cuda_constrain_sat(tmpdir, clear_cuda_version):
+def test_cuda_constrain_sat(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cuda-constrain"),)
 
-    with env_var("CONDA_OVERRIDE_CUDA", "10.0"):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            final_state = solver.solve_final_state()
-            # print(convert_to_dist_str(final_state))
-            order = add_subdir_to_iter(("channel-1::cuda-constrain-10.0-0",))
-            assert convert_to_dist_str(final_state) == order
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "10.0")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        final_state = solver.solve_final_state()
+        # print(convert_to_dist_str(final_state))
+        order = add_subdir_to_iter(("channel-1::cuda-constrain-10.0-0",))
+        assert convert_to_dist_str(final_state) == order
 
 
 @pytest.mark.skip(reason="known broken; fix to be implemented")
-def test_cuda_constrain_unsat(tmpdir, clear_cuda_version):
+def test_cuda_constrain_unsat(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cuda-constrain"),)
 
     # No cudatoolkit in index for CUDA 8.0
-    with env_var("CONDA_OVERRIDE_CUDA", "8.0"):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            with pytest.raises(UnsatisfiableError) as exc:
-                solver.solve_final_state()
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "8.0")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        with pytest.raises(UnsatisfiableError) as exc:
+            solver.solve_final_state()
 
     assert str(exc.value).strip() == dals(
         f"""The following specifications were found to be incompatible with your system:
@@ -379,29 +387,30 @@ Your installed version is: 8.0"""
 
 
 @pytest.mark.skipif(not on_linux, reason="linux-only test")
-def test_cuda_glibc_sat(tmpdir, clear_cuda_version):
+def test_cuda_glibc_sat(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cuda-glibc"),)
 
-    with (
-        env_var("CONDA_OVERRIDE_CUDA", "10.0"),
-        env_var("CONDA_OVERRIDE_GLIBC", "2.23"),
-    ):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            final_state = solver.solve_final_state()
-            # print(convert_to_dist_str(final_state))
-            order = add_subdir_to_iter(("channel-1::cuda-glibc-10.0-0",))
-            assert convert_to_dist_str(final_state) == order
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "10.0")
+    monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.23")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        final_state = solver.solve_final_state()
+        # print(convert_to_dist_str(final_state))
+        order = add_subdir_to_iter(("channel-1::cuda-glibc-10.0-0",))
+        assert convert_to_dist_str(final_state) == order
 
 
 @pytest.mark.skip(reason="known broken; fix to be implemented")
 @pytest.mark.skipif(not on_linux, reason="linux-only test")
-def test_cuda_glibc_unsat_depend(tmpdir, clear_cuda_version):
+def test_cuda_glibc_unsat_depend(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cuda-glibc"),)
 
-    with env_var("CONDA_OVERRIDE_CUDA", "8.0"), env_var("CONDA_OVERRIDE_GLIBC", "2.23"):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            with pytest.raises(UnsatisfiableError) as exc:
-                solver.solve_final_state()
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "8.0")
+    monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.23")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        with pytest.raises(UnsatisfiableError) as exc:
+            solver.solve_final_state()
 
     assert str(exc.value).strip() == dals(
         f"""The following specifications were found to be incompatible with your system:
@@ -415,29 +424,34 @@ Your installed version is: 8.0"""
 
 @pytest.mark.skip(reason="known broken; fix to be implemented")
 @pytest.mark.skipif(not on_linux, reason="linux-only test")
-def test_cuda_glibc_unsat_constrain(tmpdir, clear_cuda_version):
+def test_cuda_glibc_unsat_constrain(
+    tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch
+):
     specs = (MatchSpec("cuda-glibc"),)
 
-    with (
-        env_var("CONDA_OVERRIDE_CUDA", "10.0"),
-        env_var("CONDA_OVERRIDE_GLIBC", "2.12"),
-    ):
-        with get_solver_cuda(tmpdir, specs) as solver:
-            with pytest.raises(UnsatisfiableError):
-                solver.solve_final_state()
+    monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "10.0")
+    monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.12")
+
+    with get_solver_cuda(tmpdir, specs) as solver:
+        with pytest.raises(UnsatisfiableError):
+            solver.solve_final_state()
 
 
 @pytest.mark.skipif(
     not (on_win or on_mac or on_linux),
     reason="archspec is only supported on win, mac or linux",
 )
-def test_archspec_call(tmpdir):
+def test_archspec_call(
+    tmpdir,
+    monkeypatch: MonkeyPatch,
+):
     specs = (MatchSpec("numpy"),)
 
-    with env_vars(), patch("archspec.cpu.host") as archspec:
-        if "CONDA_OVERRIDE_ARCHSPEC" in os.environ:
-            del os.environ["CONDA_OVERRIDE_ARCHSPEC"]
+    # Remove CONDA_OVERRIDE_ARCHSPEC if it exists.
+    monkeypatch.delenv("CONDA_OVERRIDE_ARCHSPEC", raising=False)
+    reset_context()
 
+    with patch("archspec.cpu.host") as archspec:
         with get_solver_cuda(tmpdir, specs) as solver:
             solver.solve_final_state()
             archspec.assert_called()
@@ -1296,7 +1310,7 @@ def test_broken_install(tmpdir):
     assert not solver._r.environment_is_consistent(final_state_2_mod)
 
 
-def test_conda_downgrade(tmpdir, request):
+def test_conda_downgrade(tmpdir, request, monkeypatch: MonkeyPatch):
     if context.solver == "libmamba" and on_win and forward_to_subprocess(request):
         return
 
@@ -1308,59 +1322,63 @@ def test_conda_downgrade(tmpdir, request):
             )
         )
     specs = (MatchSpec("conda-build"),)
-    with env_var(
-        "CONDA_CHANNEL_PRIORITY", "False", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        with get_solver_aggregate_1(tmpdir, specs) as solver:
-            final_state_1 = solver.solve_final_state()
-            pprint(convert_to_dist_str(final_state_1))
-            order = add_subdir_to_iter(
-                (
-                    "channel-4::ca-certificates-2018.03.07-0",
-                    "channel-2::conda-env-2.6.0-0",
-                    "channel-2::libffi-3.2.1-1",
-                    "channel-4::libgcc-ng-8.2.0-hdf63c60_0",
-                    "channel-4::libstdcxx-ng-8.2.0-hdf63c60_0",
-                    "channel-2::zlib-1.2.11-0",
-                    "channel-4::ncurses-6.1-hf484d3e_0",
-                    "channel-4::openssl-1.0.2p-h14c3975_0",
-                    "channel-4::patchelf-0.9-hf484d3e_2",
-                    "channel-4::tk-8.6.7-hc745277_3",
-                    "channel-4::xz-5.2.4-h14c3975_4",
-                    "channel-4::yaml-0.1.7-had09818_2",
-                    "channel-4::libedit-3.1.20170329-h6b74fdf_2",
-                    "channel-4::readline-7.0-ha6073c6_4",
-                    "channel-4::sqlite-3.24.0-h84994c4_0",
-                    "channel-4::python-3.7.0-hc3d631a_0",
-                    "channel-4::asn1crypto-0.24.0-py37_0",
-                    "channel-4::beautifulsoup4-4.6.3-py37_0",
-                    "channel-4::certifi-2018.8.13-py37_0",
-                    "channel-4::chardet-3.0.4-py37_1",
-                    "channel-4::cryptography-vectors-2.3-py37_0",
-                    "channel-4::filelock-3.0.4-py37_0",
-                    "channel-4::glob2-0.6-py37_0",
-                    "channel-4::idna-2.7-py37_0",
-                    "channel-4::markupsafe-1.0-py37h14c3975_1",
-                    "channel-4::pkginfo-1.4.2-py37_1",
-                    "channel-4::psutil-5.4.6-py37h14c3975_0",
-                    "channel-4::pycosat-0.6.3-py37h14c3975_0",
-                    "channel-4::pycparser-2.18-py37_1",
-                    "channel-4::pysocks-1.6.8-py37_0",
-                    "channel-4::pyyaml-3.13-py37h14c3975_0",
-                    "channel-4::ruamel_yaml-0.15.46-py37h14c3975_0",
-                    "channel-4::six-1.11.0-py37_1",
-                    "channel-4::cffi-1.11.5-py37h9745a5d_0",
-                    "channel-4::setuptools-40.0.0-py37_0",
-                    "channel-4::cryptography-2.3-py37hb7f436b_0",
-                    "channel-4::jinja2-2.10-py37_0",
-                    "channel-4::pyopenssl-18.0.0-py37_0",
-                    "channel-4::urllib3-1.23-py37_0",
-                    "channel-4::requests-2.19.1-py37_0",
-                    "channel-4::conda-4.5.10-py37_0",
-                    "channel-4::conda-build-3.12.1-py37_0",
-                )
+
+    monkeypatch.setenv("CONDA_CHANNEL_PRIORITY", "False")
+    reset_context()
+
+    with get_solver_aggregate_1(tmpdir, specs) as solver:
+        final_state_1 = solver.solve_final_state()
+        pprint(convert_to_dist_str(final_state_1))
+        order = add_subdir_to_iter(
+            (
+                "channel-4::ca-certificates-2018.03.07-0",
+                "channel-2::conda-env-2.6.0-0",
+                "channel-2::libffi-3.2.1-1",
+                "channel-4::libgcc-ng-8.2.0-hdf63c60_0",
+                "channel-4::libstdcxx-ng-8.2.0-hdf63c60_0",
+                "channel-2::zlib-1.2.11-0",
+                "channel-4::ncurses-6.1-hf484d3e_0",
+                "channel-4::openssl-1.0.2p-h14c3975_0",
+                "channel-4::patchelf-0.9-hf484d3e_2",
+                "channel-4::tk-8.6.7-hc745277_3",
+                "channel-4::xz-5.2.4-h14c3975_4",
+                "channel-4::yaml-0.1.7-had09818_2",
+                "channel-4::libedit-3.1.20170329-h6b74fdf_2",
+                "channel-4::readline-7.0-ha6073c6_4",
+                "channel-4::sqlite-3.24.0-h84994c4_0",
+                "channel-4::python-3.7.0-hc3d631a_0",
+                "channel-4::asn1crypto-0.24.0-py37_0",
+                "channel-4::beautifulsoup4-4.6.3-py37_0",
+                "channel-4::certifi-2018.8.13-py37_0",
+                "channel-4::chardet-3.0.4-py37_1",
+                "channel-4::cryptography-vectors-2.3-py37_0",
+                "channel-4::filelock-3.0.4-py37_0",
+                "channel-4::glob2-0.6-py37_0",
+                "channel-4::idna-2.7-py37_0",
+                "channel-4::markupsafe-1.0-py37h14c3975_1",
+                "channel-4::pkginfo-1.4.2-py37_1",
+                "channel-4::psutil-5.4.6-py37h14c3975_0",
+                "channel-4::pycosat-0.6.3-py37h14c3975_0",
+                "channel-4::pycparser-2.18-py37_1",
+                "channel-4::pysocks-1.6.8-py37_0",
+                "channel-4::pyyaml-3.13-py37h14c3975_0",
+                "channel-4::ruamel_yaml-0.15.46-py37h14c3975_0",
+                "channel-4::six-1.11.0-py37_1",
+                "channel-4::cffi-1.11.5-py37h9745a5d_0",
+                "channel-4::setuptools-40.0.0-py37_0",
+                "channel-4::cryptography-2.3-py37hb7f436b_0",
+                "channel-4::jinja2-2.10-py37_0",
+                "channel-4::pyopenssl-18.0.0-py37_0",
+                "channel-4::urllib3-1.23-py37_0",
+                "channel-4::requests-2.19.1-py37_0",
+                "channel-4::conda-4.5.10-py37_0",
+                "channel-4::conda-build-3.12.1-py37_0",
             )
-            assert convert_to_dist_str(final_state_1) == order
+        )
+        assert convert_to_dist_str(final_state_1) == order
+
+    monkeypatch.delenv("CONDA_CHANNEL_PRIORITY")
+    reset_context()
 
     specs_to_add = (MatchSpec("itsdangerous"),)  # MatchSpec("conda"),
     saved_sys_prefix = sys.prefix
@@ -1578,7 +1596,7 @@ def test_unfreeze_when_required(tmpdir):
         assert convert_to_dist_str(final_state_2) == order
 
 
-def test_auto_update_conda(tmpdir):
+def test_auto_update_conda(tmpdir, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("conda=1.3"),)
     with get_solver(tmpdir, specs) as solver:
         final_state_1 = solver.solve_final_state()
@@ -1600,9 +1618,69 @@ def test_auto_update_conda(tmpdir):
         )
         assert convert_to_dist_str(final_state_1) == order
 
-    with env_vars(
-        {"CONDA_AUTO_UPDATE_CONDA": "yes"}, stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
+    monkeypatch.setenv("CONDA_AUTO_UPDATE_CONDA", "yes")
+    reset_context()
+    specs_to_add = (MatchSpec("pytz"),)
+    with get_solver(
+        tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
+    ) as solver:
+        final_state_2 = solver.solve_final_state()
+        # PrefixDag(final_state_2, specs).open_url()
+        print(convert_to_dist_str(final_state_2))
+        order = add_subdir_to_iter(
+            (
+                "channel-1::openssl-1.0.1c-0",
+                "channel-1::readline-6.2-0",
+                "channel-1::sqlite-3.7.13-0",
+                "channel-1::system-5.8-1",
+                "channel-1::tk-8.5.13-0",
+                "channel-1::yaml-0.1.4-0",
+                "channel-1::zlib-1.2.7-0",
+                "channel-1::python-2.7.5-0",
+                "channel-1::pytz-2013b-py27_0",
+                "channel-1::pyyaml-3.10-py27_0",
+                "channel-1::conda-1.3.5-py27_0",
+            )
+        )
+        assert convert_to_dist_str(final_state_2) == order
+
+    monkeypatch.delenv("CONDA_AUTO_UPDATE_CONDA")
+    reset_context()
+
+    saved_sys_prefix = sys.prefix
+    try:
+        sys.prefix = tmpdir.strpath
+
+        monkeypatch.setenv("CONDA_AUTO_UPDATE_CONDA", "yes")
+        reset_context()
+
+        specs_to_add = (MatchSpec("pytz"),)
+        with get_solver(
+            tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
+        ) as solver:
+            final_state_2 = solver.solve_final_state()
+            # PrefixDag(final_state_2, specs).open_url()
+            print(convert_to_dist_str(final_state_2))
+            order = add_subdir_to_iter(
+                (
+                    "channel-1::openssl-1.0.1c-0",
+                    "channel-1::readline-6.2-0",
+                    "channel-1::sqlite-3.7.13-0",
+                    "channel-1::system-5.8-1",
+                    "channel-1::tk-8.5.13-0",
+                    "channel-1::yaml-0.1.4-0",
+                    "channel-1::zlib-1.2.7-0",
+                    "channel-1::python-2.7.5-0",
+                    "channel-1::pytz-2013b-py27_0",
+                    "channel-1::pyyaml-3.10-py27_0",
+                    "channel-1::conda-1.5.2-py27_0",
+                )
+            )
+            assert convert_to_dist_str(final_state_2) == order
+
+        monkeypatch.setenv("CONDA_AUTO_UPDATE_CONDA", "no")
+        reset_context()
+
         specs_to_add = (MatchSpec("pytz"),)
         with get_solver(
             tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
@@ -1626,70 +1704,11 @@ def test_auto_update_conda(tmpdir):
                 )
             )
             assert convert_to_dist_str(final_state_2) == order
-
-    saved_sys_prefix = sys.prefix
-    try:
-        sys.prefix = tmpdir.strpath
-        with env_vars(
-            {"CONDA_AUTO_UPDATE_CONDA": "yes"},
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            specs_to_add = (MatchSpec("pytz"),)
-            with get_solver(
-                tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
-            ) as solver:
-                final_state_2 = solver.solve_final_state()
-                # PrefixDag(final_state_2, specs).open_url()
-                print(convert_to_dist_str(final_state_2))
-                order = add_subdir_to_iter(
-                    (
-                        "channel-1::openssl-1.0.1c-0",
-                        "channel-1::readline-6.2-0",
-                        "channel-1::sqlite-3.7.13-0",
-                        "channel-1::system-5.8-1",
-                        "channel-1::tk-8.5.13-0",
-                        "channel-1::yaml-0.1.4-0",
-                        "channel-1::zlib-1.2.7-0",
-                        "channel-1::python-2.7.5-0",
-                        "channel-1::pytz-2013b-py27_0",
-                        "channel-1::pyyaml-3.10-py27_0",
-                        "channel-1::conda-1.5.2-py27_0",
-                    )
-                )
-                assert convert_to_dist_str(final_state_2) == order
-
-        with env_vars(
-            {"CONDA_AUTO_UPDATE_CONDA": "no"},
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            specs_to_add = (MatchSpec("pytz"),)
-            with get_solver(
-                tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
-            ) as solver:
-                final_state_2 = solver.solve_final_state()
-                # PrefixDag(final_state_2, specs).open_url()
-                print(convert_to_dist_str(final_state_2))
-                order = add_subdir_to_iter(
-                    (
-                        "channel-1::openssl-1.0.1c-0",
-                        "channel-1::readline-6.2-0",
-                        "channel-1::sqlite-3.7.13-0",
-                        "channel-1::system-5.8-1",
-                        "channel-1::tk-8.5.13-0",
-                        "channel-1::yaml-0.1.4-0",
-                        "channel-1::zlib-1.2.7-0",
-                        "channel-1::python-2.7.5-0",
-                        "channel-1::pytz-2013b-py27_0",
-                        "channel-1::pyyaml-3.10-py27_0",
-                        "channel-1::conda-1.3.5-py27_0",
-                    )
-                )
-                assert convert_to_dist_str(final_state_2) == order
     finally:
         sys.prefix = saved_sys_prefix
 
 
-def test_explicit_conda_downgrade(tmpdir):
+def test_explicit_conda_downgrade(tmpdir, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("conda=1.5"),)
     with get_solver(tmpdir, specs) as solver:
         final_state_1 = solver.solve_final_state()
@@ -1711,9 +1730,41 @@ def test_explicit_conda_downgrade(tmpdir):
         )
         assert convert_to_dist_str(final_state_1) == order
 
-    with env_vars(
-        {"CONDA_AUTO_UPDATE_CONDA": "yes"}, stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
+    monkeypatch.setenv("CONDA_AUTO_UPDATE_CONDA", "yes")
+    reset_context()
+
+    specs_to_add = (MatchSpec("conda=1.3"),)
+    with get_solver(
+        tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
+    ) as solver:
+        final_state_2 = solver.solve_final_state()
+        # PrefixDag(final_state_2, specs).open_url()
+        print(convert_to_dist_str(final_state_2))
+        order = add_subdir_to_iter(
+            (
+                "channel-1::openssl-1.0.1c-0",
+                "channel-1::readline-6.2-0",
+                "channel-1::sqlite-3.7.13-0",
+                "channel-1::system-5.8-1",
+                "channel-1::tk-8.5.13-0",
+                "channel-1::yaml-0.1.4-0",
+                "channel-1::zlib-1.2.7-0",
+                "channel-1::python-2.7.5-0",
+                "channel-1::pyyaml-3.10-py27_0",
+                "channel-1::conda-1.3.5-py27_0",
+            )
+        )
+        assert convert_to_dist_str(final_state_2) == order
+
+    monkeypatch.delenv("CONDA_AUTO_UPDATE_CONDA")
+    reset_context()
+
+    saved_sys_prefix = sys.prefix
+    try:
+        sys.prefix = tmpdir.strpath
+
+        monkeypatch.setenv("CONDA_AUTO_UPDATE_CONDA", "yes")
+        reset_context()
         specs_to_add = (MatchSpec("conda=1.3"),)
         with get_solver(
             tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
@@ -1737,67 +1788,36 @@ def test_explicit_conda_downgrade(tmpdir):
             )
             assert convert_to_dist_str(final_state_2) == order
 
-    saved_sys_prefix = sys.prefix
-    try:
-        sys.prefix = tmpdir.strpath
-        with env_vars(
-            {"CONDA_AUTO_UPDATE_CONDA": "yes"},
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            specs_to_add = (MatchSpec("conda=1.3"),)
-            with get_solver(
-                tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
-            ) as solver:
-                final_state_2 = solver.solve_final_state()
-                # PrefixDag(final_state_2, specs).open_url()
-                print(convert_to_dist_str(final_state_2))
-                order = add_subdir_to_iter(
-                    (
-                        "channel-1::openssl-1.0.1c-0",
-                        "channel-1::readline-6.2-0",
-                        "channel-1::sqlite-3.7.13-0",
-                        "channel-1::system-5.8-1",
-                        "channel-1::tk-8.5.13-0",
-                        "channel-1::yaml-0.1.4-0",
-                        "channel-1::zlib-1.2.7-0",
-                        "channel-1::python-2.7.5-0",
-                        "channel-1::pyyaml-3.10-py27_0",
-                        "channel-1::conda-1.3.5-py27_0",
-                    )
-                )
-                assert convert_to_dist_str(final_state_2) == order
+        monkeypatch.setenv("CONDA_AUTO_UPDATE_CONDA", "no")
+        reset_context()
 
-        with env_vars(
-            {"CONDA_AUTO_UPDATE_CONDA": "no"},
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            specs_to_add = (MatchSpec("conda=1.3"),)
-            with get_solver(
-                tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
-            ) as solver:
-                final_state_2 = solver.solve_final_state()
-                # PrefixDag(final_state_2, specs).open_url()
-                print(convert_to_dist_str(final_state_2))
-                order = add_subdir_to_iter(
-                    (
-                        "channel-1::openssl-1.0.1c-0",
-                        "channel-1::readline-6.2-0",
-                        "channel-1::sqlite-3.7.13-0",
-                        "channel-1::system-5.8-1",
-                        "channel-1::tk-8.5.13-0",
-                        "channel-1::yaml-0.1.4-0",
-                        "channel-1::zlib-1.2.7-0",
-                        "channel-1::python-2.7.5-0",
-                        "channel-1::pyyaml-3.10-py27_0",
-                        "channel-1::conda-1.3.5-py27_0",
-                    )
+        specs_to_add = (MatchSpec("conda=1.3"),)
+        with get_solver(
+            tmpdir, specs_to_add, prefix_records=final_state_1, history_specs=specs
+        ) as solver:
+            final_state_2 = solver.solve_final_state()
+            # PrefixDag(final_state_2, specs).open_url()
+            print(convert_to_dist_str(final_state_2))
+            order = add_subdir_to_iter(
+                (
+                    "channel-1::openssl-1.0.1c-0",
+                    "channel-1::readline-6.2-0",
+                    "channel-1::sqlite-3.7.13-0",
+                    "channel-1::system-5.8-1",
+                    "channel-1::tk-8.5.13-0",
+                    "channel-1::yaml-0.1.4-0",
+                    "channel-1::zlib-1.2.7-0",
+                    "channel-1::python-2.7.5-0",
+                    "channel-1::pyyaml-3.10-py27_0",
+                    "channel-1::conda-1.3.5-py27_0",
                 )
-                assert convert_to_dist_str(final_state_2) == order
+            )
+            assert convert_to_dist_str(final_state_2) == order
     finally:
         sys.prefix = saved_sys_prefix
 
 
-def test_aggressive_update_packages(tmpdir):
+def test_aggressive_update_packages(tmpdir, monkeypatch: MonkeyPatch):
     def solve(prev_state, specs_to_add, order):
         final_state_1, specs = prev_state
         specs_to_add = tuple(MatchSpec(spec_str) for spec_str in specs_to_add)
@@ -1813,106 +1833,106 @@ def test_aggressive_update_packages(tmpdir):
     # test with "libpng", "cmake": both have multiple versions and no requirements in "channel-1"
 
     empty_state = ((), ())
-    with env_vars(
-        {"CONDA_AGGRESSIVE_UPDATE_PACKAGES": ""},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        base_state = solve(
-            empty_state,
-            ["libpng=1.2"],
-            add_subdir_to_iter(("channel-1::libpng-1.2.50-0",)),
-        )
+
+    monkeypatch.setenv("CONDA_AGGRESSIVE_UPDATE_PACKAGES", "")
+    reset_context()
+
+    base_state = solve(
+        empty_state,
+        ["libpng=1.2"],
+        add_subdir_to_iter(("channel-1::libpng-1.2.50-0",)),
+    )
 
     # # ~~has "libpng" restricted to "=1.2" by history_specs~~ NOPE!
     # In conda 4.6 making aggressive_update *more* aggressive, making it override history specs.
     state_1 = base_state
-    with env_vars(
-        {"CONDA_AGGRESSIVE_UPDATE_PACKAGES": "libpng"},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        solve(
-            state_1,
-            ["cmake=2.8.9"],
-            add_subdir_to_iter(
-                (
-                    "channel-1::cmake-2.8.9-0",
-                    "channel-1::libpng-1.5.13-1",
-                )
-            ),
-        )
-    with env_vars(
-        {"CONDA_AGGRESSIVE_UPDATE_PACKAGES": ""},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        state_1_2 = solve(
-            state_1,
-            ["cmake=2.8.9"],
-            add_subdir_to_iter(
-                (
-                    "channel-1::cmake-2.8.9-0",
-                    "channel-1::libpng-1.2.50-0",
-                )
-            ),
-        )
-    with env_vars(
-        {"CONDA_AGGRESSIVE_UPDATE_PACKAGES": "libpng"},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        solve(
-            state_1_2,
-            ["cmake>2.8.9"],
-            add_subdir_to_iter(
-                (
-                    "channel-1::cmake-2.8.10.2-0",
-                    "channel-1::libpng-1.5.13-1",
-                )
-            ),
-        )
+
+    monkeypatch.setenv("CONDA_AGGRESSIVE_UPDATE_PACKAGES", "libpng")
+    reset_context()
+
+    solve(
+        state_1,
+        ["cmake=2.8.9"],
+        add_subdir_to_iter(
+            (
+                "channel-1::cmake-2.8.9-0",
+                "channel-1::libpng-1.5.13-1",
+            )
+        ),
+    )
+
+    monkeypatch.setenv("CONDA_AGGRESSIVE_UPDATE_PACKAGES", "")
+    reset_context()
+
+    state_1_2 = solve(
+        state_1,
+        ["cmake=2.8.9"],
+        add_subdir_to_iter(
+            (
+                "channel-1::cmake-2.8.9-0",
+                "channel-1::libpng-1.2.50-0",
+            )
+        ),
+    )
+
+    monkeypatch.setenv("CONDA_AGGRESSIVE_UPDATE_PACKAGES", "libpng")
+    reset_context()
+
+    solve(
+        state_1_2,
+        ["cmake>2.8.9"],
+        add_subdir_to_iter(
+            (
+                "channel-1::cmake-2.8.10.2-0",
+                "channel-1::libpng-1.5.13-1",
+            )
+        ),
+    )
 
     # use new history_specs to remove "libpng" version restriction
     state_2 = (base_state[0], (MatchSpec("libpng"),))
-    with env_vars(
-        {"CONDA_AGGRESSIVE_UPDATE_PACKAGES": "libpng"},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        solve(
-            state_2,
-            ["cmake=2.8.9"],
-            add_subdir_to_iter(
-                (
-                    "channel-1::cmake-2.8.9-0",
-                    "channel-1::libpng-1.5.13-1",
-                )
-            ),
-        )
-    with env_vars(
-        {"CONDA_AGGRESSIVE_UPDATE_PACKAGES": ""},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        state_2_2 = solve(
-            state_2,
-            ["cmake=2.8.9"],
-            add_subdir_to_iter(
-                (
-                    "channel-1::cmake-2.8.9-0",
-                    "channel-1::libpng-1.2.50-0",
-                )
-            ),
-        )
-    with env_vars(
-        {"CONDA_AGGRESSIVE_UPDATE_PACKAGES": "libpng"},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        solve(
-            state_2_2,
-            ["cmake>2.8.9"],
-            add_subdir_to_iter(
-                (
-                    "channel-1::cmake-2.8.10.2-0",
-                    "channel-1::libpng-1.5.13-1",
-                )
-            ),
-        )
+
+    monkeypatch.setenv("CONDA_AGGRESSIVE_UPDATE_PACKAGES", "libpng")
+    reset_context()
+
+    solve(
+        state_2,
+        ["cmake=2.8.9"],
+        add_subdir_to_iter(
+            (
+                "channel-1::cmake-2.8.9-0",
+                "channel-1::libpng-1.5.13-1",
+            )
+        ),
+    )
+
+    monkeypatch.setenv("CONDA_AGGRESSIVE_UPDATE_PACKAGES", "")
+    reset_context()
+
+    state_2_2 = solve(
+        state_2,
+        ["cmake=2.8.9"],
+        add_subdir_to_iter(
+            (
+                "channel-1::cmake-2.8.9-0",
+                "channel-1::libpng-1.2.50-0",
+            )
+        ),
+    )
+
+    monkeypatch.setenv("CONDA_AGGRESSIVE_UPDATE_PACKAGES", "libpng")
+    reset_context()
+
+    solve(
+        state_2_2,
+        ["cmake>2.8.9"],
+        add_subdir_to_iter(
+            (
+                "channel-1::cmake-2.8.10.2-0",
+                "channel-1::libpng-1.5.13-1",
+            )
+        ),
+    )
 
 
 def test_python2_update(tmpdir):
@@ -2332,7 +2352,7 @@ def test_fast_update_with_update_modifier_not_set(tmpdir):
 
 
 @pytest.mark.integration
-def test_pinned_1(tmpdir):
+def test_pinned_1(tmpdir, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("numpy"),)
     with get_solver(tmpdir, specs) as solver:
         final_state_1 = solver.solve_final_state()
@@ -2352,193 +2372,194 @@ def test_pinned_1(tmpdir):
         )
         assert convert_to_dist_str(final_state_1) == order
 
-    with env_var(
-        "CONDA_PINNED_PACKAGES",
-        "python=2.6&iopro<=1.4.2",
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        specs = (MatchSpec("system=5.8=0"),)
-        with get_solver(tmpdir, specs) as solver:
-            final_state_1 = solver.solve_final_state()
-            # PrefixDag(final_state_1, specs).open_url()
-            pprint(convert_to_dist_str(final_state_1))
-            order = add_subdir_to_iter(("channel-1::system-5.8-0",))
-            assert convert_to_dist_str(final_state_1) == order
+    monkeypatch.setenv("CONDA_PINNED_PACKAGES", "python=2.6&iopro<=1.4.2")
+    reset_context()
 
-        # ignore_pinned=True
-        specs_to_add = (MatchSpec("python"),)
-        with get_solver(
-            tmpdir,
-            specs_to_add=specs_to_add,
-            prefix_records=final_state_1,
-            history_specs=specs,
-        ) as solver:
-            final_state_2 = solver.solve_final_state(ignore_pinned=True)
-            # PrefixDag(final_state_1, specs).open_url()
-            pprint(convert_to_dist_str(final_state_2))
-            order = add_subdir_to_iter(
-                (
-                    "channel-1::openssl-1.0.1c-0",
-                    "channel-1::readline-6.2-0",
-                    "channel-1::sqlite-3.7.13-0",
-                    "channel-1::system-5.8-0",
-                    "channel-1::tk-8.5.13-0",
-                    "channel-1::zlib-1.2.7-0",
-                    "channel-1::python-3.3.2-0",
-                )
+    specs = (MatchSpec("system=5.8=0"),)
+    with get_solver(tmpdir, specs) as solver:
+        final_state_1 = solver.solve_final_state()
+        # PrefixDag(final_state_1, specs).open_url()
+        pprint(convert_to_dist_str(final_state_1))
+        order = add_subdir_to_iter(("channel-1::system-5.8-0",))
+        assert convert_to_dist_str(final_state_1) == order
+
+    # ignore_pinned=True
+    specs_to_add = (MatchSpec("python"),)
+    with get_solver(
+        tmpdir,
+        specs_to_add=specs_to_add,
+        prefix_records=final_state_1,
+        history_specs=specs,
+    ) as solver:
+        final_state_2 = solver.solve_final_state(ignore_pinned=True)
+        # PrefixDag(final_state_1, specs).open_url()
+        pprint(convert_to_dist_str(final_state_2))
+        order = add_subdir_to_iter(
+            (
+                "channel-1::openssl-1.0.1c-0",
+                "channel-1::readline-6.2-0",
+                "channel-1::sqlite-3.7.13-0",
+                "channel-1::system-5.8-0",
+                "channel-1::tk-8.5.13-0",
+                "channel-1::zlib-1.2.7-0",
+                "channel-1::python-3.3.2-0",
             )
-            assert convert_to_dist_str(final_state_2) == order
-
-        # ignore_pinned=False
-        specs_to_add = (MatchSpec("python"),)
-        with get_solver(
-            tmpdir,
-            specs_to_add=specs_to_add,
-            prefix_records=final_state_1,
-            history_specs=specs,
-        ) as solver:
-            final_state_2 = solver.solve_final_state(ignore_pinned=False)
-            # PrefixDag(final_state_1, specs).open_url()
-            pprint(convert_to_dist_str(final_state_2))
-            order = add_subdir_to_iter(
-                (
-                    "channel-1::openssl-1.0.1c-0",
-                    "channel-1::readline-6.2-0",
-                    "channel-1::sqlite-3.7.13-0",
-                    "channel-1::system-5.8-0",
-                    "channel-1::tk-8.5.13-0",
-                    "channel-1::zlib-1.2.7-0",
-                    "channel-1::python-2.6.8-6",
-                )
-            )
-            assert convert_to_dist_str(final_state_2) == order
-
-        # incompatible CLI and configured specs
-        specs_to_add = (MatchSpec("scikit-learn==0.13"),)
-        with get_solver(
-            tmpdir,
-            specs_to_add=specs_to_add,
-            prefix_records=final_state_1,
-            history_specs=specs,
-        ) as solver:
-            if context.solver == "libmamba":
-                # LIBMAMBA ADJUSTMENT
-                # Original tests checks for SpecsConfigurationConflictError
-                # being raised but libmamba will fails with UnsatisfiableError
-                # instead. Hence, we check the error string.
-                with pytest.raises(UnsatisfiableError) as exc_info:
-                    solver.solve_final_state(ignore_pinned=False)
-                error = str(exc_info.value)
-                assert "package scikit-learn-0.13" in error
-                assert "requires python 2.7*" in error
-            else:
-                with pytest.raises(SpecsConfigurationConflictError) as exc:
-                    solver.solve_final_state(ignore_pinned=False)
-                kwargs = exc.value._kwargs
-                assert kwargs["requested_specs"] == ["scikit-learn==0.13"]
-                assert kwargs["pinned_specs"] == ["python=2.6"]
-
-        specs_to_add = (MatchSpec("numba"),)
-        history_specs = (
-            MatchSpec("python"),
-            MatchSpec("system=5.8=0"),
         )
-        with get_solver(
-            tmpdir,
-            specs_to_add=specs_to_add,
-            prefix_records=final_state_2,
-            history_specs=history_specs,
-        ) as solver:
-            final_state_3 = solver.solve_final_state()
-            # PrefixDag(final_state_1, specs).open_url()
-            pprint(convert_to_dist_str(final_state_3))
-            order = add_subdir_to_iter(
-                (
-                    "channel-1::openssl-1.0.1c-0",
-                    "channel-1::readline-6.2-0",
-                    "channel-1::sqlite-3.7.13-0",
-                    "channel-1::system-5.8-0",
-                    "channel-1::tk-8.5.13-0",
-                    "channel-1::zlib-1.2.7-0",
-                    "channel-1::llvm-3.2-0",
-                    "channel-1::python-2.6.8-6",
-                    "channel-1::argparse-1.2.1-py26_0",
-                    "channel-1::llvmpy-0.11.2-py26_0",
-                    "channel-1::numpy-1.7.1-py26_0",
-                    "channel-1::numba-0.8.1-np17py26_0",
-                )
-            )
-            assert convert_to_dist_str(final_state_3) == order
+        assert convert_to_dist_str(final_state_2) == order
 
-        specs_to_add = (MatchSpec("python"),)
-        history_specs = (
-            MatchSpec("python"),
-            MatchSpec("system=5.8=0"),
-            MatchSpec("numba"),
+    # ignore_pinned=False
+    specs_to_add = (MatchSpec("python"),)
+    with get_solver(
+        tmpdir,
+        specs_to_add=specs_to_add,
+        prefix_records=final_state_1,
+        history_specs=specs,
+    ) as solver:
+        final_state_2 = solver.solve_final_state(ignore_pinned=False)
+        # PrefixDag(final_state_1, specs).open_url()
+        pprint(convert_to_dist_str(final_state_2))
+        order = add_subdir_to_iter(
+            (
+                "channel-1::openssl-1.0.1c-0",
+                "channel-1::readline-6.2-0",
+                "channel-1::sqlite-3.7.13-0",
+                "channel-1::system-5.8-0",
+                "channel-1::tk-8.5.13-0",
+                "channel-1::zlib-1.2.7-0",
+                "channel-1::python-2.6.8-6",
+            )
         )
-        with get_solver(
-            tmpdir,
-            specs_to_add=specs_to_add,
-            prefix_records=final_state_3,
-            history_specs=history_specs,
-        ) as solver:
-            final_state_4 = solver.solve_final_state(
-                update_modifier=UpdateModifier.UPDATE_DEPS
-            )
-            # PrefixDag(final_state_1, specs).open_url()
-            pprint(convert_to_dist_str(final_state_4))
-            order = add_subdir_to_iter(
-                (
-                    "channel-1::openssl-1.0.1c-0",
-                    "channel-1::readline-6.2-0",
-                    "channel-1::sqlite-3.7.13-0",
-                    "channel-1::system-5.8-1",
-                    "channel-1::tk-8.5.13-0",
-                    "channel-1::zlib-1.2.7-0",
-                    "channel-1::llvm-3.2-0",
-                    "channel-1::python-2.6.8-6",
-                    "channel-1::argparse-1.2.1-py26_0",
-                    "channel-1::llvmpy-0.11.2-py26_0",
-                    "channel-1::numpy-1.7.1-py26_0",
-                    "channel-1::numba-0.8.1-np17py26_0",
-                )
-            )
-            assert convert_to_dist_str(final_state_4) == order
+        assert convert_to_dist_str(final_state_2) == order
 
-        specs_to_add = (MatchSpec("python"),)
-        history_specs = (
-            MatchSpec("python"),
-            MatchSpec("system=5.8=0"),
-            MatchSpec("numba"),
+    # incompatible CLI and configured specs
+    specs_to_add = (MatchSpec("scikit-learn==0.13"),)
+    with get_solver(
+        tmpdir,
+        specs_to_add=specs_to_add,
+        prefix_records=final_state_1,
+        history_specs=specs,
+    ) as solver:
+        if context.solver == "libmamba":
+            # LIBMAMBA ADJUSTMENT
+            # Original tests checks for SpecsConfigurationConflictError
+            # being raised but libmamba will fails with UnsatisfiableError
+            # instead. Hence, we check the error string.
+            with pytest.raises(UnsatisfiableError) as exc_info:
+                solver.solve_final_state(ignore_pinned=False)
+            error = str(exc_info.value)
+            assert "package scikit-learn-0.13" in error
+            assert "requires python 2.7*" in error
+        else:
+            with pytest.raises(SpecsConfigurationConflictError) as exc:
+                solver.solve_final_state(ignore_pinned=False)
+            kwargs = exc.value._kwargs
+            assert kwargs["requested_specs"] == ["scikit-learn==0.13"]
+            assert kwargs["pinned_specs"] == ["python=2.6"]
+
+    specs_to_add = (MatchSpec("numba"),)
+    history_specs = (
+        MatchSpec("python"),
+        MatchSpec("system=5.8=0"),
+    )
+    with get_solver(
+        tmpdir,
+        specs_to_add=specs_to_add,
+        prefix_records=final_state_2,
+        history_specs=history_specs,
+    ) as solver:
+        final_state_3 = solver.solve_final_state()
+        # PrefixDag(final_state_1, specs).open_url()
+        pprint(convert_to_dist_str(final_state_3))
+        order = add_subdir_to_iter(
+            (
+                "channel-1::openssl-1.0.1c-0",
+                "channel-1::readline-6.2-0",
+                "channel-1::sqlite-3.7.13-0",
+                "channel-1::system-5.8-0",
+                "channel-1::tk-8.5.13-0",
+                "channel-1::zlib-1.2.7-0",
+                "channel-1::llvm-3.2-0",
+                "channel-1::python-2.6.8-6",
+                "channel-1::argparse-1.2.1-py26_0",
+                "channel-1::llvmpy-0.11.2-py26_0",
+                "channel-1::numpy-1.7.1-py26_0",
+                "channel-1::numba-0.8.1-np17py26_0",
+            )
         )
-        with get_solver(
-            tmpdir,
-            specs_to_add=specs_to_add,
-            prefix_records=final_state_4,
-            history_specs=history_specs,
-        ) as solver:
-            final_state_5 = solver.solve_final_state(
-                update_modifier=UpdateModifier.UPDATE_ALL
+        assert convert_to_dist_str(final_state_3) == order
+
+    specs_to_add = (MatchSpec("python"),)
+    history_specs = (
+        MatchSpec("python"),
+        MatchSpec("system=5.8=0"),
+        MatchSpec("numba"),
+    )
+    with get_solver(
+        tmpdir,
+        specs_to_add=specs_to_add,
+        prefix_records=final_state_3,
+        history_specs=history_specs,
+    ) as solver:
+        final_state_4 = solver.solve_final_state(
+            update_modifier=UpdateModifier.UPDATE_DEPS
+        )
+        # PrefixDag(final_state_1, specs).open_url()
+        pprint(convert_to_dist_str(final_state_4))
+        order = add_subdir_to_iter(
+            (
+                "channel-1::openssl-1.0.1c-0",
+                "channel-1::readline-6.2-0",
+                "channel-1::sqlite-3.7.13-0",
+                "channel-1::system-5.8-1",
+                "channel-1::tk-8.5.13-0",
+                "channel-1::zlib-1.2.7-0",
+                "channel-1::llvm-3.2-0",
+                "channel-1::python-2.6.8-6",
+                "channel-1::argparse-1.2.1-py26_0",
+                "channel-1::llvmpy-0.11.2-py26_0",
+                "channel-1::numpy-1.7.1-py26_0",
+                "channel-1::numba-0.8.1-np17py26_0",
             )
-            # PrefixDag(final_state_1, specs).open_url()
-            pprint(convert_to_dist_str(final_state_5))
-            order = add_subdir_to_iter(
-                (
-                    "channel-1::openssl-1.0.1c-0",
-                    "channel-1::readline-6.2-0",
-                    "channel-1::sqlite-3.7.13-0",
-                    "channel-1::system-5.8-1",
-                    "channel-1::tk-8.5.13-0",
-                    "channel-1::zlib-1.2.7-0",
-                    "channel-1::llvm-3.2-0",
-                    "channel-1::python-2.6.8-6",
-                    "channel-1::argparse-1.2.1-py26_0",
-                    "channel-1::llvmpy-0.11.2-py26_0",
-                    "channel-1::numpy-1.7.1-py26_0",
-                    "channel-1::numba-0.8.1-np17py26_0",
-                )
+        )
+        assert convert_to_dist_str(final_state_4) == order
+
+    specs_to_add = (MatchSpec("python"),)
+    history_specs = (
+        MatchSpec("python"),
+        MatchSpec("system=5.8=0"),
+        MatchSpec("numba"),
+    )
+    with get_solver(
+        tmpdir,
+        specs_to_add=specs_to_add,
+        prefix_records=final_state_4,
+        history_specs=history_specs,
+    ) as solver:
+        final_state_5 = solver.solve_final_state(
+            update_modifier=UpdateModifier.UPDATE_ALL
+        )
+        # PrefixDag(final_state_1, specs).open_url()
+        pprint(convert_to_dist_str(final_state_5))
+        order = add_subdir_to_iter(
+            (
+                "channel-1::openssl-1.0.1c-0",
+                "channel-1::readline-6.2-0",
+                "channel-1::sqlite-3.7.13-0",
+                "channel-1::system-5.8-1",
+                "channel-1::tk-8.5.13-0",
+                "channel-1::zlib-1.2.7-0",
+                "channel-1::llvm-3.2-0",
+                "channel-1::python-2.6.8-6",
+                "channel-1::argparse-1.2.1-py26_0",
+                "channel-1::llvmpy-0.11.2-py26_0",
+                "channel-1::numpy-1.7.1-py26_0",
+                "channel-1::numba-0.8.1-np17py26_0",
             )
-            assert convert_to_dist_str(final_state_5) == order
+        )
+        assert convert_to_dist_str(final_state_5) == order
+
+    monkeypatch.delenv("CONDA_PINNED_PACKAGES")
+    reset_context()
 
     # now update without pinning
     if context.solver == "libmamba":
@@ -2862,7 +2883,7 @@ def test_remove_with_constrained_dependencies(tmpdir):
             assert spec in convert_to_dist_str(unlink_dists_2)
 
 
-def test_priority_1(tmpdir, request):
+def test_priority_1(tmpdir, request, monkeypatch: MonkeyPatch):
     if context.solver == "libmamba":
         request.applymarker(
             pytest.mark.xfail(
@@ -2874,100 +2895,100 @@ def test_priority_1(tmpdir, request):
             )
         )
 
-    with env_var(
-        "CONDA_SUBDIR", "linux-64", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        specs = (
-            MatchSpec("pandas"),
-            MatchSpec("python=2.7"),
+    monkeypatch.setenv("CONDA_SUBDIR", "linux-64")
+    reset_context()
+
+    specs = (
+        MatchSpec("pandas"),
+        MatchSpec("python=2.7"),
+    )
+
+    monkeypatch.setenv("CONDA_CHANNEL_PRIORITY", "True")
+    reset_context()
+
+    with get_solver_aggregate_1(tmpdir, specs) as solver:
+        final_state_1 = solver.solve_final_state()
+        pprint(convert_to_dist_str(final_state_1))
+        order = add_subdir_to_iter(
+            (
+                "channel-2::mkl-2017.0.3-0",
+                "channel-2::openssl-1.0.2l-0",
+                "channel-2::readline-6.2-2",
+                "channel-2::sqlite-3.13.0-0",
+                "channel-2::tk-8.5.18-0",
+                "channel-2::zlib-1.2.11-0",
+                "channel-2::python-2.7.13-0",
+                "channel-2::numpy-1.13.1-py27_0",
+                "channel-2::pytz-2017.2-py27_0",
+                "channel-2::six-1.10.0-py27_0",
+                "channel-2::python-dateutil-2.6.1-py27_0",
+                "channel-2::pandas-0.20.3-py27_0",
+            )
         )
-        with env_var(
-            "CONDA_CHANNEL_PRIORITY",
-            "True",
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            with get_solver_aggregate_1(tmpdir, specs) as solver:
-                final_state_1 = solver.solve_final_state()
-                pprint(convert_to_dist_str(final_state_1))
-                order = add_subdir_to_iter(
-                    (
-                        "channel-2::mkl-2017.0.3-0",
-                        "channel-2::openssl-1.0.2l-0",
-                        "channel-2::readline-6.2-2",
-                        "channel-2::sqlite-3.13.0-0",
-                        "channel-2::tk-8.5.18-0",
-                        "channel-2::zlib-1.2.11-0",
-                        "channel-2::python-2.7.13-0",
-                        "channel-2::numpy-1.13.1-py27_0",
-                        "channel-2::pytz-2017.2-py27_0",
-                        "channel-2::six-1.10.0-py27_0",
-                        "channel-2::python-dateutil-2.6.1-py27_0",
-                        "channel-2::pandas-0.20.3-py27_0",
-                    )
-                )
-                assert convert_to_dist_str(final_state_1) == order
+        assert convert_to_dist_str(final_state_1) == order
 
-        with env_var(
-            "CONDA_CHANNEL_PRIORITY",
-            "False",
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            with get_solver_aggregate_1(
-                tmpdir, specs, prefix_records=final_state_1, history_specs=specs
-            ) as solver:
-                final_state_2 = solver.solve_final_state()
-                pprint(convert_to_dist_str(final_state_2))
-                # python and pandas will be updated as they are explicit specs.  Other stuff may or may not,
-                #     as required to satisfy python and pandas
-                order = add_subdir_to_iter(
-                    (
-                        "channel-4::python-2.7.15-h1571d57_0",
-                        "channel-4::pandas-0.23.4-py27h04863e7_0",
-                    )
-                )
-                for spec in order:
-                    assert spec in convert_to_dist_str(final_state_2)
+    monkeypatch.setenv("CONDA_CHANNEL_PRIORITY", "False")
+    reset_context()
 
-        # channel priority taking effect here.  channel-2 should be the channel to draw from.  Downgrades expected.
+    with get_solver_aggregate_1(
+        tmpdir, specs, prefix_records=final_state_1, history_specs=specs
+    ) as solver:
+        final_state_2 = solver.solve_final_state()
+        pprint(convert_to_dist_str(final_state_2))
         # python and pandas will be updated as they are explicit specs.  Other stuff may or may not,
         #     as required to satisfy python and pandas
-        with get_solver_aggregate_1(
-            tmpdir, specs, prefix_records=final_state_2, history_specs=specs
-        ) as solver:
-            final_state_3 = solver.solve_final_state()
-            pprint(convert_to_dist_str(final_state_3))
-            order = add_subdir_to_iter(
-                (
-                    "channel-2::python-2.7.13-0",
-                    "channel-2::pandas-0.20.3-py27_0",
-                )
+        order = add_subdir_to_iter(
+            (
+                "channel-4::python-2.7.15-h1571d57_0",
+                "channel-4::pandas-0.23.4-py27h04863e7_0",
             )
-            for spec in order:
-                assert spec in convert_to_dist_str(final_state_3)
+        )
+        for spec in order:
+            assert spec in convert_to_dist_str(final_state_2)
 
-        specs_to_add = (MatchSpec("six<1.10"),)
-        specs_to_remove = (MatchSpec("pytz"),)
-        with get_solver_aggregate_1(
-            tmpdir,
-            specs_to_add=specs_to_add,
-            specs_to_remove=specs_to_remove,
-            prefix_records=final_state_3,
-            history_specs=specs,
-        ) as solver:
-            final_state_4 = solver.solve_final_state()
-            pprint(convert_to_dist_str(final_state_4))
-            order = add_subdir_to_iter(
-                (
-                    "channel-2::python-2.7.13-0",
-                    "channel-2::six-1.9.0-py27_0",
-                )
+    monkeypatch.delenv("CONDA_CHANNEL_PRIORITY")
+    reset_context()
+
+    # channel priority taking effect here.  channel-2 should be the channel to draw from.  Downgrades expected.
+    # python and pandas will be updated as they are explicit specs.  Other stuff may or may not,
+    #     as required to satisfy python and pandas
+    with get_solver_aggregate_1(
+        tmpdir, specs, prefix_records=final_state_2, history_specs=specs
+    ) as solver:
+        final_state_3 = solver.solve_final_state()
+        pprint(convert_to_dist_str(final_state_3))
+        order = add_subdir_to_iter(
+            (
+                "channel-2::python-2.7.13-0",
+                "channel-2::pandas-0.20.3-py27_0",
             )
-            for spec in order:
-                assert spec in convert_to_dist_str(final_state_4)
-            assert "pandas" not in convert_to_dist_str(final_state_4)
+        )
+        for spec in order:
+            assert spec in convert_to_dist_str(final_state_3)
+
+    specs_to_add = (MatchSpec("six<1.10"),)
+    specs_to_remove = (MatchSpec("pytz"),)
+    with get_solver_aggregate_1(
+        tmpdir,
+        specs_to_add=specs_to_add,
+        specs_to_remove=specs_to_remove,
+        prefix_records=final_state_3,
+        history_specs=specs,
+    ) as solver:
+        final_state_4 = solver.solve_final_state()
+        pprint(convert_to_dist_str(final_state_4))
+        order = add_subdir_to_iter(
+            (
+                "channel-2::python-2.7.13-0",
+                "channel-2::six-1.9.0-py27_0",
+            )
+        )
+        for spec in order:
+            assert spec in convert_to_dist_str(final_state_4)
+        assert "pandas" not in convert_to_dist_str(final_state_4)
 
 
-def test_features_solve_1(tmpdir, request):
+def test_features_solve_1(tmpdir, request, monkeypatch: MonkeyPatch):
     request.applymarker(
         pytest.mark.xfail(
             context.solver == "libmamba",
@@ -2980,57 +3001,58 @@ def test_features_solve_1(tmpdir, request):
     #   and channel-4 is a view of the newer pkgs/main/linux-64
     # The channel list, equivalent to context.channels is ('channel-2', 'channel-4')
     specs = (MatchSpec("python=2.7"), MatchSpec("numpy"), MatchSpec("nomkl"))
-    with env_var(
-        "CONDA_CHANNEL_PRIORITY", "True", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        with get_solver_aggregate_1(tmpdir, specs) as solver:
-            final_state_1 = solver.solve_final_state()
-            pprint(convert_to_dist_str(final_state_1))
-            order = add_subdir_to_iter(
-                (
-                    "channel-2::nomkl-1.0-0",
-                    "channel-2::libgfortran-3.0.0-1",
-                    "channel-2::openssl-1.0.2l-0",
-                    "channel-2::readline-6.2-2",
-                    "channel-2::sqlite-3.13.0-0",
-                    "channel-2::tk-8.5.18-0",
-                    "channel-2::zlib-1.2.11-0",
-                    "channel-2::openblas-0.2.19-0",
-                    "channel-2::python-2.7.13-0",
-                    "channel-2::numpy-1.13.1-py27_nomkl_0",
-                )
-            )
-            assert convert_to_dist_str(final_state_1) == order
 
-    with env_var(
-        "CONDA_CHANNEL_PRIORITY", "False", stack_callback=conda_tests_ctxt_mgmt_def_pol
-    ):
-        with get_solver_aggregate_1(tmpdir, specs) as solver:
-            final_state_1 = solver.solve_final_state()
-            pprint(convert_to_dist_str(final_state_1))
-            order = add_subdir_to_iter(
-                (
-                    "channel-4::blas-1.0-openblas",
-                    "channel-4::ca-certificates-2018.03.07-0",
-                    "channel-2::libffi-3.2.1-1",
-                    "channel-4::libgcc-ng-8.2.0-hdf63c60_0",
-                    "channel-4::libgfortran-ng-7.2.0-hdf63c60_3",
-                    "channel-4::libstdcxx-ng-8.2.0-hdf63c60_0",
-                    "channel-2::zlib-1.2.11-0",
-                    "channel-4::libopenblas-0.2.20-h9ac9557_7",
-                    "channel-4::ncurses-6.1-hf484d3e_0",
-                    "channel-4::nomkl-3.0-0",
-                    "channel-4::openssl-1.0.2p-h14c3975_0",
-                    "channel-4::tk-8.6.7-hc745277_3",
-                    "channel-4::libedit-3.1.20170329-h6b74fdf_2",
-                    "channel-4::readline-7.0-ha6073c6_4",
-                    "channel-4::sqlite-3.24.0-h84994c4_0",
-                    "channel-4::python-2.7.15-h1571d57_0",
-                    "channel-4::numpy-base-1.15.0-py27h7cdd4dd_0",
-                    "channel-4::numpy-1.15.0-py27h2aefc1b_0",
-                )
+    monkeypatch.setenv("CONDA_CHANNEL_PRIORITY", "True")
+    reset_context()
+
+    with get_solver_aggregate_1(tmpdir, specs) as solver:
+        final_state_1 = solver.solve_final_state()
+        pprint(convert_to_dist_str(final_state_1))
+        order = add_subdir_to_iter(
+            (
+                "channel-2::nomkl-1.0-0",
+                "channel-2::libgfortran-3.0.0-1",
+                "channel-2::openssl-1.0.2l-0",
+                "channel-2::readline-6.2-2",
+                "channel-2::sqlite-3.13.0-0",
+                "channel-2::tk-8.5.18-0",
+                "channel-2::zlib-1.2.11-0",
+                "channel-2::openblas-0.2.19-0",
+                "channel-2::python-2.7.13-0",
+                "channel-2::numpy-1.13.1-py27_nomkl_0",
             )
-            assert convert_to_dist_str(final_state_1) == order
+        )
+        assert convert_to_dist_str(final_state_1) == order
+
+    monkeypatch.setenv("CONDA_CHANNEL_PRIORITY", "False")
+    reset_context()
+
+    with get_solver_aggregate_1(tmpdir, specs) as solver:
+        final_state_1 = solver.solve_final_state()
+        pprint(convert_to_dist_str(final_state_1))
+        order = add_subdir_to_iter(
+            (
+                "channel-4::blas-1.0-openblas",
+                "channel-4::ca-certificates-2018.03.07-0",
+                "channel-2::libffi-3.2.1-1",
+                "channel-4::libgcc-ng-8.2.0-hdf63c60_0",
+                "channel-4::libgfortran-ng-7.2.0-hdf63c60_3",
+                "channel-4::libstdcxx-ng-8.2.0-hdf63c60_0",
+                "channel-2::zlib-1.2.11-0",
+                "channel-4::libopenblas-0.2.20-h9ac9557_7",
+                "channel-4::ncurses-6.1-hf484d3e_0",
+                "channel-4::nomkl-3.0-0",
+                "channel-4::openssl-1.0.2p-h14c3975_0",
+                "channel-4::tk-8.6.7-hc745277_3",
+                "channel-4::libedit-3.1.20170329-h6b74fdf_2",
+                "channel-4::readline-7.0-ha6073c6_4",
+                "channel-4::sqlite-3.24.0-h84994c4_0",
+                "channel-4::python-2.7.15-h1571d57_0",
+                "channel-4::numpy-base-1.15.0-py27h7cdd4dd_0",
+                "channel-4::numpy-1.15.0-py27h2aefc1b_0",
+            )
+        )
+        assert convert_to_dist_str(final_state_1) == order
 
 
 @pytest.mark.integration  # this test is slower, so we'll lump it into integration
@@ -3261,34 +3283,33 @@ def test_freeze_deps_1(tmpdir):
 #         assert tuple(final_state_3) == tuple(solver._index[Dist(d)] for d in order)
 
 
-def test_current_repodata_usage(tmpdir):
-    config = {
-        # force this to False, because otherwise tests
-        # fail when run with old conda-build
-        "CONDA_USE_ONLY_TAR_BZ2": False,
-        # explicitly set env var so libmamba recognizes
-        # the explicit setting (ignored otherwise)
-        "CONDA_REPODATA_FNS": "current_repodata.json",
-    }
-    with env_vars(config, stack_callback=conda_tests_ctxt_mgmt_def_pol):
-        solver = context.plugin_manager.get_solver_backend()(
-            tmpdir.strpath,
-            (Channel(CHANNEL_DIR_V1),),
-            ("win-64",),
-            specs_to_add=[MatchSpec("zlib")],
-            repodata_fn="current_repodata.json",
-        )
-        final_state = solver.solve_final_state()
-        # zlib 1.2.11, vc 14.1, vs2015_runtime, virtual package for vc track_feature
-        assert final_state
-        checked = False
-        for prec in final_state:
-            if prec.name == "zlib":
-                assert prec.version == "1.2.11"
-                assert prec.fn.endswith(".conda")
-                checked = True
-        if not checked:
-            raise ValueError("Didn't have expected state in solve (needed zlib record)")
+def test_current_repodata_usage(tmpdir, monkeypatch: MonkeyPatch):
+    # force this to False, because otherwise tests
+    # fail when run with old conda-build
+    monkeypatch.setenv("CONDA_USE_ONLY_TAR_BZ2", "False")
+    # explicitly set env var so libmamba recognizes
+    # the explicit setting (ignored otherwise)
+    monkeypatch.setenv("CONDA_REPODATA_FNS", "current_repodata.json")
+    reset_context()
+
+    solver = context.plugin_manager.get_solver_backend()(
+        tmpdir.strpath,
+        (Channel(CHANNEL_DIR_V1),),
+        ("win-64",),
+        specs_to_add=[MatchSpec("zlib")],
+        repodata_fn="current_repodata.json",
+    )
+    final_state = solver.solve_final_state()
+    # zlib 1.2.11, vc 14.1, vs2015_runtime, virtual package for vc track_feature
+    assert final_state
+    checked = False
+    for prec in final_state:
+        if prec.name == "zlib":
+            assert prec.version == "1.2.11"
+            assert prec.fn.endswith(".conda")
+            checked = True
+    if not checked:
+        raise ValueError("Didn't have expected state in solve (needed zlib record)")
 
 
 def test_current_repodata_fallback(tmpdir):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR drops all uses of `env_var` and `env_vars` contexts from `tests/core/test_solve.py`.

xref #14095

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
