### PR TITLE
Fixes a problem with `tests/env/test_create.py::test_create_advanced_pip`

### DIFF
--- a/tests/env/support/advanced-pip/env_template.yml
+++ b/tests/env/support/advanced-pip/env_template.yml
@@ -15,7 +15,7 @@ dependencies:
 
     # Install in editable mode.
     # More natural than - "--editable=git+https://github.com/neithere/argh.git#egg=argh
-    - -e git+file:///"ARGH_PATH_PLACEHOLDER#egg=argh"
+    - -e git+file://localhost:"ARGH_PATH_PLACEHOLDER#egg=argh"
 
     # You could also specify a package in a directory.
     # The directory can be relative to this environment file.


### PR DESCRIPTION
### Description

This is a small pull request to fix a broken test I discovered while reviewing this pull request in conda-libmamba-solver (that repository runs this repository's test suite):

- https://github.com/conda/conda-libmamba-solver/pull/686

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
