### PR TITLE
Un-skip `test_run_readonly_env` for Windows

### DIFF
--- a/tests/cli/test_main_run.py
+++ b/tests/cli/test_main_run.py
@@ -84,7 +84,7 @@ def test_run_uncaptured(
 def test_run_readonly_env(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture, request):
     with tmp_env() as prefix:
         # Remove write permissions
-        if sys.platform == "win32":
+        if on_win:
             username = os.environ.get("USERNAME")
             subprocess.run(
                 ["icacls", str(prefix), "/deny", f"{username}:W"],


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR un-skips the `test_run_readonly_env` test for `conda run` to support Windows by using [the `icacls` utility](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls) to deny and restore write permissions for the environment.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
