### PR TITLE
[POC]: Add `conda_libmamba_solver` to list of "internal" plugins

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -400,8 +400,10 @@ class CondaPluginManager(pluggy.PluginManager):
         """
         Disables all currently registered plugins except built-in conda plugins
         """
+        # treat conda plugins and conda-libmamba-solver plugins as internal plugins
+        internal_plugins = ("conda.plugins.", "conda_libmamba_solver.")
         for name, plugin in self.list_name_plugin():
-            if not name.startswith("conda.plugins.") and not self.is_blocked(name):
+            if not name.startswith(internal_plugins) and not self.is_blocked(name):
                 self.set_blocked(name)
 
     def get_subcommands(self) -> dict[str, CondaSubcommand]:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

POC showing how we could go about treating the libmamba solver as an internal plugin that cannot be disabled via `--no-plugins`.

IMO we shouldn't be hardcoding this but allowing this to be configured via condarc.

Ref: https://github.com/conda/conda/issues/14719

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
