### PR TITLE
Don't use https for test sign metadata url

### DIFF
--- a/tests/trust/test_signature_verification.py
+++ b/tests/trust/test_signature_verification.py
@@ -353,7 +353,7 @@ def test_signature_verification(
 
     # enable signature verification
     monkeypatch.setenv("CONDA_EXTRA_SAFETY_CHECKS", "true")
-    monkeypatch.setenv("CONDA_SIGNING_METADATA_URL_BASE", url := "https://example.com")
+    monkeypatch.setenv("CONDA_SIGNING_METADATA_URL_BASE", url := "http://example.com")
     reset_context()
     assert context.extra_safety_checks
     assert context.signing_metadata_url_base == url


### PR DESCRIPTION
### Description

This PR fixes the `test_signature_verification` tests. I think the simplest fix is to use the `http://example.com` endpoint instead of `https://example.com`. This doesn't change the integrity of the tests and avoids the https certificate verification.


They are currently failing on the main branch:

```
$ python -m pytest tests/trust/test_signature_verification.py::test_signature_verification

FAILED tests/trust/test_signature_verification.py::test_signature_verification[first.tar.bz2-True] - requests.exceptions.ConnectionError: HTTPSConnectionPool(host='test.example.com', port=443): Max retries exceeded with url: /key_mgr.json (Caused by NameResolutionError("HTTPSConnection(host='test.example.com', port=443): Failed to resolve 'test.example.com' ([Errno -2] Name or service not known)"))
. . .
```

## A few notes

### Looking into if there is an issue with the example.com certs

Checking the certs on example.com, they are valid:
```
 curl -vI https://example.com/key.json
*   Trying 104.18.27.120:443...
* Connected to example.com (104.18.27.120) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
. . .
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=example.com
*  start date: Feb 13 18:53:48 2026 GMT
*  expire date: May 14 18:57:50 2026 GMT
*  subjectAltName: host "example.com" matched cert's "example.com"
*  issuer: C=US; O=SSL Corporation; CN=Cloudflare TLS Issuing ECC CA 3
*  SSL certificate verify ok.
. . .
HTTP/2 200 
< date: Mon, 16 Feb 2026 18:24:39 GMT
date: Mon, 16 Feb 2026 18:24:39 GMT
...
```
Notice this certificate was recently updated `start date: Feb 13 18:53:48 2026 GMT`.

However, conda includes the following headers in it's these types of requests
```
{'Accept-Encoding': 'gzip, deflate, compress, identity', 'Content-Type': 'application/json'}
```

Trying to manually curl with these headers does produce an error:
```
$ curl -v -H "Accept-Encoding: gzip, deflate, compress, identity" -H 'Content-Type: application/json' https://example.com

...
* TLSv1.2 (IN), TLS header, Supplemental data (23):
Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
* Failure writing output to destination
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
* stopped the pause stream!
* Connection #0 to host example.com left intact
```

### Is this a bug in the tests/conda

I don't think this is a bug with the tests. For example, you can use a different `https` url
```
diff --git a/tests/trust/test_signature_verification.py b/tests/trust/test_signature_verification.py
index e6b4c3067..7a36406e6 100644
--- a/tests/trust/test_signature_verification.py
+++ b/tests/trust/test_signature_verification.py
@@ -353,7 +353,7 @@ def test_signature_verification(
 
     # enable signature verification
     monkeypatch.setenv("CONDA_EXTRA_SAFETY_CHECKS", "true")
-    monkeypatch.setenv("CONDA_SIGNING_METADATA_URL_BASE", url := "https://example.com")
+    monkeypatch.setenv("CONDA_SIGNING_METADATA_URL_BASE", url := "https://github.com")
     reset_context()
     assert context.extra_safety_checks
     assert context.signing_metadata_url_base == url
```

This also fixes the tests.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~~[ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~~
- [x] Add / update necessary tests?
- ~~[ ] Add / update outdated documentation?~~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
