### PR TITLE
Fix `MatchSpec` serialisation for `version=*`

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -342,6 +342,10 @@ class MatchSpec(metaclass=MatchSpecType):
                     builder.append(version)
             elif version[-2:] == ".*":
                 builder.append("=" + version[:-2])
+            # Skip wildcard-only versions, to avoid an empty "=*" in the output.
+            # See https://github.com/conda/conda/issues/14357 for more info.
+            elif version == "*":
+                pass
             elif version[-1] == "*":
                 builder.append("=" + version[:-1])
             elif version.startswith("=="):

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -242,6 +242,24 @@ def test_canonical_string_forms():
     # assert m("*/win-32::numpy-1.10-py38_0[channel=defaults]") == "defaults/win-32::numpy==1.10=py38_0"
 
 
+# Regression test for #14357
+def test_version_wildcard_serialization():
+    assert m("name[version=*,build=*py27*]") == "name[build=*py27*]"
+
+    spec = MatchSpec(name="name", version="*", build="*py27*")
+
+    assert str(spec) == "name[build=*py27*]"
+
+    assert m("name[version=*]") == "name"
+
+    assert m("conda-forge::name[version=*]") == "conda-forge::name"
+
+    assert m("name[version=1.2.*,build=*py27*]") == "name=1.2[build=*py27*]"
+    assert m("name[version=1.*]") == "name=1"
+
+    assert m("name[version=*,build_number=3]") == "name[build_number=3]"
+
+
 @pytest.mark.skip(reason="key-value features interface has been disabled in conda 4.4")
 def test_key_value_features_canonical_string_forms():
     assert (


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

When `version=*` is specified in a MatchSpec, it was being serialised with an empty `=` sign, as describef by @jaimergp in #14357. That is, `name[version=*,build=*py27*]` returned a `name=[build=*py27*]`, when it should be a `name[build=*py27*]`  instead. So we skip the wildcard-only version during serialisation since it's redundant and matches any version.

Closes #14357

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
