### PR TITLE
Defer heavy imports in notices/core.py and main_env.py (A4)

### DIFF
--- a/conda/cli/main_env.py
+++ b/conda/cli/main_env.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import main_export
-
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace, _SubParsersAction
 
@@ -19,6 +17,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         main_env_list,
         main_env_remove,
         main_env_update,
+        main_export,
     )
 
     p = sub_parsers.add_parser(

--- a/conda/notices/core.py
+++ b/conda/notices/core.py
@@ -11,16 +11,13 @@ from typing import TYPE_CHECKING
 
 from ..base.constants import NOTICES_DECORATOR_DISPLAY_INTERVAL, NOTICES_FN
 from ..base.context import context
-from ..models.channel import get_channel_objs
-from . import cache, fetch, views
-from .types import ChannelNoticeResultSet
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from ..base.context import Context
     from ..models.channel import Channel, MultiChannel
-    from .types import ChannelNotice, ChannelNoticeResponse
+    from .types import ChannelNotice, ChannelNoticeResponse, ChannelNoticeResultSet
 
 # Used below in type hints
 ChannelName = str
@@ -44,6 +41,10 @@ def retrieve_notices(
                             (defaults to True).
         silent: Whether to use a spinner when fetching and caching notices.
     """
+    from ..models.channel import get_channel_objs
+    from . import cache, fetch
+    from .types import ChannelNoticeResultSet
+
     channel_name_urls = get_channel_name_and_urls(get_channel_objs(context))
     channel_notice_responses = fetch.get_notice_responses(
         channel_name_urls, silent=silent
@@ -78,6 +79,8 @@ def retrieve_notices(
 
 def display_notices(channel_notice_set: ChannelNoticeResultSet) -> None:
     """Prints the channel notices to std out."""
+    from . import cache, views
+
     views.print_notices(channel_notice_set.channel_notices)
 
     # Updates cache database, marking displayed notices as "viewed"
@@ -132,7 +135,8 @@ def notices(func):
 
                 except Exception:
                     try:
-                        # Remove the notices cache file if we encounter an exception
+                        from . import cache
+
                         cache.clear_cache()
                     except OSError:
                         pass
@@ -215,6 +219,8 @@ def is_channel_notices_cache_expired() -> bool:
     attribute of the file. Anything older than what is specified as
     the NOTICES_DECORATOR_DISPLAY_INTERVAL is considered expired.
     """
+    from . import cache
+
     cache_file = cache.get_notices_cache_file()
 
     cache_file_stat = cache_file.stat()

--- a/news/15867-deferred-subcommand-imports
+++ b/news/15867-deferred-subcommand-imports
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Defer heavy imports in `notices/core.py` and `cli/main_env.py` to reduce the module cost of loading individual subcommand modules. (#15867)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_env_imports.py
+++ b/tests/cli/test_main_env_imports.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Verify that importing conda.cli.main_env does not eagerly load main_export."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_main_env_does_not_eagerly_import_main_export() -> None:
+    """main_env should defer main_export until configure_parser() is called."""
+    snippet = textwrap.dedent("""\
+        import sys
+        import conda.cli.main_env
+        print("conda.cli.main_export" in sys.modules)
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Probe failed: {result.stderr}"
+    assert result.stdout.strip() == "False", (
+        "main_export was loaded at import time; it should be deferred to configure_parser()"
+    )

--- a/tests/notices/test_deferred_imports.py
+++ b/tests/notices/test_deferred_imports.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Verify that importing conda.notices.core does not eagerly load heavy deps.
+
+These tests run in a subprocess to get a clean sys.modules snapshot,
+ensuring the deferred imports in notices/core.py are actually deferred.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "conda.notices.fetch",
+        "conda.notices.cache",
+        "conda.notices.views",
+        "conda.notices.types",
+        "conda.models.channel",
+    ],
+)
+def test_notices_core_does_not_eagerly_import(module: str) -> None:
+    """Importing notices.core should not pull in fetch, cache, views, or models."""
+    snippet = textwrap.dedent(f"""\
+        import sys
+        from conda.notices.core import notices, retrieve_notices, display_notices
+        present = "{module}" in sys.modules
+        print(present)
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Probe failed: {result.stderr}"
+    assert result.stdout.strip() == "False", (
+        f"{module} was loaded at import time; it should be deferred"
+    )
+
+
+def test_notices_core_does_not_load_requests() -> None:
+    """The @notices decorator should be importable without pulling in requests."""
+    snippet = textwrap.dedent("""\
+        import sys
+        from conda.notices.core import notices
+        print("requests" in sys.modules)
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Probe failed: {result.stderr}"
+    assert result.stdout.strip() == "False", (
+        "requests was loaded by importing notices.core; it should be deferred"
+    )


### PR DESCRIPTION
### Description

Defer module-level imports in `conda/notices/core.py` and `conda/cli/main_env.py` so that importing these modules no longer pulls in the full notices dependency tree (`requests`, `concurrent.futures`, `models.channel`, etc.).

**`notices/core.py`**: moves `get_channel_objs`, `cache`, `fetch`, `views`, and `ChannelNoticeResultSet` from module-level into the functions that actually use them (`retrieve_notices`, `display_notices`, `is_channel_notices_cache_expired`, and the `notices` decorator error handler). The `@notices` decorator remains unchanged on all `main_*.py` files — it's now cheap to import because the heavy work is deferred to when notices are actually fetched.

**`main_env.py`**: moves the `from . import main_export` from module-level into `configure_parser()`, alongside the other `main_env_*` imports that were already deferred.

This is a follow-up to the lazy subcommand parser loading in #15868 (A2/A3). Once subcommands load individually, A4 cuts the per-subcommand module cost significantly:

| Module | Baseline | With A4 | Savings |
|---|---|---|---|
| `main_create` | +560 modules, 183 ms | +173 modules, 65 ms | −387 modules, −118 ms |
| `main_install` | +560 modules, 176 ms | +173 modules, 69 ms | −387 modules, −107 ms |
| `main_env` | +647 modules, 282 ms | +32 modules, 10 ms | −615 modules, −272 ms |

Without A2/A3 (current eager `generate_parser()` path), the savings are negligible (~4 modules) because `conda_argparse` pulls everything in regardless.

Part of #15867. Related: #13567, #14500.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~ (no user-facing docs needed)
