### PR TITLE
Remove uses of `env_var`/`env_vars` from `tests/models/test_channel.py`

### DIFF
--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -16,7 +16,7 @@ from conda.base.context import (
 )
 from conda.common.compat import on_win
 from conda.common.configuration import YamlRawParameter
-from conda.common.io import env_unmodified, env_var, env_vars
+from conda.common.io import env_unmodified
 from conda.common.serialize import yaml_round_trip_load
 from conda.common.url import join, join_url
 from conda.gateways.disk.create import mkdir_p
@@ -589,38 +589,36 @@ def test_migrated_custom_channels(testdata: None):
     ]
 
 
-def test_local_channel(testdata: None):
+def test_local_channel(testdata: None, monkeypatch: MonkeyPatch):
     conda_bld_path = join(gettempdir(), "conda-bld")
     mkdir_p(conda_bld_path)
     try:
-        with env_var(
-            "CONDA_CROOT",
-            conda_bld_path,
-            stack_callback=conda_tests_ctxt_mgmt_def_pol,
-        ):
-            Channel._reset_state()
-            channel = Channel("local")
-            assert channel._channels[0].name.rsplit("/", 1)[-1] == "conda-bld"
-            assert channel.channel_name == "local"
-            assert channel.platform is None
-            assert channel.package_filename is None
-            assert channel.auth is None
-            assert channel.token is None
-            assert channel.scheme is None
-            assert channel.canonical_name == "local"
-            local_channel_first_subchannel = channel._channels[0].name
+        monkeypatch.setenv("CONDA_CROOT", conda_bld_path)
+        reset_context()
 
-            channel = Channel(local_channel_first_subchannel)
-            assert channel.channel_name == local_channel_first_subchannel
-            assert channel.platform is None
-            assert channel.package_filename is None
-            assert channel.auth is None
-            assert channel.token is None
-            assert channel.scheme == "file"
-            assert channel.canonical_name == "local"
+        Channel._reset_state()
+        channel = Channel("local")
+        assert channel._channels[0].name.rsplit("/", 1)[-1] == "conda-bld"
+        assert channel.channel_name == "local"
+        assert channel.platform is None
+        assert channel.package_filename is None
+        assert channel.auth is None
+        assert channel.token is None
+        assert channel.scheme is None
+        assert channel.canonical_name == "local"
+        local_channel_first_subchannel = channel._channels[0].name
 
-            assert channel.urls() == Channel(local_channel_first_subchannel).urls()
-            assert channel.urls()[0].startswith("file:///")
+        channel = Channel(local_channel_first_subchannel)
+        assert channel.channel_name == local_channel_first_subchannel
+        assert channel.platform is None
+        assert channel.package_filename is None
+        assert channel.auth is None
+        assert channel.token is None
+        assert channel.scheme == "file"
+        assert channel.canonical_name == "local"
+
+        assert channel.urls() == Channel(local_channel_first_subchannel).urls()
+        assert channel.urls()[0].startswith("file:///")
     finally:
         rm_rf(conda_bld_path)
 
@@ -728,18 +726,18 @@ def testdata2() -> None:
     Channel._reset_state()
 
 
