### PR TITLE
Add `factory=` kwarg to `deprecated.constant`

### DIFF
--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -31,6 +31,9 @@ class DeprecatedError(RuntimeError):
     pass
 
 
+_UNSET = object()
+
+
 # inspired by deprecation (https://deprecation.readthedocs.io/en/latest/) and
 # CPython's warnings._deprecated
 class DeprecationHandler:
@@ -289,8 +292,9 @@ class DeprecationHandler:
         deprecate_in: str,
         remove_in: str,
         constant: str,
-        value: Any,
+        value: Any = _UNSET,
         *,
+        factory: Callable[[], Any] | None = None,
         addendum: str | None = None,
         stack: int = 0,
         deprecation_type: type[Warning] = DeprecationWarning,
@@ -300,10 +304,26 @@ class DeprecationHandler:
         :param deprecate_in: Version in which code will be marked as deprecated.
         :param remove_in: Version in which code is expected to be removed.
         :param constant:
-        :param value:
+        :param value: The value to return when the deprecated constant is
+            accessed. Mutually exclusive with ``factory``.
+        :param factory: A zero-argument callable invoked the first time the
+            deprecated constant is accessed; the result is cached. Use this to
+            avoid paying registration-time costs (e.g., heavy imports) for a
+            symbol that may never be accessed. Mutually exclusive with ``value``.
         :param addendum: Optional additional messaging. Useful to indicate what to do instead.
         :param stack: Optional stacklevel increment.
         """
+        if (value is _UNSET) == (factory is None):
+            raise TypeError(
+                f"deprecated.constant({constant!r}, ...): pass exactly one of "
+                "`value` or `factory=`."
+            )
+        if factory is not None and not callable(factory):
+            raise TypeError(
+                f"deprecated.constant({constant!r}, factory=...): `factory` "
+                "must be a zero-argument callable."
+            )
+
         # detect calling module
         module, fullname = self._get_module(stack)
         # detect function name and generate message
@@ -329,7 +349,14 @@ class DeprecationHandler:
             deprecations = _ConstantDeprecationRegistry(fullname, fallback)
             module.__getattr__ = deprecations  # type: ignore[method-assign]
 
-        deprecations.register(constant, message, category, stack, value)
+        deprecations.register(
+            constant,
+            message,
+            category,
+            stack,
+            value if factory is None else factory,
+            factory=factory is not None,
+        )
 
     def topic(
         self: Self,
@@ -447,7 +474,7 @@ class _ConstantDeprecationRegistry:
     when registered constants are accessed.
     """
 
