### PR TITLE
Skip plugin hooks in `do_call()` when manager not loaded (A11)

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -220,24 +220,7 @@ class _Activator(metaclass=abc.ABCMeta):
     def execute(self):
         # return value meant to be written to stdout
         self._parse_and_set_args()
-
-        # Avoid loading plugins solely to run activation hooks. If another
-        # code path has already initialized the plugin manager, preserve the
-        # existing pre/post hook behavior.
-        from .plugins.manager import get_plugin_manager
-
-        try:
-            plugins_loaded = get_plugin_manager.cache_info().currsize > 0
-        except (AttributeError, TypeError):
-            # Tests may patch the cached factory; keep hooks enabled then.
-            plugins_loaded = True
-
-        if plugins_loaded:
-            context.plugin_manager.invoke_pre_commands(self.command)
-        response = getattr(self, self.command)()
-        if plugins_loaded:
-            context.plugin_manager.invoke_post_commands(self.command)
-        return response
+        return getattr(self, self.command)()
 
     def template_unset_var(self, key: str) -> str:
         return self.unset_var_tmpl % key

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -221,24 +221,7 @@ class _Activator(metaclass=abc.ABCMeta):
     def execute(self):
         # return value meant to be written to stdout
         self._parse_and_set_args()
-
-        # Avoid loading plugins solely to run activation hooks. If another
-        # code path has already initialized the plugin manager, preserve the
-        # existing pre/post hook behavior.
-        from .plugins.manager import get_plugin_manager
-
-        try:
-            plugins_loaded = get_plugin_manager.cache_info().currsize > 0
-        except (AttributeError, TypeError):
-            # Tests may patch the cached factory; keep hooks enabled then.
-            plugins_loaded = True
-
-        if plugins_loaded:
-            context.plugin_manager.invoke_pre_commands(self.command)
-        response = getattr(self, self.command)()
-        if plugins_loaded:
-            context.plugin_manager.invoke_post_commands(self.command)
-        return response
+        return getattr(self, self.command)()
 
     def template_unset_var(self, key: str) -> str:
         return self.unset_var_tmpl % key

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -185,9 +185,23 @@ def do_call(args: argparse.Namespace, parser: ArgumentParser):
         module = import_module(module_name)
         command = module_name.split(".")[-1].replace("main_", "")
 
-        context.plugin_manager.invoke_pre_commands(command)
+        # Only invoke plugin hooks when the plugin manager has already been
+        # loaded.  With lazy subcommand parser loading (A2/A3), commands like
+        # `conda run` reach do_call() without triggering plugin discovery,
+        # so accessing context.plugin_manager here would load all plugins
+        # (~430 modules, ~240 ms) for commands that never use them.
+        from ..plugins.manager import get_plugin_manager
+
+        try:
+            plugins_loaded = get_plugin_manager.cache_info().currsize > 0
+        except (AttributeError, TypeError):
+            plugins_loaded = True
+
+        if plugins_loaded:
+            context.plugin_manager.invoke_pre_commands(command)
         result = getattr(module, func_name)(args, parser)
-        context.plugin_manager.invoke_post_commands(command)
+        if plugins_loaded:
+            context.plugin_manager.invoke_post_commands(command)
     return result
 
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -97,6 +97,9 @@ BUILTIN_COMMANDS = {
 }
 """List of built-in commands; these cannot be overridden by plugin subcommands."""
 
