### PR TITLE
Require explicit `conda.plugins.types` import (A22)

### DIFF
--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -27,7 +27,6 @@ as well as conda's internal implementations of plugins.
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
 
 from ..deprecations import deprecated
@@ -36,31 +35,15 @@ from .hookspec import hookimpl
 if TYPE_CHECKING:
     from types import ModuleType
 
-__all__ = ["hookimpl", "types"]
+__all__ = ["hookimpl"]
 
 
 def _load_types() -> ModuleType:
-    # ``__import__`` avoids recursing through this module's own
-    # ``__getattr__`` via ``_handle_fromlist``.
     return __import__("conda.plugins.types", fromlist=["types"])
 
 
-def __getattr__(
-    name: str,
-    # Default-arg capture keeps sys.is_finalizing reachable during
-    # interpreter shutdown, when module globals get cleared.
-    _finalizing=sys.is_finalizing,
-) -> object:
-    if _finalizing():
-        raise AttributeError(name)
-    if name == "types":
-        return _load_types()
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-# ``deprecated.constant`` installs its own registry as ``__getattr__`` and
-# chains to the one defined above as its fallback, so ``conda.plugins.types``
-# resolves lazily while the 16 deprecated re-exports still warn on access.
+# ``deprecated.constant`` installs its own registry as module ``__getattr__``,
+# so the 16 deprecated re-exports still warn on access.
 for name in (
     "CondaAuthHandler",
     "CondaEnvironmentSpecifier",

--- a/conda/plugins/__init__.py
+++ b/conda/plugins/__init__.py
@@ -25,121 +25,65 @@ as well as conda's internal implementations of plugins.
 
 """
 
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
 from ..deprecations import deprecated
-from . import types
 from .hookspec import hookimpl
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 __all__ = ["hookimpl", "types"]
 
-deprecated.constant(
-    "26.3",
-    "26.9",
+
+def _load_types() -> ModuleType:
+    # ``__import__`` avoids recursing through this module's own
+    # ``__getattr__`` via ``_handle_fromlist``.
+    return __import__("conda.plugins.types", fromlist=["types"])
+
+
+def __getattr__(
+    name: str,
+    # Default-arg capture keeps sys.is_finalizing reachable during
+    # interpreter shutdown, when module globals get cleared.
+    _finalizing=sys.is_finalizing,
+) -> object:
+    if _finalizing():
+        raise AttributeError(name)
+    if name == "types":
+        return _load_types()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# ``deprecated.constant`` installs its own registry as ``__getattr__`` and
+# chains to the one defined above as its fallback, so ``conda.plugins.types``
+# resolves lazily while the 16 deprecated re-exports still warn on access.
+for name in (
     "CondaAuthHandler",
-    types.CondaAuthHandler,
-    addendum="Use `conda.plugins.types.CondaAuthHandler` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaEnvironmentSpecifier",
-    types.CondaEnvironmentSpecifier,
-    addendum="Use `conda.plugins.types.CondaEnvironmentSpecifier` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaHealthCheck",
-    types.CondaHealthCheck,
-    addendum="Use `conda.plugins.types.CondaHealthCheck` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaPostCommand",
-    types.CondaPostCommand,
-    addendum="Use `conda.plugins.types.CondaPostCommand` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaPostSolve",
-    types.CondaPostSolve,
-    addendum="Use `conda.plugins.types.CondaPostSolve` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaPostTransactionAction",
-    types.CondaPostTransactionAction,
-    addendum="Use `conda.plugins.types.CondaPostTransactionAction` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaPreCommand",
-    types.CondaPreCommand,
-    addendum="Use `conda.plugins.types.CondaPreCommand` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaPrefixDataLoader",
-    types.CondaPrefixDataLoader,
-    addendum="Use `conda.plugins.types.CondaPrefixDataLoader` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaPreSolve",
-    types.CondaPreSolve,
-    addendum="Use `conda.plugins.types.CondaPreSolve` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaPreTransactionAction",
-    types.CondaPreTransactionAction,
-    addendum="Use `conda.plugins.types.CondaPreTransactionAction` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaReporterBackend",
-    types.CondaReporterBackend,
-    addendum="Use `conda.plugins.types.CondaReporterBackend` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaRequestHeader",
-    types.CondaRequestHeader,
-    addendum="Use `conda.plugins.types.CondaRequestHeader` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaSetting",
-    types.CondaSetting,
-    addendum="Use `conda.plugins.types.CondaSetting` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaSolver",
-    types.CondaSolver,
-    addendum="Use `conda.plugins.types.CondaSolver` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaSubcommand",
-    types.CondaSubcommand,
-    addendum="Use `conda.plugins.types.CondaSubcommand` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
     "CondaVirtualPackage",
-    types.CondaVirtualPackage,
-    addendum="Use `conda.plugins.types.CondaVirtualPackage` instead.",
-)
+):
+    deprecated.constant(
+        "26.3",
+        "26.9",
+        name,
+        factory=lambda n=name: getattr(_load_types(), n),
+        addendum=f"Use `conda.plugins.types.{name}` instead.",
+    )
+del name

--- a/news/15867-lazy-plugins-types
+++ b/news/15867-lazy-plugins-types
@@ -1,0 +1,8 @@
+### Enhancements
+
+* `conda.plugins` no longer eagerly imports `conda.plugins.types` at module
+  load time. The 756-line submodule loads on first attribute access (or via
+  an explicit `import conda.plugins.types`), and the 16 deprecated re-exports
+  (`conda.plugins.CondaSolver` etc.) now use `deprecated.constant(factory=...)`
+  so `conda.plugins.types` stays off the cold-start path unless one of those
+  names is actually referenced. (#15893)

--- a/news/15867-lazy-plugins-types
+++ b/news/15867-lazy-plugins-types
@@ -1,8 +1,7 @@
 ### Enhancements
 
 * `conda.plugins` no longer eagerly imports `conda.plugins.types` at module
-  load time. The 756-line submodule loads on first attribute access (or via
-  an explicit `import conda.plugins.types`), and the 16 deprecated re-exports
-  (`conda.plugins.CondaSolver` etc.) now use `deprecated.constant(factory=...)`
-  so `conda.plugins.types` stays off the cold-start path unless one of those
-  names is actually referenced. (#15893)
+  load time. The 756-line submodule loads only via an explicit
+  `import conda.plugins.types`, or when one of the 16 deprecated re-exports
+  (`conda.plugins.CondaSolver` etc.) is referenced through
+  `deprecated.constant(factory=...)`. (#15893)

--- a/tests/plugins/test_lazy_types.py
+++ b/tests/plugins/test_lazy_types.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Verify ``conda.plugins.types`` loads lazily and its deprecated re-exports."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import warnings
+
+import pytest
+
+_DEPRECATED_NAMES = (
+    "CondaAuthHandler",
+    "CondaEnvironmentSpecifier",
+    "CondaHealthCheck",
+    "CondaPostCommand",
+    "CondaPostSolve",
+    "CondaPostTransactionAction",
+    "CondaPreCommand",
+    "CondaPrefixDataLoader",
+    "CondaPreSolve",
+    "CondaPreTransactionAction",
+    "CondaReporterBackend",
+    "CondaRequestHeader",
+    "CondaSetting",
+    "CondaSolver",
+    "CondaSubcommand",
+    "CondaVirtualPackage",
+)
+
+
+def test_plugins_types_not_imported_on_plugins_import() -> None:
+    """Importing ``conda.plugins`` must not eagerly import ``conda.plugins.types``."""
+    script = textwrap.dedent("""
+        import sys
+        import conda.plugins
+        print("conda.plugins.types" in sys.modules)
+    """)
+    env = {k: v for k, v in os.environ.items() if k != "EAGER_IMPORT"}
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "False", result.stdout
+
+
+def test_plugins_types_attribute_loads_lazily_without_warning() -> None:
+    """``conda.plugins.types`` attribute access loads the submodule, no warning."""
+    import conda.plugins
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        types_module = conda.plugins.types
+
+    assert types_module is sys.modules["conda.plugins.types"]
+    assert not any(
+        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
+        for w in caught
+    ), [str(w.message) for w in caught]
+
+
+@pytest.mark.parametrize("name", _DEPRECATED_NAMES)
+def test_deprecated_plugin_type_access_warns(name: str) -> None:
+    """Each re-export on ``conda.plugins`` still warns and resolves to the type."""
+    import conda.plugins
+    import conda.plugins.types as types_mod
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        value = getattr(conda.plugins, name)
+
+    assert any(
+        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
+        for w in caught
+    ), f"expected a (Pending)DeprecationWarning for conda.plugins.{name}"
+    assert value is getattr(types_mod, name)
+
+
+def test_unknown_attribute_raises() -> None:
+    """Unknown attributes still raise ``AttributeError``."""
+    import conda.plugins
+
+    with pytest.raises(AttributeError):
+        conda.plugins.does_not_exist

--- a/tests/plugins/test_lazy_types.py
+++ b/tests/plugins/test_lazy_types.py
@@ -50,19 +50,30 @@ def test_plugins_types_not_imported_on_plugins_import() -> None:
     assert result.stdout.strip() == "False", result.stdout
 
 
-def test_plugins_types_attribute_loads_lazily_without_warning() -> None:
-    """``conda.plugins.types`` attribute access loads the submodule, no warning."""
-    import conda.plugins
+def test_plugins_types_requires_explicit_import() -> None:
+    """``conda.plugins.types`` is available only after explicit import."""
+    script = textwrap.dedent("""
+        import conda.plugins
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        types_module = conda.plugins.types
+        try:
+            conda.plugins.types
+        except AttributeError:
+            print("missing")
+        else:
+            raise SystemExit("conda.plugins.types should require explicit import")
 
-    assert types_module is sys.modules["conda.plugins.types"]
-    assert not any(
-        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
-        for w in caught
-    ), [str(w.message) for w in caught]
+        import conda.plugins.types
+        print(conda.plugins.types.__name__)
+    """)
+    env = {k: v for k, v in os.environ.items() if k != "EAGER_IMPORT"}
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["missing", "conda.plugins.types"]
 
 
 @pytest.mark.parametrize("name", _DEPRECATED_NAMES)

--- a/tests/plugins/test_lazy_types.py
+++ b/tests/plugins/test_lazy_types.py
@@ -82,14 +82,9 @@ def test_deprecated_plugin_type_access_warns(name: str) -> None:
     import conda.plugins
     import conda.plugins.types as types_mod
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with pytest.deprecated_call():
         value = getattr(conda.plugins, name)
 
-    assert any(
-        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
-        for w in caught
-    ), f"expected a (Pending)DeprecationWarning for conda.plugins.{name}"
     assert value is getattr(types_mod, name)
 
 

--- a/tests/plugins/test_lazy_types.py
+++ b/tests/plugins/test_lazy_types.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 import sys
 import textwrap
-import warnings
 
 import pytest
 


### PR DESCRIPTION
### Description

Stop `conda.plugins` from eagerly importing `conda.plugins.types`, and stop exposing `types` as an implicit attribute after only `import conda.plugins`. Plugin authors should use an explicit `import conda.plugins.types`; the deprecated `conda.plugins.CondaSolver`-style re-exports remain available for their deprecation window and now load `conda.plugins.types` lazily through `deprecated.constant(factory=...)`.

Part of the startup-latency work tracked in #15867 (A22), using the `factory=` kwarg added in #15925.

What changed in `conda/plugins/__init__.py`:

- Dropped the eager `from . import types`.
- Removed `types` from `__all__`, so `conda.plugins.types` requires `import conda.plugins.types`.
- Replaced the 16 eager `deprecated.constant("26.3", "26.9", name, types.X, …)` calls with a loop that registers each name using `deprecated.constant(factory=lambda n=name: getattr(_load_types(), n), …)`.

Performance check with `hyperfine --shell=none` and the repo devenv Python:

- `origin/main`: `import conda.plugins` eagerly imports `types`: 153.2 ms ± 9.2 ms.
- This PR: `import conda.plugins` keeps `types` unloaded: 29.8 ms ± 1.8 ms.
- The explicit-import-only version is statistically tied with the previous lazy-attribute version (`1.00 ± 0.09`).

Tests (`tests/plugins/test_lazy_types.py`):

- `conda.plugins.types` is not in `sys.modules` after `import conda.plugins` (subprocess-isolated check).
- `conda.plugins.types` raises `AttributeError` until `import conda.plugins.types` is used.
- All 16 legacy re-exports emit a `(Pending)DeprecationWarning` and resolve to the type from `conda.plugins.types` (parametrized).
- Unknown attributes still raise `AttributeError`.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
