### PR TITLE
Use stdlib json instead of requests.compat.json

### DIFF
--- a/conda/common/serialize/json.py
+++ b/conda/common/serialize/json.py
@@ -4,14 +4,12 @@
 
 from __future__ import annotations
 
+import json  # noqa: TID251
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
 from frozendict import frozendict
-
-# detect the best json library to use
-from requests.compat import json
 
 if TYPE_CHECKING:
     from io import IO

--- a/news/fix-stdlib-json
+++ b/news/fix-stdlib-json
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Improve initialization time by using stdlib `json` instead of `requests.compat.json` in `conda.common.serialize.json`, avoiding many transitive imports. (#15838)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Re-applies #15849, which was reverted in #15865 to allow the startup benchmarks (#15850) to establish a CodSpeed baseline first.

Replace `from requests.compat import json` with `import json` in `conda/common/serialize/json.py`.

The `requests.compat` module is a Python 2-era compatibility shim whose JSON handling does:

```python
try:
    import simplejson as json
except ImportError:
    import json
```

Since `simplejson` is never installed in conda environments, this always resolves to stdlib `json`. But importing `requests.compat` to get there also unconditionally loads `urllib3`, `chardet`/`charset_normalizer`, and a chain of ~120 other modules — all to end up with the same `json` module we could import directly.

```
requests (67) → urllib3 (29) → cryptography (30) → charset_normalizer (9) → email.* (15)
```

Measured impact (hyperfine, Python 3.13):

| Phase                    | Before | After | Saved  |
| ------------------------ | ------ | ----- | ------ |
| Context init time        | 109 ms | 52 ms | −57 ms |
| Modules at context ready | 389    | 209   | −180   |

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] ~Add / update necessary tests?~
  No behavioral change — `simplejson` is not present in conda environments and `requests.compat.json` always resolves to stdlib `json`. All existing tests cover this path unchanged.
- [x] ~Add / update outdated documentation?~
  Not applicable — internal import change with no user-facing API impact.