### PR TITLE
Make `subdirs` take precedence for `Channel` instances over `Channel.platform`

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -260,6 +260,9 @@ class Channel(metaclass=ChannelType):
         with_credentials: bool = False,
         subdirs: Iterable[str] | None = None,
     ) -> list[str]:
+        # Track whether subdirs was explicitly provided.
+        subdirs_explicit = subdirs is not None
+
         if subdirs is None:
             subdirs = context.subdirs
 
@@ -275,7 +278,10 @@ class Channel(metaclass=ChannelType):
         base = join_url(*base)
 
         def _platforms() -> Iterator[str]:
-            if self.platform:
+            # If subdirs were explicitly passed, we use them instead of self.platform.
+            if subdirs_explicit:
+                yield from subdirs
+            elif self.platform:
                 yield self.platform
                 if self.platform != "noarch":
                     yield "noarch"

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -137,6 +137,31 @@ def test_url_channel_w_platform():
         ]
 
 
+# Regression test for #14258
+def test_subdirs_kwarg_takes_precedence_over_platform():
+    """Test that an explicitly passed subdirs parameter will override the channel's platform."""
+    with env_unmodified(conda_tests_ctxt_mgmt_def_pol):
+        channel = Channel("conda-forge/linux-aarch64")
+
+        assert channel.urls() == [
+            "https://conda.anaconda.org/conda-forge/linux-aarch64",
+            "https://conda.anaconda.org/conda-forge/noarch",
+        ]
+
+        assert channel.urls(subdirs=("linux-64", "noarch")) == [
+            "https://conda.anaconda.org/conda-forge/linux-64",
+            "https://conda.anaconda.org/conda-forge/noarch",
+        ]
+        assert channel.urls(subdirs=("osx-64", "noarch")) == [
+            "https://conda.anaconda.org/conda-forge/osx-64",
+            "https://conda.anaconda.org/conda-forge/noarch",
+        ]
+
+        assert channel.urls(subdirs=("win-64",)) == [
+            "https://conda.anaconda.org/conda-forge/win-64",
+        ]
+
+
 def test_bare_channel_http():
     url = "http://conda-01"
     channel = Channel(url)

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -161,6 +161,13 @@ def test_subdirs_kwarg_takes_precedence_over_platform():
             "https://conda.anaconda.org/conda-forge/win-64",
         ]
 
+        # that that URL-based channels also work the same way
+        channel = Channel("https://repo.anaconda.com/pkgs/main/osx-64")
+        assert channel.urls(subdirs=("linux-64", "noarch")) == [
+            "https://repo.anaconda.com/pkgs/main/linux-64",
+            "https://repo.anaconda.com/pkgs/main/noarch",
+        ]
+
 
 def test_bare_channel_http():
     url = "http://conda-01"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR fixes a bug where `Channel.urls(subdirs=...)` silently ignored the `subdirs` keyword argument when instances of the `Channel` class had a `platform` defined (e.g., when created with `"conda-forge/linux-aarch64"`, for example).

I've modified the `_platforms()` helper function in `Channel.urls()` to check whether `subdirs` was explicitly provided by the user. When an explicit subdirs parameter is passed, it now takes precedence over the `self.platform` setting. The change maintains backward compatibility; as (i) calling `.urls()` without arguments continues to use `self.platform` if defined, and (ii) calling `.urls(subdirs=<...>)` with explicit `subdirs` now correctly uses those `subdirs`.

@jaimergp had the following suggestions, quoting from the issue:

> I would rearrange the code so subdirs takes precedence, or error out if both sources are defined, or at least warn that subdirs is being ignored!

I've proceeded with the first approach in this PR.

Closes #14258. Please let me know if a news entry is required – happy to add one if needed!

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
