### PR TITLE
Add reporting for missing packages to configured channels in Exceptio…

### DIFF
--- a/conda/exception_handler.py
+++ b/conda/exception_handler.py
@@ -69,9 +69,12 @@ class ExceptionHandler:
             CondaError,
             CondaMemoryError,
             NoSpaceLeftError,
+            PackagesNotFoundInChannelsError,
         )
 
         if isinstance(exc_val, CondaError):
+            if isinstance(exc_val, PackagesNotFoundInChannelsError):
+                self._report_missing_packages(exc_val)
             if exc_val.reportable:
                 return self.handle_reportable_application_exception(exc_val, exc_tb)
             else:
@@ -104,6 +107,81 @@ class ExceptionHandler:
         from .exceptions import print_conda_exception
 
         print_conda_exception(exc_val, exc_tb)
+
+    def _report_missing_packages(self, exc_val: BaseException) -> None:
+        """Fire-and-forget GET report to each configured channel for missing packages.
+
+        Sends ``GET {base_channel_url}/missing?name=version&...`` for every
+        deduplicated base channel URL found in the exception.  The response
+        code is intentionally ignored.  All failures are silently logged at
+        DEBUG level so this method can never disrupt the normal error path.
+        """
+        import urllib.error
+        import urllib.request
+        from urllib.parse import urlencode
+
+        try:
+            from .base.context import context
+
+            if context.offline:
+                return
+
+            from .models.channel import Channel
+            from .models.match_spec import MatchSpec
+
+            # Build query params from the missing package specs.
+            params: list[tuple[str, str]] = []
+            for pkg in exc_val.packages:
+                if isinstance(pkg, MatchSpec):
+                    name = pkg.name
+                    version = str(pkg.version) if pkg.version is not None else "*"
+                elif hasattr(pkg, "name") and hasattr(pkg, "version"):
+                    # PackageRecord or similar
+                    name = pkg.name
+                    version = str(pkg.version)
+                else:
+                    # Raw string spec — treat the whole string as the name
+                    name = str(pkg)
+                    version = "*"
+                if name:
+                    params.append((name, version))
+
+            if not params:
+                return
+
+            query_string = urlencode(params)
+
+            # Collect deduplicated base channel URLs (strips subdirs like /linux-64).
+            seen: set[str] = set()
+            base_urls: list[str] = []
+            for channel_url in exc_val.channel_urls:
+                base = Channel(channel_url).base_url
+                if base and base not in seen:
+                    seen.add(base)
+                    base_urls.append(base)
+
+            if not base_urls:
+                return
+
+            self.write_out(
+                f"Sending missing package report to {len(base_urls)} channel(s)."
+            )
+
+            for base_url in base_urls:
+                report_url = f"{base_url}/missing?{query_string}"
+                log.debug("Reporting missing packages to: %s", report_url)
+                try:
+                    with urllib.request.urlopen(report_url, timeout=5):
+                        pass
+                except urllib.error.HTTPError:
+                    pass  # response code ignored by design
+                except Exception as e:
+                    log.debug(
+                        "Missing package report failed for %s: %r", base_url, e
+                    )
+
+        except Exception as e:
+            log.debug("_report_missing_packages failed: %r", e)
 
     def handle_unexpected_exception(
         self, exc_val: BaseException, exc_tb: TracebackType

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,8 +3,12 @@
 import getpass
 import json
 import sys
+import urllib.error
+from urllib.parse import parse_qs, urlparse
 from contextlib import nullcontext
 from unittest.mock import patch
+
+
 
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
@@ -24,6 +28,7 @@ from conda.exceptions import (
     ExceptionHandler,
     KnownPackageClobberError,
     PackagesNotFoundError,
+    PackagesNotFoundInChannelsError,
     PathNotFoundError,
     ProxyError,
     SharedLinkPathClobberError,
@@ -31,6 +36,7 @@ from conda.exceptions import (
     UnknownPackageClobberError,
     conda_exception_handler,
 )
+from conda.models.match_spec import MatchSpec
 
 
 def _raise_helper(exception):
@@ -909,3 +915,183 @@ def test_ExceptionHandler_deprecations(
     raises_context = pytest.raises(raises) if raises else nullcontext()
     with pytest.deprecated_call(), raises_context:
         getattr(ExceptionHandler(), function)()
+
+
+def test_report_missing_packages_fires_get_to_base_channel_url(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """GET is sent to the base channel URL (subdir stripped) with package specs as query params."""
+
+    monkeypatch.setenv("CONDA_OFFLINE", "false")
+    reset_context()
+
+    urlopen_mock = mocker.patch("urllib.request.urlopen")
+
+    exc = PackagesNotFoundInChannelsError(
+        [MatchSpec("numpy>=1.20")],
+        ["https://conda.anaconda.org/conda-forge/linux-64"],
+    )
+    ExceptionHandler()._report_missing_packages(exc)
+
+    urlopen_mock.assert_called_once()
+    url_called = urlopen_mock.call_args[0][0]
+
+    parsed = urlparse(url_called)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "conda.anaconda.org"
+    assert parsed.path == "/conda-forge/missing"
+
+    qs = parse_qs(parsed.query)
+    assert qs.get("numpy") == [">=1.20"]
+
+
+def test_report_missing_packages_raw_string_spec(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Raw string package specs are passed as name=* in the query."""
+
+    monkeypatch.setenv("CONDA_OFFLINE", "false")
+    reset_context()
+
+    urlopen_mock = mocker.patch("urllib.request.urlopen")
+
+    exc = PackagesNotFoundInChannelsError(
+        ["scipy"],
+        ["https://conda.anaconda.org/conda-forge/linux-64"],
+    )
+    ExceptionHandler()._report_missing_packages(exc)
+
+    urlopen_mock.assert_called_once()
+    url_called = urlopen_mock.call_args[0][0]
+
+    qs = parse_qs(urlparse(url_called).query)
+    assert qs.get("scipy") == ["*"]
+
+
+def test_report_missing_packages_skips_when_offline(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """No GET is attempted when conda is in offline mode."""
+    monkeypatch.setenv("CONDA_OFFLINE", "true")
+    reset_context()
+
+    urlopen_mock = mocker.patch("urllib.request.urlopen")
+
+    exc = PackagesNotFoundInChannelsError(
+        ["numpy"],
+        ["https://conda.anaconda.org/conda-forge/linux-64"],
+    )
+    ExceptionHandler()._report_missing_packages(exc)
+
+    urlopen_mock.assert_not_called()
+
+
+def test_report_missing_packages_swallows_http_error(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An HTTP error response from the channel does not propagate."""
+    monkeypatch.setenv("CONDA_OFFLINE", "false")
+    reset_context()
+
+    mocker.patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.HTTPError(
+            "https://conda.anaconda.org/conda-forge/missing",
+            404,
+            "Not Found",
+            {},
+            None,
+        ),
+    )
+
+    exc = PackagesNotFoundInChannelsError(
+        ["numpy"],
+        ["https://conda.anaconda.org/conda-forge/linux-64"],
+    )
+    # Must not raise regardless of HTTP response code
+    ExceptionHandler()._report_missing_packages(exc)
+
+
+def test_report_missing_packages_deduplicates_channels(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Multiple subdirs of the same channel collapse to a single GET per base URL."""
+    monkeypatch.setenv("CONDA_OFFLINE", "false")
+    reset_context()
+
+    urlopen_mock = mocker.patch("urllib.request.urlopen")
+
+    exc = PackagesNotFoundInChannelsError(
+        ["scipy"],
+        [
+            "https://conda.anaconda.org/conda-forge/linux-64",
+            "https://conda.anaconda.org/conda-forge/noarch",  # same base, different subdir
+            "https://repo.anaconda.com/pkgs/main/linux-64",  # different base
+        ],
+    )
+    ExceptionHandler()._report_missing_packages(exc)
+
+    assert urlopen_mock.call_count == 2
+    base_paths = {
+        urlopen_mock.call_args_list[0][0][0].split("?")[0],
+        urlopen_mock.call_args_list[1][0][0].split("?")[0],
+    }
+    assert base_paths == {
+        "https://conda.anaconda.org/conda-forge/missing",
+        "https://repo.anaconda.com/pkgs/main/missing",
+    }
+
+
+def test_report_missing_packages_informs_user(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture,
+) -> None:
+    """A human-readable message is written to stderr before the requests are sent."""
+    monkeypatch.setenv("CONDA_OFFLINE", "false")
+    reset_context()
+
+    mocker.patch("urllib.request.urlopen")
+
+    exc = PackagesNotFoundInChannelsError(
+        ["numpy"],
+        [
+            "https://conda.anaconda.org/conda-forge/linux-64",
+            "https://repo.anaconda.com/pkgs/main/linux-64",
+        ],
+    )
+    ExceptionHandler()._report_missing_packages(exc)
+
+    _, stderr = capsys.readouterr()
+    assert "Sending missing package report to 2 channel(s)." in stderr
+
+
+def test_handle_exception_hooks_report_for_packages_not_found_in_channels(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """handle_exception() calls _report_missing_packages for PackagesNotFoundInChannelsError
+    but not for other CondaError subclasses."""
+    monkeypatch.setenv("CONDA_OFFLINE", "false")
+    reset_context()
+
+    mocker.patch("urllib.request.urlopen")
+    spy = mocker.spy(ExceptionHandler, "_report_missing_packages")
+
+    # PackagesNotFoundInChannelsError must trigger the report
+    exc_channels = PackagesNotFoundInChannelsError(
+        ["numpy"],
+        ["https://conda.anaconda.org/conda-forge/linux-64"],
+    )
+    ExceptionHandler()(_raise_helper, exc_channels)
+    assert spy.call_count == 1
+
+    # Generic PackagesNotFoundError must NOT trigger the report
+    exc_generic = PackagesNotFoundError(["numpy"])
+    ExceptionHandler()(_raise_helper, exc_generic)
+    assert spy.call_count == 1  # unchanged


### PR DESCRIPTION
This pull request adds a new feature to automatically report missing packages to conda channels when a `PackagesNotFoundInChannelsError` is raised. The reporting mechanism sends a GET request to each relevant channel's `/missing` endpoint with the missing package specs, helping channel maintainers track demand. The implementation is robust, avoids disrupting the normal error path, and is thoroughly tested.

**New missing package reporting feature:**

* Added a `_report_missing_packages` method to `ExceptionHandler` in `conda/exception_handler.py` that sends a fire-and-forget GET request to each deduplicated base channel URL when a `PackagesNotFoundInChannelsError` occurs. This includes handling various spec formats, skipping in offline mode, and logging failures at DEBUG level.
* Modified `handle_exception` to call `_report_missing_packages` when handling `PackagesNotFoundInChannelsError`.

**Testing and validation:**

* Introduced comprehensive tests in `tests/test_exceptions.py` to verify correct GET request formation, handling of raw string specs, offline mode behavior, HTTP error swallowing, channel deduplication, user messaging, and integration with `handle_exception`.
* Added necessary imports and test setup for the new feature and exception class. [[1]](diffhunk://#diff-f46006e3f43ffb1dd5d6862005427f6620f4dcfb1fa2f883d8482550069eeeccR6-R12) [[2]](diffhunk://#diff-f46006e3f43ffb1dd5d6862005427f6620f4dcfb1fa2f883d8482550069eeeccR31-R39)