### PR TITLE
Bump `setup-miniconda` to v4.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@bce0bd83659520ccaf4925e604d458d512f7df37 # v4.0.0
         with:
           condarc-file: .github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -262,7 +262,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@bce0bd83659520ccaf4925e604d458d512f7df37 # v4.0.0
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -363,7 +363,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@bce0bd83659520ccaf4925e604d458d512f7df37 # v4.0.0
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -432,7 +432,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@bce0bd83659520ccaf4925e604d458d512f7df37 # v4.0.0
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -584,7 +584,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@bce0bd83659520ccaf4925e604d458d512f7df37 # v4.0.0
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -678,7 +678,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@bce0bd83659520ccaf4925e604d458d512f7df37 # v4.0.0
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -846,7 +846,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@bce0bd83659520ccaf4925e604d458d512f7df37 # v4.0.0
         with:
           condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -262,7 +262,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -363,7 +363,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -432,7 +432,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -584,7 +584,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -678,7 +678,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -846,7 +846,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -262,7 +262,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -363,7 +363,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -432,7 +432,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -584,7 +584,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
@@ -678,7 +678,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: .github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
@@ -846,7 +846,7 @@ jobs:
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@a89f5d49e7a95ca6cffbca8032777572e8d748d7 # main (post-v3.3.0 perf improvements)
+        uses: conda-incubator/setup-miniconda@77236efeba76d591229f44c36f2469426cc33dec # main (post-v3.3.0 perf improvements)
         with:
           condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup

--- a/news/15923-setup-miniconda-v4
+++ b/news/15923-setup-miniconda-v4
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Bump `conda-incubator/setup-miniconda` to v4.0.0 across `.github/workflows/tests.yml`. v4.0.0 ships the perf work tested in #15741, including direct `.condarc` YAML writes, local `isDefaultEnvironment` resolution, parallelized Windows `takeown`, bulk-move pkg cleanup, and dropped HTML index scraping; the Node.js 24 runtime is the breaking change motivating the major bump. (#15923)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Bumps `conda-incubator/setup-miniconda` from the unreleased `main`-tip pin (`77236ef`) to the freshly cut [**v4.0.0**](https://github.com/conda-incubator/setup-miniconda/releases/tag/v4.0.0) (`bce0bd8`, 2026-04-23) across all seven `Setup Miniconda` steps in `.github/workflows/tests.yml`.

This started as a perf follow-up to #15741. That experiment pinned to a `main` SHA to measure the combined impact of an upstream speedup series; v4.0.0 is now the first tagged release that contains all of that work, so this PR is ready to merge as a normal upgrade rather than an experimental probe.

### What's in v4.0.0

**Breaking**
- conda-incubator/setup-miniconda#459 — Node.js 24.x action runtime (motivates the major bump)
- conda-incubator/setup-miniconda#450 — ESM build (needed for `@actions/exec` v3)

**Performance (what #15741 / this PR were measuring)**
- conda-incubator/setup-miniconda#465 — fix double channel config apply
- conda-incubator/setup-miniconda#467 — bulk-move extracted pkgs on Windows post-run cleanup
- conda-incubator/setup-miniconda#475 — split shell init and activation (drops spurious warning)
- conda-incubator/setup-miniconda#482 — channel parsing / URL validation
- conda-incubator/setup-miniconda#486 — remove HTML index scraping for Miniconda version validation
- conda-incubator/setup-miniconda#487 — parallelize Windows `takeown` calls with `Promise.all`
- conda-incubator/setup-miniconda#488 — replace `isDefaultEnvironment` subprocess with local YAML reads
- conda-incubator/setup-miniconda#489 — replace `conda config` subprocesses with direct `.condarc` YAML writes

**Features**
- conda-incubator/setup-miniconda#469 — new `conda-init` input to optionally skip `conda init` and document activation for restricted environments
- conda-incubator/setup-miniconda#481 — stricter TypeScript + typing
- conda-incubator/setup-miniconda#480 — more tests, Codecov integration, coverage badge
- conda-incubator/setup-miniconda#479 — TypeDoc-based API docs with GitHub Pages + Netlify previews

**Fixes**
- conda-incubator/setup-miniconda#470 — fix `name-version-build` syntax expansion
- conda-incubator/setup-miniconda#498 — skip Netlify preview for Dependabot PRs

### CI impact (from the `main`-tip measurement)

Comparing `test-setup-miniconda-perf-followup` at `60258538` against the scheduled Tests run on `main` at the same base SHA (`24713551394` vs `24636624333`):

| Metric | PR | baseline | Δ | % |
|---|---|---|---|---|
| **Total job-time** (sum across 83 jobs) | **1033 min** | **1819 min** | **−786 min** | **−43.2%** |
| Wall time (first-start → last-finish) | 118 min | 107 min | +11 min | +10.2% |

Wall-time went up because the PR ran at a peak UTC hour with more runner queuing; total job-time is the representative figure. Per-OS medians:

| OS | n | PR mean | base mean | Δ mean |
|---|---|---|---|---|
| linux | 60 | 10m 50s | 21m 16s | **−11m 34s** |
| windows | 15 | 19m 16s | 27m 07s | **−8m 10s** |
| macos | 5 | 18m 43s | 26m 57s | **−9m 47s** |

Six `linux / 3.13 / conda-forge / integration` shards account for ~355 min of the 786 min delta (individual shards went from 108 min → 14 min). A step-level diff on the worst shard showed the gap lives entirely in `Run Tests`, not in the `Setup Miniconda` step itself (7–8 s in both runs), so the outlier is most likely the old pin hitting a slow/hung-test pattern that the new conda-config / YAML fast paths in #488/#489 dodge. Excluding all six outlier shards, the remaining 77 jobs still show **−45.9% total job-time**; the median delta is unchanged.

14 jobs came in slower than baseline, all on Python 3.14 and all within ≤ 5% relative. Nothing screams revert; worth watching on the re-run.

### Checklist - did you ...

- [x] Add a file to the `news` directory (using the template) for the next release's release notes?
- [x] Add / update necessary tests? (no new code — action bump only)
- [x] Add / update outdated documentation? (n/a)