### PR TITLE
Include `platform` in `Channel` equality and hash checks

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -348,17 +348,25 @@ class Channel(metaclass=ChannelType):
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Channel):
-            return self.location == other.location and self.name == other.name
+            return (
+                self.location == other.location
+                and self.name == other.name
+                and self.platform == other.platform
+            )
         else:
             try:
                 _other = Channel(other)
-                return self.location == _other.location and self.name == _other.name
+                return (
+                    self.location == _other.location
+                    and self.name == _other.name
+                    and self.platform == _other.platform
+                )
             except Exception as e:
                 log.debug("%r", e)
                 return False
 
     def __hash__(self) -> int:
-        return hash((self.location, self.name))
+        return hash((self.location, self.name, self.platform))
 
     def __nonzero__(self) -> bool:
         return any((self.location, self.name))


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR fixes a bug where `Channel` equality and hash checks ignored the `platform` attribute, causing channels with different platforms to be considered equal. The `__eq__()` and `__hash__()` methods now not only compare the `location` and `name`, but also include the`platform`. Hence, we have:

```python
>>> Channel("conda-forge/linux-aarch64") == Channel("conda-forge/linux-64")
False # this was previously True
```

Closes #14259

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
