### PR TITLE
Replace auxlib.Entity package records with slotted dataclasses (A19b)

### DIFF
--- a/conda/models/_legacy_record_fields.py
+++ b/conda/models/_legacy_record_fields.py
@@ -1,0 +1,195 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Legacy auxlib.Entity-based field descriptors for ``conda.models.records``.
+
+Kept around one release cycle so that plugins and downstreams importing the
+old descriptor names from :mod:`conda.models.records` continue to resolve.
+The dataclass-based record classes in :mod:`conda.models.records` no longer
+use any of these; they only exist to preserve import-time compatibility for
+code that still builds its own :class:`conda.auxlib.entity.Entity` subclasses.
+
+This module is imported lazily via ``deprecated.constant(factory=...)``.
+"""
+
+from __future__ import annotations
+
+from boltons.timeutils import dt_to_timestamp, isoparse
+
+from ..auxlib.entity import (
+    ComposableField,
+    EnumField,
+    ListField,
+    NumberField,
+    StringField,
+)
+from ..base.context import context
+from ..common.compat import isiterable
+from ..exceptions import PathNotFoundError
+from .channel import Channel
+from .enums import NoarchType, PackageType
+
+
+class NoarchField(EnumField):
+    def box(self, instance, instance_type, val):
+        return super().box(instance, instance_type, NoarchType.coerce(val))
+
+
+class TimestampField(NumberField):
+    def __init__(self):
+        super().__init__(default=0, required=False, default_in_dump=False)
+
+    @staticmethod
+    def _make_seconds(val):
+        if val:
+            val = val
+            if val > 253402300799:  # 9999-12-31
+                val /= (
+                    1000  # convert milliseconds to seconds; see conda/conda-build#1988
+                )
+        return val
+
+    @staticmethod
+    def _make_milliseconds(val):
+        if val:
+            if val < 253402300799:  # 9999-12-31
+                val *= 1000
+            val = val
+        return val
+
+    def box(self, instance, instance_type, val):
+        return self._make_seconds(super().box(instance, instance_type, val))
+
+    def dump(self, instance, instance_type, val):
+        return int(self._make_milliseconds(super().dump(instance, instance_type, val)))
+
+    def __get__(self, instance, instance_type):
+        try:
+            return super().__get__(instance, instance_type)
+        except AttributeError:
+            try:
+                return int(dt_to_timestamp(isoparse(instance.date)))
+            except (AttributeError, ValueError):
+                return 0
+
+
+class _FeaturesField(ListField):
+    def __init__(self, **kwargs):
+        super().__init__(str, **kwargs)
+
+    def box(self, instance, instance_type, val):
+        if isinstance(val, str):
+            val = val.replace(" ", ",").split(",")
+        val = tuple(f for f in (ff.strip() for ff in val) if f)
+        return super().box(instance, instance_type, val)
+
+    def dump(self, instance, instance_type, val):
+        if isiterable(val):
+            return " ".join(val)
+        else:
+            return val or ()
+
+
+class ChannelField(ComposableField):
+    def __init__(self, aliases=()):
+        super().__init__(Channel, required=False, aliases=aliases)
+
+    def dump(self, instance, instance_type, val):
+        if val:
+            return str(val)
+        else:
+            val = instance.channel
+            return str(val)
+
+    def __get__(self, instance, instance_type):
+        try:
+            return super().__get__(instance, instance_type)
+        except AttributeError:
+            url = instance.url
+            return self.unbox(instance, instance_type, Channel(url))
+
+
+class SubdirField(StringField):
+    def __init__(self):
+        super().__init__(required=False)
+
+    def __get__(self, instance, instance_type):
+        try:
+            return super().__get__(instance, instance_type)
+        except AttributeError:
+            try:
+                url = instance.url
+            except AttributeError:
+                url = None
+            if url:
+                return self.unbox(instance, instance_type, Channel(url).subdir)
+
+            try:
+                platform, arch = instance.platform.name, instance.arch
+            except AttributeError:
+                platform, arch = None, None
+            if platform and not arch:
+                return self.unbox(instance, instance_type, "noarch")
+            elif platform:
+                if "x86" in arch:
+                    arch = "64" if "64" in arch else "32"
+                return self.unbox(instance, instance_type, f"{platform}-{arch}")
+            else:
+                return self.unbox(instance, instance_type, context.subdir)
+
+
+class FilenameField(StringField):
+    def __init__(self, aliases=()):
+        super().__init__(required=False, aliases=aliases)
+
+    def __get__(self, instance, instance_type):
+        try:
+            return super().__get__(instance, instance_type)
+        except AttributeError:
+            try:
+                url = instance.url
+                fn = Channel(url).package_filename
+                if not fn:
+                    raise AttributeError()
+            except AttributeError:
+                fn = f"{instance.name}-{instance.version}-{instance.build}"
+            if not fn:
+                raise ValueError("Filename cannot be empty.")
+            return self.unbox(instance, instance_type, fn)
+
+
+class PackageTypeField(EnumField):
+    def __init__(self):
+        super().__init__(
+            PackageType,
+            required=False,
+            nullable=True,
+            default=None,
+            default_in_dump=False,
+        )
+
+    def __get__(self, instance, instance_type):
+        val = super().__get__(instance, instance_type)
+        if val is None:
+            noarch_val = instance.noarch
+            if noarch_val:
+                type_map = {
+                    NoarchType.generic: PackageType.NOARCH_GENERIC,
+                    NoarchType.python: PackageType.NOARCH_PYTHON,
+                }
+                val = type_map[NoarchType.coerce(noarch_val)]
+                val = self.unbox(instance, instance_type, val)
+        return val
+
+
+class Md5Field(StringField):
+    def __init__(self):
+        super().__init__(required=False, nullable=True)
+
+    def __get__(self, instance, instance_type):
+        try:
+            return super().__get__(instance, instance_type)
+        except AttributeError as e:
+            try:
+                return instance._calculate_md5sum()
+            except PathNotFoundError:
+                raise e

--- a/conda/models/_legacy_record_fields.py
+++ b/conda/models/_legacy_record_fields.py
@@ -72,6 +72,14 @@ class TimestampField(NumberField):
                 return 0
 
 
+class IndexedTimestampField(TimestampField):
+    def __get__(self, instance, instance_type):
+        try:
+            return NumberField.__get__(self, instance, instance_type)
+        except AttributeError:
+            return 0
+
+
 class _FeaturesField(ListField):
     def __init__(self, **kwargs):
         super().__init__(str, **kwargs)

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -278,18 +278,24 @@ def resolve_features(val: Any, record: PackageRecord) -> tuple[str, ...]:
     return tuple(f for f in (ff.strip() for ff in val) if f)
 
 
-def resolve_as_tuple(val: Any, record: PackageRecord) -> tuple:
+def resolve_as_tuple(
+    val: Any,
+    record: PackageRecord,
+    field_name: str = "sequence",
+) -> tuple:
     if isinstance(val, tuple):
         return val
     if not val:
         return ()
+    if isinstance(val, str):
+        raise ValidationError(field_name, val)
     return tuple(val)
 
 
 def resolve_optional_tuple(val: Any, record: PackageRecord) -> tuple | None:
     if val is None:
         return None
-    return resolve_as_tuple(val, record)
+    return resolve_as_tuple(val, record, "_requested_specs")
 
 
 def resolve_noarch(val: Any, record: PackageRecord) -> NoarchType | None:
@@ -387,10 +393,10 @@ class PackageRecord:
         "timestamp": resolve_timestamp,
         "track_features": resolve_features,
         "features": resolve_features,
-        "depends": resolve_as_tuple,
-        "constrains": resolve_as_tuple,
-        "flags": resolve_as_tuple,
-        "files": resolve_as_tuple,
+        "depends": partial(resolve_as_tuple, field_name="depends"),
+        "constrains": partial(resolve_as_tuple, field_name="constrains"),
+        "flags": partial(resolve_as_tuple, field_name="flags"),
+        "files": partial(resolve_as_tuple, field_name="files"),
         "noarch": resolve_noarch,
         "package_type": resolve_package_type,
         "platform": resolve_platform,
@@ -500,9 +506,9 @@ class PackageRecord:
                 setattr_(self, fname, sys.intern(val))
 
     def __setattr__(self, name: str, value: Any) -> None:
-        value = coerce_and_validate(name, value)
         if resolve := self.FIELD_RESOLVERS.get(name):
             value = resolve(value, self)
+        value = coerce_and_validate(name, value)
         object.__setattr__(self, name, value)
         if name in PKEY_FIELDS and hasattr(self, "_pkey_cache"):
             self.invalidate_pkey()

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import enum
 import json  # noqa: TID251
 import sys
-from dataclasses import MISSING, dataclass, field, fields
+from dataclasses import MISSING, dataclass, field, fields, is_dataclass
 from functools import cache, partial
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
@@ -32,6 +32,7 @@ from ..auxlib.entity import (
     ListField,
     StringField,
 )
+from ..auxlib.exceptions import ValidationError
 from ..deprecations import deprecated
 from .channel import Channel
 from .enums import FileMode, LinkType, NoarchType, PackageType, PathEnum, Platform
@@ -39,6 +40,8 @@ from .enums import FileMode, LinkType, NoarchType, PackageType, PathEnum, Platfo
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
+
+    from .match_spec import MatchSpec
 
 
 class LinkTypeField(EnumField):
@@ -93,6 +96,50 @@ SENTINEL = object()
 
 TS_BOUNDARY = 253402300799  # 9999-12-31 in epoch seconds
 
+REQUIRED_FIELDS = ("name", "version", "build", "build_number")
+
+STRING_FIELDS = frozenset(
+    {
+        "name",
+        "version",
+        "build",
+        "subdir",
+        "fn",
+        "md5",
+        "legacy_bz2_md5",
+        "url",
+        "sha256",
+        "arch",
+        "preferred_env",
+        "python_site_packages_path",
+        "license",
+        "license_family",
+        "date",
+        "package_tarball_full_path",
+        "extracted_package_dir",
+        "requested_spec",
+        "auth",
+    }
+)
+
+INTEGER_FIELDS = frozenset({"build_number", "legacy_bz2_size", "size"})
+
+SEQUENCE_FIELDS = frozenset(
+    {
+        "depends",
+        "constrains",
+        "flags",
+        "track_features",
+        "features",
+        "files",
+        "_requested_specs",
+    }
+)
+
+PKEY_FIELDS = frozenset(
+    {"channel", "subdir", "name", "version", "build_number", "build", "fn"}
+)
+
 CACHE_FIELDS = frozenset({"_pkey_cache", "_hash_cache", "_memoized_md5"})
 
 FIELDS_EXCLUDED_FROM_DUMP = frozenset({"metadata"})
@@ -135,10 +182,10 @@ class Dumpable(Protocol):
 
 @cache
 def get_field_info(cls: type) -> tuple[tuple[str, Any, Any], ...]:
-    """Return (name, default, default_factory) for each public field of *cls*."""
+    """Return initialization metadata for each constructor field of *cls*."""
     info: list[tuple[str, Any, Any]] = []
     for f in fields(cls):
-        if f.name in CACHE_FIELDS:
+        if not f.init:
             continue
         default = f.default if f.default is not MISSING else SENTINEL
         default_factory = (
@@ -163,8 +210,8 @@ def get_dump_specs(cls: type) -> tuple[tuple[str, bool, Any], ...]:
 
 @cache
 def get_known_fields(cls: type) -> frozenset[str]:
-    """Return the set of non-cache field names for *cls*."""
-    return frozenset(f.name for f in fields(cls) if f.name not in CACHE_FIELDS)
+    """Return constructor field names for *cls*."""
+    return frozenset(f.name for f in fields(cls) if f.init)
 
 
 def resolve_channel(val: Any, record: PackageRecord) -> Channel | None:
@@ -209,6 +256,13 @@ def resolve_fn(val: Any, record: PackageRecord) -> str:
 
 
 def resolve_timestamp(val: Any, record: PackageRecord) -> int | float:
+    if not val and record.date:
+        from boltons.timeutils import dt_to_timestamp, isoparse
+
+        try:
+            return int(dt_to_timestamp(isoparse(record.date)))
+        except (TypeError, ValueError):
+            return 0
     if val and val > TS_BOUNDARY:
         return val / 1000
     return val
@@ -230,6 +284,12 @@ def resolve_as_tuple(val: Any, record: PackageRecord) -> tuple:
     if not val:
         return ()
     return tuple(val)
+
+
+def resolve_optional_tuple(val: Any, record: PackageRecord) -> tuple | None:
+    if val is None:
+        return None
+    return resolve_as_tuple(val, record)
 
 
 def resolve_noarch(val: Any, record: PackageRecord) -> NoarchType | None:
@@ -285,9 +345,34 @@ def dump_nested(val: Any) -> Any:
     return val.dump() if isinstance(val, Dumpable) else val
 
 
+def coerce_and_validate(name: str, val: Any) -> Any:
+    """Preserve the scalar validation performed by the old Entity fields."""
+    if val is None:
+        if name in REQUIRED_FIELDS:
+            raise ValidationError(name)
+        return val
+    if name in STRING_FIELDS:
+        if isinstance(val, (int, float, complex)):
+            return str(val)
+        if not isinstance(val, str):
+            raise ValidationError(name, val)
+    elif name in INTEGER_FIELDS and not isinstance(val, int):
+        raise ValidationError(name, val)
+    elif name == "timestamp" and not isinstance(val, (int, float)):
+        raise ValidationError(name, val)
+    elif name in SEQUENCE_FIELDS and not isinstance(val, tuple):
+        raise ValidationError(name, val)
+    return val
+
+
 @dataclass(slots=True, init=False, eq=False, repr=False)
 class PackageRecord:
-    """Representation of a concrete package archive (tarball or .conda file)."""
+    """Representation of a concrete package archive (tarball or .conda file).
+
+    The subclasses add information for solved, cached, and installed packages,
+    but do not add fields to :attr:`_pkey`. Records with the same identity
+    fields therefore compare equal and produce the same hash across subclasses.
+    """
 
     ALIASES: ClassVar[dict[str, str]] = {
         "build_string": "build",
@@ -358,7 +443,6 @@ class PackageRecord:
     size: int | None = None
 
     metadata: set[str] = field(default_factory=set, repr=False)
-
     _pkey_cache: tuple | None = field(
         default=None, repr=False, compare=False, init=False
     )
@@ -371,30 +455,57 @@ class PackageRecord:
             if alias in kwargs and canonical not in kwargs:
                 kwargs[canonical] = kwargs.pop(alias)
 
+        for name in REQUIRED_FIELDS:
+            if name not in kwargs:
+                raise ValidationError(
+                    name,
+                    msg=(
+                        f"{self.__class__.__name__} requires a {name} field. "
+                        f"Instantiated with {kwargs}"
+                    ),
+                )
+
         for name, default, default_factory in get_field_info(self.__class__):
             val = kwargs.get(name, SENTINEL)
             if val is SENTINEL:
                 if default_factory is not None:
-                    setattr_(self, name, default_factory())
+                    val = default_factory()
                 else:
-                    setattr_(self, name, default)
-            else:
-                setattr_(self, name, val)
+                    val = default
+            if name not in self.FIELD_RESOLVERS:
+                val = coerce_and_validate(name, val)
+            setattr_(self, name, val)
+
+        for f_obj in fields(self.__class__):
+            if f_obj.init:
+                continue
+            if f_obj.default_factory is not MISSING:
+                setattr_(self, f_obj.name, f_obj.default_factory())
+            elif f_obj.default is not MISSING:
+                setattr_(self, f_obj.name, f_obj.default)
 
         for name, resolve in self.FIELD_RESOLVERS.items():
             val = getattr(self, name, SENTINEL)
             if val is not SENTINEL:
-                resolved = resolve(val, self)
-                if resolved is not val:
-                    setattr_(self, name, resolved)
+                resolved = (
+                    val
+                    if name == "timestamp" and name in kwargs and not val
+                    else resolve(val, self)
+                )
+                setattr_(self, name, coerce_and_validate(name, resolved))
 
         for fname in INTERN_FIELDS:
             val = getattr(self, fname, None)
             if isinstance(val, str):
                 setattr_(self, fname, sys.intern(val))
 
-        setattr_(self, "_pkey_cache", None)
-        setattr_(self, "_hash_cache", None)
+    def __setattr__(self, name: str, value: Any) -> None:
+        value = coerce_and_validate(name, value)
+        if resolve := self.FIELD_RESOLVERS.get(name):
+            value = resolve(value, self)
+        object.__setattr__(self, name, value)
+        if name in PKEY_FIELDS and hasattr(self, "_pkey_cache"):
+            self.invalidate_pkey()
 
     def __getitem__(self, item: str) -> Any:
         try:
@@ -407,6 +518,7 @@ class PackageRecord:
 
     @property
     def channel_name(self) -> str | None:
+        """The canonical name of the channel of this package."""
         ch = self.channel
         if ch is None:
             return None
@@ -428,6 +540,12 @@ class PackageRecord:
 
     @property
     def _pkey(self) -> tuple:
+        """Components used for record comparison and hashing.
+
+        The key contains the channel name, subdir, name, version, build number,
+        and build string. It also contains the filename when
+        :ref:`separate_format_cache <auto-config-reference>` is enabled.
+        """
         cached = self._pkey_cache
         if cached is not None:
             return cached
@@ -504,16 +622,16 @@ class PackageRecord:
                 src = obj
             elif isinstance(obj, Dumpable):
                 src = obj.dump()
+            elif is_dataclass(obj):
+                src = {f.name: getattr(obj, f.name) for f in fields(obj)}
             elif hasattr(obj, "__dict__"):
                 src = obj.__dict__
-            elif hasattr(obj, "__slots__"):
-                src = {
-                    s: getattr(obj, s)
-                    for s in obj.__slots__
-                    if hasattr(obj, s) and not s.startswith("_")
-                }
             else:
-                continue
+                src = {
+                    name: getattr(obj, name)
+                    for name in known | cls.ALIASES.keys()
+                    if hasattr(obj, name)
+                }
             for k, v in src.items():
                 target = cls.ALIASES.get(k, k) if k not in known else k
                 if target in known and target not in kwargs and v is not None:
@@ -570,7 +688,7 @@ class PackageRecord:
             "version": self.version,
         }
 
-    def to_match_spec(self):
+    def to_match_spec(self) -> MatchSpec:
         from .match_spec import MatchSpec
 
         return MatchSpec(
@@ -581,7 +699,7 @@ class PackageRecord:
             build=self.build,
         )
 
-    def to_simple_match_spec(self):
+    def to_simple_match_spec(self) -> MatchSpec:
         from .match_spec import MatchSpec
 
         return MatchSpec(name=self.name, version=self.version)
@@ -606,13 +724,17 @@ class PackageRecord:
 
     @property
     def spec(self) -> str:
+        """Return package spec as ``name=version=build``."""
         return f"{self.name}={self.version}={self.build}"
 
     @property
     def spec_no_build(self) -> str:
+        """Return package spec as ``name=version``."""
         return f"{self.name}={self.version}"
 
     def record_id(self) -> str:
+        # Used only by link.py's change report. This is not an official record
+        # identifier until it gains a namespace and a stable format.
         ch = self.channel
         ch_name = getattr(ch, "name", "") if ch else ""
         return f"{ch_name}/{self.subdir}::{self.name}-{self.version}-{self.build}"
@@ -669,9 +791,16 @@ class PackageRecord:
 
 @dataclass(slots=True, init=False, eq=False, repr=False)
 class PackageCacheRecord(PackageRecord):
-    """Representation of a package in the local package cache."""
+    """Representation of a package in the local package cache.
 
