### PR TITLE
fix: incorrect type in aliases parameter

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -256,7 +256,7 @@ class Context(Configuration):
     force_32bit = ParameterLoader(PrimitiveParameter(False))
     non_admin_enabled = ParameterLoader(PrimitiveParameter(True))
     prefix_data_interoperability = ParameterLoader(
-        PrimitiveParameter(False), aliases="pip_interop_enabled"
+        PrimitiveParameter(False), aliases=("pip_interop_enabled",)
     )
 
     @property


### PR DESCRIPTION
### Description

I noticed the following when reading the conda config option page: [here](https://docs.conda.io/projects/conda/en/latest/configuration.html)

```
# # prefix_data_interoperability (bool)
# #   aliases: p, i, p, _, i, n, t, e, r, o, p, _, e, n, a, b, l, e, d
# #   Enable plugins to allow conda to interact with non-conda-installed
# #   packages.
# # 
# prefix_data_interoperability: false
```

Notice the `aliases` line has treated the string `pip_interop_enabled` as a list and separated each letter with a comma.  This was clearly not the intent - this change corrects it.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
