### PR TITLE
Remove osx-64 (Intel Mac) from canary builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -788,8 +788,6 @@ jobs:
             subdir: linux-64
           - runs-on: ubuntu-24.04-arm
             subdir: linux-aarch64
-          - runs-on: macos-15-intel
-            subdir: osx-64
           - runs-on: macos-latest
             subdir: osx-arm64
           - runs-on: windows-latest


### PR DESCRIPTION
## Summary

Remove Intel Mac (osx-64) from canary builds as it's no longer supported.

## Details

The canary build for `macos-15-intel` has been failing. Intel Mac support is being phased out.

See failed run: https://github.com/conda/conda/actions/runs/21705632541/job/62607033157