+    This specialization adds the local archive and extracted-directory paths.
+    It does not add fields to :attr:`PackageRecord._pkey`, so equal package and
+    prefix records continue to compare equal and produce the same hash.
+    """
+
+    # Full path to the local package archive.
     package_tarball_full_path: str = ""
+    # Full path to the local extracted package directory.
     extracted_package_dir: str = ""
     _memoized_md5: str | None = field(
         default=None, repr=False, compare=False, init=False
@@ -679,12 +808,14 @@ class PackageCacheRecord(PackageRecord):
 
     @property
     def is_fetched(self) -> bool:
+        """Whether the package archive exists locally."""
         from ..gateways.disk.read import isfile
 
         return isfile(self.package_tarball_full_path)
 
     @property
     def is_extracted(self) -> bool:
+        """Whether the package has been extracted locally."""
         from ..gateways.disk.read import isdir, isfile
 
         epd = self.extracted_package_dir
@@ -692,15 +823,11 @@ class PackageCacheRecord(PackageRecord):
 
     @property
     def tarball_basename(self) -> str:
+        """The basename of the local package archive."""
         return Path(self.package_tarball_full_path).name
 
     def calculate_md5sum(self) -> str | None:
-        # ``_memoized_md5`` is a slot but is not populated by PackageRecord's
-        # __init__ (it's listed in CACHE_FIELDS which skips initialization),
-        # so on a freshly-constructed PackageCacheRecord the slot read would
-        # raise AttributeError. Use getattr with a default to keep the slow
-        # path reachable on first call.
-        memoized = getattr(self, "_memoized_md5", None)
+        memoized = self._memoized_md5
         if memoized:
             return memoized
         if Path(self.package_tarball_full_path).is_file():
@@ -736,8 +863,8 @@ def _make_md5_auto_compute_property() -> property:
         auto = self.calculate_md5sum()
         if auto is not None:
             deprecated.topic(
-                "26.9",
                 "27.3",
+                "27.9",
                 topic="Implicit md5 auto-compute on PackageCacheRecord.md5",
                 addendum="Call PackageCacheRecord.calculate_md5sum() explicitly instead.",
             )
@@ -754,18 +881,30 @@ PackageCacheRecord.md5 = _make_md5_auto_compute_property()
 
 @dataclass(slots=True, init=False, eq=False, repr=False)
 class SolvedRecord(PackageRecord):
-    """Representation of a package returned as part of a solver solution."""
+    """Representation of a package returned as part of a solver solution.
+
+    This sits between :class:`PackageRecord` and :class:`PrefixRecord`, adding
+    the requested specs used by lockfiles without requiring an artifact on disk.
+    """
 
     ALIASES: ClassVar[dict[str, str]] = {
         **PackageRecord.ALIASES,
         "requested_specs": "_requested_specs",
     }
 
+    FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
+        **PackageRecord.FIELD_RESOLVERS,
+        "_requested_specs": resolve_optional_tuple,
+    }
+
+    # The MatchSpec explicitly requested by the user, if any.
     requested_spec: str | None = None
+    # All MatchSpecs explicitly requested by the user, if available.
     _requested_specs: tuple[str, ...] | None = None
 
     @property
     def requested_specs(self) -> tuple[str, ...]:
+        """Return plural requested specs, falling back to ``requested_spec``."""
         val = self._requested_specs
         if val:
             return tuple(val)
@@ -775,9 +914,10 @@ class SolvedRecord(PackageRecord):
         return ()
 
     def dump(self) -> dict[str, Any]:
+        """Expose requested specs under their public plural field name."""
         dumped = PackageRecord.dump(self)
         if dumped.get("_requested_specs"):
-            dumped["requested_specs"] = dumped.pop("_requested_specs")
+            dumped["requested_specs"] = list(dumped.pop("_requested_specs"))
         elif spec := dumped.get("requested_spec"):
             dumped["requested_specs"] = [spec]
         return dumped
@@ -785,15 +925,22 @@ class SolvedRecord(PackageRecord):
 
 @dataclass(slots=True, init=False, eq=False, repr=False)
 class PrefixRecord(SolvedRecord):
-    """Representation of a package installed in a local conda environment."""
+    """Representation of a package installed in a local conda environment.
+
+    This specialization adds paths, link information, and local cache paths.
+    It does not add fields to :attr:`PackageRecord._pkey`. Instances are
+    generally loaded from JSON files in ``$prefix/conda-meta``.
+    """
 
     FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
-        **PackageRecord.FIELD_RESOLVERS,
+        **SolvedRecord.FIELD_RESOLVERS,
         "paths_data": resolve_paths_data,
     }
 
+    # Local cache paths, if known.
     package_tarball_full_path: str = ""
     extracted_package_dir: str = ""
+    # Files and detailed path/link metadata recorded for the installation.
     files: tuple[str, ...] = ()
     paths_data: Any = None
     link: Any = None
@@ -858,8 +1005,8 @@ for _name in (
     "Md5Field",
 ):
     deprecated.constant(
-        "26.9",
         "27.3",
+        "27.9",
         _name,
         factory=partial(_legacy_field, _name),
         addendum=(

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -15,28 +15,30 @@ Object inheritance:
 
 from __future__ import annotations
 
-from os.path import basename, join
+import enum
+import json  # noqa: TID251
+import sys
+from dataclasses import MISSING, dataclass, field, fields
+from functools import cache, partial
 from pathlib import Path
-
-from boltons.timeutils import dt_to_timestamp, isoparse
+from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
 
 from ..auxlib.entity import (
     BooleanField,
-    ComposableField,
     DictSafeMixin,
     Entity,
     EnumField,
     IntegerField,
     ListField,
-    NumberField,
     StringField,
 )
-from ..base.context import context
-from ..common.compat import isiterable
-from ..exceptions import PathNotFoundError
+from ..deprecations import deprecated
 from .channel import Channel
 from .enums import FileMode, LinkType, NoarchType, PackageType, PathEnum, Platform
-from .match_spec import MatchSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
 
 
 class LinkTypeField(EnumField):
@@ -50,167 +52,12 @@ class LinkTypeField(EnumField):
         return super().box(instance, instance_type, val)
 
 
-class NoarchField(EnumField):
-    def box(self, instance, instance_type, val):
-        return super().box(instance, instance_type, NoarchType.coerce(val))
-
-
-class TimestampField(NumberField):
-    def __init__(self):
-        super().__init__(default=0, required=False, default_in_dump=False)
-
-    @staticmethod
-    def _make_seconds(val):
-        if val:
-            val = val
-            if val > 253402300799:  # 9999-12-31
-                val /= (
-                    1000  # convert milliseconds to seconds; see conda/conda-build#1988
-                )
-        return val
-
-    @staticmethod
-    def _make_milliseconds(val):
-        if val:
-            if val < 253402300799:  # 9999-12-31
-                val *= 1000  # convert seconds to milliseconds
-            val = val
-        return val
-
-    def box(self, instance, instance_type, val):
-        return self._make_seconds(super().box(instance, instance_type, val))
-
-    def dump(self, instance, instance_type, val):
-        return int(
-            self._make_milliseconds(super().dump(instance, instance_type, val))
-        )  # whether in seconds or milliseconds, type must be int (not float) for backward compat
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError:
-            try:
-                return int(dt_to_timestamp(isoparse(instance.date)))
-            except (AttributeError, ValueError):
-                return 0
-
-
 class Link(DictSafeMixin, Entity):
     source = StringField()
     type = LinkTypeField(LinkType, required=False)
 
 
 EMPTY_LINK = Link(source="")
-
-
-class _FeaturesField(ListField):
-    def __init__(self, **kwargs):
-        super().__init__(str, **kwargs)
-
-    def box(self, instance, instance_type, val):
-        if isinstance(val, str):
-            val = val.replace(" ", ",").split(",")
-        val = tuple(f for f in (ff.strip() for ff in val) if f)
-        return super().box(instance, instance_type, val)
-
-    def dump(self, instance, instance_type, val):
-        if isiterable(val):
-            return " ".join(val)
-        else:
-            return val or ()  # default value is (), and default_in_dump=False
-
-
-class ChannelField(ComposableField):
-    def __init__(self, aliases=()):
-        super().__init__(Channel, required=False, aliases=aliases)
-
-    def dump(self, instance, instance_type, val):
-        if val:
-            return str(val)
-        else:
-            val = instance.channel  # call __get__
-            return str(val)
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError:
-            url = instance.url
-            return self.unbox(instance, instance_type, Channel(url))
-
-
-class SubdirField(StringField):
-    def __init__(self):
-        super().__init__(required=False)
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError:
-            try:
-                url = instance.url
-            except AttributeError:
-                url = None
-            if url:
-                return self.unbox(instance, instance_type, Channel(url).subdir)
-
-            try:
-                platform, arch = instance.platform.name, instance.arch
-            except AttributeError:
-                platform, arch = None, None
-            if platform and not arch:
-                return self.unbox(instance, instance_type, "noarch")
-            elif platform:
-                if "x86" in arch:
-                    arch = "64" if "64" in arch else "32"
-                return self.unbox(instance, instance_type, f"{platform}-{arch}")
-            else:
-                return self.unbox(instance, instance_type, context.subdir)
-
-
-class FilenameField(StringField):
-    def __init__(self, aliases=()):
-        super().__init__(required=False, aliases=aliases)
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError:
-            try:
-                url = instance.url
-                fn = Channel(url).package_filename
-                if not fn:
-                    raise AttributeError()
-            except AttributeError:
-                fn = f"{instance.name}-{instance.version}-{instance.build}"
-            if not fn:
-                raise ValueError("Filename cannot be empty.")
-            return self.unbox(instance, instance_type, fn)
-
-
-class PackageTypeField(EnumField):
-    def __init__(self):
-        super().__init__(
-            PackageType,
-            required=False,
-            nullable=True,
-            default=None,
-            default_in_dump=False,
-        )
-
-    def __get__(self, instance, instance_type):
-        val = super().__get__(instance, instance_type)
-        if val is None:
-            # look in noarch field
-            noarch_val = instance.noarch
-            if noarch_val:
-                type_map = {
-                    NoarchType.generic: PackageType.NOARCH_GENERIC,
-                    NoarchType.python: PackageType.NOARCH_PYTHON,
-                }
-                val = type_map[NoarchType.coerce(noarch_val)]
-                val = self.unbox(instance, instance_type, val)
-        return val
 
 
 class PathData(Entity):
@@ -226,12 +73,10 @@ class PathData(Entity):
 
     @property
     def path(self):
-        # because I don't have aliases as an option for entity fields yet
         return self._path
 
 
 class PathDataV1(PathData):
-    # TODO: sha256 and size_in_bytes should be required for all PathEnum.hardlink, but not for softlink and directory
     sha256 = StringField(required=False, nullable=True)
     size_in_bytes = IntegerField(required=False, nullable=True)
     inode_paths = ListField(str, required=False, nullable=True)
@@ -240,229 +85,497 @@ class PathDataV1(PathData):
 
 
 class PathsData(Entity):
-    # from info/paths.json
     paths_version = IntegerField()
     paths = ListField(PathDataV1)
 
 
-class PackageRecord(DictSafeMixin, Entity):
-    """Representation of a concrete package archive (tarball or .conda file).
+SENTINEL = object()
 
-    It captures all the relevant information about a given package archive, including its source,
-    in the following attributes.
+TS_BOUNDARY = 253402300799  # 9999-12-31 in epoch seconds
 
-    Note that there are three subclasses, :class:`SolvedRecord`, :class:`PrefixRecord` and
-    :class:`PackageCacheRecord`. These capture the same information, but are augmented with
-    additional information relevant for these sources of packages.
+CACHE_FIELDS = frozenset({"_pkey_cache", "_hash_cache", "_memoized_md5"})
 
-    Further note that :class:`PackageRecord` makes use of its :attr:`_pkey`
-    for comparison and hash generation.
-    This means that for common operations, like comparisons between :class:`PackageRecord` s
-    and reference of :class:`PackageRecord` s in mappings, _different_ objects appear identical.
-    The fields taken into account are marked in the following list of attributes.
-    The subclasses do not add further attributes to the :attr:`_pkey`.
-    """
+FIELDS_EXCLUDED_FROM_DUMP = frozenset({"metadata"})
 
-    name = StringField()
-    """The name of the package.
+FIELDS_WITHOUT_DEFAULT_IN_DUMP = frozenset(
+    {
+        "md5",
+        "legacy_bz2_md5",
+        "legacy_bz2_size",
+        "url",
+        "sha256",
+        "flags",
+        "track_features",
+        "features",
+        "noarch",
+        "preferred_env",
+        "python_site_packages_path",
+        "license",
+        "license_family",
+        "package_type",
+        "timestamp",
+        "paths_data",
+        "package_tarball_full_path",
+        "extracted_package_dir",
+    }
+)
 
-    Part of the :attr:`_pkey`.
-    """
+NOARCH_TO_PACKAGE_TYPE: dict[NoarchType, PackageType] = {
+    NoarchType.generic: PackageType.NOARCH_GENERIC,
+    NoarchType.python: PackageType.NOARCH_PYTHON,
+}
 
-    version = StringField()
-    """The version of the package.
+INTERN_FIELDS = frozenset({"name", "version", "build", "subdir"})
 
-    Part of the :attr:`_pkey`.
-    """
 
-    build = StringField(aliases=("build_string",))
-    """The build string of the package.
+@runtime_checkable
+class Dumpable(Protocol):
+    def dump(self) -> dict[str, Any]: ...
 
-    Part of the :attr:`_pkey`.
-    """
 
-    build_number = IntegerField()
-    """The build number of the package.
+@cache
+def get_field_info(cls: type) -> tuple[tuple[str, Any, Any], ...]:
+    """Return (name, default, default_factory) for each public field of *cls*."""
+    info: list[tuple[str, Any, Any]] = []
+    for f in fields(cls):
+        if f.name in CACHE_FIELDS:
+            continue
+        default = f.default if f.default is not MISSING else SENTINEL
+        default_factory = (
+            f.default_factory if f.default_factory is not MISSING else None
+        )
+        info.append((f.name, default, default_factory))
+    return tuple(info)
 
-    Part of the :attr:`_pkey`.
-    """
 
-    # the canonical code abbreviation for PackageRef is `pref`
-    # fields required to uniquely identifying a package
+@cache
+def get_dump_specs(cls: type) -> tuple[tuple[str, bool, Any], ...]:
+    """Return (name, include_default, field_default) per dumpable field."""
+    specs: list[tuple[str, bool, Any]] = []
+    for f in fields(cls):
+        if f.name in CACHE_FIELDS or f.name in FIELDS_EXCLUDED_FROM_DUMP:
+            continue
+        include_default = f.name not in FIELDS_WITHOUT_DEFAULT_IN_DUMP
+        default = f.default if f.default is not MISSING else SENTINEL
+        specs.append((f.name, include_default, default))
+    return tuple(specs)
 
-    channel = ChannelField(aliases=("schannel",))
-    """The channel where the package can be found."""
 
-    subdir = SubdirField()
-    """The subdir, i.e. ``noarch`` or a platform (``linux-64`` or similar).
+@cache
+def get_known_fields(cls: type) -> frozenset[str]:
+    """Return the set of non-cache field names for *cls*."""
+    return frozenset(f.name for f in fields(cls) if f.name not in CACHE_FIELDS)
 
-    Part of the :attr:`_pkey`.
-    """
 
-    fn = FilenameField(aliases=("filename",))
-    """The filename of the package.
+def resolve_channel(val: Any, record: PackageRecord) -> Channel | None:
+    if val is not None:
+        if isinstance(val, Channel):
+            return val
+        return Channel(val)
+    url = record.url
+    if url:
+        return Channel(url)
+    return None
 
-    Only part of the :attr:`_pkey` if :ref:`separate_format_cache <auto-config-reference>`
-    is ``true`` (default: ``false``).
-    """
 
-    md5 = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
+def resolve_subdir(val: Any, record: PackageRecord) -> str | None:
+    if val is not None:
+        return val
+    url = record.url
+    if url:
+        subdir = Channel(url).subdir
+        if subdir:
+            return subdir
+    plat = record.platform
+    arch = record.arch
+    if plat is not None:
+        plat_name = plat.name if isinstance(plat, Platform) else str(plat)
+        if not arch:
+            return "noarch"
+        if "x86" in arch:
+            arch = "64" if "64" in arch else "32"
+        return f"{plat_name}-{arch}"
+    from ..base.context import context
+
+    return context.subdir
+
+
+def resolve_fn(val: Any, record: PackageRecord) -> str:
+    if val is not None:
+        return val
+    url = record.url
+    if url:
+        fn = Channel(url).package_filename
+        if fn:
+            return fn
+    return f"{record.name}-{record.version}-{record.build}"
+
+
+def resolve_timestamp(val: Any, record: PackageRecord) -> int | float:
+    if val and val > TS_BOUNDARY:
+        return val / 1000
+    return val
+
+
+def resolve_features(val: Any, record: PackageRecord) -> tuple[str, ...]:
+    if isinstance(val, tuple):
+        return val
+    if not val:
+        return ()
+    if isinstance(val, str):
+        val = val.replace(" ", ",").split(",")
+    return tuple(f for f in (ff.strip() for ff in val) if f)
+
+
+def resolve_as_tuple(val: Any, record: PackageRecord) -> tuple:
+    if isinstance(val, tuple):
+        return val
+    if not val:
+        return ()
+    return tuple(val)
+
+
+def resolve_noarch(val: Any, record: PackageRecord) -> NoarchType | None:
+    if val is None or isinstance(val, NoarchType):
+        return val
+    return NoarchType.coerce(val)
+
+
+def resolve_package_type(val: Any, record: PackageRecord) -> PackageType | None:
+    if val is None or isinstance(val, PackageType):
+        return val
+    return PackageType(val)
+
+
+def resolve_platform(val: Any, record: PackageRecord) -> Platform | None:
+    if val is None or isinstance(val, Platform):
+        return val
+    try:
+        return Platform(val)
+    except ValueError:
+        return Platform[val]
+
+
+def resolve_paths_data(val: Any, record: PrefixRecord) -> Any:
+    if isinstance(val, dict):
+        return PathsData(**val)
+    return val
+
+
+def dump_channel(val: Any) -> str:
+    return str(val) if val else ""
+
+
+def dump_timestamp(val: Any) -> int:
+    if not val:
+        return 0
+    if val < TS_BOUNDARY:
+        val *= 1000
+    return int(val)
+
+
+def dump_features(val: Any) -> str | tuple:
+    if isinstance(val, (tuple, list)):
+        return " ".join(val) if val else ()
+    return val or ()
+
+
+def dump_enum(val: Any) -> Any:
+    return val.value if isinstance(val, enum.Enum) else val
+
+
+def dump_nested(val: Any) -> Any:
+    return val.dump() if isinstance(val, Dumpable) else val
+
+
+@dataclass(slots=True, init=False, eq=False, repr=False)
+class PackageRecord:
+    """Representation of a concrete package archive (tarball or .conda file)."""
+
+    ALIASES: ClassVar[dict[str, str]] = {
+        "build_string": "build",
+        "schannel": "channel",
+        "filename": "fn",
+    }
+
+    FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
+        "channel": resolve_channel,
+        "subdir": resolve_subdir,
+        "fn": resolve_fn,
+        "timestamp": resolve_timestamp,
+        "track_features": resolve_features,
+        "features": resolve_features,
+        "depends": resolve_as_tuple,
+        "constrains": resolve_as_tuple,
+        "flags": resolve_as_tuple,
+        "files": resolve_as_tuple,
+        "noarch": resolve_noarch,
+        "package_type": resolve_package_type,
+        "platform": resolve_platform,
+    }
+
+    DUMP_TRANSFORMS: ClassVar[dict[str, Callable]] = {
+        "channel": dump_channel,
+        "timestamp": dump_timestamp,
+        "track_features": dump_features,
+        "features": dump_features,
+        "platform": dump_enum,
+        "noarch": dump_enum,
+        "package_type": dump_enum,
+        "link": dump_nested,
+        "paths_data": dump_nested,
+    }
+
+    name: str = ""
+    version: str = ""
+    build: str = ""
+    build_number: int = 0
+    channel: Channel | None = None
+    subdir: str | None = None
+    fn: str | None = None
+
+    md5: str | None = None
+    legacy_bz2_md5: str | None = None
+    legacy_bz2_size: int | None = None
+    url: str | None = None
+    sha256: str | None = None
+
+    arch: str | None = None
+    platform: Platform | None = None
+
+    depends: tuple[str, ...] = ()
+    constrains: tuple[str, ...] = ()
+    flags: tuple[str, ...] = ()
+    track_features: tuple[str, ...] = ()
+    features: tuple[str, ...] = ()
+
+    noarch: NoarchType | None = None
+    preferred_env: str | None = None
+    python_site_packages_path: str | None = None
+    license: str | None = None
+    license_family: str | None = None
+    package_type: PackageType | None = None
+
+    timestamp: int | float = 0
+    date: str | None = None
+    size: int | None = None
+
+    metadata: set[str] = field(default_factory=set, repr=False)
+
+    _pkey_cache: tuple | None = field(
+        default=None, repr=False, compare=False, init=False
     )
-    """The md5 checksum of the package."""
+    _hash_cache: int | None = field(default=None, repr=False, compare=False, init=False)
 
-    legacy_bz2_md5 = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
-    )
-    """If this is a ``.conda`` package and a corresponding ``.tar.bz2`` package exists, this may contain the md5 checksum of that package."""
+    def __init__(self, **kwargs: Any) -> None:
+        setattr_ = object.__setattr__
 
-    legacy_bz2_size = IntegerField(required=False, nullable=True, default_in_dump=False)
-    """If this is a ``.conda`` package and a corresponding ``.tar.bz2`` package exists, this may contain the size of that package."""
+        for alias, canonical in self.ALIASES.items():
+            if alias in kwargs and canonical not in kwargs:
+                kwargs[canonical] = kwargs.pop(alias)
 
-    url = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
-    )
-    """The download url of the package."""
+        for name, default, default_factory in get_field_info(self.__class__):
+            val = kwargs.get(name, SENTINEL)
+            if val is SENTINEL:
+                if default_factory is not None:
+                    setattr_(self, name, default_factory())
+                else:
+                    setattr_(self, name, default)
+            else:
+                setattr_(self, name, val)
 
-    sha256 = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
-    )
-    """The sha256 checksum of the package."""
+        for name, resolve in self.FIELD_RESOLVERS.items():
+            val = getattr(self, name, SENTINEL)
+            if val is not SENTINEL:
+                resolved = resolve(val, self)
+                if resolved is not val:
+                    setattr_(self, name, resolved)
+
+        for fname in INTERN_FIELDS:
+            val = getattr(self, fname, None)
+            if isinstance(val, str):
+                setattr_(self, fname, sys.intern(val))
+
+        setattr_(self, "_pkey_cache", None)
+        setattr_(self, "_hash_cache", None)
+
+    def __getitem__(self, item: str) -> Any:
+        try:
+            return getattr(self, item)
+        except AttributeError:
+            raise KeyError(item) from None
+
+    def get(self, item: str, default: Any = None) -> Any:
+        return getattr(self, item, default)
 
     @property
     def channel_name(self) -> str | None:
-        """str: The canonical name of the channel of this package.
+        ch = self.channel
+        if ch is None:
+            return None
+        return getattr(ch, "canonical_name", str(ch))
 
