### PR TITLE
Lazy subcommand parser loading (A2/A3)

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -404,11 +404,29 @@ class _LazyParserMap(dict):
         super().__init__()
         self._action = action
 
+    @property
+    def _ready(self):
+        """True once the owning action is initialized and not mid-build."""
+        action = self._action
+        return hasattr(action, "_lazy_loaders") and not getattr(
+            action, "_building", False
+        )
+
     def _resolve(self, key):
         """Ensure *key* is fully loaded (builtin or plugin)."""
+        if not self._ready:
+            return
         self._action._ensure_loaded(key)
         if not super().__contains__(key):
             self._action._ensure_plugins_loaded()
+
+    def _resolve_all(self):
+        """Load every lazy subcommand and all plugins."""
+        if not self._ready:
+            return
+        for name in list(self._action._lazy_loaders):
+            self._action._ensure_loaded(name)
+        self._action._ensure_plugins_loaded()
 
     def __getitem__(self, key):
         self._resolve(key)
@@ -421,6 +439,26 @@ class _LazyParserMap(dict):
     def __contains__(self, key):
         self._resolve(key)
         return super().__contains__(key)
+
+    def items(self):
+        self._resolve_all()
+        return super().items()
+
+    def values(self):
+        self._resolve_all()
+        return super().values()
+
+    def keys(self):
+        self._resolve_all()
+        return super().keys()
+
+    def __iter__(self):
+        self._resolve_all()
+        return super().__iter__()
+
+    def __len__(self):
+        self._resolve_all()
+        return super().__len__()
 
 
 class _LazySubParsersAction(_GreedySubParsersAction):
@@ -437,17 +475,21 @@ class _LazySubParsersAction(_GreedySubParsersAction):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._name_parser_map = _LazyParserMap(self)
-        # choices is the same dict object in argparse's _SubParsersAction
         self.choices = self._name_parser_map
         self._lazy_loaders: dict[str, tuple[str, dict]] = {}
         self._lazy_aliases: dict[str, str] = {}
         self._loading_name: str | None = None
         self._plugins_loaded = False
+        self._building = False
 
     def add_lazy_subcommand(self, name, module_path, help_text, **kwargs):
         """Register a lazy-loaded subcommand with a stub parser."""
         aliases = kwargs.get("aliases", ())
-        stub = super().add_parser(name, help=help_text, **kwargs)
+        self._building = True
+        try:
+            stub = super().add_parser(name, help=help_text, **kwargs)
+        finally:
+            self._building = False
         self._lazy_loaders[name] = (module_path, kwargs)
         for alias in aliases:
             self._lazy_aliases[alias] = name

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -236,6 +236,9 @@ BUILTIN_COMMANDS = {
 }
 """Names (and aliases) of built-in commands; these cannot be overridden by plugin subcommands."""
 
+_PLUGIN_FREE_BUILTIN_COMMANDS = frozenset({"activate", "deactivate", "run"})
+"""Built-in commands that intentionally skip plugin discovery."""
+
 _BUILTIN_SUBCOMMANDS_BY_NAME = {
     name: (module_path, help_text, extra_kwargs)
     for name, module_path, help_text, extra_kwargs in _BUILTIN_SUBCOMMANDS
@@ -355,12 +358,10 @@ class ArgumentParser(ArgumentParserBase):
             action.choices, dict
         ):
             # Unknown command: discover plugins before rejecting so that plugin
-            # subcommands appear in the "choose from" error message.  Must read
-            # from _name_parser_map (not choices) after loading because the
-            # sort-reassignment above disconnects choices from _name_parser_map.
+            # subcommands appear in the sorted "choose from" error message.
             if not isiterable(value) and value not in action._name_parser_map:
                 action._ensure_plugins_loaded()
-            action.choices = dict(sorted(action._name_parser_map.items()))
+                action.choices = dict(sorted(dict.items(action._name_parser_map)))
         elif isinstance(action, _GreedySubParsersAction) and isinstance(
             action.choices, dict
         ):
@@ -580,10 +581,11 @@ class _LazySubParsersAction(_GreedySubParsersAction):
     def __call__(self, parser, namespace, values, option_string=None):
         parser_name = values[0]
         self._ensure_loaded(parser_name)
