### PR TITLE
Drop ChannelType metaclass from conda.models.channel (A19a)

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -12,6 +12,7 @@ Object inheritance:
 from __future__ import annotations
 
 from copy import copy
+from functools import cache
 from logging import getLogger
 from typing import TYPE_CHECKING
 
@@ -36,6 +37,7 @@ from ..common.url import (
     split_scheme_auth_token,
     urlparse,
 )
+from ..deprecations import deprecated
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -48,31 +50,7 @@ if TYPE_CHECKING:
 log = getLogger(__name__)
 
 
-class ChannelType(type):
-    """
-    This metaclass does basic caching and enables static constructor method usage with a
-    single arg.
-    """
-
-    def __call__(cls, *args, **kwargs):
-        if len(args) == 1 and not kwargs:
-            value = args[0]
-            if isinstance(value, Channel):
-                return value
-            elif value in Channel._cache_:
-                return Channel._cache_[value]
-            else:
-                c = Channel._cache_[value] = Channel.from_value(value)
-                return c
-        elif "channels" in kwargs:
-            # presence of 'channels' kwarg indicates MultiChannel
-            channels = tuple(cls(**_kwargs) for _kwargs in kwargs["channels"])
-            return MultiChannel(kwargs["name"], channels)
-        else:
-            return super().__call__(*args, **kwargs)
-
-
-class Channel(metaclass=ChannelType):
+class Channel:
     """
     Channel:
     scheme <> auth <> location <> token <> channel <> subchannel <> platform <> package_filename
@@ -82,11 +60,20 @@ class Channel(metaclass=ChannelType):
 
     """
 
-    _cache_ = {}
-
     @staticmethod
     def _reset_state() -> None:
-        Channel._cache_ = {}
+        Channel.from_value.cache_clear()
+
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 1 and not kwargs:
+            value = args[0]
+            if isinstance(value, Channel):
+                return value
+            return cls.from_value(value)
+        if "channels" in kwargs:
+            channels = tuple(cls(**_kw) for _kw in kwargs["channels"])
+            return MultiChannel(kwargs["name"], channels)
+        return super().__new__(cls)
 
     def __init__(
         self,
@@ -98,6 +85,8 @@ class Channel(metaclass=ChannelType):
         platform: str | None = None,
         package_filename: str | None = None,
     ):
+        if self.__dict__:
+            return
         self.scheme = scheme
         self.auth = auth
         self.location = location
@@ -127,6 +116,7 @@ class Channel(metaclass=ChannelType):
         return _get_channel_for_name(channel_name)
 
     @staticmethod
