### PR TITLE
Demo: Environment spec plugin api refactor

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -24,6 +24,7 @@ from ..common.io import swallow_broken_pipe
 from ..common.path import expand, paths_equal
 from ..deprecations import deprecated
 from ..exceptions import (
+    CondaError,
     EnvironmentFileNotFound,
     EnvironmentFileTypeMismatchError,
     InvalidSpec,
@@ -298,11 +299,14 @@ def validate_environment_files_consistency(files: list[str]) -> None:
     if not files or len(files) <= 1:
         return  # Nothing to validate if there are 0 or 1 files
 
+    def get_env_spec_plugin_name(f):
+        try:
+            return context.plugin_manager.get_environment_specifier2(f).name
+        except CondaError:
+            return context.plugin_manager.get_environment_specifier(f).name
+
     # Get types for all files using the plugin manager
-    file_types = {
-        file: context.plugin_manager.get_environment_specifier(file).name
-        for file in files
-    }
+    file_types = {file: get_env_spec_plugin_name(file) for file in files}
     # If there's more than one unique type, raise an error
     if len(set(file_types.values())) > 1:
         raise EnvironmentFileTypeMismatchError(file_types)

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -622,6 +622,12 @@ def add_parser_environment_specifier(p: ArgumentParser) -> None:
     from ..base.context import context
     from ..common.constants import NULL
 
+    def choices_func():
+        return (
+            context.plugin_manager.get_environment_specifiers()
+            | context.plugin_manager.get_environment_specifiers2()
+        )
+
     p.add_argument(
         "--environment-specifier",
         "--env-spec",  # for brevity
@@ -639,7 +645,7 @@ def add_parser_environment_specifier(p: ArgumentParser) -> None:
         "--format",
         dest="environment_specifier",
         action=LazyChoicesAction,
-        choices_func=context.plugin_manager.get_environment_specifiers,
+        choices_func=choices_func,
         default=NULL,
         help=(
             "Format for the created environment. If not specified, "

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -118,12 +118,10 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     else:
         filename = abspath(expanduser(expandvars(args.file)))
 
-    spec_hook = context.plugin_manager.get_environment_specifier(
+    env = context.plugin_manager.get_environment(
         source=filename,
         name=context.environment_specifier,
     )
-    spec = spec_hook.environment_spec(filename)
-    env = spec.env
 
     active_pkgs = prefix_data.map_records()
     specification_pkgs = (

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -116,16 +116,15 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     validate_file_exists(args.file)
 
     # detect the file format and get the env representation
-    spec_hook = context.plugin_manager.get_environment_specifier(
+    spec_hook = context.plugin_manager.get_environment_specifier2(
         source=args.file,
         name=context.environment_specifier,
     )
-    spec = spec_hook.environment_spec(args.file)
-    if context.subdir not in spec.available_platforms:
+    if context.subdir not in spec_hook.available_platforms:
         raise PlatformMismatchError(
-            [(args.file, spec.available_platforms)], context.subdir
+            [(args.file, spec_hook.available_platforms)], context.subdir
         )
-    env = spec.env_for(context.subdir)
+    env = spec_hook.env_for(context.subdir)
 
     # FIXME conda code currently requires args to have a name or prefix
     # don't overwrite name if it's given. gh-254

--- a/conda/cli/main_env_update.py
+++ b/conda/cli/main_env_update.py
@@ -93,15 +93,15 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     validate_file_exists(args.file)
 
     # detect the file format and get the env representation
-    spec_hook = context.plugin_manager.get_environment(
-        source=args.file, name=context.environment_specifier
+    spec_hook = context.plugin_manager.get_environment_specifier2(
+        source=args.file,
+        name=context.environment_specifier,
     )
-    spec = spec_hook.environment_spec(args.file)
-    if context.subdir not in spec.available_platforms:
+    if context.subdir not in spec_hook.available_platforms:
         raise PlatformMismatchError(
-            [(args.file, spec.available_platforms)], context.subdir
+            [(args.file, spec_hook.available_platforms)], context.subdir
         )
-    env = spec.env_for(context.subdir)
+    env = spec_hook.env_for(context.subdir)
 
     if not (args.name or args.prefix):
         if not env.name:

--- a/conda/cli/main_env_update.py
+++ b/conda/cli/main_env_update.py
@@ -93,9 +93,8 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     validate_file_exists(args.file)
 
     # detect the file format and get the env representation
-    spec_hook = context.plugin_manager.get_environment_specifier(
-        source=args.file,
-        name=context.environment_specifier,
+    spec_hook = context.plugin_manager.get_environment(
+        source=args.file, name=context.environment_specifier
     )
     spec = spec_hook.environment_spec(args.file)
     if context.subdir not in spec.available_platforms:

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -13,10 +13,11 @@ from concurrent.futures import Executor, Future, ThreadPoolExecutor, as_complete
 from contextlib import contextmanager
 from enum import Enum
 from errno import EPIPE, ESHUTDOWN
-from functools import partial, wraps
+from functools import lru_cache, partial, wraps
 from io import BytesIO, StringIO
 from logging import CRITICAL, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
+from pathlib import Path
 from threading import Lock
 from time import time
 from typing import TYPE_CHECKING
@@ -35,9 +36,33 @@ from ..deprecations import deprecated
 from .compat import encode_environment, on_win
 from .constants import NULL
 from .path import expand
+from .url import is_url, urlparse
 
 log = getLogger(__name__)
 IS_INTERACTIVE = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+@lru_cache(maxsize=128)
+def load_file(filename: str) -> str:
+    """Load and return a string from a given file"""
+    from ..exceptions import CondaFileIOError
+    from ..gateways.connection.download import download_text
+    from ..gateways.connection.session import CONDA_SESSION_SCHEMES
+
+    if is_url(filename) and urlparse(filename).scheme in CONDA_SESSION_SCHEMES:
+        file_contents = download_text(filename)
+    elif not os.path.exists(filename):
+        raise CondaFileIOError(
+            filepath=filename,
+            message="File does not exist on disk",
+        )
+    else:
+        file_path = Path(filename)
+        try:
+            file_contents = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            file_contents = file_path.read_text(encoding="utf-16")
+    return file_contents
 
 
 class DeltaSecondsFormatter(Formatter):

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -717,6 +717,65 @@ class CondaSpecs:
         yield from ()
 
     @_hookspec
+    def conda_environment_specifiers2(self) -> Iterable[CondaEnvironmentSpecifier]:
+        """
+        Register new conda env spec type
+
+        The example below defines a type of conda env file called "random". It
+        can parse a file with the file extension `.random`. This plugin will ignore
+        whatever is in the input environment file and produce an environment with a
+        random name and with random packages.
+
+        **Example:**
+
+        .. code-block:: python
+
+            import json
+            import random
+            from pathlib import Path
+            from subprocess import run
+            from conda import plugins
+            from conda.env.env import Environment
+
+            packages = ["python", "numpy", "scipy", "matplotlib", "pandas", "scikit-learn"]
+
+
+            def validate(data: str):
+                # Return early if no filename was provided
+                if filename is None:
+                    return False
+
+                # Extract the file extension (e.g., '.txt' or '' if no extension)
+                file_ext = os.path.splitext(filename)[1]
+
+                # Check if the file has a supported extension and exists
+                return any(
+                    spec_ext == file_ext and os.path.exists(filename)
+                    for spec_ext in RandomSpec.extensions
+                )
+
+
+            def env(data: str):
+                return Environment(
+                    name="".join(random.choice("0123456789abcdef") for i in range(6)),
+                    dependencies=[random.choice(packages) for i in range(6)],
+                )
+
+
+            @plugins.hookimpl
+            def conda_environment_specifiers():
+                yield plugins.CondaEnvSpec(
+                    name="random",
+                    detection_supported=True,
+                    validate=validate,
+                    env=env,
+                    aliases=("rnd",),
+                    default_filenames=("*.random",),
+                )
+        """
+        yield from ()
+
+    @_hookspec
     def conda_environment_exporters(self) -> Iterable[CondaEnvironmentExporter]:
         """
         Register new conda environment exporter

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -30,6 +30,7 @@ from ..common.io import dashlist, load_file
 from ..common.iterators import groupby_to_dict
 from ..exceptions import (
     AmbiguousEnvironmentSpecPlugin,
+    CondaError,
     CondaValueError,
     EnvironmentExporterNotDetected,
     EnvironmentSpecPluginNotDetected,
@@ -1050,7 +1051,7 @@ class CondaPluginManager(pluggy.PluginManager):
         Raises EnvironmentSpecPluginNotDetected if no plugins were found.
         Raises CondaValueError if the requested plugin is not available.
 
-        :param filename: full path to the environment spec file/source
+        :param source: full path to the environment spec file/source
         :param name: name of the environment plugin to load
         :returns: an environment specifier plugin that matches the provided plugin name, or can handle the provided file
         """
@@ -1064,9 +1065,21 @@ class CondaPluginManager(pluggy.PluginManager):
         source: str,
         name: str | None = None,
     ) -> Environment:
+        """
+        Gets the environment from the CondaEnvironmentSpecifier or CondaEnvironmentSpecifier2 apis.
+
+        :param source: full path to the environment spec file/source
+        :param name: name of the environment plugin to load
+        :returns: an environment from a plugin that matches the provided plugin name, or can handle the provided file
+        """
         data = load_file(source)
-        plugin = self.get_environment_specifier2(source, name)
-        return plugin.env(data)
+        try:
+            plugin = self.get_environment_specifier2(source, name)
+            return plugin.env(data)
+        except CondaError:
+            spec_hook = self.get_environment_specifier(source, name)
+            spec = spec_hook.environment_spec(source)
+            return spec.env
 
     def get_environment_exporters(self) -> Iterable[CondaEnvironmentExporter]:
         """

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, overload
 
 import pluggy
 
-from ..auxlib import NULL
+from ..auxlib import NULL, dals
 from ..base.constants import APP_NAME, DEFAULT_CONSOLE_REPORTER_BACKEND
 from ..base.context import context
 from ..common.io import dashlist, load_file
@@ -1060,6 +1060,7 @@ class CondaPluginManager(pluggy.PluginManager):
         else:
             return self.get_environment_specifier2_by_name(source=source, name=name)
 
+    # TODO: should this be falling back to the old plugin format?
     def get_environment(
         self,
         source: str,

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -1064,8 +1064,8 @@ class CondaPluginManager(pluggy.PluginManager):
         source: str,
         name: str | None = None,
     ) -> Environment:
-        plugin = self.get_environment_specifier2(source, name)
         data = load_file(source)
+        plugin = self.get_environment_specifier2(source, name)
         return plugin.env(data)
 
     def get_environment_exporters(self) -> Iterable[CondaEnvironmentExporter]:

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -26,7 +26,7 @@ import pluggy
 from ..auxlib import NULL
 from ..base.constants import APP_NAME, DEFAULT_CONSOLE_REPORTER_BACKEND
 from ..base.context import context
-from ..common.io import dashlist
+from ..common.io import dashlist, load_file
 from ..common.iterators import groupby_to_dict
 from ..exceptions import (
     AmbiguousEnvironmentSpecPlugin,
@@ -61,12 +61,14 @@ if TYPE_CHECKING:
     from ..common.path import PathType
     from ..core.path_actions import Action
     from ..core.solve import Solver
+    from ..models.environment import Environment
     from ..models.match_spec import MatchSpec
     from ..models.records import PackageRecord
     from .types import (
         CondaAuthHandler,
         CondaEnvironmentExporter,
         CondaEnvironmentSpecifier,
+        CondaEnvironmentSpecifier2,
         CondaHealthCheck,
         CondaPackageExtractor,
         CondaPlugin,
@@ -835,6 +837,236 @@ class CondaPluginManager(pluggy.PluginManager):
             return self.detect_environment_specifier(source)
         else:
             return self.get_environment_specifier_by_name(source=source, name=name)
+
+    def get_environment_specifiers2(
+        self, *, supports_detection: bool | None = None, with_aliases: bool = True
+    ) -> dict[str, CondaEnvironmentSpecifier2]:
+        """
+         Returns a mapping from environment specifier v2 name to environment specifier v2.
+
+         :param supports_detection: ternary value that returns either everything, only supporting
+                                    detection or not supporting detection.
+        :param with_aliases: whether to include aliased values of environment specifiers.
+        """
+        if supports_detection is None:
+            env_spec_hooks = [
+                h for h in self.get_hook_results("environment_specifiers2")
+            ]
+        else:
+            env_spec_hooks = [
+                h
+                for h in self.get_hook_results("environment_specifiers2")
+                if h.detection_supported == supports_detection
+            ]
+
+        if not with_aliases:
+            return {hook.name: hook for hook in env_spec_hooks}
+
+        try:
+            return self._get_name_and_alias_mapping(env_spec_hooks)
+        except PluginError as err:
+            raise PluginError(
+                f"Plugin name conflicts detected in environment specifiers.\n{err}"
+            )
+
+    def get_environment_specifier2_by_name(
+        self,
+        source: str,
+        name: str,
+    ) -> CondaEnvironmentSpecifier2:
+        """Get an environment specifier v2 plugin by name
+
+        :param source: full path to the environment spec file/source
+        :param name: name of the environment plugin to load
+        :raises CondaValueError: if the requested plugin is not available.
+        :raises PluginError: if the requested plugin is unable to handle the provided file.
+        :returns: an environment specifier plugin that matches the provided plugin name, or can handle the provided file
+        """
+        name = name.lower().strip()
+        plugins = self.get_environment_specifiers2()
+
+        try:
+            plugin = plugins[name]
+        except KeyError:
+            raise CondaValueError(
+                f"You have chosen an unrecognized environment"
+                f" specifier type ({name}). Choose one of: "
+                f"{dashlist(plugins)}"
+            )
+        else:
+            data = load_file(source)
+            # Try to load the plugin and check if it can handle the environment spec
+            try:
+                if plugin.validate(data):
+                    return plugin
+            except Exception as e:
+                raise PluginError(
+                    dals(
+                        f"""
+                        An error occurred when handling '{source}' with plugin '{name}'.
+
+                        {type(e).__name__}: {e}
+                        """
+                    )
+                )
+            else:
+                # If the plugin was not able to handle the environment spec, raise an error
+                raise PluginError(
+                    f"Requested plugin '{name}' is unable to handle environment spec '{source}'"
+                )
+
+    def _detect_filename_env_spec2(
+        self,
+        source: str,
+        basename: str,
+        hooks: dict[str, CondaEnvironmentSpecifier2],
+    ) -> list[CondaEnvironmentSpecifier2]:
+        """Detect environment specifier v2 by filename pattern matching.
+
+        :param basename: basename of the source file
+        :param hooks: mapping of environment specifier plugins
+        :returns: list of matching plugins, or None if no filename matches
+        """
+        found = [
+            hook
+            for hook_name, hook in hooks.items()
+            if hook.default_filenames
+            and any(
+                fnmatch.fnmatch(basename, pattern) for pattern in hook.default_filenames
+            )
+        ]
+
+        if len(found) > 1:
+            raise PluginError(
+                f"Too many plugins found that can handle the environment file '{source}'.\n\n"
+                "Try using --env-spec=<spec-name> to more exactly specify the environment spec\n"
+                "parser you want to use.\n\n"
+                "Available env specs:\n"
+                f"{dashlist(self.get_environment_specifiers2())}"
+            )
+
+        if len(found) == 1:
+            data = load_file(source)
+            try:
+                if found[0].validate(data):
+                    return found
+            except Exception as e:
+                raise PluginError(
+                    f"Failed to parse environment specification from file: {e}"
+                ) from e
+
+        return found
+
+    @staticmethod
+    def _detect_content_env_spec2(
+        source: str,
+        hooks: dict[str, CondaEnvironmentSpecifier2],
+    ) -> list[CondaEnvironmentSpecifier2]:
+        """Detect environment specifier v2 by content-based autodetection.
+
+        :param source: full path to the environment spec file or source
+        :param hooks: mapping of environment specifier plugins
+        :returns: tuple of (found plugins, autodetect disabled plugin names)
+        """
+        found = []
+        data = load_file(source)
+        for hook_name, hook in hooks.items():
+            log.debug("EnvironmentSpec hook: checking %s", hook_name)
+            try:
+                if hook.validate(data):
+                    log.debug(
+                        "EnvironmentSpec hook: %s can be %s",
+                        source,
+                        hook_name,
+                    )
+                    found.append(hook)
+            except Exception:
+                pass
+
+        return found
+
+    def detect_environment_specifier2(self, source: str) -> CondaEnvironmentSpecifier2:
+        """Detect the environment specifier v2 plugin for a given spec source
+
+        Uses two-phase detection:
+        1. Filename-based filtering using fnmatch patterns
+        2. Fallback to content-based autodetection (can_handle())
+
+        Raises PluginError if more than one environment_spec plugin is found to be able to handle the file.
+        Raises EnvironmentSpecPluginNotDetected if no plugins were found.
+
+        :param source: full path to the environment spec file or source
+        :returns: an environment specifier plugin that can handle the provided file
+        """
+        hooks = self.get_environment_specifiers2(
+            supports_detection=True, with_aliases=False
+        )
+        basename = os.path.basename(source)
+
+        # Filename detection
+        found = self._detect_filename_env_spec2(source, basename, hooks)
+
+        if len(found) == 0:
+            # Filename matching didn't find anything; try content based detection
+            found = self._detect_content_env_spec2(source, hooks)
+
+            if len(found) > 1:
+                raise PluginError(
+                    f"Too many plugins found that can handle the environment file '{source}'.\n\n"
+                    "Try using --env-spec=<spec-name> to more exactly specify the environment spec\n"
+                    "parser you want to use.\n\n"
+                    "Available env specs:\n"
+                    f"{dashlist(self.get_environment_specifiers2())}"
+                )
+
+        if len(found) == 1:
+            return found[0]
+
+        # HACK: if there was no plugin found, try to catch all `environment.yml` plugin
+        # FUTURE: Remove this final try at using the environment.yml to read the environment
+        # file. This should be removed in "26.9" when the deprecations warning for
+        # environment.yml's that are not compliant with cep-0024 are removed.
+        try:
+            return self.get_environment_specifier2_by_name(
+                source=source, name="environment.yml"
+            )
+        except (PluginError, CondaValueError) as exc:
+            # raise error if no plugins found that can read the environment file
+            raise EnvironmentSpecPluginNotDetected(
+                name=source,
+                plugin_names=hooks,
+                autodetect_disabled_plugins=self.get_environment_specifiers2(
+                    supports_detection=False
+                ),
+            ) from exc
+
+    def get_environment_specifier2(
+        self,
+        source: str,
+        name: str | None = None,
+    ) -> CondaEnvironmentSpecifier2:
+        """Get the environment specifier v2 plugin for a given spec source, or given a plugin name
+        Raises PluginError if more than one environment_spec plugin is found to be able to handle the file.
+        Raises EnvironmentSpecPluginNotDetected if no plugins were found.
+        Raises CondaValueError if the requested plugin is not available.
+
+        :param filename: full path to the environment spec file/source
+        :param name: name of the environment plugin to load
+        :returns: an environment specifier plugin that matches the provided plugin name, or can handle the provided file
+        """
+        if not name:
+            return self.detect_environment_specifier2(source)
+        else:
+            return self.get_environment_specifier2_by_name(source=source, name=name)
+
+    def get_environment(
+        self,
+        source: str,
+        name: str | None = None,
+    ) -> Environment:
+        plugin = self.get_environment_specifier2(source, name)
+        data = load_file(source)
+        return plugin.env(data)
 
     def get_environment_exporters(self) -> Iterable[CondaEnvironmentExporter]:
         """

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -736,6 +736,8 @@ class CondaEnvironmentSpecifier2(CondaPlugin):
         requesting it as a cli argument or setting in .condarc. By default, autodetection is enabled.
     :param env: callable that parses the file and returns an Environment object
     :param validate: callable that determines if the plugin can handle a given file based on the file content
+    :param description: user-friendly description of what the format does. Defaults to the name if not provided.
+    :param environment_format: EnvironmentFormat category. Defaults to EnvironmentFormat.environment.
     """
 
     name: str
@@ -744,6 +746,42 @@ class CondaEnvironmentSpecifier2(CondaPlugin):
     aliases: tuple[str, ...] = field(default_factory=tuple)
     default_filenames: tuple[str, ...] = field(default_factory=tuple)
     detection_supported: bool = True
+    description: str | None = field(default=None)
+    environment_format: EnvironmentFormat = field(default=EnvironmentFormat.environment)
+
+    @property
+    def available_platforms(self) -> tuple[str, ...]:
+        """
+        Platforms this spec can produce an ``Environment`` for.
+
+        Defaults to ``(context.subdir,)``. Multi-platform specs
+        (``conda-lock.yml``, ``pixi.lock``) override to return every
+        platform declared in the input file.
+        """
+        from ..base.context import context
+
+        return (context.subdir,)
+
+    def env_for(self, platform: str) -> Environment:
+        """
+        Return the ``Environment`` for a specific platform.
+
+        Defaults to returning :attr:`env` when ``platform`` matches
+        ``context.subdir``, and raising :class:`ValueError` otherwise.
+        Multi-platform specs override this method to build the
+        ``Environment`` directly from the parsed input file without
+        constructing one per platform.
+
+        To iterate every platform a spec covers::
+
+            envs = (spec.env_for(p) for p in spec.available_platforms)
+        """
+        if platform not in self.available_platforms:
+            raise ValueError(
+                f"Platform {platform!r} not available in this spec. "
+                f"Available platforms: {', '.join(self.available_platforms)}"
+            )
+        return self.env
 
     def __post_init__(self):
         super().__post_init__()  # Handle name normalization

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -721,6 +721,43 @@ class CondaEnvironmentSpecifier(CondaPlugin):
 
 
 @dataclass
+class CondaEnvironmentSpecifier2(CondaPlugin):
+    """
+    Return type to use when defining a conda env spec plugin hook (v2).
+
+    For details on how this is used, see
+    :meth:`~conda.plugins.hookspec.CondaSpecs.conda_environment_specifiers2`.
+
+    :param name: name of the spec (e.g., ``environment_yaml``)
+    :param aliases: user-friendly format aliases (e.g., ("yaml",)). Defaults to an empty list.
+    :param default_filenames: default filename patterns this specifier handles (e.g., ("environment.yml", "*.conda-lock.yml"))
+    :param detection_supported: boolean that determines if the plugin should be included in the set of available plugins
+        checked during environment_spec plugin detection. If False, the only way to use the plugin will be through explicitly
+        requesting it as a cli argument or setting in .condarc. By default, autodetection is enabled.
+    :param env: callable that parses the file and returns an Environment object
+    :param validate: callable that determines if the plugin can handle a given file based on the file content
+    """
+
+    name: str
+    env: Callable[[str], Environment]
+    validate: Callable[[str], bool]
+    aliases: tuple[str, ...] = field(default_factory=tuple)
+    default_filenames: tuple[str, ...] = field(default_factory=tuple)
+    detection_supported: bool = True
+
+    def __post_init__(self):
+        super().__post_init__()  # Handle name normalization
+        # Normalize aliases using same pattern as name normalization
+        try:
+            self.aliases = tuple(
+                dict.fromkeys(alias.lower().strip() for alias in self.aliases)
+            )
+        except AttributeError:
+            # AttributeError: alias is not a string
+            raise PluginError(f"Invalid plugin aliases for {self!r}")
+
+
+@dataclass
 class CondaEnvironmentExporter(CondaPlugin):
     """
     **EXPERIMENTAL**


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description


This demo is an alternative approach to https://github.com/conda/conda/pull/15490.

It brings the form of the environment spec plugins closer to export plugins. In that, the `CondaEnvironmentSpecifier` dataclass becomes:

```python
@dataclass
class CondaEnvironmentSpecifier2
    name: str
    validate: Callable[[str], bool]
    env: Callable[[str], Environment]
    detection_supported: bool
```

I think this implies a clearer way to extend functionality and puts the style of this plugin more in line with other existing plugins.

This demo also applies the suggested api changes from https://github.com/conda/conda/pull/15490. That is, passing the contents of the environment spec file to plugins. And caching the results of reading from the environment spec file.

Additional key changes:
* Stop accepting filename in the validation function. Plugins should only be validating on file contents. The function signature can become `validate: Callable[[str], bool]`
* raise errors instead of returning `false` in validate functions. This allows for passing back more information to conda when validation for a plugin fails. Conda can use this information to provide more feedback in case of errors.

Things that are missing from this demo:
* if this approach is acccepted, I think its probably a good option to deprecate the `conda.env.specs` module
* will require a change in conda-lockfiles
 
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