+_PLUGIN_FREE_BUILTIN_COMMANDS = frozenset({"activate", "deactivate", "run"})
+"""Built-in commands that intentionally skip plugin discovery and command hooks."""
+
 BUILTIN_COMMAND_PARSERS = {
     "activate": configure_parser_activate,
     "clean": configure_parser_clean,
@@ -202,23 +205,14 @@ def do_call(args: argparse.Namespace, parser: ArgumentParser):
         # func_name should always be 'execute'
         module = import_module(module_name)
         command = module_name.split(".")[-1].replace("main_", "")
+        invoke_command_hooks = (
+            command.removeprefix("mock_") not in _PLUGIN_FREE_BUILTIN_COMMANDS
+        )
 
-        # Only invoke plugin hooks when the plugin manager has already been
-        # loaded.  With lazy subcommand parser loading (A2/A3), commands like
-        # `conda run` reach do_call() without triggering plugin discovery,
-        # so accessing context.plugin_manager here would load all plugins
-        # (~430 modules, ~240 ms) for commands that never use them.
-        from ..plugins.manager import get_plugin_manager
-
-        try:
-            plugins_loaded = get_plugin_manager.cache_info().currsize > 0
-        except (AttributeError, TypeError):
-            plugins_loaded = True
-
-        if plugins_loaded:
+        if invoke_command_hooks:
             context.plugin_manager.invoke_pre_commands(command)
         result = getattr(module, func_name)(args, parser)
-        if plugins_loaded:
+        if invoke_command_hooks:
             context.plugin_manager.invoke_post_commands(command)
     return result
 

--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -203,9 +203,23 @@ def do_call(args: argparse.Namespace, parser: ArgumentParser):
         module = import_module(module_name)
         command = module_name.split(".")[-1].replace("main_", "")
 
-        context.plugin_manager.invoke_pre_commands(command)
+        # Only invoke plugin hooks when the plugin manager has already been
+        # loaded.  With lazy subcommand parser loading (A2/A3), commands like
+        # `conda run` reach do_call() without triggering plugin discovery,
+        # so accessing context.plugin_manager here would load all plugins
+        # (~430 modules, ~240 ms) for commands that never use them.
+        from ..plugins.manager import get_plugin_manager
+
+        try:
+            plugins_loaded = get_plugin_manager.cache_info().currsize > 0
+        except (AttributeError, TypeError):
+            plugins_loaded = True
+
+        if plugins_loaded:
+            context.plugin_manager.invoke_pre_commands(command)
         result = getattr(module, func_name)(args, parser)
-        context.plugin_manager.invoke_post_commands(command)
+        if plugins_loaded:
+            context.plugin_manager.invoke_post_commands(command)
     return result
 
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -150,6 +150,15 @@ class CondaSpecs:
         """
         Register pre-command functions in conda.
 
+        .. note::
+           Pre-command hooks are best-effort. They are only invoked when the
+           plugin manager has already been loaded by the time a command runs.
+           Fast paths that skip plugin discovery (e.g. ``conda shell.* activate``,
+           or subcommands reached via the lazy subparser) do not fire these
+           hooks. Do not rely on them for correctness; treat them as
+           opportunistic hooks for user-visible side effects (logging,
+           notifications, etc.).
+
         **Example:**
 
         .. code-block:: python
@@ -175,6 +184,15 @@ class CondaSpecs:
     def conda_post_commands(self) -> Iterable[CondaPostCommand]:
         """
         Register post-command functions in conda.
+
+        .. note::
+           Post-command hooks are best-effort. They are only invoked when the
+           plugin manager has already been loaded by the time a command runs.
+           Fast paths that skip plugin discovery (e.g. ``conda shell.* activate``,
+           or subcommands reached via the lazy subparser) do not fire these
+           hooks. Do not rely on them for correctness; treat them as
+           opportunistic hooks for user-visible side effects (logging,
+           notifications, etc.).
 
         **Example:**
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -156,13 +156,11 @@ class CondaSpecs:
         Register pre-command functions in conda.
 
         .. note::
-           Pre-command hooks are best-effort. They are only invoked when the
-           plugin manager has already been loaded by the time a command runs.
-           Fast paths that skip plugin discovery, such as ``conda shell.*``
-           activation commands or ``do_call()`` subcommands reached while the
-           plugin manager is still cold, do not fire these hooks. Do not rely
-           on them for correctness; treat them as opportunistic hooks for
-           user-visible side effects (logging, notifications, etc.).
+           Pre-command hooks are not invoked for ``conda run`` or shell
+           activation commands (``activate``, ``deactivate``, ``reactivate``,
+           and ``hook``). These commands intentionally skip plugin discovery
+           to preserve their startup fast paths. Use ``run_for`` to select
+           from the remaining built-in and plugin subcommands.
 
         **Example:**
 
@@ -191,13 +189,11 @@ class CondaSpecs:
         Register post-command functions in conda.
 
         .. note::
-           Post-command hooks are best-effort. They are only invoked when the
-           plugin manager has already been loaded by the time a command runs.
-           Fast paths that skip plugin discovery, such as ``conda shell.*``
-           activation commands or ``do_call()`` subcommands reached while the
-           plugin manager is still cold, do not fire these hooks. Do not rely
-           on them for correctness; treat them as opportunistic hooks for
-           user-visible side effects (logging, notifications, etc.).
+           Post-command hooks are not invoked for ``conda run`` or shell
+           activation commands (``activate``, ``deactivate``, ``reactivate``,
+           and ``hook``). These commands intentionally skip plugin discovery
+           to preserve their startup fast paths. Use ``run_for`` to select
+           from the remaining built-in and plugin subcommands.
 
         **Example:**
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -155,10 +155,14 @@ class CondaSpecs:
         """
         Register pre-command functions in conda.
 
-        Shell activation commands avoid loading the plugin manager for startup
-        performance. These hooks run for ``conda shell.* activate``,
-        ``deactivate``, ``reactivate``, and ``hook`` only if the plugin manager
-        was already loaded by another code path.
+        .. note::
+           Pre-command hooks are best-effort. They are only invoked when the
+           plugin manager has already been loaded by the time a command runs.
+           Fast paths that skip plugin discovery, such as ``conda shell.*``
+           activation commands or ``do_call()`` subcommands reached while the
+           plugin manager is still cold, do not fire these hooks. Do not rely
+           on them for correctness; treat them as opportunistic hooks for
+           user-visible side effects (logging, notifications, etc.).
 
         **Example:**
 
@@ -186,10 +190,14 @@ class CondaSpecs:
         """
         Register post-command functions in conda.
 
-        Shell activation commands avoid loading the plugin manager for startup
-        performance. These hooks run for ``conda shell.* activate``,
-        ``deactivate``, ``reactivate``, and ``hook`` only if the plugin manager
-        was already loaded by another code path.
+        .. note::
+           Post-command hooks are best-effort. They are only invoked when the
+           plugin manager has already been loaded by the time a command runs.
+           Fast paths that skip plugin discovery, such as ``conda shell.*``
+           activation commands or ``do_call()`` subcommands reached while the
+           plugin manager is still cold, do not fire these hooks. Do not rely
+           on them for correctness; treat them as opportunistic hooks for
+           user-visible side effects (logging, notifications, etc.).
 
         **Example:**
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -150,13 +150,11 @@ class CondaSpecs:
         Register pre-command functions in conda.
 
         .. note::
-           Pre-command hooks are best-effort. They are only invoked when the
-           plugin manager has already been loaded by the time a command runs.
-           Fast paths that skip plugin discovery, such as ``conda shell.*``
-           activation commands or ``do_call()`` subcommands reached while the
-           plugin manager is still cold, do not fire these hooks. Do not rely
-           on them for correctness; treat them as opportunistic hooks for
-           user-visible side effects (logging, notifications, etc.).
+           Pre-command hooks are not invoked for ``conda run`` or shell
+           activation commands (``activate``, ``deactivate``, ``reactivate``,
+           and ``hook``). These commands intentionally skip plugin discovery
+           to preserve their startup fast paths. Use ``run_for`` to select
+           from the remaining built-in and plugin subcommands.
 
         **Example:**
 
@@ -185,13 +183,11 @@ class CondaSpecs:
         Register post-command functions in conda.
 
         .. note::
-           Post-command hooks are best-effort. They are only invoked when the
-           plugin manager has already been loaded by the time a command runs.
-           Fast paths that skip plugin discovery, such as ``conda shell.*``
-           activation commands or ``do_call()`` subcommands reached while the
-           plugin manager is still cold, do not fire these hooks. Do not rely
-           on them for correctness; treat them as opportunistic hooks for
-           user-visible side effects (logging, notifications, etc.).
+           Post-command hooks are not invoked for ``conda run`` or shell
+           activation commands (``activate``, ``deactivate``, ``reactivate``,
+           and ``hook``). These commands intentionally skip plugin discovery
+           to preserve their startup fast paths. Use ``run_for`` to select
+           from the remaining built-in and plugin subcommands.
 
         **Example:**
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -149,10 +149,14 @@ class CondaSpecs:
         """
         Register pre-command functions in conda.
 
-        Shell activation commands avoid loading the plugin manager for startup
-        performance. These hooks run for ``conda shell.* activate``,
-        ``deactivate``, ``reactivate``, and ``hook`` only if the plugin manager
-        was already loaded by another code path.
+        .. note::
+           Pre-command hooks are best-effort. They are only invoked when the
+           plugin manager has already been loaded by the time a command runs.
+           Fast paths that skip plugin discovery, such as ``conda shell.*``
+           activation commands or ``do_call()`` subcommands reached while the
+           plugin manager is still cold, do not fire these hooks. Do not rely
+           on them for correctness; treat them as opportunistic hooks for
+           user-visible side effects (logging, notifications, etc.).
 
         **Example:**
 
@@ -180,10 +184,14 @@ class CondaSpecs:
         """
         Register post-command functions in conda.
 
-        Shell activation commands avoid loading the plugin manager for startup
-        performance. These hooks run for ``conda shell.* activate``,
-        ``deactivate``, ``reactivate``, and ``hook`` only if the plugin manager
-        was already loaded by another code path.
+        .. note::
+           Post-command hooks are best-effort. They are only invoked when the
+           plugin manager has already been loaded by the time a command runs.
+           Fast paths that skip plugin discovery, such as ``conda shell.*``
+           activation commands or ``do_call()`` subcommands reached while the
+           plugin manager is still cold, do not fire these hooks. Do not rely
+           on them for correctness; treat them as opportunistic hooks for
+           user-visible side effects (logging, notifications, etc.).
 
         **Example:**
 

--- a/news/15867-skip-plugin-hooks-run
+++ b/news/15867-skip-plugin-hooks-run
@@ -1,6 +1,10 @@
 ### Enhancements
 
-* Skip plugin pre/post command hooks in `do_call()` when the plugin manager has not been loaded, avoiding unnecessary plugin discovery for commands like `conda run`. (#15867)
+* Skip plugin `pre_commands` / `post_commands` hooks in `do_call()` when the plugin manager has not been loaded
+  yet. With lazy subcommand parser loading (see #15873, #15874), commands such as `conda run` reach `do_call()`
+  without triggering plugin discovery, so touching `context.plugin_manager` would load ~430 modules (~240 ms)
+  for commands that do not use them. Plugin authors should treat pre/post command hooks as best-effort and
+  should not rely on them for correctness; see the note in `conda.plugins.hookspec`. (#15867)
 
 ### Bug fixes
 

--- a/news/15867-skip-plugin-hooks-run
+++ b/news/15867-skip-plugin-hooks-run
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Skip plugin pre/post command hooks in `do_call()` when the plugin manager has not been loaded, avoiding unnecessary plugin discovery for commands like `conda run`. (#15867)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/15867-skip-plugin-hooks-run
+++ b/news/15867-skip-plugin-hooks-run
@@ -1,23 +1,7 @@
 ### Enhancements
 
-* Skip plugin `pre_commands` / `post_commands` hooks in `do_call()` when the plugin manager has not been loaded
-  yet. With lazy subcommand parser loading (see #15873, #15874), commands such as `conda run` reach `do_call()`
-  without triggering plugin discovery, so touching `context.plugin_manager` would load ~430 modules (~240 ms)
-  for commands that do not use them. Plugin authors should treat pre/post command hooks as best-effort and
-  should not rely on them for correctness; see the note in `conda.plugins.hookspec`. (#15867)
-
-### Bug fixes
-
-* <news item>
-
-### Deprecations
-
-* <news item>
+* Skip plugin discovery and pre- and post-command hooks for `conda run` and shell activation commands. (#15867 via #15883)
 
 ### Docs
 
-* <news item>
-
-### Other
-
-* <news item>
+* Document which commands do not invoke pre- and post-command hooks. (#15867 via #15883)

--- a/news/15867-skip-plugin-hooks-run
+++ b/news/15867-skip-plugin-hooks-run
@@ -1,7 +1,0 @@
-### Enhancements
-
-* Skip plugin discovery and pre- and post-command hooks for `conda run` and shell activation commands. (#15867 via #15883)
-
-### Docs
-
-* Document which commands do not invoke pre- and post-command hooks. (#15867 via #15883)

--- a/releases/news/15867-skip-plugin-hooks-run
+++ b/releases/news/15867-skip-plugin-hooks-run
@@ -1,0 +1,7 @@
+### Enhancements
+
+* Skip plugin discovery and pre-command and post-command hooks for `conda run` and shell activation commands. (#15867 via #15883)
+
+### Docs
+
+* Document which commands do not invoke pre-command and post-command hooks. (#15867 via #15883)

--- a/tests/cli/test_do_call_plugin_guard.py
+++ b/tests/cli/test_do_call_plugin_guard.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Verify that do_call() skips plugin hooks when the plugin manager is not loaded.
+
+This guard is effective when combined with lazy subcommand parser loading
+(A2/A3, #15868), which allows commands like `conda run` to reach do_call()
+without triggering plugin discovery.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+
+from conda.cli.conda_argparse import do_call
+from conda.plugins.manager import get_plugin_manager
+
+
+@pytest.fixture()
+def _clear_plugin_manager_cache():
+    """Clear get_plugin_manager's LRU cache so do_call sees an unloaded state."""
+    get_plugin_manager.cache_clear()
+    yield
+    get_plugin_manager.cache_clear()
+
+
+@pytest.mark.usefixtures("_clear_plugin_manager_cache")
+def test_plugin_hooks_skipped_when_manager_not_loaded() -> None:
+    """When the plugin manager has not been loaded, do_call should not trigger it."""
+    assert get_plugin_manager.cache_info().currsize == 0
+
+    executed = []
+
+    def fake_execute(args, parser):
+        executed.append(True)
+        return 0
+
+    # Patch a minimal args.func to point at our fake module
+    import types
+
+    fake_module = types.ModuleType("conda.cli.main_fake")
+    fake_module.execute = fake_execute
+    import sys
+
+    sys.modules["conda.cli.main_fake"] = fake_module
+    try:
+        args = Namespace(func="conda.cli.main_fake.execute")
+        result = do_call(args, parser=None)
+        assert result == 0
+        assert executed == [True]
+        # The plugin manager should still not be loaded
+        assert get_plugin_manager.cache_info().currsize == 0
+    finally:
+        del sys.modules["conda.cli.main_fake"]

--- a/tests/cli/test_do_call_plugin_guard.py
+++ b/tests/cli/test_do_call_plugin_guard.py
@@ -1,55 +1,31 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""Verify that do_call() skips plugin hooks when the plugin manager is not loaded.
-
-This guard is effective when combined with lazy subcommand parser loading
-(A2/A3, #15868), which allows commands like `conda run` to reach do_call()
-without triggering plugin discovery.
-"""
+"""Verify that plugin-free built-in commands do not invoke command hooks."""
 
 from __future__ import annotations
 
 from argparse import Namespace
+from importlib import import_module
 
 import pytest
 
+from conda.base.context import context
 from conda.cli.conda_argparse import do_call
-from conda.plugins.manager import get_plugin_manager
 
 
-@pytest.fixture()
-def _clear_plugin_manager_cache():
-    """Clear get_plugin_manager's LRU cache so do_call sees an unloaded state."""
-    get_plugin_manager.cache_clear()
-    yield
-    get_plugin_manager.cache_clear()
+@pytest.mark.parametrize(
+    "module_name",
+    ("main_mock_activate", "main_mock_deactivate", "main_run"),
+)
+def test_plugin_free_builtin_commands_skip_hooks(mocker, module_name: str) -> None:
+    module = import_module(f"conda.cli.{module_name}")
+    execute = mocker.patch.object(module, "execute", return_value=0)
+    pre_command = mocker.spy(context.plugin_manager, "invoke_pre_commands")
+    post_command = mocker.spy(context.plugin_manager, "invoke_post_commands")
 
+    args = Namespace(func=f"conda.cli.{module_name}.execute")
+    assert do_call(args, parser=None) == 0
 
-@pytest.mark.usefixtures("_clear_plugin_manager_cache")
-def test_plugin_hooks_skipped_when_manager_not_loaded() -> None:
-    """When the plugin manager has not been loaded, do_call should not trigger it."""
-    assert get_plugin_manager.cache_info().currsize == 0
-
-    executed = []
-
-    def fake_execute(args, parser):
-        executed.append(True)
-        return 0
-
-    # Patch a minimal args.func to point at our fake module
-    import types
-
-    fake_module = types.ModuleType("conda.cli.main_fake")
-    fake_module.execute = fake_execute
-    import sys
-
-    sys.modules["conda.cli.main_fake"] = fake_module
-    try:
-        args = Namespace(func="conda.cli.main_fake.execute")
-        result = do_call(args, parser=None)
-        assert result == 0
-        assert executed == [True]
-        # The plugin manager should still not be loaded
-        assert get_plugin_manager.cache_info().currsize == 0
-    finally:
-        del sys.modules["conda.cli.main_fake"]
+    execute.assert_called_once_with(args, None)
+    pre_command.assert_not_called()
+    post_command.assert_not_called()

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2181,40 +2181,14 @@ def plugin(
     "command",
     ["activate", "deactivate", "reactivate", "hook"],
 )
-def test_pre_post_command_invoked(plugin: PrePostCommandPlugin, command: str) -> None:
+def test_pre_post_command_not_invoked(
+    plugin: PrePostCommandPlugin, command: str
+) -> None:
     activator = PosixActivator([command])
     activator.execute()
 
-    assert len(plugin.pre_command_action.mock_calls) == 1
-    assert len(plugin.post_command_action.mock_calls) == 1
-
-
-@pytest.mark.parametrize(
-    "command",
-    ["activate", "deactivate", "reactivate", "hook"],
-)
-def test_pre_post_command_raises(plugin: PrePostCommandPlugin, command: str) -> None:
-    exc_message = "💥"
-
-    # first test post-command exceptions (sine they happen last)
-    plugin.post_command_action.side_effect = Exception(exc_message)
-
-    activator = PosixActivator([command])
-    with pytest.raises(Exception, match=exc_message):
-        activator.execute()
-
-    assert len(plugin.pre_command_action.mock_calls) == 1
-    assert len(plugin.post_command_action.mock_calls) == 1
-
-    # now test pre-command exceptions
-    plugin.pre_command_action.side_effect = Exception(exc_message)
-
-    activator = PosixActivator([command])
-    with pytest.raises(Exception, match=exc_message):
-        activator.execute()
-
-    assert len(plugin.pre_command_action.mock_calls) == 2
-    assert len(plugin.post_command_action.mock_calls) == 1
+    assert len(plugin.pre_command_action.mock_calls) == 0
+    assert len(plugin.post_command_action.mock_calls) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2182,40 +2182,14 @@ def plugin(
     "command",
     ["activate", "deactivate", "reactivate", "hook"],
 )
-def test_pre_post_command_invoked(plugin: PrePostCommandPlugin, command: str) -> None:
+def test_pre_post_command_not_invoked(
+    plugin: PrePostCommandPlugin, command: str
+) -> None:
     activator = PosixActivator([command])
     activator.execute()
 
-    assert len(plugin.pre_command_action.mock_calls) == 1
-    assert len(plugin.post_command_action.mock_calls) == 1
-
-
-@pytest.mark.parametrize(
-    "command",
-    ["activate", "deactivate", "reactivate", "hook"],
-)
-def test_pre_post_command_raises(plugin: PrePostCommandPlugin, command: str) -> None:
-    exc_message = "💥"
-
-    # first test post-command exceptions (sine they happen last)
-    plugin.post_command_action.side_effect = Exception(exc_message)
-
-    activator = PosixActivator([command])
-    with pytest.raises(Exception, match=exc_message):
-        activator.execute()
-
-    assert len(plugin.pre_command_action.mock_calls) == 1
-    assert len(plugin.post_command_action.mock_calls) == 1
-
-    # now test pre-command exceptions
-    plugin.pre_command_action.side_effect = Exception(exc_message)
-
-    activator = PosixActivator([command])
-    with pytest.raises(Exception, match=exc_message):
-        activator.execute()
-
-    assert len(plugin.pre_command_action.mock_calls) == 2
-    assert len(plugin.post_command_action.mock_calls) == 1
+    assert len(plugin.pre_command_action.mock_calls) == 0
+    assert len(plugin.post_command_action.mock_calls) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Apply the same `cache_info()` guard pattern from A6 (#15877) to `do_call()` in `conda_argparse.py`. When the plugin manager has not been loaded (i.e. `get_plugin_manager` was never called), skip `invoke_pre/post_commands` rather than triggering full plugin discovery.

This is effective when combined with lazy subcommand parser loading (A2/A3, #15868): once `generate_parser()` no longer triggers plugin discovery, commands like `conda run` reach `do_call()` without the plugin manager loaded. Skipping the hooks avoids ~430 modules and ~240 ms of unnecessary plugin loading.

PoC measurements showed `conda run` dropping from 831 modules (352 ms) to 249 modules (117 ms) — a 3.0x speedup.

**Depends on:** A2/A3 (#15868) for the guard to be meaningful. Without lazy parser loading, `generate_parser()` still loads the plugin manager before `do_call()` runs.

Part of #15867. See also #14993.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~ (no user-facing docs needed)
