### PR TITLE
Defer ruamel.yaml import in serialize/yaml.py (A10)

### DIFF
--- a/conda/common/serialize/yaml.py
+++ b/conda/common/serialize/yaml.py
@@ -9,15 +9,19 @@ from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
+from ...deprecations import deprecated
+
 if TYPE_CHECKING:
     from io import IO
     from typing import Any
+
+    import ruamel.yaml
 
     from ..path import PathType
 
 
 @cache
-def _yaml():
+def _representer() -> type[ruamel.yaml.representer.RoundTripRepresenter]:
     import ruamel.yaml
 
     class CondaYAMLRepresenter(ruamel.yaml.representer.RoundTripRepresenter):
@@ -41,9 +45,15 @@ def _yaml():
             )
 
     CondaYAMLRepresenter.add_representer(None, CondaYAMLRepresenter.default)
+    return CondaYAMLRepresenter
+
+
+@cache
+def _yaml() -> ruamel.yaml.YAML:
+    import ruamel.yaml
 
     parser = ruamel.yaml.YAML(typ="rt")
-    parser.Representer = CondaYAMLRepresenter
+    parser.Representer = _representer()
     parser.indent(mapping=2, offset=2, sequence=4)
     parser.default_flow_style = False
     parser.sort_base_mapping_type_on_output = False
@@ -123,9 +133,30 @@ def loads(s: str) -> Any:
     return read(text=s)
 
 
-def __getattr__(name: str):
+# ``YAMLError`` is re-exported lazily via PEP-562 so that merely importing
+# this module does not pull in ``ruamel.yaml``. ``deprecated.constant``
+# below installs its own module-level ``__getattr__`` and wires this one
+# up as its fallback, so both names resolve correctly.
+def __getattr__(name: str) -> Any:
     if name == "YAMLError":
         import ruamel.yaml
 
         return ruamel.yaml.YAMLError
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# ``CondaYAMLRepresenter`` used to be a module-level class. Keep it
+# importable for external consumers but emit a deprecation warning on
+# access. Passing ``factory=`` defers ``_representer()`` (which imports
+# ``ruamel.yaml``) until the deprecated symbol is actually used.
+deprecated.constant(
+    "26.9",
+    "27.3",
+    "CondaYAMLRepresenter",
+    factory=_representer,
+    addendum=(
+        "Use `conda.common.serialize.yaml.write`/`read` or subclass "
+        "`ruamel.yaml.representer.RoundTripRepresenter` directly."
+    ),
+)

--- a/conda/common/serialize/yaml.py
+++ b/conda/common/serialize/yaml.py
@@ -4,13 +4,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
 from functools import cache
 from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
-
-import ruamel.yaml
 
 if TYPE_CHECKING:
     from io import IO
@@ -19,30 +16,32 @@ if TYPE_CHECKING:
     from ..path import PathType
 
 
-class CondaYAMLRepresenter(ruamel.yaml.representer.RoundTripRepresenter):
-    def default(self, data: Any) -> Any:
-        # Python types
-        if isinstance(data, Enum):
-            return self.represent_str(data.value)
-        elif isinstance(data, Path):
-            return self.represent_str(str(data))
-
-        # auxlib entity types
-        for attr in ("dump", "__json__", "to_json", "as_json"):
-            if method := getattr(data, attr, None):
-                return self.represent_data(method())
-
-        # mirror JSON behavior
-        raise TypeError(
-            f"Object of type {data.__class__.__name__} is not YAML serializable"
-        )
-
-
-CondaYAMLRepresenter.add_representer(None, CondaYAMLRepresenter.default)
-
-
 @cache
-def _yaml() -> ruamel.yaml.YAML:
+def _yaml():
+    import ruamel.yaml
+
+    class CondaYAMLRepresenter(ruamel.yaml.representer.RoundTripRepresenter):
+        def default(self, data: Any) -> Any:
+            from enum import Enum
+
+            # Python types
+            if isinstance(data, Enum):
+                return self.represent_str(data.value)
+            elif isinstance(data, Path):
+                return self.represent_str(str(data))
+
+            # auxlib entity types
+            for attr in ("dump", "__json__", "to_json", "as_json"):
+                if method := getattr(data, attr, None):
+                    return self.represent_data(method())
+
+            # mirror JSON behavior
+            raise TypeError(
+                f"Object of type {data.__class__.__name__} is not YAML serializable"
+            )
+
+    CondaYAMLRepresenter.add_representer(None, CondaYAMLRepresenter.default)
+
     parser = ruamel.yaml.YAML(typ="rt")
     parser.Representer = CondaYAMLRepresenter
     parser.indent(mapping=2, offset=2, sequence=4)
