### PR TITLE
Use stdlib json instead of requests.compat.json

### DIFF
--- a/conda/common/serialize/json.py
+++ b/conda/common/serialize/json.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import json
+import json  # noqa: TID251
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, overload

--- a/news/fix-stdlib-json
+++ b/news/fix-stdlib-json
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Use stdlib `json` instead of `requests.compat.json` in `conda.common.serialize.json`, avoiding the transitive import of `requests`, `urllib3`, `cryptography`, and ~120 other modules during context initialization. (#15838)
+* Improve initialization time by using stdlib `json` instead of `requests.compat.json` in `conda.common.serialize.json`, avoiding many transitive imports. (#15838)
 
 ### Bug fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,9 +231,6 @@ select = [
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]
-"conda/common/serialize/json.py" = [
-  "TID251",  # this file IS the json wrapper; it must import stdlib json
-]
 "conda/testing/*" = [
   "S101",  # forbid assert
 ]


### PR DESCRIPTION
### Description

Replace `from requests.compat import json` with `import json` in `conda/common/serialize/json.py`.

The `requests.compat` module is a Python 2-era compatibility shim whose JSON handling does:

```python
try:
    import simplejson as json
except ImportError:
    import json
```

Since `simplejson` is never installed in conda environments, this always resolves to stdlib `json`. But importing `requests.compat` to get there also unconditionally loads `urllib3`, `chardet`/`charset_normalizer`, and a chain of ~120 other modules — all to end up with the same `json` module we could import directly.

```
requests (67) → urllib3 (29) → cryptography (30) → charset_normalizer (9) → email.* (15)
```

Measured impact (hyperfine, Python 3.13):

| Phase | Before | After | Saved |
|---|---|---|---|
| Context init time | 109 ms | 52 ms | −57 ms |
| Modules at context ready | 389 | 209 | −180 |

The saving is most significant for commands that skip plugin loading (e.g., `conda activate` with deferred plugin hooks), where it contributes to a 4.4× overall speedup. For commands that trigger full plugin loading, `requests` is re-loaded via plugin entry points — the full benefit requires combining this fix with deferred plugin discovery (future PR).

> **Note on CodSpeed results:** CodSpeed reports no performance change because the existing benchmarks measure command execution, not process startup. The import savings happen before any benchmark function runs. #15850 adds startup benchmarks that would track this.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
      No behavioral change — `simplejson` is not present in conda environments and `requests.compat.json` always resolves to stdlib `json`. All existing tests cover this path unchanged.
- [ ] ~Add / update outdated documentation?~
      Not applicable — internal import change with no user-facing API impact.