### PR TITLE
Simplify `get_virtual_precs()`  testing helper

### DIFF
--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -145,19 +145,7 @@ def test_no_gpu_cuda_patched(monkeypatch):
 
 
 def get_virtual_precs() -> Iterable[PackageRecord]:
-    index = conda.core.index.ReducedIndex(
-        prefix=context.default_prefix,
-        channels=context.default_channels,
-        subdirs=context.subdirs,
-        specs=(),
-        repodata_fn=context.repodata_fns[0],
-    )
-
-    yield from (
-        prec
-        for prec in index
-        if prec.channel.name == "@" and prec.name.startswith("__")
-    )
+    yield from conda.core.index.Index().system_packages.values()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Noticed we were asking for a (costly!) reduced index just to fetch the virtual packages 🤔 I don't understand why we need a reduced index, so I'm trying to see if everything works in `Index().system_packages` (which is what we use in the Solver code anyway).

This should be substantially faster. Many of the `test_virtual_packages` are in the top 20 slowest tests in `durations/Linux.json` (excluding `classic` tests):

```
('tests/test_create.py::test_conda_downgrade[libmamba]', 210.00337609756951)
('tests/test_create.py::test_channel_usage_replacing_python[libmamba]', 185.5725305342632)
('tests/test_create.py::test_strict_resolve_get_reduced_index[libmamba]', 101.416928248073)
('tests/plugins/test_transaction_hooks.py::test_transaction_hooks_invoked', 100.35200374537318)
('tests/cli/test_main_install.py::test_conda_pip_interop_dependency_satisfied_by_pip', 100.15335786291325)
('tests/plugins/test_transaction_hooks.py::test_pre_transaction_raises_exception', 87.88660357171304)
('tests/test_create.py::test_create_install_update_remove_smoketest[libmamba]', 67.73845317217005)
('tests/plugins/test_virtual_packages.py::test_subdir_override[linux-64]', 56.455603871309165)
('tests/plugins/test_virtual_packages.py::test_linux_override[1.0-True]', 56.14638817235558)
('tests/plugins/test_transaction_hooks.py::test_post_transaction_raises_exception', 53.97710087712655)
('tests/plugins/test_virtual_packages.py::test_linux_override[None-True]', 50.93012454049793)
('tests/plugins/test_virtual_packages.py::test_glibc_override[None-False]', 50.755366907713594)
('tests/plugins/test_virtual_packages.py::test_linux_value', 50.74478219695829)
('tests/plugins/test_virtual_packages.py::test_glibc_override[1.0-True]', 50.68473584918586)
('tests/plugins/test_virtual_packages.py::test_subdir_override[osx-64]', 35.61484231667408)
('tests/test_create.py::test_install_python_and_search[libmamba]', 33.96395358397417)
('tests/plugins/test_virtual_packages.py::test_osx_override[None-False]', 32.008698376875266)
('tests/plugins/test_virtual_packages.py::test_archspec_override[None-False]', 31.896993964484313)
('tests/plugins/test_virtual_packages.py::test_archspec_override[bla-True]', 31.711449150136854)
('tests/test_create.py::test_clone_env_with_conda[libmamba]', 31.597974604166968)
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
