### PR TITLE
Keep parent shell environment

### DIFF
--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -1422,6 +1422,7 @@ def _config_fish_content(conda_prefix):
         """
         # >>> conda initialize >>>
         # !! Contents within this block are managed by 'conda init' !!
+        set -g __conda_env_keep "$CONDA_PREFIX"
         if test -f %(conda_exe)s
             eval %(conda_exe)s "shell.fish" "hook" $argv | source
         else
@@ -1431,6 +1432,10 @@ def _config_fish_content(conda_prefix):
                 set -x PATH "%(conda_prefix)s/bin" $PATH
             end
         end
+        if test -n "$__conda_env_keep"
+            conda activate "$__conda_env_keep"
+        end
+        set -e __conda_env_keep
         # <<< conda initialize <<<
         """
     ) % {
@@ -1566,6 +1571,7 @@ def _config_xonsh_content(conda_prefix):
         """
     # >>> conda initialize >>>
     # !! Contents within this block are managed by 'conda init' !!
+    __conda_env_keep = $CONDA_PREFIX if 'CONDA_PREFIX' in ${{...}} else None
     if !(test -f "{conda_exe}"):
         import sys as _sys
         from types import ModuleType as _ModuleType
@@ -1576,6 +1582,9 @@ def _config_xonsh_content(conda_prefix):
                             filename="$({conda_exe} shell.xonsh hook)")
         _sys.modules["xontrib.conda"] = _mod
         del _sys, _mod, _ModuleType
+    if __conda_env_keep:
+        conda activate @(__conda_env_keep)
+    del __conda_env_keep
     # <<< conda initialize <<<
     """
     ).format(conda_exe=conda_exe)
@@ -1684,9 +1693,12 @@ def _bashrc_content(conda_prefix, shell):
             """
         # >>> conda initialize >>>
         # !! Contents within this block are managed by 'conda init' !!
+        __conda_env_keep="$CONDA_PREFIX"
         if [ -f '%(conda_exe)s' ]; then
             eval "$('%(conda_exe)s' 'shell.%(shell)s' 'hook')"
         fi
+        [ -n "$__conda_env_keep" ] && conda activate "$__conda_env_keep"
+        unset __conda_env_keep
         # <<< conda initialize <<<
         """
         ) % {
@@ -1699,10 +1711,17 @@ def _bashrc_content(conda_prefix, shell):
                 """
             # >>> conda initialize >>>
             # !! Contents within this block are managed by 'conda init' !!
+            if ( $?CONDA_PREFIX ) then
+                set __conda_env_keep="$CONDA_PREFIX"
+            endif
             if ( -f "%(conda_prefix)s/etc/profile.d/conda.csh" ) then
                 source "%(conda_prefix)s/etc/profile.d/conda.csh"
             else
                 setenv PATH "%(conda_bin)s:$PATH"
+            endif
+            if ( $?__conda_env_keep ) then
+                conda activate "$__conda_env_keep"
+                unset __conda_env_keep
             endif
             # <<< conda initialize <<<
             """
@@ -1717,6 +1736,7 @@ def _bashrc_content(conda_prefix, shell):
                 """
             # >>> conda initialize >>>
             # !! Contents within this block are managed by 'conda init' !!
+            __conda_env_keep="$CONDA_PREFIX"
             __conda_setup="$('%(conda_exe)s' 'shell.%(shell)s' 'hook' 2> /dev/null)"
             if [ $? -eq 0 ]; then
                 eval "$__conda_setup"
@@ -1728,6 +1748,8 @@ def _bashrc_content(conda_prefix, shell):
                 fi
             fi
             unset __conda_setup
+            [ -n "$__conda_env_keep" ] && conda activate "$__conda_env_keep"
+            unset __conda_env_keep
             # <<< conda initialize <<<
             """
             ) % {
@@ -2130,9 +2152,14 @@ def _powershell_profile_content(conda_prefix):
         f"""
     #region conda initialize
     # !! Contents within this block are managed by 'conda init' !!
+    $__conda_env_keep = $Env:CONDA_PREFIX
     If (Test-Path "{conda_exe}") {{
         (& "{conda_exe}" "shell.powershell" "hook") | Out-String | ?{{$_}} | Invoke-Expression
     }}
+    If ($__conda_env_keep) {{
+        conda activate "$__conda_env_keep"
+    }}
+    Remove-Variable __conda_env_keep
     #endregion
     """
     )

--- a/news/keep-parent-shell-environment
+++ b/news/keep-parent-shell-environment
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Preserve parent shell's activated conda environment when starting a new shell. The init scripts now save `CONDA_PREFIX` before initialization and reactivate the environment afterward. (#15449)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -1010,6 +1010,7 @@ def test_init_sh_user_unix(verbose):
 
             # >>> conda initialize >>>
             # !! Contents within this block are managed by 'conda init' !!
+            __conda_env_keep="$CONDA_PREFIX"
             __conda_setup="$('{prefix}/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
             if [ $? -eq 0 ]; then
                 eval "$__conda_setup"
@@ -1021,6 +1022,8 @@ def test_init_sh_user_unix(verbose):
                 fi
             fi
             unset __conda_setup
+            [ -n "$__conda_env_keep" ] && conda activate "$__conda_env_keep"
+            unset __conda_env_keep
             # <<< conda initialize <<<
 
             # . etc/profile.d/conda.sh  # commented out by conda initialize
@@ -1119,9 +1122,12 @@ def test_init_sh_user_windows(verbose):
 
             # >>> conda initialize >>>
             # !! Contents within this block are managed by 'conda init' !!
+            __conda_env_keep="$CONDA_PREFIX"
             if [ -f '{cygpath_conda_prefix}/Scripts/conda.exe' ]; then
                 eval "$('{cygpath_conda_prefix}/Scripts/conda.exe' 'shell.bash' 'hook')"
             fi
+            [ -n "$__conda_env_keep" ] && conda activate "$__conda_env_keep"
+            unset __conda_env_keep
             # <<< conda initialize <<<
 
             # . etc/profile.d/conda.sh  # commented out by conda initialize


### PR DESCRIPTION
### Description

When starting a subshell from an activated conda environment, `CONDA_PREFIX` is lost because the init script reinitializes conda without preserving the parent's state.

This causes a problem: whenever I open a new shell session from an already-activated environment (e.g., py312)—such as launching screen, tmux, or opening VS Code from the terminal—the environment is reset back to base. As a result, I must manually reactivate the environment in every new shell.

I believe the conda initialization script should detect whether an environment is already active and, if so, automatically activate the same environment in the new shell.

**Solution**: Save `CONDA_PREFIX` before conda initialization, then reactivate after setup completes.

**Shells modified**:
- Bash/Zsh/Posix (Linux/macOS/Windows MSYS)
- Csh/Tcsh
- Fish (uses `set -g` for correct scoping)
- PowerShell
- Xonsh

Example init block (bash):
```bash
# >>> conda initialize >>>
__conda_env_keep="$CONDA_PREFIX"
__conda_setup="$('/path/to/conda' 'shell.bash' 'hook' 2> /dev/null)"
if [ $? -eq 0 ]; then
    eval "$__conda_setup"
else
    # fallback logic...
fi
unset __conda_setup
[ -n "$__conda_env_keep" ] && conda activate "$__conda_env_keep"
unset __conda_env_keep
# <<< conda initialize <<<
```

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?
