### PR TITLE
Replace pre-commit git-diff local hook with ruff's show-fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,10 +71,9 @@ repos:
     hooks:
       # lint & attempt to correct failures (e.g. pyupgrade)
       - id: ruff-check
-        args: [--fix, --diff]
+        args: [--fix]
       # compatible replacement for black
       - id: ruff-format
-        args: [--diff]
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.15.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ exclude = [
   "tests/data/conda_format_repo",
   "tests/data/env_metadata",
 ]
+show-fixes = true
 
 [tool.ruff.lint]
 flake8-type-checking = {exempt-modules = [], strict = true}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`langauge: system` has been deprecated (it is now `language: unsupported`) but either way both of these are unsupported on the pre-commit CI.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
