### PR TITLE
Updating `MockContext` to be more flexible (fixing broken tests)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import logging
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -298,7 +297,7 @@ def plugin_config(mocker) -> tuple[type[Configuration], str]:
             """
             Return a MagicMock object if a property cannot be found.
             """
-            return MagicMock()
+            return mocker.MagicMock()
 
         @property
         def plugins(self) -> PluginConfig:


### PR DESCRIPTION
### Description

Fixes: #15489

I think adding blanket a `__getattr__` that returns a `MagicMock` object is a good idea to prevent future breakage. Let me know if another approach would work better.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
