### PR TITLE
Make Linux CI resilient: emscripten-forge channel + Ubuntu apt mirror

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -292,8 +292,18 @@ jobs:
       - name: Setup Shells
         # for tests/shell, so only necessary for integration tests
         if: matrix.test-type == 'integration'
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt update && sudo apt install ash csh fish tcsh zsh
+          # The default Azure-hosted Ubuntu apt mirror has been hanging
+          # for hours on the integration jobs. Switch to the canonical
+          # archive and let apt retry on transient failures so a single
+          # mirror outage does not block CI.
+          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y --no-install-recommends \
+            -o Acquire::Retries=3 ash csh fish tcsh zsh
           # xonsh is installed with conda in step above
           # Initialize all shells
           python -m conda init --all

--- a/news/fix-ci-apt-mirror
+++ b/news/fix-ci-apt-mirror
@@ -1,0 +1,7 @@
+### Other
+
+* Make the Linux integration jobs resilient to Azure-hosted Ubuntu apt
+  mirror outages by switching to the canonical `archive.ubuntu.com`
+  mirror and enabling apt retries (`Acquire::Retries=3`). Also install
+  shells (`ash`, `csh`, `fish`, `tcsh`, `zsh`) non-interactively with
+  `--no-install-recommends` to shrink the download footprint.

--- a/news/fix-emscripten-forge-channel-url
+++ b/news/fix-emscripten-forge-channel-url
@@ -1,0 +1,10 @@
+### Bug fixes
+
+* Update `tests/cli/test_cli_install.py::test_emscripten_forge` to use
+  `https://repo.prefix.dev/emscripten-forge-4x`, the channel URL
+  recommended by the [emscripten-forge installation docs][docs]. The
+  legacy `https://repo.mamba.pm/emscripten-forge` host has been
+  unreachable, causing the integration test to fail on every CI run
+  across all platforms.
+
+[docs]: https://emscripten-forge.org/usage/installing_packages/

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -122,9 +122,9 @@ def test_emscripten_forge(
         "--platform=emscripten-wasm32",
         "--override-channels",
         "-c",
-        "https://repo.mamba.pm/emscripten-forge",
+        "https://repo.prefix.dev/emscripten-forge-4x",
         "-c",
-        "conda-forge",
+        "https://repo.prefix.dev/conda-forge",
         "pyjs",
     ) as prefix:
         assert package_is_installed(prefix, "pyjs")


### PR DESCRIPTION
Two CI reliability fixes for `main` — both triggered by external services that conda tests depend on going down.

## Problem 1: `repo.mamba.pm` is unreachable

- The integration test `test_emscripten_forge` fetches repodata from `https://repo.mamba.pm/emscripten-forge`.
- That host is currently unreachable (port 443 connection refused).
- As a result, every CI run on `main` fails on this single test across Linux, macOS, and Windows — see the [latest run][run] where ~10 jobs failed exclusively on it.

### Fix

Switch the test to the channel URLs recommended by the upstream [emscripten-forge installation docs][docs]:

| Before | After |
| --- | --- |
| `https://repo.mamba.pm/emscripten-forge` | `https://repo.prefix.dev/emscripten-forge-4x` |
| `conda-forge` | `https://repo.prefix.dev/conda-forge` |

Test-only change; no production code paths are touched.

### Verification

```console
$ curl -sIL https://repo.prefix.dev/emscripten-forge-4x/noarch/repodata.json | head -1
HTTP/2 200
$ curl -sIL https://repo.prefix.dev/emscripten-forge-4x/emscripten-wasm32/repodata.json | head -1
HTTP/2 200
```

`pyjs` is present in the `emscripten-wasm32` repodata (385 packages total).

## Problem 2: Azure Ubuntu apt mirror is hanging

- The `Setup Shells` step on `linux (ubuntu-latest, …, integration, *)` jobs has been hanging for 2.5+ hours on `apt update && apt install ash csh fish tcsh zsh`. See the stuck jobs [72505417891][stuck1] and [72505417918][stuck2] in the run linked above.
- GitHub-hosted `ubuntu-latest` resolves apt against `azure.archive.ubuntu.com`, which has been intermittently unresponsive.
- The `ubuntu-24.04-arm` runners (which use a different mirror) all completed in ~10 minutes — confirming this is a mirror-specific outage, not a workload regression.

### Fix

Make the step resilient instead of dependent on a single mirror:

- Switch to the canonical `archive.ubuntu.com` via `sed` (no-op if the source is already pointed elsewhere).
- Enable `Acquire::Retries=3` so transient failures self-heal.
- Install non-interactively with `-y --no-install-recommends` and `DEBIAN_FRONTEND=noninteractive` to make the step robust and lighter.

## Checklist

- [x] Added news entries: `news/fix-emscripten-forge-channel-url`, `news/fix-ci-apt-mirror`

[run]: https://github.com/conda/conda/actions/runs/24772971806
[docs]: https://emscripten-forge.org/usage/installing_packages/
[stuck1]: https://github.com/conda/conda/actions/runs/24772971806/job/72505417891
[stuck2]: https://github.com/conda/conda/actions/runs/24772971806/job/72505417918