-def test_unexpanded_variables(testdata2: None):
-    with env_var("EXPANDED_PWD", "pass44"):
-        channel = Channel("unexpanded")
-        assert channel.auth == "user1:$UNEXPANDED_PWD"
+def test_unexpanded_variables(testdata2: None, monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("EXPANDED_PWD", "pass44")
+    channel = Channel("unexpanded")
+    assert channel.auth == "user1:$UNEXPANDED_PWD"
 
 
-def test_expanded_variables(testdata2: None):
-    with env_var("EXPANDED_PWD", "pass44"):
-        channel = Channel("expanded")
-        assert channel.auth == "user33:pass44"
-        assert context.channels[0] == "http://user22:pass44@some.url:8080"
-        assert context.allowlist_channels[0] == "http://user22:pass44@some.url:8080"
+def test_expanded_variables(testdata2: None, monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("EXPANDED_PWD", "pass44")
+    channel = Channel("expanded")
+    assert channel.auth == "user33:pass44"
+    assert context.channels[0] == "http://user22:pass44@some.url:8080"
+    assert context.allowlist_channels[0] == "http://user22:pass44@some.url:8080"
 
 
 @pytest.fixture
@@ -1026,31 +1024,31 @@ def test_file_url_with_backslashes():
     ]
 
 
-def test_env_var_file_urls():
+def test_env_var_file_urls(monkeypatch: MonkeyPatch):
     channels = (
         "file://\\\\network_share\\shared_folder\\path\\conda",
         "https://some.url/ch_name",
         "file:///some/place/on/my/machine",
     )
-    with env_var("CONDA_CHANNELS", ",".join(channels)):
-        new_context = Context(())
-        assert new_context.channels == channels
+    monkeypatch.setenv("CONDA_CHANNELS", ",".join(channels))
+    new_context = Context(())
+    assert new_context.channels == channels
 
-        prioritized = prioritize_channels(new_context.channels)
-        network_share = "file://network_share/shared_folder/path/conda"
-        some_url = "https://some.url/ch_name"
-        local_path = "file:///some/place/on/my/machine"
-        assert prioritized == {
-            f"{network_share}/{context.subdir}": (network_share, 0),
-            f"{network_share}/noarch": (network_share, 0),
-            f"{some_url}/{context.subdir}": (some_url, 1),
-            f"{some_url}/noarch": (some_url, 1),
-            f"{local_path}/{context.subdir}": (local_path, 2),
-            f"{local_path}/noarch": (local_path, 2),
-        }
+    prioritized = prioritize_channels(new_context.channels)
+    network_share = "file://network_share/shared_folder/path/conda"
+    some_url = "https://some.url/ch_name"
+    local_path = "file:///some/place/on/my/machine"
+    assert prioritized == {
+        f"{network_share}/{context.subdir}": (network_share, 0),
+        f"{network_share}/noarch": (network_share, 0),
+        f"{some_url}/{context.subdir}": (some_url, 1),
+        f"{some_url}/noarch": (some_url, 1),
+        f"{local_path}/{context.subdir}": (local_path, 2),
+        f"{local_path}/noarch": (local_path, 2),
+    }
 
 
-def test_subdirs_env_var():
+def test_subdirs_env_var(monkeypatch: MonkeyPatch):
     subdirs = ("linux-highest", "linux-64", "noarch")
 
     def _channel_urls(channels=None):
@@ -1059,59 +1057,55 @@ def test_subdirs_env_var():
             for subdir in subdirs:
                 yield join_url(channel.base_url, subdir)
 
-    with env_vars(
-        {"CONDA_SUBDIRS": ",".join(subdirs)},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        c = Channel("defaults")
-        assert c.urls() == list(_channel_urls())
+    monkeypatch.setenv("CONDA_SUBDIRS", ",".join(subdirs))
+    reset_context()
 
-        c = Channel("conda-forge")
-        assert c.urls() == list(_channel_urls(("conda-forge",)))
+    c = Channel("defaults")
+    assert c.urls() == list(_channel_urls())
 
-        channels = ("bioconda", "conda-forge")
-        prioritized = prioritize_channels(channels)
-        assert prioritized == {
-            "https://conda.anaconda.org/bioconda/linux-highest": ("bioconda", 0),
-            "https://conda.anaconda.org/bioconda/linux-64": ("bioconda", 0),
-            "https://conda.anaconda.org/bioconda/noarch": ("bioconda", 0),
-            "https://conda.anaconda.org/conda-forge/linux-highest": (
-                "conda-forge",
-                1,
-            ),
-            "https://conda.anaconda.org/conda-forge/linux-64": ("conda-forge", 1),
-            "https://conda.anaconda.org/conda-forge/noarch": ("conda-forge", 1),
-        }
+    c = Channel("conda-forge")
+    assert c.urls() == list(_channel_urls(("conda-forge",)))
 
-        prioritized = prioritize_channels(channels, subdirs=("linux-again", "noarch"))
-        assert prioritized == {
-            "https://conda.anaconda.org/bioconda/linux-again": ("bioconda", 0),
-            "https://conda.anaconda.org/bioconda/noarch": ("bioconda", 0),
-            "https://conda.anaconda.org/conda-forge/linux-again": (
-                "conda-forge",
-                1,
-            ),
-            "https://conda.anaconda.org/conda-forge/noarch": ("conda-forge", 1),
-        }
+    channels = ("bioconda", "conda-forge")
+    prioritized = prioritize_channels(channels)
+    assert prioritized == {
+        "https://conda.anaconda.org/bioconda/linux-highest": ("bioconda", 0),
+        "https://conda.anaconda.org/bioconda/linux-64": ("bioconda", 0),
+        "https://conda.anaconda.org/bioconda/noarch": ("bioconda", 0),
+        "https://conda.anaconda.org/conda-forge/linux-highest": (
+            "conda-forge",
+            1,
+        ),
+        "https://conda.anaconda.org/conda-forge/linux-64": ("conda-forge", 1),
+        "https://conda.anaconda.org/conda-forge/noarch": ("conda-forge", 1),
+    }
+
+    prioritized = prioritize_channels(channels, subdirs=("linux-again", "noarch"))
+    assert prioritized == {
+        "https://conda.anaconda.org/bioconda/linux-again": ("bioconda", 0),
+        "https://conda.anaconda.org/bioconda/noarch": ("bioconda", 0),
+        "https://conda.anaconda.org/conda-forge/linux-again": (
+            "conda-forge",
+            1,
+        ),
+        "https://conda.anaconda.org/conda-forge/noarch": ("conda-forge", 1),
+    }
 
 
-def test_subdir_env_var():
-    with env_var(
-        "CONDA_SUBDIR",
-        "osx-1012-x84_64",
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        channel = Channel(
-            "https://conda.anaconda.org/msarahan/osx-1012-x84_64/clangxx_osx-1012-x86_64-10.12-h0bb54af_0.tar.bz2"
-        )
-        assert channel.base_url == "https://conda.anaconda.org/msarahan"
-        assert (
-            channel.package_filename
-            == "clangxx_osx-1012-x86_64-10.12-h0bb54af_0.tar.bz2"
-        )
-        assert (
-            channel.platform == "osx-1012-x84_64"
-        )  # the platform attribute is misnamed here in conda 4.3; conda 4.4 code can correctly use the channel.subdir attribute
+def test_subdir_env_var(monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("CONDA_SUBDIR", "osx-1012-x84_64")
+    reset_context()
+
+    channel = Channel(
+        "https://conda.anaconda.org/msarahan/osx-1012-x84_64/clangxx_osx-1012-x86_64-10.12-h0bb54af_0.tar.bz2"
+    )
+    assert channel.base_url == "https://conda.anaconda.org/msarahan"
+    assert (
+        channel.package_filename == "clangxx_osx-1012-x86_64-10.12-h0bb54af_0.tar.bz2"
+    )
+    assert (
+        channel.platform == "osx-1012-x84_64"
+    )  # the platform attribute is misnamed here in conda 4.3; conda 4.4 code can correctly use the channel.subdir attribute
 
 
 def test_regression_against_unknown_none():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR removes uses of `env_var`/`env_vars` from `tests/models/test_channel.py` and replaces them with `monkeypatch.setenv(<...>)`.

xref #14095

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
