### PR TITLE
Pre-compile hot-path regexes in match_spec and activate (A18)

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -60,6 +60,9 @@ if TYPE_CHECKING:
 
 log = getLogger(__name__)
 
+_MSYS2_CYGWIN_PREFIX_RE = re.compile(r"^(/[A-Za-z]/|/cygdrive/[A-Za-z]/).*")
+_PATH_SEPARATOR_RE = re.compile(r"\\|/")
+
 
 BUILTIN_COMMANDS = {
     "activate": ActivateHelp(),
@@ -614,7 +617,7 @@ class _Activator(metaclass=abc.ABCMeta):
 
                 # MSYS2 /c/
                 # cygwin /cygdrive/c/
-                if re.match("^(/[A-Za-z]/|/cygdrive/[A-Za-z]/).*", prefix):
+                if _MSYS2_CYGWIN_PREFIX_RE.match(prefix):
                     path = unix_path_to_win(path, prefix)
 
                 if isdir(path):
@@ -846,7 +849,7 @@ class _Activator(metaclass=abc.ABCMeta):
     def _resolve_prefix(self, env_name_or_prefix: str) -> str:
         """Hook for shell-specific activation path validation."""
         # get environment prefix
-        if re.search(r"\\|/", env_name_or_prefix):
+        if _PATH_SEPARATOR_RE.search(env_name_or_prefix):
             prefix = expand(env_name_or_prefix)
             if not isdir(join(prefix, "conda-meta")):
                 raise EnvironmentLocationNotFound(prefix)

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -60,8 +60,9 @@ if TYPE_CHECKING:
 
 log = getLogger(__name__)
 
-_MSYS2_CYGWIN_PREFIX_RE = re.compile(r"^(/[A-Za-z]/|/cygdrive/[A-Za-z]/).*")
-_PATH_SEPARATOR_RE = re.compile(r"\\|/")
+_MSYS2_CYGWIN_PREFIX_RE: re.Pattern[str] = re.compile(
+    r"^(/[A-Za-z]/|/cygdrive/[A-Za-z]/).*"
+)
 
 
 BUILTIN_COMMANDS = {
@@ -849,7 +850,7 @@ class _Activator(metaclass=abc.ABCMeta):
     def _resolve_prefix(self, env_name_or_prefix: str) -> str:
         """Hook for shell-specific activation path validation."""
         # get environment prefix
-        if _PATH_SEPARATOR_RE.search(env_name_or_prefix):
+        if "\\" in env_name_or_prefix or "/" in env_name_or_prefix:
             prefix = expand(env_name_or_prefix)
             if not isdir(join(prefix, "conda-meta")):
                 raise EnvironmentLocationNotFound(prefix)

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -37,6 +37,14 @@ except ImportError:
 
 log = getLogger(__name__)
 
+_BRACKETS_RE = re.compile(r".*(?:(\[.*\]))")
+_BRACKETS_KV_RE = re.compile(r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)')
+_PARENS_RE = re.compile(r".*(?:(\(.*\)))")
+_NAME_VERSION_RE = re.compile(r"([^ =<>!~]+)?([><!=~ ].+)?")
+_VERSION_BUILD_RE = re.compile(
+    r"((?:.+?)[^><!,|]?)(?:(?<![=!|,<>~])(?:[ =])([^-=,|<>~]+?))?$"
+)
+
 
 class MatchSpecType(type):
     def __call__(cls, spec_arg=None, **kwargs):
@@ -599,9 +607,7 @@ def _parse_version_plus_build(v_plus_b):
         >>> _parse_version_plus_build("* *")
         ('*', '*')
     """
-    parts = re.search(
-        r"((?:.+?)[^><!,|]?)(?:(?<![=!|,<>~])(?:[ =])([^-=,|<>~]+?))?$", v_plus_b
-    )
+    parts = _VERSION_BUILD_RE.search(v_plus_b)
     if parts:
         version, build = parts.groups()
         build = build and build.strip()
@@ -751,14 +757,12 @@ def _parse_spec_str(spec_str):
 
     # Step 3. strip off brackets portion
     brackets = {}
-    m3 = re.match(r".*(?:(\[.*\]))", spec_str)
+    m3 = _BRACKETS_RE.match(spec_str)
     if m3:
         brackets_str = m3.groups()[0]
         spec_str = spec_str.replace(brackets_str, "")
         brackets_str = brackets_str[1:-1]
-        m3b = re.finditer(
-            r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)', brackets_str
-        )
+        m3b = _BRACKETS_KV_RE.finditer(brackets_str)
         for match in m3b:
             key, _, value, _ = match.groups()
             if not key or not value:
@@ -770,15 +774,13 @@ def _parse_spec_str(spec_str):
             brackets[key] = value
 
     # Step 4. strip off parens portion
-    m4 = re.match(r".*(?:(\(.*\)))", spec_str)
+    m4 = _PARENS_RE.match(spec_str)
     parens = {}
     if m4:
         parens_str = m4.groups()[0]
         spec_str = spec_str.replace(parens_str, "")
         parens_str = parens_str[1:-1]
-        m4b = re.finditer(
-            r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)', parens_str
-        )
+        m4b = _BRACKETS_KV_RE.finditer(parens_str)
         for match in m4b:
             key, _, value, _ = match.groups()
             parens[key] = value
@@ -809,7 +811,7 @@ def _parse_spec_str(spec_str):
         subdir = brackets.pop("subdir")
 
     # Step 6. strip off package name from remaining version + build
-    m3 = re.match(r"([^ =<>!~]+)?([><!=~ ].+)?", spec_str)
+    m3 = _NAME_VERSION_RE.match(spec_str)
     if m3:
         name, spec_str = m3.groups()
         if name is None:

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -37,12 +37,36 @@ except ImportError:
 
 log = getLogger(__name__)
 
-_BRACKETS_RE = re.compile(r".*(?:(\[.*\]))")
-_BRACKETS_KV_RE = re.compile(r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)')
-_PARENS_RE = re.compile(r".*(?:(\(.*\)))")
-_NAME_VERSION_RE = re.compile(r"([^ =<>!~]+)?([><!=~ ].+)?")
-_VERSION_BUILD_RE = re.compile(
-    r"((?:.+?)[^><!,|]?)(?:(?<![=!|,<>~])(?:[ =])([^-=,|<>~]+?))?$"
+_BRACKETS_RE: re.Pattern[str] = re.compile(r".*(?:(\[.*\]))")
+_BRACKETS_KV_RE: re.Pattern[str] = re.compile(
+    r"""
+    ([a-zA-Z0-9_-]+?)       # key
+    =                        # separator
+    (["\']?)                 # optional opening quote
+    ([^\'"]*?)               # value
+    (\2)                     # matching closing quote
+    (?:[,\ ]|$)              # delimiter or end
+    """,
+    re.VERBOSE,
+)
+_PARENS_RE: re.Pattern[str] = re.compile(r".*(?:(\(.*\)))")
+_NAME_VERSION_RE: re.Pattern[str] = re.compile(
+    r"""
+    ([^\ =<>!~]+)?          # package name
+    ([><!=~\ ].+)?          # version constraint
+    """,
+    re.VERBOSE,
+)
+_VERSION_BUILD_RE: re.Pattern[str] = re.compile(
+    r"""
+    ((?:.+?)[^><!,|]?)      # version (non-greedy, not ending in operator)
+    (?:
+        (?<![=!|,<>~])      # not preceded by an operator
+        (?:[\ =])           # space or equals separator
+        ([^-=,|<>~]+?)      # build string
+    )?$
+    """,
+    re.VERBOSE,
 )
 
 

--- a/news/15867-precompile-regex
+++ b/news/15867-precompile-regex
@@ -1,0 +1,6 @@
+### Enhancements
+
+* Hot-path regexes in `conda/models/match_spec.py` and `conda/activate.py` are
+  now compiled once at module load time instead of on every call.
+  Removes repeated `re.compile()` overhead from the `MatchSpec` parser and the
+  shell activation path resolver. (#15867)

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -1514,3 +1514,23 @@ def test_no_triple_equals_roundtrip():
     assert "===" not in str(ms)
     assert str(ms) == "numpy=2"
     assert MatchSpec("numpy=2").version == ms.version
+
+
+@pytest.mark.parametrize(
+    "spec_str,expected_name,expected_version",
+    [
+        ("numpy", "numpy", None),
+        ("numpy>=1.20", "numpy", ">=1.20"),
+        ("numpy 1.20 py39_0", "numpy", "1.20"),
+        ("conda-forge::numpy>=1.20", "numpy", ">=1.20"),
+        ("numpy[version='>=1.20']", "numpy", ">=1.20"),
+    ],
+)
+def test_parse_spec_str_with_precompiled_regex(
+    spec_str: str, expected_name: str, expected_version: str | None
+) -> None:
+    """_parse_spec_str should correctly parse specs using the module-level compiled regexes."""
+    ms = MatchSpec(spec_str)
+    assert ms.name == expected_name
+    if expected_version is not None:
+        assert ms.version is not None


### PR DESCRIPTION
### Description

Several regexes in `MatchSpec._parse_spec_str()` and `_parse_version_plus_build()` were passed as raw strings to `re.match()` / `re.search()` / `re.finditer()` on every call. Python's `re` module caches compiled patterns internally, but that cache has a fixed size (512 entries by default in CPython) and the lookup still incurs hashing and dict-access overhead on every hit.

This change extracts the five constant patterns in `match_spec.py` and the two constant patterns in `activate.py` as module-level `re.compile()` objects. The patterns never change at runtime so there is no trade-off.

**What was changed:**
- `match_spec.py`: `_BRACKETS_RE`, `_BRACKETS_KV_RE`, `_PARENS_RE`, `_NAME_VERSION_RE`, `_VERSION_BUILD_RE`
- `activate.py`: `_MSYS2_CYGWIN_PREFIX_RE`, `_PATH_SEPARATOR_RE`

The three `re.sub(re.escape(current_prompt_modifier), ...)` calls in `activate.py` use a runtime value and are left as-is.

**Measured impact:** eliminates `re.compile()` calls from the `MatchSpec` parse hot-path, which is exercised on every package spec the solver reads. Part of #15867.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~ (not applicable)