### PR TITLE
Bump conda-libmamba-solver from 24.11.0 to 25.4.0

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - sphinxcontrib-qthelp==1.0.6
   - sphinxcontrib-serializinghtml==1.1.9
   - tqdm>=4
-  - conda-libmamba-solver>=24.11.0
+  - conda-libmamba-solver>=25.4.0
   - pip>25
   - pip:
       - sphinxcontrib-plantuml==0.21

--- a/news/15289_Bump_conda-libmamba-solver_from_24.11.0_to_25.4.0
+++ b/news/15289_Bump_conda-libmamba-solver_from_24.11.0_to_25.4.0
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Bump conda-libmamba-solver from 24.11.0 to 25.4.0 ( #15289 )
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/15289_Bump_conda-libmamba-solver_from_24.11.0_to_25.4.0
+++ b/news/15289_Bump_conda-libmamba-solver_from_24.11.0_to_25.4.0
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Bump conda-libmamba-solver from 24.11.0 to 25.4.0 ( #15289 )
+* Require `conda-libmamba-solver >=25.4.0` (#15289)
 
 ### Deprecations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "boltons >=23.0.0",
   "charset-normalizer",
   # Disabled due to conda-libmamba-solver not being available on PyPI
-  # "conda-libmamba-solver >=24.11.0",
+  # "conda-libmamba-solver >=25.4.0",
   "conda-package-handling >=2.2.0",
   "distro >=1.5.0",
   "frozendict >=2.4.2",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - archspec >=0.2.3
     - boltons >=23.0.0
     - charset-normalizer
-    - conda-libmamba-solver >=24.11.0
+    - conda-libmamba-solver >=25.4.0
     - conda-package-handling >=2.2.0
     - distro >=1.5.0
     - frozendict >=2.4.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ archspec >=0.2.3
 boltons >=23.0.0
 charset-normalizer
 conda-content-trust >=0.2.0  # for signature verification
-conda-libmamba-solver >=24.11.0
+conda-libmamba-solver >=25.4.0
 conda-package-handling >=2.2.0
 distro >=1.5.0
 frozendict >=2.4.2


### PR DESCRIPTION

### Description

In Conda 25.9.0, some deprecated functionality that earlier versions of conda-libmamba-solver used was removed. While conda-libmamba-solver updated its logic and released 25.4.0, Conda kept the older lower bound of 24.11. As a result users could update Conda, but still get the older conda-libmamba-solver. This would lead to issues running Conda after. To fix this, bump the lower bounds of conda-libmamba-solver in Conda.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->

<hr>

Fixes https://github.com/conda/conda/issues/15287