### PR TITLE
Pin conda-libmamba-solver to 25.4.0 or newer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - archspec >=0.2.3
     - boltons >=23.0.0
     - charset-normalizer
-    - conda-libmamba-solver >=24.11.0
+    - conda-libmamba-solver >=25.4.0
     - conda-package-handling >=2.2.0
     - distro >=1.5.0
     - frozendict >=2.4.2


### PR DESCRIPTION
### Description

Updating `conda` to 25.9.0 while leaving `conda-libmamba-solver` on 25.3.0 breaks the solver due to removal of `conda.common.io.Spinner` - see https://github.com/ilastik/ilastik/pull/3077

If I understand correctly, this should be prevented by `conda` pinning `conda-libmamba-solver` to the oldest version that fixes the deprecated usage, [25.4.0](https://github.com/conda/conda-libmamba-solver/releases/tag/25.4.0).

I'm not familiar with the conda repo so let me know if I did it wrong :)

### Checklist

~- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
~- [ ] Add / update necessary tests?~
~- [ ] Add / update outdated documentation?~