### PR TITLE
Support windows env creation from non-windows OSes

### DIFF
--- a/conda/common/path/python.py
+++ b/conda/common/path/python.py
@@ -8,8 +8,6 @@ import re
 from logging import getLogger
 from os.path import join, split, splitext
 
-from ..compat import on_win
-
 log = getLogger(__name__)
 
 
@@ -49,18 +47,26 @@ def parse_entry_point_def(ep_definition):
     return command, module, func
 
 
-def get_python_short_path(python_version=None):
-    if on_win:
+def get_python_short_path(python_version=None, subdir=None):
+    from conda.base.context import context
+
+    if subdir is None:
+        subdir = context.subdir
+    if subdir.startswith("win-"):
         return "python.exe"
     if python_version and "." not in python_version:
         python_version = ".".join(python_version)
     return join("bin", "python%s" % (python_version or ""))
 
 
-def get_python_site_packages_short_path(python_version):
+def get_python_site_packages_short_path(python_version, subdir=None):
+    from conda.base.context import context
+
+    if subdir is None:
+        subdir = context.subdir
     if python_version is None:
         return None
-    elif on_win:
+    elif subdir.startswith("win-"):
         return "Lib/site-packages"
     else:
         py_ver = get_major_minor_version(python_version)

--- a/news/15690-create-windows-env-unix
+++ b/news/15690-create-windows-env-unix
@@ -1,0 +1,22 @@
+### Enhancements
+
+* Support creating windows environments in other operating systems. This
+  fixes creating python entry points for windows from unixes by using
+  the stub executable even on other operating systems if the subdir is
+  windows. (#15690)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -541,28 +541,43 @@ def test_conda_update_package_is_not_name_only_spec(
             conda_cli("update", f"--prefix={prefix}", "conda-forge::*")
 
 
+@pytest.mark.parametrize("subdir", ["linux-64", "osx-64", "win-64"])
 def test_noarch_python_package_with_entry_points(
-    tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
+    tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture, subdir: str
 ):
     """
     Makes sure that entry point file is installed.
 
     This test uses "pygments" as a Python package because it has no other dependencies and has an
     entry point script, "pygmentize".
+
+    Note: win-arm64 is not tested because conda/shell/cli-arm64.exe does not exist yet
     """
-    with tmp_env("pygments") as prefix:
+    extra = []
+    if subdir.startswith("linux-") and not context.subdir.startswith("linux-"):
+        # ncurses package on defaults require a case sensitive file system
+        extra.extend(["-c", "conda-forge"])
+    elif subdir == "win-arm64":
+        # win-arm64 not on defaults yet
+        extra.extend(["-c", "conda-forge"])
+
+    with tmp_env("pygments", "--subdir", subdir, *extra) as prefix:
         py_ver = get_major_minor_version(PrefixData(prefix).get("python", None).version)
-        sp_dir = get_python_site_packages_short_path(py_ver)
+        sp_dir = get_python_site_packages_short_path(py_ver, subdir)
         py_file = sp_dir + "/pygments/__init__.py"
         pyc_file = pyc_path(py_file, py_ver)
         assert (prefix / py_file).is_file()
-        assert (prefix / pyc_file).is_file()
-        exe_path = (
-            prefix / BIN_DIRECTORY / ("pygmentize.exe" if on_win else "pygmentize")
-        )
+
+        if subdir.startswith("win-"):
+            exe_path = prefix / "Scripts" / "pygmentize.exe"
+        else:
+            exe_path = prefix / "bin" / "pygmentize"
         assert exe_path.is_file()
-        output = check_output([exe_path, "--help"], text=True)
-        assert "usage: pygmentize" in output
+
+        if subdir == context.subdir:
+            assert (prefix / pyc_file).is_file()
+            output = check_output([exe_path, "--help"], text=True)
+            assert "usage: pygmentize" in output
 
         conda_cli("remove", f"--prefix={prefix}", "pygments", "--yes")
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->

* Support creating windows environments in other operating systems. This
  fixes creating python entry points for windows from unixes by using
  the stub executable even on other operating systems if the subdir is
  windows. (#15690)
