### PR TITLE
Improve `CondaSubcommand` typing

### DIFF
--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -14,7 +14,7 @@ import os
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from requests.auth import AuthBase
 
@@ -74,7 +74,7 @@ class CondaPlugin:
             raise PluginError(f"Invalid plugin name for {self!r}")
 
 
-@dataclass
+@dataclass(init=False)
 class CondaSubcommand(CondaPlugin):
     """
     Return type to use when defining a conda subcommand plugin hook.
@@ -82,19 +82,56 @@ class CondaSubcommand(CondaPlugin):
     For details on how this is used, see
     :meth:`~conda.plugins.hookspec.CondaSpecs.conda_subcommands`.
 
+    Subcommands support two shapes, distinguished by ``configure_parser``:
+
+    * If ``configure_parser`` is set, ``action`` receives the parsed
+      :class:`argparse.Namespace`.
+    * If ``configure_parser`` is omitted, ``action`` receives the remaining
+      argv as :class:`tuple[str, ...]`.
+
     :param name: Subcommand name (e.g., ``conda my-subcommand-name``).
     :param summary: Subcommand summary, will be shown in ``conda --help``.
     :param action: Callable that will be run when the subcommand is invoked.
     :param configure_parser: Callable that will be run when the subcommand parser is initialized.
     """
 
-    name: str
     summary: str
-    action: Callable[
-        [Namespace | tuple[str]],  # arguments
-        int | None,  # return code
-    ]
+    action: Callable[[Namespace], int | None] | Callable[[tuple[str, ...]], int | None]
     configure_parser: Callable[[ArgumentParser], None] | None = field(default=None)
+
+    @overload
+    def __init__(
+        self,
+        *,
+        name: str,
+        summary: str,
+        action: Callable[[Namespace], int | None],
+        configure_parser: Callable[[ArgumentParser], None],
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        name: str,
+        summary: str,
+        action: Callable[[tuple[str, ...]], int | None],
+        configure_parser: None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        summary: str,
+        action: Callable[[Namespace], int | None]
+        | Callable[[tuple[str, ...]], int | None],
+        configure_parser: Callable[[ArgumentParser], None] | None = None,
+    ) -> None:
+        super().__init__(name=name)
+        self.summary = summary
+        self.action = action
+        self.configure_parser = configure_parser
 
 
 @dataclass


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fix args typing (`tuple[str, ...]` not `tuple[str]`). Implement overloads to clearly show that:
- defined `configure_parser` means `args` is a `Namespace`
- undefined `configure_parser` means `args` is the raw tuple of strings

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