-        Part of the :attr:`_pkey`.
-        """
-        return getattr(self.channel, "canonical_name", None)
+    def effective_package_type(self) -> PackageType | None:
+        val = self.package_type
+        if val is not None:
+            return val
+        noarch_val = self.noarch
+        if noarch_val:
+            noarch_coerced = (
+                noarch_val
+                if isinstance(noarch_val, NoarchType)
+                else NoarchType.coerce(noarch_val)
+            )
+            return NOARCH_TO_PACKAGE_TYPE.get(noarch_coerced)
+        return None
 
     @property
-    def _pkey(self):
-        """tuple: The components of the PackageRecord that are used for comparison and hashing.
-
-        The :attr:`_pkey` is a tuple made up of the following fields of the :class:`PackageRecord`.
-        Two :class:`PackageRecord` s test equal if their respective :attr:`_pkey` s are equal.
-        The hash of the :class:`PackageRecord` (important for dictionary access) is the hash of the :attr:`_pkey`.
-
-        The included fields are:
-
-        * :attr:`channel_name`
-        * :attr:`subdir`
-        * :attr:`name`
-        * :attr:`version`
-        * :attr:`build_number`
-        * :attr:`build`
-        * :attr:`fn` only if :ref:`separate_format_cache <auto-config-reference>` is set to true (default: false)
-        """
-        try:
-            return self.__pkey
-        except AttributeError:
-            __pkey = self.__pkey = [
-                self.channel.canonical_name,
-                self.subdir,
-                self.name,
-                self.version,
-                self.build_number,
-                self.build,
-            ]
-            # NOTE: fn is included to distinguish between .conda and .tar.bz2 packages
-            if context.separate_format_cache:
-                __pkey.append(self.fn)
-            self.__pkey = tuple(__pkey)
-            return self.__pkey
-
-    def __hash__(self):
-        try:
-            return self._hash
-        except AttributeError:
-            self._hash = hash(self._pkey)
-        return self._hash
-
-    def __eq__(self, other):
-        return self._pkey == other._pkey
-
-    def dist_str(self, canonical_name: bool = True) -> str:
-        return "{}{}::{}-{}-{}".format(
-            self.channel.canonical_name if canonical_name else self.channel.name,
-            ("/" + self.subdir) if self.subdir else "",
+    def _pkey(self) -> tuple:
+        cached = self._pkey_cache
+        if cached is not None:
+            return cached
+        ch = self.channel
+        ch_name = getattr(ch, "canonical_name", str(ch)) if ch else ""
+        pk: list[Any] = [
+            ch_name,
+            self.subdir,
             self.name,
             self.version,
+            self.build_number,
             self.build,
-        )
+        ]
+        from ..base.context import context
 
-    def dist_fields_dump(self):
+        if context.separate_format_cache:
+            pk.append(self.fn)
+        result = tuple(pk)
+        object.__setattr__(self, "_pkey_cache", result)
+        return result
+
+    def invalidate_pkey(self) -> None:
+        object.__setattr__(self, "_pkey_cache", None)
+        object.__setattr__(self, "_hash_cache", None)
+
+    def __hash__(self) -> int:
+        cached = self._hash_cache
+        if cached is not None:
+            return cached
+        h = hash(self._pkey)
+        object.__setattr__(self, "_hash_cache", h)
+        return h
+
+    def __eq__(self, other: object) -> bool:
+        if not hasattr(other, "_pkey"):
+            return NotImplemented
+        return self._pkey == other._pkey
+
+    def dump(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        transforms = self.DUMP_TRANSFORMS
+        for name, include_default, default in get_dump_specs(self.__class__):
+            val = getattr(self, name, SENTINEL)
+            if val is SENTINEL:
+                continue
+
+            if val is None:
+                if not include_default:
+                    continue
+                if default is not SENTINEL and default is None:
+                    continue
+            if not include_default:
+                if (
+                    (default is not SENTINEL and val == default)
+                    or val == ()
+                    or val == 0
+                ):
+                    continue
+
+            transform = transforms.get(name)
+            if transform is not None:
+                val = transform(val)
+
+            result[name] = val
+        return result
+
+    @classmethod
+    def from_objects(cls, *objects: Any, **overrides: Any) -> PackageRecord:
+        kwargs: dict[str, Any] = {}
+        known = get_known_fields(cls)
+
+        for obj in objects:
+            if isinstance(obj, dict):
+                src = obj
+            elif isinstance(obj, Dumpable):
+                src = obj.dump()
+            elif hasattr(obj, "__dict__"):
+                src = obj.__dict__
+            elif hasattr(obj, "__slots__"):
+                src = {
+                    s: getattr(obj, s)
+                    for s in obj.__slots__
+                    if hasattr(obj, s) and not s.startswith("_")
+                }
+            else:
+                continue
+            for k, v in src.items():
+                target = cls.ALIASES.get(k, k) if k not in known else k
+                if target in known and target not in kwargs and v is not None:
+                    kwargs[target] = v
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> PackageRecord:
+        return cls(**json.loads(json_str))
+
+    @classmethod
+    def load(cls, data_dict: dict[str, Any]) -> PackageRecord:
+        return cls(**data_dict)
+
+    def __str__(self) -> str:
+        ch = self.channel
+        ch_name = getattr(ch, "canonical_name", "") if ch else ""
+        return f"{ch_name}/{self.subdir}::{self.name}=={self.version}={self.build}"
+
+    def __repr__(self) -> str:
+        parts: list[str] = []
+        for f_obj in fields(self.__class__):
+            if f_obj.name in CACHE_FIELDS or f_obj.name == "metadata":
+                continue
+            val = getattr(self, f_obj.name, SENTINEL)
+            if val is SENTINEL or val is None or val == () or val == "":
+                continue
+            parts.append(f"{f_obj.name}={val!r}")
+        return f"{self.__class__.__name__}({', '.join(parts)})"
+
+    def dist_str(self, canonical_name: bool = True) -> str:
+        ch = self.channel
+        if ch is None:
+            ch_str = ""
+        elif canonical_name:
+            ch_str = getattr(ch, "canonical_name", str(ch))
+        else:
+            ch_str = getattr(ch, "name", str(ch))
+        subdir = self.subdir
+        sub = f"/{subdir}" if subdir else ""
+        return f"{ch_str}{sub}::{self.name}-{self.version}-{self.build}"
+
+    def dist_fields_dump(self) -> dict[str, Any]:
+        ch = self.channel
         return {
-            "base_url": self.channel.base_url,
+            "base_url": getattr(ch, "base_url", "") if ch else "",
             "build_number": self.build_number,
             "build_string": self.build,
-            "channel": self.channel.name,
+            "channel": getattr(ch, "name", "") if ch else "",
             "dist_name": self.dist_str().split(":")[-1],
             "name": self.name,
             "platform": self.subdir,
             "version": self.version,
         }
 
-    arch = StringField(required=False, nullable=True)  # so legacy
-    platform = EnumField(Platform, required=False, nullable=True)  # so legacy
-
-    depends = ListField(str, default=())
-    constrains = ListField(str, default=())
-
-    flags = ListField(str, default=(), required=False, default_in_dump=False)
-
-    track_features = _FeaturesField(required=False, default=(), default_in_dump=False)
-    features = _FeaturesField(required=False, default=(), default_in_dump=False)
-
-    noarch = NoarchField(
-        NoarchType, required=False, nullable=True, default=None, default_in_dump=False
-    )  # TODO: rename to package_type
-    preferred_env = StringField(
-        required=False, nullable=True, default=None, default_in_dump=False
-    )
-    python_site_packages_path = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
-    )
-    license = StringField(
-        required=False, nullable=True, default=None, default_in_dump=False
-    )
-    license_family = StringField(
-        required=False, nullable=True, default=None, default_in_dump=False
-    )
-    package_type = PackageTypeField()
-
-    @property
-    def is_unmanageable(self):
-        return self.package_type in PackageType.unmanageable_package_types()
-
-    timestamp = TimestampField()
-
-    @property
-    def combined_depends(self):
+    def to_match_spec(self):
         from .match_spec import MatchSpec
 
-        result = {ms.name: ms for ms in MatchSpec.merge(self.depends)}
-        for spec in self.constrains or ():
-            ms = MatchSpec(spec)
-            result[ms.name] = MatchSpec(ms, optional=(ms.name not in result))
-        return tuple(result.values())
-
-    # the canonical code abbreviation for PackageRecord is `prec`, not to be confused with
-    # PackageCacheRecord (`pcrec`) or PrefixRecord (`prefix_rec`)
-    #
-    # important for "choosing" a package (i.e. the solver), listing packages
-    # (like search), and for verifying downloads
-    #
-    # this is the highest level of the record inheritance model that MatchSpec is designed to
-    # work with
-
-    date = StringField(required=False)
-    size = IntegerField(required=False)
-
-    def __str__(self):
-        return f"{self.channel.canonical_name}/{self.subdir}::{self.name}=={self.version}={self.build}"
-
-    def to_match_spec(self):
         return MatchSpec(
             channel=self.channel,
             subdir=self.subdir,
@@ -472,41 +585,45 @@ class PackageRecord(DictSafeMixin, Entity):
         )
 
     def to_simple_match_spec(self):
-        return MatchSpec(
-            name=self.name,
-            version=self.version,
-        )
+        from .match_spec import MatchSpec
+
+        return MatchSpec(name=self.name, version=self.version)
 
     @property
-    def namekey(self):
-        return "global:" + self.name
+    def is_unmanageable(self) -> bool:
+        return self.effective_package_type() in PackageType.unmanageable_package_types()
 
     @property
-    def spec(self):
-        """Return package spec: name=version=build"""
+    def combined_depends(self) -> tuple:
+        from .match_spec import MatchSpec
+
+        result = {ms.name: ms for ms in MatchSpec.merge(self.depends)}
+        for spec in self.constrains or ():
+            ms = MatchSpec(spec)
+            result[ms.name] = MatchSpec(ms, optional=(ms.name not in result))
+        return tuple(result.values())
+
+    @property
+    def namekey(self) -> str:
+        return f"global:{self.name}"
+
+    @property
+    def spec(self) -> str:
         return f"{self.name}={self.version}={self.build}"
 
     @property
-    def spec_no_build(self):
-        """Return package spec without build: name=version"""
+    def spec_no_build(self) -> str:
         return f"{self.name}={self.version}"
 
-    def record_id(self):
-        # WARNING: This is right now only used in link.py _change_report_str(). It is not
-        #          the official record_id / uid until it gets namespace.  Even then, we might
-        #          make the format different.  Probably something like
-        #              channel_name/subdir:namespace:name-version-build_number-build_string
-        return f"{self.channel.name}/{self.subdir}::{self.name}-{self.version}-{self.build}"
-
-    metadata: set[str]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.metadata = set()
+    def record_id(self) -> str:
+        ch = self.channel
+        ch_name = getattr(ch, "name", "") if ch else ""
+        return f"{ch_name}/{self.subdir}::{self.name}-{self.version}-{self.build}"
 
     @classmethod
-    def feature(cls, feature_name) -> PackageRecord:
-        # necessary for the SAT solver to do the right thing with features
+    def feature(cls, feature_name: str) -> PackageRecord:
+        from ..base.context import context
+
         pkg_name = f"{feature_name}@"
         return cls(
             name=pkg_name,
@@ -522,7 +639,10 @@ class PackageRecord(DictSafeMixin, Entity):
 
     @classmethod
     def virtual_package(
-        cls, name: str, version: str | None = None, build_string: str | None = None
+        cls,
+        name: str,
+        version: str | None = None,
+        build_string: str | None = None,
     ) -> PackageRecord:
         """
         Create a virtual package record.
@@ -535,6 +655,8 @@ class PackageRecord(DictSafeMixin, Entity):
         Returns:
             A PackageRecord representing the virtual package.
         """
+        from ..base.context import context
+
         return cls(
             package_type=PackageType.VIRTUAL_SYSTEM,
             name=name,
@@ -548,121 +670,115 @@ class PackageRecord(DictSafeMixin, Entity):
         )
 
 
-class Md5Field(StringField):
-    def __init__(self):
-        super().__init__(required=False, nullable=True)
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError as e:
-            try:
-                return instance._calculate_md5sum()
-            except PathNotFoundError:
-                raise e
-
-
+@dataclass(slots=True, init=False, eq=False, repr=False)
 class PackageCacheRecord(PackageRecord):
-    """Representation of a package that has been downloaded or unpacked in the local package cache.
+    """Representation of a package in the local package cache."""
 
-    Specialization of :class:`PackageRecord` that adds information for packages that exist in the
-    local package cache, either as the downloaded package file, or unpacked in its own package dir,
-    or both.
-
-    Note that this class does not add new fields to the :attr:`PackageRecord._pkey` so that a pure
-    :class:`PackageRecord` object that has the same ``_pkey`` fields as a different
-    :class:`PackageCacheRecord` object (or, indeed, a :class:`PrefixRecord` object) will be considered
-    equal and will produce the same hash.
-    """
-
-    package_tarball_full_path = StringField()
-    """Full path to the local package file."""
-
-    extracted_package_dir = StringField()
-    """Full path to the local extracted package."""
-
-    md5 = Md5Field()
-    """The md5 checksum of the package.
-
-    If the package file exists locally, this class can calculate a missing checksum on-the-fly.
-    """
+    package_tarball_full_path: str = ""
+    extracted_package_dir: str = ""
+    _memoized_md5: str | None = field(
+        default=None, repr=False, compare=False, init=False
+    )
 
     @property
-    def is_fetched(self):
-        """bool: Whether the package file exists locally."""
+    def is_fetched(self) -> bool:
         from ..gateways.disk.read import isfile
 
         return isfile(self.package_tarball_full_path)
 
     @property
-    def is_extracted(self):
-        """bool: Whether the package has been extracted locally."""
+    def is_extracted(self) -> bool:
         from ..gateways.disk.read import isdir, isfile
 
         epd = self.extracted_package_dir
-        return isdir(epd) and isfile(join(epd, "info", "index.json"))
+        return isdir(epd) and isfile(str(Path(epd) / "info" / "index.json"))
 
     @property
-    def tarball_basename(self):
-        """str: The basename of the local package file."""
-        return basename(self.package_tarball_full_path)
+    def tarball_basename(self) -> str:
+        return Path(self.package_tarball_full_path).name
 
-    def _calculate_md5sum(self):
-        memoized_md5 = getattr(self, "_memoized_md5", None)
-        if memoized_md5:
-            return memoized_md5
-
-        from os.path import isfile
-
-        if isfile(self.package_tarball_full_path):
+    def calculate_md5sum(self) -> str | None:
+        # ``_memoized_md5`` is a slot but is not populated by PackageRecord's
+        # __init__ (it's listed in CACHE_FIELDS which skips initialization),
+        # so on a freshly-constructed PackageCacheRecord the slot read would
+        # raise AttributeError. Use getattr with a default to keep the slow
+        # path reachable on first call.
+        memoized = getattr(self, "_memoized_md5", None)
+        if memoized:
+            return memoized
+        if Path(self.package_tarball_full_path).is_file():
             from ..gateways.disk.read import compute_sum
 
             md5sum = compute_sum(self.package_tarball_full_path, "md5")
-            setattr(self, "_memoized_md5", md5sum)
+            object.__setattr__(self, "_memoized_md5", md5sum)
             return md5sum
+        return None
 
 
+def _make_md5_auto_compute_property() -> property:
+    """Build the backwards-compatible ``md5`` descriptor for PackageCacheRecord.
+
+    The old ``Md5Field`` descriptor hashed the tarball on attribute read when
+    the field was unset. That behaviour is kept one release cycle via this
+    property; the getter falls through to :meth:`calculate_md5sum` and uses
+    the ``deprecated`` framework to nudge callers toward the explicit method.
+
+    The property is attached after the class body because
+    ``@dataclass(slots=True)`` strips class attributes whose names match
+    inherited fields (``md5`` lives on :class:`PackageRecord`) before
+    allocating slots, which otherwise silently drops an inline property.
+    Storage stays on the inherited slot so ``record.md5 = "abc"`` keeps
+    working.
+    """
+    slot = PackageRecord.__dict__["md5"]
+
+    def fget(self: PackageCacheRecord) -> str | None:
+        value = slot.__get__(self, type(self))
+        if value is not None:
+            return value
+        auto = self.calculate_md5sum()
+        if auto is not None:
+            deprecated.topic(
+                "26.9",
+                "27.3",
+                topic="Implicit md5 auto-compute on PackageCacheRecord.md5",
+                addendum="Call PackageCacheRecord.calculate_md5sum() explicitly instead.",
+            )
+        return auto
+
+    def fset(self: PackageCacheRecord, value: str | None) -> None:
+        slot.__set__(self, value)
+
+    return property(fget, fset)
+
+
+PackageCacheRecord.md5 = _make_md5_auto_compute_property()
+
+
+@dataclass(slots=True, init=False, eq=False, repr=False)
 class SolvedRecord(PackageRecord):
-    """Representation of a package that has been returned as part of a solver solution.
+    """Representation of a package returned as part of a solver solution."""
 
-    This sits between :class:`PackageRecord` and :class:`PrefixRecord`, simply adding
-    ``requested_spec`` (and ``requested_specs``) so they can be used in lockfiles without
-    requiring the artifact on disk.
-    """
+    ALIASES: ClassVar[dict[str, str]] = {
+        **PackageRecord.ALIASES,
+        "requested_specs": "_requested_specs",
+    }
 
-    requested_spec = StringField(required=False)
-    """
-    The :class:`MatchSpec` that the user requested or ``None``
-    if the package it was installed as a dependency.
-    """
-    _requested_specs = ListField(
-        str, required=False, nullable=True, aliases=("requested_specs",)
-    )
-    """
-    The :class:`MatchSpec` objects that the user requested or ``()``
-    if the package was installed as a dependency.
-    See also `.requested_specs` property.
-    """
+    requested_spec: str | None = None
+    _requested_specs: tuple[str, ...] | None = None
 
     @property
     def requested_specs(self) -> tuple[str, ...]:
-        """
-        This property will use 'requested_spec' as the source for
-        'requested_specs' for old `conda-meta/*.json` files that
-        did not define the plural version.
-        """
-        if specs := self.get("_requested_specs", None):
-            return tuple(specs)
-        if spec := self.get("requested_spec", None):
+        val = self._requested_specs
+        if val:
+            return tuple(val)
+        spec = self.requested_spec
+        if spec:
             return (spec,)
         return ()
 
-    def dump(self):
-        """
-        We need to expose _requested_specs as its public counterpart,
-        and also expose single specs as a plural list for backwards compatibility.
-        """
-        dumped = super().dump()
+    def dump(self) -> dict[str, Any]:
+        dumped = PackageRecord.dump(self)
         if dumped.get("_requested_specs"):
             dumped["requested_specs"] = dumped.pop("_requested_specs")
         elif spec := dumped.get("requested_spec"):
@@ -670,43 +786,21 @@ class SolvedRecord(PackageRecord):
         return dumped
 
 
+@dataclass(slots=True, init=False, eq=False, repr=False)
 class PrefixRecord(SolvedRecord):
-    """Representation of a package that is installed in a local conda environmnet.
+    """Representation of a package installed in a local conda environment."""
 
-    Specialization of :class:`PackageRecord` that adds information for packages that are installed
-    in a local conda environment or prefix.
+    FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
+        **PackageRecord.FIELD_RESOLVERS,
+        "paths_data": resolve_paths_data,
+    }
 
-    Note that this class does not add new fields to the :attr:`PackageRecord._pkey` so that a pure
-    :class:`PackageRecord` object that has the same ``_pkey`` fields as a different
-    :class:`PrefixRecord` object (or, indeed, a :class:`PackageCacheRecord` object) will be considered
-    equal and will produce the same hash.
-
-    Objects of this class are generally constructed from metadata in json files inside `$prefix/conda-meta`.
-    """
-
-    package_tarball_full_path = StringField(required=False)
-    """The path to the originating package file, usually in the local cache."""
-
-    extracted_package_dir = StringField(required=False)
-    """The path to the extracted package directory, usually in the local cache."""
-
-    files = ListField(str, default=(), required=False)
-    """The list of all files comprising the package as relative paths from the prefix root."""
-
-    paths_data = ComposableField(
-        PathsData, required=False, nullable=True, default_in_dump=False
-    )
-    """List with additional information about the files, e.g. checksums and link type."""
-
-    link = ComposableField(Link, required=False)
-    """Information about how the package was linked into the prefix."""
-
-    # app = ComposableField(App, required=False)
-
-    # There have been requests in the past to save remote server auth
-    # information with the package.  Open to rethinking that though.
-    auth = StringField(required=False, nullable=True)
-    """Authentication information."""
+    package_tarball_full_path: str = ""
+    extracted_package_dir: str = ""
+    files: tuple[str, ...] = ()
+    paths_data: Any = None
+    link: Any = None
+    auth: str | None = None
 
     def _get_json_fn(self) -> str:
         return f"{self.name}-{self.version}-{self.build}.json"
@@ -723,28 +817,61 @@ class PrefixRecord(SolvedRecord):
             Total size in bytes of all files installed by this package.
         """
         total_size = 0
-
         meta_file = prefix_path / "conda-meta" / self._get_json_fn()
         try:
             total_size += meta_file.stat().st_size
         except OSError:
             pass
-
-        for path_data in self.paths_data.paths:
-            if path_data.path_type in (PathEnum.softlink, PathEnum.directory):
-                continue
-            if getattr(path_data, "size_in_bytes", None) is not None:
-                total_size += path_data.size_in_bytes
-                continue
-
-            file_path = Path(prefix_path) / path_data._path
-            try:
-                total_size += file_path.stat().st_size
-            except OSError:
-                pass
-
+        if self.paths_data is not None:
+            for path_data in self.paths_data.paths:
+                if path_data.path_type in (PathEnum.softlink, PathEnum.directory):
+                    continue
+                if getattr(path_data, "size_in_bytes", None) is not None:
+                    total_size += path_data.size_in_bytes
+                    continue
+                file_path = prefix_path / path_data._path
+                try:
+                    total_size += file_path.stat().st_size
+                except OSError:
+                    pass
         return total_size
 
-    # @classmethod
-    # def load(cls, conda_meta_json_path):
-    #     return cls()
+
+def _legacy_field(name: str) -> type:
+    """Lazy-import a deprecated ``auxlib.Entity`` field descriptor by name.
+
+    Used as the ``factory=`` callable in the module-level
+    :func:`deprecated.constant` registrations below so that importing
+    :mod:`conda.models.records` does not drag ``boltons.timeutils`` et al.
+    onto the cold-start path for callers of the new dataclass records.
+    """
+    from . import _legacy_record_fields
+
+    return getattr(_legacy_record_fields, name)
+
+
+for _name in (
+    "NoarchField",
+    "TimestampField",
+    "_FeaturesField",
+    "ChannelField",
+    "SubdirField",
+    "FilenameField",
+    "PackageTypeField",
+    "Md5Field",
+):
+    deprecated.constant(
+        "26.9",
+        "27.3",
+        _name,
+        factory=partial(_legacy_field, _name),
+        addendum=(
+            "auxlib.Entity-based record field descriptors are no longer used "
+            "by conda's record classes; record classes have moved to "
+            "``@dataclass(slots=True)``. Subclasses of "
+            "``conda.auxlib.entity.Entity`` can keep the descriptor by "
+            "vendoring it or by importing the base class from "
+            "``conda.auxlib.entity`` directly."
+        ),
+    )
+del _name

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -172,10 +172,7 @@ def resolve_channel(val: Any, record: PackageRecord) -> Channel | None:
         if isinstance(val, Channel):
             return val
         return Channel(val)
-    url = record.url
-    if url:
-        return Channel(url)
-    return None
+    return Channel(record.url)
 
 
 def resolve_subdir(val: Any, record: PackageRecord) -> str | None:

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -285,18 +285,24 @@ def resolve_features(val: Any, record: PackageRecord) -> tuple[str, ...]:
     return tuple(f for f in (ff.strip() for ff in val) if f)
 
 
-def resolve_as_tuple(val: Any, record: PackageRecord) -> tuple:
+def resolve_as_tuple(
+    val: Any,
+    record: PackageRecord,
+    field_name: str = "sequence",
+) -> tuple:
     if isinstance(val, tuple):
         return val
     if not val:
         return ()
+    if isinstance(val, str):
+        raise ValidationError(field_name, val)
     return tuple(val)
 
 
 def resolve_optional_tuple(val: Any, record: PackageRecord) -> tuple | None:
     if val is None:
         return None
-    return resolve_as_tuple(val, record)
+    return resolve_as_tuple(val, record, "_requested_specs")
 
 
 def resolve_noarch(val: Any, record: PackageRecord) -> NoarchType | None:
@@ -395,10 +401,10 @@ class PackageRecord:
         "indexed_timestamp": resolve_indexed_timestamp,
         "track_features": resolve_features,
         "features": resolve_features,
