### PR TITLE
Use epic ID and GraphQL to link sub-issues

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -37,6 +37,8 @@ env:
     Windows
   GH_TOKEN: ${{ secrets.AUTO_REPORT_TEST_FAILURE }}
   ISSUE_TEMPLATE: |
+    <!-- test_name: ${TEST_NAME} -->
+
     [slow-tests.yml]: ${WORKFLOW_URL}
 
     ## Slow Test Review
@@ -94,6 +96,7 @@ jobs:
 
           # GraphQL query to fetch sub-issues with pagination
           # (gh CLI doesn't expose sub-issue linking yet: https://github.com/cli/cli/issues/10298)
+          incomplete_count=0
           fetch_sub_issues() {
             local cursor=""
             local has_next="true"
@@ -107,7 +110,7 @@ jobs:
                   repository(owner: $owner, name: $repo) {
                     issue(number: $number) {
                       subIssues(first: 100'"$after_clause"') {
-                        nodes { number state title }
+                        nodes { number state body }
                         pageInfo { hasNextPage endCursor }
                       }
                     }
@@ -115,32 +118,31 @@ jobs:
                 }
               ' -f owner="${REPO_OWNER}" -f repo="${REPO_NAME}" -F number="${EPIC_NUMBER}")
 
-              # jq: extract sub-issues as tab-separated values (number, state, title)
-              echo "$response" | jq -r '
+              # jq: extract sub-issues as tab-separated values (number, state, test_name)
+              while IFS=$'\t' read -r number state test_name; do
+                # Only count sub-issues with our anchor (ignore manually linked)
+                [[ -z "$test_name" ]] && continue
+                [[ "$state" == "OPEN" ]] && ((++incomplete_count))
+                echo "#${number} [${state}] \`${test_name}\`"
+                echo "$test_name" >> /tmp/tracked_tests.txt
+              done < <(echo "$response" | jq -r '
                 .data.repository.issue.subIssues.nodes[] |
-                "\(.number)\t\(.state)\t\(.title)"
-              '
+                (.body | capture("<!-- test_name: (?<test>.+) -->") | .test) as $test |
+                "\(.number)\t\(.state)\t\($test // "")"
+              ')
 
               has_next=$(echo "$response" | jq -r '.data.repository.issue.subIssues.pageInfo.hasNextPage')
               cursor=$(echo "$response" | jq -r '.data.repository.issue.subIssues.pageInfo.endCursor')
             done
           }
 
-          fetch_sub_issues > /tmp/sub_issues.txt
+          echo "::group::Sub-issue details"
+          fetch_sub_issues
+          echo "::endgroup::"
 
-          # Count total and incomplete sub-issues
-          total_count=$(wc -l < /tmp/sub_issues.txt 2>/dev/null) || total_count=0
-          incomplete_count=$(grep -c $'\tOPEN\t' /tmp/sub_issues.txt 2>/dev/null) || incomplete_count=0
+          # Count total and report incomplete sub-issues count
+          total_count=$(wc -l < /tmp/tracked_tests.txt 2>/dev/null) || total_count=0
           echo "Sub-issues: ${total_count} total, ${incomplete_count} incomplete"
-
-          if [[ -s /tmp/sub_issues.txt ]]; then
-            echo "::group::Sub-issue details"
-            cat /tmp/sub_issues.txt
-            echo "::endgroup::"
-          fi
-
-          # Extract test names from sub-issue titles (format: "Review slow test: `<test_name>`")
-          cut -f3 /tmp/sub_issues.txt | sed 's/^Review slow test: `\(.*\)`$/\1/' > /tmp/tracked_tests.txt || true
           echo "incomplete_count=${incomplete_count}" >> "$GITHUB_OUTPUT"
 
       - name: Fetch duration files


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Followup to #15659

`slow-tests.yml` workflow works perfectly for dry-run (https://github.com/conda/conda/actions/runs/21594484853) but fails for actual runs (https://github.com/conda/conda/actions/runs/21594760449) because `gh` CLI doesn't support issue linking so we need to use GraphQL instead.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
