### PR TITLE
Enable ruff G004 rule; use lazy log formatting across codebase

### DIFF
--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -146,7 +146,8 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     if response.rc != 0:
         log = getLogger(__name__)
         log.error(
-            f"`conda run {' '.join(args.executable_call)}` failed. (See above for error)"
+            "`conda run %s` failed. (See above for error)",
+            " ".join(args.executable_call),
         )
 
     # remove script
@@ -154,6 +155,6 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         rm_rf(script)
     else:
         log = getLogger(__name__)
-        log.warning(f"CONDA_TEST_SAVE_TEMPS :: retaining main_run script {script}")
+        log.warning("CONDA_TEST_SAVE_TEMPS :: retaining main_run script %s", script)
 
     return response.rc

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -1764,15 +1764,19 @@ def unique_sequence_map(*, unique_key: str):
 
                 if unique_key_value is None:
                     log.error(
-                        f'Configuration: skipping {mapping} for "{func.__name__}"; unique key '
-                        f'"{unique_key}" not present on mapping'
+                        'Configuration: skipping %s for "%s"; unique key "%s" not present on mapping',
+                        mapping,
+                        func.__name__,
+                        unique_key,
                     )
                     continue
 
                 if unique_key_value in new_sequence_mapping:
                     log.error(
-                        f'Configuration: skipping {mapping} for "{func.__name__}"; value '
-                        f'"{unique_key_value}" already present'
+                        'Configuration: skipping %s for "%s"; value "%s" already present',
+                        mapping,
+                        func.__name__,
+                        unique_key_value,
                     )
                     continue
 

--- a/conda/core/envs_manager.py
+++ b/conda/core/envs_manager.py
@@ -71,9 +71,9 @@ def register_env(location: str) -> None:
         os.makedirs(user_environments_txt_directory, exist_ok=True)
     except OSError as exc:
         log.warning(
-            "Unable to register environment. "
-            f"Could not create {user_environments_txt_directory}. "
-            f"Reason: {exc}"
+            "Unable to register environment. Could not create %s. Reason: %s",
+            user_environments_txt_directory,
+            exc,
         )
         return
 
@@ -145,7 +145,7 @@ def list_all_known_prefixes() -> list[str]:
                 # not be readable (if on network file system for example)
                 all_env_paths.update(_clean_environments_txt(environments_txt_file))
             except PermissionError:
-                log.warning(f"Unable to access {environments_txt_file}")
+                log.warning("Unable to access %s", environments_txt_file)
 
     # in case environments.txt files aren't complete, also add all known conda environments in
     # all envs_dirs

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1171,7 +1171,7 @@ class UnlinkLinkTransaction:
         )
         if linking_new_python:
             python_record = linking_new_python.repodata_record
-            log.debug(f"found in current transaction python: {python_record}")
+            log.debug("found in current transaction python: %s", python_record)
             return version_and_sp(python_record)
         python_record = PrefixData(target_prefix).get("python", None)
         if python_record:
@@ -1185,7 +1185,7 @@ class UnlinkLinkTransaction:
             )
             if unlinking_python is None:
                 # python is already linked and not being unlinked
-                log.debug(f"found in current prefix, python: {python_record}")
+                log.debug("found in current prefix, python: %s", python_record)
                 return version_and_sp(python_record)
         # no python in the finished environment
         log.debug("no python version found in prefix")
