### PR TITLE
Add `PackageRecord.key` and `PackageRecord.stem`

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -685,9 +685,7 @@ class ProgressiveFetchExtract:
                 size=pcrec_from_read_only_cache.get("size") or size,
                 md5=pcrec_from_read_only_cache.get("md5") or md5,
             )
-            trgt_extracted_dirname = strip_pkg_extension(pcrec_from_read_only_cache.fn)[
-                0
-            ]
+            trgt_extracted_dirname = pcrec_from_read_only_cache.stem
             extract_action = ExtractPackageAction(
                 source_full_path=cache_action.target_full_path,
                 target_pkgs_dir=first_writable_cache.pkgs_dir,
@@ -716,7 +714,7 @@ class ProgressiveFetchExtract:
         extract_action = ExtractPackageAction(
             source_full_path=cache_action.target_full_path,
             target_pkgs_dir=first_writable_cache.pkgs_dir,
-            target_extracted_dirname=strip_pkg_extension(pref_or_spec.fn)[0],
+            target_extracted_dirname=pref_or_spec.stem,
             record_or_spec=pref_or_spec,
             sha256=sha256,
             size=size,

--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -33,7 +33,7 @@ from ..base.context import context, locate_prefix_by_name
 from ..common.compat import on_mac, on_win
 from ..common.constants import NULL
 from ..common.io import time_recorder
-from ..common.path import expand, paths_equal, strip_pkg_extension
+from ..common.path import expand, paths_equal
 from ..common.serialize import json
 from ..common.url import mask_anaconda_token
 from ..common.url import remove_auth as url_remove_auth
@@ -484,16 +484,13 @@ class PrefixData(metaclass=PrefixDataType):
         return self.interoperability
 
     def _get_json_fn(self, prefix_record: PrefixRecord) -> str:
+        # Pip interop: .dist-info packages
         fn = prefix_record.fn
-        # Check package extensions (dynamic) or .dist-info (pip-installed)
-        stripped, ext = strip_pkg_extension(fn)
-        if not ext and fn.endswith(".dist-info"):
-            stripped = fn[: -len(".dist-info")]
-        elif not ext:
-            raise ValueError(
-                f"Attempted to make prefix record for unknown package type: {fn}"
-            )
-        return stripped + ".json"
+        if fn.endswith(".dist-info"):
+            return fn[: -len(".dist-info")] + ".json"
+
+        # Regular packages: use stem (key/fn stripped of extension)
+        return prefix_record.stem + ".json"
 
     def insert(self, prefix_record: PrefixRecord, remove_auth: bool = True) -> None:
         if prefix_record.name in self._prefix_records:

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -690,8 +690,17 @@ class SubdirData(metaclass=SubdirDataType):
 
                 # lazy
                 # package_record = PackageRecord(**info)
-                info["fn"] = fn
-                info["url"] = join_url(base_url_w_credentials, fn)
+                # Store the repodata dict key
+                info["key"] = fn
+
+                # Preserve fn from entry if present, otherwise fall back to key
+                if "fn" not in info:
+                    info["fn"] = fn
+
+                # Preserve url from entry if present, otherwise construct from fn
+                if "url" not in info:
+                    info["url"] = join_url(base_url_w_credentials, info["fn"])
+
                 _package_records.append(info)
                 record_index = len(_package_records) - 1
                 _names_index[info["name"]].append(record_index)

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -33,6 +33,7 @@ from ..auxlib.entity import (
 )
 from ..base.context import context
 from ..common.compat import isiterable
+from ..common.path import strip_pkg_extension
 from ..deprecations import deprecated
 from ..exceptions import PathNotFoundError
 from .channel import Channel
@@ -306,6 +307,24 @@ class PackageRecord(DictSafeMixin, Entity):
     Only part of the :attr:`_pkey` if :ref:`separate_format_cache <auto-config-reference>`
     is ``true`` (default: ``false``).
     """
+
+    key = StringField(
+        default=None, required=False, nullable=True, default_in_dump=False
+    )
+    """The repodata dictionary key for this package (internal use).
+
+    For traditional conda packages, this equals the filename.
+    For wheel packages in repodata v3, this may differ from the filename.
+    """
+
+    @property
+    def stem(self) -> str:
+        """The base name for extracted package directory, conda-meta JSON, etc.
+
+        This is the key with any package extension removed.
+        """
+        key = self.key if self.key else self.fn
+        return strip_pkg_extension(key)[0]
 
     md5 = StringField(
         default=None, required=False, nullable=True, default_in_dump=False


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #15620

This PR separates the concept of **repodata package key** from **filename** in `PackageRecord`, enabling proper support for non-conda packages (e.g., wheels in repodata v3) where the package filename doesn't follow the `{name}-{version}-{build_string}` naming convention.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
