### PR TITLE
Memoize context.root_writable to avoid repeated file-open (A14)

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -756,7 +756,7 @@ class Context(Configuration):
         else:
             return 8 * struct.calcsize("P")
 
-    @property
+    @memoizedproperty
     def root_writable(self) -> bool:
         # rather than using conda.gateways.disk.test.prefix_is_writable
         # let's shortcut and assume the root prefix exists

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -758,7 +758,7 @@ class Context(Configuration):
         else:
             return 8 * struct.calcsize("P")
 
-    @property
+    @memoizedproperty
     def root_writable(self) -> bool:
         # rather than using conda.gateways.disk.test.prefix_is_writable
         # let's shortcut and assume the root prefix exists

--- a/news/15867-memoize-root-writable
+++ b/news/15867-memoize-root-writable
@@ -1,0 +1,5 @@
+### Enhancements
+
+* `context.root_writable` is now a `@memoizedproperty`. The previous `@property`
+  opened a file handle on every access; results are now cached for the lifetime
+  of the `Context` instance. (#15867)

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -19,6 +19,7 @@ from conda.auxlib.ish import dals
 from conda.base.constants import (
     DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
     DEFAULT_CHANNELS,
+    PREFIX_MAGIC_FILE,
     ChannelPriority,
     PathConflict,
 )
@@ -971,3 +972,50 @@ def test_category_map_covers_all_parameters(context_testdata: None) -> None:
         mapped = [m for m in mapped if m != extra]
 
     assert not set(parameters).difference(mapped)
+
+
+@pytest.mark.parametrize(
+    "env_var,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+    ],
+)
+def test_root_writable_reflects_filesystem(
+    tmp_path, monkeypatch, env_var, expected
+) -> None:
+    """root_writable should return True when the magic file is accessible."""
+    magic = tmp_path / PREFIX_MAGIC_FILE
+    magic.parent.mkdir(parents=True, exist_ok=True)
+    magic.touch()
+
+    monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
+    reset_context()
+
+    assert context.root_writable is expected
+
+
+def test_root_writable_is_memoized(tmp_path, monkeypatch) -> None:
+    """root_writable must return the same cached value on repeated access."""
+    magic = tmp_path / PREFIX_MAGIC_FILE
+    magic.parent.mkdir(parents=True, exist_ok=True)
+    magic.touch()
+
+    monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
+    reset_context()
+
+    first = context.root_writable
+    second = context.root_writable
+
+    assert first == second
+    # memoizedproperty stores the value under the attribute name on the instance.
+    assert "root_writable" in context.__dict__
+
+
+def test_root_writable_false_when_magic_file_missing(tmp_path, monkeypatch) -> None:
+    """root_writable should be False when the prefix magic file does not exist."""
+    monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
+    reset_context()
+
+    assert context.root_writable is False

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -974,17 +974,7 @@ def test_category_map_covers_all_parameters(context_testdata: None) -> None:
     assert not set(parameters).difference(mapped)
 
 
-@pytest.mark.parametrize(
-    "env_var,expected",
-    [
-        ("1", True),
-        ("true", True),
-        ("TRUE", True),
-    ],
-)
-def test_root_writable_reflects_filesystem(
-    tmp_path, monkeypatch, env_var, expected
-) -> None:
+def test_root_writable_reflects_filesystem(tmp_path: Path, monkeypatch) -> None:
     """root_writable should return True when the magic file is accessible."""
     magic = tmp_path / PREFIX_MAGIC_FILE
     magic.parent.mkdir(parents=True, exist_ok=True)
@@ -993,10 +983,10 @@ def test_root_writable_reflects_filesystem(
     monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
     reset_context()
 
-    assert context.root_writable is expected
+    assert context.root_writable is True
 
 
-def test_root_writable_is_memoized(tmp_path, monkeypatch) -> None:
+def test_root_writable_is_memoized(tmp_path: Path, monkeypatch) -> None:
     """root_writable must return the same cached value on repeated access."""
     magic = tmp_path / PREFIX_MAGIC_FILE
     magic.parent.mkdir(parents=True, exist_ok=True)
@@ -1008,12 +998,13 @@ def test_root_writable_is_memoized(tmp_path, monkeypatch) -> None:
     first = context.root_writable
     second = context.root_writable
 
-    assert first == second
-    # memoizedproperty stores the value under the attribute name on the instance.
-    assert "root_writable" in context.__dict__
+    assert first is second
+    assert "__root_writable" in context._cache_
 
 
-def test_root_writable_false_when_magic_file_missing(tmp_path, monkeypatch) -> None:
+def test_root_writable_false_when_magic_file_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
     """root_writable should be False when the prefix magic file does not exist."""
     monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
     reset_context()

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -19,6 +19,7 @@ from conda.auxlib.ish import dals
 from conda.base.constants import (
     DEFAULT_AGGRESSIVE_UPDATE_PACKAGES,
     DEFAULT_CHANNELS,
+    PREFIX_MAGIC_FILE,
     ChannelPriority,
     PathConflict,
 )
@@ -1013,3 +1014,50 @@ def test_preview_enabled_returns_false_when_not_configured(
 
 def test_preview_enabled_returns_false_when_empty(context_testdata: None) -> None:
     assert not context.preview_enabled("env-setup")
+
+
+@pytest.mark.parametrize(
+    "env_var,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+    ],
+)
+def test_root_writable_reflects_filesystem(
+    tmp_path, monkeypatch, env_var, expected
+) -> None:
+    """root_writable should return True when the magic file is accessible."""
+    magic = tmp_path / PREFIX_MAGIC_FILE
+    magic.parent.mkdir(parents=True, exist_ok=True)
+    magic.touch()
+
+    monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
+    reset_context()
+
+    assert context.root_writable is expected
+
+
+def test_root_writable_is_memoized(tmp_path, monkeypatch) -> None:
+    """root_writable must return the same cached value on repeated access."""
+    magic = tmp_path / PREFIX_MAGIC_FILE
+    magic.parent.mkdir(parents=True, exist_ok=True)
+    magic.touch()
+
+    monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
+    reset_context()
+
+    first = context.root_writable
+    second = context.root_writable
+
+    assert first == second
+    # memoizedproperty stores the value under the attribute name on the instance.
+    assert "root_writable" in context.__dict__
+
+
+def test_root_writable_false_when_magic_file_missing(tmp_path, monkeypatch) -> None:
+    """root_writable should be False when the prefix magic file does not exist."""
+    monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
+    reset_context()
+
+    assert context.root_writable is False

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -1016,17 +1016,7 @@ def test_preview_enabled_returns_false_when_empty(context_testdata: None) -> Non
     assert not context.preview_enabled("env-setup")
 
 
-@pytest.mark.parametrize(
-    "env_var,expected",
-    [
-        ("1", True),
-        ("true", True),
-        ("TRUE", True),
-    ],
-)
-def test_root_writable_reflects_filesystem(
-    tmp_path, monkeypatch, env_var, expected
-) -> None:
+def test_root_writable_reflects_filesystem(tmp_path: Path, monkeypatch) -> None:
     """root_writable should return True when the magic file is accessible."""
     magic = tmp_path / PREFIX_MAGIC_FILE
     magic.parent.mkdir(parents=True, exist_ok=True)
@@ -1035,10 +1025,10 @@ def test_root_writable_reflects_filesystem(
     monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
     reset_context()
 
-    assert context.root_writable is expected
+    assert context.root_writable is True
 
 
-def test_root_writable_is_memoized(tmp_path, monkeypatch) -> None:
+def test_root_writable_is_memoized(tmp_path: Path, monkeypatch) -> None:
     """root_writable must return the same cached value on repeated access."""
     magic = tmp_path / PREFIX_MAGIC_FILE
     magic.parent.mkdir(parents=True, exist_ok=True)
@@ -1050,12 +1040,13 @@ def test_root_writable_is_memoized(tmp_path, monkeypatch) -> None:
     first = context.root_writable
     second = context.root_writable
 
-    assert first == second
-    # memoizedproperty stores the value under the attribute name on the instance.
-    assert "root_writable" in context.__dict__
+    assert first is second
+    assert "__root_writable" in context._cache_
 
 
-def test_root_writable_false_when_magic_file_missing(tmp_path, monkeypatch) -> None:
+def test_root_writable_false_when_magic_file_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
     """root_writable should be False when the prefix magic file does not exist."""
     monkeypatch.setenv("CONDA_ROOT_PREFIX", str(tmp_path))
     reset_context()


### PR DESCRIPTION
### Description

`context.root_writable` was a plain `@property` that opened a file handle against `$CONDA_ROOT_PREFIX/conda-meta/.conda_lock` on every access. It is called from `envs_dirs` and several other properties, so a single `conda` invocation can trigger it multiple times.

Switching to `@memoizedproperty` caches the result on the `Context` instance after the first call. The result does not change during a single process lifetime, so this is always safe.

**Measured impact:** eliminates repeated `open()` + `close()` syscalls on every access. Part of #15867.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~ (not applicable)