@@ -1673,7 +1673,7 @@ def run_script(
                 rm_rf(script_caller)
             else:
                 log.warning(
-                    f"CONDA_TEST_SAVE_TEMPS :: retaining run_script {script_caller}"
+                    "CONDA_TEST_SAVE_TEMPS :: retaining run_script %s", script_caller
                 )
 
 

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -129,7 +129,9 @@ class PackageCacheData(metaclass=PackageCacheType):
                 except ValidationError as err:
                     # ValidationError: package fields are invalid
                     log.warning(
-                        f"Failed to create package cache record for '{base_name}'. {err}"
+                        "Failed to create package cache record for '%s'. %s",
+                        base_name,
+                        err,
                     )
                     package_cache_record = None
 

--- a/conda/env/installers/pip.py
+++ b/conda/env/installers/pip.py
@@ -62,7 +62,8 @@ def _pip_install_via_requirements(prefix, specs, args, *_, workdir=None, **kwarg
                 os.remove(requirements.name)
             else:
                 log.warning(
-                    f"CONDA_TEST_SAVE_TEMPS :: retaining pip requirements.txt {requirements.name}"
+                    "CONDA_TEST_SAVE_TEMPS :: retaining pip requirements.txt %s",
+                    requirements.name,
                 )
     return get_pip_installed_packages(stdout)
 

--- a/conda/exception_handler.py
+++ b/conda/exception_handler.py
@@ -387,7 +387,7 @@ class ExceptionHandler:
                 if response and response.status_code:
                     self.write_out(f" HTTP {response.status_code}")
         except Exception as e:
-            log.debug(f"{e!r}")
+            log.debug("%r", e)
 
     @deprecated(
         "26.9",

--- a/conda/gateways/connection/download.py
+++ b/conda/gateways/connection/download.py
@@ -283,7 +283,7 @@ def download_http_errors(url: str):
         yield
 
     except ConnectionResetError as e:
-        log.debug(f"{e}, trying again")
+        log.debug("%s, trying again", e)
         # where does retry happen?
         raise
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -347,7 +347,7 @@ def create_link(src, dst, link_type=LinkType.hardlink, force=False):
         if lexists(dst) and not isdir(dst):
             if not force:
                 maybe_raise(BasicClobberError(src, dst, context), context)
-            log.info(f"file exists, but clobbering for directory: {dst!r}")
+            log.info("file exists, but clobbering for directory: %r", dst)
             rm_rf(dst)
         mkdir_p(dst)
         return
@@ -361,7 +361,7 @@ def create_link(src, dst, link_type=LinkType.hardlink, force=False):
     if lexists(dst):
         if not force:
             maybe_raise(BasicClobberError(src, dst, context), context)
-        log.info(f"file exists, but clobbering: {dst!r}")
+        log.info("file exists, but clobbering: %r", dst)
         rm_rf(dst)
 
     if link_type == LinkType.hardlink:

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -92,12 +92,15 @@ def rmtree(path):
             except CalledProcessError as e:
                 if e.returncode != 5:
                     log.error(
-                        f"Removing folder {name} the fast way failed.  Output was: {out}"
+                        "Removing folder %s the fast way failed.  Output was: %s",
+                        name,
+                        out,
                     )
                     raise
                 else:
                     log.debug(
-                        f"removing dir contents the fast way failed.  Output was: {out}"
+                        "removing dir contents the fast way failed.  Output was: %s",
+                        out,
                     )
     else:
         try:
@@ -126,7 +129,8 @@ def rmtree(path):
                     )
                 except CalledProcessError:
                     log.debug(
-                        f"removing dir contents the fast way failed.  Output was: {out}"
+                        "removing dir contents the fast way failed.  Output was: %s",
+                        out,
                     )
 
             shutil.rmtree(".empty")
@@ -173,17 +177,21 @@ def unlink_or_rename_to_trash(path):
                         )
                     except CalledProcessError:
                         log.debug(
-                            f"renaming file path {path} to trash failed.  Output was: {out}"
+                            "renaming file path %s to trash failed.  Output was: %s",
+                            path,
+                            out,
                         )
 
                 else:
                     log.debug(
-                        f"{trash_script} is missing.  Conda was not installed correctly or has been "
-                        "corrupted.  Please file an issue on the conda github repo."
+                        "%s is missing.  Conda was not installed correctly or has been "
+                        "corrupted.  Please file an issue on the conda github repo.",
+                        trash_script,
                     )
             log.warning(
-                f"Could not remove or rename {path}.  Please remove this file manually (you "
-                "may need to reboot to free file handles)"
+                "Could not remove or rename %s.  Please remove this file manually (you "
+                "may need to reboot to free file handles)",
+                path,
             )
 
 

--- a/conda/gateways/disk/update.py
+++ b/conda/gateways/disk/update.py
@@ -81,8 +81,9 @@ def rename(source_path, destination_path, force=False):
                     stdout, stderr = p.communicate()
                 else:
                     log.debug(
-                        f"{rename_script} is missing.  Conda was not installed correctly or has been "
-                        "corrupted.  Please file an issue on the conda github repo."
+                        "%s is missing.  Conda was not installed correctly or has been "
+                        "corrupted.  Please file an issue on the conda github repo.",
+                        rename_script,
                     )
             elif e.errno in (EINVAL, EXDEV, EPERM):
                 # https://github.com/conda/conda/issues/6811

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -459,7 +459,8 @@ class RepodataState(UserDict):
             return (value, last_checked)
         except (KeyError, ValueError, TypeError) as e:
             log.warning(
-                f"error parsing `has_` object from `<cache key>{CACHE_STATE_SUFFIX}`",
+                "error parsing `has_` object from `<cache key>%s`",
+                CACHE_STATE_SUFFIX,
                 exc_info=e,
             )
             self.pop(key)
@@ -605,7 +606,9 @@ class RepodataCache:
             self.load(state_only=True, binary=binary)
         except (FileNotFoundError, json.JSONDecodeError) as e:
             if isinstance(e, json.JSONDecodeError):
-                log.warning(f"{e.__class__.__name__} loading {self.cache_path_state}")
+                log.warning(
+                    "%s loading %s", e.__class__.__name__, self.cache_path_state
+                )
             self.state.clear()
         return self.state
 

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -65,7 +65,7 @@ def any_subprocess(args: Sequence[str], prefix, env=None, cwd=None):
             rm_rf(script_caller)
         else:
             log.warning(
-                f"CONDA_TEST_SAVE_TEMPS :: retaining pip run_script {script_caller}"
+                "CONDA_TEST_SAVE_TEMPS :: retaining pip run_script %s", script_caller
             )
     if hasattr(stdout, "decode"):
         stdout = stdout.decode("utf-8", errors="replace")

--- a/conda/models/version.py
+++ b/conda/models/version.py
@@ -564,7 +564,9 @@ class VersionSpec(BaseSpec, metaclass=SingleStrArgCachingType):
                     log.warning(
                         "Using .* with relational operator is superfluous and deprecated "
                         "and will be removed in a future version of conda. Your spec was "
-                        f"{vo_str}, but conda is ignoring the .* and treating it as {vo_str[:-2]}"
+                        "%s, but conda is ignoring the .* and treating it as %s",
+                        vo_str,
+                        vo_str[:-2],
                     )
                     vo_str = vo_str[:-2]
             try:

--- a/conda/notices/core.py
+++ b/conda/notices/core.py
@@ -121,7 +121,7 @@ def notices(func):
             except OSError as exc:
                 # If we encounter any OSError related error, we simply abandon
                 # fetching notices
-                logger.error(f"Unable to open cache file: {str(exc)}")
+                logger.error("Unable to open cache file: %s", exc)
 
             if channel_notice_set is not None:
                 try:

--- a/conda/notices/fetch.py
+++ b/conda/notices/fetch.py
@@ -66,17 +66,17 @@ def get_channel_notice_response(url: str, name: str) -> ChannelNoticeResponse | 
             url, allow_redirects=False, timeout=5
         )  # timeout: connect, read
     except requests.exceptions.Timeout:
