### PR TITLE
Clear SIGALRM in finally block in timeout() function

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -389,10 +389,11 @@ def timeout(timeout_secs, func, *args, default_return=None, **kwargs):
 
         try:
             ret = func(*args, **kwargs)
-            signal.alarm(0)
             return ret
         except (TimeoutException, KeyboardInterrupt):  # pragma: no cover
             return default_return
+        finally:
+            signal.alarm(0)
 
 
 # use this for debugging, because ProcessPoolExecutor isn't pdb/ipdb friendly

--- a/news/15702-fix-timeout-signal-alarm-cleanup
+++ b/news/15702-fix-timeout-signal-alarm-cleanup
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Clear SIGALRM in ``finally`` block in ``timeout()`` function to prevent the alarm from firing unexpectedly when the wrapped function raises an unexpected exception.


### PR DESCRIPTION
Fixes #15702

### Description

The `timeout()` function in `conda/common/io.py` sets a SIGALRM signal before running a wrapped function, but only cleared the alarm if the function returned normally. If the function raised an unexpected exception (e.g., `SSLError`, `SSLEOFError`), the alarm remained set and could fire at an arbitrary later time, causing a `TimeoutException` to interrupt unrelated code.

This fix moves the `signal.alarm(0)` call to a `finally` block, ensuring the alarm is always cleared regardless of how the function exits (normal return, expected exception, or unexpected exception).

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

```
 conda/common/io.py                          | 3 ++-
 news/15702-fix-timeout-signal-alarm-cleanup | 3 +++
 2 files changed, 5 insertions(+), 1 deletion(-)
```