+    @cache
     def from_value(value: str | None) -> Channel:
         """Construct a new :class:`Channel` from a single value.
 
@@ -425,19 +415,27 @@ class MultiChannel(Channel):
     def __init__(
         self,
         name: str,
-        channels: Iterable[Channel],
+        channels: Iterable[Channel] | None = None,
         platform: str | None = None,
     ):
+        # ``channels`` is optional so the post-``__new__`` ``__init__`` pass
+        # on the single-arg path (e.g. ``Channel("defaults")`` returning a
+        # cached ``MultiChannel`` from ``Channel.from_value``) binds cleanly.
+        # The re-entry guard below short-circuits before anything here runs.
+        if self.__dict__:
+            return
         self.name = name
         self.location = None
 
-        # assume all channels are Channels (not MultiChannels)
-        if platform:
-            channels = (
-                Channel(**{**channel.dump(), "platform": platform})
-                for channel in channels
-            )
-        self._channels = tuple(channels)
+        if channels is None:
+            self._channels = ()
+        else:
+            if platform:
+                channels = (
+                    Channel(**{**channel.dump(), "platform": platform})
+                    for channel in channels
+                )
+            self._channels = tuple(channels)
 
         self.scheme = None
         self.auth = None
@@ -738,3 +736,16 @@ def get_channel_objs(ctx: Context) -> tuple[Channel, ...]:
 
 
 context.register_reset_callaback(Channel._reset_state)
+
+
+deprecated.constant(
+    "26.9",
+    "27.3",
+    "ChannelType",
+    type(Channel),
+    addendum=(
+        "`Channel` no longer uses a metaclass; single-arg construction and "
+        "`MultiChannel` dispatch moved to `Channel.__new__`. "
+        "Use `type(Channel)` (i.e. the builtin `type`) if you need the metaclass."
+    ),
+)

--- a/news/15867-channel-metaclass
+++ b/news/15867-channel-metaclass
@@ -1,0 +1,10 @@
+### Enhancements
+
+* Drop the `ChannelType` metaclass from `conda.models.channel.Channel`. Single-argument
+  `Channel(value)` construction and `MultiChannel` dispatch have moved to `Channel.__new__`,
+  and the per-value cache is now `@functools.cache` on `Channel.from_value`. (#15867)
+
+### Deprecations
+
+* Deprecate `conda.models.channel.ChannelType`. `Channel` is now a regular class;
+  use the builtin `type(Channel)` if you need to inspect the metaclass. (#15867)

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -200,7 +200,6 @@ def test_use_only_tar_bz2(monkeypatch: MonkeyPatch, platform=OVERRIDE_PLATFORM):
 
 def test_subdir_data_coverage(monkeypatch: MonkeyPatch, platform=OVERRIDE_PLATFORM):
     # disable SSL_VERIFY to cover 'turn off warnings' line
-    monkeypatch.setattr("conda.models.channel.Channel._cache_", {})
     monkeypatch.setenv("CONDA_PLATFORM", platform)
     monkeypatch.setenv("CONDA_SSL_VERIFY", "false")
     reset_context()

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -61,26 +61,26 @@ def test_channel_host_port():
 
 def test_channel_cache():
     Channel._reset_state()
-    assert len(Channel._cache_) == 0
+    assert Channel.from_value.cache_info().currsize == 0
     dc = Channel("defaults")
-    assert len(Channel._cache_) == 1
+    assert Channel.from_value.cache_info().currsize == 1
     dc1 = Channel("defaults")
-    assert len(Channel._cache_) == 1
+    assert Channel.from_value.cache_info().currsize == 1
     dc2 = Channel("defaults")
-    assert len(Channel._cache_) == 1
+    assert Channel.from_value.cache_info().currsize == 1
 
     assert dc1 is dc
     assert dc2 is dc
 
     dc3 = Channel(dc)
-    assert len(Channel._cache_) == 1
+    assert Channel.from_value.cache_info().currsize == 1
     assert dc3 is dc
 
     ccc = Channel("conda-canary")
-    assert len(Channel._cache_) == 2
+    assert Channel.from_value.cache_info().currsize == 2
 
     ccc1 = Channel("conda-canary")
-    assert len(Channel._cache_) == 2
+    assert Channel.from_value.cache_info().currsize == 2
     assert ccc1 is ccc
 
 
@@ -1287,7 +1287,7 @@ def test_multichannel_priority():
 
 
 def test_ppc64le_vs_ppc64():
-    Channel._cache_.clear()
+    Channel._reset_state()
 
     ppc64_channel = Channel("https://conda.anaconda.org/dummy-channel/linux-ppc64")
     assert ppc64_channel.subdir == "linux-ppc64"
@@ -1302,8 +1302,8 @@ def test_ppc64le_vs_ppc64():
         ppc64le_channel.url(with_credentials=True)
         == "https://conda.anaconda.org/dummy-channel/linux-ppc64le"
     )
-    print(Channel._cache_)
-    Channel._cache_.clear()
+    print(Channel.from_value.cache_info())
+    Channel._reset_state()
 
     ppc64le_channel = Channel("https://conda.anaconda.org/dummy-channel/linux-ppc64le")
     assert ppc64le_channel.subdir == "linux-ppc64le"


### PR DESCRIPTION
### Description

Replace the `ChannelType` metaclass on `conda.models.channel.Channel` with `Channel.__new__` plus `@functools.cache` on `Channel.from_value`. Split out of #15916 per @kenodegard's review comment so the records and channel refactors can be reviewed and merged independently.

The `ChannelType` metaclass only existed to do two things at construction time:

1. Intercept single-arg `Channel(value)` calls for caching and identity.
2. Dispatch on the `channels=` kwarg to `MultiChannel`.

Both behaviours now live on the class itself:

- `Channel.__new__` handles the single-arg identity/cache fast path and the `channels=` kwarg dispatch to `MultiChannel`, returning a regular instance otherwise.
- `Channel.__init__` short-circuits on re-entry (when `__new__` returned a cached instance) via an empty-`__dict__` check, so Python's normal `__init__` pass after a cached `__new__` does not re-assign attributes on the cached object.
- `Channel.from_value` is wrapped with `@functools.cache` for the per-value caching the old `Channel._cache_` dict provided; `_reset_state()` now calls `cache_clear()` and stays wired to `context.register_reset_callaback`.
- `MultiChannel` mirrors the `__init__` re-entry guard and accepts a `**_extra` sink so `dump()`-based round-trips (e.g. `Channel(**{**channel.dump(), "platform": platform})`) keep working.

Refs: #15867

#### Deprecations

Adds a `deprecated.constant` shim so `from conda.models.channel import ChannelType` keeps working for one release cycle (deprecate 26.9, remove 27.3). The shim points at `type(Channel)`, so `isinstance(x, ChannelType)` stays semantically equivalent. Anyone doing `class Foo(metaclass=ChannelType)` gets a `PendingDeprecationWarning` and can migrate to a plain class.

#### Caveats reviewers should look at

Pickle and `copy.deepcopy` round-trip correctly, checked locally and covered by the existing `tests/models/test_channel.py` suite (`test_channel_cache`, `test_ppc64le_vs_ppc64`, the multichannel tests).

Subclassing still works for the common case of overriding attributes via kwargs. @kenodegard flagged one ordering pattern on the original PR:

```python
class SubChannel(Channel):
    def __init__(self, *args, **kwargs):
        self.value = ...
        super().__init__(*args, **kwargs)
```

`super().__init__` sees a non-empty `__dict__` and short-circuits, so attributes set before it would be preserved but attributes assigned by `Channel.__init__` would not. `MultiChannel` does not call `super().__init__()`, so it is unaffected. Downstream subclasses that rely on `Channel.__init__` setting their attributes should call `super().__init__()` first.

Single-arg subclass construction (`MyChannel("url")`) still returns a plain `Channel`, same as on `main`; the old `ChannelType.__call__` already hardcoded `Channel.from_value` in this path. Kwargs-based subclass construction is unchanged.

`@functools.cache` on `from_value` replaces the old module-level `Channel._cache_` dict. Same invalidation semantics via `context.register_reset_callaback(Channel._reset_state)`.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes? (`news/15867-channel-metaclass`)
- [x] Add / update necessary tests? (existing `tests/models/test_channel.py` cache tests updated to use `Channel.from_value.cache_info()` / `cache_clear()`; the `ChannelType` deprecation shim verified to emit `PendingDeprecationWarning` and resolve to `type(Channel)`)
- [ ] Add / update outdated documentation? (no user-facing docs affected; `Channel` keeps the same public API)