-        logger.info(f"Request timed out for channel: {name} url: {url}")
+        logger.info("Request timed out for channel: %s url: %s", name, url)
         return
     except requests.exceptions.RequestException as exc:
-        logger.error(f"Request error <{exc}> for channel: {name} url: {url}")
+        logger.error("Request error <%s> for channel: %s url: %s", exc, name, url)
         return
 
     try:
         if resp.status_code < 300:
             return ChannelNoticeResponse(url, name, json_data=resp.json())
         else:
-            logger.info(f"Received {resp.status_code} when trying to GET {url}")
+            logger.info("Received %s when trying to GET %s", resp.status_code, url)
     except ValueError:
-        logger.info(f"Unable to parse JSON data for {url}")
+        logger.info("Unable to parse JSON data for %s", url)
         return ChannelNoticeResponse(url, name, json_data=None)

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -225,7 +225,9 @@ class CondaPluginManager(pluggy.PluginManager):
                     # a traceback; instead we pass exc_info conditionally on
                     # context.verbosity
                     log.warning(
-                        f"Error while loading conda entry point: {entry_point.name} ({err})",
+                        "Error while loading conda entry point: %s (%s)",
+                        entry_point.name,
+                        err,
                         exc_info=err if context.info else None,
                     )
                     continue
@@ -504,8 +506,9 @@ class CondaPluginManager(pluggy.PluginManager):
         reporter_backend = reporter_backends_map.get(name, None)
         if reporter_backend is None:
             log.warning(
-                f'Unable to find reporter backend: "{name}"; '
-                f'falling back to using "{DEFAULT_CONSOLE_REPORTER_BACKEND}"'
+                'Unable to find reporter backend: "%s"; falling back to using "%s"',
+                name,
+                DEFAULT_CONSOLE_REPORTER_BACKEND,
             )
             return reporter_backends_map.get(DEFAULT_CONSOLE_REPORTER_BACKEND)
         else:

