### PR TITLE
Read cache preserving etag

### DIFF
--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -408,6 +408,9 @@ class RepodataState(UserDict):
     # Enforce string type on these keys
     _strings = {"mod", "etag", "cache_control", "url"}
 
+    # updated by RepodataCache.load()
+    cache_path_stat: None | os.stat_result
+
     def __init__(
         self,
         cache_path_json: Path | str = "",
@@ -421,6 +424,7 @@ class RepodataState(UserDict):
         self.cache_path_state = pathlib.Path(cache_path_state)
         # XXX may not be that useful/used compared to the full URL
         self.repodata_fn = repodata_fn
+        self.cache_path_stat = None
 
     @property
     def mod(self) -> str:
@@ -516,6 +520,37 @@ class RepodataState(UserDict):
             should_check = not self.cache_path_json.exists()
         return should_check
 
+    def is_valid_etag(self) -> bool:
+        """
+        Return True if self.cache_path_stat, loaded by RepodataCache, matches
+        our saved size and mtime.
+        """
+        json_stat = self.cache_path_stat
+        if not json_stat:
+            return False
+
+        if not (
+            self.get("mtime_ns") == json_stat.st_mtime_ns
+            and self.get("size") == json_stat.st_size
+        ):
+            return False
+
+        return True
+
+    def clear_etag(self):
+        """
+        Clear cache headers from state. Should be called when replacing the
+        cached path.
+        """
+        self.update(
+            {
+                ETAG_KEY: "",
+                LAST_MODIFIED_KEY: "",
+                CACHE_CONTROL_KEY: "",
+                "size": 0,
+            }
+        )
+
     def __contains__(self, key: str) -> bool:
         key = self._aliased.get(key, key)
         return super().__contains__(key)
@@ -575,7 +610,12 @@ class RepodataCache:
         """Out-of-band etag and other state needed by the RepoInterface."""
         return self.cache_path_json.with_suffix(CACHE_STATE_SUFFIX)
 
-    def load(self, *, state_only=False, binary=False) -> str | bytes:
+    def load(self, *, state_only=False, binary=False, clear_etag=True) -> str | bytes:
+        """
+        Load state and repodata.json with careful locking, to make sure that we
+        get a complete state_file and that the associated cached data is not
+        changed under our noses.
+        """
         # read state and repodata.json with locking
 
         # lock {CACHE_STATE_SUFFIX} file
@@ -601,33 +641,38 @@ class RepodataCache:
                     json_data = cache_path.read_text()
 
             json_stat = cache_path.stat()
-            if not (
-                state.get("mtime_ns") == json_stat.st_mtime_ns
-                and state.get("size") == json_stat.st_size
-            ):
-                # clear mod, etag, cache_control to encourage re-download
-                state.update(
-                    {
-                        ETAG_KEY: "",
-                        LAST_MODIFIED_KEY: "",
-                        CACHE_CONTROL_KEY: "",
-                        "size": 0,
-                    }
-                )
+            self.state.cache_path_stat = json_stat
+
+            # Older versions of this code always cleared the etag; instead, newer clients should
+            if clear_etag:
+                if not (
+                    state.get("mtime_ns") == json_stat.st_mtime_ns
+                    and state.get("size") == json_stat.st_size
+                ):
+                    # clear mod, etag, cache_control to encourage re-download
+                    state.update(
+                        {
+                            ETAG_KEY: "",
+                            LAST_MODIFIED_KEY: "",
+                            CACHE_CONTROL_KEY: "",
+                            "size": 0,
+                        }
+                    )
+
             # Replace data in special self.state dict subclass with key aliases
             self.state.clear()
             self.state.update(state)
 
         return json_data
 
-    def load_state(self, binary=False):
+    def load_state(self, binary=False, clear_etag=False):
         """
         Update self.state without reading repodata.
 
         Return self.state.
         """
         try:
-            self.load(state_only=True, binary=binary)
+            self.load(state_only=True, binary=binary, clear_etag=clear_etag)
         except (FileNotFoundError, json.JSONDecodeError) as e:
             if isinstance(e, json.JSONDecodeError):
                 log.warning(

--- a/news/read-cache-preserving-etag
+++ b/news/read-cache-preserving-etag
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Add methods to read cache metadata without clearing cache-control headers.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Expand on the "binary or text" cache feature.

Meant to let us avoid [directly reading cache metadata in conda-libmamba-solver](https://github.com/conda/conda-libmamba-solver/blob/main/conda_libmamba_solver/shards.py#L572).

The state should probably have a method to return the appropriate cache headers so that callers don't need to know about individual keys in that structure.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
