### PR TITLE
macOS: Fix false positive clobber error with dist-info

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -23,7 +23,7 @@ from ..auxlib.collection import first
 from ..auxlib.ish import dals
 from ..base.constants import DEFAULTS_CHANNEL_NAME, PREFIX_MAGIC_FILE, SafetyChecks
 from ..base.context import context
-from ..common.compat import ensure_text_type, on_win
+from ..common.compat import ensure_text_type, on_mac, on_win
 from ..common.io import (
     DummyExecutor,
     ThreadLimitedThreadPoolExecutor,
@@ -676,9 +676,9 @@ class UnlinkLinkTransaction:
         unlink_action_groups = prefix_action_group.unlink_action_groups
         prefix_record_groups = prefix_action_group.prefix_record_groups
 
-        lower_on_win = lambda p: p.lower() if on_win else p
+        normalize_path = lambda p: p.lower() if (on_win or on_mac) else p
         unlink_paths = {
-            lower_on_win(axn.target_short_path)
+            normalize_path(axn.target_short_path)
             for grp in unlink_action_groups
             for axn in grp.actions
             if isinstance(axn, UnlinkPathAction)
@@ -707,7 +707,7 @@ class UnlinkLinkTransaction:
                         else ()
                     )
                 for path in target_short_paths:
-                    path = lower_on_win(path)
+                    path = normalize_path(path)
                     link_paths_dict[path].append(axn)
                     if path not in unlink_paths and lexists(join(target_prefix, path)):
                         # we have a collision; at least try to figure out where it came from

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -1,7 +1,16 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
+from unittest.mock import MagicMock, create_autospec, patch
+
+import pytest
+
+from conda.common.compat import on_mac, on_win
 from conda.core import link
+from conda.core.link import PrefixActions, UnlinkLinkTransaction
+from conda.core.path_actions import CreatePrefixRecordAction, UnlinkPathAction
+from conda.exceptions import UnknownPackageClobberError
+from conda.models.enums import LinkType
 from conda.models.records import PackageRecord
 
 
@@ -214,3 +223,137 @@ def test_calculate_change_report_superseded():
     )
 
     assert change_report.superseded_precs.get("global:mypackage") is not None
