### PR TITLE
Add multi-platform `available_platforms` and `env_for` to `EnvironmentSpecBase`

### DIFF
--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -104,7 +104,11 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..env.env import print_result
     from ..env.installers.base import get_installer
     from ..env.pip_util import get_pip_workdir
-    from ..exceptions import CondaEnvException, CondaValueError, InvalidInstaller
+    from ..exceptions import (
+        CondaEnvException,
+        InvalidInstaller,
+        PlatformMismatchError,
+    )
     from ..gateways.disk.delete import rm_rf
     from .common import validate_file_exists
 
@@ -118,10 +122,8 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     )
     spec = spec_hook.environment_spec(args.file)
     if context.subdir not in spec.available_platforms:
-        raise CondaValueError(
-            f"{args.file!r} does not include packages for {context.subdir}.\n"
-            f"Available platforms: {', '.join(spec.available_platforms)}\n"
-            f"Select one with --platform=<subdir>."
+        raise PlatformMismatchError(
+            [(args.file, spec.available_platforms)], context.subdir
         )
     env = spec.env_for(context.subdir)
 

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -119,8 +119,9 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     spec = spec_hook.environment_spec(args.file)
     if context.subdir not in spec.available_platforms:
         raise CondaValueError(
-            f"{args.file!r} does not include packages for {context.subdir}. "
-            f"Available platforms: {', '.join(spec.available_platforms)}"
+            f"{args.file!r} does not include packages for {context.subdir}.\n"
+            f"Available platforms: {', '.join(spec.available_platforms)}\n"
+            f"Select one with --platform=<subdir>."
         )
     env = spec.env_for(context.subdir)
 

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -104,7 +104,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..env.env import print_result
     from ..env.installers.base import get_installer
     from ..env.pip_util import get_pip_workdir
-    from ..exceptions import CondaEnvException, InvalidInstaller
+    from ..exceptions import CondaEnvException, CondaValueError, InvalidInstaller
     from ..gateways.disk.delete import rm_rf
     from .common import validate_file_exists
 
@@ -117,7 +117,12 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         name=context.environment_specifier,
     )
     spec = spec_hook.environment_spec(args.file)
-    env = spec.env
+    if context.subdir not in spec.available_platforms:
+        raise CondaValueError(
+            f"{args.file!r} does not include packages for {context.subdir}. "
+            f"Available platforms: {', '.join(spec.available_platforms)}"
+        )
+    env = spec.env_for(context.subdir)
 
     # FIXME conda code currently requires args to have a name or prefix
     # don't overwrite name if it's given. gh-254

--- a/conda/cli/main_env_update.py
+++ b/conda/cli/main_env_update.py
@@ -82,7 +82,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..core.prefix_data import PrefixData
     from ..env.env import print_result
     from ..env.installers.base import get_installer
-    from ..exceptions import CondaEnvException, InvalidInstaller
+    from ..exceptions import CondaEnvException, CondaValueError, InvalidInstaller
     from .common import validate_file_exists
 
     # validate incoming arguments
@@ -94,7 +94,12 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         name=context.environment_specifier,
     )
     spec = spec_hook.environment_spec(args.file)
-    env = spec.env
+    if context.subdir not in spec.available_platforms:
+        raise CondaValueError(
+            f"{args.file!r} does not include packages for {context.subdir}. "
+            f"Available platforms: {', '.join(spec.available_platforms)}"
+        )
+    env = spec.env_for(context.subdir)
 
     if not (args.name or args.prefix):
         if not env.name:

--- a/conda/cli/main_env_update.py
+++ b/conda/cli/main_env_update.py
@@ -82,7 +82,11 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..core.prefix_data import PrefixData
     from ..env.env import print_result
     from ..env.installers.base import get_installer
-    from ..exceptions import CondaEnvException, CondaValueError, InvalidInstaller
+    from ..exceptions import (
+        CondaEnvException,
+        InvalidInstaller,
+        PlatformMismatchError,
+    )
     from .common import validate_file_exists
 
     # validate incoming arguments
@@ -95,10 +99,8 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     )
     spec = spec_hook.environment_spec(args.file)
     if context.subdir not in spec.available_platforms:
