### PR TITLE
DOC: Add /NoRegistry and /NoShortcuts options to Windows install docs

### DIFF
--- a/docs/source/user-guide/install/windows.rst
+++ b/docs/source/user-guide/install/windows.rst
@@ -54,6 +54,11 @@ argument. The following optional arguments are supported:
   Python.
   ``0`` indicates Python won't be registered as the system's default. ``1``
   indicates Python will be registered as the system's default.
+* ``/NoRegistry=[0|1]``---Default is ``0``.
+  ``1`` prevents the installer from writing any registry entries,
+  which is useful for creating portable installations.
+* ``/NoShortcuts=[0|1]``---Default is ``0``.
+  ``1`` prevents the installer from creating any Start Menu shortcuts.
 * ``/S``---Install in silent mode.
 * ``/D=<installation path>``---Destination installation path.
   Must be the last argument. Do not wrap in quotation marks.
@@ -67,6 +72,14 @@ current user without registering Python as the system's default:
 .. code-block:: bat
 
    start /wait "" Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /D=%UserProfile%\Miniconda3
+
+**Example:** The following command installs Miniconda for the
+current user without creating Start Menu shortcuts or registry entries
+(useful for portable installations):
+
+.. code-block:: bat
+
+   start /wait "" Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /NoRegistry=1 /NoShortcuts=1 /S /D=%UserProfile%\Miniconda3
 
 
 Updating conda


### PR DESCRIPTION
## Problem

The Windows installer supports two useful options that are currently undocumented in the user guide, despite being available in the installer itself:
-  — prevents writing registry entries (useful for portable installations)
-  — prevents creating Start Menu shortcuts

This was reported in #11368.

## Analysis

Looking at the Windows installer source and development scripts, both options are already implemented and functional. However, users relying solely on the official documentation have no way to discover them. This is particularly problematic for CI/CD and portable deployment scenarios where registry modifications and shortcut creation are undesirable.

## Solution

Add documentation for both  and  options to , including:
- Description of each option's behavior
- Default values
- A practical example showing a combined portable installation command

## Benchmarks

N/A — documentation change only. Built locally with cd docs && make html
make[1]: Entering directory '/home/deploy/hermes-workspaces/clawmogorov/repos/conda/docs'
make[1]: Leaving directory '/home/deploy/hermes-workspaces/clawmogorov/repos/conda/docs' to verify correct rendering.

## Notes

- Default values ( for both) align with the existing installer behavior.
- The example command follows the same formatting style as the existing documentation.