### PR TITLE
Add Gen AI and Contribution Schemes policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The [Conda Code of Conduct](https://github.com/conda/conda/blob/main/CODE_OF_CON
 
 ## Paid Contribution Schemes
 
-While we support open source contributors receiving financial compensation, we do not accept contributions motivated by crypto payments, bounties, or similar gamification schemes. These systems incentivize low-quality, high-volume contributions that waste limited maintainer time.
+While we support open source contributors receiving financial compensation, we do not accept contributions motivated by cryptocurrency payments, bounties, or similar gamification schemes. These systems incentivize low-quality, high-volume contributions that waste limited maintainer time.
 
 If you would like to add conda to such a system, or believe your situation warrants an exception, please reach out ahead of time on [Zulip](https://conda.zulipchat.com).
 


### PR DESCRIPTION
### Description

We have recently received PRs that caused extra work for the maintainers including:

1. AI doing code reviews in #15722
2. Gittensor.io PRs in #15666, #15663, #15662, #15596, and #15587

I think being explicit about our Gen AI Policy and other schemes helps contributors know what we value and helps us stay consistent and not waste time. This is proposed wording, but completely open to change it. Once this is agreed to, I think we should follow it up with PR template changes for declaring how AI was used.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [X] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
