### PR TITLE
Defer `concurrent.futures` in `common/io.py` (A9)

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -9,7 +9,6 @@ import os
 import signal
 import sys
 from collections import defaultdict
-from concurrent.futures import Executor, Future, ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from enum import Enum
 from errno import EPIPE, ESHUTDOWN
@@ -17,7 +16,6 @@ from functools import partial, wraps
 from io import BytesIO, StringIO
 from logging import CRITICAL, WARN, Formatter, StreamHandler, getLogger
 from os.path import dirname, isdir, isfile, join
-from threading import Lock
 from time import time
 from typing import TYPE_CHECKING
 
@@ -494,65 +492,91 @@ def timeout(
             return default_return
 
 
-# use this for debugging, because ProcessPoolExecutor isn't pdb/ipdb friendly
-class DummyExecutor(Executor):
-    """Synchronous executor for debugging; executes tasks in the current thread."""
+def _load_concurrency() -> None:
+    """Lazily define executor classes and as_completed on first access.
 
-    def __init__(self) -> None:
-        self._shutdown = False
-        self._shutdownLock = Lock()
+    Importing concurrent.futures + threading costs ~45 modules.  Deferring
+    this to first use keeps ``import conda.common.io`` lightweight for code
+    paths that never use parallel I/O (dashlist, time_recorder, etc.).
+    """
+    from concurrent.futures import (
+        Executor,
+        Future,
+        ThreadPoolExecutor,
+        as_completed,
+    )
+    from threading import Lock
 
-    def submit(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Future[Any]:
-        with self._shutdownLock:
-            if self._shutdown:
-                raise RuntimeError("cannot schedule new futures after shutdown")
+    class DummyExecutor(Executor):
+        """Synchronous executor for debugging; executes tasks in the current thread."""
 
-            f = Future()
+        def __init__(self) -> None:
+            self._shutdown = False
+            self._shutdownLock = Lock()
+
+        def submit(
+            self, fn: Callable[..., Any], *args: Any, **kwargs: Any
+        ) -> Future[Any]:
+            with self._shutdownLock:
+                if self._shutdown:
+                    raise RuntimeError("cannot schedule new futures after shutdown")
+
+                f = Future()
+                try:
+                    result = fn(*args, **kwargs)
+                except BaseException as e:
+                    f.set_exception(e)
+                else:
+                    f.set_result(result)
+
+                return f
+
+        def map(
+            self,
+            func: Callable[..., Any],
+            *iterables: Iterable[Any],
+        ) -> Iterator[Any]:
+            """Map function over iterables, yielding results one at a time."""
+            for iterable in iterables:
+                for thing in iterable:
+                    yield func(thing)
+
+        def shutdown(self, wait: bool = True) -> None:
+            with self._shutdownLock:
+                self._shutdown = True
+
+    class ThreadLimitedThreadPoolExecutor(ThreadPoolExecutor):
+        """Thread pool executor that gracefully handles thread creation limits."""
+
+        def __init__(self, max_workers: int = 10) -> None:
+            super().__init__(max_workers)
+
+        def _adjust_thread_count(self) -> None:
             try:
-                result = fn(*args, **kwargs)
-            except BaseException as e:
-                f.set_exception(e)
-            else:
-                f.set_result(result)
+                return super()._adjust_thread_count()
+            except RuntimeError:
+                # RuntimeError: can't start new thread
+                # See https://github.com/conda/conda/issues/6624
+                if len(self._threads) > 0:
+                    pass
+                else:
+                    raise
 
-            return f
-
-    def map(
-        self,
-        func: Callable[..., Any],
-        *iterables: Iterable[Any],
-    ) -> Iterator[Any]:
-        """Map function over iterables, yielding results one at a time."""
-        for iterable in iterables:
-            for thing in iterable:
-                yield func(thing)
-
-    def shutdown(self, wait: bool = True) -> None:
-        with self._shutdownLock:
-            self._shutdown = True
+    globals()["DummyExecutor"] = DummyExecutor
+    globals()["ThreadLimitedThreadPoolExecutor"] = ThreadLimitedThreadPoolExecutor
+    globals()["as_completed"] = as_completed
 
 
-class ThreadLimitedThreadPoolExecutor(ThreadPoolExecutor):
-    """Thread pool executor that gracefully handles thread creation limits."""
-
-    def __init__(self, max_workers: int = 10) -> None:
-        super().__init__(max_workers)
-
-    def _adjust_thread_count(self) -> None:
-        try:
-            return super()._adjust_thread_count()
-        except RuntimeError:
-            # RuntimeError: can't start new thread
-            # See https://github.com/conda/conda/issues/6624
-            if len(self._threads) > 0:
-                # It's ok to not be able to start new threads if we already have at least
-                # one thread alive.
-                pass
-            else:
-                raise
+_LAZY_CONCURRENCY = frozenset(
+    {"DummyExecutor", "ThreadLimitedThreadPoolExecutor", "as_completed"}
+)
 
 
-as_completed = as_completed
+def __getattr__(name: str):
+    if name in _LAZY_CONCURRENCY:
+        _load_concurrency()
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_instrumentation_record_file() -> str:

--- a/news/15867-defer-concurrency-imports
+++ b/news/15867-defer-concurrency-imports
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Defer `concurrent.futures` and `threading` imports in `common/io.py` so they only load when executor classes (`DummyExecutor`, `ThreadLimitedThreadPoolExecutor`) are first accessed. (#15867)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/common/test_io_deferred_imports.py
+++ b/tests/common/test_io_deferred_imports.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Verify that importing conda.common.io does not eagerly load concurrency modules."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_io_does_not_eagerly_import_concurrent_futures() -> None:
+    """concurrent.futures should only load when executor classes are accessed."""
+    snippet = textwrap.dedent("""\
+        import sys
+        import conda.common.io
+        print("concurrent.futures" in sys.modules)
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Probe failed: {result.stderr}"
+    assert result.stdout.strip() == "False", (
+        "concurrent.futures was loaded at import time; it should be deferred"
+    )
+
+
+def test_lazy_executor_classes_work() -> None:
+    """DummyExecutor and ThreadLimitedThreadPoolExecutor should still work when accessed."""
+    snippet = textwrap.dedent("""\
+        import sys
+        from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor, as_completed
+        assert "concurrent.futures" in sys.modules
+        e = DummyExecutor()
+        f = e.submit(lambda: 42)
+        assert f.result() == 42
+        e.shutdown()
+        print("ok")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Probe failed: {result.stderr}"
+    assert result.stdout.strip() == "ok"


### PR DESCRIPTION
### Description

Use PEP 562 `__getattr__` to lazily define `DummyExecutor`, `ThreadLimitedThreadPoolExecutor`, and `as_completed` in `conda/common/io.py`.

`concurrent.futures` costs ~45 modules to import. This module is loaded whenever `common/io.py` is imported, even for lightweight utilities like `dashlist` or `time_recorder`. Deferring the executor classes to first access means only code that actually uses parallel I/O pays the cost.

Part of #15867. Related: #13567, #14500.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~ (no user-facing docs needed)