-        "depends": resolve_as_tuple,
-        "constrains": resolve_as_tuple,
-        "flags": resolve_as_tuple,
-        "files": resolve_as_tuple,
+        "depends": partial(resolve_as_tuple, field_name="depends"),
+        "constrains": partial(resolve_as_tuple, field_name="constrains"),
+        "flags": partial(resolve_as_tuple, field_name="flags"),
+        "files": partial(resolve_as_tuple, field_name="files"),
         "noarch": resolve_noarch,
         "package_type": resolve_package_type,
         "platform": resolve_platform,
@@ -510,9 +516,9 @@ class PackageRecord:
                 setattr_(self, fname, sys.intern(val))
 
     def __setattr__(self, name: str, value: Any) -> None:
-        value = coerce_and_validate(name, value)
         if resolve := self.FIELD_RESOLVERS.get(name):
             value = resolve(value, self)
+        value = coerce_and_validate(name, value)
         object.__setattr__(self, name, value)
         if name in PKEY_FIELDS and hasattr(self, "_pkey_cache"):
             self.invalidate_pkey()

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -173,10 +173,7 @@ def resolve_channel(val: Any, record: PackageRecord) -> Channel | None:
         if isinstance(val, Channel):
             return val
         return Channel(val)
-    url = record.url
-    if url:
-        return Channel(url)
-    return None
+    return Channel(record.url)
 
 
 def resolve_subdir(val: Any, record: PackageRecord) -> str | None:

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -334,6 +334,12 @@ def resolve_paths_data(val: Any, record: PrefixRecord) -> Any:
     return val
 
 
+def resolve_link(val: Any, record: PrefixRecord) -> Any:
+    if isinstance(val, dict):
+        return Link(**val)
+    return val
+
+
 def dump_channel(val: Any) -> str:
     return str(val) if val else ""
 
@@ -642,6 +648,13 @@ class PackageRecord:
                 src = obj
             elif isinstance(obj, Dumpable):
                 src = obj.dump()
+                if isinstance(obj, PackageRecord):
+                    # Empty sequences and zero timestamps still take precedence.
+                    for name in FIELDS_WITHOUT_DEFAULT_IN_DUMP:
+                        if name not in src:
+                            value = getattr(obj, name, None)
+                            if value == () or value == 0:
+                                src[name] = value
             elif is_dataclass(obj):
                 src = {f.name: getattr(obj, f.name) for f in fields(obj)}
             elif hasattr(obj, "__dict__"):
@@ -972,6 +985,7 @@ class PrefixRecord(SolvedRecord):
     FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
         **SolvedRecord.FIELD_RESOLVERS,
         "paths_data": resolve_paths_data,
+        "link": resolve_link,
     }
 
     # Local cache paths, if known.

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -270,6 +270,8 @@ def resolve_timestamp(val: Any, record: PackageRecord) -> int | float:
 
 
 def resolve_indexed_timestamp(val: Any, record: PackageRecord) -> int | float:
+    if val is None:
+        return 0
     if val and val > TS_BOUNDARY:
         return val / 1000
     return val
@@ -371,7 +373,9 @@ def coerce_and_validate(name: str, val: Any) -> Any:
             raise ValidationError(name, val)
     elif name in INTEGER_FIELDS and not isinstance(val, int):
         raise ValidationError(name, val)
-    elif name == "timestamp" and not isinstance(val, (int, float)):
+    elif name in ("timestamp", "indexed_timestamp") and not isinstance(
+        val, (int, float)
+    ):
         raise ValidationError(name, val)
     elif name in SEQUENCE_FIELDS and not isinstance(val, tuple):
         raise ValidationError(name, val)
@@ -1030,6 +1034,7 @@ def _legacy_field(name: str) -> type:
 for _name in (
     "NoarchField",
     "TimestampField",
+    "IndexedTimestampField",
     "_FeaturesField",
     "ChannelField",
     "SubdirField",

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -15,28 +15,30 @@ Object inheritance:
 
 from __future__ import annotations
 
-from os.path import basename, join
+import enum
+import json  # noqa: TID251
+import sys
+from dataclasses import MISSING, dataclass, field, fields
+from functools import cache, partial
 from pathlib import Path
-
-from boltons.timeutils import dt_to_timestamp, isoparse
+from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
 
 from ..auxlib.entity import (
     BooleanField,
-    ComposableField,
     DictSafeMixin,
     Entity,
     EnumField,
     IntegerField,
     ListField,
-    NumberField,
     StringField,
 )
-from ..base.context import context
-from ..common.compat import isiterable
-from ..exceptions import PathNotFoundError
+from ..deprecations import deprecated
 from .channel import Channel
 from .enums import FileMode, LinkType, NoarchType, PackageType, PathEnum, Platform
-from .match_spec import MatchSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
 
 
 class LinkTypeField(EnumField):
@@ -50,175 +52,12 @@ class LinkTypeField(EnumField):
         return super().box(instance, instance_type, val)
 
 
-class NoarchField(EnumField):
-    def box(self, instance, instance_type, val):
-        return super().box(instance, instance_type, NoarchType.coerce(val))
-
-
-class TimestampField(NumberField):
-    def __init__(self):
-        super().__init__(default=0, required=False, default_in_dump=False)
-
-    @staticmethod
-    def _make_seconds(val):
-        if val:
-            val = val
-            if val > 253402300799:  # 9999-12-31
-                val /= (
-                    1000  # convert milliseconds to seconds; see conda/conda-build#1988
-                )
-        return val
-
-    @staticmethod
-    def _make_milliseconds(val):
-        if val:
-            if val < 253402300799:  # 9999-12-31
-                val *= 1000  # convert seconds to milliseconds
-            val = val
-        return val
-
-    def box(self, instance, instance_type, val):
-        return self._make_seconds(super().box(instance, instance_type, val))
-
-    def dump(self, instance, instance_type, val):
-        return int(
-            self._make_milliseconds(super().dump(instance, instance_type, val))
-        )  # whether in seconds or milliseconds, type must be int (not float) for backward compat
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError:
-            try:
-                return int(dt_to_timestamp(isoparse(instance.date)))
-            except (AttributeError, ValueError):
-                return 0
-
-
-class IndexedTimestampField(TimestampField):
-    def __get__(self, instance, instance_type):
-        try:
-            return NumberField.__get__(self, instance, instance_type)
-        except AttributeError:
-            return 0
-
-
 class Link(DictSafeMixin, Entity):
     source = StringField()
     type = LinkTypeField(LinkType, required=False)
 
 
 EMPTY_LINK = Link(source="")
-
-
-class _FeaturesField(ListField):
-    def __init__(self, **kwargs):
-        super().__init__(str, **kwargs)
-
-    def box(self, instance, instance_type, val):
-        if isinstance(val, str):
-            val = val.replace(" ", ",").split(",")
-        val = tuple(f for f in (ff.strip() for ff in val) if f)
-        return super().box(instance, instance_type, val)
-
-    def dump(self, instance, instance_type, val):
-        if isiterable(val):
-            return " ".join(val)
-        else:
-            return val or ()  # default value is (), and default_in_dump=False
-
-
-class ChannelField(ComposableField):
-    def __init__(self, aliases=()):
-        super().__init__(Channel, required=False, aliases=aliases)
-
-    def dump(self, instance, instance_type, val):
-        if val:
-            return str(val)
-        else:
-            val = instance.channel  # call __get__
-            return str(val)
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError:
-            url = instance.url
-            return self.unbox(instance, instance_type, Channel(url))
-
-
-class SubdirField(StringField):
-    def __init__(self):
-        super().__init__(required=False)
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError:
-            try:
-                url = instance.url
-            except AttributeError:
-                url = None
-            if url:
-                return self.unbox(instance, instance_type, Channel(url).subdir)
-
-            try:
-                platform, arch = instance.platform.name, instance.arch
-            except AttributeError:
-                platform, arch = None, None
-            if platform and not arch:
-                return self.unbox(instance, instance_type, "noarch")
-            elif platform:
-                if "x86" in arch:
-                    arch = "64" if "64" in arch else "32"
-                return self.unbox(instance, instance_type, f"{platform}-{arch}")
-            else:
-                return self.unbox(instance, instance_type, context.subdir)
-
-
-class FilenameField(StringField):
-    def __init__(self, aliases=()):
-        super().__init__(required=False, aliases=aliases)
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError:
-            try:
-                url = instance.url
-                fn = Channel(url).package_filename
-                if not fn:
-                    raise AttributeError()
-            except AttributeError:
-                fn = f"{instance.name}-{instance.version}-{instance.build}"
-            if not fn:
-                raise ValueError("Filename cannot be empty.")
-            return self.unbox(instance, instance_type, fn)
-
-
-class PackageTypeField(EnumField):
-    def __init__(self):
-        super().__init__(
-            PackageType,
-            required=False,
-            nullable=True,
-            default=None,
-            default_in_dump=False,
-        )
-
-    def __get__(self, instance, instance_type):
-        val = super().__get__(instance, instance_type)
-        if val is None:
-            # look in noarch field
-            noarch_val = instance.noarch
-            if noarch_val:
-                type_map = {
-                    NoarchType.generic: PackageType.NOARCH_GENERIC,
-                    NoarchType.python: PackageType.NOARCH_PYTHON,
-                }
-                val = type_map[NoarchType.coerce(noarch_val)]
-                val = self.unbox(instance, instance_type, val)
-        return val
 
 
 class PathData(Entity):
@@ -234,12 +73,10 @@ class PathData(Entity):
 
     @property
     def path(self):
-        # because I don't have aliases as an option for entity fields yet
         return self._path
 
 
 class PathDataV1(PathData):
-    # TODO: sha256 and size_in_bytes should be required for all PathEnum.hardlink, but not for softlink and directory
     sha256 = StringField(required=False, nullable=True)
     size_in_bytes = IntegerField(required=False, nullable=True)
     inode_paths = ListField(str, required=False, nullable=True)
@@ -248,230 +85,507 @@ class PathDataV1(PathData):
 
 
 class PathsData(Entity):
-    # from info/paths.json
     paths_version = IntegerField()
     paths = ListField(PathDataV1)
 
 
-class PackageRecord(DictSafeMixin, Entity):
-    """Representation of a concrete package archive (tarball or .conda file).
+SENTINEL = object()
 
-    It captures all the relevant information about a given package archive, including its source,
-    in the following attributes.
+TS_BOUNDARY = 253402300799  # 9999-12-31 in epoch seconds
 
-    Note that there are three subclasses, :class:`SolvedRecord`, :class:`PrefixRecord` and
-    :class:`PackageCacheRecord`. These capture the same information, but are augmented with
-    additional information relevant for these sources of packages.
+CACHE_FIELDS = frozenset({"_pkey_cache", "_hash_cache", "_memoized_md5"})
 
-    Further note that :class:`PackageRecord` makes use of its :attr:`_pkey`
-    for comparison and hash generation.
-    This means that for common operations, like comparisons between :class:`PackageRecord` s
-    and reference of :class:`PackageRecord` s in mappings, _different_ objects appear identical.
-    The fields taken into account are marked in the following list of attributes.
-    The subclasses do not add further attributes to the :attr:`_pkey`.
-    """
+FIELDS_EXCLUDED_FROM_DUMP = frozenset({"metadata"})
 
-    name = StringField()
-    """The name of the package.
+FIELDS_WITHOUT_DEFAULT_IN_DUMP = frozenset(
+    {
+        "md5",
+        "legacy_bz2_md5",
+        "legacy_bz2_size",
+        "url",
+        "sha256",
+        "flags",
+        "track_features",
+        "features",
+        "noarch",
+        "preferred_env",
+        "python_site_packages_path",
+        "license",
+        "license_family",
+        "package_type",
+        "timestamp",
+        "indexed_timestamp",
+        "paths_data",
+        "package_tarball_full_path",
+        "extracted_package_dir",
+    }
+)
 
-    Part of the :attr:`_pkey`.
-    """
+NOARCH_TO_PACKAGE_TYPE: dict[NoarchType, PackageType] = {
+    NoarchType.generic: PackageType.NOARCH_GENERIC,
+    NoarchType.python: PackageType.NOARCH_PYTHON,
+}
 
-    version = StringField()
-    """The version of the package.
+INTERN_FIELDS = frozenset({"name", "version", "build", "subdir"})
 
-    Part of the :attr:`_pkey`.
-    """
 
-    build = StringField(aliases=("build_string",))
-    """The build string of the package.
+@runtime_checkable
+class Dumpable(Protocol):
+    def dump(self) -> dict[str, Any]: ...
 
-    Part of the :attr:`_pkey`.
-    """
 
-    build_number = IntegerField()
-    """The build number of the package.
+@cache
+def get_field_info(cls: type) -> tuple[tuple[str, Any, Any], ...]:
+    """Return (name, default, default_factory) for each public field of *cls*."""
+    info: list[tuple[str, Any, Any]] = []
+    for f in fields(cls):
+        if f.name in CACHE_FIELDS:
+            continue
+        default = f.default if f.default is not MISSING else SENTINEL
+        default_factory = (
+            f.default_factory if f.default_factory is not MISSING else None
+        )
+        info.append((f.name, default, default_factory))
+    return tuple(info)
 
-    Part of the :attr:`_pkey`.
-    """
 
-    # the canonical code abbreviation for PackageRef is `pref`
-    # fields required to uniquely identifying a package
+@cache
+def get_dump_specs(cls: type) -> tuple[tuple[str, bool, Any], ...]:
+    """Return (name, include_default, field_default) per dumpable field."""
+    specs: list[tuple[str, bool, Any]] = []
+    for f in fields(cls):
+        if f.name in CACHE_FIELDS or f.name in FIELDS_EXCLUDED_FROM_DUMP:
+            continue
+        include_default = f.name not in FIELDS_WITHOUT_DEFAULT_IN_DUMP
+        default = f.default if f.default is not MISSING else SENTINEL
+        specs.append((f.name, include_default, default))
+    return tuple(specs)
 
-    channel = ChannelField(aliases=("schannel",))
-    """The channel where the package can be found."""
 
-    subdir = SubdirField()
-    """The subdir, i.e. ``noarch`` or a platform (``linux-64`` or similar).
+@cache
+def get_known_fields(cls: type) -> frozenset[str]:
+    """Return the set of non-cache field names for *cls*."""
+    return frozenset(f.name for f in fields(cls) if f.name not in CACHE_FIELDS)
 
-    Part of the :attr:`_pkey`.
-    """
 
-    fn = FilenameField(aliases=("filename",))
-    """The filename of the package.
+def resolve_channel(val: Any, record: PackageRecord) -> Channel | None:
+    if val is not None:
+        if isinstance(val, Channel):
+            return val
+        return Channel(val)
+    url = record.url
+    if url:
+        return Channel(url)
+    return None
 
-    Only part of the :attr:`_pkey` if :ref:`separate_format_cache <auto-config-reference>`
-    is ``true`` (default: ``false``).
-    """
 
-    md5 = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
+def resolve_subdir(val: Any, record: PackageRecord) -> str | None:
+    if val is not None:
+        return val
+    url = record.url
+    if url:
+        subdir = Channel(url).subdir
+        if subdir:
+            return subdir
+    plat = record.platform
+    arch = record.arch
+    if plat is not None:
+        plat_name = plat.name if isinstance(plat, Platform) else str(plat)
+        if not arch:
+            return "noarch"
+        if "x86" in arch:
+            arch = "64" if "64" in arch else "32"
+        return f"{plat_name}-{arch}"
+    from ..base.context import context
+
+    return context.subdir
+
+
+def resolve_fn(val: Any, record: PackageRecord) -> str:
+    if val is not None:
+        return val
+    url = record.url
+    if url:
+        fn = Channel(url).package_filename
+        if fn:
+            return fn
+    return f"{record.name}-{record.version}-{record.build}"
+
+
+def resolve_timestamp(val: Any, record: PackageRecord) -> int | float:
+    if val and val > TS_BOUNDARY:
+        return val / 1000
+    return val
+
+
+def resolve_indexed_timestamp(val: Any, record: PackageRecord) -> int | float:
+    if val and val > TS_BOUNDARY:
+        return val / 1000
+    return val
+
+
+def resolve_features(val: Any, record: PackageRecord) -> tuple[str, ...]:
+    if isinstance(val, tuple):
+        return val
+    if not val:
+        return ()
+    if isinstance(val, str):
+        val = val.replace(" ", ",").split(",")
+    return tuple(f for f in (ff.strip() for ff in val) if f)
+
+
+def resolve_as_tuple(val: Any, record: PackageRecord) -> tuple:
+    if isinstance(val, tuple):
+        return val
+    if not val:
+        return ()
+    return tuple(val)
+
+
+def resolve_noarch(val: Any, record: PackageRecord) -> NoarchType | None:
+    if val is None or isinstance(val, NoarchType):
+        return val
+    return NoarchType.coerce(val)
+
+
+def resolve_package_type(val: Any, record: PackageRecord) -> PackageType | None:
+    if val is None or isinstance(val, PackageType):
+        return val
+    return PackageType(val)
+
+
+def resolve_platform(val: Any, record: PackageRecord) -> Platform | None:
+    if val is None or isinstance(val, Platform):
+        return val
+    try:
+        return Platform(val)
+    except ValueError:
+        return Platform[val]
+
+
+def resolve_paths_data(val: Any, record: PrefixRecord) -> Any:
+    if isinstance(val, dict):
+        return PathsData(**val)
+    return val
+
+
+def dump_channel(val: Any) -> str:
+    return str(val) if val else ""
+
+
+def dump_timestamp(val: Any) -> int:
+    if not val:
+        return 0
+    if val < TS_BOUNDARY:
+        val *= 1000
+    return int(val)
+
+
+def dump_features(val: Any) -> str | tuple:
+    if isinstance(val, (tuple, list)):
+        return " ".join(val) if val else ()
+    return val or ()
+
+
+def dump_enum(val: Any) -> Any:
+    return val.value if isinstance(val, enum.Enum) else val
+
+
+def dump_nested(val: Any) -> Any:
+    return val.dump() if isinstance(val, Dumpable) else val
+
+
+@dataclass(slots=True, init=False, eq=False, repr=False)
+class PackageRecord:
+    """Representation of a concrete package archive (tarball or .conda file)."""
+
+    ALIASES: ClassVar[dict[str, str]] = {
+        "build_string": "build",
+        "schannel": "channel",
+        "filename": "fn",
+    }
+
+    FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
+        "channel": resolve_channel,
+        "subdir": resolve_subdir,
+        "fn": resolve_fn,
+        "timestamp": resolve_timestamp,
+        "indexed_timestamp": resolve_indexed_timestamp,
+        "track_features": resolve_features,
+        "features": resolve_features,
+        "depends": resolve_as_tuple,
+        "constrains": resolve_as_tuple,
+        "flags": resolve_as_tuple,
+        "files": resolve_as_tuple,
+        "noarch": resolve_noarch,
+        "package_type": resolve_package_type,
+        "platform": resolve_platform,
+    }
+
+    DUMP_TRANSFORMS: ClassVar[dict[str, Callable]] = {
+        "channel": dump_channel,
+        "timestamp": dump_timestamp,
+        "indexed_timestamp": dump_timestamp,
+        "track_features": dump_features,
+        "features": dump_features,
+        "platform": dump_enum,
+        "noarch": dump_enum,
+        "package_type": dump_enum,
+        "link": dump_nested,
+        "paths_data": dump_nested,
+    }
+
+    name: str = ""
+    version: str = ""
+    build: str = ""
+    build_number: int = 0
+    channel: Channel | None = None
+    subdir: str | None = None
+    fn: str | None = None
+
+    md5: str | None = None
+    legacy_bz2_md5: str | None = None
+    legacy_bz2_size: int | None = None
+    url: str | None = None
+    sha256: str | None = None
+
+    arch: str | None = None
+    platform: Platform | None = None
+
+    depends: tuple[str, ...] = ()
+    constrains: tuple[str, ...] = ()
+    flags: tuple[str, ...] = ()
+    track_features: tuple[str, ...] = ()
+    features: tuple[str, ...] = ()
+
+    noarch: NoarchType | None = None
+    preferred_env: str | None = None
+    python_site_packages_path: str | None = None
+    license: str | None = None
+    license_family: str | None = None
+    package_type: PackageType | None = None
+
+    timestamp: int | float = 0
+    indexed_timestamp: int | float = 0
+    date: str | None = None
+    size: int | None = None
+
+    metadata: set[str] = field(default_factory=set, repr=False)
+
+    _pkey_cache: tuple | None = field(
+        default=None, repr=False, compare=False, init=False
     )
-    """The md5 checksum of the package."""
+    _hash_cache: int | None = field(default=None, repr=False, compare=False, init=False)
 
-    legacy_bz2_md5 = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
-    )
-    """If this is a ``.conda`` package and a corresponding ``.tar.bz2`` package exists, this may contain the md5 checksum of that package."""
+    def __init__(self, **kwargs: Any) -> None:
+        setattr_ = object.__setattr__
 
-    legacy_bz2_size = IntegerField(required=False, nullable=True, default_in_dump=False)
-    """If this is a ``.conda`` package and a corresponding ``.tar.bz2`` package exists, this may contain the size of that package."""
+        for alias, canonical in self.ALIASES.items():
+            if alias in kwargs and canonical not in kwargs:
+                kwargs[canonical] = kwargs.pop(alias)
 
-    url = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
-    )
-    """The download url of the package."""
+        for name, default, default_factory in get_field_info(self.__class__):
+            val = kwargs.get(name, SENTINEL)
+            if val is SENTINEL:
+                if default_factory is not None:
+                    setattr_(self, name, default_factory())
+                else:
+                    setattr_(self, name, default)
+            else:
+                setattr_(self, name, val)
 
-    sha256 = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
-    )
-    """The sha256 checksum of the package."""
+        for name, resolve in self.FIELD_RESOLVERS.items():
+            val = getattr(self, name, SENTINEL)
+            if val is not SENTINEL:
+                resolved = resolve(val, self)
+                if resolved is not val:
+                    setattr_(self, name, resolved)
+
+        for fname in INTERN_FIELDS:
+            val = getattr(self, fname, None)
+            if isinstance(val, str):
+                setattr_(self, fname, sys.intern(val))
+
+        setattr_(self, "_pkey_cache", None)
+        setattr_(self, "_hash_cache", None)
+
+    def __getitem__(self, item: str) -> Any:
+        try:
+            return getattr(self, item)
+        except AttributeError:
+            raise KeyError(item) from None
+
+    def get(self, item: str, default: Any = None) -> Any:
+        return getattr(self, item, default)
 
     @property
     def channel_name(self) -> str | None:
