### PR TITLE
checkout conda-build, test for missing imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -903,7 +903,7 @@ jobs:
       - name: Install conda, conda-build source code
         env:
           PIP_NO_BUILD_ISOLATION: '1'
-        run: >
+        run: |
           python -m pip install hatchling hatch-vcs
           python -m pip install -e conda -e conda-build -vv --no-deps
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -900,6 +900,9 @@ jobs:
           condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
 
+      - name: Install conda, conda-build source code
+        run: python -m pip install -e conda/ -e conda-build/  -vv --no-deps --no-build-isolation
+
       - name: Conda Install
         working-directory: conda
         run: >
@@ -913,9 +916,6 @@ jobs:
           --file ../conda-build/tests/requirements-ci.txt
           --file ../conda-build/tests/requirements-${{ runner.os }}.txt
           python=${{ matrix.python-version }}
-
-      - name: Install conda-build
-        run: python -m pip install -e conda-build/ -vv --no-deps
 
       - name: Conda Info
         run: python -m conda info --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -909,9 +909,6 @@ jobs:
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
-          --file ../conda-libmamba-solver/dev/requirements.txt
-          ${{ matrix.test-type == 'conda-libmamba-solver' && '--file ../conda-libmamba-solver/tests/requirements.txt' || '' }}
-          ${{ env.REQUIREMENTS_TRUSTSTORE }}
           python=${{ matrix.python-version }}
 
       - name: Install conda-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -850,3 +850,96 @@ jobs:
           anaconda-org-channel: conda-canary
           anaconda-org-label: ${{ env.ANACONDA_ORG_LABEL }}
           anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
+
+  # check conda-build imports
+  downstream:
+    # only run test suite if there are code changes
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell
+        shell: bash -el {0}  # bash exit immediately on error + login shell
+    strategy:
+      fail-fast: false
+      matrix:
+        # test all lower versions (w/ defaults) and upper version (w/ defaults and conda-forge)
+        python-version: ['3.13']
+        default-channel: [defaults]
+
+    steps:
+      - name: Checkout conda/conda # CONDA-LIBMAMBA-SOLVER CHANGE
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
+          path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
+
+      - name: Checkout conda/conda-build
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          repository: conda/conda-build  # CONDA-LIBMAMBA-SOLVER CHANGE
+          path: conda-build  # CONDA-LIBMAMBA-SOLVER CHANGE
+
+      - name: Hash + Timestamp
+        run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
+
+      - name: Cache Conda
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/conda_pkgs_dir
+          key: cache-${{ env.HASH }}
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
+        with:
+          # CONDA-LIBMAMBA-SOLVER CHANGE: add conda/
+          condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
+          run-post: false  # skip post cleanup
+
+      - name: Conda Install
+        working-directory: conda
+        run: >
+          conda install
+          --yes
+          --file tests/requirements.txt
+          --file tests/requirements-${{ runner.os }}.txt
+          --file tests/requirements-ci.txt
+          --file tests/requirements-s3.txt
+          --file ../conda-libmamba-solver/dev/requirements.txt
+          ${{ matrix.test-type == 'conda-libmamba-solver' && '--file ../conda-libmamba-solver/tests/requirements.txt' || '' }}
+          ${{ env.REQUIREMENTS_TRUSTSTORE }}
+          python=${{ matrix.python-version }}
+
+      - name: Install conda-build
+        run: python -m pip install -e conda-build/ -vv --no-deps
+
+      - name: Conda Info
+        run: python -m conda info --verbose
+
+      - name: Conda Config
+        run: conda config --show-sources
+
+      - name: Conda List
+        run: conda list --show-channel-urls
+
+      - name: Setup Shells
+        # for tests/shell, so only necessary for integration tests
+        if: matrix.test-type == 'integration'
+        run: sudo apt update && sudo apt install ash csh fish tcsh xonsh zsh
+
+      - name: Check conda-build tests for missing imports
+        working-directory: conda-build
+        run: python -m pytest --collect-only
+
+      - name: Upload Test Results
+        if: '!cancelled()'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-${{ env.HASH }}
+          path: |
+            conda-build/test-report.xml
+          retention-days: 1  # temporary, combined in aggregate below

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -934,5 +934,6 @@ jobs:
       - name: Check conda-build tests for missing imports
         working-directory: conda-build
         # clear warnings, only looking for test initialization failures
