### PR TITLE
Add `CondaPluginWithAliases` protocol

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -53,7 +53,7 @@ from .subcommands.doctor import health_checks
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-    from typing import Any, Literal, cast
+    from typing import Any, Literal, TypeVar, cast
 
     from pluggy import HookImpl
     from requests.auth import AuthBase
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
         CondaEnvironmentSpecifier,
         CondaHealthCheck,
         CondaPackageExtractor,
-        CondaPlugin,
+        CondaPluginWithAliases,
         CondaPostCommand,
         CondaPostSolve,
         CondaPostTransactionAction,
@@ -85,6 +85,8 @@ if TYPE_CHECKING:
         CondaSubcommand,
         CondaVirtualPackage,
     )
+
+    P = TypeVar("P", bound=CondaPluginWithAliases)
 
 log = logging.getLogger(__name__)
 
@@ -587,7 +589,7 @@ class CondaPluginManager(pluggy.PluginManager):
         self, *, supports_detection: bool | None = None, with_aliases: bool = True
     ) -> dict[str, CondaEnvironmentSpecifier]:
         """
-         Returns a mapping from environment specifier name to environment specifier.
+        Returns a mapping from environment specifier name to environment specifier.
 
         :param supports_detection: ternary value that returns either everything, only supporting
                                     detection or not supporting detection.
@@ -614,17 +616,15 @@ class CondaPluginManager(pluggy.PluginManager):
                 f"Plugin name conflicts detected in environment specifiers.\n{err}"
             )
 
-    def _get_name_and_alias_mapping(
-        self, plugins: Iterable[CondaPlugin]
-    ) -> dict[str, CondaEnvironmentSpecifier]:
+    def _get_name_and_alias_mapping(self, plugins: Iterable[P]) -> dict[str, P]:
         """
         Get a mapping from plugin names (including aliases) to plugin.
 
-        :param plugins: List of plugins that have a name and aliases attribute.
-        :return: Dict mapping format name to CondaEnvironmentExporter
-        :raises PluginError: If multiple exporters use the same format name or alias
+        :param plugins: Plugins that expose a ``name`` and ``aliases``.
+        :return: Mapping from each canonical name and alias to the corresponding plugin.
+        :raises PluginError: If multiple plugins use the same name or alias.
         """
-        mapping = {}
+        mapping: dict[str, P] = {}
         conflicts = {}  # format_name -> set of plugin names
 
         for plugin in plugins:

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from collections.abc import Callable, Iterable
     from contextlib import AbstractContextManager
-    from typing import Any, ClassVar, Literal, TypeAlias
+    from typing import Any, ClassVar, Literal, Protocol, TypeAlias
 
     from ..auxlib import _Null
     from ..common.configuration import Parameter
@@ -55,6 +55,20 @@ if TYPE_CHECKING:
     # Callback type for health check fixer confirmation prompts.
     # Raises CondaSystemExit if user declines, or DryRunExit in dry-run mode.
     ConfirmCallback: TypeAlias = Callable[[str], None]
+
+    class CondaPluginWithAliases(Protocol):
+        """
+        Structural type for plugins that expose a canonical :attr:`~CondaPlugin.name`
+        and :attr:`aliases`.
+
+        Used when building lookup mappings that include alternate names (for example
+        environment specifiers, exporters, and settings). Concrete types such as
+        :class:`CondaSetting`, :class:`CondaEnvironmentSpecifier`, and
+        :class:`CondaEnvironmentExporter` satisfy this protocol.
+        """
+
+        name: str
+        aliases: tuple[str, ...]
 
 
 @dataclass


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Small type annotation improvement to `_get_name_and_alias_mapping`. Adding this protocol ensures proper typing for:
- `get_environment_specifiers` which returns `dict[str, CondaEnvironmentSpecifier]` and
- `get_exporter_format_mapping` which returns `dict[str, CondaEnvironmentExporter]`

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