+
+
+@pytest.mark.skipif(
+    not (on_win or on_mac),
+    reason="Test requires case-insensitive filesystem (Windows or macOS)",
+)
+def test_case_mismatch_no_collision_on_case_insensitive_filesystem(tmp_path):
+    """
+    Test that paths differing only in case don't cause false collisions
+    on case-insensitive filesystems.
+    """
+    target_prefix = str(tmp_path)
+    site_packages = tmp_path / "lib" / "python3.13" / "site-packages"
+    site_packages.mkdir(parents=True)
+
+    old_path = "lib/python3.13/site-packages/PyJWT-2.10.1.dist-info/INSTALLER"
+    new_path = "lib/python3.13/site-packages/pyjwt-2.10.1.dist-info/INSTALLER"
+
+    old_dist_info = site_packages / "PyJWT-2.10.1.dist-info"
+    old_dist_info.mkdir()
+    (old_dist_info / "INSTALLER").write_text("conda")
+
+    transaction_context = MagicMock()
+    old_prefix_record = MagicMock()
+    old_prefix_record.files = [old_path]
+    unlink_action = UnlinkPathAction(
+        transaction_context, old_prefix_record, target_prefix, old_path
+    )
+
+    new_package_info = MagicMock()
+    new_package_info.repodata_record.dist_str.return_value = (
+        "defaults/osx-arm64::pyjwt-2.10.1-py313hca03da5_1"
+    )
+    new_link_action = MagicMock()
+    new_link_action.target_short_path = new_path
+    new_link_action.link_type = LinkType.hardlink
+
+    create_prefix_action = create_autospec(CreatePrefixRecordAction, instance=True)
+    create_prefix_action.package_info = new_package_info
+    create_prefix_action.all_link_path_actions = [new_link_action]
+
+    prefix_action_group = PrefixActions(
+        remove_menu_action_groups=(),
+        unlink_action_groups=(MagicMock(actions=[unlink_action]),),
+        unregister_action_groups=(),
+        link_action_groups=(),
+        register_action_groups=(),
+        compile_action_groups=(),
+        make_menu_action_groups=(),
+        entry_point_action_groups=(),
+        prefix_record_groups=(MagicMock(actions=[create_prefix_action]),),
+    )
+
+    with patch("conda.core.link.PrefixData") as mock_prefix_data:
+        mock_prefix_data.return_value.iter_records.return_value = []
+        errors = UnlinkLinkTransaction._verify_prefix_level(
+            (target_prefix, prefix_action_group)
+        )
+
+    assert len(errors) == 0
+
+
+def test_legitimate_collision_still_detected(tmp_path):
+    """
+    Test that legitimate path collisions are still detected correctly.
+    """
+    target_prefix = str(tmp_path)
+    site_packages = tmp_path / "lib" / "python3.13" / "site-packages"
+    site_packages.mkdir(parents=True)
+
+    path = "lib/python3.13/site-packages/somefile.txt"
+    (site_packages / "somefile.txt").write_text("content")
+
+    new_package_info = MagicMock()
+    new_package_info.repodata_record.dist_str.return_value = (
+        "defaults/osx-arm64::somepackage-1.0.0-py313_0"
+    )
+    new_link_action = MagicMock()
+    new_link_action.target_short_path = path
+    new_link_action.link_type = LinkType.hardlink
+
+    create_prefix_action = create_autospec(CreatePrefixRecordAction, instance=True)
+    create_prefix_action.package_info = new_package_info
+    create_prefix_action.all_link_path_actions = [new_link_action]
+
+    prefix_action_group = PrefixActions(
+        remove_menu_action_groups=(),
+        unlink_action_groups=(MagicMock(actions=[]),),
+        unregister_action_groups=(),
+        link_action_groups=(),
+        register_action_groups=(),
+        compile_action_groups=(),
+        make_menu_action_groups=(),
+        entry_point_action_groups=(),
+        prefix_record_groups=(MagicMock(actions=[create_prefix_action]),),
+    )
+
+    with patch("conda.core.link.PrefixData") as mock_prefix_data:
+        mock_prefix_data.return_value.iter_records.return_value = []
+        errors = UnlinkLinkTransaction._verify_prefix_level(
+            (target_prefix, prefix_action_group)
+        )
+
+    assert len(errors) > 0
+    assert isinstance(errors[0], UnknownPackageClobberError)
+
+
+@pytest.mark.parametrize(
+    "path1,path2",
+    [
+        ("PyJWT-2.10.1.dist-info/INSTALLER", "pyjwt-2.10.1.dist-info/installer"),
+        ("SomeFile.txt", "somefile.txt"),
+        ("MIXED_CASE", "mixed_case"),
+    ],
+)
+def test_path_normalization_logic(path1, path2):
+    """
+    Test that path normalization logic works correctly.
+
+    On case-insensitive filesystems (Windows, macOS), paths that differ only
+    in case should normalize to the same value for comparison.
+    """
+    normalize_path = lambda p: p.lower() if (on_win or on_mac) else p
+
+    normalized1 = normalize_path(path1)
+    normalized2 = normalize_path(path2)
+
+    if on_win or on_mac:
+        assert normalized1 == normalized2
+        assert normalized1 == path1.lower()
+        assert normalized2 == path2.lower()
+    else:
+        assert normalized1 == path1
+        assert normalized2 == path2


### PR DESCRIPTION
### Description

Fixes #15472. Normalizes paths on macOS during prefix level link verification to prevent raising a ClobberError when the dist-info folder name had been changed between package versions. This normalization was already being done on Windows, but macOS filesystems are also not case sensitive by default.

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
