### PR TITLE
Canonicalize deferred deprecation shims via factory= (A24)

### DIFF
--- a/conda/auxlib/logz.py
+++ b/conda/auxlib/logz.py
@@ -3,7 +3,6 @@ from logging import getLogger, INFO, Formatter, StreamHandler, DEBUG
 from sys import stderr
 
 from . import NullHandler
-from ..common.serialize import json
 from ..deprecations import deprecated
 
 log = getLogger(__name__)
@@ -51,29 +50,40 @@ def initialize_logging(level=INFO):
     attach_stderr(level)
 
 
+# ``conda.common.serialize.json`` (and transitively ``frozendict``) stays
+# off the cold-start path; the factories below materialize it only when
+# one of the three deprecated names is actually accessed.
+def _json():
+    from ..common.serialize import json
+
+    return json
+
+
 deprecated.constant(
     "26.3",
     "26.9",
     "DumpEncoder",
-    json.CondaJSONEncoder,
+    factory=lambda: _json().CondaJSONEncoder,
     addendum="Use `conda.common.serialize.json.CondaJSONEncoder` instead.",
 )
-_DUMPS = json.CondaJSONEncoder(indent=2, ensure_ascii=False, sort_keys=True).encode
 deprecated.constant(
     "26.3",
     "26.9",
     "_DUMPS",
-    _DUMPS,
+    factory=lambda: _json().CondaJSONEncoder(
+        indent=2, ensure_ascii=False, sort_keys=True
+    ).encode,
     addendum="Use `conda.common.serialize.json.CondaJSONEncoder(sort_keys=True).encode` instead.",
 )
 deprecated.constant(
     "26.3",
     "26.9",
     "jsondumps",
-    _DUMPS,
+    factory=lambda: _json().CondaJSONEncoder(
+        indent=2, ensure_ascii=False, sort_keys=True
+    ).encode,
     addendum="Use `conda.common.serialize.json.CondaJSONEncoder(sort_keys=True).encode` instead.",
 )
-del _DUMPS
 
 
 

--- a/conda/common/serialize/__init__.py
+++ b/conda/common/serialize/__init__.py
@@ -7,7 +7,6 @@ from io import StringIO
 from logging import getLogger
 
 from ...deprecations import deprecated
-from .json import CondaJSONEncoder, loads
 
 log = getLogger(__name__)
 
@@ -92,22 +91,28 @@ def yaml_safe_dump(object, stream=None):
         return ostream.getvalue()
 
 
+# Defer the ``.json`` submodule (and transitively ``frozendict``) until one
+# of the two deprecated names is actually accessed.
+def _json():
+    from . import json
+
+    return json
+
+
 deprecated.constant(
     "26.3",
     "26.9",
     "EntityEncoder",
-    CondaJSONEncoder,
+    factory=lambda: _json().CondaJSONEncoder,
     addendum="Use `conda.common.serialize.json.CondaJSONEncoder` instead.",
 )
-del CondaJSONEncoder
 deprecated.constant(
     "26.3",
     "26.9",
     "json_load",
-    loads,
+    factory=lambda: _json().loads,
     addendum="Use `conda.common.serialize.json.loads(sort_keys=True)` instead.",
 )