--- a/conda/plugins/subcommands/doctor/__init__.py
+++ b/conda/plugins/subcommands/doctor/__init__.py
@@ -81,7 +81,7 @@ def execute(args: Namespace) -> int:
     if check_names:
         unknown = set(check_names) - set(checks.keys())
         if unknown:
-            log.warning(f"Unknown health check(s): {', '.join(sorted(unknown))}")
+            log.warning("Unknown health check(s): %s", ", ".join(sorted(unknown)))
         checks = {n: c for n, c in checks.items() if n in check_names}
 
     # Run health checks
@@ -90,7 +90,7 @@ def execute(args: Namespace) -> int:
         try:
             check.action(prefix, context.verbose)
         except Exception as err:
-            log.warning(f"Error running health check: {name} ({err})")
+            log.warning("Error running health check: %s (%s)", name, err)
 
     # If --fix was provided, run fixes
     if getattr(args, "fix", False):
@@ -117,7 +117,7 @@ def execute(args: Namespace) -> int:
                 # User cancelled the fix
                 pass
             except Exception as err:
-                log.warning(f"Error running fix: {name} ({err})")
+                log.warning("Error running fix: %s (%s)", name, err)
                 exit_code = 1
         return exit_code
 

--- a/conda/plugins/subcommands/doctor/health_checks/altered_files.py
+++ b/conda/plugins/subcommands/doctor/health_checks/altered_files.py
@@ -37,7 +37,9 @@ def find_altered_packages(prefix: str | Path) -> dict[str, list[str]]:
             metadata = json.loads(file.read_text())
         except Exception as exc:
             logger.error(
-                f"Could not load the json file {file} because of the following error: {exc}."
+                "Could not load the json file %s because of the following error: %s.",
+                file,
+                exc,
             )
             continue
 

--- a/conda/plugins/subcommands/doctor/health_checks/environment_txt.py
+++ b/conda/plugins/subcommands/doctor/health_checks/environment_txt.py
@@ -41,8 +41,9 @@ def check_envs_txt_file(prefix: str | os.PathLike | Path) -> bool:
                 return True
     except (IsADirectoryError, FileNotFoundError, PermissionError) as err:
         logger.error(
-            f"{envs_txt_file} could not be "
-            f"accessed because of the following error: {err}"
+            "%s could not be accessed because of the following error: %s",
+            envs_txt_file,
+            err,
         )
     return False
 

--- a/conda/testing/fixtures.py
+++ b/conda/testing/fixtures.py
@@ -656,7 +656,9 @@ def context_aware_monkeypatch(monkeypatch: MonkeyPatch) -> MonkeyPatch:
         for obj, name, _ in monkeypatch._setitem
         if obj is os.environ and name.startswith("CONDA_")
     ]:
