### PR TITLE
Remove test permissions helper function `_make_read_only`

### DIFF
--- a/tests/gateways/disk/test_delete.py
+++ b/tests/gateways/disk/test_delete.py
@@ -12,11 +12,12 @@ from conda.common.compat import on_win
 from conda.gateways.disk.create import TemporaryDirectory, create_link, mkdir_p
 from conda.gateways.disk.delete import backoff_rmdir, rm_rf
 from conda.gateways.disk.link import islink, symlink
+from conda.gateways.disk.permissions import make_read_only
 from conda.gateways.disk.test import softlink_supported
 from conda.gateways.disk.update import touch
 from conda.models.enums import LinkType
 
-from .test_permissions import _make_read_only, _try_open, tempdir
+from .test_permissions import _try_open, tempdir
 
 
 def _write_file(path, content):
@@ -31,19 +32,7 @@ def test_remove_file():
         touch(test_path)
         assert isfile(test_path)
         _try_open(test_path)
-        _make_read_only(test_path)
-        pytest.raises((IOError, OSError), _try_open, test_path)
-        assert rm_rf(test_path)
-        assert not isfile(test_path)
-
-
-def test_remove_file_to_trash():
-    with tempdir() as td:
-        test_path = join(td, "test_path")
-        touch(test_path)
-        assert isfile(test_path)
-        _try_open(test_path)
-        _make_read_only(test_path)
+        make_read_only(test_path)
         pytest.raises((IOError, OSError), _try_open, test_path)
         assert rm_rf(test_path)
         assert not isfile(test_path)

--- a/tests/gateways/disk/test_permissions.py
+++ b/tests/gateways/disk/test_permissions.py
@@ -8,9 +8,6 @@ from errno import EACCES, ENOENT, EPERM, EROFS
 from os.path import isfile, join, lexists
 from shutil import rmtree
 from stat import (
-    S_IRGRP,
-    S_IROTH,
-    S_IRUSR,
     S_IRWXG,
     S_IRWXO,
     S_IRWXU,
@@ -23,6 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
+from conda.gateways.disk.permissions import make_read_only
 from conda.gateways.disk.update import touch
 
 
@@ -50,10 +48,6 @@ def _remove_read_only(func, path, exc):
         func(path)
     else:
         pass
-
-
-def _make_read_only(path):
-    os.chmod(path, S_IRUSR | S_IRGRP | S_IROTH)
 
 
 def _can_write_file(test, content):
@@ -92,7 +86,7 @@ def test_make_writable():
         touch(test_path)
         assert isfile(test_path)
         _try_open(test_path)
-        _make_read_only(test_path)
+        make_read_only(test_path)
         pytest.raises((IOError, OSError), _try_open, test_path)
         make_writable(test_path)
         _try_open(test_path)
@@ -147,7 +141,7 @@ def test_recursive_make_writable():
         touch(test_path)
         assert isfile(test_path)
         _try_open(test_path)
-        _make_read_only(test_path)
+        make_read_only(test_path)
         pytest.raises((IOError, OSError), _try_open, test_path)
         recursive_make_writable(test_path)
         _try_open(test_path)
@@ -164,7 +158,7 @@ def test_make_executable():
         touch(test_path)
         assert isfile(test_path)
         _try_open(test_path)
-        _make_read_only(test_path)
+        make_read_only(test_path)
         assert not _can_write_file(test_path, "welcome to the ministry of silly walks")
         assert not _can_execute(test_path)
         make_executable(test_path)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This function is not really needed as we already have a `conda.gateways.disk.permissions.make_read_only` function with more or less the same functionality, so I've removed it.

Also, the tests `test_remove_file` and `test_remove_file_to_trash` had identical code, so I've deduplicated them by removing one of them.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
