### PR TITLE
Update typing for `conda.common.iterators`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1230,7 +1230,7 @@ class Context(Configuration):
                 if context.plugin_manager.has_package_extension(x)
                 else "spec"
             ),
-            sequence=self._create_default_packages,
+            self._create_default_packages,
         )
 
         if grouped_packages.get("explicit", None):

--- a/conda/common/iterators.py
+++ b/conda/common/iterators.py
@@ -4,27 +4,42 @@
 
 from __future__ import annotations
 
-import collections
-import itertools
 from typing import TYPE_CHECKING
 
+from ..deprecations import deprecated
+
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
-    from typing import Any
+    from collections.abc import Callable, Iterable
+    from typing import Any, TypeVar
+
+    T = TypeVar("T")
+    K = TypeVar("K")
 
 
-def groupby_to_dict(keyfunc, sequence):
+@deprecated.argument(
+    "26.9",
+    "27.3",
+    "sequence",
+    rename="iterable",
+    addendum="Use `collections.defaultdict` instead.",
+)
+def groupby_to_dict(
+    keyfunc: Callable[[T], K], iterable: Iterable[T]
+) -> dict[K, list[T]]:
     """A `toolz`-style groupby implementation.
 
     Returns a dictionary of { key: [group] } instead of iterators.
     """
-    result = collections.defaultdict(list)
-    for key, group in itertools.groupby(sequence, keyfunc):
+    from collections import defaultdict
+    from itertools import groupby
+
+    result: dict[K, list[T]] = defaultdict(list)
+    for key, group in groupby(iterable, keyfunc):
         result[key].extend(group)
     return dict(result)
 
 
-def unique(sequence: Sequence[Any]) -> Generator[Any, None, None]:
+def unique(iterable: Iterable[T]) -> Iterable[T]:
     """A `toolz` inspired `unique` implementation.
 
     Returns a generator of unique elements in the sequence
@@ -33,7 +48,7 @@ def unique(sequence: Sequence[Any]) -> Generator[Any, None, None]:
     yield from (
         # seen.add always returns None so we will always return element
         seen.add(element) or element
-        for element in sequence
+        for element in iterable
         # only pass along novel elements
         if element not in seen
     )

--- a/conda/common/iterators.py
+++ b/conda/common/iterators.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     "27.3",
     "sequence",
     rename="iterable",
-    addendum="Use `collections.defaultdict` instead.",
 )
 def groupby_to_dict(
     keyfunc: Callable[[T], K], iterable: Iterable[T]
@@ -39,6 +38,12 @@ def groupby_to_dict(
     return dict(result)
 
 
+@deprecated.argument(
+    "26.9",
+    "27.3",
+    "sequence",
+    rename="iterable",
+)
 def unique(iterable: Iterable[T]) -> Iterable[T]:
     """A `toolz` inspired `unique` implementation.
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While looking to use the `groupby_to_dict` found that the typing was incomplete/insufficient. Made comparable improvements to `unique` as well.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