-    deprecations: dict[str, tuple[str, type[Warning], int, Any]] = field(
+    deprecations: dict[str, tuple[str, type[Warning], int, Any, bool]] = field(
         default_factory=dict,
         init=False,
         repr=False,
@@ -457,8 +484,13 @@ class _ConstantDeprecationRegistry:
 
     def __call__(self, name: str) -> Any:
         if name in self.deprecations:
-            message, category, stacklevel, value = self.deprecations[name]
+            message, category, stacklevel, value, is_factory = self.deprecations[name]
             warnings.warn(message, category, stacklevel=stacklevel)
+            if is_factory:
+                # invoke the factory once and cache the result so future accesses
+                # return the same object without paying the materialization cost
+                value = value()
+                self.deprecations[name] = (message, category, stacklevel, value, False)
             return value
 
         if self.fallback:
@@ -473,9 +505,11 @@ class _ConstantDeprecationRegistry:
         category: type[Warning],
         stack: int,
         value: Any,
+        *,
+        factory: bool = False,
     ) -> None:
         # stacklevel=2 points from __call__ to user code accessing the constant
-        self.deprecations[constant] = (message, category, 2 + stack, value)
+        self.deprecations[constant] = (message, category, 2 + stack, value, factory)
 
 
 deprecated = DeprecationHandler(__version__)

--- a/docs/source/dev-guide/deprecations.md
+++ b/docs/source/dev-guide/deprecations.md
@@ -195,6 +195,36 @@ del Bar
 Constants deprecation relies on the module's `__getattr__` introduced in [PEP-562](https://peps.python.org/pep-0562/).
 :::
 
+### Deferred constants
+
+When the value of a deprecated constant is expensive to materialize (for example, a class whose definition requires a heavy import), pass a zero-argument callable to the `factory=` keyword instead of passing `value` positionally. The factory is only invoked the first time the deprecated symbol is accessed; the result is cached for subsequent accesses, so identity is preserved:
+
+```{code-block} python
+:caption: Example file, `foo.py`.
+from conda.deprecations import deprecated
+
+
+def _make_heavy():
+    import some_heavy_dependency
+    return some_heavy_dependency.Thing
+
+
+deprecated.constant(
+    "23.9",
+    "24.3",
+    "HEAVY_THING",
+    factory=_make_heavy,
+    addendum="Use `lightweight_alternative` instead.",
+)
+```
+
+```{code-block} pycon
+:caption: Example invocation.
+>>> import foo  # some_heavy_dependency is NOT imported
+>>> foo.HEAVY_THING  # some_heavy_dependency is imported now, and only now
+<stdin>:1: PendingDeprecationWarning: foo.HEAVY_THING is pending deprecation and will be removed in 24.3. Use `lightweight_alternative` instead.
+```
+
 ## Modules
 
 Entire modules can be also be deprecated:

--- a/news/deprecated-constant-factory
+++ b/news/deprecated-constant-factory
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add `factory=` kwarg to `conda.deprecations.deprecated.constant` as a mutually-exclusive alternative to positional `value`. When given, the callable is invoked (and the result cached) only on first access of the deprecated symbol. Enables deprecating symbols whose materialization would otherwise force heavy imports at registration time, without giving up the canonical `deprecated.constant` API.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Document `factory=` kwarg on `deprecated.constant` in the deprecations dev-guide.
+
+### Other
+
+* <news item>

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -228,6 +228,69 @@ def test_constant_multiple_same_module(module: ModuleType) -> None:
         assert w[2].filename == __file__
 
 
+def test_constant_factory(module: ModuleType) -> None:
+    """``factory=`` defers value materialization until first access."""
+    deprecated = DeprecationHandler("2.0")
+
+    calls = {"count": 0}
+
+    def make_value() -> object:
+        calls["count"] += 1
+        return {"id": "materialized"}
+
+    deprecated.constant("2.0", "3.0", "LAZY_CONST", factory=make_value)
+
+    # registration alone must not call the factory
+    assert calls["count"] == 0
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        first = module.LAZY_CONST
+
+    assert calls["count"] == 1
+    assert first == {"id": "materialized"}
+    assert any(
+        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
+        for w in caught
+    )
+
+    # subsequent accesses must return the cached object and not re-invoke
+    # the factory (but still warn)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        second = module.LAZY_CONST
+        third = module.LAZY_CONST
+
+    assert calls["count"] == 1
+    assert second is first
+    assert third is first
+    assert len(caught) == 2
+
+
+def test_constant_factory_rejects_non_callable() -> None:
+    """``factory=`` with a non-callable must fail fast at registration."""
+    deprecated = DeprecationHandler("2.0")
+
+    with pytest.raises(TypeError, match="zero-argument callable"):
+        deprecated.constant("2.0", "3.0", "BAD_FACTORY", factory=42)
+
+
+def test_constant_requires_value_or_factory() -> None:
+    """Passing neither ``value`` nor ``factory=`` is a TypeError."""
+    deprecated = DeprecationHandler("2.0")
+
+    with pytest.raises(TypeError, match="exactly one of"):
+        deprecated.constant("2.0", "3.0", "NO_VALUE")
+
+
+def test_constant_rejects_value_and_factory_together() -> None:
+    """Passing both ``value`` and ``factory=`` is a TypeError."""
+    deprecated = DeprecationHandler("2.0")
+
+    with pytest.raises(TypeError, match="exactly one of"):
+        deprecated.constant("2.0", "3.0", "BOTH", 42, factory=lambda: 43)
+
+
 @parametrize_dev
 def test_topic(
     deprecated: DeprecationHandler,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Add a keyword-only `factory=` argument to `conda.deprecations.deprecated.constant` as a mutually-exclusive alternative to positional `value`. When given, `factory` must be a zero-argument callable; it is invoked the first time the deprecated symbol is accessed and the result is cached for subsequent accesses so identity is preserved.

#### Motivation

Today `deprecated.constant(deprecate_in, remove_in, name, value, ...)` captures `value` eagerly at registration time. This is fine for cheap values (strings, ints, already-imported classes) but breaks down when the value requires a heavy import — typical for "this symbol was moved to another module" deprecations.

Concrete example from the conda startup work (#15867): `conda.common.serialize.yaml.CondaYAMLRepresenter` was previously a module-level class. Moving it inside `_yaml()` to defer `ruamel.yaml` (32 modules) is a clean win, but registering it via `deprecated.constant(..., CondaYAMLRepresenter)` would force `ruamel.yaml` to import at registration time, erasing the gain. Other in-flight conda PRs hit the same problem and had to either (a) delete `deprecated.constant` calls and hand-roll `warnings.warn` (#15893, A22) or (b) hand-roll a custom `__getattr__` that lazily calls `deprecated.constant` on first access and is silent on that first access due to call-timing (#15868, A2/A3).

`factory=` lets all of these stay on the canonical public API.

#### API

The shape mirrors `dataclasses.field(default=..., default_factory=...)` — two mutually-exclusive ways to provide the underlying value:

```python
from conda.deprecations import deprecated


def _make_heavy():
    import some_heavy_dependency
    return some_heavy_dependency.Thing


deprecated.constant(
    "26.9", "27.3",
    "HEAVY_THING",
    factory=_make_heavy,
    addendum="Use `lightweight_alternative` instead.",
)
```

```pycon
>>> import foo  # some_heavy_dependency is NOT imported
>>> foo.HEAVY_THING  # some_heavy_dependency imports now, and only now
<stdin>:1: PendingDeprecationWarning: foo.HEAVY_THING is pending deprecation and will be removed in 27.3. Use `lightweight_alternative` instead.
>>> foo.HEAVY_THING is foo.HEAVY_THING  # cached, identity preserved
True
```

- Passing neither `value` nor `factory=` is a `TypeError`.
- Passing both `value` and `factory=` is a `TypeError`.
- Passing `factory=` with a non-callable is a `TypeError`.
- All existing `deprecated.constant(...)` call sites keep working unchanged.

#### Why only `constant`?

I reviewed every `DeprecationHandler` API:

| API | "Value" captured? | Benefits from a factory? |
|---|---|---|
| `@deprecated(...)` | the decorated callable | ❌ the callable is defined in the module being loaded |
| `@deprecated.argument(...)` | no value | ❌ |
| `deprecated.action(...)` | an `Action` class | ❌ argparse is already imported at the callsite |
| `deprecated.module(...)` | no value, fires at import | ❌ |
| `deprecated.topic(...)` | no value | ❌ |
| `deprecated.constant(...)` | eager `value` | ✅ this PR |

`constant` is the only API where the captured value can trigger arbitrary imports. The other APIs either take no value, or take something that by construction is already imported.

#### Tests

- `test_constant_factory` — registration does not invoke the factory; first access invokes it exactly once and emits the warning; subsequent accesses return the cached object (identity preserved) and still warn.
- `test_constant_factory_rejects_non_callable` — registering `factory=42` raises `TypeError` with a clear message.
- `test_constant_requires_value_or_factory` — passing neither is a `TypeError`.
- `test_constant_rejects_value_and_factory_together` — passing both is a `TypeError`.

#### Follow-ups

Open PRs in the conda-startup track that rebase on this and drop their bespoke shims in favor of `deprecated.constant(..., factory=...)`:

- #15882 (A10, driving case) — `conda.common.serialize.yaml.CondaYAMLRepresenter`.
- #15868 (A2/A3) — removes a custom `__getattr__` + "register-on-first-access" trick in `conda/cli/conda_argparse.py` (the current trick also has a minor bug where the first access is silent; `factory=` fixes it).
- #15893 (A22) — restores the 16 canonical `deprecated.constant` calls in `conda/plugins/__init__.py` that had to be deleted because they eagerly pulled in `conda.plugins.types`.
- #15926 (A24) — canonicalizes the remaining open-coded shims in `conda/auxlib/logz.py` and `conda/common/serialize/__init__.py` that eagerly import `conda.common.serialize.json` today.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? (`docs/source/dev-guide/deprecations.md`)


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