-        # Always discover plugins when a subcommand is dispatched so that
-        # the builtin-override check in configure_parser_plugins() runs even
-        # when the invoked command is a builtin (e.g. `conda info --help`).
-        self._ensure_plugins_loaded()
+        if parser_name not in _PLUGIN_FREE_BUILTIN_COMMANDS:
+            # Discover plugins when a subcommand is dispatched so that the
+            # builtin-override check in configure_parser_plugins() runs even
+            # when the invoked command is a builtin (e.g. `conda info --help`).
+            self._ensure_plugins_loaded()
         super().__call__(parser, namespace, values, option_string)
 
     def _get_subactions(self):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -46,8 +46,8 @@ from .helpers import (  # noqa: F401
 
 log = getLogger(__name__)
 
-# Map configure_parser_* names to their modules for lazy re-export (backward compat).
-_CONFIGURE_PARSER_EXPORTS: dict[str, str] = {
+
+_DEPRECATED_CONFIGURE_PARSER_EXPORTS: dict[str, str] = {
     "configure_parser_activate": "conda.cli.main_mock_activate",
     "configure_parser_clean": "conda.cli.main_clean",
     "configure_parser_commands": "conda.cli.main_commands",
@@ -70,24 +70,58 @@ _CONFIGURE_PARSER_EXPORTS: dict[str, str] = {
     "configure_parser_update": "conda.cli.main_update",
 }
 
+_DEPRECATED_RC_PATH_EXPORTS = frozenset({
+    "user_rc_path",
+    "sys_rc_path",
+    "escaped_user_rc_path",
+    "escaped_sys_rc_path",
+})
+
 
 def __getattr__(name: str):
-    # Lazy re-export of configure_parser_* functions
-    if name in _CONFIGURE_PARSER_EXPORTS:
-        mod = import_module(_CONFIGURE_PARSER_EXPORTS[name])
+    # Lazily register deprecated re-exports using conda's deprecation system.
+    # deprecated.constant() installs a _ConstantDeprecationRegistry as the module's
+    # __getattr__; on first access here we register + return the value silently,
+    # and all subsequent accesses go through the registry and emit the warning.
+    from ..deprecations import deprecated
+
+    if name in _DEPRECATED_CONFIGURE_PARSER_EXPORTS:
+        module_path = _DEPRECATED_CONFIGURE_PARSER_EXPORTS[name]
+        mod = import_module(module_path)
         val = mod.configure_parser
-        globals()[name] = val
+        deprecated.constant(
+            "26.5",
+            "27.3",
+            name,
+            val,
+            addendum=f"Use `from {module_path} import configure_parser` instead.",
+        )
         return val
 
-    # Lazy re-export of rc_path variables (avoids eagerly importing context)
-    if name in ("user_rc_path", "sys_rc_path", "escaped_user_rc_path", "escaped_sys_rc_path"):
+    if name in _DEPRECATED_RC_PATH_EXPORTS:
         from ..base.context import sys_rc_path, user_rc_path
 
-        globals()["user_rc_path"] = user_rc_path
-        globals()["sys_rc_path"] = sys_rc_path
-        globals()["escaped_user_rc_path"] = user_rc_path.replace("%", "%%")
-        globals()["escaped_sys_rc_path"] = sys_rc_path.replace("%", "%%")
-        return globals()[name]
+        _rc_addenda = {
+            "user_rc_path": "Use `from conda.base.context import user_rc_path` instead.",
+            "sys_rc_path": "Use `from conda.base.context import sys_rc_path` instead.",
+            "escaped_user_rc_path": "Use `from conda.base.context import user_rc_path` and escape locally.",
+            "escaped_sys_rc_path": "Use `from conda.base.context import sys_rc_path` and escape locally.",
+        }
+        _rc_values = {
+            "user_rc_path": user_rc_path,
+            "sys_rc_path": sys_rc_path,
+            "escaped_user_rc_path": user_rc_path.replace("%", "%%"),
+            "escaped_sys_rc_path": sys_rc_path.replace("%", "%%"),
+        }
+        val = _rc_values[name]
+        deprecated.constant(
+            "26.5",
+            "27.3",
+            name,
+            val,
+            addendum=_rc_addenda[name],
+        )
+        return val
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -148,114 +148,131 @@ for _name, _factory, _addendum in (
 del _name, _factory, _addendum
 
 
-_BUILTIN_SUBCOMMANDS: list[tuple[str, str, str, dict]] = [
-    # (name, module_path, help_text, extra_kwargs)
-    ("activate", "conda.cli.main_mock_activate", "Activate a conda environment.", {}),
-    ("clean", "conda.cli.main_clean", "Remove unused packages and caches.", {}),
-    (
-        "commands",
-        "conda.cli.main_commands",
-        "List all available conda subcommands (including those from plugins). "
+BUILTIN_SUBCOMMANDS: dict[str, dict] = {
+    "activate": {
+        "module": "conda.cli.main_mock_activate",
+        "help": "Activate a conda environment.",
+        "kwargs": {},
+    },
+    "clean": {
+        "module": "conda.cli.main_clean",
+        "help": "Remove unused packages and caches.",
+        "kwargs": {},
+    },
+    "commands": {
+        "module": "conda.cli.main_commands",
+        "help": "List all available conda subcommands (including those from plugins). "
         "Generally only used by tab-completion.",
-        {},
-    ),
-    (
-        "compare",
-        "conda.cli.main_compare",
-        "Compare packages between conda environments.",
-        {},
-    ),
-    ("config", "conda.cli.main_config", "Modify configuration values in .condarc.", {}),
-    (
-        "create",
-        "conda.cli.main_create",
-        "Create a new conda environment from a list of specified packages.",
-        {},
-    ),
-    (
-        "deactivate",
-        "conda.cli.main_mock_deactivate",
-        "Deactivate the current active conda environment.",
-        {},
-    ),
-    ("env", "conda.cli.main_env", "Create and manage conda environments.", {}),
-    ("export", "conda.cli.main_export", "Export a conda environment to a file.", {}),
-    (
-        "info",
-        "conda.cli.main_info",
-        "Display information about current conda install.",
-        {},
-    ),
-    ("init", "conda.cli.main_init", "Initialize conda for shell interaction.", {}),
-    (
-        "install",
-        "conda.cli.main_install",
-        "Install a list of packages into a specified conda environment.",
-        {},
-    ),
-    (
-        "list",
-        "conda.cli.main_list",
-        "List installed packages in a conda environment.",
-        {},
-    ),
-    ("notices", "conda.cli.main_notices", "Retrieve latest channel notifications.", {}),
-    (
-        "package",
-        "conda.cli.main_package",
-        "Create low-level conda packages. (EXPERIMENTAL)",
-        {},
-    ),
-    (
-        "remove",
-        "conda.cli.main_remove",
-        "Remove a list of packages from a specified conda environment.",
-        {"aliases": ["uninstall"]},
-    ),
-    ("rename", "conda.cli.main_rename", "Rename an existing environment.", {}),
-    ("run", "conda.cli.main_run", "Run an executable in a conda environment.", {}),
-    (
-        "search",
-        "conda.cli.main_search",
-        "Search for packages and display associated information "
+        "kwargs": {},
+    },
+    "compare": {
+        "module": "conda.cli.main_compare",
+        "help": "Compare packages between conda environments.",
+        "kwargs": {},
+    },
+    "config": {
+        "module": "conda.cli.main_config",
+        "help": "Modify configuration values in .condarc.",
+        "kwargs": {},
+    },
+    "create": {
+        "module": "conda.cli.main_create",
+        "help": "Create a new conda environment from a list of specified packages.",
+        "kwargs": {},
+    },
+    "deactivate": {
+        "module": "conda.cli.main_mock_deactivate",
+        "help": "Deactivate the current active conda environment.",
+        "kwargs": {},
+    },
+    "env": {
+        "module": "conda.cli.main_env",
+        "help": "Create and manage conda environments.",
+        "kwargs": {},
+    },
+    "export": {
+        "module": "conda.cli.main_export",
+        "help": "Export a conda environment to a file.",
+        "kwargs": {},
+    },
+    "info": {
+        "module": "conda.cli.main_info",
+        "help": "Display information about current conda install.",
+        "kwargs": {},
+    },
+    "init": {
+        "module": "conda.cli.main_init",
+        "help": "Initialize conda for shell interaction.",
+        "kwargs": {},
+    },
+    "install": {
+        "module": "conda.cli.main_install",
+        "help": "Install a list of packages into a specified conda environment.",
+        "kwargs": {},
+    },
+    "list": {
+        "module": "conda.cli.main_list",
+        "help": "List installed packages in a conda environment.",
+        "kwargs": {},
+    },
+    "notices": {
+        "module": "conda.cli.main_notices",
+        "help": "Retrieve latest channel notifications.",
+        "kwargs": {},
+    },
+    "package": {
+        "module": "conda.cli.main_package",
+        "help": "Create low-level conda packages. (EXPERIMENTAL)",
+        "kwargs": {},
+    },
+    "remove": {
+        "module": "conda.cli.main_remove",
+        "help": "Remove a list of packages from a specified conda environment.",
+        "kwargs": {"aliases": ["uninstall"]},
+    },
+    "rename": {
+        "module": "conda.cli.main_rename",
+        "help": "Rename an existing environment.",
+        "kwargs": {},
+    },
+    "run": {
+        "module": "conda.cli.main_run",
+        "help": "Run an executable in a conda environment.",
+        "kwargs": {},
+    },
+    "search": {
+        "module": "conda.cli.main_search",
+        "help": "Search for packages and display associated information "
         "using the MatchSpec format.",
-        {},
-    ),
-    (
-        "update",
-        "conda.cli.main_update",
-        "Update conda packages to the latest compatible version.",
-        {"aliases": ["upgrade"]},
-    ),
-]
+        "kwargs": {},
+    },
+    "update": {
+        "module": "conda.cli.main_update",
+        "help": "Update conda packages to the latest compatible version.",
+        "kwargs": {"aliases": ["upgrade"]},
+    },
+}
+"""Built-in subcommand module, help, and parser metadata."""
 
 BUILTIN_COMMANDS = {
     name
-    for command, _, _, kwargs in _BUILTIN_SUBCOMMANDS
-    for name in (command, *kwargs.get("aliases", ()))
+    for command, subcommand in BUILTIN_SUBCOMMANDS.items()
+    for name in (command, *subcommand["kwargs"].get("aliases", ()))
 }
 """Names (and aliases) of built-in commands; these cannot be overridden by plugin subcommands."""
-
-BUILTIN_SUBCOMMAND_HELP = {
-    name: help_text for name, _, help_text, _ in _BUILTIN_SUBCOMMANDS
-}
-"""Help text for built-in subcommands."""
 
 _PLUGIN_FREE_BUILTIN_COMMANDS = frozenset({"activate", "deactivate", "run"})
 """Built-in commands that intentionally skip plugin discovery."""
 
-_BUILTIN_SUBCOMMANDS_BY_NAME = {
-    name: (module_path, help_text, extra_kwargs)
-    for name, module_path, help_text, extra_kwargs in _BUILTIN_SUBCOMMANDS
-}
-
 
 def _configure_builtin_subcommand(sub_parsers, name: str) -> ArgumentParser:
-    module_path, _, extra_kwargs = _BUILTIN_SUBCOMMANDS_BY_NAME[name]
     if isinstance(sub_parsers, _LazySubParsersAction):
         sub_parsers._ensure_loaded(name)
         return sub_parsers._name_parser_map[name]
-    return import_module(module_path).configure_parser(sub_parsers, **extra_kwargs)
+    subcommand = BUILTIN_SUBCOMMANDS[name]
+    return import_module(subcommand["module"]).configure_parser(
+        sub_parsers, **subcommand["kwargs"]
+    )
 
 
 def generate_pre_parser(**kwargs) -> ArgumentParser:
@@ -303,8 +320,13 @@ def generate_parser(**kwargs) -> ArgumentParser:
         required=True,
     )
 
-    for name, module_path, help_text, extra_kwargs in _BUILTIN_SUBCOMMANDS:
-        sub_parsers.add_lazy_subcommand(name, module_path, help_text, **extra_kwargs)
+    for name, subcommand in BUILTIN_SUBCOMMANDS.items():
+        sub_parsers.add_lazy_subcommand(
+            name,
+            subcommand["module"],
+            subcommand["help"],
+            **subcommand["kwargs"],
+        )
 
     return parser
 
@@ -681,7 +703,7 @@ def configure_parser_plugins(sub_parsers) -> None:
             continue
 
         # create the parser for the subcommand
-        if preview and name in _BUILTIN_SUBCOMMANDS_BY_NAME:
+        if preview and name in BUILTIN_SUBCOMMANDS:
             parser = _configure_builtin_subcommand(sub_parsers, name)
         else:
             parser = sub_parsers.add_parser(

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -406,6 +406,10 @@ class _LazyParserMap(dict):
 
     def __getitem__(self, key):
         self._action._ensure_loaded(key)
+        # If the key is still absent after loading builtins, it may be a plugin
+        # subcommand (e.g. sphinx-argparse navigating to :path: doctor).
+        if key not in self:
+            self._action._ensure_plugins_loaded()
         return super().__getitem__(key)
 
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -431,6 +431,10 @@ class _LazySubParsersAction(_GreedySubParsersAction):
     def __call__(self, parser, namespace, values, option_string=None):
         parser_name = values[0]
         self._ensure_loaded(parser_name)
+        # Always discover plugins when a subcommand is dispatched so that
+        # the builtin-override check in configure_parser_plugins() runs even
+        # when the invoked command is a builtin (e.g. `conda info --help`).
+        self._ensure_plugins_loaded()
         super().__call__(parser, namespace, values, option_string)
 
     def _get_subactions(self):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -314,11 +314,13 @@ class ArgumentParser(ArgumentParserBase):
         if isinstance(action, _LazySubParsersAction) and isinstance(
             action.choices, dict
         ):
-            action.choices = dict(sorted(action.choices.items()))
-            # Unknown command: discover plugins before rejecting
-            if not isiterable(value) and value not in action.choices:
+            # Unknown command: discover plugins before rejecting so that plugin
+            # subcommands appear in the "choose from" error message.  Must read
+            # from _name_parser_map (not choices) after loading because the
+            # sort-reassignment above disconnects choices from _name_parser_map.
+            if not isiterable(value) and value not in action._name_parser_map:
                 action._ensure_plugins_loaded()
-                action.choices = dict(sorted(action.choices.items()))
+            action.choices = dict(sorted(action._name_parser_map.items()))
         elif isinstance(action, _GreedySubParsersAction) and isinstance(
             action.choices, dict
         ):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -236,6 +236,11 @@ BUILTIN_COMMANDS = {
 }
 """Names (and aliases) of built-in commands; these cannot be overridden by plugin subcommands."""
 
+BUILTIN_SUBCOMMAND_HELP = {
+    name: help_text for name, _, help_text, _ in _BUILTIN_SUBCOMMANDS
+}
+"""Help text for built-in subcommands."""
+
 _PLUGIN_FREE_BUILTIN_COMMANDS = frozenset({"activate", "deactivate", "run"})
 """Built-in commands that intentionally skip plugin discovery."""
 
@@ -243,10 +248,6 @@ _BUILTIN_SUBCOMMANDS_BY_NAME = {
     name: (module_path, help_text, extra_kwargs)
     for name, module_path, help_text, extra_kwargs in _BUILTIN_SUBCOMMANDS
 }
-
-
-def _get_builtin_subcommand_help(name: str) -> str:
-    return _BUILTIN_SUBCOMMANDS_BY_NAME[name][1]
 
 
 def _configure_builtin_subcommand(sub_parsers, name: str) -> ArgumentParser:

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -12,14 +12,19 @@ from argparse import (
     RawDescriptionHelpFormatter,
 )
 from argparse import ArgumentParser as ArgumentParserBase
-from functools import partial
 from importlib import import_module
 from logging import getLogger
 from subprocess import Popen
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
 
 from .. import __version__
 from ..common.compat import isiterable, on_win
 from ..common.constants import NULL
+from ..deprecations import deprecated
 from ..plugins.previews import is_preview_subcommand
 from .actions import ExtendConstAction, NullCountAction  # noqa: F401
 from .helpers import (  # noqa: F401
@@ -47,85 +52,112 @@ from .helpers import (  # noqa: F401
 log = getLogger(__name__)
 
 
-_DEPRECATED_CONFIGURE_PARSER_EXPORTS: dict[str, str] = {
-    "configure_parser_activate": "conda.cli.main_mock_activate",
-    "configure_parser_clean": "conda.cli.main_clean",
-    "configure_parser_commands": "conda.cli.main_commands",
-    "configure_parser_compare": "conda.cli.main_compare",
-    "configure_parser_config": "conda.cli.main_config",
-    "configure_parser_create": "conda.cli.main_create",
-    "configure_parser_deactivate": "conda.cli.main_mock_deactivate",
-    "configure_parser_env": "conda.cli.main_env",
-    "configure_parser_export": "conda.cli.main_export",
-    "configure_parser_info": "conda.cli.main_info",
-    "configure_parser_init": "conda.cli.main_init",
-    "configure_parser_install": "conda.cli.main_install",
-    "configure_parser_list": "conda.cli.main_list",
-    "configure_parser_notices": "conda.cli.main_notices",
-    "configure_parser_package": "conda.cli.main_package",
-    "configure_parser_remove": "conda.cli.main_remove",
-    "configure_parser_rename": "conda.cli.main_rename",
-    "configure_parser_run": "conda.cli.main_run",
-    "configure_parser_search": "conda.cli.main_search",
-    "configure_parser_update": "conda.cli.main_update",
-}
+# Deprecated ``configure_parser_*`` re-exports.
+#
+# These symbols were moved to their own ``conda.cli.main_*`` modules but kept
+# importable from ``conda.cli.conda_argparse`` for backwards compatibility.
+# Each is registered via ``deprecated.constant(factory=...)`` (introduced in
+# #15925) so the target ``main_*`` module is only imported on first access --
+# which, combined with the lazy subcommand parser map below, is the whole
+# point of A2/A3: ``import conda.cli.conda_argparse`` must not drag in 20+
+# subcommand modules.
+def _configure_parser_factory(module_path: str) -> Callable[[], Any]:
+    """Build a ``factory=`` callable that imports ``module_path`` lazily."""
 
-_DEPRECATED_RC_PATH_EXPORTS = frozenset(
-    {
+    def _factory() -> Any:
+        return import_module(module_path).configure_parser
+
+    return _factory
+
+
+for _name, _module_path in (
+    ("configure_parser_activate", "conda.cli.main_mock_activate"),
+    ("configure_parser_clean", "conda.cli.main_clean"),
+    ("configure_parser_commands", "conda.cli.main_commands"),
+    ("configure_parser_compare", "conda.cli.main_compare"),
+    ("configure_parser_config", "conda.cli.main_config"),
+    ("configure_parser_create", "conda.cli.main_create"),
+    ("configure_parser_deactivate", "conda.cli.main_mock_deactivate"),
+    ("configure_parser_env", "conda.cli.main_env"),
+    ("configure_parser_export", "conda.cli.main_export"),
+    ("configure_parser_info", "conda.cli.main_info"),
+    ("configure_parser_init", "conda.cli.main_init"),
+    ("configure_parser_install", "conda.cli.main_install"),
+    ("configure_parser_list", "conda.cli.main_list"),
+    ("configure_parser_notices", "conda.cli.main_notices"),
+    ("configure_parser_package", "conda.cli.main_package"),
+    ("configure_parser_remove", "conda.cli.main_remove"),
+    ("configure_parser_rename", "conda.cli.main_rename"),
+    ("configure_parser_run", "conda.cli.main_run"),
+    ("configure_parser_search", "conda.cli.main_search"),
+    ("configure_parser_update", "conda.cli.main_update"),
+):
+    deprecated.constant(
+        "26.5",
+        "27.3",
+        _name,
+        factory=_configure_parser_factory(_module_path),
+        addendum=f"Use `from {_module_path} import configure_parser` instead.",
+    )
+del _name, _module_path
+
+
+# Deprecated ``*_rc_path`` re-exports.
+#
+# These moved to ``conda.base.context`` but must stay importable from
+# ``conda.cli.conda_argparse``. Using ``factory=`` here defers the
+# ``conda.base.context`` import (itself on the cold-start path but still
+# avoided when nobody touches these symbols).
+def _user_rc_path() -> str:
+    from ..base.context import user_rc_path
+
+    return user_rc_path
+
+
+def _sys_rc_path() -> str:
+    from ..base.context import sys_rc_path
+
+    return sys_rc_path
+
+
+def _escaped_user_rc_path() -> str:
+    return _user_rc_path().replace("%", "%%")
+
+
+def _escaped_sys_rc_path() -> str:
+    return _sys_rc_path().replace("%", "%%")
+
+
+for _name, _factory, _addendum in (
+    (
         "user_rc_path",
+        _user_rc_path,
+        "Use `from conda.base.context import user_rc_path` instead.",
+    ),
+    (
         "sys_rc_path",
+        _sys_rc_path,
+        "Use `from conda.base.context import sys_rc_path` instead.",
+    ),
+    (
         "escaped_user_rc_path",
+        _escaped_user_rc_path,
+        "Use `from conda.base.context import user_rc_path` and escape locally.",
+    ),
+    (
         "escaped_sys_rc_path",
-    }
-)
-
-
-def __getattr__(name: str):
-    # Lazily register deprecated re-exports using conda's deprecation system.
-    # deprecated.constant() installs a _ConstantDeprecationRegistry as the module's
-    # __getattr__; on first access here we register + return the value silently,
-    # and all subsequent accesses go through the registry and emit the warning.
-    from ..deprecations import deprecated
-
-    if name in _DEPRECATED_CONFIGURE_PARSER_EXPORTS:
-        module_path = _DEPRECATED_CONFIGURE_PARSER_EXPORTS[name]
-        mod = import_module(module_path)
-        val = mod.configure_parser
-        deprecated.constant(
-            "26.5",
-            "27.3",
-            name,
-            val,
-            addendum=f"Use `from {module_path} import configure_parser` instead.",
-        )
-        return val
-
-    if name in _DEPRECATED_RC_PATH_EXPORTS:
-        from ..base.context import sys_rc_path, user_rc_path
-
-        _rc_addenda = {
-            "user_rc_path": "Use `from conda.base.context import user_rc_path` instead.",
-            "sys_rc_path": "Use `from conda.base.context import sys_rc_path` instead.",
-            "escaped_user_rc_path": "Use `from conda.base.context import user_rc_path` and escape locally.",
-            "escaped_sys_rc_path": "Use `from conda.base.context import sys_rc_path` and escape locally.",
-        }
-        _rc_values = {
-            "user_rc_path": user_rc_path,
-            "sys_rc_path": sys_rc_path,
-            "escaped_user_rc_path": user_rc_path.replace("%", "%%"),
-            "escaped_sys_rc_path": sys_rc_path.replace("%", "%%"),
-        }
-        val = _rc_values[name]
-        deprecated.constant(
-            "26.5",
-            "27.3",
-            name,
-            val,
-            addendum=_rc_addenda[name],
-        )
-        return val
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        _escaped_sys_rc_path,
+        "Use `from conda.base.context import sys_rc_path` and escape locally.",
+    ),
+):
+    deprecated.constant(
+        "26.5",
+        "27.3",
+        _name,
+        factory=_factory,
+        addendum=_addendum,
+    )
+del _name, _factory, _addendum
 
 
 _BUILTIN_SUBCOMMANDS: list[tuple[str, str, str, dict]] = [
@@ -215,28 +247,18 @@ for _name, _module, _help, _kw in _BUILTIN_SUBCOMMANDS:
         BUILTIN_COMMANDS.add(_alias)
 """Names (and aliases) of built-in commands; these cannot be overridden by plugin subcommands."""
 
-BUILTIN_COMMAND_PARSERS = {
-    "activate": configure_parser_activate,
-    "clean": configure_parser_clean,
-    "commands": configure_parser_commands,
-    "compare": configure_parser_compare,
-    "config": configure_parser_config,
-    "create": configure_parser_create,
-    "deactivate": configure_parser_deactivate,
-    "env": configure_parser_env,
-    "export": configure_parser_export,
-    "info": configure_parser_info,
-    "init": configure_parser_init,
-    "install": configure_parser_install,
-    "list": configure_parser_list,
-    "notices": configure_parser_notices,
-    "package": configure_parser_package,
-    "remove": partial(configure_parser_remove, aliases=["uninstall"]),
-    "rename": configure_parser_rename,
-    "run": configure_parser_run,
-    "search": configure_parser_search,
-    "update": partial(configure_parser_update, aliases=["upgrade"]),
+_BUILTIN_SUBCOMMANDS_BY_NAME = {
+    name: (module_path, extra_kwargs)
+    for name, module_path, _help_text, extra_kwargs in _BUILTIN_SUBCOMMANDS
 }
+
+
+def _configure_builtin_subcommand(sub_parsers, name: str) -> ArgumentParser:
+    module_path, extra_kwargs = _BUILTIN_SUBCOMMANDS_BY_NAME[name]
+    if isinstance(sub_parsers, _LazySubParsersAction):
+        sub_parsers._ensure_loaded(name)
+        return sub_parsers._name_parser_map[name]
+    return import_module(module_path).configure_parser(sub_parsers, **extra_kwargs)
 
 
 def generate_pre_parser(**kwargs) -> ArgumentParser:
@@ -660,8 +682,8 @@ def configure_parser_plugins(sub_parsers) -> None:
             continue
 
         # create the parser for the subcommand
-        if preview and name in BUILTIN_COMMAND_PARSERS:
-            parser = BUILTIN_COMMAND_PARSERS[name](sub_parsers)
+        if preview and name in _BUILTIN_SUBCOMMANDS_BY_NAME:
+            parser = _configure_builtin_subcommand(sub_parsers, name)
         else:
             parser = sub_parsers.add_parser(
                 name,

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -404,13 +404,23 @@ class _LazyParserMap(dict):
         super().__init__()
         self._action = action
 
-    def __getitem__(self, key):
+    def _resolve(self, key):
+        """Ensure *key* is fully loaded (builtin or plugin)."""
         self._action._ensure_loaded(key)
-        # If the key is still absent after loading builtins, it may be a plugin
-        # subcommand (e.g. sphinx-argparse navigating to :path: doctor).
-        if key not in self:
+        if not super().__contains__(key):
             self._action._ensure_plugins_loaded()
+
+    def __getitem__(self, key):
+        self._resolve(key)
         return super().__getitem__(key)
+
+    def get(self, key, default=None):
+        self._resolve(key)
+        return super().get(key, default)
+
+    def __contains__(self, key):
+        self._resolve(key)
+        return super().__contains__(key)
 
 
 class _LazySubParsersAction(_GreedySubParsersAction):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -428,6 +428,20 @@ class _LazyParserMap(dict):
             self._action._ensure_loaded(name)
         self._action._ensure_plugins_loaded()
 
+    def _known_names(self):
+        """Builtin names known without running any configure_parser or plugin discovery.
+
+        The union of already-materialized entries in the underlying dict (stubs and
+        real parsers), pending lazy-loader names, and aliases. Plugin-provided
+        subcommand names are not included here; callers that need them should use
+        ``items()`` / ``values()`` / ``_resolve_all()``.
+        """
+        names = set(super().keys())
+        action = self._action
+        names.update(getattr(action, "_lazy_loaders", ()))
+        names.update(getattr(action, "_lazy_aliases", ()))
+        return names
+
     def __getitem__(self, key):
         self._resolve(key)
         return super().__getitem__(key)
@@ -437,8 +451,22 @@ class _LazyParserMap(dict):
         return super().get(key, default)
 
     def __contains__(self, key):
-        self._resolve(key)
-        return super().__contains__(key)
+        # Cheap path: any known builtin name (stub parser already registered,
+        # pending lazy loader, or alias) answers without importing the
+        # subcommand module or running configure_parser.
+        if super().__contains__(key):
+            return True
+        if not self._ready:
+            return False
+        action = self._action
+        if key in action._lazy_loaders or key in action._lazy_aliases:
+            return True
+        # Unknown builtin: fall back to plugin discovery so plugin subcommand
+        # names resolve. Guarded by _plugins_loaded so this runs at most once.
+        if not action._plugins_loaded:
+            action._ensure_plugins_loaded()
+            return super().__contains__(key)
+        return False
 
     def items(self):
         self._resolve_all()
@@ -449,16 +477,20 @@ class _LazyParserMap(dict):
         return super().values()
 
     def keys(self):
-        self._resolve_all()
-        return super().keys()
+        # Return known builtin names without materializing every subcommand
+        # parser or triggering plugin discovery. argparse internals call this
+        # on the hot path (help formatting, error messages); loading 20+
+        # subcommand modules + all plugins there would defeat lazy loading.
+        # Callers that need plugin subcommand names should use items()/values().
+        if not self._ready:
+            return super().keys()
+        return self._known_names()
 
     def __iter__(self):
-        self._resolve_all()
-        return super().__iter__()
+        return iter(self.keys())
 
     def __len__(self):
-        self._resolve_all()
-        return super().__len__()
+        return len(self.keys())
 
 
 class _LazySubParsersAction(_GreedySubParsersAction):

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -18,8 +18,6 @@ from logging import getLogger
 from subprocess import Popen
 
 from .. import __version__
-from ..auxlib.ish import dals
-from ..base.context import context, sys_rc_path, user_rc_path
 from ..common.compat import isiterable, on_win
 from ..common.constants import NULL
 from ..plugins.previews import is_preview_subcommand
@@ -45,57 +43,121 @@ from .helpers import (  # noqa: F401
     add_parser_update_modifiers,
     add_parser_verbose,
 )
-from .main_clean import configure_parser as configure_parser_clean
-from .main_commands import configure_parser as configure_parser_commands
-from .main_compare import configure_parser as configure_parser_compare
-from .main_config import configure_parser as configure_parser_config
-from .main_create import configure_parser as configure_parser_create
-from .main_env import configure_parser as configure_parser_env
-from .main_export import configure_parser as configure_parser_export
-from .main_info import configure_parser as configure_parser_info
-from .main_init import configure_parser as configure_parser_init
-from .main_install import configure_parser as configure_parser_install
-from .main_list import configure_parser as configure_parser_list
-from .main_mock_activate import configure_parser as configure_parser_activate
-from .main_mock_deactivate import configure_parser as configure_parser_deactivate
-from .main_notices import configure_parser as configure_parser_notices
-from .main_package import configure_parser as configure_parser_package
-from .main_remove import configure_parser as configure_parser_remove
-from .main_rename import configure_parser as configure_parser_rename
-from .main_run import configure_parser as configure_parser_run
-from .main_search import configure_parser as configure_parser_search
-from .main_update import configure_parser as configure_parser_update
 
 log = getLogger(__name__)
 
-escaped_user_rc_path = user_rc_path.replace("%", "%%")
-escaped_sys_rc_path = sys_rc_path.replace("%", "%%")
-
-BUILTIN_COMMANDS = {
-    "activate",  # Mock entry for shell command
-    "clean",
-    "commands",
-    "compare",
-    "config",
-    "create",
-    "deactivate",  # Mock entry for shell command
-    "env",
-    "export",
-    "info",
-    "init",
-    "install",
-    "list",
-    "notices",
-    "package",
-    "remove",
-    "rename",
-    "run",
-    "search",
-    "uninstall",  # remove alias
-    "update",
-    "upgrade",  # update alias
+# Map configure_parser_* names to their modules for lazy re-export (backward compat).
+_CONFIGURE_PARSER_EXPORTS: dict[str, str] = {
+    "configure_parser_activate": "conda.cli.main_mock_activate",
+    "configure_parser_clean": "conda.cli.main_clean",
+    "configure_parser_commands": "conda.cli.main_commands",
+    "configure_parser_compare": "conda.cli.main_compare",
+    "configure_parser_config": "conda.cli.main_config",
+    "configure_parser_create": "conda.cli.main_create",
+    "configure_parser_deactivate": "conda.cli.main_mock_deactivate",
+    "configure_parser_env": "conda.cli.main_env",
+    "configure_parser_export": "conda.cli.main_export",
+    "configure_parser_info": "conda.cli.main_info",
+    "configure_parser_init": "conda.cli.main_init",
+    "configure_parser_install": "conda.cli.main_install",
+    "configure_parser_list": "conda.cli.main_list",
+    "configure_parser_notices": "conda.cli.main_notices",
+    "configure_parser_package": "conda.cli.main_package",
+    "configure_parser_remove": "conda.cli.main_remove",
+    "configure_parser_rename": "conda.cli.main_rename",
+    "configure_parser_run": "conda.cli.main_run",
+    "configure_parser_search": "conda.cli.main_search",
+    "configure_parser_update": "conda.cli.main_update",
 }
-"""List of built-in commands; these cannot be overridden by plugin subcommands."""
+
+
+def __getattr__(name: str):
+    # Lazy re-export of configure_parser_* functions
+    if name in _CONFIGURE_PARSER_EXPORTS:
+        mod = import_module(_CONFIGURE_PARSER_EXPORTS[name])
+        val = mod.configure_parser
+        globals()[name] = val
+        return val
+
+    # Lazy re-export of rc_path variables (avoids eagerly importing context)
+    if name in ("user_rc_path", "sys_rc_path", "escaped_user_rc_path", "escaped_sys_rc_path"):
+        from ..base.context import sys_rc_path, user_rc_path
+
+        globals()["user_rc_path"] = user_rc_path
+        globals()["sys_rc_path"] = sys_rc_path
+        globals()["escaped_user_rc_path"] = user_rc_path.replace("%", "%%")
+        globals()["escaped_sys_rc_path"] = sys_rc_path.replace("%", "%%")
+        return globals()[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+_BUILTIN_SUBCOMMANDS: list[tuple[str, str, str, dict]] = [
+    # (name, module_path, help_text, extra_kwargs)
+    ("activate", "conda.cli.main_mock_activate", "Activate a conda environment.", {}),
+    ("clean", "conda.cli.main_clean", "Remove unused packages and caches.", {}),
+    (
+        "commands",
+        "conda.cli.main_commands",
+        "List all available conda subcommands (including those from plugins). "
+        "Generally only used by tab-completion.",
+        {},
+    ),
+    ("compare", "conda.cli.main_compare", "Compare packages between conda environments.", {}),
+    ("config", "conda.cli.main_config", "Modify configuration values in .condarc.", {}),
+    (
+        "create",
+        "conda.cli.main_create",
+        "Create a new conda environment from a list of specified packages.",
+        {},
+    ),
+    (
+        "deactivate",
+        "conda.cli.main_mock_deactivate",
+        "Deactivate the current active conda environment.",
+        {},
+    ),
+    ("env", "conda.cli.main_env", "Create and manage conda environments.", {}),
+    ("export", "conda.cli.main_export", "Export a given environment", {}),
+    ("info", "conda.cli.main_info", "Display information about current conda install.", {}),
+    ("init", "conda.cli.main_init", "Initialize conda for shell interaction.", {}),
+    (
+        "install",
+        "conda.cli.main_install",
+        "Install a list of packages into a specified conda environment.",
+        {},
+    ),
+    ("list", "conda.cli.main_list", "List installed packages in a conda environment.", {}),
+    ("notices", "conda.cli.main_notices", "Retrieve latest channel notifications.", {}),
+    ("package", "conda.cli.main_package", "Create low-level conda packages. (EXPERIMENTAL)", {}),
+    (
+        "remove",
+        "conda.cli.main_remove",
+        "Remove a list of packages from a specified conda environment.",
+        {"aliases": ["uninstall"]},
+    ),
+    ("rename", "conda.cli.main_rename", "Rename an existing environment.", {}),
+    ("run", "conda.cli.main_run", "Run an executable in a conda environment.", {}),
+    (
+        "search",
+        "conda.cli.main_search",
+        "Search for packages and display associated information "
+        "using the MatchSpec format.",
+        {},
+    ),
+    (
+        "update",
+        "conda.cli.main_update",
+        "Update conda packages to the latest compatible version.",
+        {"aliases": ["upgrade"]},
+    ),
+]
+
+BUILTIN_COMMANDS = {name for name, *_ in _BUILTIN_SUBCOMMANDS}
+for _name, _module, _help, _kw in _BUILTIN_SUBCOMMANDS:
+    for _alias in _kw.get("aliases", ()):
+        BUILTIN_COMMANDS.add(_alias)
+"""Names (and aliases) of built-in commands; these cannot be overridden by plugin subcommands."""
 
 BUILTIN_COMMAND_PARSERS = {
     "activate": configure_parser_activate,
@@ -162,23 +224,12 @@ def generate_parser(**kwargs) -> ArgumentParser:
         title="commands",
         description="The following built-in and plugins subcommands are available.",
         dest="cmd",
-        action=_GreedySubParsersAction,
+        action=_LazySubParsersAction,
         required=True,
     )
 
-    preview_plugin_commands = {
-        name
-        for name, plugin_subcommand in context.plugin_manager.get_subcommands().items()
-        if is_preview_subcommand(plugin_subcommand)
-    }
-
-    # We only register built-ins that are not overridden by bundled previews.
-    for builtin, config_func in BUILTIN_COMMAND_PARSERS.items():
-        if builtin not in preview_plugin_commands:
-            config_func(sub_parsers)
-
-    # Special configure call just for plugin subcommands
-    configure_parser_plugins(sub_parsers)
+    for name, module_path, help_text, extra_kwargs in _BUILTIN_SUBCOMMANDS:
+        sub_parsers.add_lazy_subcommand(name, module_path, help_text, **extra_kwargs)
 
     return parser
 
@@ -188,6 +239,8 @@ def do_call(args: argparse.Namespace, parser: ArgumentParser):
     Serves as the primary entry point for commands referred to in this file and for
     all registered plugin subcommands.
     """
+    from ..base.context import context
+
     # let's see if during the parsing phase it was discovered that the
     # called command was in fact a plugin subcommand
     if plugin_subcommand := getattr(args, "_plugin_subcommand", None):
@@ -224,8 +277,15 @@ class ArgumentParser(ArgumentParserBase):
             add_parser_help(self)
 
     def _check_value(self, action, value):
-        # For our greedy subparsers, sort the choices by their repr for stable output
-        if isinstance(action, _GreedySubParsersAction) and isinstance(
+        if isinstance(action, _LazySubParsersAction) and isinstance(
+            action.choices, dict
+        ):
+            action.choices = dict(sorted(action.choices.items()))
+            # Unknown command: discover plugins before rejecting
+            if not isiterable(value) and value not in action.choices:
+                action._ensure_plugins_loaded()
+                action.choices = dict(sorted(action.choices.items()))
+        elif isinstance(action, _GreedySubParsersAction) and isinstance(
             action.choices, dict
         ):
             action.choices = dict(sorted(action.choices.items()))
@@ -273,6 +333,76 @@ class _GreedySubParsersAction(argparse._SubParsersAction):
         return sorted(self._choices_actions, key=lambda action: action.dest)
 
 
+class _LazySubParsersAction(_GreedySubParsersAction):
+    """Extends _GreedySubParsersAction with lazy loading of subcommand parsers.
+
+    Registers lightweight stub parsers for all built-in subcommands at
+    generate_parser() time (name + help text only). The real configure_parser
+    is called on demand when a subcommand is actually invoked.
+
+    Plugin subcommand discovery is deferred until a non-builtin command is
+    requested or --help is displayed.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._lazy_loaders: dict[str, tuple[str, dict]] = {}
+        self._lazy_aliases: dict[str, str] = {}
+        self._loading_name: str | None = None
+        self._plugins_loaded = False
+
+    def add_lazy_subcommand(self, name, module_path, help_text, **kwargs):
+        """Register a lazy-loaded subcommand with a stub parser."""
+        aliases = kwargs.get("aliases", ())
+        stub = super().add_parser(name, help=help_text, **kwargs)
+        self._lazy_loaders[name] = (module_path, kwargs)
+        for alias in aliases:
+            self._lazy_aliases[alias] = name
+        return stub
+
+    def add_parser(self, name, **kwargs):
+        """During lazy loading, return the existing stub instead of creating a new parser."""
+        if self._loading_name is not None and name in self._name_parser_map:
+            parser = self._name_parser_map[name]
+            for attr in ("description", "epilog"):
+                if attr in kwargs:
+                    setattr(parser, attr, kwargs[attr])
+            return parser
+        return super().add_parser(name, **kwargs)
+
+    def _ensure_loaded(self, name):
+        """Load a lazy subcommand's full parser configuration."""
+        canonical = self._lazy_aliases.get(name, name)
+        if canonical not in self._lazy_loaders:
+            return
+        module_path, loader_kwargs = self._lazy_loaders.pop(canonical)
+        for alias in loader_kwargs.get("aliases", ()):
+            self._lazy_aliases.pop(alias, None)
+        self._loading_name = canonical
+        try:
+            mod = import_module(module_path)
+            mod.configure_parser(self, **loader_kwargs)
+        finally:
+            self._loading_name = None
+
+    def _ensure_plugins_loaded(self):
+        """Discover and register plugin subcommands on demand."""
+        if self._plugins_loaded:
+            return
+        self._plugins_loaded = True
+        configure_parser_plugins(self)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser_name = values[0]
+        self._ensure_loaded(parser_name)
+        super().__call__(parser, namespace, values, option_string)
+
+    def _get_subactions(self):
+        """Ensure plugins are discovered before listing subcommands in help."""
+        self._ensure_plugins_loaded()
+        return super()._get_subactions()
+
+
 def _exec(executable_args, env_vars):
     return (_exec_win if on_win else _exec_unix)(executable_args, env_vars)
 
@@ -298,6 +428,9 @@ def configure_parser_plugins(sub_parsers) -> None:
     :meth:`~conda.plugins.types.CondaSubcommand.configure_parser`
     with the newly created subcommand specific argument parser.
     """
+    from ..auxlib.ish import dals
+    from ..base.context import context
+
     plugin_subcommands = context.plugin_manager.get_subcommands()
     plugin_names = frozenset(plugin_subcommands)
     alias_to_plugin_names: dict[str, set[str]] = {}

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -15,11 +15,6 @@ from argparse import ArgumentParser as ArgumentParserBase
 from importlib import import_module
 from logging import getLogger
 from subprocess import Popen
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any
 
 from .. import __version__
 from ..common.compat import isiterable, on_win
@@ -61,15 +56,6 @@ log = getLogger(__name__)
 # which, combined with the lazy subcommand parser map below, is the whole
 # point of A2/A3: ``import conda.cli.conda_argparse`` must not drag in 20+
 # subcommand modules.
-def _configure_parser_factory(module_path: str) -> Callable[[], Any]:
-    """Build a ``factory=`` callable that imports ``module_path`` lazily."""
-
-    def _factory() -> Any:
-        return import_module(module_path).configure_parser
-
-    return _factory
-
-
 for _name, _module_path in (
     ("configure_parser_activate", "conda.cli.main_mock_activate"),
     ("configure_parser_clean", "conda.cli.main_clean"),
@@ -93,10 +79,12 @@ for _name, _module_path in (
     ("configure_parser_update", "conda.cli.main_update"),
 ):
     deprecated.constant(
-        "26.5",
         "27.3",
+        "27.9",
         _name,
-        factory=_configure_parser_factory(_module_path),
+        factory=lambda module_path=_module_path: (
+            import_module(module_path).configure_parser
+        ),
         addendum=f"Use `from {_module_path} import configure_parser` instead.",
     )
 del _name, _module_path
@@ -151,8 +139,8 @@ for _name, _factory, _addendum in (
     ),
 ):
     deprecated.constant(
-        "26.5",
         "27.3",
+        "27.9",
         _name,
         factory=_factory,
         addendum=_addendum,
@@ -191,7 +179,7 @@ _BUILTIN_SUBCOMMANDS: list[tuple[str, str, str, dict]] = [
         {},
     ),
     ("env", "conda.cli.main_env", "Create and manage conda environments.", {}),
-    ("export", "conda.cli.main_export", "Export a given environment", {}),
+    ("export", "conda.cli.main_export", "Export a conda environment to a file.", {}),
     (
         "info",
         "conda.cli.main_info",
@@ -241,20 +229,25 @@ _BUILTIN_SUBCOMMANDS: list[tuple[str, str, str, dict]] = [
     ),
 ]
 
-BUILTIN_COMMANDS = {name for name, *_ in _BUILTIN_SUBCOMMANDS}
-for _name, _module, _help, _kw in _BUILTIN_SUBCOMMANDS:
-    for _alias in _kw.get("aliases", ()):
-        BUILTIN_COMMANDS.add(_alias)
+BUILTIN_COMMANDS = {
+    name
+    for command, _, _, kwargs in _BUILTIN_SUBCOMMANDS
+    for name in (command, *kwargs.get("aliases", ()))
+}
 """Names (and aliases) of built-in commands; these cannot be overridden by plugin subcommands."""
 
 _BUILTIN_SUBCOMMANDS_BY_NAME = {
-    name: (module_path, extra_kwargs)
-    for name, module_path, _help_text, extra_kwargs in _BUILTIN_SUBCOMMANDS
+    name: (module_path, help_text, extra_kwargs)
+    for name, module_path, help_text, extra_kwargs in _BUILTIN_SUBCOMMANDS
 }
 
 
+def _get_builtin_subcommand_help(name: str) -> str:
+    return _BUILTIN_SUBCOMMANDS_BY_NAME[name][1]
+
+
 def _configure_builtin_subcommand(sub_parsers, name: str) -> ArgumentParser:
-    module_path, extra_kwargs = _BUILTIN_SUBCOMMANDS_BY_NAME[name]
+    module_path, _, extra_kwargs = _BUILTIN_SUBCOMMANDS_BY_NAME[name]
     if isinstance(sub_parsers, _LazySubParsersAction):
         sub_parsers._ensure_loaded(name)
         return sub_parsers._name_parser_map[name]

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -70,12 +70,14 @@ _DEPRECATED_CONFIGURE_PARSER_EXPORTS: dict[str, str] = {
     "configure_parser_update": "conda.cli.main_update",
 }
 
-_DEPRECATED_RC_PATH_EXPORTS = frozenset({
-    "user_rc_path",
-    "sys_rc_path",
-    "escaped_user_rc_path",
-    "escaped_sys_rc_path",
-})
+_DEPRECATED_RC_PATH_EXPORTS = frozenset(
+    {
+        "user_rc_path",
+        "sys_rc_path",
+        "escaped_user_rc_path",
+        "escaped_sys_rc_path",
+    }
+)
 
 
 def __getattr__(name: str):
@@ -137,7 +139,12 @@ _BUILTIN_SUBCOMMANDS: list[tuple[str, str, str, dict]] = [
         "Generally only used by tab-completion.",
         {},
     ),
-    ("compare", "conda.cli.main_compare", "Compare packages between conda environments.", {}),
+    (
+        "compare",
+        "conda.cli.main_compare",
+        "Compare packages between conda environments.",
+        {},
+    ),
     ("config", "conda.cli.main_config", "Modify configuration values in .condarc.", {}),
     (
         "create",
@@ -153,7 +160,12 @@ _BUILTIN_SUBCOMMANDS: list[tuple[str, str, str, dict]] = [
     ),
     ("env", "conda.cli.main_env", "Create and manage conda environments.", {}),
     ("export", "conda.cli.main_export", "Export a given environment", {}),
-    ("info", "conda.cli.main_info", "Display information about current conda install.", {}),
+    (
+        "info",
+        "conda.cli.main_info",
+        "Display information about current conda install.",
+        {},
+    ),
     ("init", "conda.cli.main_init", "Initialize conda for shell interaction.", {}),
     (
         "install",
@@ -161,9 +173,19 @@ _BUILTIN_SUBCOMMANDS: list[tuple[str, str, str, dict]] = [
         "Install a list of packages into a specified conda environment.",
         {},
     ),
-    ("list", "conda.cli.main_list", "List installed packages in a conda environment.", {}),
+    (
+        "list",
+        "conda.cli.main_list",
+        "List installed packages in a conda environment.",
+        {},
+    ),
     ("notices", "conda.cli.main_notices", "Retrieve latest channel notifications.", {}),
-    ("package", "conda.cli.main_package", "Create low-level conda packages. (EXPERIMENTAL)", {}),
+    (
+        "package",
+        "conda.cli.main_package",
+        "Create low-level conda packages. (EXPERIMENTAL)",
+        {},
+    ),
     (
         "remove",
         "conda.cli.main_remove",
@@ -369,6 +391,24 @@ class _GreedySubParsersAction(argparse._SubParsersAction):
         return sorted(self._choices_actions, key=lambda action: action.dest)
 
 
+class _LazyParserMap(dict):
+    """A dict that triggers lazy parser loading on key access.
+
+    Used as the _name_parser_map for _LazySubParsersAction so that any
+    consumer reading a specific subcommand parser (e.g. sphinx-argparse
+    navigating a :path: directive) gets the fully-configured parser rather
+    than the lightweight stub registered at generate_parser() time.
+    """
+
+    def __init__(self, action):
+        super().__init__()
+        self._action = action
+
+    def __getitem__(self, key):
+        self._action._ensure_loaded(key)
+        return super().__getitem__(key)
+
+
 class _LazySubParsersAction(_GreedySubParsersAction):
     """Extends _GreedySubParsersAction with lazy loading of subcommand parsers.
 
@@ -382,6 +422,9 @@ class _LazySubParsersAction(_GreedySubParsersAction):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._name_parser_map = _LazyParserMap(self)
+        # choices is the same dict object in argparse's _SubParsersAction
+        self.choices = self._name_parser_map
         self._lazy_loaders: dict[str, tuple[str, dict]] = {}
         self._lazy_aliases: dict[str, str] = {}
         self._loading_name: str | None = None

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -343,7 +343,10 @@ def do_call(args: argparse.Namespace, parser: ArgumentParser):
 def find_builtin_commands(parser: ArgumentParserBase) -> tuple[str, ...]:
     # ArgumentParser doesn't have an API for getting back what subparsers
     # exist, so we need to use internal properties to do so.
-    return tuple(parser._subparsers._group_actions[0].choices.keys())
+    subparser_action = parser._subparsers._group_actions[0]
+    if isinstance(subparser_action, _LazySubParsersAction):
+        subparser_action._ensure_plugins_loaded()
+    return tuple(subparser_action.choices.keys())
 
 
 class ArgumentParser(ArgumentParserBase):

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -24,9 +24,10 @@ log = getLogger(__name__)
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from .actions import ExtendConstAction
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_output_and_prompt_options
 
-    summary = "Remove unused packages and caches."
+    summary = _get_builtin_subcommand_help("clean")
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -24,10 +24,10 @@ log = getLogger(__name__)
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from .actions import ExtendConstAction
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_output_and_prompt_options
 
-    summary = _get_builtin_subcommand_help("clean")
+    summary = BUILTIN_SUBCOMMAND_HELP["clean"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -24,10 +24,10 @@ log = getLogger(__name__)
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from .actions import ExtendConstAction
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_output_and_prompt_options
 
-    summary = BUILTIN_SUBCOMMAND_HELP["clean"]
+    summary = BUILTIN_SUBCOMMANDS["clean"]["help"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_commands.py
+++ b/conda/cli/main_commands.py
@@ -30,6 +30,11 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
 def execute(args: Namespace, parser: ArgumentParser) -> int:
     from .conda_argparse import find_builtin_commands
 
+    # Ensure plugin subcommands are discovered before listing
+    sub_parsers_action = parser._subparsers._group_actions[0]
+    if hasattr(sub_parsers_action, "_ensure_plugins_loaded"):
+        sub_parsers_action._ensure_plugins_loaded()
+
     print(
         *sorted(find_builtin_commands(parser)),
         sep="\n",

--- a/conda/cli/main_commands.py
+++ b/conda/cli/main_commands.py
@@ -14,12 +14,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
+    from .conda_argparse import _get_builtin_subcommand_help
+
     p = sub_parsers.add_parser(
         "commands",
-        help=(
-            "List all available conda subcommands (including those from plugins). "
-            "Generally only used by tab-completion."
-        ),
+        help=_get_builtin_subcommand_help("commands"),
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_commands.execute")

--- a/conda/cli/main_commands.py
+++ b/conda/cli/main_commands.py
@@ -14,11 +14,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
 
     p = sub_parsers.add_parser(
         "commands",
-        help=BUILTIN_SUBCOMMAND_HELP["commands"],
+        help=BUILTIN_SUBCOMMANDS["commands"]["help"],
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_commands.execute")

--- a/conda/cli/main_commands.py
+++ b/conda/cli/main_commands.py
@@ -14,11 +14,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
 
     p = sub_parsers.add_parser(
         "commands",
-        help=_get_builtin_subcommand_help("commands"),
+        help=BUILTIN_SUBCOMMAND_HELP["commands"],
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_commands.execute")

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -22,10 +22,10 @@ log = logging.getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_json, add_parser_prefix
 
-    summary = _get_builtin_subcommand_help("compare")
+    summary = BUILTIN_SUBCOMMAND_HELP["compare"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -22,9 +22,10 @@ log = logging.getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_json, add_parser_prefix
 
-    summary = "Compare packages between conda environments."
+    summary = _get_builtin_subcommand_help("compare")
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -22,10 +22,10 @@ log = logging.getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_json, add_parser_prefix
 
-    summary = BUILTIN_SUBCOMMAND_HELP["compare"]
+    summary = BUILTIN_SUBCOMMANDS["compare"]["help"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -19,9 +19,10 @@ log = logging.getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_json, add_parser_prefix
 
-    summary = "Compare packages between conda environments."
+    summary = _get_builtin_subcommand_help("compare")
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -19,10 +19,10 @@ log = logging.getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_json, add_parser_prefix
 
-    summary = BUILTIN_SUBCOMMAND_HELP["compare"]
+    summary = BUILTIN_SUBCOMMANDS["compare"]["help"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -19,10 +19,10 @@ log = logging.getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_json, add_parser_prefix
 
-    summary = _get_builtin_subcommand_help("compare")
+    summary = BUILTIN_SUBCOMMAND_HELP["compare"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -39,12 +39,13 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..base.constants import CONDA_HOMEPAGE_URL
     from ..base.context import context, sys_rc_path, user_rc_path
     from ..common.constants import NULL
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_json, add_parser_prefix_to_group
 
     escaped_user_rc_path = user_rc_path.replace("%", "%%")
     escaped_sys_rc_path = sys_rc_path.replace("%", "%%")
 
-    summary = "Modify configuration values in .condarc."
+    summary = _get_builtin_subcommand_help("config")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -39,13 +39,13 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..base.constants import CONDA_HOMEPAGE_URL
     from ..base.context import context, sys_rc_path, user_rc_path
     from ..common.constants import NULL
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_json, add_parser_prefix_to_group
 
     escaped_user_rc_path = user_rc_path.replace("%", "%%")
     escaped_sys_rc_path = sys_rc_path.replace("%", "%%")
 
-    summary = _get_builtin_subcommand_help("config")
+    summary = BUILTIN_SUBCOMMAND_HELP["config"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -39,13 +39,13 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..base.constants import CONDA_HOMEPAGE_URL
     from ..base.context import context, sys_rc_path, user_rc_path
     from ..common.constants import NULL
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_json, add_parser_prefix_to_group
 
     escaped_user_rc_path = user_rc_path.replace("%", "%%")
     escaped_sys_rc_path = sys_rc_path.replace("%", "%%")
 
-    summary = BUILTIN_SUBCOMMAND_HELP["config"]
+    summary = BUILTIN_SUBCOMMANDS["config"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -53,6 +53,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_parser_create_install_update,
         add_parser_default_packages,
@@ -60,7 +61,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = "Create a new conda environment from a list of specified packages."
+    summary = _get_builtin_subcommand_help("create")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -53,7 +53,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_parser_create_install_update,
         add_parser_default_packages,
@@ -61,7 +61,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["create"]
+    summary = BUILTIN_SUBCOMMANDS["create"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -53,7 +53,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_parser_create_install_update,
         add_parser_default_packages,
@@ -61,7 +61,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = _get_builtin_subcommand_help("create")
+    summary = BUILTIN_SUBCOMMAND_HELP["create"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -54,7 +54,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_parser_create_install_update,
         add_parser_default_packages,
@@ -62,7 +62,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = _get_builtin_subcommand_help("create")
+    summary = BUILTIN_SUBCOMMAND_HELP["create"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -54,6 +54,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_parser_create_install_update,
         add_parser_default_packages,
@@ -61,7 +62,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = "Create a new conda environment from a list of specified packages."
+    summary = _get_builtin_subcommand_help("create")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -54,7 +54,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_parser_create_install_update,
         add_parser_default_packages,
@@ -62,7 +62,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["create"]
+    summary = BUILTIN_SUBCOMMANDS["create"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_env.py
+++ b/conda/cli/main_env.py
@@ -19,11 +19,11 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         main_env_update,
         main_export,
     )
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
 
     p = sub_parsers.add_parser(
         "env",
-        help=_get_builtin_subcommand_help("env"),
+        help=BUILTIN_SUBCOMMAND_HELP["env"],
         **kwargs,
     )
 

--- a/conda/cli/main_env.py
+++ b/conda/cli/main_env.py
@@ -19,10 +19,11 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         main_env_update,
         main_export,
     )
+    from .conda_argparse import _get_builtin_subcommand_help
 
     p = sub_parsers.add_parser(
         "env",
-        help="Create and manage conda environments.",
+        help=_get_builtin_subcommand_help("env"),
         **kwargs,
     )
 

--- a/conda/cli/main_env.py
+++ b/conda/cli/main_env.py
@@ -19,11 +19,11 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         main_env_update,
         main_export,
     )
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
 
     p = sub_parsers.add_parser(
         "env",
-        help=BUILTIN_SUBCOMMAND_HELP["env"],
+        help=BUILTIN_SUBCOMMANDS["env"]["help"],
         **kwargs,
     )
 

--- a/conda/cli/main_export.py
+++ b/conda/cli/main_export.py
@@ -64,10 +64,10 @@ def epilog() -> str:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import LazyChoicesAction, add_parser_json, add_parser_prefix
 
-    summary = BUILTIN_SUBCOMMAND_HELP["export"]
+    summary = BUILTIN_SUBCOMMANDS["export"]["help"]
     description = dals(
         """
         Export a conda environment to a file. The set of supported formats

--- a/conda/cli/main_export.py
+++ b/conda/cli/main_export.py
@@ -64,9 +64,10 @@ def epilog() -> str:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import LazyChoicesAction, add_parser_json, add_parser_prefix
 
-    summary = "Export a conda environment to a file."
+    summary = _get_builtin_subcommand_help("export")
     description = dals(
         """
         Export a conda environment to a file. The set of supported formats

--- a/conda/cli/main_export.py
+++ b/conda/cli/main_export.py
@@ -64,10 +64,10 @@ def epilog() -> str:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import LazyChoicesAction, add_parser_json, add_parser_prefix
 
-    summary = _get_builtin_subcommand_help("export")
+    summary = BUILTIN_SUBCOMMAND_HELP["export"]
     description = dals(
         """
         Export a conda environment to a file. The set of supported formats

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -33,10 +33,10 @@ log = getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..common.constants import NULL
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_json
 
-    summary = BUILTIN_SUBCOMMAND_HELP["info"]
+    summary = BUILTIN_SUBCOMMANDS["info"]["help"]
     description = summary
     epilog = ""
 

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -33,9 +33,10 @@ log = getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..common.constants import NULL
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_json
 
-    summary = "Display information about current conda install."
+    summary = _get_builtin_subcommand_help("info")
     description = summary
     epilog = ""
 

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -33,10 +33,10 @@ log = getLogger(__name__)
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..common.constants import NULL
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_json
 
-    summary = _get_builtin_subcommand_help("info")
+    summary = BUILTIN_SUBCOMMAND_HELP["info"]
     description = summary
     epilog = ""
 

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -35,10 +35,10 @@ INSTALLER_INFO_FIELDS = ("name", "version", "platform", "type")
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..common.constants import NULL
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_json
 
-    summary = _get_builtin_subcommand_help("info")
+    summary = BUILTIN_SUBCOMMAND_HELP["info"]
     description = summary
     epilog = ""
 

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -35,10 +35,10 @@ INSTALLER_INFO_FIELDS = ("name", "version", "platform", "type")
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..common.constants import NULL
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_json
 
-    summary = BUILTIN_SUBCOMMAND_HELP["info"]
+    summary = BUILTIN_SUBCOMMANDS["info"]["help"]
     description = summary
     epilog = ""
 

--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -35,9 +35,10 @@ INSTALLER_INFO_FIELDS = ("name", "version", "platform", "type")
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..common.constants import NULL
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_json
 
-    summary = "Display information about current conda install."
+    summary = _get_builtin_subcommand_help("info")
     description = summary
     epilog = ""
 

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -22,10 +22,10 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..base.constants import COMPATIBLE_SHELLS
     from ..common.compat import on_win
     from ..common.constants import NULL
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_json
 
-    summary = BUILTIN_SUBCOMMAND_HELP["init"]
+    summary = BUILTIN_SUBCOMMANDS["init"]["help"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -22,9 +22,10 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..base.constants import COMPATIBLE_SHELLS
     from ..common.compat import on_win
     from ..common.constants import NULL
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_json
 
-    summary = "Initialize conda for shell interaction."
+    summary = _get_builtin_subcommand_help("init")
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -22,10 +22,10 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..base.constants import COMPATIBLE_SHELLS
     from ..common.compat import on_win
     from ..common.constants import NULL
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_json
 
-    summary = _get_builtin_subcommand_help("init")
+    summary = BUILTIN_SUBCOMMAND_HELP["init"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -20,6 +20,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -28,7 +29,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = "Install a list of packages into a specified conda environment."
+    summary = _get_builtin_subcommand_help("install")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -20,7 +20,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -29,7 +29,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = _get_builtin_subcommand_help("install")
+    summary = BUILTIN_SUBCOMMAND_HELP["install"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -20,7 +20,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -29,7 +29,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["install"]
+    summary = BUILTIN_SUBCOMMANDS["install"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -21,7 +21,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -30,7 +30,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = _get_builtin_subcommand_help("install")
+    summary = BUILTIN_SUBCOMMAND_HELP["install"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -21,6 +21,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -29,7 +30,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = "Install a list of packages into a specified conda environment."
+    summary = _get_builtin_subcommand_help("install")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -21,7 +21,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -30,7 +30,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["install"]
+    summary = BUILTIN_SUBCOMMANDS["install"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..base.constants import CONDA_LIST_FIELDS
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_parser_json,
         add_parser_prefix,
@@ -32,7 +32,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         comma_separated_stripped,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["list"]
+    summary = BUILTIN_SUBCOMMANDS["list"]["help"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..base.constants import CONDA_LIST_FIELDS
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_parser_json,
         add_parser_prefix,
@@ -31,7 +32,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         comma_separated_stripped,
     )
 
-    summary = "List installed packages in a conda environment."
+    summary = _get_builtin_subcommand_help("list")
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_list.py
+++ b/conda/cli/main_list.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..base.constants import CONDA_LIST_FIELDS
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_parser_json,
         add_parser_prefix,
@@ -32,7 +32,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         comma_separated_stripped,
     )
 
-    summary = _get_builtin_subcommand_help("list")
+    summary = BUILTIN_SUBCOMMAND_HELP["list"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_mock_activate.py
+++ b/conda/cli/main_mock_activate.py
@@ -17,9 +17,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
+    from .conda_argparse import _get_builtin_subcommand_help
+
     p = sub_parsers.add_parser(
         "activate",
-        help="Activate a conda environment.",
+        help=_get_builtin_subcommand_help("activate"),
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_mock_activate.execute")

--- a/conda/cli/main_mock_activate.py
+++ b/conda/cli/main_mock_activate.py
@@ -17,11 +17,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
 
     p = sub_parsers.add_parser(
         "activate",
-        help=_get_builtin_subcommand_help("activate"),
+        help=BUILTIN_SUBCOMMAND_HELP["activate"],
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_mock_activate.execute")

--- a/conda/cli/main_mock_activate.py
+++ b/conda/cli/main_mock_activate.py
@@ -17,11 +17,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
 
     p = sub_parsers.add_parser(
         "activate",
-        help=BUILTIN_SUBCOMMAND_HELP["activate"],
+        help=BUILTIN_SUBCOMMANDS["activate"]["help"],
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_mock_activate.execute")

--- a/conda/cli/main_mock_deactivate.py
+++ b/conda/cli/main_mock_deactivate.py
@@ -16,9 +16,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
+    from .conda_argparse import _get_builtin_subcommand_help
+
     p = sub_parsers.add_parser(
         "deactivate",
-        help="Deactivate the current active conda environment.",
+        help=_get_builtin_subcommand_help("deactivate"),
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_mock_deactivate.execute")

--- a/conda/cli/main_mock_deactivate.py
+++ b/conda/cli/main_mock_deactivate.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
 
     p = sub_parsers.add_parser(
         "deactivate",
-        help=BUILTIN_SUBCOMMAND_HELP["deactivate"],
+        help=BUILTIN_SUBCOMMANDS["deactivate"]["help"],
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_mock_deactivate.execute")

--- a/conda/cli/main_mock_deactivate.py
+++ b/conda/cli/main_mock_deactivate.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
 
     p = sub_parsers.add_parser(
         "deactivate",
-        help=_get_builtin_subcommand_help("deactivate"),
+        help=BUILTIN_SUBCOMMAND_HELP["deactivate"],
         **kwargs,
     )
     p.set_defaults(func="conda.cli.main_mock_deactivate.execute")

--- a/conda/cli/main_notices.py
+++ b/conda/cli/main_notices.py
@@ -10,10 +10,10 @@ from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_channels, add_parser_json
 
-    summary = BUILTIN_SUBCOMMAND_HELP["notices"]
+    summary = BUILTIN_SUBCOMMANDS["notices"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_notices.py
+++ b/conda/cli/main_notices.py
@@ -10,9 +10,10 @@ from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_channels, add_parser_json
 
-    summary = "Retrieve latest channel notifications."
+    summary = _get_builtin_subcommand_help("notices")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_notices.py
+++ b/conda/cli/main_notices.py
@@ -10,10 +10,10 @@ from argparse import ArgumentParser, Namespace, _SubParsersAction
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_channels, add_parser_json
 
-    summary = _get_builtin_subcommand_help("notices")
+    summary = BUILTIN_SUBCOMMAND_HELP["notices"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_package.py
+++ b/conda/cli/main_package.py
@@ -15,10 +15,10 @@ from os.path import abspath, basename, dirname, isdir, isfile, islink, join
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_prefix
 
-    summary = BUILTIN_SUBCOMMAND_HELP["package"]
+    summary = BUILTIN_SUBCOMMANDS["package"]["help"]
     description = summary
     epilog = ""
 

--- a/conda/cli/main_package.py
+++ b/conda/cli/main_package.py
@@ -15,10 +15,10 @@ from os.path import abspath, basename, dirname, isdir, isfile, islink, join
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_prefix
 
-    summary = _get_builtin_subcommand_help("package")
+    summary = BUILTIN_SUBCOMMAND_HELP["package"]
     description = summary
     epilog = ""
 

--- a/conda/cli/main_package.py
+++ b/conda/cli/main_package.py
@@ -15,9 +15,10 @@ from os.path import abspath, basename, dirname, isdir, isfile, islink, join
 
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_prefix
 
-    summary = "Create low-level conda packages. (EXPERIMENTAL)"
+    summary = _get_builtin_subcommand_help("package")
     description = summary
     epilog = ""
 

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -17,6 +17,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_channels,
@@ -28,7 +29,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = "Remove a list of packages from a specified conda environment. "
+    summary = _get_builtin_subcommand_help("remove")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -17,7 +17,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_channels,
@@ -29,7 +29,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = _get_builtin_subcommand_help("remove")
+    summary = BUILTIN_SUBCOMMAND_HELP["remove"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -17,7 +17,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from ..common.constants import NULL
     from .actions import NullCountAction
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_channels,
@@ -29,7 +29,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["remove"]
+    summary = BUILTIN_SUBCOMMANDS["remove"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -18,7 +18,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_channels,
@@ -30,7 +30,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["remove"]
+    summary = BUILTIN_SUBCOMMANDS["remove"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -18,6 +18,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_channels,
@@ -29,7 +30,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = "Remove a list of packages from a specified conda environment. "
+    summary = _get_builtin_subcommand_help("remove")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -18,7 +18,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_channels,
@@ -30,7 +30,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_solver,
     )
 
-    summary = _get_builtin_subcommand_help("remove")
+    summary = BUILTIN_SUBCOMMAND_HELP["remove"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_rename.py
+++ b/conda/cli/main_rename.py
@@ -19,10 +19,10 @@ if TYPE_CHECKING:
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_output_and_prompt_options, add_parser_prefix
 
-    summary = _get_builtin_subcommand_help("rename")
+    summary = BUILTIN_SUBCOMMAND_HELP["rename"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_rename.py
+++ b/conda/cli/main_rename.py
@@ -19,9 +19,10 @@ if TYPE_CHECKING:
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_output_and_prompt_options, add_parser_prefix
 
-    summary = "Rename an existing environment."
+    summary = _get_builtin_subcommand_help("rename")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_rename.py
+++ b/conda/cli/main_rename.py
@@ -19,10 +19,10 @@ if TYPE_CHECKING:
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_output_and_prompt_options, add_parser_prefix
 
-    summary = BUILTIN_SUBCOMMAND_HELP["rename"]
+    summary = BUILTIN_SUBCOMMANDS["rename"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -16,9 +16,10 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import add_parser_prefix, add_parser_verbose
 
-    summary = "Run an executable in a conda environment."
+    summary = _get_builtin_subcommand_help("run")
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -16,10 +16,10 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import add_parser_prefix, add_parser_verbose
 
-    summary = _get_builtin_subcommand_help("run")
+    summary = BUILTIN_SUBCOMMAND_HELP["run"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -16,10 +16,10 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from ..deprecations import deprecated
     from .actions import NullCountAction
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import add_parser_prefix, add_parser_verbose
 
-    summary = BUILTIN_SUBCOMMAND_HELP["run"]
+    summary = BUILTIN_SUBCOMMANDS["run"]["help"]
     description = summary
     epilog = dals(
         """

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_parser_channels,
         add_parser_json,
@@ -30,7 +31,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_networking,
     )
 
-    summary = "Search for packages and display associated information using the MatchSpec format."
+    summary = _get_builtin_subcommand_help("search")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_parser_channels,
         add_parser_json,
@@ -31,7 +31,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_networking,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["search"]
+    summary = BUILTIN_SUBCOMMANDS["search"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_parser_channels,
         add_parser_json,
@@ -31,7 +31,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_networking,
     )
 
-    summary = _get_builtin_subcommand_help("search")
+    summary = BUILTIN_SUBCOMMAND_HELP["search"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_parser_channels,
         add_parser_json,
@@ -31,7 +31,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_platform,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["search"]
+    summary = BUILTIN_SUBCOMMANDS["search"]["help"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_parser_channels,
         add_parser_json,
@@ -31,7 +31,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_platform,
     )
 
-    summary = _get_builtin_subcommand_help("search")
+    summary = BUILTIN_SUBCOMMAND_HELP["search"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_search.py
+++ b/conda/cli/main_search.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_parser_channels,
         add_parser_json,
@@ -30,7 +31,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_platform,
     )
 
-    summary = "Search for packages and display associated information using the MatchSpec format."
+    summary = _get_builtin_subcommand_help("search")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
+    from .conda_argparse import _get_builtin_subcommand_help
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -27,7 +28,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = "Update conda packages to the latest compatible version."
+    summary = _get_builtin_subcommand_help("update")
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
-    from .conda_argparse import _get_builtin_subcommand_help
+    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -28,7 +28,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = _get_builtin_subcommand_help("update")
+    summary = BUILTIN_SUBCOMMAND_HELP["update"]
     description = dals(
         f"""
         {summary}

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
-    from .conda_argparse import BUILTIN_SUBCOMMAND_HELP
+    from .conda_argparse import BUILTIN_SUBCOMMANDS
     from .helpers import (
         add_parser_create_install_update,
         add_parser_frozen_env,
@@ -28,7 +28,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         add_parser_update_modifiers,
     )
 
-    summary = BUILTIN_SUBCOMMAND_HELP["update"]
+    summary = BUILTIN_SUBCOMMANDS["update"]["help"]
     description = dals(
         f"""
         {summary}

--- a/news/15867-lazy-subcommand-parser
+++ b/news/15867-lazy-subcommand-parser
@@ -1,0 +1,8 @@
+### Enhancements
+
+* Defer loading of subcommand parser modules until the subcommand is actually invoked, reducing the number of modules imported at startup and improving `conda` startup latency.
+
+### Deprecations
+
+* `conda.cli.conda_argparse.configure_parser_*` functions are pending deprecation. Import `configure_parser` directly from the relevant `conda.cli.main_*` module instead.
+* `conda.cli.conda_argparse.user_rc_path`, `sys_rc_path`, `escaped_user_rc_path`, and `escaped_sys_rc_path` are pending deprecation. Use `conda.base.context.user_rc_path` / `sys_rc_path` instead.

--- a/news/15867-lazy-subcommand-parser
+++ b/news/15867-lazy-subcommand-parser
@@ -1,8 +1,8 @@
 ### Enhancements
 
-* Defer loading of subcommand parser modules until the subcommand is actually invoked, reducing the number of modules imported at startup and improving `conda` startup latency.
+* Defer loading of subcommand parser modules until the subcommand is actually invoked, reducing the number of modules imported at startup and improving `conda` startup latency. (#15868)
 
 ### Deprecations
 
-* `conda.cli.conda_argparse.configure_parser_*` functions are pending deprecation. Import `configure_parser` directly from the relevant `conda.cli.main_*` module instead.
-* `conda.cli.conda_argparse.user_rc_path`, `sys_rc_path`, `escaped_user_rc_path`, and `escaped_sys_rc_path` are pending deprecation. Use `conda.base.context.user_rc_path` / `sys_rc_path` instead.
+* `conda.cli.conda_argparse.configure_parser_*` re-exported function names are pending deprecation. Import `configure_parser` directly from the relevant `conda.cli.main_*` module instead. (#15868)
+* `conda.cli.conda_argparse.user_rc_path`, `sys_rc_path`, `escaped_user_rc_path`, and `escaped_sys_rc_path` are pending deprecation. Use `conda.base.context.user_rc_path` / `sys_rc_path` instead. (#15868)

--- a/news/15867-lazy-subcommand-parser
+++ b/news/15867-lazy-subcommand-parser
@@ -1,8 +1,0 @@
-### Enhancements
-
-* Defer loading of subcommand parser modules until the subcommand is actually invoked, reducing the number of modules imported at startup and improving `conda` startup latency. (#15868)
-
-### Deprecations
-
-* `conda.cli.conda_argparse.configure_parser_*` re-exported function names are pending deprecation. Import `configure_parser` directly from the relevant `conda.cli.main_*` module instead. (#15868)
-* `conda.cli.conda_argparse.user_rc_path`, `sys_rc_path`, `escaped_user_rc_path`, and `escaped_sys_rc_path` are pending deprecation. Use `conda.base.context.user_rc_path` / `sys_rc_path` instead. (#15868)

--- a/releases/news/15867-lazy-subcommand-parser
+++ b/releases/news/15867-lazy-subcommand-parser
@@ -1,0 +1,8 @@
+### Enhancements
+
+* Defer loading of subcommand parser modules until the subcommand is actually invoked, reducing the number of modules imported at startup and improving `conda` startup latency. (#15867 via #15868)
+
+### Deprecations
+
+* `conda.cli.conda_argparse.configure_parser_*` re-exported function names are pending deprecation. Import `configure_parser` directly from the relevant `conda.cli.main_*` module instead. (#15867 via #15868)
+* `conda.cli.conda_argparse.user_rc_path`, `sys_rc_path`, `escaped_user_rc_path`, and `escaped_sys_rc_path` are pending deprecation. Use `conda.base.context.user_rc_path` / `sys_rc_path` instead. (#15867 via #15868)

--- a/releases/news/15867-lazy-subcommand-parser
+++ b/releases/news/15867-lazy-subcommand-parser
@@ -4,5 +4,5 @@
 
 ### Deprecations
 
-* `conda.cli.conda_argparse.configure_parser_*` re-exported function names are pending deprecation. Import `configure_parser` directly from the relevant `conda.cli.main_*` module instead. (#15867 via #15868)
-* `conda.cli.conda_argparse.user_rc_path`, `sys_rc_path`, `escaped_user_rc_path`, and `escaped_sys_rc_path` are pending deprecation. Use `conda.base.context.user_rc_path` / `sys_rc_path` instead. (#15867 via #15868)
+* Mark the `conda.cli.conda_argparse.configure_parser_*` re-exported functions as pending deprecation, to be removed in 27.9. Import `configure_parser` directly from the relevant `conda.cli.main_*` module instead. (#15867 via #15868)
+* Mark `conda.cli.conda_argparse.user_rc_path`, `sys_rc_path`, `escaped_user_rc_path`, and `escaped_sys_rc_path` as pending deprecation, to be removed in 27.9. Use `conda.base.context.user_rc_path` or `sys_rc_path` instead. (#15867 via #15868)

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -77,6 +77,10 @@ def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
         ("conda.cli.conda_argparse.add_parser_verbose", isfunction),
         ("conda.cli.conda_argparse.ArgumentParser", isclass),
         ("conda.cli.conda_argparse.BUILTIN_COMMANDS", lambda x: isinstance(x, set)),
+        (
+            "conda.cli.conda_argparse.BUILTIN_SUBCOMMAND_HELP",
+            lambda x: isinstance(x, dict),
+        ),
         ("conda.cli.conda_argparse.configure_parser_plugins", isfunction),
         ("conda.cli.conda_argparse.do_call", isfunction),
         ("conda.cli.conda_argparse.ExtendConstAction", isclass),

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -78,7 +78,7 @@ def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
         ("conda.cli.conda_argparse.ArgumentParser", isclass),
         ("conda.cli.conda_argparse.BUILTIN_COMMANDS", lambda x: isinstance(x, set)),
         (
-            "conda.cli.conda_argparse.BUILTIN_SUBCOMMAND_HELP",
+            "conda.cli.conda_argparse.BUILTIN_SUBCOMMANDS",
             lambda x: isinstance(x, dict),
         ),
         ("conda.cli.conda_argparse.configure_parser_plugins", isfunction),

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -74,9 +74,28 @@ def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
         ("conda.cli.conda_argparse.add_parser_solver_mode", isfunction),
         ("conda.cli.conda_argparse.add_parser_update_modifiers", isfunction),
         ("conda.cli.conda_argparse.add_parser_verbose", isfunction),
-        # derived from argparse.ArgumentParser
         ("conda.cli.conda_argparse.ArgumentParser", isclass),
         ("conda.cli.conda_argparse.BUILTIN_COMMANDS", lambda x: isinstance(x, set)),
+        ("conda.cli.conda_argparse.configure_parser_plugins", isfunction),
+        ("conda.cli.conda_argparse.do_call", isfunction),
+        ("conda.cli.conda_argparse.ExtendConstAction", isclass),
+        ("conda.cli.conda_argparse.find_builtin_commands", isfunction),
+        ("conda.cli.conda_argparse.generate_parser", isfunction),
+        ("conda.cli.conda_argparse.generate_pre_parser", isfunction),
+        ("conda.cli.conda_argparse.NullCountAction", isclass),
+    ],
+)
+def test_imports(path: str, validate: Callable[[Any], bool]):
+    path, attr = path.rsplit(".", 1)
+    module = importlib.import_module(path)
+    assert hasattr(module, attr)
+    assert validate(getattr(module, attr))
+
+
+@pytest.mark.parametrize(
+    "path,validate",
+    [
+        # configure_parser_* functions moved to their own main_* modules (deprecated in 26.5)
         ("conda.cli.conda_argparse.configure_parser_clean", isfunction),
         ("conda.cli.conda_argparse.configure_parser_compare", isfunction),
         ("conda.cli.conda_argparse.configure_parser_config", isfunction),
@@ -87,29 +106,27 @@ def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
         ("conda.cli.conda_argparse.configure_parser_list", isfunction),
         ("conda.cli.conda_argparse.configure_parser_notices", isfunction),
         ("conda.cli.conda_argparse.configure_parser_package", isfunction),
-        ("conda.cli.conda_argparse.configure_parser_plugins", isfunction),
         ("conda.cli.conda_argparse.configure_parser_remove", isfunction),
         ("conda.cli.conda_argparse.configure_parser_rename", isfunction),
         ("conda.cli.conda_argparse.configure_parser_run", isfunction),
         ("conda.cli.conda_argparse.configure_parser_search", isfunction),
         ("conda.cli.conda_argparse.configure_parser_update", isfunction),
-        ("conda.cli.conda_argparse.do_call", isfunction),
+        # rc_path variables moved to conda.base.context (deprecated in 26.5)
         ("conda.cli.conda_argparse.escaped_sys_rc_path", lambda x: isinstance(x, str)),
         ("conda.cli.conda_argparse.escaped_user_rc_path", lambda x: isinstance(x, str)),
-        ("conda.cli.conda_argparse.ExtendConstAction", isclass),
-        ("conda.cli.conda_argparse.find_builtin_commands", isfunction),
-        ("conda.cli.conda_argparse.generate_parser", isfunction),
-        ("conda.cli.conda_argparse.generate_pre_parser", isfunction),
-        ("conda.cli.conda_argparse.NullCountAction", isclass),
         ("conda.cli.conda_argparse.sys_rc_path", lambda x: isinstance(x, str)),
         ("conda.cli.conda_argparse.user_rc_path", lambda x: isinstance(x, str)),
     ],
 )
-def test_imports(path: str, validate: Callable[[Any], bool]):
+def test_deprecated_imports(path: str, validate: Callable[[Any], bool]):
+    """Verify deprecated re-exports still work but emit PendingDeprecationWarning."""
     path, attr = path.rsplit(".", 1)
     module = importlib.import_module(path)
+    # First access registers the deprecation without warning (lazy registration).
     assert hasattr(module, attr)
-    assert validate(getattr(module, attr))
+    # Second access goes through the _ConstantDeprecationRegistry and warns.
+    with pytest.warns(PendingDeprecationWarning):
+        assert validate(getattr(module, attr))
 
 
 def test_sorted_commands_in_error(capsys: CaptureFixture):

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -129,6 +129,44 @@ def test_deprecated_imports(path: str, validate: Callable[[Any], bool]):
         assert validate(getattr(module, attr))
 
 
+def test_lazy_parser_map_cheap_introspection():
+    """keys/__iter__/__contains__ on the lazy parser map must not trigger
+    per-subcommand parser loading or plugin discovery.
+
+    argparse internals call these on the hot path (help formatting, error
+    messages, _check_value). Triggering ``configure_parser`` for every
+    subcommand or loading all plugins there would cancel out the whole point
+    of lazy subcommand loading.
+    """
+    parser = generate_parser()
+    action = parser._subparsers._group_actions[0]
+
+    # Snapshot state before any map-side introspection happens.
+    pending_before = set(action._lazy_loaders)
+    plugins_loaded_before = action._plugins_loaded
+    assert pending_before, "expected some builtin subcommands pending lazy load"
+
+    # keys()/__iter__/__contains__ for a known builtin must not load anything.
+    keys = set(action._name_parser_map.keys())
+    assert pending_before <= keys
+    assert set(iter(action._name_parser_map)) == keys
+    assert "install" in action._name_parser_map
+    assert "create" in action._name_parser_map
+
+    assert set(action._lazy_loaders) == pending_before, (
+        "__contains__/keys/__iter__ must not run configure_parser for builtins"
+    )
+    assert action._plugins_loaded is plugins_loaded_before, (
+        "__contains__/keys/__iter__ must not trigger plugin discovery for builtins"
+    )
+
+    # Unknown name: allowed to discover plugins once (to answer whether the
+    # name is a plugin-provided subcommand), but still must not load any
+    # builtin parsers.
+    assert "this-subcommand-does-not-exist" not in action._name_parser_map
+    assert set(action._lazy_loaders) == pending_before
+
+
 def test_sorted_commands_in_error(capsys: CaptureFixture):
     p = ArgumentParser()
     sp = p.add_subparsers(

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.cli.conda_argparse import (
+    _PLUGIN_FREE_BUILTIN_COMMANDS,
     ArgumentParser,
     _GreedySubParsersAction,
     generate_parser,
@@ -166,6 +167,23 @@ def test_lazy_parser_map_cheap_introspection():
     # builtin parsers.
     assert "this-subcommand-does-not-exist" not in action._name_parser_map
     assert set(action._lazy_loaders) == pending_before
+
+
+@pytest.mark.parametrize(
+    "args",
+    (["activate"], ["deactivate"], ["run", "python"]),
+)
+def test_plugin_free_builtin_commands_skip_discovery(
+    args: list[str],
+    clear_plugin_manager_cache: None,
+) -> None:
+    from conda.plugins.manager import get_plugin_manager
+
+    parser = generate_parser()
+    parser.parse_args(args)
+
+    assert args[0] in _PLUGIN_FREE_BUILTIN_COMMANDS
+    assert get_plugin_manager.cache_info().currsize == 0
 
 
 def test_sorted_commands_in_error(capsys: CaptureFixture):

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -119,14 +119,16 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
     ],
 )
 def test_deprecated_imports(path: str, validate: Callable[[Any], bool]):
-    """Verify deprecated re-exports still work but emit PendingDeprecationWarning."""
+    """Verify deprecated re-exports still work and emit PendingDeprecationWarning
+    on *every* access (including the first), now that they are registered via
+    ``deprecated.constant(factory=...)`` at module import time."""
     path, attr = path.rsplit(".", 1)
     module = importlib.import_module(path)
-    # First access registers the deprecation without warning (lazy registration).
-    assert hasattr(module, attr)
-    # Second access goes through the _ConstantDeprecationRegistry and warns.
     with pytest.warns(PendingDeprecationWarning):
-        assert validate(getattr(module, attr))
+        value = getattr(module, attr)
+    assert validate(value)
+    with pytest.warns(PendingDeprecationWarning):
+        assert getattr(module, attr) is value
 
 
 def test_lazy_parser_map_cheap_introspection():

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -119,15 +119,14 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
     ],
 )
 def test_deprecated_imports(path: str, validate: Callable[[Any], bool]):
-    """Verify deprecated re-exports still work and emit PendingDeprecationWarning
-    on *every* access (including the first), now that they are registered via
-    ``deprecated.constant(factory=...)`` at module import time."""
+    """Verify deprecated re-exports still work and warn on every access."""
     path, attr = path.rsplit(".", 1)
     module = importlib.import_module(path)
-    with pytest.warns(PendingDeprecationWarning):
+    warning_types = (PendingDeprecationWarning, DeprecationWarning)
+    with pytest.warns(warning_types):
         value = getattr(module, attr)
     assert validate(value)
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(warning_types):
         assert getattr(module, attr) is value
 
 

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -95,7 +95,7 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
 @pytest.mark.parametrize(
     "path,validate",
     [
-        # configure_parser_* functions moved to their own main_* modules (deprecated in 26.5)
+        # configure_parser_* functions moved to their own main_* modules (deprecated in 27.3)
         ("conda.cli.conda_argparse.configure_parser_clean", isfunction),
         ("conda.cli.conda_argparse.configure_parser_compare", isfunction),
         ("conda.cli.conda_argparse.configure_parser_config", isfunction),
@@ -111,7 +111,7 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
         ("conda.cli.conda_argparse.configure_parser_run", isfunction),
         ("conda.cli.conda_argparse.configure_parser_search", isfunction),
         ("conda.cli.conda_argparse.configure_parser_update", isfunction),
-        # rc_path variables moved to conda.base.context (deprecated in 26.5)
+        # rc_path variables moved to conda.base.context (deprecated in 27.3)
         ("conda.cli.conda_argparse.escaped_sys_rc_path", lambda x: isinstance(x, str)),
         ("conda.cli.conda_argparse.escaped_user_rc_path", lambda x: isinstance(x, str)),
         ("conda.cli.conda_argparse.sys_rc_path", lambda x: isinstance(x, str)),

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -109,7 +109,7 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
 @pytest.mark.parametrize(
     "path,validate",
     [
-        # configure_parser_* functions moved to their own main_* modules (deprecated in 26.5)
+        # configure_parser_* functions moved to their own main_* modules (deprecated in 27.3)
         ("conda.cli.conda_argparse.configure_parser_clean", isfunction),
         ("conda.cli.conda_argparse.configure_parser_compare", isfunction),
         ("conda.cli.conda_argparse.configure_parser_config", isfunction),
@@ -125,7 +125,7 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
         ("conda.cli.conda_argparse.configure_parser_run", isfunction),
         ("conda.cli.conda_argparse.configure_parser_search", isfunction),
         ("conda.cli.conda_argparse.configure_parser_update", isfunction),
-        # rc_path variables moved to conda.base.context (deprecated in 26.5)
+        # rc_path variables moved to conda.base.context (deprecated in 27.3)
         ("conda.cli.conda_argparse.escaped_sys_rc_path", lambda x: isinstance(x, str)),
         ("conda.cli.conda_argparse.escaped_user_rc_path", lambda x: isinstance(x, str)),
         ("conda.cli.conda_argparse.sys_rc_path", lambda x: isinstance(x, str)),

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.cli.conda_argparse import (
+    _PLUGIN_FREE_BUILTIN_COMMANDS,
     ArgumentParser,
     _GreedySubParsersAction,
     generate_parser,
@@ -180,6 +181,23 @@ def test_lazy_parser_map_cheap_introspection():
     # builtin parsers.
     assert "this-subcommand-does-not-exist" not in action._name_parser_map
     assert set(action._lazy_loaders) == pending_before
+
+
+@pytest.mark.parametrize(
+    "args",
+    (["activate"], ["deactivate"], ["run", "python"]),
+)
+def test_plugin_free_builtin_commands_skip_discovery(
+    args: list[str],
+    clear_plugin_manager_cache: None,
+) -> None:
+    from conda.plugins.manager import get_plugin_manager
+
+    parser = generate_parser()
+    parser.parse_args(args)
+
+    assert args[0] in _PLUGIN_FREE_BUILTIN_COMMANDS
+    assert get_plugin_manager.cache_info().currsize == 0
 
 
 def test_sorted_commands_in_error(capsys: CaptureFixture):

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -88,9 +88,28 @@ def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
         ("conda.cli.conda_argparse.add_parser_solver_mode", isfunction),
         ("conda.cli.conda_argparse.add_parser_update_modifiers", isfunction),
         ("conda.cli.conda_argparse.add_parser_verbose", isfunction),
-        # derived from argparse.ArgumentParser
         ("conda.cli.conda_argparse.ArgumentParser", isclass),
         ("conda.cli.conda_argparse.BUILTIN_COMMANDS", lambda x: isinstance(x, set)),
+        ("conda.cli.conda_argparse.configure_parser_plugins", isfunction),
+        ("conda.cli.conda_argparse.do_call", isfunction),
+        ("conda.cli.conda_argparse.ExtendConstAction", isclass),
+        ("conda.cli.conda_argparse.find_builtin_commands", isfunction),
+        ("conda.cli.conda_argparse.generate_parser", isfunction),
+        ("conda.cli.conda_argparse.generate_pre_parser", isfunction),
+        ("conda.cli.conda_argparse.NullCountAction", isclass),
+    ],
+)
+def test_imports(path: str, validate: Callable[[Any], bool]):
+    path, attr = path.rsplit(".", 1)
+    module = importlib.import_module(path)
+    assert hasattr(module, attr)
+    assert validate(getattr(module, attr))
+
+
+@pytest.mark.parametrize(
+    "path,validate",
+    [
+        # configure_parser_* functions moved to their own main_* modules (deprecated in 26.5)
         ("conda.cli.conda_argparse.configure_parser_clean", isfunction),
         ("conda.cli.conda_argparse.configure_parser_compare", isfunction),
         ("conda.cli.conda_argparse.configure_parser_config", isfunction),
@@ -101,29 +120,27 @@ def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
         ("conda.cli.conda_argparse.configure_parser_list", isfunction),
         ("conda.cli.conda_argparse.configure_parser_notices", isfunction),
         ("conda.cli.conda_argparse.configure_parser_package", isfunction),
-        ("conda.cli.conda_argparse.configure_parser_plugins", isfunction),
         ("conda.cli.conda_argparse.configure_parser_remove", isfunction),
         ("conda.cli.conda_argparse.configure_parser_rename", isfunction),
         ("conda.cli.conda_argparse.configure_parser_run", isfunction),
         ("conda.cli.conda_argparse.configure_parser_search", isfunction),
         ("conda.cli.conda_argparse.configure_parser_update", isfunction),
-        ("conda.cli.conda_argparse.do_call", isfunction),
+        # rc_path variables moved to conda.base.context (deprecated in 26.5)
         ("conda.cli.conda_argparse.escaped_sys_rc_path", lambda x: isinstance(x, str)),
         ("conda.cli.conda_argparse.escaped_user_rc_path", lambda x: isinstance(x, str)),
-        ("conda.cli.conda_argparse.ExtendConstAction", isclass),
-        ("conda.cli.conda_argparse.find_builtin_commands", isfunction),
-        ("conda.cli.conda_argparse.generate_parser", isfunction),
-        ("conda.cli.conda_argparse.generate_pre_parser", isfunction),
-        ("conda.cli.conda_argparse.NullCountAction", isclass),
         ("conda.cli.conda_argparse.sys_rc_path", lambda x: isinstance(x, str)),
         ("conda.cli.conda_argparse.user_rc_path", lambda x: isinstance(x, str)),
     ],
 )
-def test_imports(path: str, validate: Callable[[Any], bool]):
+def test_deprecated_imports(path: str, validate: Callable[[Any], bool]):
+    """Verify deprecated re-exports still work but emit PendingDeprecationWarning."""
     path, attr = path.rsplit(".", 1)
     module = importlib.import_module(path)
+    # First access registers the deprecation without warning (lazy registration).
     assert hasattr(module, attr)
-    assert validate(getattr(module, attr))
+    # Second access goes through the _ConstantDeprecationRegistry and warns.
+    with pytest.warns(PendingDeprecationWarning):
+        assert validate(getattr(module, attr))
 
 
 def test_sorted_commands_in_error(capsys: CaptureFixture):

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -92,7 +92,7 @@ def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
         ("conda.cli.conda_argparse.ArgumentParser", isclass),
         ("conda.cli.conda_argparse.BUILTIN_COMMANDS", lambda x: isinstance(x, set)),
         (
-            "conda.cli.conda_argparse.BUILTIN_SUBCOMMAND_HELP",
+            "conda.cli.conda_argparse.BUILTIN_SUBCOMMANDS",
             lambda x: isinstance(x, dict),
         ),
         ("conda.cli.conda_argparse.configure_parser_plugins", isfunction),

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -143,6 +143,44 @@ def test_deprecated_imports(path: str, validate: Callable[[Any], bool]):
         assert validate(getattr(module, attr))
 
 
+def test_lazy_parser_map_cheap_introspection():
+    """keys/__iter__/__contains__ on the lazy parser map must not trigger
+    per-subcommand parser loading or plugin discovery.
+
+    argparse internals call these on the hot path (help formatting, error
+    messages, _check_value). Triggering ``configure_parser`` for every
+    subcommand or loading all plugins there would cancel out the whole point
+    of lazy subcommand loading.
+    """
+    parser = generate_parser()
+    action = parser._subparsers._group_actions[0]
+
+    # Snapshot state before any map-side introspection happens.
+    pending_before = set(action._lazy_loaders)
+    plugins_loaded_before = action._plugins_loaded
+    assert pending_before, "expected some builtin subcommands pending lazy load"
+
+    # keys()/__iter__/__contains__ for a known builtin must not load anything.
+    keys = set(action._name_parser_map.keys())
+    assert pending_before <= keys
+    assert set(iter(action._name_parser_map)) == keys
+    assert "install" in action._name_parser_map
+    assert "create" in action._name_parser_map
+
+    assert set(action._lazy_loaders) == pending_before, (
+        "__contains__/keys/__iter__ must not run configure_parser for builtins"
+    )
+    assert action._plugins_loaded is plugins_loaded_before, (
+        "__contains__/keys/__iter__ must not trigger plugin discovery for builtins"
+    )
+
+    # Unknown name: allowed to discover plugins once (to answer whether the
+    # name is a plugin-provided subcommand), but still must not load any
+    # builtin parsers.
+    assert "this-subcommand-does-not-exist" not in action._name_parser_map
+    assert set(action._lazy_loaders) == pending_before
+
+
 def test_sorted_commands_in_error(capsys: CaptureFixture):
     p = ArgumentParser()
     sp = p.add_subparsers(

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -133,14 +133,16 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
     ],
 )
 def test_deprecated_imports(path: str, validate: Callable[[Any], bool]):
-    """Verify deprecated re-exports still work but emit PendingDeprecationWarning."""
+    """Verify deprecated re-exports still work and emit PendingDeprecationWarning
+    on *every* access (including the first), now that they are registered via
+    ``deprecated.constant(factory=...)`` at module import time."""
     path, attr = path.rsplit(".", 1)
     module = importlib.import_module(path)
-    # First access registers the deprecation without warning (lazy registration).
-    assert hasattr(module, attr)
-    # Second access goes through the _ConstantDeprecationRegistry and warns.
     with pytest.warns(PendingDeprecationWarning):
-        assert validate(getattr(module, attr))
+        value = getattr(module, attr)
+    assert validate(value)
+    with pytest.warns(PendingDeprecationWarning):
+        assert getattr(module, attr) is value
 
 
 def test_lazy_parser_map_cheap_introspection():

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -133,15 +133,14 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
     ],
 )
 def test_deprecated_imports(path: str, validate: Callable[[Any], bool]):
-    """Verify deprecated re-exports still work and emit PendingDeprecationWarning
-    on *every* access (including the first), now that they are registered via
-    ``deprecated.constant(factory=...)`` at module import time."""
+    """Verify deprecated re-exports still work and warn on every access."""
     path, attr = path.rsplit(".", 1)
     module = importlib.import_module(path)
-    with pytest.warns(PendingDeprecationWarning):
+    warning_types = (PendingDeprecationWarning, DeprecationWarning)
+    with pytest.warns(warning_types):
         value = getattr(module, attr)
     assert validate(value)
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(warning_types):
         assert getattr(module, attr) is value
 
 

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -91,6 +91,10 @@ def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
         ("conda.cli.conda_argparse.add_parser_verbose", isfunction),
         ("conda.cli.conda_argparse.ArgumentParser", isclass),
         ("conda.cli.conda_argparse.BUILTIN_COMMANDS", lambda x: isinstance(x, set)),
+        (
+            "conda.cli.conda_argparse.BUILTIN_SUBCOMMAND_HELP",
+            lambda x: isinstance(x, dict),
+        ),
         ("conda.cli.conda_argparse.configure_parser_plugins", isfunction),
         ("conda.cli.conda_argparse.do_call", isfunction),
         ("conda.cli.conda_argparse.ExtendConstAction", isclass),

--- a/tests/plugins/test_subcommands.py
+++ b/tests/plugins/test_subcommands.py
@@ -12,6 +12,7 @@ from conda import plugins
 from conda.auxlib.ish import dals
 from conda.base.context import context
 from conda.cli.conda_argparse import (
+    _PLUGIN_FREE_BUILTIN_COMMANDS,
     BUILTIN_COMMANDS,
     find_builtin_commands,
     generate_parser,
@@ -179,18 +180,23 @@ def test_cannot_override_builtin_commands(command, plugin_manager, mocker, conda
         conda_cli(command, "--help")
 
     # assertions; make sure we got the right error messages and didn't invoke the custom command
-    assert mock_log.error.mock_calls == [
-        mocker.call(
-            dals(
-                f"""
-                The plugin '{command}' is trying to override the built-in command
-                with the same name, which is not allowed.
+    expected_log_calls = (
+        []
+        if command in _PLUGIN_FREE_BUILTIN_COMMANDS
+        else [
+            mocker.call(
+                dals(
+                    f"""
+                    The plugin '{command}' is trying to override the built-in command
+                    with the same name, which is not allowed.
 
-                Please uninstall the plugin to stop seeing this error message.
-                """
+                    Please uninstall the plugin to stop seeing this error message.
+                    """
+                )
             )
-        )
-    ]
+        ]
+    )
+    assert mock_log.error.mock_calls == expected_log_calls
 
     assert mocked.mock_calls == []
 


### PR DESCRIPTION
Part of #15867 (A2 + A3).

### Problem

`conda/cli/conda_argparse.py` used to import all 20 `main_*` subcommand modules at module-load time via 20 `from .main_X import configure_parser as configure_parser_X` statements. Since `conda_argparse` is loaded on every `conda` invocation, every subcommand module -- and its transitive dependency tree -- was imported regardless of which command was actually run.

### Solution

Introduces `_LazySubParsersAction` (subclass of `_GreedySubParsersAction`) and a `_LazyParserMap` for the `_name_parser_map`:

- Stub parsers (name + help text) are registered for all built-in subcommands at `generate_parser()` time, without importing their modules.
- The real `configure_parser()` call is deferred until the subcommand is actually invoked; at that point its module is imported and the stub is filled in.
- `_LazyParserMap.keys()` / `__iter__` / `__contains__` answer from the pending-loader table and alias map, so argparse's help formatting and error messages don't trigger mass loading.
- Plugin discovery is deferred until `--help` is rendered (`_get_subactions`) or a subcommand is dispatched (`__call__`) -- `conda commands`, invalid-command errors, and the built-in-override check all still work.

The deprecated `configure_parser_*` functions and `*_rc_path` strings remain importable from `conda.cli.conda_argparse` and are registered via `deprecated.constant(factory=...)` (the canonical API from #15925), so their target modules (`conda.cli.main_*`, `conda.base.context`) also stay off the cold-start path until the deprecated name is touched. First access emits `PendingDeprecationWarning` as expected.

### Measured impact

macOS ARM64, devenv Python 3.13, 30 runs, `hyperfine --warmup 3`.

**Isolated ceiling** -- pure parser construction, no subcommand dispatched:

```
python -c "from conda.cli.conda_argparse import generate_parser
generate_parser().parse_args(['--version'])"
```

| | `main` | this PR | Δ |
|---|---|---|---|
| wall-clock | 545.0 ± 12.4 ms | 63.5 ± 7.1 ms | **−481.5 ms (8.6×)** |
| `sys.modules` total | 926 | 125 | **−801** |
| `conda.cli.main_*` | 26 | 0 | −26 |
| `conda.*` total | 170 | 11 | −159 |

**Bare module import** (captures the +1.2 ms cost of the 24 module-scope `deprecated.constant(factory=...)` registrations):

```
python -c "import conda.cli.conda_argparse"
```

| | pre-refactor A2/A3 | this PR | Δ |
|---|---|---|---|
| wall-clock | 58.7 ± 6.2 ms | 59.9 ± 4.2 ms | +1.2 ms (within σ) |

**End-to-end commands** (`conda --version`, `conda <cmd> --help`): essentially flat vs. `main`. Once a subcommand is dispatched or top-level help is rendered, `_ensure_plugins_loaded()` runs and pulls in the plugin subcommand modules. The lazy parser still avoids the 19 *other* builtin subcommands, but on this machine their transitive overlap with plugin discovery hides most of that in wall-clock. The isolated ceiling above is the honest upper bound; real-command savings compound once A6 (plugin-skip on activate) and A11 (plugin-skip on `conda run`) land.

### Notes

- Earlier revisions of this PR measured −142 ms / −505 modules against a pre-Track-A baseline. Most of Track A has since merged (A1, A4, A5, A5b, A7, A12, A15, A17, A18, A20a, A20b, A21, A23); none of those merges targeted the eager-subcommand-parser path, so the isolated delta here is bigger now, not smaller. See #15867 note ¹⁵ for the methodology.
- The previous revision registered deprecated re-exports lazily from a custom `__getattr__`. That had a small but real bug -- the first access to each deprecated symbol was silent, because the `_ConstantDeprecationRegistry` only took over *after* the first call had already returned. Migrating to module-scope `deprecated.constant(factory=...)` closes that hole at a noise-level import-time cost (+1.2 ms).

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- ~Add / update outdated documentation?~ Not applicable.
