### PR TITLE
`ConsoleReporterRenderer.render` to include a trailing newline

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -487,14 +487,13 @@ class InfoRenderer:
         if self._context.json:
             return {"root_prefix": self._context.root_prefix}
         else:
-            return f"{self._context.root_prefix}\n"
+            return self._context.root_prefix
 
     def _channels_component(self) -> str | dict:
         if self._context.json:
             return {"channels": self._context.channels}
         else:
-            channels_str = "\n".join(self._context.channels)
-            return f"{channels_str}\n"
+            return "\n".join(self._context.channels)
 
     def _detail_component(self) -> dict[str, str]:
         return get_main_info_display(self._info_dict)
@@ -513,7 +512,7 @@ class InfoRenderer:
             f"sys.version: {sys.version[:40]}...",
             f"sys.prefix: {sys.prefix}",
             f"sys.executable: {sys.executable}",
-            "conda location: {}".format(self._info_dict["conda_location"]),
+            f"conda location: {self._info_dict['conda_location']}",
         ]
 
         subcommands = self._context.plugin_manager.get_subcommands()
@@ -537,8 +536,6 @@ class InfoRenderer:
 
         for name, value in sorted(self._info_dict["env_vars"].items()):
             output.append(f"{name}: {value}")
-
-        output.append("")
 
         return "\n".join(output)
 

--- a/conda/plugins/reporter_backends/console.py
+++ b/conda/plugins/reporter_backends/console.py
@@ -197,12 +197,7 @@ class ConsoleReporterRenderer(ReporterRendererBase):
         return "\n".join(table_parts)
 
     @staticmethod
-    def envs_list(
-        prefixes: Iterable[PathType | PrefixData], output=True, **kwargs
-    ) -> str:
-        if not output:
-            return ""
-
+    def envs_list(prefixes: Iterable[PathType | PrefixData], **kwargs) -> str:
         show_size = kwargs.get("show_size", False)
 
         output = [

--- a/conda/plugins/reporter_backends/console.py
+++ b/conda/plugins/reporter_backends/console.py
@@ -34,6 +34,7 @@ from ..types import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from typing import Any
 
     from ...common.path import PathType
 
@@ -185,23 +186,25 @@ class ConsoleReporterRenderer(ReporterRendererBase):
     Default implementation for console reporting in conda
     """
 
+    def render(self, data: Any, **kwargs) -> str:
+        text = super().render(data, **kwargs)
+        # trailing newline
+        return text if text.endswith("\n") else f"{text}\n"
+
     def detail_view(self, data: dict[str, str | int | bool], **kwargs) -> str:
-        table_parts = [""]
+        table_parts = []
         longest_header = max(map(len, data.keys()))
 
         for header, value in data.items():
             table_parts.append(f" {header:>{longest_header}} : {value}")
 
-        table_parts.append("\n")
+        # leading and trailing newlines
+        return "\n" + "\n".join(table_parts) + "\n"
 
-        return "\n".join(table_parts)
-
-    @staticmethod
-    def envs_list(prefixes: Iterable[PathType | PrefixData], **kwargs) -> str:
+    def envs_list(self, prefixes: Iterable[PathType | PrefixData], **kwargs) -> str:
         show_size = kwargs.get("show_size", False)
 
         output = [
-            "",
             "# conda environments:",
             "#",
             "# * -> active",
@@ -227,9 +230,8 @@ class ConsoleReporterRenderer(ReporterRendererBase):
                 env_prefix = PrefixData(env_prefix)
             output.append(disp_env(env_prefix))
 
-        output.append("\n")
-
-        return "\n".join(output)
+        # leading and trailing newlines
+        return "\n" + "\n".join(output) + "\n"
 
     def progress_bar(
         self,

--- a/conda/plugins/reporter_backends/console.py
+++ b/conda/plugins/reporter_backends/console.py
@@ -199,9 +199,10 @@ class ConsoleReporterRenderer(ReporterRendererBase):
             table_parts.append(f" {header:>{longest_header}} : {value}")
 
         # leading and trailing newlines
-        return "\n" + "\n".join(table_parts) + "\n"
+        return "\n" + "\n".join(table_parts) + "\n\n"
 
-    def envs_list(self, prefixes: Iterable[PathType | PrefixData], **kwargs) -> str:
+    @staticmethod
+    def envs_list(prefixes: Iterable[PathType | PrefixData], **kwargs) -> str:
         show_size = kwargs.get("show_size", False)
 
         output = [
@@ -231,7 +232,7 @@ class ConsoleReporterRenderer(ReporterRendererBase):
             output.append(disp_env(env_prefix))
 
         # leading and trailing newlines
-        return "\n" + "\n".join(output) + "\n"
+        return "\n" + "\n".join(output) + "\n\n"
 
     def progress_bar(
         self,

--- a/tests/plugins/reporter_backends/test_console.py
+++ b/tests/plugins/reporter_backends/test_console.py
@@ -28,7 +28,7 @@ def test_console_reporter_renderer():
     console_reporter_renderer = ConsoleReporterRenderer()
 
     assert console_reporter_renderer.detail_view(test_data) == expected_table_str
-    assert console_reporter_renderer.render(test_str) == test_str
+    assert console_reporter_renderer.render(test_str) == f"{test_str}\n"
 
     progress_bar = console_reporter_renderer.progress_bar(
         description="Test progress bar description", io_context_manager=nullcontext()
@@ -53,17 +53,6 @@ def test_console_reporter_renderer_envs_list(mocker):
     output = console_reporter_renderer.envs_list(["/tmp/envs"])
 
     assert f"envs                     {Path('/tmp/envs')}" in output
-
-
-def test_console_reporter_renderer_envs_list_output_false():
-    """
-    Test for the case when output=False; it should return an empty string
-    """
-    console_reporter_renderer = ConsoleReporterRenderer()
-
-    output = console_reporter_renderer.envs_list(["/tmp/envs"], output=False)
-
-    assert output == ""
 
 
 def test_tqdm_progress_bar_os_error(mocker):

--- a/tests/plugins/test_reporter_backends.py
+++ b/tests/plugins/test_reporter_backends.py
@@ -76,7 +76,7 @@ def test_default_reporter_backends_are_registered(default_reporter_backend_plugi
 @pytest.mark.parametrize(
     "method,backend,argument,expected",
     [
-        ("render", DEFAULT_CONSOLE_REPORTER_BACKEND, "test", "test"),
+        ("render", DEFAULT_CONSOLE_REPORTER_BACKEND, "test", "test\n"),
         ("render", DEFAULT_JSON_REPORTER_BACKEND, "test", '"test"'),
         (
             "detail_view",

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -30,7 +30,7 @@ def test_render(capsys: CaptureFixture):
     render("test-string")
 
     stdout, stderr = capsys.readouterr()
-    assert stdout == "test-string"
+    assert stdout == "test-string\n"
     assert not stderr
 
     # Test rendering of object with a style


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

In trying to use the reporter backend (e.g., https://github.com/conda/conda/pull/15876) I've found `ConsoleReporterRenderer.render`'s lack of a trailing newline an oddity that adds friction to adoption/replacing usage of `print`/`logging`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
    - Skipped news since there is no user facing change
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
