### PR TITLE
Add -NoProfile to all PowerShell invocations

### DIFF
--- a/dev/start
+++ b/dev/start
@@ -279,7 +279,7 @@ if ! [ -f "${_DEVENV}/conda-meta/history" ]; then
         if [ "${_MACH}" = "Darwin" ] || [ "${_MACH}" = "Linux" ]; then
             curl -L --fail --silent --show-error "${_DOWNLOAD_URL}" -o "${_INSTALLER_FILE}"
         else
-            powershell.exe -Command "Invoke-WebRequest -Uri '${_DOWNLOAD_URL}' -OutFile '${_INSTALLER_FILE}' | Out-Null"
+            powershell.exe -NoProfile -Command "Invoke-WebRequest -Uri '${_DOWNLOAD_URL}' -OutFile '${_INSTALLER_FILE}' | Out-Null"
         fi
         if ! [ $? = 0 ] || [ ! -s "${_INSTALLER_FILE}" ]; then
             echo "Error: failed to download ${_INSTALLER_TYPE} (file missing or empty)" 1>&2

--- a/dev/start.bat
+++ b/dev/start.bat
@@ -13,7 +13,7 @@
 @IF "%~1"=="" @GOTO :ARGS_END
 
 :: convert to uppercase
-@FOR /F "usebackq delims=" %%I IN (`powershell.exe "'%~1'.toUpper()"`) DO @SET "_ARG=%%~I"
+@FOR /F "usebackq delims=" %%I IN (`powershell.exe -NoProfile -Command "'%~1'.toUpper()"`) DO @SET "_ARG=%%~I"
 
 @IF "%_ARG%"=="/P" (
     @SET "_PYTHON=%~2"
@@ -164,7 +164,7 @@
 
 @IF EXIST "%_INSTALLER_FILE%" @GOTO :DOWNLOADED
 @ECHO Downloading %_INSTALLER_TYPE%...
-@powershell.exe "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri '%_DOWNLOAD_URL%' -OutFile '%_INSTALLER_FILE%' | Out-Null"
+@powershell.exe -NoProfile -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri '%_DOWNLOAD_URL%' -OutFile '%_INSTALLER_FILE%' | Out-Null"
 @FOR %%F IN ("%_INSTALLER_FILE%") DO @IF NOT EXIST "%%F" (
     @ECHO Error: failed to download %_INSTALLER_TYPE% (file missing) 1>&2
     @EXIT /B 1
@@ -325,7 +325,7 @@
 @FINDSTR /R /C:"^devenv:" "%USERPROFILE%\.condarc" > NUL
 @IF NOT %ErrorLevel%==0 @EXIT /B 0
 :: read devenv key (with path expansion)
-@FOR /F "usebackq delims=" %%I IN (`powershell.exe "(Select-String -Path '~\.condarc' -Pattern '^devenv:\s*(.+)' | Select-Object -Last 1).Matches.Groups[1].Value -replace '^~',""$Env:UserProfile"""`) DO @SET "_DEVENV=%%~fI"
+@FOR /F "usebackq delims=" %%I IN (`powershell.exe -NoProfile -Command "(Select-String -Path '~\.condarc' -Pattern '^devenv:\s*(.+)' | Select-Object -Last 1).Matches.Groups[1].Value -replace '^~',""$Env:UserProfile"""`) DO @SET "_DEVENV=%%~fI"
 @GOTO :EOF
 
 :INSTALLER_TYPE_CONDARC
@@ -336,14 +336,14 @@
 @FINDSTR /R /C:"^installer_type:" "%USERPROFILE%\.condarc" > NUL
 @IF NOT %ErrorLevel%==0 @EXIT /B 0
 :: read installer_type key
-@FOR /F "usebackq delims=" %%I IN (`powershell.exe "(Select-String -Path '~\.condarc' -Pattern '^installer_type:\s*(.+)' | Select-Object -Last 1).Matches.Groups[1].Value"`) DO @SET "_INSTALLER_TYPE=%%I"
+@FOR /F "usebackq delims=" %%I IN (`powershell.exe -NoProfile -Command "(Select-String -Path '~\.condarc' -Pattern '^installer_type:\s*(.+)' | Select-Object -Last 1).Matches.Groups[1].Value"`) DO @SET "_INSTALLER_TYPE=%%I"
 @GOTO :EOF
 
 :UPDATING
 :: check if explicitly updating or if 24 hrs since last update
 @IF %_UPDATE%==0 @EXIT /B 0
 @IF NOT EXIST "%_UPDATED%" @EXIT /B 0
-@powershell.exe "Exit (Get-Item '"%_UPDATED%"').LastWriteTime -ge (Get-Date).AddHours(-24)"
+@powershell.exe -NoProfile -Command "Exit (Get-Item '"%_UPDATED%"').LastWriteTime -ge (Get-Date).AddHours(-24)"
 @EXIT /B %ErrorLevel%
 
 :DRYRUN


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Updated both dev/start and dev/start.bat scripts to include the -NoProfile flag in all PowerShell commands. This ensures a consistent and clean PowerShell environment, avoiding potential issues from user profile scripts.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