-        run: python -m pytest --collect-only -p no:warnings -p no:errors
-
+        run: |
+          python -c "import re, sys, pathlib; pyproject = pathlib.Path('pyproject.toml'); pyproject.write_text(re.sub('(filterwarnings.*?])', '', pyproject.read_text(), flags=re.MULTILINE |  re.DOTALL))"
+          python -m pytest --collect-only

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -921,6 +921,12 @@ jobs:
           --file ../conda-build/tests/requirements-${{ runner.os }}.txt
           python=${{ matrix.python-version }}
 
+      - name: Install conda, conda-build source code again for some reason
+        env:
+          PIP_NO_BUILD_ISOLATION: '1'
+        run: |
+          python -m pip install -e conda -e conda-build -vv --no-deps
+
       - name: Conda Info
         run: python -m conda info --verbose
 
@@ -931,7 +937,7 @@ jobs:
         run: conda list --show-channel-urls
 
       - name: Check correct conda, conda-build installed
-        run: python -c "import conda; print(conda.__file__); import conda_build; print(conda_build.__file__)"
+        run: python -c "import conda, conda_build; print(conda.__file__, conda_build.__file__)"
 
       - name: Check conda-build tests for missing imports
         working-directory: conda-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -901,7 +901,7 @@ jobs:
           run-post: false  # skip post cleanup
 
       - name: Install conda, conda-build source code
-        run: python -m pip install -e conda/ -e conda-build/  -vv --no-deps --no-build-isolation
+        run: python -m pip install hatchling hatch-vcs -e conda/ -e conda-build/  -vv --no-deps --no-build-isolation
 
       - name: Conda Install
         working-directory: conda

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -936,11 +936,3 @@ jobs:
         # clear filterwarnings, only looking for test initialization failures
         run: python -m pytest --collect-only --filterwarnings=
 
-      - name: Upload Test Results
-        if: '!cancelled()'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: test-results-${{ env.HASH }}
-          path: |
-            conda-build/test-report.xml
-          retention-days: 1  # temporary, combined in aggregate below

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -870,19 +870,19 @@ jobs:
         default-channel: [defaults]
 
     steps:
-      - name: Checkout conda/conda # CONDA-LIBMAMBA-SOLVER CHANGE
+      - name: Checkout conda/conda
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-          repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
+          repository: conda/conda
+          path: conda
 
       - name: Checkout conda/conda-build
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-          repository: conda/conda-build  # CONDA-LIBMAMBA-SOLVER CHANGE
-          path: conda-build  # CONDA-LIBMAMBA-SOLVER CHANGE
+          repository: conda/conda-build
+          path: conda-build
 
       - name: Hash + Timestamp
         run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
@@ -896,16 +896,8 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
-          # CONDA-LIBMAMBA-SOLVER CHANGE: add conda/
           condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
-
-      - name: Install conda, conda-build source code
-        env:
-          PIP_NO_BUILD_ISOLATION: '1'
-        run: |
-          python -m pip install hatchling hatch-vcs
-          python -m pip install -e conda -e conda-build -vv --no-deps
 
       - name: Conda Install
         working-directory: conda
@@ -921,11 +913,11 @@ jobs:
           --file ../conda-build/tests/requirements-${{ runner.os }}.txt
           python=${{ matrix.python-version }}
 
-      - name: Install conda, conda-build source code again for some reason
+      - name: Install conda, conda-build source code
         env:
           PIP_NO_BUILD_ISOLATION: '1'
         run: |