-        log.debug(f"monkeypatch cleanup: undo & reset context: {', '.join(conda_vars)}")
+        log.debug(
+            "monkeypatch cleanup: undo & reset context: %s", ", ".join(conda_vars)
+        )
         monkeypatch.undo()
         # reload context without search paths
         reset_context([])
@@ -750,7 +752,7 @@ class HttpTestServerFixture:
 
     def __post_init__(self):
         """Log server startup for debugging."""
-        log.debug(f"HTTP test server started: {self.url}")
+        log.debug("HTTP test server started: %s", self.url)
 
     def get_url(self, path: str = "") -> str:
         """

--- a/news/15867-lazy-logging
+++ b/news/15867-lazy-logging
@@ -1,0 +1,6 @@
+### Enhancements
+
+* Replace f-string log calls with `%`-style lazy formatting across the
+  codebase. String interpolation is now deferred until the log record is
+  actually emitted. Enable the ruff `G004` rule to enforce this going
+  forward. (#15867)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ select = [
   "E",  # pycodestyle errors
   "F",  # pyflakes
   "FA",  # flake8-future-annotations
+  "G004",  # flake8-logging-format: no f-strings in log calls
   "I",  # isort
   "ISC",  # flake8-implicit-str-concat
   "RUF100",  # Unused noqa directive

--- a/tests/cli/test_main_notices.py
+++ b/tests/cli/test_main_notices.py
@@ -398,9 +398,11 @@ def test_notices_does_not_interrupt_command_on_failure(
 
     assert exit_code == 0
 
-    assert mock_logger.call_args == mocker.call(
-        f"Unable to open cache file: {error_message}"
-    )
+    mock_logger.assert_called_once()
+    fmt, exc = mock_logger.call_args.args
+    assert fmt == "Unable to open cache file: %s"
+    assert isinstance(exc, PermissionError)
+    assert str(exc) == error_message
 
 
 def test_notices_cannot_read_cache_files(

--- a/tests/common/test_configuration.py
+++ b/tests/common/test_configuration.py
@@ -903,8 +903,10 @@ def test_unique_sequence_map_error_with_duplicates(
     assert test_obj.test_prop() == ({"backend": "json"},)
     assert log_mock.error.mock_calls == [
         mocker.call(
-            "Configuration: skipping {'backend': 'json'} for \"test_prop\"; "
-            'value "json" already present'
+            'Configuration: skipping %s for "%s"; value "%s" already present',
+            {"backend": "json"},
+            "test_prop",
+            "json",
         )
     ]
 
@@ -924,7 +926,9 @@ def test_unique_sequence_map_error_with_unique_key(
     assert test_obj.test_prop() == ({"backend": "json"},)
     assert log_mock.error.mock_calls == [
         mocker.call(
-            "Configuration: skipping {'value': 'test'} for \"test_prop\"; "
-            'unique key "backend" not present on mapping'
+            'Configuration: skipping %s for "%s"; unique key "%s" not present on mapping',
+            {"value": "test"},
+            "test_prop",
+            "backend",
         )
     ]

--- a/tests/core/test_envs_manager.py
+++ b/tests/core/test_envs_manager.py
@@ -192,4 +192,5 @@ def test_register_env_directory_creation_error(mocker):
 
     mock_call, *_ = mock_log.warning.mock_calls
 
-    assert f"Could not create {conda_dir}" in mock_call.args[0]
+    assert "Could not create %s" in mock_call.args[0]
+    assert mock_call.args[1] == conda_dir

--- a/tests/gateways/test_zstd.py
+++ b/tests/gateways/test_zstd.py
@@ -192,7 +192,7 @@ def test_repodata_info_jsondecodeerror(
 
     sd2.load()
 
-    assert any(record[0].startswith("JSONDecodeError") for record in records)
+    assert any("JSONDecodeError" in str(arg) for record in records for arg in record)
 
 
 @pytest.mark.parametrize("repodata_use_zst", [True, False])

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -129,9 +129,9 @@ def test_load_entrypoints_importerror(
 
     assert mocked_warning.call_count == 1
     assert mocked_warning.call_args.args[0] == (
-        "Error while loading conda entry point: importerror "
-        "(No module named 'package_that_does_not_exist')"
+        "Error while loading conda entry point: %s (%s)"
     )
+    assert mocked_warning.call_args.args[1] == "importerror"
 
 
 def test_load_entrypoints_blocked(plugin_manager: CondaPluginManager):

--- a/tests/shell/test_cmd_exe.py
+++ b/tests/shell/test_cmd_exe.py
@@ -64,7 +64,7 @@ def test_cmd_exe_basic_integration(
         sh.clear()
 
         PATH0 = sh.get_env_var("PATH", "").split(os.pathsep)
-        log.debug(f"{PATH0=}")
+        log.debug("PATH0=%s", PATH0)
         sh.sendline(f'conda {activate} "{charizard}"')
 
         sh.sendline("chcp")
@@ -73,7 +73,7 @@ def test_cmd_exe_basic_integration(
         sh.assert_env_var("CONDA_SHLVL", "1")
 
         PATH1 = sh.get_env_var("PATH", "").split(os.pathsep)
-        log.debug(f"{PATH1=}")
+        log.debug("PATH1=%s", PATH1)
         sh.sendline('powershell -NoProfile -c "(Get-Command conda).Source"')
         sh.expect_exact(conda_bat)
 
@@ -82,7 +82,7 @@ def test_cmd_exe_basic_integration(
         sh.assert_env_var("CONDA_EXE", escape(sys.executable))
         sh.assert_env_var("CONDA_PREFIX", charizard, True)
         PATH2 = sh.get_env_var("PATH", "").split(os.pathsep)
-        log.debug(f"{PATH2=}")
+        log.debug("PATH2=%s", PATH2)
 
         sh.sendline('powershell -NoProfile -c "(Get-Command conda -All).Source"')
         sh.expect_exact(conda_bat)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ def get_prefix_containing_test_programs(test_programs=()):
     for test_program in test_programs:
         test_program_on_path = which(test_program)
         if not test_program_on_path:
-            log.warning(f"{test_program} not found on PATH")
+            log.warning("%s not found on PATH", test_program)
             return None
         else:
             test_program_in_prefix = []
@@ -88,7 +88,7 @@ def get_prefix_containing_test_programs(test_programs=()):
                     return None
             if len(set(test_program_in_prefix)) != 1:
                 log.warning(
-                    f"test_programs ({test_programs}) not all found in the same prefix"
+                    "test_programs (%s) not all found in the same prefix", test_programs
                 )
                 return None
             return prefixes[test_program_in_prefix[0]]


### PR DESCRIPTION
### Description

Replace `log.debug(f"...")` / `log.warning(f"...")` calls with `%-style` lazy formatting (`log.debug("...", arg)`) across the codebase. With f-strings the string is always interpolated before calling the log method, even when the log level is disabled. With `%`-style arguments the interpolation is deferred until the logging framework decides to emit the record.

Enable the ruff [`G004`](https://docs.astral.sh/ruff/rules/logging-f-string/) rule to enforce this going forward.

Files changed: `cli/main_run.py`, `common/configuration.py`, `core/envs_manager.py`, `core/link.py`, `core/package_cache_data.py`, `env/installers/pip.py`, `exception_handler.py`, `gateways/connection/download.py`, `gateways/disk/create.py`, `gateways/disk/delete.py`, `gateways/disk/update.py`, `gateways/repodata/__init__.py`, `gateways/subprocess.py`, `models/version.py`, `notices/core.py`, `notices/fetch.py`, `plugins/manager.py`, `plugins/subcommands/doctor/__init__.py`, `plugins/subcommands/doctor/health_checks/altered_files.py`, `plugins/subcommands/doctor/health_checks/environment_txt.py`, `testing/fixtures.py`.

The `deepcopy` → dict comprehension change in `resolve.py` (the other half of A20) has been split into #15917.

Part of #15867.

### Checklist - did you ...

- [x] Add a file to the `news` directory (using the template) for the next release's release notes?
- [x] Add / update necessary tests?
- ~~Add / update outdated documentation?~~ (not applicable)