### PR TITLE
Drop uses of `env_var`/`env_vars` contexts from `tests/core/test_initialize.py`

### DIFF
--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -14,10 +14,10 @@ import pytest
 
 from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT
 from conda.auxlib.ish import dals
-from conda.base.context import conda_tests_ctxt_mgmt_def_pol, context, reset_context
+from conda.base.context import context, reset_context
 from conda.cli.common import stdout_json
 from conda.common.compat import on_win, open_utf8
-from conda.common.io import captured, env_var, env_vars
+from conda.common.io import captured
 from conda.common.path import (
     BIN_DIRECTORY,
     get_python_short_path,
@@ -52,6 +52,8 @@ from conda.models.enums import LinkType
 from conda.testing.helpers import tempdir
 
 if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
     from conda.testing.fixtures import CondaCLIFixture
 
 CONDA_EXE = "conda.exe" if on_win else "conda"
@@ -628,14 +630,14 @@ def test__get_python_info(verbose):
     assert site_packages_dir.endswith("site-packages")
 
 
-def test_install_1(verbose):
-    with env_vars(
-        {"CONDA_DRY_RUN": "true", "CONDA_VERBOSITY": "0"},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        with tempdir() as conda_temp_prefix:
-            with captured() as c:
-                install(conda_temp_prefix)
+def test_install_1(verbose, monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("CONDA_DRY_RUN", "true")
+    monkeypatch.setenv("CONDA_VERBOSITY", "0")
+    reset_context()
+
+    with tempdir() as conda_temp_prefix:
+        with captured() as c:
+            install(conda_temp_prefix)
 
     assert "WARNING: Cannot install xonsh wrapper" in c.stderr
     if on_win:
@@ -684,28 +686,28 @@ def test_install_1(verbose):
         assert line.strip().startswith("modified"), line
 
 
-def test_initialize_dev_bash(verbose):
+def test_initialize_dev_bash(verbose, monkeypatch: MonkeyPatch):
     with pytest.raises(CondaValueError):
         initialize_dev("bash", conda_source_root=join("a", "b", "c"))
 
-    with env_vars(
-        {"CONDA_DRY_RUN": "true", "CONDA_VERBOSITY": "0"},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        with tempdir() as conda_temp_prefix:
-            new_py = abspath(join(conda_temp_prefix, get_python_short_path()))
-            mkdir_p(dirname(new_py))
-            create_link(
-                abspath(sys.executable),
-                new_py,
-                LinkType.hardlink if on_win else LinkType.softlink,
+    monkeypatch.setenv("CONDA_DRY_RUN", "true")
+    monkeypatch.setenv("CONDA_VERBOSITY", "0")
+    reset_context()
+
+    with tempdir() as conda_temp_prefix:
+        new_py = abspath(join(conda_temp_prefix, get_python_short_path()))
+        mkdir_p(dirname(new_py))
+        create_link(
+            abspath(sys.executable),
+            new_py,
+            LinkType.hardlink if on_win else LinkType.softlink,
+        )
+        with captured() as c:
+            initialize_dev(
+                "bash",
+                dev_env_prefix=conda_temp_prefix,
+                conda_source_root=CONDA_SOURCE_ROOT,
             )
-            with captured() as c:
-                initialize_dev(
-                    "bash",
-                    dev_env_prefix=conda_temp_prefix,
-                    conda_source_root=CONDA_SOURCE_ROOT,
-                )
 
     print(c.stdout)
     print(c.stderr, file=sys.stderr)
@@ -767,25 +769,25 @@ def test_initialize_dev_bash(verbose):
     assert "unset CONDA_SHLVL" in c.stdout
 
 
-def test_initialize_dev_cmd_exe(verbose):
-    with env_vars(
-        {"CONDA_DRY_RUN": "true", "CONDA_VERBOSITY": "0"},
-        stack_callback=conda_tests_ctxt_mgmt_def_pol,
-    ):
-        with tempdir() as conda_temp_prefix:
-            new_py = abspath(join(conda_temp_prefix, get_python_short_path()))
-            mkdir_p(dirname(new_py))
-            create_link(
-                abspath(sys.executable),
-                new_py,
-                LinkType.hardlink if on_win else LinkType.softlink,
+def test_initialize_dev_cmd_exe(verbose, monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("CONDA_DRY_RUN", "true")
+    monkeypatch.setenv("CONDA_VERBOSITY", "0")
+    reset_context()
+
+    with tempdir() as conda_temp_prefix:
+        new_py = abspath(join(conda_temp_prefix, get_python_short_path()))
+        mkdir_p(dirname(new_py))
+        create_link(
+            abspath(sys.executable),
+            new_py,
+            LinkType.hardlink if on_win else LinkType.softlink,
+        )
+        with captured() as c:
+            initialize_dev(
+                "cmd.exe",
+                dev_env_prefix=conda_temp_prefix,
+                conda_source_root=CONDA_SOURCE_ROOT,
             )
-            with captured() as c:
-                initialize_dev(
-                    "cmd.exe",
-                    dev_env_prefix=conda_temp_prefix,
-                    conda_source_root=CONDA_SOURCE_ROOT,
-                )
 
     print(c.stdout)
     print(c.stderr, file=sys.stderr)
@@ -1036,7 +1038,7 @@ def test_init_sh_user_windows(verbose):
 
 
 @pytest.mark.skipif(not on_win, reason="win-only test")
-def test_init_cmd_exe_registry(verbose):
+def test_init_cmd_exe_registry(verbose, monkeypatch: MonkeyPatch):
     def _read_windows_registry_mock(target_path, value=None):
         if not value:
             value = "yada\\yada\\conda_hook.bat"
@@ -1052,11 +1054,12 @@ def test_init_cmd_exe_registry(verbose):
     try:
         target_path = r"HKEY_CURRENT_USER\Software\Microsoft\Command Processor\AutoRun"
         conda_prefix = "c:\\Users\\Lars\\miniconda"
-        with env_var(
-            "CONDA_DRY_RUN", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol
-        ):
-            with captured() as c:
-                initialize.init_cmd_exe_registry(target_path, conda_prefix)
+
+        monkeypatch.setenv("CONDA_DRY_RUN", "true")
+        reset_context()
+
+        with captured() as c:
+            initialize.init_cmd_exe_registry(target_path, conda_prefix)
     finally:
         initialize._read_windows_registry = orig_read_windows_registry
         initialize.join = orig_join
@@ -1072,13 +1075,12 @@ def test_init_cmd_exe_registry(verbose):
     try:
         target_path = r"HKEY_CURRENT_USER\Software\Microsoft\Command Processor\AutoRun"
         conda_prefix = "c:\\Users\\Lars\\miniconda"
-        with env_var(
-            "CONDA_DRY_RUN", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol
-        ):
-            with captured() as c:
-                initialize.init_cmd_exe_registry(
-                    target_path, conda_prefix, reverse=True
-                )
+
+        monkeypatch.setenv("CONDA_DRY_RUN", "true")
+        reset_context()
+
+        with captured() as c:
+            initialize.init_cmd_exe_registry(target_path, conda_prefix, reverse=True)
     finally:
         initialize._read_windows_registry = orig_read_windows_registry
         initialize.join = orig_join
@@ -1328,6 +1330,7 @@ def test_add_condabin_to_path_registry(
     expected_write_calls_count,
     expected_written_path,
     expected_written_type,
+    monkeypatch: MonkeyPatch,
 ):
     conda_prefix = "C:\\Users\\test\\miniconda3"
     target_path = "HKEY_CURRENT_USER\\Environment\\PATH"
@@ -1347,20 +1350,20 @@ def test_add_condabin_to_path_registry(
 
     # --- Execute the function under test ---
     if dry_run:
-        with env_var(
-            "CONDA_DRY_RUN", "true", stack_callback=conda_tests_ctxt_mgmt_def_pol
-        ):
-            result = add_condabin_to_path_registry(
-                target_path, conda_prefix, reverse=reverse
-            )
+        monkeypatch.setenv("CONDA_DRY_RUN", "true")
+        reset_context()
+
+        result = add_condabin_to_path_registry(
+            target_path, conda_prefix, reverse=reverse
+        )
     else:
         # Ensure CONDA_DRY_RUN is not set or false for non-dry-run cases
-        with env_var(
-            "CONDA_DRY_RUN", None, stack_callback=conda_tests_ctxt_mgmt_def_pol
-        ):
-            result = add_condabin_to_path_registry(
-                target_path, conda_prefix, reverse=reverse
-            )
+        monkeypatch.setenv("CONDA_DRY_RUN", "")
+        reset_context()
+
+        result = add_condabin_to_path_registry(
+            target_path, conda_prefix, reverse=reverse
+        )
 
     # --- Assertions ---
     assert result == expected_result


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR contributes towards #14095, and removes the last few traces for `env_var` and `env_vars` in test-related files. In particular, this PR removes them from `tests/core/test_initialize.py`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