-        """str: The canonical name of the channel of this package.
+        ch = self.channel
+        if ch is None:
+            return None
+        return getattr(ch, "canonical_name", str(ch))
 
-        Part of the :attr:`_pkey`.
-        """
-        return getattr(self.channel, "canonical_name", None)
+    def effective_package_type(self) -> PackageType | None:
+        val = self.package_type
+        if val is not None:
+            return val
+        noarch_val = self.noarch
+        if noarch_val:
+            noarch_coerced = (
+                noarch_val
+                if isinstance(noarch_val, NoarchType)
+                else NoarchType.coerce(noarch_val)
+            )
+            return NOARCH_TO_PACKAGE_TYPE.get(noarch_coerced)
+        return None
 
     @property
-    def _pkey(self):
-        """tuple: The components of the PackageRecord that are used for comparison and hashing.
-
-        The :attr:`_pkey` is a tuple made up of the following fields of the :class:`PackageRecord`.
-        Two :class:`PackageRecord` s test equal if their respective :attr:`_pkey` s are equal.
-        The hash of the :class:`PackageRecord` (important for dictionary access) is the hash of the :attr:`_pkey`.
-
-        The included fields are:
-
-        * :attr:`channel_name`
-        * :attr:`subdir`
-        * :attr:`name`
-        * :attr:`version`
-        * :attr:`build_number`
-        * :attr:`build`
-        * :attr:`fn` only if :ref:`separate_format_cache <auto-config-reference>` is set to true (default: false)
-        """
-        try:
-            return self.__pkey
-        except AttributeError:
-            __pkey = self.__pkey = [
-                self.channel.canonical_name,
-                self.subdir,
-                self.name,
-                self.version,
-                self.build_number,
-                self.build,
-            ]
-            # NOTE: fn is included to distinguish between .conda and .tar.bz2 packages
-            if context.separate_format_cache:
-                __pkey.append(self.fn)
-            self.__pkey = tuple(__pkey)
-            return self.__pkey
-
-    def __hash__(self):
-        try:
-            return self._hash
-        except AttributeError:
-            self._hash = hash(self._pkey)
-        return self._hash
-
-    def __eq__(self, other):
-        return self._pkey == other._pkey
-
-    def dist_str(self, canonical_name: bool = True) -> str:
-        return "{}{}::{}-{}-{}".format(
-            self.channel.canonical_name if canonical_name else self.channel.name,
-            ("/" + self.subdir) if self.subdir else "",
+    def _pkey(self) -> tuple:
+        cached = self._pkey_cache
+        if cached is not None:
+            return cached
+        ch = self.channel
+        ch_name = getattr(ch, "canonical_name", str(ch)) if ch else ""
+        pk: list[Any] = [
+            ch_name,
+            self.subdir,
             self.name,
             self.version,
+            self.build_number,
             self.build,
-        )
+        ]
+        from ..base.context import context
 