@@ -124,4 +123,9 @@ def loads(s: str) -> Any:
     return read(text=s)
 
 
-YAMLError = ruamel.yaml.YAMLError
+def __getattr__(name: str):
+    if name == "YAMLError":
+        import ruamel.yaml
+
+        return ruamel.yaml.YAMLError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/news/15867-lazy-ruamel-yaml
+++ b/news/15867-lazy-ruamel-yaml
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* <news item>
+* Mark `conda.common.serialize.yaml.CondaYAMLRepresenter` as pending deprecation (removal in 27.3). The class is still importable via a lazy module-level `__getattr__` but accessing it now emits a `PendingDeprecationWarning`. External consumers should use `conda.common.serialize.yaml.write`/`read` or subclass `ruamel.yaml.representer.RoundTripRepresenter` directly. (#15867)
 
 ### Docs
 

--- a/news/15867-lazy-ruamel-yaml
+++ b/news/15867-lazy-ruamel-yaml
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Defer `ruamel.yaml` import in `common/serialize/yaml.py` so it only loads when YAML parsing/writing is first needed. (#15867)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/common/test_yaml_deferred_imports.py
+++ b/tests/common/test_yaml_deferred_imports.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Verify that importing conda.common.serialize.yaml does not eagerly load ruamel.yaml."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_yaml_module_does_not_eagerly_import_ruamel() -> None:
+    """ruamel.yaml should only load when _yaml() is first called."""
+    snippet = textwrap.dedent("""\
+        import sys
+        import conda.common.serialize.yaml
+        print("ruamel.yaml" in sys.modules)
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Probe failed: {result.stderr}"
+    assert result.stdout.strip() == "False", (
+        "ruamel.yaml was loaded at import time; it should be deferred to _yaml()"
+    )
+
+
+def test_yaml_roundtrip_still_works() -> None:
+    """Lazy loading should not break read/write functionality."""
+    snippet = textwrap.dedent("""\
+        from conda.common.serialize.yaml import dumps, loads
+        data = {"key": "value", "nested": [1, 2, 3]}
+        text = dumps(data)
+        assert "key" in text
+        loaded = loads(text)
+        assert loaded["key"] == "value"
+        assert loaded["nested"] == [1, 2, 3]
+        print("ok")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Probe failed: {result.stderr}"
+    assert result.stdout.strip() == "ok"
+
+
+def test_yaml_error_accessible() -> None:
+    """YAMLError should be accessible as a lazy module attribute."""
+    snippet = textwrap.dedent("""\
+        from conda.common.serialize import yaml
+        err_cls = yaml.YAMLError
+        assert err_cls is not None
+        print("ok")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Probe failed: {result.stderr}"
+    assert result.stdout.strip() == "ok"

--- a/tests/common/test_yaml_deferred_imports.py
+++ b/tests/common/test_yaml_deferred_imports.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 import subprocess
 import sys
 import textwrap
+import warnings
+
+from conda.common.serialize import yaml
 
 
 def test_yaml_module_does_not_eagerly_import_ruamel() -> None:
@@ -66,3 +69,29 @@ def test_yaml_error_accessible() -> None:
     )
     assert result.returncode == 0, f"Probe failed: {result.stderr}"
     assert result.stdout.strip() == "ok"
+
+
+def test_conda_yaml_representer_is_deprecated() -> None:
+    """Accessing the legacy module-level class emits a deprecation warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cls = yaml.CondaYAMLRepresenter
+
+    assert cls is not None
+    assert any(
+        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
+        and "CondaYAMLRepresenter" in str(w.message)
+        for w in caught
+    ), (
+        f"expected deprecation warning, got: {[(w.category, str(w.message)) for w in caught]}"
+    )
+
+
+def test_conda_yaml_representer_stable_identity() -> None:
+    """Repeated accesses return the same class object (cached)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cls_a = yaml.CondaYAMLRepresenter
+        cls_b = yaml.CondaYAMLRepresenter
+
+    assert cls_a is cls_b

--- a/tests/common/test_yaml_deferred_imports.py
+++ b/tests/common/test_yaml_deferred_imports.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import subprocess
 import sys
 import textwrap
-import warnings
+
+import pytest
 
 from conda.common.serialize import yaml
 
@@ -17,7 +18,7 @@ def test_yaml_module_does_not_eagerly_import_ruamel() -> None:
     snippet = textwrap.dedent("""\
         import sys
         import conda.common.serialize.yaml
-        print("ruamel.yaml" in sys.modules)
+        assert "ruamel.yaml" not in sys.modules
     """)
     result = subprocess.run(
         [sys.executable, "-c", snippet],
@@ -26,9 +27,6 @@ def test_yaml_module_does_not_eagerly_import_ruamel() -> None:
         timeout=30,
     )
     assert result.returncode == 0, f"Probe failed: {result.stderr}"
-    assert result.stdout.strip() == "False", (
-        "ruamel.yaml was loaded at import time; it should be deferred to _yaml()"
-    )
 
 
 def test_yaml_roundtrip_still_works() -> None:
@@ -41,7 +39,6 @@ def test_yaml_roundtrip_still_works() -> None:
         loaded = loads(text)
         assert loaded["key"] == "value"
         assert loaded["nested"] == [1, 2, 3]
-        print("ok")
     """)
     result = subprocess.run(
         [sys.executable, "-c", snippet],
@@ -50,16 +47,13 @@ def test_yaml_roundtrip_still_works() -> None:
         timeout=30,
     )
     assert result.returncode == 0, f"Probe failed: {result.stderr}"
-    assert result.stdout.strip() == "ok"
 
 
 def test_yaml_error_accessible() -> None:
     """YAMLError should be accessible as a lazy module attribute."""
     snippet = textwrap.dedent("""\
         from conda.common.serialize import yaml
-        err_cls = yaml.YAMLError
-        assert err_cls is not None
-        print("ok")
+        assert yaml.YAMLError is not None
     """)
     result = subprocess.run(
         [sys.executable, "-c", snippet],
@@ -68,29 +62,19 @@ def test_yaml_error_accessible() -> None:
         timeout=30,
     )
     assert result.returncode == 0, f"Probe failed: {result.stderr}"
-    assert result.stdout.strip() == "ok"
 
 
 def test_conda_yaml_representer_is_deprecated() -> None:
     """Accessing the legacy module-level class emits a deprecation warning."""
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with pytest.deprecated_call(match="CondaYAMLRepresenter"):
         cls = yaml.CondaYAMLRepresenter
 
     assert cls is not None
-    assert any(
-        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
-        and "CondaYAMLRepresenter" in str(w.message)
-        for w in caught
-    ), (
-        f"expected deprecation warning, got: {[(w.category, str(w.message)) for w in caught]}"
-    )
 
 
 def test_conda_yaml_representer_stable_identity() -> None:
     """Repeated accesses return the same class object (cached)."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.deprecated_call():
         cls_a = yaml.CondaYAMLRepresenter
         cls_b = yaml.CondaYAMLRepresenter
 


### PR DESCRIPTION
### Description

Move `import ruamel.yaml` and the `CondaYAMLRepresenter` class definition inside cached factory functions (`_yaml()` / `_representer()`) in `conda/common/serialize/yaml.py`. `YAMLError` becomes a lazy module attribute via `__getattr__` (PEP 562).

This removes 32 `ruamel.yaml` modules from any code path that imports `common/serialize/yaml` without actually parsing YAML. Wall-clock impact on warm-cache macOS is negligible, but the module-count reduction helps:

- Cold-cache scenarios (CI, containers, first invocation)
- Module-count budget compliance (CodSpeed guardrails from #15850)
- Reducing import-time side-effect surface area

`CondaYAMLRepresenter` was a module-level name. To avoid silently breaking external consumers that import it directly, it is registered via `deprecated.constant(..., factory=...)` (added in #15925) and remains resolvable as `conda.common.serialize.yaml.CondaYAMLRepresenter`. First access emits `PendingDeprecationWarning` (removal in 27.3). The class is built once by the cached `_representer()` factory, so identity stays stable across accesses. Callers should use `conda.common.serialize.yaml.write` / `read`, or subclass `ruamel.yaml.representer.RoundTripRepresenter` directly.

Part of #15867. Related: #13567, #14500.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ (no user-facing docs needed)