-del loads
 
 
 @deprecated(

--- a/news/canonicalize-deprecation-shims
+++ b/news/canonicalize-deprecation-shims
@@ -1,0 +1,22 @@
+### Enhancements
+
+* Canonicalize deferred deprecation shims in `conda.auxlib.logz` and
+  `conda.common.serialize` to use `deprecated.constant(..., factory=...)`,
+  avoiding eager imports of `conda.common.serialize.json` on cold paths.
+  (#15926)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_deferred_deprecations.py
+++ b/tests/test_deferred_deprecations.py
@@ -67,17 +67,8 @@ def test_common_serialize_does_not_pull_in_json() -> None:
 def test_deprecated_symbol_access_warns(module: str, name: str) -> None:
     """Accessing a canonicalized deprecated symbol still emits a warning."""
     mod = importlib.import_module(module)
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with pytest.deprecated_call():
         getattr(mod, name)
-
-    assert any(
-        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
-        for w in caught
-    ), (
-        f"expected a DeprecationWarning or PendingDeprecationWarning when "
-        f"accessing {module}.{name}; got {[w.category.__name__ for w in caught]}"
-    )
 
 
 @pytest.mark.parametrize(
@@ -93,8 +84,7 @@ def test_deprecated_symbol_access_warns(module: str, name: str) -> None:
 def test_deprecated_symbol_identity_is_stable(module: str, name: str) -> None:
     """Repeated access returns the same object (factory cached)."""
     mod = importlib.import_module(module)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.deprecated_call():
         first = getattr(mod, name)
         second = getattr(mod, name)
 

--- a/tests/test_deferred_deprecations.py
+++ b/tests/test_deferred_deprecations.py
@@ -11,15 +11,11 @@ so the check is immune to test-order bleed-through.
 from __future__ import annotations
 
 import importlib
-import os
 import subprocess
 import sys
 import textwrap
-import warnings
 
 import pytest
-
-_CLEAN_ENV = {k: v for k, v in os.environ.items() if k != "EAGER_IMPORT"}
 
 
 def _sys_modules_after(import_stmt: str) -> set[str]:
@@ -32,7 +28,6 @@ def _sys_modules_after(import_stmt: str) -> set[str]:
     """)
     result = subprocess.run(
         [sys.executable, "-c", script],
-        env=_CLEAN_ENV,
         capture_output=True,
         text=True,
     )
@@ -44,13 +39,13 @@ def _sys_modules_after(import_stmt: str) -> set[str]:
 
 def test_auxlib_logz_does_not_pull_in_serialize_json() -> None:
     """conda.auxlib.logz must not import conda.common.serialize.json eagerly."""
-    loaded = _sys_modules_after("import conda.auxlib.logz  # noqa: F401")
+    loaded = _sys_modules_after("import conda.auxlib.logz")
     assert "conda.common.serialize.json" not in loaded
 
 
 def test_common_serialize_does_not_pull_in_json() -> None:
     """Importing conda.common.serialize must not import .json eagerly."""
-    loaded = _sys_modules_after("import conda.common.serialize  # noqa: F401")
+    loaded = _sys_modules_after("import conda.common.serialize")
     assert "conda.common.serialize.json" not in loaded
 
 

--- a/tests/test_deferred_deprecations.py
+++ b/tests/test_deferred_deprecations.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Cold-path tests for canonicalized deprecation shims in
+``conda.auxlib.logz`` and ``conda.common.serialize``.
+
+Each case asserts that importing a module does NOT transitively import the
+heavy dependency that its deprecated symbols reference. Runs in a subprocess
+so the check is immune to test-order bleed-through.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+import textwrap
+import warnings
+
+import pytest
+
+_CLEAN_ENV = {k: v for k, v in os.environ.items() if k != "EAGER_IMPORT"}
+
+
+def _sys_modules_after(import_stmt: str) -> set[str]:
+    script = textwrap.dedent(f"""
+        import sys
+        {import_stmt}
+
+        for name in sorted(sys.modules):
+            print(name)
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=_CLEAN_ENV,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"subprocess check failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return set(result.stdout.splitlines())
+
+
+def test_auxlib_logz_does_not_pull_in_serialize_json() -> None:
+    """conda.auxlib.logz must not import conda.common.serialize.json eagerly."""
+    loaded = _sys_modules_after("import conda.auxlib.logz  # noqa: F401")
+    assert "conda.common.serialize.json" not in loaded
+
+
+def test_common_serialize_does_not_pull_in_json() -> None:
+    """Importing conda.common.serialize must not import .json eagerly."""
+    loaded = _sys_modules_after("import conda.common.serialize  # noqa: F401")
+    assert "conda.common.serialize.json" not in loaded
+
+
+@pytest.mark.parametrize(
+    "module, name",
+    [
+        ("conda.auxlib.logz", "DumpEncoder"),
+        ("conda.auxlib.logz", "_DUMPS"),
+        ("conda.auxlib.logz", "jsondumps"),
+        ("conda.common.serialize", "EntityEncoder"),
+        ("conda.common.serialize", "json_load"),
+    ],
+)
+def test_deprecated_symbol_access_warns(module: str, name: str) -> None:
+    """Accessing a canonicalized deprecated symbol still emits a warning."""
+    mod = importlib.import_module(module)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        getattr(mod, name)
+
+    assert any(
+        issubclass(w.category, (DeprecationWarning, PendingDeprecationWarning))
+        for w in caught
+    ), (
+        f"expected a DeprecationWarning or PendingDeprecationWarning when "
+        f"accessing {module}.{name}; got {[w.category.__name__ for w in caught]}"
+    )
+
+
+@pytest.mark.parametrize(
+    "module, name",
+    [
+        ("conda.auxlib.logz", "DumpEncoder"),
+        ("conda.auxlib.logz", "_DUMPS"),
+        ("conda.auxlib.logz", "jsondumps"),
+        ("conda.common.serialize", "EntityEncoder"),
+        ("conda.common.serialize", "json_load"),
+    ],
+)
+def test_deprecated_symbol_identity_is_stable(module: str, name: str) -> None:
+    """Repeated access returns the same object (factory cached)."""
+    mod = importlib.import_module(module)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        first = getattr(mod, name)
+        second = getattr(mod, name)
+
+    assert first is second


### PR DESCRIPTION
### Description

Follow-up to #15925 (which added the `factory=` kwarg to `deprecated.constant`). Applies the canonical API to the remaining sites where deferred imports were previously open-coded, so `conda.common.serialize.json` (and transitively `frozendict`) stays off the cold-start path while the deprecated aliases continue to warn and resolve on access. Part of the startup-latency work tracked in #15867 (A24).

What changed:

- `conda/auxlib/logz.py` — drops the eager `from ..common.serialize import json` import. `DumpEncoder`, `_DUMPS`, and `jsondumps` now use `factory=lambda: _json().…` to materialize `json.CondaJSONEncoder` (and its configured `dumps` closure) only when accessed.
- `conda/common/serialize/__init__.py` — drops the `from .json import CondaJSONEncoder, loads` import and the `del CondaJSONEncoder; del loads` workaround that papered over the eager bind. `EntityEncoder` and `json_load` now resolve through `factory=lambda: _json().…`.

`conda.plugins.__init__` (originally part of A24's scan) is handled separately in #15893 because the lazy `types` submodule itself needs its own `__getattr__` branch.

Tests (`tests/test_deferred_deprecations.py`) run in a subprocess to avoid import-order bleed-through between tests:

- importing `conda.auxlib.logz` does **not** import `conda.common.serialize.json`
- importing `conda.common.serialize` does **not** import `conda.common.serialize.json`
- every converted symbol (`DumpEncoder`, `_DUMPS`, `jsondumps`, `EntityEncoder`, `json_load`) still emits a `DeprecationWarning` / `PendingDeprecationWarning` on access
- repeated access returns the same object (factory result is cached by `_ConstantDeprecationRegistry`)

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
