### PR TITLE
Constrain conda-build >= 25.9 in next release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - truststore >=0.8.0           # [py>=310]
     - zstandard >=0.15
   run_constrained:
-    - conda-build >=3.27
+    - conda-build >=25.9
     - conda-content-trust >=0.1.1
     - conda-env >=2.6
 


### PR DESCRIPTION
Removals, renames in this conda release will constrain the minimum compatible conda-build version.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This release changes symbols used by conda-build.

See also https://github.com/conda/conda-build/pull/5790

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