-        raise CondaValueError(
-            f"{args.file!r} does not include packages for {context.subdir}.\n"
-            f"Available platforms: {', '.join(spec.available_platforms)}\n"
-            f"Select one with --platform=<subdir>."
+        raise PlatformMismatchError(
+            [(args.file, spec.available_platforms)], context.subdir
         )
     env = spec.env_for(context.subdir)
 

--- a/conda/cli/main_env_update.py
+++ b/conda/cli/main_env_update.py
@@ -96,8 +96,9 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     spec = spec_hook.environment_spec(args.file)
     if context.subdir not in spec.available_platforms:
         raise CondaValueError(
-            f"{args.file!r} does not include packages for {context.subdir}. "
-            f"Available platforms: {', '.join(spec.available_platforms)}"
+            f"{args.file!r} does not include packages for {context.subdir}.\n"
+            f"Available platforms: {', '.join(spec.available_platforms)}\n"
+            f"Select one with --platform=<subdir>."
         )
     env = spec.env_for(context.subdir)
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1088,6 +1088,41 @@ class CondaValueError(CondaError, ValueError):
         super().__init__(message, *args, **kwargs)
 
 
+class PlatformMismatchError(CondaValueError):
+    """
+    Raised when one or more environment specs do not cover the requested platform.
+
+    The message is derived from a list of ``(source, available_platforms)`` pairs
+    so the wording stays consistent whether the failure comes from a single file
+    (``conda env create``, ``conda env update``) or several
+    (``Environment.from_cli`` with multiple ``-f`` / ``--file`` arguments).
+    """
+
+    def __init__(
+        self,
+        incompatible: Iterable[tuple[str, Iterable[str]]],
+        subdir: str,
+    ):
+        items = [(source, tuple(platforms)) for source, platforms in incompatible]
+        if len(items) == 1:
+            source, platforms = items[0]
+            message = (
+                f"{source!r} does not include packages for {subdir}.\n"
+                f"Available platforms: {', '.join(platforms)}\n"
+                f"Select one with --platform=<subdir>."
+            )
+        else:
+            details = "\n".join(
+                f"  {source!r}: {', '.join(platforms)}" for source, platforms in items
+            )
+            message = (
+                f"The following files do not include packages for {subdir}:\n"
+                f"{details}\n"
+                f"Select a supported platform with --platform=<subdir>."
+            )
+        super().__init__(message)
+
+
 class CyclicalDependencyError(CondaError, ValueError):
     def __init__(self, packages_with_cycles: Iterable[PackageRecord], **kwargs):
         from .models.records import PackageRecord

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1106,19 +1106,29 @@ class PlatformMismatchError(CondaValueError):
         items = [(source, tuple(platforms)) for source, platforms in incompatible]
         if len(items) == 1:
             source, platforms = items[0]
+            platform_flags = " ".join(
+                f"--platform {p}" for p in (*platforms, subdir)
+            )
             message = (
-                f"{source!r} does not include packages for {subdir}.\n"
+                f"Environment file '{source}' does not include packages for {subdir}.\n"
                 f"Available platforms: {', '.join(platforms)}\n"
-                f"Select one with --platform=<subdir>."
+                f"\n"
+                f"To install on {subdir}, regenerate the environment file with "
+                f"{subdir} as a configured platform, for example:\n"
+                f"\n"
+                f"    conda export --file {source} {platform_flags}"
             )
         else:
             details = "\n".join(
-                f"  {source!r}: {', '.join(platforms)}" for source, platforms in items
+                f"  '{source}': {', '.join(platforms)}" for source, platforms in items
             )
             message = (
-                f"The following files do not include packages for {subdir}:\n"
+                f"The following environment files do not include packages for "
+                f"{subdir}:\n"
                 f"{details}\n"
-                f"Select a supported platform with --platform=<subdir>."
+                f"\n"
+                f"Regenerate each file with {subdir} as a configured platform "
+                f"(e.g. via `conda export --file <path> --platform {subdir} ...`)."
             )
         super().__init__(message)
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1106,9 +1106,7 @@ class PlatformMismatchError(CondaValueError):
         items = [(source, tuple(platforms)) for source, platforms in incompatible]
         if len(items) == 1:
             source, platforms = items[0]
-            platform_flags = " ".join(
-                f"--platform {p}" for p in (*platforms, subdir)
-            )
+            platform_flags = " ".join(f"--platform {p}" for p in (*platforms, subdir))
             message = (
                 f"Environment file '{source}' does not include packages for {subdir}.\n"
                 f"Available platforms: {', '.join(platforms)}\n"

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -15,7 +15,7 @@ from ..base.context import context, validate_channels
 from ..common.constants import NULL
 from ..common.iterators import groupby_to_dict as groupby
 from ..core.prefix_data import PrefixData
-from ..exceptions import CondaValueError
+from ..exceptions import CondaValueError, PlatformMismatchError
 from ..history import History
 from ..misc import get_package_records_from_explicit
 from .match_spec import MatchSpec
@@ -552,14 +552,7 @@ class Environment:
             if context.subdir not in spec.available_platforms:
                 incompatible.append((fpath, spec.available_platforms))
         if incompatible:
-            details = "\n".join(
-                f"  {fp!r}: {', '.join(plats)}" for fp, plats in incompatible
-            )
-            raise CondaValueError(
-                f"The following files do not include packages for {context.subdir}:\n"
-                f"{details}\n"
-                f"Select a supported platform with --platform=<subdir>."
-            )
+            raise PlatformMismatchError(incompatible, context.subdir)
         for fpath, spec in file_specs.items():
             env = spec.env_for(context.subdir)
             envs_from_file.append(env)

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -546,8 +546,14 @@ class Environment:
                 name=context.environment_specifier,
             )
             spec = spec_hook.environment_spec(fpath)
-            envs_from_file.append(spec.env)
-            fpath_envs_map[fpath] = spec.env
+            if context.subdir not in spec.available_platforms:
+                raise CondaValueError(
+                    f"{fpath!r} does not include packages for {context.subdir}. "
+                    f"Available platforms: {', '.join(spec.available_platforms)}"
+                )
+            env = spec.env_for(context.subdir)
+            envs_from_file.append(env)
+            fpath_envs_map[fpath] = env
 
         # Add default packages if required. If the default package is already
         # present in the list of specs, don't add it (this will override any

--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -540,17 +540,27 @@ class Environment:
 
         envs_from_file = []
         fpath_envs_map = {}
+        file_specs = {}
+        incompatible = []
         for fpath in args.file:
             spec_hook = context.plugin_manager.get_environment_specifier(
                 source=fpath,
                 name=context.environment_specifier,
             )
             spec = spec_hook.environment_spec(fpath)
+            file_specs[fpath] = spec
             if context.subdir not in spec.available_platforms:
-                raise CondaValueError(
-                    f"{fpath!r} does not include packages for {context.subdir}. "
-                    f"Available platforms: {', '.join(spec.available_platforms)}"
-                )
+                incompatible.append((fpath, spec.available_platforms))
+        if incompatible:
+            details = "\n".join(
+                f"  {fp!r}: {', '.join(plats)}" for fp, plats in incompatible
+            )
+            raise CondaValueError(
+                f"The following files do not include packages for {context.subdir}:\n"
+                f"{details}\n"
+                f"Select a supported platform with --platform=<subdir>."
+            )
+        for fpath, spec in file_specs.items():
             env = spec.env_for(context.subdir)
             envs_from_file.append(env)
             fpath_envs_map[fpath] = env

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -643,15 +643,32 @@ class EnvironmentSpecBase(ABC):
 
         return (context.subdir,)
 
+    def env_for(self, platform: str) -> Environment:
+        """
+        Return the ``Environment`` for a specific platform.
+
+        Defaults to returning :attr:`env` when ``platform`` matches
+        ``context.subdir``, and raising :class:`ValueError` otherwise.
+        Multi-platform specs override to hydrate directly from the parsed
+        input file without materialising every platform.
+        """
+        if platform not in self.available_platforms:
+            raise ValueError(
+                f"Platform {platform!r} not available in this spec. "
+                f"Available platforms: {', '.join(self.available_platforms)}"
+            )
+        return self.env
+
     @property
     def multiplatform_envs(self) -> Iterable[Environment]:
         """
         Yield one ``Environment`` per platform in :attr:`available_platforms`.
 
-        Defaults to yielding :attr:`env`. Inverse of the exporter side's
-        ``multiplatform_export(Iterable[Environment])``.
+        Defaults to :meth:`env_for` over :attr:`available_platforms`. Inverse
+        of the exporter side's ``multiplatform_export(Iterable[Environment])``.
         """
-        yield self.env
+        for platform in self.available_platforms:
+            yield self.env_for(platform)
 
 
 class EnvironmentFormat(enum.Enum):

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -649,8 +649,9 @@ class EnvironmentSpecBase(ABC):
 
         Defaults to returning :attr:`env` when ``platform`` matches
         ``context.subdir``, and raising :class:`ValueError` otherwise.
-        Multi-platform specs override to hydrate directly from the parsed
-        input file without materialising every platform.
+        Multi-platform specs override this method to build the
+        ``Environment`` directly from the parsed input file without
+        constructing one per platform.
 
         To iterate every platform a spec covers::
 

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -644,7 +644,7 @@ class EnvironmentSpecBase(ABC):
         return (context.subdir,)
 
     @property
-    def envs(self) -> Iterable[Environment]:
+    def multiplatform_envs(self) -> Iterable[Environment]:
         """
         Yield one ``Environment`` per platform in :attr:`available_platforms`.
 

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -651,6 +651,10 @@ class EnvironmentSpecBase(ABC):
         ``context.subdir``, and raising :class:`ValueError` otherwise.
         Multi-platform specs override to hydrate directly from the parsed
         input file without materialising every platform.
+
+        To iterate every platform a spec covers::
+
+            envs = (spec.env_for(p) for p in spec.available_platforms)
         """
         if platform not in self.available_platforms:
             raise ValueError(
@@ -658,17 +662,6 @@ class EnvironmentSpecBase(ABC):
                 f"Available platforms: {', '.join(self.available_platforms)}"
             )
         return self.env
-
-    @property
-    def multiplatform_envs(self) -> Iterable[Environment]:
-        """
-        Yield one ``Environment`` per platform in :attr:`available_platforms`.
-
-        Defaults to :meth:`env_for` over :attr:`available_platforms`. Inverse
-        of the exporter side's ``multiplatform_export(Iterable[Environment])``.
-        """
-        for platform in self.available_platforms:
-            yield self.env_for(platform)
 
 
 class EnvironmentFormat(enum.Enum):

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -630,6 +630,41 @@ class EnvironmentSpecBase(ABC):
         """
         raise NotImplementedError()
 
+    @property
+    def available_platforms(self) -> tuple[str, ...]:
+        """
+        Platforms this spec can produce an :class:`~conda.models.environment.Environment` for.
+
+        Defaults to ``(context.subdir,)`` for backward compatibility with
+        single-platform specs (e.g. ``environment.yml``, ``requirements.txt``).
+        Multi-platform specs (e.g. ``conda-lock.yml``, ``pixi.lock``) should
+        override this to expose the full platform set declared in the input
+        file.
+
+        :returns tuple[str, ...]: tuple of platform subdir strings
+            (e.g. ``("linux-64", "osx-arm64")``).
+        """
+        from ..base.context import context
+
+        return (context.subdir,)
+
+    @property
+    def envs(self) -> Iterable[Environment]:
+        """
+        Multi-platform view of the parsed environment spec.
+
+        Defaults to yielding :attr:`env` for backward compatibility with
+        single-platform specs. Multi-platform specs should override this to
+        yield one :class:`~conda.models.environment.Environment` per platform
+        covered by the input file. Symmetric with the exporter side's
+        :attr:`CondaEnvironmentExporter.multiplatform_export` callback, which
+        accepts an :class:`~collections.abc.Iterable` of
+        :class:`~conda.models.environment.Environment` objects.
+
+        :returns Iterable[Environment]: one Environment per platform.
+        """
+        yield self.env
+
 
 class EnvironmentFormat(enum.Enum):
     """

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -633,16 +633,11 @@ class EnvironmentSpecBase(ABC):
     @property
     def available_platforms(self) -> tuple[str, ...]:
         """
-        Platforms this spec can produce an :class:`~conda.models.environment.Environment` for.
+        Platforms this spec can produce an ``Environment`` for.
 
-        Defaults to ``(context.subdir,)`` for backward compatibility with
-        single-platform specs (e.g. ``environment.yml``, ``requirements.txt``).
-        Multi-platform specs (e.g. ``conda-lock.yml``, ``pixi.lock``) should
-        override this to expose the full platform set declared in the input
-        file.
-
-        :returns tuple[str, ...]: tuple of platform subdir strings
-            (e.g. ``("linux-64", "osx-arm64")``).
+        Defaults to ``(context.subdir,)``. Multi-platform specs
+        (``conda-lock.yml``, ``pixi.lock``) override to return every
+        platform declared in the input file.
         """
         from ..base.context import context
 
@@ -651,17 +646,10 @@ class EnvironmentSpecBase(ABC):
     @property
     def envs(self) -> Iterable[Environment]:
         """
-        Multi-platform view of the parsed environment spec.
+        Yield one ``Environment`` per platform in :attr:`available_platforms`.
 
-        Defaults to yielding :attr:`env` for backward compatibility with
-        single-platform specs. Multi-platform specs should override this to
-        yield one :class:`~conda.models.environment.Environment` per platform
-        covered by the input file. Symmetric with the exporter side's
-        :attr:`CondaEnvironmentExporter.multiplatform_export` callback, which
-        accepts an :class:`~collections.abc.Iterable` of
-        :class:`~conda.models.environment.Environment` objects.
-
-        :returns Iterable[Environment]: one Environment per platform.
+        Defaults to yielding :attr:`env`. Inverse of the exporter side's
+        ``multiplatform_export(Iterable[Environment])``.
         """
         yield self.env
 

--- a/docs/source/dev-guide/plugins/environment_specifiers.rst
+++ b/docs/source/dev-guide/plugins/environment_specifiers.rst
@@ -42,8 +42,8 @@ specs. Single-platform specs (``environment.yml``, ``requirements.txt``) can ign
 
 * ``available_platforms`` Tuple of platform subdirs this spec covers. Defaults to
   ``(context.subdir,)``.
-* ``envs`` Iterable of ``Environment`` objects, one per platform. Defaults to yielding
-  ``self.env``. Inverse of the exporter side's ``multiplatform_export``.
+* ``multiplatform_envs`` Iterable of ``Environment`` objects, one per platform. Defaults
+  to yielding ``self.env``. Inverse of the exporter side's ``multiplatform_export``.
 
 Multi-platform specs (``conda-lock.yml``, ``pixi.lock``) override both to return every
 platform declared in the input file.

--- a/docs/source/dev-guide/plugins/environment_specifiers.rst
+++ b/docs/source/dev-guide/plugins/environment_specifiers.rst
@@ -37,6 +37,20 @@ of its abstract methods:
 * ``can_handle`` Determines if the defined plugin can read and operate on the provided file.
 * ``env`` Expresses the provided environment file as a conda environment object.
 
+In addition, the base class provides two default-implemented properties for multi-platform
+introspection. Single-platform specs (e.g. ``environment.yml``, ``requirements.txt``) need
+not override them:
+
+* ``available_platforms`` Tuple of platform subdirs this spec can produce an ``Environment``
+  for. Defaults to ``(context.subdir,)``. Multi-platform specs (e.g. ``conda-lock.yml``,
+  ``pixi.lock``) should override this to expose the full platform set declared in the
+  input file.
+* ``envs`` Iterable of ``Environment`` objects, one per platform. Defaults to yielding
+  ``self.env``. Multi-platform specs should override this to yield one ``Environment``
+  per platform in ``available_platforms``. Symmetric with the exporter side's
+  :attr:`~conda.plugins.types.CondaEnvironmentExporter.multiplatform_export` callback,
+  which accepts an iterable of ``Environment`` objects.
+
 The class may also define the boolean class variable `detection_supported`. When set to
 ``True``, the plugin will be included in the environment spec type discovery process. Otherwise,
 the plugin will only be able to be used when it is specifically selected. By default, this

--- a/docs/source/dev-guide/plugins/environment_specifiers.rst
+++ b/docs/source/dev-guide/plugins/environment_specifiers.rst
@@ -44,12 +44,13 @@ Single-platform specs (``environment.yml``, ``requirements.txt``) can ignore the
   ``(context.subdir,)``.
 * ``env_for(platform)`` Return the ``Environment`` for a specific platform. Defaults
   to ``env`` if ``platform == context.subdir``, raises otherwise.
-* ``multiplatform_envs`` Iterable of ``Environment`` objects, one per platform in
-  ``available_platforms``. Defaults to ``env_for`` over ``available_platforms``.
-  Inverse of the exporter side's ``multiplatform_export``.
 
-Multi-platform specs (``conda-lock.yml``, ``pixi.lock``) typically only need to override
-``available_platforms`` and ``env_for``; ``multiplatform_envs`` follows for free.
+Multi-platform specs (``conda-lock.yml``, ``pixi.lock``) override both to expose the
+full platform set declared in the input file. Callers iterate with:
+
+.. code-block:: python
+
+    envs = (spec.env_for(p) for p in spec.available_platforms)
 
 The class may also define the boolean class variable `detection_supported`. When set to
 ``True``, the plugin will be included in the environment spec type discovery process. Otherwise,

--- a/docs/source/dev-guide/plugins/environment_specifiers.rst
+++ b/docs/source/dev-guide/plugins/environment_specifiers.rst
@@ -37,16 +37,19 @@ of its abstract methods:
 * ``can_handle`` Determines if the defined plugin can read and operate on the provided file.
 * ``env`` Expresses the provided environment file as a conda environment object.
 
-The base class also provides two default-implemented properties for multi-platform
-specs. Single-platform specs (``environment.yml``, ``requirements.txt``) can ignore them:
+The base class also provides default-implemented APIs for multi-platform specs.
+Single-platform specs (``environment.yml``, ``requirements.txt``) can ignore them:
 
 * ``available_platforms`` Tuple of platform subdirs this spec covers. Defaults to
   ``(context.subdir,)``.
-* ``multiplatform_envs`` Iterable of ``Environment`` objects, one per platform. Defaults
-  to yielding ``self.env``. Inverse of the exporter side's ``multiplatform_export``.
+* ``env_for(platform)`` Return the ``Environment`` for a specific platform. Defaults
+  to ``env`` if ``platform == context.subdir``, raises otherwise.
+* ``multiplatform_envs`` Iterable of ``Environment`` objects, one per platform in
+  ``available_platforms``. Defaults to ``env_for`` over ``available_platforms``.
+  Inverse of the exporter side's ``multiplatform_export``.
 
-Multi-platform specs (``conda-lock.yml``, ``pixi.lock``) override both to return every
-platform declared in the input file.
+Multi-platform specs (``conda-lock.yml``, ``pixi.lock``) typically only need to override
+``available_platforms`` and ``env_for``; ``multiplatform_envs`` follows for free.
 
 The class may also define the boolean class variable `detection_supported`. When set to
 ``True``, the plugin will be included in the environment spec type discovery process. Otherwise,

--- a/docs/source/dev-guide/plugins/environment_specifiers.rst
+++ b/docs/source/dev-guide/plugins/environment_specifiers.rst
@@ -37,19 +37,16 @@ of its abstract methods:
 * ``can_handle`` Determines if the defined plugin can read and operate on the provided file.
 * ``env`` Expresses the provided environment file as a conda environment object.
 
-In addition, the base class provides two default-implemented properties for multi-platform
-introspection. Single-platform specs (e.g. ``environment.yml``, ``requirements.txt``) need
-not override them:
+The base class also provides two default-implemented properties for multi-platform
+specs. Single-platform specs (``environment.yml``, ``requirements.txt``) can ignore them:
 
-* ``available_platforms`` Tuple of platform subdirs this spec can produce an ``Environment``
-  for. Defaults to ``(context.subdir,)``. Multi-platform specs (e.g. ``conda-lock.yml``,
-  ``pixi.lock``) should override this to expose the full platform set declared in the
-  input file.
+* ``available_platforms`` Tuple of platform subdirs this spec covers. Defaults to
+  ``(context.subdir,)``.
 * ``envs`` Iterable of ``Environment`` objects, one per platform. Defaults to yielding
-  ``self.env``. Multi-platform specs should override this to yield one ``Environment``
-  per platform in ``available_platforms``. Symmetric with the exporter side's
-  :attr:`~conda.plugins.types.CondaEnvironmentExporter.multiplatform_export` callback,
-  which accepts an iterable of ``Environment`` objects.
+  ``self.env``. Inverse of the exporter side's ``multiplatform_export``.
+
+Multi-platform specs (``conda-lock.yml``, ``pixi.lock``) override both to return every
+platform declared in the input file.
 
 The class may also define the boolean class variable `detection_supported`. When set to
 ``True``, the plugin will be included in the environment spec type discovery process. Otherwise,

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -1,12 +1,10 @@
 ### Enhancements
 
-* Add ``available_platforms`` and ``envs`` properties to
-  :class:`~conda.plugins.types.EnvironmentSpecBase` (**EXPERIMENTAL**), with
-  default implementations returning ``(context.subdir,)`` and ``self.env``
-  respectively. Multi-platform environment specifiers (e.g. lockfile loaders
-  for ``conda-lock.yml`` and ``pixi.lock``) can override these properties to
-  expose every platform declared in the input file. Symmetric with the
-  exporter side's ``multiplatform_export`` callback. (#15927)
+* Add default-implemented ``available_platforms`` and ``envs`` properties to
+  :class:`~conda.plugins.types.EnvironmentSpecBase` (**EXPERIMENTAL**).
+  Multi-platform specs (``conda-lock.yml``, ``pixi.lock``) can override both
+  to expose every platform in the input file. Inverse of the exporter side's
+  ``multiplatform_export``. (#15927)
 
 ### Bug fixes
 
@@ -18,8 +16,7 @@
 
 ### Docs
 
-* Document the new ``available_platforms`` and ``envs`` properties on
-  :class:`~conda.plugins.types.EnvironmentSpecBase`. (#15927)
+* Document ``available_platforms`` and ``envs`` on ``EnvironmentSpecBase``. (#15927)
 
 ### Other
 

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -1,11 +1,10 @@
 ### Enhancements
 
-* Add default-implemented ``available_platforms``, ``env_for(platform)``, and
-  ``multiplatform_envs`` APIs to :class:`~conda.plugins.types.EnvironmentSpecBase`
-  (**EXPERIMENTAL**). Multi-platform specs (``conda-lock.yml``, ``pixi.lock``)
-  typically only need to override ``available_platforms`` and ``env_for``;
-  ``multiplatform_envs`` follows for free. Inverse of the exporter side's
-  ``multiplatform_export``. (#15927)
+* Add default-implemented ``available_platforms`` and ``env_for(platform)``
+  to :class:`~conda.plugins.types.EnvironmentSpecBase` (**EXPERIMENTAL**),
+  enabling multi-platform environment specifiers (``conda-lock.yml``,
+  ``pixi.lock``) to expose every platform declared in the input file without
+  mutating ``context.subdir``. (#15927)
 
 ### Bug fixes
 
@@ -17,7 +16,7 @@
 
 ### Docs
 
-* Document ``available_platforms``, ``env_for``, and ``multiplatform_envs`` on
+* Document ``available_platforms`` and ``env_for`` on
   ``EnvironmentSpecBase``. (#15927)
 
 ### Other

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -1,10 +1,10 @@
 ### Enhancements
 
-* Add default-implemented ``available_platforms`` and ``envs`` properties to
-  :class:`~conda.plugins.types.EnvironmentSpecBase` (**EXPERIMENTAL**).
-  Multi-platform specs (``conda-lock.yml``, ``pixi.lock``) can override both
-  to expose every platform in the input file. Inverse of the exporter side's
-  ``multiplatform_export``. (#15927)
+* Add default-implemented ``available_platforms`` and ``multiplatform_envs``
+  properties to :class:`~conda.plugins.types.EnvironmentSpecBase`
+  (**EXPERIMENTAL**). Multi-platform specs (``conda-lock.yml``, ``pixi.lock``)
+  can override both to expose every platform in the input file. Inverse of the
+  exporter side's ``multiplatform_export``. (#15927)
 
 ### Bug fixes
 
@@ -16,7 +16,8 @@
 
 ### Docs
 
-* Document ``available_platforms`` and ``envs`` on ``EnvironmentSpecBase``. (#15927)
+* Document ``available_platforms`` and ``multiplatform_envs`` on
+  ``EnvironmentSpecBase``. (#15927)
 
 ### Other
 

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -1,18 +1,8 @@
 ### Enhancements
 
-* Add default-implemented ``available_platforms`` and ``env_for(platform)``
-  to :class:`~conda.plugins.types.EnvironmentSpecBase` (**EXPERIMENTAL**),
-  enabling multi-platform environment specifiers (``conda-lock.yml``,
-  ``pixi.lock``) to expose every platform declared in the input file without
-  mutating ``context.subdir``. (#15927)
-* ``conda env create`` / ``conda env update`` now validate that the spec file
-  covers the current platform via ``available_platforms`` and hydrate the
-  target ``Environment`` via ``env_for(context.subdir)``. The error message
-  lists the platforms the file does declare and points at ``--platform=<subdir>``
-  as the resolution. (#15927)
-* :meth:`~conda.models.environment.Environment.from_cli` now pre-flights every
-  ``-f`` / ``--file`` argument before hydrating any of them and reports all
-  files that do not cover the current platform in a single error. (#15927)
+* Add default-implemented `available_platforms` and `env_for(platform)` on `EnvironmentSpecBase` (**EXPERIMENTAL**) for multi-platform environment specifiers (`conda-lock.yml`, `pixi.lock`). (#15927)
+* `conda env create` / `conda env update` check `context.subdir in spec.available_platforms` before calling `spec.env_for(context.subdir)` and raise `CondaValueError` with the platforms the file does cover when the check fails. (#15927)
+* `Environment.from_cli` pre-flights every `-f` / `--file` argument and reports all files that do not cover `context.subdir` in a single error instead of stopping at the first mismatch. (#15927)
 
 ### Bug fixes
 
@@ -24,8 +14,7 @@
 
 ### Docs
 
-* Document ``available_platforms`` and ``env_for`` on
-  ``EnvironmentSpecBase``. (#15927)
+* Document `available_platforms` and `env_for` on `EnvironmentSpecBase`. (#15927)
 
 ### Other
 

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -1,10 +1,11 @@
 ### Enhancements
 
-* Add default-implemented ``available_platforms`` and ``multiplatform_envs``
-  properties to :class:`~conda.plugins.types.EnvironmentSpecBase`
+* Add default-implemented ``available_platforms``, ``env_for(platform)``, and
+  ``multiplatform_envs`` APIs to :class:`~conda.plugins.types.EnvironmentSpecBase`
   (**EXPERIMENTAL**). Multi-platform specs (``conda-lock.yml``, ``pixi.lock``)
-  can override both to expose every platform in the input file. Inverse of the
-  exporter side's ``multiplatform_export``. (#15927)
+  typically only need to override ``available_platforms`` and ``env_for``;
+  ``multiplatform_envs`` follows for free. Inverse of the exporter side's
+  ``multiplatform_export``. (#15927)
 
 ### Bug fixes
 
@@ -16,7 +17,7 @@
 
 ### Docs
 
-* Document ``available_platforms`` and ``multiplatform_envs`` on
+* Document ``available_platforms``, ``env_for``, and ``multiplatform_envs`` on
   ``EnvironmentSpecBase``. (#15927)
 
 ### Other

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -1,7 +1,7 @@
 ### Enhancements
 
 * Add default-implemented `available_platforms` and `env_for(platform)` on `EnvironmentSpecBase` (**EXPERIMENTAL**) for multi-platform environment specifiers (`conda-lock.yml`, `pixi.lock`). (#15927)
-* `conda env create` / `conda env update` check `context.subdir in spec.available_platforms` before calling `spec.env_for(context.subdir)` and raise `PlatformMismatchError` with the platforms the file does cover when the check fails. (#15927)
+* `conda env create` / `conda env update` check `context.subdir in spec.available_platforms` before calling `spec.env_for(context.subdir)` and raise `PlatformMismatchError` with the platforms the file does cover and a `conda export` command that includes the current platform when the check fails. (#15927)
 * `Environment.from_cli` pre-flights every `-f` / `--file` argument and reports all files that do not cover `context.subdir` in a single `PlatformMismatchError` instead of stopping at the first mismatch. (#15927)
 * Add `PlatformMismatchError` (subclass of `CondaValueError`) so the wording stays consistent across `conda env create`, `conda env update`, and `Environment.from_cli`. (#15927)
 

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -1,8 +1,9 @@
 ### Enhancements
 
 * Add default-implemented `available_platforms` and `env_for(platform)` on `EnvironmentSpecBase` (**EXPERIMENTAL**) for multi-platform environment specifiers (`conda-lock.yml`, `pixi.lock`). (#15927)
-* `conda env create` / `conda env update` check `context.subdir in spec.available_platforms` before calling `spec.env_for(context.subdir)` and raise `CondaValueError` with the platforms the file does cover when the check fails. (#15927)
-* `Environment.from_cli` pre-flights every `-f` / `--file` argument and reports all files that do not cover `context.subdir` in a single error instead of stopping at the first mismatch. (#15927)
+* `conda env create` / `conda env update` check `context.subdir in spec.available_platforms` before calling `spec.env_for(context.subdir)` and raise `PlatformMismatchError` with the platforms the file does cover when the check fails. (#15927)
+* `Environment.from_cli` pre-flights every `-f` / `--file` argument and reports all files that do not cover `context.subdir` in a single `PlatformMismatchError` instead of stopping at the first mismatch. (#15927)
+* Add `PlatformMismatchError` (subclass of `CondaValueError`) so the wording stays consistent across `conda env create`, `conda env update`, and `Environment.from_cli`. (#15927)
 
 ### Bug fixes
 

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -7,7 +7,12 @@
   mutating ``context.subdir``. (#15927)
 * ``conda env create`` / ``conda env update`` now validate that the spec file
   covers the current platform via ``available_platforms`` and hydrate the
-  target ``Environment`` via ``env_for(context.subdir)``. (#15927)
+  target ``Environment`` via ``env_for(context.subdir)``. The error message
+  lists the platforms the file does declare and points at ``--platform=<subdir>``
+  as the resolution. (#15927)
+* :meth:`~conda.models.environment.Environment.from_cli` now pre-flights every
+  ``-f`` / ``--file`` argument before hydrating any of them and reports all
+  files that do not cover the current platform in a single error. (#15927)
 
 ### Bug fixes
 

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -5,6 +5,9 @@
   enabling multi-platform environment specifiers (``conda-lock.yml``,
   ``pixi.lock``) to expose every platform declared in the input file without
   mutating ``context.subdir``. (#15927)
+* ``conda env create`` / ``conda env update`` now validate that the spec file
+  covers the current platform via ``available_platforms`` and hydrate the
+  target ``Environment`` via ``env_for(context.subdir)``. (#15927)
 
 ### Bug fixes
 

--- a/news/15927-envspec-multiplatform
+++ b/news/15927-envspec-multiplatform
@@ -1,0 +1,26 @@
+### Enhancements
+
+* Add ``available_platforms`` and ``envs`` properties to
+  :class:`~conda.plugins.types.EnvironmentSpecBase` (**EXPERIMENTAL**), with
+  default implementations returning ``(context.subdir,)`` and ``self.env``
+  respectively. Multi-platform environment specifiers (e.g. lockfile loaders
+  for ``conda-lock.yml`` and ``pixi.lock``) can override these properties to
+  expose every platform declared in the input file. Symmetric with the
+  exporter side's ``multiplatform_export`` callback. (#15927)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Document the new ``available_platforms`` and ``envs`` properties on
+  :class:`~conda.plugins.types.EnvironmentSpecBase`. (#15927)
+
+### Other
+
+* <news item>

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -669,10 +669,16 @@ def test_from_cli_pre_flight_rejects_incompatible_files(
         Environment.from_cli(SimpleNamespace(name="testenv", packages=[], file=paths))
     msg = str(exc_info.value)
     if len(paths) == 1:
-        assert f"does not include packages for {context.subdir}" in msg
+        assert (
+            f"Environment file '{paths[0]}' does not include packages for "
+            f"{context.subdir}"
+        ) in msg
     else:
-        assert f"do not include packages for {context.subdir}" in msg
-    assert "--platform=<subdir>" in msg
+        assert (
+            f"The following environment files do not include packages for "
+            f"{context.subdir}"
+        ) in msg
+    assert f"--platform {context.subdir}" in msg
     for fp in paths:
         assert fp in msg
 

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -21,6 +21,7 @@ from conda.models.environment import (
 from conda.models.match_spec import MatchSpec
 from conda.models.prefix_graph import PrefixGraph
 from conda.models.records import PackageRecord
+from conda.plugins.types import EnvironmentSpecBase
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -29,6 +30,32 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from conda.testing.fixtures import PipCLIFixture, TmpEnvFixture
+
+
+class FixedEnvSpec(EnvironmentSpecBase):
+    """Minimal `EnvironmentSpecBase` that returns a pre-built `Environment`."""
+
+    def __init__(self, env: Environment):
+        self._env = env
+
+    def can_handle(self) -> bool:
+        return True
+
+    @property
+    def env(self) -> Environment:
+        return self._env
+
+    @property
+    def available_platforms(self) -> tuple[str, ...]:
+        return (self._env.platform,)
+
+    def env_for(self, platform: str) -> Environment:
+        if platform != self._env.platform:
+            raise ValueError(
+                f"Platform {platform!r} not available. "
+                f"Available platforms: {self._env.platform}"
+            )
+        return self._env
 
 
 def test_create_environment_missing_required_fields():
@@ -307,7 +334,7 @@ def test_from_cli_override_channels_excludes_file_channels(mocker: MockerFixture
     mocker.patch(
         "conda.models.environment.context.plugin_manager.get_environment_specifier",
         return_value=SimpleNamespace(
-            environment_spec=lambda fpath: SimpleNamespace(env=file_env)
+            environment_spec=lambda fpath: FixedEnvSpec(file_env)
         ),
     )
 
@@ -337,7 +364,7 @@ def test_from_cli_channel_order_base_file_cli(mocker: MockerFixture):
     mocker.patch(
         "conda.models.environment.context.plugin_manager.get_environment_specifier",
         return_value=SimpleNamespace(
-            environment_spec=lambda fpath: SimpleNamespace(env=file_env)
+            environment_spec=lambda fpath: FixedEnvSpec(file_env)
         ),
     )
     mocker.patch(
@@ -589,6 +616,31 @@ def test_from_cli_with_specs():
     assert env.explicit_packages == []
 
 
+def test_from_cli_rejects_file_without_current_platform(mocker: MockerFixture):
+    """`Environment.from_cli` raises if the spec has no packages for context.subdir."""
+    other_platform = "linux-64" if context.subdir != "linux-64" else "osx-arm64"
+    file_env = Environment(
+        prefix="/path",
+        platform=other_platform,
+        requested_packages=[MatchSpec("numpy")],
+        explicit_packages=[],
+    )
+    mocker.patch(
+        "conda.models.environment.context.plugin_manager.get_environment_specifier",
+        return_value=SimpleNamespace(
+            environment_spec=lambda fpath: FixedEnvSpec(file_env)
+        ),
+    )
+    with pytest.raises(CondaValueError, match="does not include packages"):
+        Environment.from_cli(
+            SimpleNamespace(
+                name="testenv",
+                packages=[],
+                file=["/some/env.yaml"],
+            )
+        )
+
+
 def test_from_cli_with_explicit_specs(mocker: MockerFixture):
     # Mock the function that retrieves explicit package records to return
     # a fake value. We'll use this to compare to the expected output.
@@ -635,7 +687,7 @@ def test_from_cli_with_files(mocker: MockerFixture):
         config=EnvironmentConfig.from_context(),
     )
     mock_spec = SimpleNamespace(
-        environment_spec=lambda fpath: SimpleNamespace(env=fake_env)
+        environment_spec=lambda fpath: FixedEnvSpec(fake_env)
     )
     mocker.patch(
         "conda.models.environment.context.plugin_manager.get_environment_specifier",
@@ -727,7 +779,7 @@ def test_from_cli_environment_inject_default_packages_override_file(
         platform=context.subdir,
         requested_packages=[MatchSpec("numpy==2.3.1")],
     )
-    mock_spec = type("Spec", (), {"env": fake_env})()
+    mock_spec = FixedEnvSpec(fake_env)
     mock_hook = type("Hook", (), {"environment_spec": lambda self, path: mock_spec})()
     mocker.patch(
         "conda.models.environment.context.plugin_manager.get_environment_specifier",

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -58,6 +58,37 @@ class FixedEnvSpec(EnvironmentSpecBase):
         return self._env
 
 
+class MultiPlatformEnvSpec(EnvironmentSpecBase):
+    """`EnvironmentSpecBase` covering multiple platforms, hydrating one at a time."""
+
+    def __init__(self, platforms: tuple[str, ...]):
+        self._platforms = platforms
+
+    def can_handle(self) -> bool:
+        return True
+
+    @property
+    def env(self) -> Environment:
+        return self.env_for(self._platforms[0])
+
+    @property
+    def available_platforms(self) -> tuple[str, ...]:
+        return self._platforms
+
+    def env_for(self, platform: str) -> Environment:
+        if platform not in self._platforms:
+            raise ValueError(
+                f"Platform {platform!r} not available. "
+                f"Available platforms: {', '.join(self._platforms)}"
+            )
+        return Environment(
+            prefix="/path",
+            platform=platform,
+            requested_packages=[MatchSpec("numpy")],
+            explicit_packages=[],
+        )
+
+
 def test_create_environment_missing_required_fields():
     with pytest.raises(CondaValueError):
         Environment(platform=None, prefix="/path/to/env")
@@ -616,29 +647,67 @@ def test_from_cli_with_specs():
     assert env.explicit_packages == []
 
 
-def test_from_cli_rejects_file_without_current_platform(mocker: MockerFixture):
-    """`Environment.from_cli` raises if the spec has no packages for context.subdir."""
-    other_platform = "linux-64" if context.subdir != "linux-64" else "osx-arm64"
-    file_env = Environment(
-        prefix="/path",
-        platform=other_platform,
-        requested_packages=[MatchSpec("numpy")],
-        explicit_packages=[],
-    )
+@pytest.mark.parametrize(
+    "files_platforms,expected_in_error",
+    [
+        pytest.param(
+            [("/tmp/a.yml", ("linux-64", "win-64"))],
+            ["/tmp/a.yml"],
+            id="single-incompatible",
+        ),
+        pytest.param(
+            [
+                ("/tmp/a.yml", ("linux-64", "win-64")),
+                ("/tmp/b.lock", ("linux-64", "win-64")),
+            ],
+            ["/tmp/a.yml", "/tmp/b.lock"],
+            id="multiple-incompatible",
+        ),
+    ],
+)
+def test_from_cli_pre_flight_rejects_incompatible_files(
+    mocker: MockerFixture,
+    files_platforms: list[tuple[str, tuple[str, ...]]],
+    expected_in_error: list[str],
+):
+    """Pre-flight pass reports every file that does not cover `context.subdir`."""
+    specs_by_path = {fp: MultiPlatformEnvSpec(plats) for fp, plats in files_platforms}
     mocker.patch(
         "conda.models.environment.context.plugin_manager.get_environment_specifier",
         return_value=SimpleNamespace(
-            environment_spec=lambda fpath: FixedEnvSpec(file_env)
+            environment_spec=lambda fpath: specs_by_path[fpath]
         ),
     )
-    with pytest.raises(CondaValueError, match="does not include packages"):
+    with pytest.raises(CondaValueError) as exc_info:
         Environment.from_cli(
             SimpleNamespace(
                 name="testenv",
                 packages=[],
-                file=["/some/env.yaml"],
+                file=list(specs_by_path),
             )
         )
+    msg = str(exc_info.value)
+    assert f"do not include packages for {context.subdir}" in msg
+    assert "--platform=<subdir>" in msg
+    for fp in expected_in_error:
+        assert fp in msg
+
+
+def test_from_cli_accepts_multi_platform_file_covering_current(mocker: MockerFixture):
+    """Multi-platform specs that cover `context.subdir` hydrate only that platform."""
+    spec = MultiPlatformEnvSpec(("linux-64", "osx-arm64", "win-64", context.subdir))
+    mocker.patch(
+        "conda.models.environment.context.plugin_manager.get_environment_specifier",
+        return_value=SimpleNamespace(environment_spec=lambda fpath: spec),
+    )
+    env = Environment.from_cli(
+        SimpleNamespace(
+            name="testenv",
+            packages=[],
+            file=["/tmp/multi.lock"],
+        )
+    )
+    assert env.platform == context.subdir
 
 
 def test_from_cli_with_explicit_specs(mocker: MockerFixture):

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -59,7 +59,7 @@ class FixedEnvSpec(EnvironmentSpecBase):
 
 
 class MultiPlatformEnvSpec(EnvironmentSpecBase):
-    """`EnvironmentSpecBase` covering multiple platforms, hydrating one at a time."""
+    """`EnvironmentSpecBase` covering multiple platforms, one `Environment` per call."""
 
     def __init__(self, platforms: tuple[str, ...]):
         self._platforms = platforms
@@ -694,7 +694,7 @@ def test_from_cli_pre_flight_rejects_incompatible_files(
 
 
 def test_from_cli_accepts_multi_platform_file_covering_current(mocker: MockerFixture):
-    """Multi-platform specs that cover `context.subdir` hydrate only that platform."""
+    """Multi-platform specs that cover `context.subdir` return only that platform's `Environment`."""
     spec = MultiPlatformEnvSpec(("linux-64", "osx-arm64", "win-64", context.subdir))
     mocker.patch(
         "conda.models.environment.context.plugin_manager.get_environment_specifier",

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -12,7 +12,7 @@ import pytest
 from conda.base.constants import ChannelPriority
 from conda.base.context import context, reset_context
 from conda.core.prefix_data import PrefixData
-from conda.exceptions import CondaValueError
+from conda.exceptions import CondaValueError, PlatformMismatchError
 from conda.models.environment import (
     EXTERNAL_PACKAGES_PYPI_KEY,
     Environment,
@@ -665,10 +665,13 @@ def test_from_cli_pre_flight_rejects_incompatible_files(
             environment_spec=lambda fpath: specs_by_path[fpath]
         ),
     )
-    with pytest.raises(CondaValueError) as exc_info:
+    with pytest.raises(PlatformMismatchError) as exc_info:
         Environment.from_cli(SimpleNamespace(name="testenv", packages=[], file=paths))
     msg = str(exc_info.value)
-    assert f"do not include packages for {context.subdir}" in msg
+    if len(paths) == 1:
+        assert f"does not include packages for {context.subdir}" in msg
+    else:
+        assert f"do not include packages for {context.subdir}" in msg
     assert "--platform=<subdir>" in msg
     for fp in paths:
         assert fp in msg

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -647,31 +647,18 @@ def test_from_cli_with_specs():
     assert env.explicit_packages == []
 
 
-@pytest.mark.parametrize(
-    "files_platforms,expected_in_error",
-    [
-        pytest.param(
-            [("/tmp/a.yml", ("linux-64", "win-64"))],
-            ["/tmp/a.yml"],
-            id="single-incompatible",
-        ),
-        pytest.param(
-            [
-                ("/tmp/a.yml", ("linux-64", "win-64")),
-                ("/tmp/b.lock", ("linux-64", "win-64")),
-            ],
-            ["/tmp/a.yml", "/tmp/b.lock"],
-            id="multiple-incompatible",
-        ),
-    ],
-)
+@pytest.mark.parametrize("file_count", [1, 2])
 def test_from_cli_pre_flight_rejects_incompatible_files(
-    mocker: MockerFixture,
-    files_platforms: list[tuple[str, tuple[str, ...]]],
-    expected_in_error: list[str],
+    mocker: MockerFixture, file_count: int
 ):
     """Pre-flight pass reports every file that does not cover `context.subdir`."""
-    specs_by_path = {fp: MultiPlatformEnvSpec(plats) for fp, plats in files_platforms}
+    incompatible_platforms = tuple(
+        p
+        for p in ("linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64")
+        if p != context.subdir
+    )[:2]
+    paths = [f"/tmp/f{i}.yml" for i in range(file_count)]
+    specs_by_path = {fp: MultiPlatformEnvSpec(incompatible_platforms) for fp in paths}
     mocker.patch(
         "conda.models.environment.context.plugin_manager.get_environment_specifier",
         return_value=SimpleNamespace(
@@ -679,17 +666,11 @@ def test_from_cli_pre_flight_rejects_incompatible_files(
         ),
     )
     with pytest.raises(CondaValueError) as exc_info:
-        Environment.from_cli(
-            SimpleNamespace(
-                name="testenv",
-                packages=[],
-                file=list(specs_by_path),
-            )
-        )
+        Environment.from_cli(SimpleNamespace(name="testenv", packages=[], file=paths))
     msg = str(exc_info.value)
     assert f"do not include packages for {context.subdir}" in msg
     assert "--platform=<subdir>" in msg
-    for fp in expected_in_error:
+    for fp in paths:
         assert fp in msg
 
 
@@ -755,9 +736,7 @@ def test_from_cli_with_files(mocker: MockerFixture):
         explicit_packages=[],
         config=EnvironmentConfig.from_context(),
     )
-    mock_spec = SimpleNamespace(
-        environment_spec=lambda fpath: FixedEnvSpec(fake_env)
-    )
+    mock_spec = SimpleNamespace(environment_spec=lambda fpath: FixedEnvSpec(fake_env))
     mocker.patch(
         "conda.models.environment.context.plugin_manager.get_environment_specifier",
         return_value=mock_spec,

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -646,3 +646,66 @@ def test_builtin_specifiers_have_metadata(
 
     # Verify lockfile classification
     assert specifier.environment_format == expected_environment_format
+
+
+class SinglePlatformSpec(EnvironmentSpecBase):
+    """Exercises default `envs` / `available_platforms` implementations."""
+
+    def can_handle(self) -> bool:
+        return True
+
+    @property
+    def env(self) -> Environment:
+        return Environment(prefix="/somewhere", platform="linux-64")
+
+
+class MultiPlatformSpec(EnvironmentSpecBase):
+    """Overrides `envs` / `available_platforms` to yield one env per platform."""
+
+    _PLATFORMS = ("linux-64", "osx-arm64", "win-64")
+
+    def can_handle(self) -> bool:
+        return True
+
+    @property
+    def env(self) -> Environment:
+        return Environment(prefix="/somewhere", platform=self._PLATFORMS[0])
+
+    @property
+    def available_platforms(self):
+        return self._PLATFORMS
+
+    @property
+    def envs(self):
+        for platform in self._PLATFORMS:
+            yield Environment(prefix="/somewhere", platform=platform)
+
+
+def test_env_spec_default_available_platforms_matches_context_subdir():
+    """Default `available_platforms` returns (context.subdir,)."""
+    from conda.base.context import context
+
+    spec = SinglePlatformSpec()
+    assert spec.available_platforms == (context.subdir,)
+
+
+def test_env_spec_default_envs_yields_env():
+    """Default `envs` yields exactly `self.env`."""
+    spec = SinglePlatformSpec()
+    envs = list(spec.envs)
+    assert len(envs) == 1
+    assert envs[0] is spec.env or envs[0].platform == spec.env.platform
+
+
+def test_env_spec_override_available_platforms():
+    """Subclasses can override `available_platforms` to expose multiple platforms."""
+    spec = MultiPlatformSpec()
+    assert spec.available_platforms == ("linux-64", "osx-arm64", "win-64")
+
+
+def test_env_spec_override_envs_yields_per_platform():
+    """Subclasses can override `envs` to yield one Environment per platform."""
+    spec = MultiPlatformSpec()
+    envs = list(spec.envs)
+    assert len(envs) == 3
+    assert tuple(e.platform for e in envs) == ("linux-64", "osx-arm64", "win-64")

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -656,7 +656,9 @@ class SinglePlatformSpec(EnvironmentSpecBase):
 
     @property
     def env(self) -> Environment:
-        return Environment(prefix="/somewhere", platform="linux-64")
+        from conda.base.context import context
+
+        return Environment(prefix="/somewhere", platform=context.subdir)
 
 
 class MultiPlatformSpec(EnvironmentSpecBase):
@@ -681,45 +683,44 @@ class MultiPlatformSpec(EnvironmentSpecBase):
         return Environment(prefix="/somewhere", platform=platform)
 
 
-def test_env_spec_default_available_platforms_matches_context_subdir():
-    """Default `available_platforms` returns (context.subdir,)."""
+@pytest.fixture(
+    params=[
+        pytest.param(SinglePlatformSpec, id="default-single-platform"),
+        pytest.param(MultiPlatformSpec, id="override-multi-platform"),
+    ]
+)
+def spec_and_platforms(request):
     from conda.base.context import context
 
-    spec = SinglePlatformSpec()
-    assert spec.available_platforms == (context.subdir,)
+    expected = {
+        SinglePlatformSpec: (context.subdir,),
+        MultiPlatformSpec: ("linux-64", "osx-arm64", "win-64"),
+    }[request.param]
+    return request.param(), expected
 
 
-def test_env_spec_default_env_for_returns_env():
-    """Default `env_for(context.subdir)` returns `self.env`."""
-    from conda.base.context import context
-
-    spec = SinglePlatformSpec()
-    assert spec.env_for(context.subdir).platform == spec.env.platform
+def test_available_platforms(spec_and_platforms):
+    """`available_platforms` returns every platform the spec covers."""
+    spec, expected = spec_and_platforms
+    assert spec.available_platforms == expected
 
 
-def test_env_spec_default_env_for_unknown_platform_raises():
-    """Default `env_for` raises for platforms outside `available_platforms`."""
-    spec = SinglePlatformSpec()
+def test_env_for_returns_requested_platform(spec_and_platforms):
+    """`env_for(platform)` returns an `Environment` for the requested platform."""
+    spec, expected = spec_and_platforms
+    for platform in expected:
+        assert spec.env_for(platform).platform == platform
+
+
+def test_env_for_unknown_platform_raises(spec_and_platforms):
+    """`env_for` raises for platforms outside `available_platforms`."""
+    spec, _ = spec_and_platforms
     with pytest.raises(ValueError, match="not available"):
         spec.env_for("not-a-real-platform")
 
 
-def test_env_spec_override_available_platforms():
-    """Subclasses can override `available_platforms` to expose multiple platforms."""
-    spec = MultiPlatformSpec()
-    assert spec.available_platforms == ("linux-64", "osx-arm64", "win-64")
-
-
-def test_env_spec_override_env_for_targets_platform():
-    """Overridden `env_for` returns the Environment for the requested platform."""
-    spec = MultiPlatformSpec()
-    assert spec.env_for("osx-arm64").platform == "osx-arm64"
-    with pytest.raises(ValueError, match="not available"):
-        spec.env_for("not-a-real-platform")
-
-
-def test_env_spec_iteration_pattern():
-    """Standard iteration pattern: env_for over available_platforms."""
-    spec = MultiPlatformSpec()
+def test_env_spec_iteration_pattern(spec_and_platforms):
+    """Standard iteration pattern: `env_for` over `available_platforms`."""
+    spec, expected = spec_and_platforms
     envs = [spec.env_for(p) for p in spec.available_platforms]
-    assert tuple(e.platform for e in envs) == ("linux-64", "osx-arm64", "win-64")
+    assert tuple(e.platform for e in envs) == expected

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -660,7 +660,7 @@ class SinglePlatformSpec(EnvironmentSpecBase):
 
 
 class MultiPlatformSpec(EnvironmentSpecBase):
-    """Overrides `multiplatform_envs` / `available_platforms` to yield one env per platform."""
+    """Overrides `available_platforms` + `env_for`; `multiplatform_envs` follows for free."""
 
     _PLATFORMS = ("linux-64", "osx-arm64", "win-64")
 
@@ -675,10 +675,10 @@ class MultiPlatformSpec(EnvironmentSpecBase):
     def available_platforms(self):
         return self._PLATFORMS
 
-    @property
-    def multiplatform_envs(self):
-        for platform in self._PLATFORMS:
-            yield Environment(prefix="/somewhere", platform=platform)
+    def env_for(self, platform: str) -> Environment:
+        if platform not in self._PLATFORMS:
+            raise ValueError(f"Platform {platform!r} not available")
+        return Environment(prefix="/somewhere", platform=platform)
 
 
 def test_env_spec_default_available_platforms_matches_context_subdir():
@@ -689,12 +689,27 @@ def test_env_spec_default_available_platforms_matches_context_subdir():
     assert spec.available_platforms == (context.subdir,)
 
 
+def test_env_spec_default_env_for_returns_env():
+    """Default `env_for(context.subdir)` returns `self.env`."""
+    from conda.base.context import context
+
+    spec = SinglePlatformSpec()
+    assert spec.env_for(context.subdir).platform == spec.env.platform
+
+
+def test_env_spec_default_env_for_unknown_platform_raises():
+    """Default `env_for` raises for platforms outside `available_platforms`."""
+    spec = SinglePlatformSpec()
+    with pytest.raises(ValueError, match="not available"):
+        spec.env_for("not-a-real-platform")
+
+
 def test_env_spec_default_multiplatform_envs_yields_env():
     """Default `multiplatform_envs` yields exactly `self.env`."""
     spec = SinglePlatformSpec()
     envs = list(spec.multiplatform_envs)
     assert len(envs) == 1
-    assert envs[0] is spec.env or envs[0].platform == spec.env.platform
+    assert envs[0].platform == spec.env.platform
 
 
 def test_env_spec_override_available_platforms():
@@ -703,8 +718,16 @@ def test_env_spec_override_available_platforms():
     assert spec.available_platforms == ("linux-64", "osx-arm64", "win-64")
 
 
+def test_env_spec_override_env_for_targets_platform():
+    """Overridden `env_for` returns the Environment for the requested platform."""
+    spec = MultiPlatformSpec()
+    assert spec.env_for("osx-arm64").platform == "osx-arm64"
+    with pytest.raises(ValueError, match="not available"):
+        spec.env_for("not-a-real-platform")
+
+
 def test_env_spec_override_multiplatform_envs_yields_per_platform():
-    """Subclasses can override `multiplatform_envs` to yield one Environment per platform."""
+    """`multiplatform_envs` falls out of `available_platforms` + `env_for`."""
     spec = MultiPlatformSpec()
     envs = list(spec.multiplatform_envs)
     assert len(envs) == 3

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -649,7 +649,7 @@ def test_builtin_specifiers_have_metadata(
 
 
 class SinglePlatformSpec(EnvironmentSpecBase):
-    """Exercises default `envs` / `available_platforms` implementations."""
+    """Exercises default `multiplatform_envs` / `available_platforms` implementations."""
 
     def can_handle(self) -> bool:
         return True
@@ -660,7 +660,7 @@ class SinglePlatformSpec(EnvironmentSpecBase):
 
 
 class MultiPlatformSpec(EnvironmentSpecBase):
-    """Overrides `envs` / `available_platforms` to yield one env per platform."""
+    """Overrides `multiplatform_envs` / `available_platforms` to yield one env per platform."""
 
     _PLATFORMS = ("linux-64", "osx-arm64", "win-64")
 
@@ -676,7 +676,7 @@ class MultiPlatformSpec(EnvironmentSpecBase):
         return self._PLATFORMS
 
     @property
-    def envs(self):
+    def multiplatform_envs(self):
         for platform in self._PLATFORMS:
             yield Environment(prefix="/somewhere", platform=platform)
 
@@ -689,10 +689,10 @@ def test_env_spec_default_available_platforms_matches_context_subdir():
     assert spec.available_platforms == (context.subdir,)
 
 
-def test_env_spec_default_envs_yields_env():
-    """Default `envs` yields exactly `self.env`."""
+def test_env_spec_default_multiplatform_envs_yields_env():
+    """Default `multiplatform_envs` yields exactly `self.env`."""
     spec = SinglePlatformSpec()
-    envs = list(spec.envs)
+    envs = list(spec.multiplatform_envs)
     assert len(envs) == 1
     assert envs[0] is spec.env or envs[0].platform == spec.env.platform
 
@@ -703,9 +703,9 @@ def test_env_spec_override_available_platforms():
     assert spec.available_platforms == ("linux-64", "osx-arm64", "win-64")
 
 
-def test_env_spec_override_envs_yields_per_platform():
-    """Subclasses can override `envs` to yield one Environment per platform."""
+def test_env_spec_override_multiplatform_envs_yields_per_platform():
+    """Subclasses can override `multiplatform_envs` to yield one Environment per platform."""
     spec = MultiPlatformSpec()
-    envs = list(spec.envs)
+    envs = list(spec.multiplatform_envs)
     assert len(envs) == 3
     assert tuple(e.platform for e in envs) == ("linux-64", "osx-arm64", "win-64")

--- a/tests/plugins/test_env_specs.py
+++ b/tests/plugins/test_env_specs.py
@@ -649,7 +649,7 @@ def test_builtin_specifiers_have_metadata(
 
 
 class SinglePlatformSpec(EnvironmentSpecBase):
-    """Exercises default `multiplatform_envs` / `available_platforms` implementations."""
+    """Exercises default `env_for` / `available_platforms` implementations."""
 
     def can_handle(self) -> bool:
         return True
@@ -660,7 +660,7 @@ class SinglePlatformSpec(EnvironmentSpecBase):
 
 
 class MultiPlatformSpec(EnvironmentSpecBase):
-    """Overrides `available_platforms` + `env_for`; `multiplatform_envs` follows for free."""
+    """Overrides `available_platforms` + `env_for` to expose multiple platforms."""
 
     _PLATFORMS = ("linux-64", "osx-arm64", "win-64")
 
@@ -704,14 +704,6 @@ def test_env_spec_default_env_for_unknown_platform_raises():
         spec.env_for("not-a-real-platform")
 
 
-def test_env_spec_default_multiplatform_envs_yields_env():
-    """Default `multiplatform_envs` yields exactly `self.env`."""
-    spec = SinglePlatformSpec()
-    envs = list(spec.multiplatform_envs)
-    assert len(envs) == 1
-    assert envs[0].platform == spec.env.platform
-
-
 def test_env_spec_override_available_platforms():
     """Subclasses can override `available_platforms` to expose multiple platforms."""
     spec = MultiPlatformSpec()
@@ -726,9 +718,8 @@ def test_env_spec_override_env_for_targets_platform():
         spec.env_for("not-a-real-platform")
 
 
-def test_env_spec_override_multiplatform_envs_yields_per_platform():
-    """`multiplatform_envs` falls out of `available_platforms` + `env_for`."""
+def test_env_spec_iteration_pattern():
+    """Standard iteration pattern: env_for over available_platforms."""
     spec = MultiPlatformSpec()
-    envs = list(spec.multiplatform_envs)
-    assert len(envs) == 3
+    envs = [spec.env_for(p) for p in spec.available_platforms]
     assert tuple(e.platform for e in envs) == ("linux-64", "osx-arm64", "win-64")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -919,29 +919,38 @@ def test_platform_mismatch_error_is_conda_value_error() -> None:
     assert isinstance(exc, CondaValueError)
 
 
-def test_platform_mismatch_error_single_source() -> None:
-    """Single-source message names the file and lists the available platforms."""
-    exc = PlatformMismatchError(
-        [("env.yml", ("osx-64", "osx-arm64"))],
-        "linux-64",
-    )
-    message = str(exc)
-    assert "'env.yml' does not include packages for linux-64" in message
-    assert "Available platforms: osx-64, osx-arm64" in message
-    assert "--platform=<subdir>" in message
-
-
-def test_platform_mismatch_error_multiple_sources() -> None:
-    """Multi-source message lists every file that does not cover the subdir."""
-    exc = PlatformMismatchError(
-        [
-            ("a.yml", ("osx-64",)),
-            ("b.yml", ("win-64", "linux-aarch64")),
-        ],
-        "linux-64",
-    )
-    message = str(exc)
-    assert "do not include packages for linux-64" in message
-    assert "'a.yml': osx-64" in message
-    assert "'b.yml': win-64, linux-aarch64" in message
-    assert "--platform=<subdir>" in message
+@pytest.mark.parametrize(
+    "sources,subdir,expected_fragments",
+    [
+        pytest.param(
+            [("env.yml", ("osx-64", "osx-arm64"))],
+            "linux-64",
+            (
+                "'env.yml' does not include packages for linux-64",
+                "Available platforms: osx-64, osx-arm64",
+                "--platform=<subdir>",
+            ),
+            id="single-source",
+        ),
+        pytest.param(
+            [("a.yml", ("osx-64",)), ("b.yml", ("win-64", "linux-aarch64"))],
+            "linux-64",
+            (
+                "do not include packages for linux-64",
+                "'a.yml': osx-64",
+                "'b.yml': win-64, linux-aarch64",
+                "--platform=<subdir>",
+            ),
+            id="multiple-sources",
+        ),
+    ],
+)
+def test_platform_mismatch_error_message(
+    sources: list[tuple[str, tuple[str, ...]]],
+    subdir: str,
+    expected_fragments: tuple[str, ...],
+) -> None:
+    """Error message names every incompatible source and suggests `--platform`."""
+    message = str(PlatformMismatchError(sources, subdir))
+    for fragment in expected_fragments:
+        assert fragment in message

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -926,9 +926,11 @@ def test_platform_mismatch_error_is_conda_value_error() -> None:
             [("env.yml", ("osx-64", "osx-arm64"))],
             "linux-64",
             (
-                "'env.yml' does not include packages for linux-64",
+                "Environment file 'env.yml' does not include packages for linux-64",
                 "Available platforms: osx-64, osx-arm64",
-                "--platform=<subdir>",
+                "regenerate the environment file with linux-64",
+                "    conda export --file env.yml "
+                "--platform osx-64 --platform osx-arm64 --platform linux-64",
             ),
             id="single-source",
         ),
@@ -936,10 +938,11 @@ def test_platform_mismatch_error_is_conda_value_error() -> None:
             [("a.yml", ("osx-64",)), ("b.yml", ("win-64", "linux-aarch64"))],
             "linux-64",
             (
-                "do not include packages for linux-64",
+                "The following environment files do not include packages for linux-64",
                 "'a.yml': osx-64",
                 "'b.yml': win-64, linux-aarch64",
-                "--platform=<subdir>",
+                "Regenerate each file with linux-64",
+                "--platform linux-64",
             ),
             id="multiple-sources",
         ),
@@ -950,7 +953,7 @@ def test_platform_mismatch_error_message(
     subdir: str,
     expected_fragments: tuple[str, ...],
 ) -> None:
-    """Error message names every incompatible source and suggests `--platform`."""
+    """Error message names every incompatible source and advises regenerating it."""
     message = str(PlatformMismatchError(sources, subdir))
     for fragment in expected_fragments:
         assert fragment in message

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -20,11 +20,13 @@ from conda.exceptions import (
     CommandNotFoundError,
     CondaHTTPError,
     CondaKeyError,
+    CondaValueError,
     DirectoryNotFoundError,
     ExceptionHandler,
     KnownPackageClobberError,
     PackagesNotFoundError,
     PathNotFoundError,
+    PlatformMismatchError,
     ProxyError,
     SharedLinkPathClobberError,
     TooManyArgumentsError,
@@ -909,3 +911,37 @@ def test_ExceptionHandler_deprecations(
     raises_context = pytest.raises(raises) if raises else nullcontext()
     with pytest.deprecated_call(), raises_context:
         getattr(ExceptionHandler(), function)()
+
+
+def test_platform_mismatch_error_is_conda_value_error() -> None:
+    """`PlatformMismatchError` is a `CondaValueError` so existing handlers keep working."""
+    exc = PlatformMismatchError([("env.yml", ("osx-64",))], "linux-64")
+    assert isinstance(exc, CondaValueError)
+
+
+def test_platform_mismatch_error_single_source() -> None:
+    """Single-source message names the file and lists the available platforms."""
+    exc = PlatformMismatchError(
+        [("env.yml", ("osx-64", "osx-arm64"))],
+        "linux-64",
+    )
+    message = str(exc)
+    assert "'env.yml' does not include packages for linux-64" in message
+    assert "Available platforms: osx-64, osx-arm64" in message
+    assert "--platform=<subdir>" in message
+
+
+def test_platform_mismatch_error_multiple_sources() -> None:
+    """Multi-source message lists every file that does not cover the subdir."""
+    exc = PlatformMismatchError(
+        [
+            ("a.yml", ("osx-64",)),
+            ("b.yml", ("win-64", "linux-aarch64")),
+        ],
+        "linux-64",
+    )
+    message = str(exc)
+    assert "do not include packages for linux-64" in message
+    assert "'a.yml': osx-64" in message
+    assert "'b.yml': win-64, linux-aarch64" in message
+    assert "--platform=<subdir>" in message


### PR DESCRIPTION
### Description

`EnvironmentSpecBase.env` returns an `Environment` for `context.subdir`. This is fine for single-platform specs (`environment.yml`, `requirements.txt`, `explicit`, CEP-24) where the spec only covers one platform anyway, but multi-platform lockfiles (`conda-lock.yml`, `pixi.lock`) hold packages for several platforms at once and there is no way to target any but the current one without mutating `context.subdir` and reparsing the input.

This PR adds two default-implemented APIs on `EnvironmentSpecBase`:

```python
@property
def available_platforms(self) -> tuple[str, ...]:
    return (context.subdir,)

def env_for(self, platform: str) -> Environment:
    if platform not in self.available_platforms:
        raise ValueError(...)
    return self.env
```

`available_platforms` reports the platforms a spec can produce an `Environment` for, and `env_for(platform)` returns the `Environment` for one of them. The defaults cover the single-platform case so existing specifiers need no changes. Multi-platform specifiers override both and iterate with `(spec.env_for(p) for p in spec.available_platforms)`, so each `Environment` is only built when a caller asks for it.

`conda env create`, `conda env update` and `Environment.from_cli_with_file_envs` previously called `spec.env` directly. They now check `context.subdir in spec.available_platforms` first and call `spec.env_for(context.subdir)` instead. When the check fails they raise `PlatformMismatchError` (a new `CondaValueError` subclass) naming the platforms the file does cover and suggesting `--platform=<subdir>`. `Environment.from_cli` collects the check results for every `-f` / `--file` argument before building any `Environment` and reports them all in one error instead of stopping at the first mismatch. A dedicated exception keeps the wording consistent across all three call sites.

Note: using `--platform=<subdir>` to select a platform the spec does cover but that does not match the host is allowed today (it is how `CONDA_SUBDIR` stages prefixes for other machines) and this PR does not change that. Whether lockfile-based installs should reject cross-platform selections by default is tracked separately in #15936.

Reference implementation on the loader side: conda-incubator/conda-lockfiles#128. Aligning the exporter plugin API the same way is tracked in #15929.

Closes #15927.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
