### PR TITLE
Specify dev env prefix to update

### DIFF
--- a/dev/start
+++ b/dev/start
@@ -312,7 +312,7 @@ fi
 if updating; then
     echo "Updating ${_INSTALLER_TYPE}..."
 
-    if ! PYTHONPATH="" "${_BASEEXE}" update --yes --quiet --all > /dev/null; then
+    if ! PYTHONPATH="" "${_BASEEXE}" update --yes --quiet --all "--prefix=${_ENV}" > /dev/null; then
         echo "Error: failed to update ${_INSTALLER_TYPE}" 1>&2
         return 1
     fi

--- a/dev/start.bat
+++ b/dev/start.bat
@@ -202,7 +202,7 @@
 @IF NOT %ErrorLevel%==0 @GOTO :UP_TO_DATE
 @ECHO Updating %_INSTALLER_TYPE%...
 
-@CALL :CONDA "%_BASEEXE%" update --yes --quiet --all > NUL
+@CALL :CONDA "%_BASEEXE%" update --yes --quiet --all "--prefix=%_ENV%" > NUL
 @IF NOT %ErrorLevel%==0 (
     @ECHO Error: failed to update %_INSTALLER_TYPE% 1>&2
     @EXIT /B 1


### PR DESCRIPTION

### Description

This PR fixes the update action in the dev env setup scripts. Now when the dev env is being updated, the dev env location is specified.

Before this change I can observe this error (on linux-64)
```
$ source ./dev/start   --update 
Choose conda installer:
  1) miniconda (default - Anaconda defaults channel)
  2) miniforge (conda-forge channel)

Note: This choice can be overridden by setting the 'installer_type' key in ~/.condarc.

Enter choice [1]: 1
Deactivating 1 environment(s)...
Updating miniconda...

DirectoryNotACondaEnvironmentError: The target directory exists, but it is not a conda environment.
Use 'conda create' to convert the directory to a conda environment.
  target directory: /home/sophia/projects/conda/devenv/Linux/x86_64/envs
```

With this change, I  don't get the error and the dev env is updated and activated as expected,
```
$ source ./dev/start  --update                                     
Choose conda installer:
  1) miniconda (default - Anaconda defaults channel)
  2) miniforge (conda-forge channel)

Note: This choice can be overridden by setting the 'installer_type' key in ~/.condarc.

Enter choice [1]: 1
Updating miniconda...
Updating devenv-3.10-miniconda...
Updating shell scripts...
Initializing shell integration...
Activating devenv-3.10-miniconda...
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
