### PR TITLE
Start ContextStack with one slot instead of three (A17)

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -2111,16 +2111,15 @@ class ContextStackObject:
 
 class ContextStack:
     def __init__(self):
-        self._stack = [ContextStackObject() for _ in range(3)]
+        self._stack = [ContextStackObject()]
         self._stack_idx = 0
         self._last_search_path = None
         self._last_argparse_args = None
 
     def push(self, search_path: PathsType, argparse_args: Namespace | None) -> None:
         self._stack_idx += 1
-        old_len = len(self._stack)
-        if self._stack_idx >= old_len:
-            self._stack.extend([ContextStackObject() for _ in range(old_len)])
+        if self._stack_idx >= len(self._stack):
+            self._stack.extend(ContextStackObject() for _ in range(len(self._stack)))
         self._stack[self._stack_idx].set_value(search_path, argparse_args)
         self.apply()
 

--- a/news/15867-contextstack-lazy-alloc
+++ b/news/15867-contextstack-lazy-alloc
@@ -1,0 +1,6 @@
+### Enhancements
+
+* `ContextStack` now allocates a single slot on construction instead of three.
+  Slots are still doubled on demand, so deep nesting works identically.
+  Eliminates two unnecessary `ContextStackObject` allocations at import time.
+  (#15867)

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -23,6 +23,7 @@ from conda.base.constants import (
     PathConflict,
 )
 from conda.base.context import (
+    ContextStack,
     channel_alias_validation,
     context,
     default_python_validation,
@@ -919,3 +920,36 @@ def test_custom_multichannels_overrides_default_channels(reset_conda_context: No
     assert [
         channel.name for channel in context.custom_multichannels["defaults"]
     ] == custom_channels
+
+
+def test_context_stack_starts_with_single_slot() -> None:
+    """ContextStack should allocate only one slot on construction."""
+    stack = ContextStack()
+    assert len(stack._stack) == 1
+    assert stack._stack_idx == 0
+
+
+@pytest.mark.parametrize("pushes", [1, 2, 3, 4])
+def test_context_stack_doubles_on_overflow(pushes: int) -> None:
+    """Pushing beyond current capacity should double the slot list."""
+    stack = ContextStack()
+    for _ in range(pushes):
+        stack._stack_idx += 1
+        if stack._stack_idx >= len(stack._stack):
+            stack._stack.extend(
+                stack._stack[0].__class__() for _ in range(len(stack._stack))
+            )
+
+    assert len(stack._stack) >= pushes + 1
+
+
+def test_context_stack_push_pop_roundtrip() -> None:
+    """push() followed by pop() should leave stack_idx unchanged."""
+    stack = ContextStack()
+    initial_idx = stack._stack_idx
+
+    stack.push((), None)
+    assert stack._stack_idx == initial_idx + 1
+
+    stack.pop()
+    assert stack._stack_idx == initial_idx


### PR DESCRIPTION
### Description

`ContextStack.__init__()` pre-allocated three `ContextStackObject` instances at startup. In practice the common path (a single `conda` invocation) never pushes the stack past depth 1. Those two extra objects are allocated, initialised with `SEARCH_PATH`, and then immediately forgotten.

This change starts with a single slot. The existing doubling strategy (`extend` by `len(self._stack)`) already handles arbitrarily deep nesting correctly — no behaviour changes for callers.

**Measured impact:** eliminates two `ContextStackObject.__init__()` calls (each of which calls `reset_context()`) at module import time. Part of #15867.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~ (not applicable)