### PR TITLE
fix: use IEC binary prefixes (KiB, MiB, GiB) in human_bytes()

### DIFF
--- a/conda/utils.py
+++ b/conda/utils.py
@@ -64,28 +64,29 @@ def human_bytes(n):
     """
     Return the number of bytes n in more human readable form.
 
-    Note: Uses SI prefixes (KB, MB, GB) instead of binary prefixes (KiB, MiB, GiB).
+    Uses IEC binary prefixes (KiB, MiB, GiB) since the calculation
+    uses base-2 (powers of 1024).
 
     Examples:
         >>> human_bytes(42)
         '42 B'
         >>> human_bytes(1042)
-        '1 KB'
+        '1 KiB'
         >>> human_bytes(10004242)
-        '9.5 MB'
+        '9.5 MiB'
         >>> human_bytes(100000004242)
-        '93.13 GB'
+        '93.13 GiB'
     """
     if n < 1024:
         return "%d B" % n
     k = n / 1024
     if k < 1024:
-        return "%d KB" % round(k)
+        return "%d KiB" % round(k)
     m = k / 1024
     if m < 1024:
-        return f"{m:.1f} MB"
+        return f"{m:.1f} MiB"
     g = m / 1024
-    return f"{g:.2f} GB"
+    return f"{g:.2f} GiB"
 
 
 # ##########################################

--- a/news/12263-iec-byte-units
+++ b/news/12263-iec-byte-units
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Use IEC binary prefixes (KiB, MiB, GiB) instead of incorrect SI-like prefixes (KB, MB, GB) in `human_bytes()`, since the calculation uses base-2 (powers of 1024). (#12263)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
## Summary

Update `human_bytes()` to use IEC binary prefixes (KiB, MiB, GiB) instead of incorrect SI-like prefixes (KB, MB, GB).

Fixes #12263

## Rationale

The `human_bytes()` function divides by 1024 (base-2), but was displaying SI prefixes (KB, MB, GB) which are defined as base-10 (powers of 1000). The IEC binary prefixes (KiB, MiB, GiB) are the correct units for base-2 calculations.

| Before | After | Meaning |
|--------|-------|---------|
| KB | KiB | 1024 bytes |
| MB | MiB | 1024² bytes |
| GB | GiB | 1024³ bytes |

## Changes

- Updated unit strings in `conda/utils.py::human_bytes()`
- Updated docstring and doctests to reflect new unit names
- Added news fragment