### PR TITLE
Switch automation workflows to ubuntu-slim runners

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,7 +15,7 @@ jobs:
         && github.event.comment.body == '@conda-bot check'
         || github.event_name == 'pull_request_target'
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check CLA
         uses: conda/actions/check-cla@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -20,7 +20,7 @@ jobs:
       !github.event.repository.fork
       && !github.event.issue.pull_request
       && contains(github.event.issue.labels.*.name, 'pending::feedback')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       # remove [pending::feedback]
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   sync:
     if: '!github.event.repository.fork'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       GLOBAL: https://raw.githubusercontent.com/conda/infra/main/.github/global.yml
       LOCAL: .github/labels.yml

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   lock:
     if: '!github.event.repository.fork'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
         with:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   add_to_project:
     if: '!github.event.repository.fork'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   stale:
     if: '!github.event.repository.fork'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       matrix:
         include:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,7 +28,7 @@ jobs:
           )
         )
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - if: github.event_name == 'issue_comment'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0


### PR DESCRIPTION
## Summary

- Switch 7 automation workflows to use the new `ubuntu-slim` runners
- These 1 vCPU Linux runners are lower cost and optimized for automation tasks

Mirrors conda/infrastructure#1275

DO NOT MERGE!

## Test plan

- [ ] Verify automation workflows run successfully with the new runners

