### PR TITLE
Use default python setting

### DIFF
--- a/dev/start
+++ b/dev/start
@@ -168,7 +168,7 @@ if [ -z "${_INSTALLER_TYPE}" ]; then
 fi
 
 # fallback to default values if not set
-_PYTHON="${_PYTHON:-3.10}"
+_PYTHON="${_PYTHON:-${_DEFAULT_PYTHON}}"
 _INSTALLER_TYPE="${_INSTALLER_TYPE:-${_DEFAULT_INSTALLER}}"
 _DEVENV="${_DEVENV:-${_DEFAULT_DEVENV}}"
 # $ uname -sm


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The `./dev/start` script has a default python defined, as suggested in the help
```
(base) sophia:conda/ (default-python-dev-env) $ source ./dev/start --help                                                                                                                                              Usage: source ./dev/start [options]

Options:
  -p, --python    VERSION    Python version for the env to activate. (default: 3.10)
```

This is pulled from the `_DEFAULT_PYTHON` variable. We should fall back to this value instead of hardcoding it here.



### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template]~(https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