-    def dist_fields_dump(self):
+        if context.separate_format_cache:
+            pk.append(self.fn)
+        result = tuple(pk)
+        object.__setattr__(self, "_pkey_cache", result)
+        return result
+
+    def invalidate_pkey(self) -> None:
+        object.__setattr__(self, "_pkey_cache", None)
+        object.__setattr__(self, "_hash_cache", None)
+
+    def __hash__(self) -> int:
+        cached = self._hash_cache
+        if cached is not None:
+            return cached
+        h = hash(self._pkey)
+        object.__setattr__(self, "_hash_cache", h)
+        return h
+
+    def __eq__(self, other: object) -> bool:
+        if not hasattr(other, "_pkey"):
+            return NotImplemented
+        return self._pkey == other._pkey
+
+    def dump(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        transforms = self.DUMP_TRANSFORMS
+        for name, include_default, default in get_dump_specs(self.__class__):
+            val = getattr(self, name, SENTINEL)
+            if val is SENTINEL:
+                continue
+
+            if val is None:
+                if not include_default:
+                    continue
+                if default is not SENTINEL and default is None:
+                    continue
+            if not include_default:
+                if (
+                    (default is not SENTINEL and val == default)
+                    or val == ()
+                    or val == 0
+                ):
+                    continue
+
+            transform = transforms.get(name)
+            if transform is not None:
+                val = transform(val)
+
+            result[name] = val
+        return result
+
+    @classmethod
+    def from_objects(cls, *objects: Any, **overrides: Any) -> PackageRecord:
+        kwargs: dict[str, Any] = {}
+        known = get_known_fields(cls)
+
+        for obj in objects:
+            if isinstance(obj, dict):
+                src = obj
+            elif isinstance(obj, Dumpable):
+                src = obj.dump()
+            elif hasattr(obj, "__dict__"):
+                src = obj.__dict__
+            elif hasattr(obj, "__slots__"):
+                src = {
+                    s: getattr(obj, s)
+                    for s in obj.__slots__
+                    if hasattr(obj, s) and not s.startswith("_")
+                }
+            else:
+                continue
+            for k, v in src.items():
+                target = cls.ALIASES.get(k, k) if k not in known else k
+                if target in known and target not in kwargs and v is not None:
+                    kwargs[target] = v
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> PackageRecord:
+        return cls(**json.loads(json_str))
+
+    @classmethod
+    def load(cls, data_dict: dict[str, Any]) -> PackageRecord:
+        return cls(**data_dict)
+
+    def __str__(self) -> str:
+        ch = self.channel
+        ch_name = getattr(ch, "canonical_name", "") if ch else ""
+        return f"{ch_name}/{self.subdir}::{self.name}=={self.version}={self.build}"
+
+    def __repr__(self) -> str:
+        parts: list[str] = []
+        for f_obj in fields(self.__class__):
+            if f_obj.name in CACHE_FIELDS or f_obj.name == "metadata":
+                continue
+            val = getattr(self, f_obj.name, SENTINEL)
+            if val is SENTINEL or val is None or val == () or val == "":
+                continue
+            parts.append(f"{f_obj.name}={val!r}")
+        return f"{self.__class__.__name__}({', '.join(parts)})"
+
+    def dist_str(self, canonical_name: bool = True) -> str:
+        ch = self.channel
+        if ch is None:
+            ch_str = ""
+        elif canonical_name:
+            ch_str = getattr(ch, "canonical_name", str(ch))
+        else:
+            ch_str = getattr(ch, "name", str(ch))
+        subdir = self.subdir
+        sub = f"/{subdir}" if subdir else ""
+        return f"{ch_str}{sub}::{self.name}-{self.version}-{self.build}"
+
+    def dist_fields_dump(self) -> dict[str, Any]:
+        ch = self.channel
         return {
-            "base_url": self.channel.base_url,
+            "base_url": getattr(ch, "base_url", "") if ch else "",
             "build_number": self.build_number,
             "build_string": self.build,
-            "channel": self.channel.name,
+            "channel": getattr(ch, "name", "") if ch else "",
             "dist_name": self.dist_str().split(":")[-1],
             "name": self.name,
             "platform": self.subdir,
             "version": self.version,
         }
 
-    arch = StringField(required=False, nullable=True)  # so legacy
-    platform = EnumField(Platform, required=False, nullable=True)  # so legacy
-
-    depends = ListField(str, default=())
-    constrains = ListField(str, default=())
-
-    flags = ListField(str, default=(), required=False, default_in_dump=False)
-
-    track_features = _FeaturesField(required=False, default=(), default_in_dump=False)
-    features = _FeaturesField(required=False, default=(), default_in_dump=False)
-
-    noarch = NoarchField(
-        NoarchType, required=False, nullable=True, default=None, default_in_dump=False
-    )  # TODO: rename to package_type
-    preferred_env = StringField(
-        required=False, nullable=True, default=None, default_in_dump=False
-    )
-    python_site_packages_path = StringField(
-        default=None, required=False, nullable=True, default_in_dump=False
-    )
-    license = StringField(
-        required=False, nullable=True, default=None, default_in_dump=False
-    )
-    license_family = StringField(
-        required=False, nullable=True, default=None, default_in_dump=False
-    )
-    package_type = PackageTypeField()
-
-    @property
-    def is_unmanageable(self):
-        return self.package_type in PackageType.unmanageable_package_types()
-
-    timestamp = TimestampField()
-    indexed_timestamp = IndexedTimestampField()
-
-    @property
-    def combined_depends(self):
+    def to_match_spec(self):
         from .match_spec import MatchSpec
 
-        result = {ms.name: ms for ms in MatchSpec.merge(self.depends)}
-        for spec in self.constrains or ():
-            ms = MatchSpec(spec)
-            result[ms.name] = MatchSpec(ms, optional=(ms.name not in result))
-        return tuple(result.values())
-
-    # the canonical code abbreviation for PackageRecord is `prec`, not to be confused with
-    # PackageCacheRecord (`pcrec`) or PrefixRecord (`prefix_rec`)
-    #
-    # important for "choosing" a package (i.e. the solver), listing packages
-    # (like search), and for verifying downloads
-    #
-    # this is the highest level of the record inheritance model that MatchSpec is designed to
-    # work with
-
-    date = StringField(required=False)
-    size = IntegerField(required=False)
-
-    def __str__(self):
-        return f"{self.channel.canonical_name}/{self.subdir}::{self.name}=={self.version}={self.build}"
-
-    def to_match_spec(self):
         return MatchSpec(
             channel=self.channel,
             subdir=self.subdir,
@@ -481,41 +595,45 @@ class PackageRecord(DictSafeMixin, Entity):
         )
 
     def to_simple_match_spec(self):
-        return MatchSpec(
-            name=self.name,
-            version=self.version,
-        )
+        from .match_spec import MatchSpec
+
+        return MatchSpec(name=self.name, version=self.version)
 
     @property
-    def namekey(self):
-        return "global:" + self.name
+    def is_unmanageable(self) -> bool:
+        return self.effective_package_type() in PackageType.unmanageable_package_types()
 
     @property
-    def spec(self):
-        """Return package spec: name=version=build"""
+    def combined_depends(self) -> tuple:
+        from .match_spec import MatchSpec
+
+        result = {ms.name: ms for ms in MatchSpec.merge(self.depends)}
+        for spec in self.constrains or ():
+            ms = MatchSpec(spec)
+            result[ms.name] = MatchSpec(ms, optional=(ms.name not in result))
+        return tuple(result.values())
+
+    @property
+    def namekey(self) -> str:
+        return f"global:{self.name}"
+
+    @property
+    def spec(self) -> str:
         return f"{self.name}={self.version}={self.build}"
 
     @property
-    def spec_no_build(self):
-        """Return package spec without build: name=version"""
+    def spec_no_build(self) -> str:
         return f"{self.name}={self.version}"
 
-    def record_id(self):
-        # WARNING: This is right now only used in link.py _change_report_str(). It is not
-        #          the official record_id / uid until it gets namespace.  Even then, we might
-        #          make the format different.  Probably something like
-        #              channel_name/subdir:namespace:name-version-build_number-build_string
-        return f"{self.channel.name}/{self.subdir}::{self.name}-{self.version}-{self.build}"
-
-    metadata: set[str]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.metadata = set()
+    def record_id(self) -> str:
+        ch = self.channel
+        ch_name = getattr(ch, "name", "") if ch else ""
+        return f"{ch_name}/{self.subdir}::{self.name}-{self.version}-{self.build}"
 
     @classmethod
-    def feature(cls, feature_name) -> PackageRecord:
-        # necessary for the SAT solver to do the right thing with features
+    def feature(cls, feature_name: str) -> PackageRecord:
+        from ..base.context import context
+
         pkg_name = f"{feature_name}@"
         return cls(
             name=pkg_name,
@@ -531,7 +649,10 @@ class PackageRecord(DictSafeMixin, Entity):
 
     @classmethod
     def virtual_package(
-        cls, name: str, version: str | None = None, build_string: str | None = None
+        cls,
+        name: str,
+        version: str | None = None,
+        build_string: str | None = None,
     ) -> PackageRecord:
         """
         Create a virtual package record.
@@ -544,6 +665,8 @@ class PackageRecord(DictSafeMixin, Entity):
         Returns:
             A PackageRecord representing the virtual package.
         """
+        from ..base.context import context
+
         return cls(
             package_type=PackageType.VIRTUAL_SYSTEM,
             name=name,
@@ -557,64 +680,32 @@ class PackageRecord(DictSafeMixin, Entity):
         )
 
 
-class Md5Field(StringField):
-    def __init__(self):
-        super().__init__(required=False, nullable=True)
-
-    def __get__(self, instance, instance_type):
-        try:
-            return super().__get__(instance, instance_type)
-        except AttributeError as e:
-            try:
-                return instance._calculate_md5sum()
-            except PathNotFoundError:
-                raise e
-
-
+@dataclass(slots=True, init=False, eq=False, repr=False)
 class PackageCacheRecord(PackageRecord):
-    """Representation of a package that has been downloaded or unpacked in the local package cache.
+    """Representation of a package in the local package cache."""
 
-    Specialization of :class:`PackageRecord` that adds information for packages that exist in the
-    local package cache, either as the downloaded package file, or unpacked in its own package dir,
-    or both.
-
-    Note that this class does not add new fields to the :attr:`PackageRecord._pkey` so that a pure
-    :class:`PackageRecord` object that has the same ``_pkey`` fields as a different
-    :class:`PackageCacheRecord` object (or, indeed, a :class:`PrefixRecord` object) will be considered
-    equal and will produce the same hash.
-    """
-
-    package_tarball_full_path = StringField()
-    """Full path to the local package file."""
-
-    extracted_package_dir = StringField()
-    """Full path to the local extracted package."""
-
-    md5 = Md5Field()
-    """The md5 checksum of the package.
-
-    If the package file exists locally, this class can calculate a missing checksum on-the-fly.
-    """
+    package_tarball_full_path: str = ""
+    extracted_package_dir: str = ""
+    _memoized_md5: str | None = field(
+        default=None, repr=False, compare=False, init=False
+    )
 
     @property
-    def is_fetched(self):
-        """bool: Whether the package file exists locally."""
+    def is_fetched(self) -> bool:
         from ..gateways.disk.read import isfile
 
         return isfile(self.package_tarball_full_path)
 
     @property
-    def is_extracted(self):
-        """bool: Whether the package has been extracted locally."""
+    def is_extracted(self) -> bool:
         from ..gateways.disk.read import isdir, isfile
 
         epd = self.extracted_package_dir
-        return isdir(epd) and isfile(join(epd, "info", "index.json"))
+        return isdir(epd) and isfile(str(Path(epd) / "info" / "index.json"))
 
     @property
-    def tarball_basename(self):
-        """str: The basename of the local package file."""
-        return basename(self.package_tarball_full_path)
+    def tarball_basename(self) -> str:
+        return Path(self.package_tarball_full_path).name
 
     def matches_metadata(self, package_ref: PackageRecord | MatchSpec) -> bool:
         """Match available size and MD5 against the requested package.
@@ -633,62 +724,88 @@ class PackageCacheRecord(PackageRecord):
                 return False
         return True
 
-    def _calculate_md5sum(self):
-        memoized_md5 = getattr(self, "_memoized_md5", None)
-        if memoized_md5:
-            return memoized_md5
-
-        from os.path import isfile
-
-        if isfile(self.package_tarball_full_path):
+    def calculate_md5sum(self) -> str | None:
+        # ``_memoized_md5`` is a slot but is not populated by PackageRecord's
+        # __init__ (it's listed in CACHE_FIELDS which skips initialization),
+        # so on a freshly-constructed PackageCacheRecord the slot read would
+        # raise AttributeError. Use getattr with a default to keep the slow
+        # path reachable on first call.
+        memoized = getattr(self, "_memoized_md5", None)
+        if memoized:
+            return memoized
+        if Path(self.package_tarball_full_path).is_file():
             from ..gateways.disk.read import compute_sum
 
             md5sum = compute_sum(self.package_tarball_full_path, "md5")
-            setattr(self, "_memoized_md5", md5sum)
+            object.__setattr__(self, "_memoized_md5", md5sum)
             return md5sum
+        return None
 
 
+def _make_md5_auto_compute_property() -> property:
+    """Build the backwards-compatible ``md5`` descriptor for PackageCacheRecord.
+
+    The old ``Md5Field`` descriptor hashed the tarball on attribute read when
+    the field was unset. That behaviour is kept one release cycle via this
+    property; the getter falls through to :meth:`calculate_md5sum` and uses
+    the ``deprecated`` framework to nudge callers toward the explicit method.
+
+    The property is attached after the class body because
+    ``@dataclass(slots=True)`` strips class attributes whose names match
+    inherited fields (``md5`` lives on :class:`PackageRecord`) before
+    allocating slots, which otherwise silently drops an inline property.
+    Storage stays on the inherited slot so ``record.md5 = "abc"`` keeps
+    working.
+    """
+    slot = PackageRecord.__dict__["md5"]
+
+    def fget(self: PackageCacheRecord) -> str | None:
+        value = slot.__get__(self, type(self))
+        if value is not None:
+            return value
+        auto = self.calculate_md5sum()
+        if auto is not None:
+            deprecated.topic(
+                "26.9",
+                "27.3",
+                topic="Implicit md5 auto-compute on PackageCacheRecord.md5",
+                addendum="Call PackageCacheRecord.calculate_md5sum() explicitly instead.",
+            )
+        return auto
+
+    def fset(self: PackageCacheRecord, value: str | None) -> None:
+        slot.__set__(self, value)
+
+    return property(fget, fset)
+
+
+PackageCacheRecord.md5 = _make_md5_auto_compute_property()
+
+
+@dataclass(slots=True, init=False, eq=False, repr=False)
 class SolvedRecord(PackageRecord):
-    """Representation of a package that has been returned as part of a solver solution.
+    """Representation of a package returned as part of a solver solution."""
 
-    This sits between :class:`PackageRecord` and :class:`PrefixRecord`, simply adding
-    ``requested_spec`` (and ``requested_specs``) so they can be used in lockfiles without
-    requiring the artifact on disk.
-    """
+    ALIASES: ClassVar[dict[str, str]] = {
+        **PackageRecord.ALIASES,
+        "requested_specs": "_requested_specs",
+    }
 
-    requested_spec = StringField(required=False)
-    """
-    The :class:`MatchSpec` that the user requested or ``None``
-    if the package it was installed as a dependency.
-    """
-    _requested_specs = ListField(
-        str, required=False, nullable=True, aliases=("requested_specs",)
-    )
-    """
-    The :class:`MatchSpec` objects that the user requested or ``()``
-    if the package was installed as a dependency.
-    See also `.requested_specs` property.
-    """
+    requested_spec: str | None = None
+    _requested_specs: tuple[str, ...] | None = None
 
     @property
     def requested_specs(self) -> tuple[str, ...]:
-        """
-        This property will use 'requested_spec' as the source for
-        'requested_specs' for old `conda-meta/*.json` files that
-        did not define the plural version.
-        """
-        if specs := self.get("_requested_specs", None):
-            return tuple(specs)
-        if spec := self.get("requested_spec", None):
+        val = self._requested_specs
+        if val:
+            return tuple(val)
+        spec = self.requested_spec
+        if spec:
             return (spec,)
         return ()
 
-    def dump(self):
-        """
-        We need to expose _requested_specs as its public counterpart,
-        and also expose single specs as a plural list for backwards compatibility.
-        """
-        dumped = super().dump()
+    def dump(self) -> dict[str, Any]:
+        dumped = PackageRecord.dump(self)
         if dumped.get("_requested_specs"):
             dumped["requested_specs"] = dumped.pop("_requested_specs")
         elif spec := dumped.get("requested_spec"):
@@ -696,43 +813,21 @@ class SolvedRecord(PackageRecord):
         return dumped
 
 
+@dataclass(slots=True, init=False, eq=False, repr=False)
 class PrefixRecord(SolvedRecord):
-    """Representation of a package that is installed in a local conda environmnet.
+    """Representation of a package installed in a local conda environment."""
 
-    Specialization of :class:`PackageRecord` that adds information for packages that are installed
-    in a local conda environment or prefix.
+    FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
+        **PackageRecord.FIELD_RESOLVERS,
+        "paths_data": resolve_paths_data,
+    }
 
-    Note that this class does not add new fields to the :attr:`PackageRecord._pkey` so that a pure
-    :class:`PackageRecord` object that has the same ``_pkey`` fields as a different
-    :class:`PrefixRecord` object (or, indeed, a :class:`PackageCacheRecord` object) will be considered
-    equal and will produce the same hash.
-
-    Objects of this class are generally constructed from metadata in json files inside `$prefix/conda-meta`.
-    """
-
-    package_tarball_full_path = StringField(required=False)
-    """The path to the originating package file, usually in the local cache."""
-
-    extracted_package_dir = StringField(required=False)
-    """The path to the extracted package directory, usually in the local cache."""
-
-    files = ListField(str, default=(), required=False)
-    """The list of all files comprising the package as relative paths from the prefix root."""
-
-    paths_data = ComposableField(
-        PathsData, required=False, nullable=True, default_in_dump=False
-    )
-    """List with additional information about the files, e.g. checksums and link type."""
-
-    link = ComposableField(Link, required=False)
-    """Information about how the package was linked into the prefix."""
-
-    # app = ComposableField(App, required=False)
-
-    # There have been requests in the past to save remote server auth
-    # information with the package.  Open to rethinking that though.
-    auth = StringField(required=False, nullable=True)
-    """Authentication information."""
+    package_tarball_full_path: str = ""
+    extracted_package_dir: str = ""
+    files: tuple[str, ...] = ()
+    paths_data: Any = None
+    link: Any = None
+    auth: str | None = None
 
     def _get_json_fn(self) -> str:
         return f"{self.name}-{self.version}-{self.build}.json"
@@ -749,28 +844,61 @@ class PrefixRecord(SolvedRecord):
             Total size in bytes of all files installed by this package.
         """
         total_size = 0
-
         meta_file = prefix_path / "conda-meta" / self._get_json_fn()
         try:
             total_size += meta_file.stat().st_size
         except OSError:
             pass
-
-        for path_data in self.paths_data.paths:
-            if path_data.path_type in (PathEnum.softlink, PathEnum.directory):
-                continue
-            if getattr(path_data, "size_in_bytes", None) is not None:
-                total_size += path_data.size_in_bytes
-                continue
-
-            file_path = Path(prefix_path) / path_data._path
-            try:
-                total_size += file_path.stat().st_size
-            except OSError:
-                pass
-
+        if self.paths_data is not None:
+            for path_data in self.paths_data.paths:
+                if path_data.path_type in (PathEnum.softlink, PathEnum.directory):
+                    continue
+                if getattr(path_data, "size_in_bytes", None) is not None:
+                    total_size += path_data.size_in_bytes
+                    continue
+                file_path = prefix_path / path_data._path
+                try:
+                    total_size += file_path.stat().st_size
+                except OSError:
+                    pass
         return total_size
 
-    # @classmethod
-    # def load(cls, conda_meta_json_path):
-    #     return cls()
+
+def _legacy_field(name: str) -> type:
+    """Lazy-import a deprecated ``auxlib.Entity`` field descriptor by name.
+
+    Used as the ``factory=`` callable in the module-level
+    :func:`deprecated.constant` registrations below so that importing
+    :mod:`conda.models.records` does not drag ``boltons.timeutils`` et al.
+    onto the cold-start path for callers of the new dataclass records.
+    """
+    from . import _legacy_record_fields
+
+    return getattr(_legacy_record_fields, name)
+
+
+for _name in (
+    "NoarchField",
+    "TimestampField",
+    "_FeaturesField",
+    "ChannelField",
+    "SubdirField",
+    "FilenameField",
+    "PackageTypeField",
+    "Md5Field",
+):
+    deprecated.constant(
+        "26.9",
+        "27.3",
+        _name,
+        factory=partial(_legacy_field, _name),
+        addendum=(
+            "auxlib.Entity-based record field descriptors are no longer used "
+            "by conda's record classes; record classes have moved to "
+            "``@dataclass(slots=True)``. Subclasses of "
+            "``conda.auxlib.entity.Entity`` can keep the descriptor by "
+            "vendoring it or by importing the base class from "
+            "``conda.auxlib.entity`` directly."
+        ),
+    )
+del _name

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -531,7 +531,7 @@ class PackageRecord:
         value = coerce_and_validate(name, value)
         object.__setattr__(self, name, value)
         if name in PKEY_FIELDS and hasattr(self, "_pkey_cache"):
-            self.invalidate_pkey()
+            self._invalidate_pkey()
 
     def __getitem__(self, item: str) -> Any:
         try:
@@ -593,7 +593,7 @@ class PackageRecord:
         object.__setattr__(self, "_pkey_cache", result)
         return result
 
-    def invalidate_pkey(self) -> None:
+    def _invalidate_pkey(self) -> None:
         object.__setattr__(self, "_pkey_cache", None)
         object.__setattr__(self, "_hash_cache", None)
 

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import enum
 import json  # noqa: TID251
 import sys
-from dataclasses import MISSING, dataclass, field, fields
+from dataclasses import MISSING, dataclass, field, fields, is_dataclass
 from functools import cache, partial
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
@@ -32,6 +32,7 @@ from ..auxlib.entity import (
     ListField,
     StringField,
 )
+from ..auxlib.exceptions import ValidationError
 from ..deprecations import deprecated
 from .channel import Channel
 from .enums import FileMode, LinkType, NoarchType, PackageType, PathEnum, Platform
@@ -39,6 +40,8 @@ from .enums import FileMode, LinkType, NoarchType, PackageType, PathEnum, Platfo
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
+
+    from .match_spec import MatchSpec
 
 
 class LinkTypeField(EnumField):
@@ -93,6 +96,50 @@ SENTINEL = object()
 
 TS_BOUNDARY = 253402300799  # 9999-12-31 in epoch seconds
 
+REQUIRED_FIELDS = ("name", "version", "build", "build_number")
+
+STRING_FIELDS = frozenset(
+    {
+        "name",
+        "version",
+        "build",
+        "subdir",
+        "fn",
+        "md5",
+        "legacy_bz2_md5",
+        "url",
+        "sha256",
+        "arch",
+        "preferred_env",
+        "python_site_packages_path",
+        "license",
+        "license_family",
+        "date",
+        "package_tarball_full_path",
+        "extracted_package_dir",
+        "requested_spec",
+        "auth",
+    }
+)
+
+INTEGER_FIELDS = frozenset({"build_number", "legacy_bz2_size", "size"})
+
+SEQUENCE_FIELDS = frozenset(
+    {
+        "depends",
+        "constrains",
+        "flags",
+        "track_features",
+        "features",
+        "files",
+        "_requested_specs",
+    }
+)
+
+PKEY_FIELDS = frozenset(
+    {"channel", "subdir", "name", "version", "build_number", "build", "fn"}
+)
+
 CACHE_FIELDS = frozenset({"_pkey_cache", "_hash_cache", "_memoized_md5"})
 
 FIELDS_EXCLUDED_FROM_DUMP = frozenset({"metadata"})
@@ -136,10 +183,10 @@ class Dumpable(Protocol):
 
 @cache
 def get_field_info(cls: type) -> tuple[tuple[str, Any, Any], ...]:
-    """Return (name, default, default_factory) for each public field of *cls*."""
+    """Return initialization metadata for each constructor field of *cls*."""
     info: list[tuple[str, Any, Any]] = []
     for f in fields(cls):
-        if f.name in CACHE_FIELDS:
+        if not f.init:
             continue
         default = f.default if f.default is not MISSING else SENTINEL
         default_factory = (
@@ -164,8 +211,8 @@ def get_dump_specs(cls: type) -> tuple[tuple[str, bool, Any], ...]:
 
 @cache
 def get_known_fields(cls: type) -> frozenset[str]:
-    """Return the set of non-cache field names for *cls*."""
-    return frozenset(f.name for f in fields(cls) if f.name not in CACHE_FIELDS)
+    """Return constructor field names for *cls*."""
+    return frozenset(f.name for f in fields(cls) if f.init)
 
 
 def resolve_channel(val: Any, record: PackageRecord) -> Channel | None:
@@ -210,6 +257,13 @@ def resolve_fn(val: Any, record: PackageRecord) -> str:
 
 
 def resolve_timestamp(val: Any, record: PackageRecord) -> int | float:
+    if not val and record.date:
+        from boltons.timeutils import dt_to_timestamp, isoparse
+
+        try:
+            return int(dt_to_timestamp(isoparse(record.date)))
+        except (TypeError, ValueError):
+            return 0
     if val and val > TS_BOUNDARY:
         return val / 1000
     return val
@@ -237,6 +291,12 @@ def resolve_as_tuple(val: Any, record: PackageRecord) -> tuple:
     if not val:
         return ()
     return tuple(val)
+
+
+def resolve_optional_tuple(val: Any, record: PackageRecord) -> tuple | None:
+    if val is None:
+        return None
+    return resolve_as_tuple(val, record)
 
 
 def resolve_noarch(val: Any, record: PackageRecord) -> NoarchType | None:
@@ -292,9 +352,34 @@ def dump_nested(val: Any) -> Any:
     return val.dump() if isinstance(val, Dumpable) else val
 
 
+def coerce_and_validate(name: str, val: Any) -> Any:
+    """Preserve the scalar validation performed by the old Entity fields."""
+    if val is None:
+        if name in REQUIRED_FIELDS:
+            raise ValidationError(name)
+        return val
+    if name in STRING_FIELDS:
+        if isinstance(val, (int, float, complex)):
+            return str(val)
+        if not isinstance(val, str):
+            raise ValidationError(name, val)
+    elif name in INTEGER_FIELDS and not isinstance(val, int):
+        raise ValidationError(name, val)
+    elif name == "timestamp" and not isinstance(val, (int, float)):
+        raise ValidationError(name, val)
+    elif name in SEQUENCE_FIELDS and not isinstance(val, tuple):
+        raise ValidationError(name, val)
+    return val
+
+
 @dataclass(slots=True, init=False, eq=False, repr=False)
 class PackageRecord:
-    """Representation of a concrete package archive (tarball or .conda file)."""
+    """Representation of a concrete package archive (tarball or .conda file).
+
+    The subclasses add information for solved, cached, and installed packages,
+    but do not add fields to :attr:`_pkey`. Records with the same identity
+    fields therefore compare equal and produce the same hash across subclasses.
+    """
 
     ALIASES: ClassVar[dict[str, str]] = {
         "build_string": "build",
@@ -368,7 +453,6 @@ class PackageRecord:
     size: int | None = None
 
     metadata: set[str] = field(default_factory=set, repr=False)
-
     _pkey_cache: tuple | None = field(
         default=None, repr=False, compare=False, init=False
     )
@@ -381,30 +465,57 @@ class PackageRecord:
             if alias in kwargs and canonical not in kwargs:
                 kwargs[canonical] = kwargs.pop(alias)
 
+        for name in REQUIRED_FIELDS:
+            if name not in kwargs:
+                raise ValidationError(
+                    name,
+                    msg=(
+                        f"{self.__class__.__name__} requires a {name} field. "
+                        f"Instantiated with {kwargs}"
+                    ),
+                )
+
         for name, default, default_factory in get_field_info(self.__class__):
             val = kwargs.get(name, SENTINEL)
             if val is SENTINEL:
                 if default_factory is not None:
-                    setattr_(self, name, default_factory())
+                    val = default_factory()
                 else:
-                    setattr_(self, name, default)
-            else:
-                setattr_(self, name, val)
+                    val = default
+            if name not in self.FIELD_RESOLVERS:
+                val = coerce_and_validate(name, val)
+            setattr_(self, name, val)
+
+        for f_obj in fields(self.__class__):
+            if f_obj.init:
+                continue
+            if f_obj.default_factory is not MISSING:
+                setattr_(self, f_obj.name, f_obj.default_factory())
+            elif f_obj.default is not MISSING:
+                setattr_(self, f_obj.name, f_obj.default)
 
         for name, resolve in self.FIELD_RESOLVERS.items():
             val = getattr(self, name, SENTINEL)
             if val is not SENTINEL:
-                resolved = resolve(val, self)
-                if resolved is not val:
-                    setattr_(self, name, resolved)
+                resolved = (
+                    val
+                    if name == "timestamp" and name in kwargs and not val
+                    else resolve(val, self)
+                )
+                setattr_(self, name, coerce_and_validate(name, resolved))
 
         for fname in INTERN_FIELDS:
             val = getattr(self, fname, None)
             if isinstance(val, str):
                 setattr_(self, fname, sys.intern(val))
 
-        setattr_(self, "_pkey_cache", None)
-        setattr_(self, "_hash_cache", None)
+    def __setattr__(self, name: str, value: Any) -> None:
+        value = coerce_and_validate(name, value)
+        if resolve := self.FIELD_RESOLVERS.get(name):
+            value = resolve(value, self)
+        object.__setattr__(self, name, value)
+        if name in PKEY_FIELDS and hasattr(self, "_pkey_cache"):
+            self.invalidate_pkey()
 
     def __getitem__(self, item: str) -> Any:
         try:
@@ -417,6 +528,7 @@ class PackageRecord:
 
     @property
     def channel_name(self) -> str | None:
+        """The canonical name of the channel of this package."""
         ch = self.channel
         if ch is None:
             return None
@@ -438,6 +550,12 @@ class PackageRecord:
 
     @property
     def _pkey(self) -> tuple:
+        """Components used for record comparison and hashing.
+
+        The key contains the channel name, subdir, name, version, build number,
+        and build string. It also contains the filename when
+        :ref:`separate_format_cache <auto-config-reference>` is enabled.
+        """
         cached = self._pkey_cache
         if cached is not None:
             return cached
@@ -514,16 +632,16 @@ class PackageRecord:
                 src = obj
             elif isinstance(obj, Dumpable):
                 src = obj.dump()
+            elif is_dataclass(obj):
+                src = {f.name: getattr(obj, f.name) for f in fields(obj)}
             elif hasattr(obj, "__dict__"):
                 src = obj.__dict__
-            elif hasattr(obj, "__slots__"):
-                src = {
-                    s: getattr(obj, s)
-                    for s in obj.__slots__
-                    if hasattr(obj, s) and not s.startswith("_")
-                }
             else:
-                continue
+                src = {
+                    name: getattr(obj, name)
+                    for name in known | cls.ALIASES.keys()
+                    if hasattr(obj, name)
+                }
             for k, v in src.items():
                 target = cls.ALIASES.get(k, k) if k not in known else k
                 if target in known and target not in kwargs and v is not None:
@@ -580,7 +698,7 @@ class PackageRecord:
             "version": self.version,
         }
 
-    def to_match_spec(self):
+    def to_match_spec(self) -> MatchSpec:
         from .match_spec import MatchSpec
 
         return MatchSpec(
@@ -591,7 +709,7 @@ class PackageRecord:
             build=self.build,
         )
 
-    def to_simple_match_spec(self):
+    def to_simple_match_spec(self) -> MatchSpec:
         from .match_spec import MatchSpec
 
         return MatchSpec(name=self.name, version=self.version)
@@ -616,13 +734,17 @@ class PackageRecord:
 
     @property
     def spec(self) -> str:
+        """Return package spec as ``name=version=build``."""
         return f"{self.name}={self.version}={self.build}"
 
     @property
     def spec_no_build(self) -> str:
+        """Return package spec as ``name=version``."""
         return f"{self.name}={self.version}"
 
     def record_id(self) -> str:
+        # Used only by link.py's change report. This is not an official record
+        # identifier until it gains a namespace and a stable format.
         ch = self.channel
         ch_name = getattr(ch, "name", "") if ch else ""
         return f"{ch_name}/{self.subdir}::{self.name}-{self.version}-{self.build}"
@@ -679,9 +801,16 @@ class PackageRecord:
 
 @dataclass(slots=True, init=False, eq=False, repr=False)
 class PackageCacheRecord(PackageRecord):
-    """Representation of a package in the local package cache."""
+    """Representation of a package in the local package cache.
 
+    This specialization adds the local archive and extracted-directory paths.
+    It does not add fields to :attr:`PackageRecord._pkey`, so equal package and
+    prefix records continue to compare equal and produce the same hash.
+    """
+
+    # Full path to the local package archive.
     package_tarball_full_path: str = ""
+    # Full path to the local extracted package directory.
     extracted_package_dir: str = ""
     _memoized_md5: str | None = field(
         default=None, repr=False, compare=False, init=False
@@ -689,12 +818,14 @@ class PackageCacheRecord(PackageRecord):
 
     @property
     def is_fetched(self) -> bool:
+        """Whether the package archive exists locally."""
         from ..gateways.disk.read import isfile
 
         return isfile(self.package_tarball_full_path)
 
     @property
     def is_extracted(self) -> bool:
+        """Whether the package has been extracted locally."""
         from ..gateways.disk.read import isdir, isfile
 
         epd = self.extracted_package_dir
@@ -702,6 +833,7 @@ class PackageCacheRecord(PackageRecord):
 
     @property
     def tarball_basename(self) -> str:
+        """The basename of the local package archive."""
         return Path(self.package_tarball_full_path).name
 
     def matches_metadata(self, package_ref: PackageRecord | MatchSpec) -> bool:
@@ -722,12 +854,7 @@ class PackageCacheRecord(PackageRecord):
         return True
 
     def calculate_md5sum(self) -> str | None:
-        # ``_memoized_md5`` is a slot but is not populated by PackageRecord's
-        # __init__ (it's listed in CACHE_FIELDS which skips initialization),
-        # so on a freshly-constructed PackageCacheRecord the slot read would
-        # raise AttributeError. Use getattr with a default to keep the slow
-        # path reachable on first call.
-        memoized = getattr(self, "_memoized_md5", None)
+        memoized = self._memoized_md5
         if memoized:
             return memoized
         if Path(self.package_tarball_full_path).is_file():
@@ -763,8 +890,8 @@ def _make_md5_auto_compute_property() -> property:
         auto = self.calculate_md5sum()
         if auto is not None:
             deprecated.topic(
-                "26.9",
                 "27.3",
+                "27.9",
                 topic="Implicit md5 auto-compute on PackageCacheRecord.md5",
                 addendum="Call PackageCacheRecord.calculate_md5sum() explicitly instead.",
             )
@@ -781,18 +908,30 @@ PackageCacheRecord.md5 = _make_md5_auto_compute_property()
 
 @dataclass(slots=True, init=False, eq=False, repr=False)
 class SolvedRecord(PackageRecord):
-    """Representation of a package returned as part of a solver solution."""
+    """Representation of a package returned as part of a solver solution.
+
+    This sits between :class:`PackageRecord` and :class:`PrefixRecord`, adding
+    the requested specs used by lockfiles without requiring an artifact on disk.
+    """
 
     ALIASES: ClassVar[dict[str, str]] = {
         **PackageRecord.ALIASES,
         "requested_specs": "_requested_specs",
     }
 
+    FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
+        **PackageRecord.FIELD_RESOLVERS,
+        "_requested_specs": resolve_optional_tuple,
+    }
+
+    # The MatchSpec explicitly requested by the user, if any.
     requested_spec: str | None = None
+    # All MatchSpecs explicitly requested by the user, if available.
     _requested_specs: tuple[str, ...] | None = None
 
     @property
     def requested_specs(self) -> tuple[str, ...]:
+        """Return plural requested specs, falling back to ``requested_spec``."""
         val = self._requested_specs
         if val:
             return tuple(val)
@@ -802,9 +941,10 @@ class SolvedRecord(PackageRecord):
         return ()
 
     def dump(self) -> dict[str, Any]:
+        """Expose requested specs under their public plural field name."""
         dumped = PackageRecord.dump(self)
         if dumped.get("_requested_specs"):
-            dumped["requested_specs"] = dumped.pop("_requested_specs")
+            dumped["requested_specs"] = list(dumped.pop("_requested_specs"))
         elif spec := dumped.get("requested_spec"):
             dumped["requested_specs"] = [spec]
         return dumped
@@ -812,15 +952,22 @@ class SolvedRecord(PackageRecord):
 
 @dataclass(slots=True, init=False, eq=False, repr=False)
 class PrefixRecord(SolvedRecord):
-    """Representation of a package installed in a local conda environment."""
+    """Representation of a package installed in a local conda environment.
+
+    This specialization adds paths, link information, and local cache paths.
+    It does not add fields to :attr:`PackageRecord._pkey`. Instances are
+    generally loaded from JSON files in ``$prefix/conda-meta``.
+    """
 
     FIELD_RESOLVERS: ClassVar[dict[str, Callable]] = {
-        **PackageRecord.FIELD_RESOLVERS,
+        **SolvedRecord.FIELD_RESOLVERS,
         "paths_data": resolve_paths_data,
     }
 
+    # Local cache paths, if known.
     package_tarball_full_path: str = ""
     extracted_package_dir: str = ""
+    # Files and detailed path/link metadata recorded for the installation.
     files: tuple[str, ...] = ()
     paths_data: Any = None
     link: Any = None
@@ -885,8 +1032,8 @@ for _name in (
     "Md5Field",
 ):
     deprecated.constant(
-        "26.9",
         "27.3",
+        "27.9",
         _name,
         factory=partial(_legacy_field, _name),
         addendum=(

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -166,7 +166,7 @@ def _export_subdir_data_to_repodata(subdir_data: SubdirData):
     packages = {}
     packages_conda = {}
     for pkg in subdir_data.iter_records():
-        if pkg.timestamp:
+        if pkg.timestamp and hasattr(pkg, "__fields__"):
             # ensure timestamp is dumped as int in milliseconds
             # (pkg.timestamp is a kept as a float in seconds)
             pkg.__fields__["timestamp"]._in_dump = True

--- a/conda/testing/solver_helpers.py
+++ b/conda/testing/solver_helpers.py
@@ -119,8 +119,8 @@ class SimpleEnvironment:
         """Turn record into data, to be written in the JSON environment/repo files."""
         data = {
             key: (",".join(value) if key in ("features", "track_features") else value)
-            for key, value in vars(record).items()
-            if key in self.REPO_DATA_KEYS
+            for key in self.REPO_DATA_KEYS
+            if (value := getattr(record, key, None)) is not None
         }
         if "subdir" not in data:
             data["subdir"] = context.subdir

--- a/news/15867-dataclass-records
+++ b/news/15867-dataclass-records
@@ -1,0 +1,31 @@
+### Enhancements
+
+* Rewrite `PackageRecord`, `PackageCacheRecord`, `SolvedRecord`, and
+  `PrefixRecord` in `conda.models.records` as `@dataclass(slots=True)`
+  classes with the same public API. Per-record instantiation is ~3× faster,
+  `dump()` serialisation is ~5× faster, and memory footprint drops by
+  26–39% depending on string duplication; at 50,000 records that's
+  ~15 MiB saved. (#15867)
+* Unify the old `COERCIONS` / `DERIVED` / `resolve_*` coercion-and-derivation
+  logic under a single `FIELD_RESOLVERS` ClassVar registry on each record
+  class. (#15867)
+
+### Deprecations
+
+* Deprecate the record-specific `auxlib.Entity` field descriptors re-exported
+  from `conda.models.records`: `SubdirField`, `ChannelField`, `FilenameField`,
+  `NoarchField`, `TimestampField`, `PackageTypeField`, `_FeaturesField`, and
+  `Md5Field`. They remain importable one release cycle via a lazy shim;
+  record classes themselves now use plain dataclass fields. (#15867)
+* Deprecate implicit md5 auto-compute on `PackageCacheRecord.md5`. The old
+  `Md5Field` descriptor hashed the tarball on attribute read when the field
+  was unset; the dataclass shim preserves that behaviour for one release
+  cycle with a `DeprecationWarning`. Call
+  `PackageCacheRecord.calculate_md5sum()` explicitly instead. (#15867)
+
+### Other
+
+* `PrefixRecord.extracted_package_dir` now defaults to `""` (matching the
+  original `StringField(required=False)` semantics) rather than `None`,
+  keeping `basename(extracted_package_dir)` callable on unpopulated records.
+  (#15867)

--- a/news/15867-dataclass-records
+++ b/news/15867-dataclass-records
@@ -5,10 +5,10 @@
   classes with the same public API. Per-record instantiation is ~3× faster,
   `dump()` serialisation is ~5× faster, and memory footprint drops by
   26–39% depending on string duplication; at 50,000 records that's
-  ~15 MiB saved. (#15867)
+  ~15 MiB saved. (#15867 via #15916)
 * Unify the old `COERCIONS` / `DERIVED` / `resolve_*` coercion-and-derivation
   logic under a single `FIELD_RESOLVERS` ClassVar registry on each record
-  class. (#15867)
+  class. (#15867 via #15916)
 
 ### Deprecations
 
@@ -16,16 +16,16 @@
   from `conda.models.records`: `SubdirField`, `ChannelField`, `FilenameField`,
   `NoarchField`, `TimestampField`, `PackageTypeField`, `_FeaturesField`, and
   `Md5Field`. They remain importable one release cycle via a lazy shim;
-  record classes themselves now use plain dataclass fields. (#15867)
+  record classes themselves now use plain dataclass fields. (#15867 via #15916)
 * Deprecate implicit md5 auto-compute on `PackageCacheRecord.md5`. The old
   `Md5Field` descriptor hashed the tarball on attribute read when the field
   was unset; the dataclass shim preserves that behaviour for one release
   cycle with a `DeprecationWarning`. Call
-  `PackageCacheRecord.calculate_md5sum()` explicitly instead. (#15867)
+  `PackageCacheRecord.calculate_md5sum()` explicitly instead. (#15867 via #15916)
 
 ### Other
 
 * `PrefixRecord.extracted_package_dir` now defaults to `""` (matching the
   original `StringField(required=False)` semantics) rather than `None`,
   keeping `basename(extracted_package_dir)` callable on unpopulated records.
-  (#15867)
+  (#15867 via #15916)

--- a/releases/news/15867-dataclass-records
+++ b/releases/news/15867-dataclass-records
@@ -1,0 +1,31 @@
+### Enhancements
+
+* Rewrite `PackageRecord`, `PackageCacheRecord`, `SolvedRecord`, and
+  `PrefixRecord` in `conda.models.records` as `@dataclass(slots=True)`
+  classes with the same public API. Per-record instantiation is ~3× faster,
+  `dump()` serialisation is ~5× faster, and memory footprint drops by
+  26–39% depending on string duplication; at 50,000 records that's
+  ~15 MiB saved. (#15867)
+* Unify the old `COERCIONS` / `DERIVED` / `resolve_*` coercion-and-derivation
+  logic under a single `FIELD_RESOLVERS` ClassVar registry on each record
+  class. (#15867)
+
+### Deprecations
+
+* Deprecate the record-specific `auxlib.Entity` field descriptors re-exported
+  from `conda.models.records`: `SubdirField`, `ChannelField`, `FilenameField`,
+  `NoarchField`, `TimestampField`, `PackageTypeField`, `_FeaturesField`, and
+  `Md5Field`. They remain importable one release cycle via a lazy shim;
+  record classes themselves now use plain dataclass fields. (#15867)
+* Deprecate implicit md5 auto-compute on `PackageCacheRecord.md5`. The old
+  `Md5Field` descriptor hashed the tarball on attribute read when the field
+  was unset; the dataclass shim preserves that behaviour for one release
+  cycle with a `DeprecationWarning`. Call
+  `PackageCacheRecord.calculate_md5sum()` explicitly instead. (#15867)
+
+### Other
+
+* `PrefixRecord.extracted_package_dir` now defaults to `""` (matching the
+  original `StringField(required=False)` semantics) rather than `None`,
+  keeping `basename(extracted_package_dir)` callable on unpopulated records.
+  (#15867)

--- a/releases/news/15867-dataclass-records
+++ b/releases/news/15867-dataclass-records
@@ -5,10 +5,10 @@
   classes with the same public API. Per-record instantiation is ~3× faster,
   `dump()` serialisation is ~5× faster, and memory footprint drops by
   26–39% depending on string duplication; at 50,000 records that's
-  ~15 MiB saved. (#15867)
+  ~15 MiB saved. (#15867 via #15916)
 * Unify the old `COERCIONS` / `DERIVED` / `resolve_*` coercion-and-derivation
   logic under a single `FIELD_RESOLVERS` ClassVar registry on each record
-  class. (#15867)
+  class. (#15867 via #15916)
 
 ### Deprecations
 
@@ -16,16 +16,16 @@
   from `conda.models.records`: `SubdirField`, `ChannelField`, `FilenameField`,
   `NoarchField`, `TimestampField`, `PackageTypeField`, `_FeaturesField`, and
   `Md5Field`. They remain importable one release cycle via a lazy shim;
-  record classes themselves now use plain dataclass fields. (#15867)
+  record classes themselves now use plain dataclass fields. (#15867 via #15916)
 * Deprecate implicit md5 auto-compute on `PackageCacheRecord.md5`. The old
   `Md5Field` descriptor hashed the tarball on attribute read when the field
   was unset; the dataclass shim preserves that behaviour for one release
   cycle with a `DeprecationWarning`. Call
-  `PackageCacheRecord.calculate_md5sum()` explicitly instead. (#15867)
+  `PackageCacheRecord.calculate_md5sum()` explicitly instead. (#15867 via #15916)
 
 ### Other
 
 * `PrefixRecord.extracted_package_dir` now defaults to `""` (matching the
   original `StringField(required=False)` semantics) rather than `None`,
   keeping `basename(extracted_package_dir)` callable on unpopulated records.
-  (#15867)
+  (#15867 via #15916)

--- a/releases/news/15867-dataclass-records
+++ b/releases/news/15867-dataclass-records
@@ -4,27 +4,21 @@
   `PrefixRecord` in `conda.models.records` as `@dataclass(slots=True)`
   classes to reduce per-record construction and serialisation overhead.
   (#15867 via #15916)
-* Unify the old `COERCIONS` / `DERIVED` / `resolve_*` coercion-and-derivation
-  logic under a single `FIELD_RESOLVERS` ClassVar registry on each record
-  class. (#15867 via #15916)
-
 ### Deprecations
 
-* Deprecate the record-specific `auxlib.Entity` field descriptors re-exported
+* Mark the record-specific `auxlib.Entity` field descriptors re-exported
   from `conda.models.records`: `SubdirField`, `ChannelField`, `FilenameField`,
   `NoarchField`, `TimestampField`, `IndexedTimestampField`, `PackageTypeField`,
-  `_FeaturesField`, and `Md5Field`. They remain importable one release cycle
-  via a lazy shim; record classes themselves now use plain dataclass fields.
-  (#15867 via #15916)
-* Deprecate implicit md5 auto-compute on `PackageCacheRecord.md5`. The old
-  `Md5Field` descriptor hashed the tarball on attribute read when the field
-  was unset; the dataclass shim preserves that behaviour for one release
-  cycle with a `DeprecationWarning`. Call
+  `_FeaturesField`, and `Md5Field` as pending deprecation, to be removed in
+  27.9. Vendor the descriptors in downstream `Entity` subclasses if they are
+  still needed. (#15867 via #15916)
+* Mark implicit md5 auto-computation on `PackageCacheRecord.md5` as pending
+  deprecation, to be removed in 27.9. Call
   `PackageCacheRecord.calculate_md5sum()` explicitly instead. (#15867 via #15916)
 
 ### Other
 
-* `PrefixRecord.extracted_package_dir` now defaults to `""` (matching the
+* Keep `PrefixRecord.extracted_package_dir` defaulting to `""` (matching the
   original `StringField(required=False)` semantics) rather than `None`,
   keeping `basename(extracted_package_dir)` callable on unpopulated records.
   (#15867 via #15916)

--- a/releases/news/15867-dataclass-records
+++ b/releases/news/15867-dataclass-records
@@ -14,9 +14,10 @@
 
 * Deprecate the record-specific `auxlib.Entity` field descriptors re-exported
   from `conda.models.records`: `SubdirField`, `ChannelField`, `FilenameField`,
-  `NoarchField`, `TimestampField`, `PackageTypeField`, `_FeaturesField`, and
-  `Md5Field`. They remain importable one release cycle via a lazy shim;
-  record classes themselves now use plain dataclass fields. (#15867 via #15916)
+  `NoarchField`, `TimestampField`, `IndexedTimestampField`, `PackageTypeField`,
+  `_FeaturesField`, and `Md5Field`. They remain importable one release cycle
+  via a lazy shim; record classes themselves now use plain dataclass fields.
+  (#15867 via #15916)
 * Deprecate implicit md5 auto-compute on `PackageCacheRecord.md5`. The old
   `Md5Field` descriptor hashed the tarball on attribute read when the field
   was unset; the dataclass shim preserves that behaviour for one release

--- a/releases/news/15867-dataclass-records
+++ b/releases/news/15867-dataclass-records
@@ -2,10 +2,8 @@
 
 * Rewrite `PackageRecord`, `PackageCacheRecord`, `SolvedRecord`, and
   `PrefixRecord` in `conda.models.records` as `@dataclass(slots=True)`
-  classes with the same public API. Per-record instantiation is ~3× faster,
-  `dump()` serialisation is ~5× faster, and memory footprint drops by
-  26–39% depending on string duplication; at 50,000 records that's
-  ~15 MiB saved. (#15867 via #15916)
+  classes to reduce per-record construction and serialisation overhead.
+  (#15867 via #15916)
 * Unify the old `COERCIONS` / `DERIVED` / `resolve_*` coercion-and-derivation
   logic under a single `FIELD_RESOLVERS` ClassVar registry on each record
   class. (#15867 via #15916)

--- a/releases/qa/15867-dataclass-records
+++ b/releases/qa/15867-dataclass-records
@@ -1,0 +1,42 @@
+### Title
+Load, copy, and clean installed package records
+
+### Why
+Package records now use slotted dataclasses. Loading installed metadata and
+combining channel metadata with cached records must preserve package identity,
+link information, and empty field values.
+
+### Platforms
+- [x] Windows
+- [x] macOS
+- [x] Linux
+
+### Prerequisites
+A conda build containing this change, access to conda-forge, and an empty
+temporary directory. Set `CONDA_PKGS_DIRS` to a new directory inside that
+temporary directory so cleanup uses a disposable package cache.
+
+### Steps
+1. Create an environment at a new temporary prefix with
+   `conda create --prefix <test-prefix> --override-channels -c conda-forge zlib`.
+2. Run `conda list --prefix <test-prefix> --json` and
+   `conda list --prefix <test-prefix> --explicit`. Save both outputs.
+3. Run `conda clean --packages --dry-run --json`, then
+   `conda clean --all --dry-run --json`.
+4. Run `conda update --prefix <test-prefix> --all --solver classic
+   --override-channels -c conda-forge --dry-run`.
+5. Repeat both `conda list` commands and compare their outputs with step 2.
+
+### Pass criteria
+Every command succeeds without record attribute errors. Cleanup and solving
+accept the installed and cached metadata. The dry runs leave the installed
+packages unchanged, including the names, versions, builds, and explicit URLs.
+
+### Out of scope / notes
+The automated `test_get_softlinked_package_dirs` test covers installed link
+metadata without a link type. The
+`test_reduced_index_preserves_channel_metadata_for_cached_track_features`
+test covers empty channel metadata taking precedence over stale cache values.
+The record tests cover link conversion on assignment and construction, along
+with copying empty features and flags and zero timestamps. Performance
+measurements are separate from this functional scenario.

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -292,7 +292,7 @@ def test_get_entry_to_link_prefers_matching_target_prefix_device(
             )
         )
 
-    calculate_md5sum = mocker.spy(PackageCacheRecord, "_calculate_md5sum")
+    calculate_md5sum = mocker.spy(PackageCacheRecord, "calculate_md5sum")
     mocker.patch.object(
         PackageCacheData,
         "query_all",

--- a/tests/models/test_records.py
+++ b/tests/models/test_records.py
@@ -1,18 +1,47 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+"""Tests for conda.models.records."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from conda.base.context import context
 from conda.core.prefix_data import PrefixData
 from conda.models.channel import Channel
-from conda.models.enums import PackageType
+from conda.models.enums import NoarchType, PackageType
 from conda.models.match_spec import MatchSpec
-from conda.models.records import PackageRecord, PrefixRecord
+from conda.models.records import (
+    PackageCacheRecord,
+    PackageRecord,
+    PrefixRecord,
+    SolvedRecord,
+)
 
-blas_value = "accelerate" if context.subdir == "osx-64" else "openblas"
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
 
 
-def test_prefix_record_no_channel():
+COMMON_KWARGS: dict[str, Any] = dict(
+    name="numpy",
+    version="1.21.0",
+    build="py39h_0",
+    build_number=0,
+    channel="conda-forge",
+    subdir="linux-64",
+    fn="numpy-1.21.0-py39h_0.conda",
+)
+
+
+@pytest.fixture()
+def dc_record() -> PackageRecord:
+    return PackageRecord(**COMMON_KWARGS)
+
+
+def test_prefix_record_no_channel() -> None:
     pr = PrefixRecord(
         name="austin",
         version="1.2.3",
@@ -52,8 +81,7 @@ def test_prefix_record_no_channel():
     )
 
 
-def test_package_record_timestamp():
-    # regression test for #6096
+def test_timestamp_seconds() -> None:
     ts_secs = 1507565728
     ts_millis = ts_secs * 1000
     rec = PackageRecord(
@@ -66,6 +94,8 @@ def test_package_record_timestamp():
     assert rec.timestamp == ts_secs
     assert rec.dump()["timestamp"] == ts_millis
 
+
+def test_timestamp_milliseconds() -> None:
     ts_millis = 1507565728999
     ts_secs = ts_millis / 1000
     rec = PackageRecord(
@@ -79,24 +109,23 @@ def test_package_record_timestamp():
     assert rec.dump()["timestamp"] == ts_millis
 
 
-def test_package_record_feature():
+def test_feature_factory() -> None:
     feature_name = "test_feature_name"
     package_name = f"{feature_name}@"
     feature_record = PackageRecord.feature(feature_name)
     md5 = "12345678901234567890123456789012"
-    track_features = (feature_name,)
-    reference_package = PackageRecord(
+    reference = PackageRecord(
         name=package_name,
         version="0",
         build="0",
         channel="@",
         subdir=context.subdir,
         md5=md5,
-        track_features=track_features,
+        track_features=(feature_name,),
         build_number=0,
         fn=package_name,
     )
-    assert feature_record == reference_package
+    assert feature_record == reference
     assert feature_record.md5 == md5
     assert feature_record.track_features == (feature_name,)
 
@@ -109,13 +138,13 @@ def test_package_record_feature():
         ("123", "testbuild"),
     ],
 )
-def test_package_virtual_package(version, build_string):
+def test_virtual_package(version: str | None, build_string: str | None) -> None:
     name = "test_vpkg_name"
     effective_version = version or "0"
     effective_build_string = build_string or "0"
-    vpkg_record = PackageRecord.virtual_package(name, version, build_string)
+    vpkg = PackageRecord.virtual_package(name, version, build_string)
     md5 = "12345678901234567890123456789012"
-    reference_package = PackageRecord(
+    reference = PackageRecord(
         package_type=PackageType.VIRTUAL_SYSTEM,
         name=name,
         version=effective_version,
@@ -126,17 +155,15 @@ def test_package_virtual_package(version, build_string):
         build_number=0,
         fn=name,
     )
-    assert vpkg_record == reference_package
-    assert vpkg_record.package_type == PackageType.VIRTUAL_SYSTEM
-    assert vpkg_record.md5 == md5
+    assert vpkg == reference
+    assert vpkg.effective_package_type() == PackageType.VIRTUAL_SYSTEM
+    assert vpkg.md5 == md5
 
 
 @pytest.mark.parametrize(
-    "name,version,build,expected_exact,expected_version",
+    "name,version,build,expected_spec,expected_no_build",
     [
-        # Basic case
         ("numpy", "1.21.0", "py39h_0", "numpy=1.21.0=py39h_0", "numpy=1.21.0"),
-        # Special characters in name, version, and build
         (
             "my-package",
             "2.1.0-alpha",
@@ -144,7 +171,6 @@ def test_package_virtual_package(version, build_string):
             "my-package=2.1.0-alpha=py38_custom.build",
             "my-package=2.1.0-alpha",
         ),
-        # Underscores and numbers
         (
             "scipy_special",
             "1.7.0",
@@ -152,7 +178,6 @@ def test_package_virtual_package(version, build_string):
             "scipy_special=1.7.0=py39_1",
             "scipy_special=1.7.0",
         ),
-        # Complex build strings
         (
             "tensorflow",
             "2.8.0",
@@ -162,10 +187,13 @@ def test_package_virtual_package(version, build_string):
         ),
     ],
 )
-def test_package_record_spec_strings(
-    name, version, build, expected_exact, expected_version
-):
-    """Test the spec and spec_no_build properties of PackageRecord."""
+def test_spec_strings(
+    name: str,
+    version: str,
+    build: str,
+    expected_spec: str,
+    expected_no_build: str,
+) -> None:
     rec = PackageRecord(
         name=name,
         version=version,
@@ -175,16 +203,11 @@ def test_package_record_spec_strings(
         subdir="linux-64",
         fn=f"{name}-{version}-{build}.conda",
     )
-
-    # Test spec property (includes build string)
-    assert rec.spec == expected_exact
-
-    # Test spec_no_build property (excludes build string)
-    assert rec.spec_no_build == expected_version
+    assert rec.spec == expected_spec
+    assert rec.spec_no_build == expected_no_build
 
 
-def test_package_record_spec_strings_vs_str():
-    """Test the spec and spec_no_build properties of PackageRecord."""
+def test_spec_strings_vs_str() -> None:
     rec = PackageRecord(
         name="scipy",
         version="1.7.0",
@@ -194,17 +217,10 @@ def test_package_record_spec_strings_vs_str():
         subdir="osx-64",
         fn="scipy-1.7.0-py39_1.conda",
     )
-
-    # The properties should not include channel/subdir information
-    assert rec.spec == "scipy=1.7.0=py39_1"  # Full spec (single equals)
-    assert rec.spec_no_build == "scipy=1.7.0"  # No build spec (single equals)
-
-    # The __str__ method includes channel/subdir information
+    assert rec.spec == "scipy=1.7.0=py39_1"
+    assert rec.spec_no_build == "scipy=1.7.0"
     assert str(rec) == "conda-forge/osx-64::scipy==1.7.0=py39_1"
-
-    # Verify they are different
     assert rec.spec != str(rec)
-    assert rec.spec_no_build != str(rec)
 
 
 @pytest.mark.parametrize(
@@ -221,8 +237,10 @@ def test_package_record_spec_strings_vs_str():
         ),
     ],
 )
-def test_record_spec_strings_inheritance(record_class, extra_kwargs):
-    """Test that both PackageRecord and PrefixRecord have spec string properties."""
+def test_spec_strings_inheritance(
+    record_class: type[PackageRecord],
+    extra_kwargs: dict[str, Any],
+) -> None:
     rec = record_class(
         name="requests",
         version="2.25.1",
@@ -233,14 +251,251 @@ def test_record_spec_strings_inheritance(record_class, extra_kwargs):
         fn="requests-2.25.1-pyhd3eb1b0_0.conda",
         **extra_kwargs,
     )
-
-    # Both record types should have the spec string properties
     assert rec.spec == "requests=2.25.1=pyhd3eb1b0_0"
     assert rec.spec_no_build == "requests=2.25.1"
 
-    # Verify that the properties exist (important for environment export)
-    assert hasattr(rec, "spec")
-    assert hasattr(rec, "spec_no_build")
+
+def test_cross_subclass_equality() -> None:
+    kwargs: dict[str, Any] = dict(
+        name="x",
+        version="1",
+        build="0",
+        build_number=0,
+        channel="@",
+        subdir="linux-64",
+    )
+    pr = PackageRecord(**kwargs)
+    sr = SolvedRecord(**kwargs)
+    pfx = PrefixRecord(**kwargs)
+    assert pr == sr == pfx
+    assert hash(pr) == hash(sr) == hash(pfx)
+    assert sr in {pr}
+    assert pfx in {pr, sr}
+
+
+def test_invalidate_pkey() -> None:
+    rec = PackageRecord(
+        name="a",
+        version="1",
+        build="0",
+        build_number=0,
+        channel="@",
+        subdir="linux-64",
+    )
+    h1 = hash(rec)
+    rec.invalidate_pkey()
+    object.__setattr__(rec, "channel", Channel("conda-forge"))
+    assert hash(rec) != h1
+
+
+def test_from_objects_dict() -> None:
+    src: dict[str, Any] = {
+        "name": "foo",
+        "version": "1.0",
+        "build": "py39",
+        "build_number": 0,
+        "channel": "defaults",
+        "subdir": "linux-64",
+    }
+    rec = PackageRecord.from_objects(src)
+    assert rec.name == "foo"
+    assert rec.channel.canonical_name == Channel("defaults").canonical_name
+
+
+def test_from_objects_entity() -> None:
+    entity = PackageRecord(**COMMON_KWARGS)
+    dc = PackageRecord.from_objects(entity)
+    assert dc.name == entity.name
+    assert dc._pkey == entity._pkey
+
+
+def test_from_json() -> None:
+    import json
+
+    data: dict[str, Any] = {
+        "name": "test",
+        "version": "1",
+        "build": "0",
+        "build_number": 0,
+        "channel": "@",
+        "subdir": "linux-64",
+    }
+    rec = PackageRecord.from_json(json.dumps(data))
+    assert rec.name == "test"
+
+
+@pytest.mark.parametrize(
+    "cls,extra_kwargs",
+    [
+        (PackageRecord, {}),
+        (SolvedRecord, {"requested_spec": "numpy>=1.20"}),
+        (PrefixRecord, {"files": ["lib/foo.py"], "md5": "abc123"}),
+    ],
+)
+def test_round_trip(cls: type[PackageRecord], extra_kwargs: dict[str, Any]) -> None:
+    kwargs: dict[str, Any] = {**COMMON_KWARGS, **extra_kwargs}
+    rec = cls(**kwargs)
+    dumped = rec.dump()
+    rec2 = cls(**dumped)
+    assert dict(rec2.dump()) == dict(dumped)
+
+
+def test_alias_build_string() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build_string="py39",
+        build_number=0,
+    )
+    assert rec.build == "py39"
+
+
+def test_alias_schannel() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        schannel="conda-forge",
+    )
+    assert isinstance(rec.channel, Channel)
+
+
+def test_alias_filename() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        filename="test-1-0.conda",
+    )
+    assert rec.fn == "test-1-0.conda"
+
+
+def test_noarch_coercion() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        noarch="python",
+    )
+    assert rec.noarch == NoarchType.python
+
+
+def test_features_coercion_from_string() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        track_features="feat1 feat2",
+    )
+    assert rec.track_features == ("feat1", "feat2")
+
+
+def test_features_coercion_from_list() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        track_features=["feat1", "feat2"],
+    )
+    assert rec.track_features == ("feat1", "feat2")
+
+
+def test_depends_as_tuple() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        depends=["python >=3.9", "numpy"],
+    )
+    assert isinstance(rec.depends, tuple)
+    assert rec.depends == ("python >=3.9", "numpy")
+
+
+def test_channel_derived_from_url() -> None:
+    rec = PackageRecord(
+        name="austin",
+        version="1.2.3",
+        build="py34_2",
+        build_number=2,
+        url="https://repo.anaconda.com/pkgs/main/win-32/austin-1.2.3-py34_2.tar.bz2",
+    )
+    assert rec.channel is not None
+    assert rec.channel.canonical_name == "defaults"
+    assert rec.fn == "austin-1.2.3-py34_2.tar.bz2"
+
+
+def test_subdir_derived_from_url() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        url="https://repo.anaconda.com/pkgs/main/win-32/t-1-0.tar.bz2",
+    )
+    assert rec.subdir == "win-32"
+
+
+def test_effective_package_type_from_noarch() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        noarch="python",
+    )
+    assert rec.effective_package_type() == PackageType.NOARCH_PYTHON
+
+
+def test_get_method() -> None:
+    rec = PackageRecord(**COMMON_KWARGS)
+    assert rec.get("version") == "1.21.0"
+    assert rec.get("nonexistent", "default") == "default"
+    assert rec.get("md5") is None
+
+
+def test_solved_record_requested_specs() -> None:
+    srec = SolvedRecord(
+        name="n",
+        version="1",
+        build="0",
+        build_number=0,
+        requested_specs=["n>=1", "n"],
+    )
+    assert srec.requested_specs == ("n>=1", "n")
+    d = srec.dump()
+    assert "requested_specs" in d
+    assert d["requested_specs"] == ["n>=1", "n"]
+
+
+def test_solved_record_single_spec_fallback() -> None:
+    srec = SolvedRecord(
+        name="n",
+        version="1",
+        build="0",
+        build_number=0,
+        requested_spec="n>=1",
+    )
+    assert srec.requested_specs == ("n>=1",)
+    d = srec.dump()
+    assert d["requested_specs"] == ["n>=1"]
+
+
+def test_prefix_record_files_coercion() -> None:
+    prec = PrefixRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+        files=["lib/foo.py", "bin/bar"],
+    )
+    assert isinstance(prec.files, tuple)
+    assert prec.files == ("lib/foo.py", "bin/bar")
 
 
 @pytest.mark.integration
@@ -253,3 +508,95 @@ def test_requested_spec(tmp_env, test_recipes_channel):
         assert sorted(requested.requested_specs) == sorted(specs)
         assert not transitive.get("requested_spec")
         assert not transitive.get("requested_specs")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "NoarchField",
+        "TimestampField",
+        "_FeaturesField",
+        "ChannelField",
+        "SubdirField",
+        "FilenameField",
+        "PackageTypeField",
+        "Md5Field",
+    ],
+)
+def test_legacy_field_descriptors_are_deprecated(name: str) -> None:
+    """Legacy ``auxlib.Entity`` field descriptors are importable with a warning."""
+    import conda.models.records as records
+
+    with pytest.warns(PendingDeprecationWarning, match=name):
+        cls = getattr(records, name)
+    assert isinstance(cls, type)
+    assert cls.__module__ == "conda.models._legacy_record_fields"
+
+
+@pytest.fixture
+def pkg_tarball(tmp_path) -> Path:
+    """Write a deterministic tarball file and return its path."""
+    tarball = tmp_path / "pkg.tar.bz2"
+    tarball.write_bytes(b"hello world")
+    return tarball
+
+
+@pytest.fixture
+def cache_record_factory(pkg_tarball):
+    """Build :class:`PackageCacheRecord` instances backed by ``pkg_tarball``."""
+
+    def _make(**overrides) -> PackageCacheRecord:
+        fields = dict(
+            name="pkg",
+            version="1.0",
+            build="0",
+            build_number=0,
+            channel="@",
+            subdir="noarch",
+            package_tarball_full_path=str(pkg_tarball),
+        )
+        fields.update(overrides)
+        return PackageCacheRecord(**fields)
+
+    return _make
+
+
+def test_package_cache_record_md5_auto_compute_is_deprecated(
+    cache_record_factory,
+) -> None:
+    """Unset ``md5`` still returns the tarball hash but emits a deprecation."""
+    record = cache_record_factory()
+
+    with pytest.warns(PendingDeprecationWarning, match="calculate_md5sum"):
+        value = record.md5
+
+    assert value == "5eb63bbbe01eeed093cb22bb8f5acdc3"
+
+
+@pytest.mark.parametrize(
+    "initial, updated",
+    [
+        pytest.param("explicit", "new-value", id="preset-then-overwrite"),
+        pytest.param(None, "assigned", id="unset-then-assign"),
+    ],
+)
+def test_package_cache_record_md5_explicit_values_do_not_warn(
+    cache_record_factory,
+    recwarn,
+    initial: str | None,
+    updated: str,
+) -> None:
+    """Explicit md5 values short-circuit auto-compute and stay silent."""
+    kwargs = {"md5": initial} if initial is not None else {}
+    record = cache_record_factory(**kwargs)
+
+    if initial is not None:
+        assert record.md5 == initial
+
+    record.md5 = updated
+    assert record.md5 == updated
+    assert not [
+        w
+        for w in recwarn.list
+        if issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
+    ]

--- a/tests/models/test_records.py
+++ b/tests/models/test_records.py
@@ -314,6 +314,15 @@ def test_invalid_field_type_on_assignment(dc_record: PackageRecord) -> None:
         dc_record.build_number = "4040"
 
 
+def test_sequence_assignment_coercion(dc_record: PackageRecord) -> None:
+    dc_record.depends = ["python >=3.10"]
+
+    assert dc_record.depends == ("python >=3.10",)
+
+    with pytest.raises(ValidationError, match="Invalid value python for depends"):
+        dc_record.depends = "python"
+
+
 def test_timestamp_falls_back_to_date() -> None:
     rec = PackageRecord(
         name="test-package",

--- a/tests/models/test_records.py
+++ b/tests/models/test_records.py
@@ -4,10 +4,12 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
 
+from conda.auxlib.exceptions import ValidationError
 from conda.base.context import context
 from conda.core.prefix_data import PrefixData
 from conda.models.channel import Channel
@@ -273,7 +275,7 @@ def test_cross_subclass_equality() -> None:
     assert pfx in {pr, sr}
 
 
-def test_invalidate_pkey() -> None:
+def test_mutating_identity_field_invalidates_pkey() -> None:
     rec = PackageRecord(
         name="a",
         version="1",
@@ -283,9 +285,58 @@ def test_invalidate_pkey() -> None:
         subdir="linux-64",
     )
     h1 = hash(rec)
-    rec.invalidate_pkey()
-    object.__setattr__(rec, "channel", Channel("conda-forge"))
+    rec.channel = Channel("conda-forge")
     assert hash(rec) != h1
+
+
+@pytest.mark.parametrize("missing", ("name", "version", "build", "build_number"))
+def test_required_fields(missing: str) -> None:
+    kwargs = dict(COMMON_KWARGS)
+    kwargs.pop(missing)
+
+    with pytest.raises(ValidationError, match=rf"requires a {missing} field"):
+        PackageRecord(**kwargs)
+
+
+def test_unknown_fields_are_ignored() -> None:
+    rec = PackageRecord(**COMMON_KWARGS, unknown=True)
+
+    assert not hasattr(rec, "unknown")
+
+
+def test_invalid_field_type() -> None:
+    with pytest.raises(ValidationError, match="Invalid value 4040 for build_number"):
+        PackageRecord(**{**COMMON_KWARGS, "build_number": "4040"})
+
+
+def test_invalid_field_type_on_assignment(dc_record: PackageRecord) -> None:
+    with pytest.raises(ValidationError, match="Invalid value 4040 for build_number"):
+        dc_record.build_number = "4040"
+
+
+def test_timestamp_falls_back_to_date() -> None:
+    rec = PackageRecord(
+        name="test-package",
+        version="1.2.3",
+        build="2",
+        build_number=2,
+        date="1970-01-02T00:00:00",
+    )
+
+    assert rec.timestamp == 86400
+
+
+def test_explicit_timestamp_does_not_fall_back_to_date() -> None:
+    rec = PackageRecord(
+        name="test-package",
+        version="1.2.3",
+        build="2",
+        build_number=2,
+        timestamp=0,
+        date="1970-01-02T00:00:00",
+    )
+
+    assert rec.timestamp == 0
 
 
 def test_from_objects_dict() -> None:
@@ -307,6 +358,25 @@ def test_from_objects_entity() -> None:
     dc = PackageRecord.from_objects(entity)
     assert dc.name == entity.name
     assert dc._pkey == entity._pkey
+
+
+def test_from_objects_includes_inherited_dataclass_fields() -> None:
+    @dataclass(slots=True)
+    class BaseRecord:
+        name: str
+        version: str
+
+    @dataclass(slots=True)
+    class ChildRecord(BaseRecord):
+        build: str
+        build_number: int
+
+    rec = PackageRecord.from_objects(ChildRecord("name", "1", "0", 0))
+
+    assert rec.name == "name"
+    assert rec.version == "1"
+    assert rec.build == "0"
+    assert rec.build_number == 0
 
 
 def test_from_json() -> None:

--- a/tests/models/test_records.py
+++ b/tests/models/test_records.py
@@ -372,6 +372,17 @@ def test_alias_filename() -> None:
     assert rec.fn == "test-1-0.conda"
 
 
+def test_missing_channel_falls_back_to_unknown_channel() -> None:
+    rec = PackageRecord(
+        name="t",
+        version="1",
+        build="0",
+        build_number=0,
+    )
+    assert isinstance(rec.channel, Channel)
+    assert rec.channel.name == "<unknown>"
+
+
 def test_noarch_coercion() -> None:
     rec = PackageRecord(
         name="t",

--- a/tests/models/test_records.py
+++ b/tests/models/test_records.py
@@ -83,7 +83,8 @@ def test_prefix_record_no_channel() -> None:
     )
 
 
-def test_timestamp_seconds() -> None:
+@pytest.mark.parametrize("field_name", ("timestamp", "indexed_timestamp"))
+def test_timestamp_seconds(field_name: str) -> None:
     ts_secs = 1507565728
     ts_millis = ts_secs * 1000
     rec = PackageRecord(
@@ -91,13 +92,14 @@ def test_timestamp_seconds() -> None:
         version="1.2.3",
         build="2",
         build_number=2,
-        timestamp=ts_secs,
+        **{field_name: ts_secs},
     )
-    assert rec.timestamp == ts_secs
-    assert rec.dump()["timestamp"] == ts_millis
+    assert getattr(rec, field_name) == ts_secs
+    assert rec.dump()[field_name] == ts_millis
 
 
-def test_timestamp_milliseconds() -> None:
+@pytest.mark.parametrize("field_name", ("timestamp", "indexed_timestamp"))
+def test_timestamp_milliseconds(field_name: str) -> None:
     ts_millis = 1507565728999
     ts_secs = ts_millis / 1000
     rec = PackageRecord(
@@ -105,10 +107,10 @@ def test_timestamp_milliseconds() -> None:
         version="1.2.3",
         build="2",
         build_number=2,
-        timestamp=ts_secs,
+        **{field_name: ts_secs},
     )
-    assert rec.timestamp == ts_secs
-    assert rec.dump()["timestamp"] == ts_millis
+    assert getattr(rec, field_name) == ts_secs
+    assert rec.dump()[field_name] == ts_millis
 
 
 def test_feature_factory() -> None:
@@ -346,6 +348,13 @@ def test_explicit_timestamp_does_not_fall_back_to_date() -> None:
     )
 
     assert rec.timestamp == 0
+
+
+def test_indexed_timestamp_none_defaults_to_zero() -> None:
+    rec = PackageRecord(**COMMON_KWARGS, indexed_timestamp=None)
+
+    assert rec.indexed_timestamp == 0
+    assert "indexed_timestamp" not in rec.dump()
 
 
 def test_from_objects_dict() -> None:
@@ -605,6 +614,7 @@ def test_requested_spec(tmp_env, test_recipes_channel):
     [
         "NoarchField",
         "TimestampField",
+        "IndexedTimestampField",
         "_FeaturesField",
         "ChannelField",
         "SubdirField",

--- a/tests/models/test_records.py
+++ b/tests/models/test_records.py
@@ -13,9 +13,10 @@ from conda.auxlib.exceptions import ValidationError
 from conda.base.context import context
 from conda.core.prefix_data import PrefixData
 from conda.models.channel import Channel
-from conda.models.enums import NoarchType, PackageType
+from conda.models.enums import LinkType, NoarchType, PackageType
 from conda.models.match_spec import MatchSpec
 from conda.models.records import (
+    Link,
     PackageCacheRecord,
     PackageRecord,
     PrefixRecord,
@@ -378,6 +379,64 @@ def test_from_objects_entity() -> None:
     assert dc._pkey == entity._pkey
 
 
+@pytest.mark.parametrize(
+    "field_name,default,cached_value",
+    [
+        ("track_features", (), ("obsolete",)),
+        ("features", (), ("obsolete",)),
+        ("flags", (), ("obsolete",)),
+        ("timestamp", 0, 123),
+        ("indexed_timestamp", 0, 123),
+    ],
+)
+def test_from_objects_preserves_record_defaults(
+    field_name: str, default: Any, cached_value: Any
+) -> None:
+    channel_record = PackageRecord(**COMMON_KWARGS, **{field_name: default})
+    cache_record = PackageCacheRecord(**COMMON_KWARGS, **{field_name: cached_value})
+
+    merged = PackageCacheRecord.from_objects(channel_record, cache_record)
+
+    assert getattr(merged, field_name) == default
+    assert field_name not in merged.dump()
+
+
+def test_from_objects_does_not_copy_metadata() -> None:
+    record = PackageRecord(**COMMON_KWARGS, metadata={"transient"})
+
+    copied = PackageRecord.from_objects(record)
+
+    assert copied.metadata == set()
+    copied.metadata.add("new")
+    assert record.metadata == {"transient"}
+
+
+def test_from_objects_uses_cache_paths_when_prefix_paths_are_missing() -> None:
+    prefix_record = PrefixRecord(**COMMON_KWARGS)
+    cache_record = PackageCacheRecord(
+        **COMMON_KWARGS,
+        package_tarball_full_path="package-cache.conda",
+        extracted_package_dir="package-cache",
+    )
+
+    merged = PackageCacheRecord.from_objects(prefix_record, cache_record)
+
+    assert merged.package_tarball_full_path == "package-cache.conda"
+    assert merged.extracted_package_dir == "package-cache"
+
+
+@pytest.mark.parametrize("record_class", [SolvedRecord, PrefixRecord])
+def test_from_objects_preserves_requested_specs_precedence(
+    record_class: type[SolvedRecord],
+) -> None:
+    first = record_class(**COMMON_KWARGS, requested_spec="numpy>=1")
+    second = record_class(**COMMON_KWARGS, requested_specs=["numpy>=2"])
+
+    merged = record_class.from_objects(first, second)
+
+    assert merged.requested_specs == ("numpy>=1",)
+
+
 def test_from_objects_includes_inherited_dataclass_fields() -> None:
     @dataclass(slots=True)
     class BaseRecord:
@@ -595,6 +654,44 @@ def test_prefix_record_files_coercion() -> None:
     )
     assert isinstance(prec.files, tuple)
     assert prec.files == ("lib/foo.py", "bin/bar")
+
+
+@pytest.mark.parametrize("assign", [False, True], ids=["constructor", "assignment"])
+@pytest.mark.parametrize(
+    "link_data,expected_type",
+    [
+        ({"source": "package-cache"}, None),
+        ({"source": "package-cache", "type": 1}, LinkType.hardlink),
+        ({"source": "package-cache", "type": "soft"}, LinkType.softlink),
+    ],
+)
+def test_prefix_record_link_coercion(
+    link_data: dict[str, Any], expected_type: LinkType | None, assign: bool
+) -> None:
+    if assign:
+        record = PrefixRecord(**COMMON_KWARGS)
+        record.link = link_data
+    else:
+        record = PrefixRecord(**COMMON_KWARGS, link=link_data)
+
+    assert isinstance(record.link, Link)
+    assert record.link.source == "package-cache"
+    assert getattr(record.link, "type", None) == expected_type
+    expected_dump = {"source": "package-cache"}
+    if expected_type is not None:
+        expected_dump["type"] = expected_type.value
+    assert record.dump()["link"] == expected_dump
+
+
+@pytest.mark.parametrize(
+    "link", [None, Link(source="package-cache", type=LinkType.softlink)]
+)
+def test_prefix_record_preserves_link(link: Link | None) -> None:
+    record = PrefixRecord(**COMMON_KWARGS, link=link)
+    assert record.link is link
+
+    record.link = link
+    assert record.link is link
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Description

Replace the `auxlib.Entity` record hierarchy in `conda/models/records.py` with slotted dataclasses to reduce the cost of constructing and serializing package records. This covers `PackageRecord`, `PackageCacheRecord`, `SolvedRecord`, and `PrefixRecord`.

This is Track A, A19b, for #15867. Following @kenodegard's review, the Channel metaclass cleanup was split into #15942 (A19a) so the two changes could land independently. #15942 has since merged.

#### Changes

- Use `@dataclass(slots=True, init=False, eq=False, repr=False)` with a custom constructor and assignment handling for field coercion and validation.
- Combine the earlier `COERCIONS`, `DERIVED`, and `resolve_*` mechanisms and record field descriptors in a `FIELD_RESOLVERS` `ClassVar` registry. Each resolver receives `(value, instance)` and returns the coerced or derived value. This includes handling `subdir=None` correctly.
- Keep serialization conversions in a separate `DUMP_TRANSFORMS` `ClassVar` registry. A `Dumpable` protocol supports nested serialization.
- Preserve `_pkey`-based identity, hashing, and equality across record classes for solver compatibility. Intern `name`, `version`, `build`, and `subdir` strings with `sys.intern()` to share repeated values.
- Retain constructor aliases from `build_string` to `build`, `schannel` to `channel`, and `filename` to `fn`. Provide explicit `dump()`, `from_objects()`, `from_json()`, and `load()` methods, plus `__getitem__` and `get()` for dict-like attribute lookup. Keep the `set()` factory for `metadata`.
- Keep `Link`, `PathData`, `PathDataV1`, and `PathsData` on `auxlib.Entity`. These hold detailed installation metadata nested in `PrefixRecord` and are outside the record construction and serialization operations measured below.
- Convert dictionaries assigned to `PrefixRecord.link` into `Link` objects during construction and later assignment, so callers such as `conda clean` can read `link.source`.
- Preserve record field values in `from_objects()`, including empty `track_features`, `features`, and `flags`, and zero `timestamp` and `indexed_timestamp` values omitted by `dump()`. An explicit empty channel `track_features` value therefore takes precedence over stale cached features.
- Preserve `PackageCacheRecord.matches_metadata()` from #16347 so same-device package-cache selection continues comparing available `size` and `md5` values with requested package metadata, including legacy `.tar.bz2` metadata.
- Keep `PrefixRecord.extracted_package_dir` defaulting to `""`, matching the old `StringField(required=False)` behavior, so `link.py` can call `basename()` on an unpopulated value.
- Guard Entity-specific `__fields__` access in `conda/testing/helpers.py` for records that no longer expose that attribute.
- Use standard library features for the replacement implementation, including `functools.cache`, `pathlib.Path`, `typing.Protocol`, and f-strings, without adding dependencies.

#### Deprecations

The record-specific Entity field descriptors remain importable from `conda.models.records` during the deprecation period. They are pending deprecation, become deprecated in 27.3, and are scheduled for removal in 27.9. The original eight descriptors are `SubdirField`, `ChannelField`, `FilenameField`, `NoarchField`, `TimestampField`, `PackageTypeField`, `_FeaturesField`, and `Md5Field`. The current implementation also includes `IndexedTimestampField`, bringing the total to nine.

A lazy `deprecated.constant(factory=partial(_legacy_field, name))` shim loads these descriptors from `conda/models/_legacy_record_fields.py` on access. Record definitions no longer import that module or its dependencies eagerly. Timestamp parsing from `date` can still load `boltons.timeutils` when needed.

`PackageCacheRecord.md5` continues to compute a missing checksum on attribute access during the same deprecation period. The old `Md5Field` called `_calculate_md5sum()` when unset. Its replacement reads the inherited `md5` slot, calls `calculate_md5sum()` when needed, and uses `deprecated.topic("27.3", "27.9", ...)` to select the warning category for the running release. Callers can use `calculate_md5sum()` explicitly. Explicitly supplied or assigned checksums do not trigger automatic calculation or its warning.

The `md5` property is attached after the class definition because `@dataclass(slots=True)` removes class attributes whose names match inherited fields while preparing slots. `_make_md5_auto_compute_property()` keeps the getter and setter local to the factory while using the inherited slot for storage.

Deprecation coverage includes nine descriptor parameter cases, the implicit `md5` calculation case, and two explicit-value cases. The `pkg_tarball` and `cache_record_factory` fixtures share the tarball setup.

Package-cache selection coverage observes the public `calculate_md5sum()` method and verifies that missing requested `md5` metadata does not trigger checksum calculation.

#### Compatibility considerations

The record classes retain their named construction, serialization, identity, and lookup methods, but the public API is not identical to `auxlib.Entity`. In particular, record instances no longer have `__fields__` or an instance `__dict__`, and there is no explicit `__contains__` implementation.

Callers cannot attach arbitrary attributes or replace methods on individual instances of these slotted record classes. Downstream code, including libmamba-solver or anaconda-client, needs review if it uses patterns such as `record.some_custom_attr = ...`. A subclass without its own `__slots__` normally gains an instance `__dict__`, so the same restriction does not automatically apply to every subclass.

<details>
<summary>Historical performance and memory measurements</summary>

These are the measurements reported in the original PR description. They are retained as historical data and do not establish performance for the current revision.

**Per operation**

50,000 iterations with realistic 14-field repodata input, median of 5 rounds, Python 3.13 on macOS ARM64:

| Operation | Entity | Dataclass | Speedup |
| --- | --- | --- | --- |
| Instantiation | 26.3 µs | 8.1 µs | 3.2x |
| `dump()` serialization | 29.9 µs | 5.3 µs | 5.6x |

**At scale**

| Scenario | Entity | Dataclass | Saved |
| --- | --- | --- | --- |
| 2,000 records (`conda list`) init | 53 ms | 16 ms | -37 ms |
| 2,000 records (`conda list`) dump | 60 ms | 11 ms | -49 ms |
| 50,000 records (solver/repodata) init | 1,317 ms | 404 ms | -913 ms |
| 50,000 records (solver/repodata) dump | 1,495 ms | 264 ms | -1,231 ms |

**Memory, 50,000 records**

| Scenario | Entity | Dataclass | Saving |
| --- | --- | --- | --- |
| All unique names | 664 bytes/rec | 493 bytes/rec | 26% less |
| Realistic duplication (~5k packages, 3 channels) | 794 bytes/rec | 483 bytes/rec | 39% less |
| Realistic total | 38.8 MiB | 23.6 MiB | saves 15 MiB |

The original description also reported a CodSpeed `test_update[libmamba-update]` result of -28%, accompanied by a "Different runtime environments" warning. It noted the same -28% result on #15887 (A14), which did not change records. Those observations limit the comparison, but do not establish that the result was noise. The local record measurements above cover different operations and do not resolve that CI result.

</details>

### Checklist - did you ...

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes? (`releases/news/15867-dataclass-records`)
- [x] If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))? (`releases/qa/15867-dataclass-records`)
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? (No user-facing documentation changes.)
