### PR TITLE
Fix `test_get_index_lazy` by adding explicit subdir to `PackageRecord`

### DIFF
--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -49,6 +49,7 @@ PLATFORMS = {
     ("Windows", "AMD64"): "win-64",
 }
 
+
 @pytest.fixture
 def pkg_cache_entries(mocker):
     miniconda_pkg_cache = load_cache_entries("miniconda.json")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The test was failing because `PackageRecord.subdir` defaults to the current platform when not explicitly set. This caused a mismatch when looking up packages for a different platform (e.g., running on `osx-arm64` but testing `linux-aarch64` packages).

Changes:
- Add explicit `subdir` field to sample package data
- Parameterize `test_get_index_lazy` to test both defaults and conda-forge channels separately, with sample data inline in the decorator
- Add `prepend=False` to Index constructor to only query the specified channel

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