-          python -m pip install -e conda -e conda-build -vv --no-deps
+          python -m pip install -e conda -e conda-build -v --no-deps
 
       - name: Conda Info
         run: python -m conda info --verbose
@@ -941,7 +933,8 @@ jobs:
 
       - name: Check conda-build tests for missing imports
         working-directory: conda-build
-        run: python -m pytest --collect-only
+        # clear filterwarnings, only looking for test initialization failures
+        run: python -m pytest --collect-only --filterwarnings=
 
       - name: Upload Test Results
         if: '!cancelled()'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -909,6 +909,9 @@ jobs:
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
           --file tests/requirements-s3.txt
+          --file ../conda-build/tests/requirements.txt
+          --file ../conda-build/tests/requirements-ci.txt
+          --file ../conda-build/tests/requirements-${{ runner.os }}.txt
           python=${{ matrix.python-version }}
 
       - name: Install conda-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -933,6 +933,6 @@ jobs:
 
       - name: Check conda-build tests for missing imports
         working-directory: conda-build
-        # clear filterwarnings, only looking for test initialization failures
-        run: python -m pytest --collect-only --filterwarnings=
+        # clear warnings, only looking for test initialization failures
+        run: python -m pytest --collect-only -p no:warnings -p no:errors
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -935,5 +935,5 @@ jobs:
         working-directory: conda-build
         # clear warnings, only looking for test initialization failures
         run: |
-          python -c "import re, sys, pathlib; pyproject = pathlib.Path('pyproject.toml'); pyproject.write_text(re.sub('(filterwarnings.*?])', '', pyproject.read_text(), flags=re.MULTILINE |  re.DOTALL))"
+          python -c "import re, sys, pathlib; pyproject = pathlib.Path('pyproject.toml'); pyproject.write_text(re.sub('(filterwarnings.*?])', '', pyproject.read_text(), flags=re.MULTILINE | re.DOTALL))"
           python -m pytest --collect-only

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -884,8 +884,8 @@ jobs:
           repository: conda/conda-build
           path: conda-build
 
-      - name: Hash + Timestamp
-        run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
+      - name: Hash + Timestamp + Job
+        run: echo "HASH=${{ runner.os }}-${{ runner.arch }}-Py${{ matrix.python-version }}-${{ matrix.default-channel }}-${{ github.job }}-$(date -u "+%Y%m")" >> $GITHUB_ENV
 
       - name: Cache Conda
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -930,10 +930,8 @@ jobs:
       - name: Conda List
         run: conda list --show-channel-urls
 
-      - name: Setup Shells
-        # for tests/shell, so only necessary for integration tests
-        if: matrix.test-type == 'integration'
-        run: sudo apt update && sudo apt install ash csh fish tcsh xonsh zsh
+      - name: Check correct conda, conda-build installed
+        run: python -c "import conda; print(conda.__file__); import conda_build; print(conda_build.__file__)"
 
       - name: Check conda-build tests for missing imports
         working-directory: conda-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -901,7 +901,11 @@ jobs:
           run-post: false  # skip post cleanup
 
       - name: Install conda, conda-build source code
-        run: python -m pip install hatchling hatch-vcs -e conda/ -e conda-build/  -vv --no-deps --no-build-isolation
+        env:
+          PIP_NO_BUILD_ISOLATION: '1'
+        run: >
+          python -m pip install hatchling hatch-vcs
+          python -m pip install -e conda -e conda-build -vv --no-deps
 
       - name: Conda Install
         working-directory: conda

--- a/news/15229-conda-build-check-imports
+++ b/news/15229-conda-build-check-imports
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Check conda-build source code for missing imports in CI (#15229)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

conda sometimes removes symbols that are not detected in the conda or conda-build CI even with the deprecation schedule.

Run conda-build test discovery, which should import most of conda-build, to see if that is all working. Don't actually run the tests.

Am looking for an ImportError currently in conda-build/tests/test_published_examples.py

Without this test, we probably would have released conda 23.9 breaking conda-build.

Fix #15229 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
