### PR TITLE
Add `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,4 +40,8 @@ Common uses: **`deprecated(...)`** (functions, methods, classes), **`.argument`*
 - Prefer **clear names** and **small, focused** tests; the body should read as the spec.
 - Keep **docstrings short**; long prose drifts from the code.
 - Avoid **`assert expr, "message"`** — use a **`#` comment** above the line if needed.
-- Prefer **`pytest-mock`**’s **`mocker`** fixture over **`unittest.mock`**.
+- Prefer using **native and installed pytest fixtures**, e.g. **`monkeypatch`**.
+- Prefer to **reuse tests wide fixtures**, and implement local fixtures if useful.
+- Use **`pytest-mock`**’s **`mocker`** fixture instead of **`unittest.mock`**, if needed.
+- Parameterize tests to reduce repetition.
+- Don't use section comments or other dividers to group code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Contributor and agent conventions
+
+Short reference for changelog entries, deprecations, and tests in **conda**. Details live in [CEP 8](https://conda.org/learn/ceps/cep-0008/) (releases) and [CEP 9](https://conda.org/learn/ceps/cep-0009/) (deprecations).
+
+## Local development
+
+Bootstrap and set up an environment for **development and testing** from the repository root:
+
+- **Unix / macOS:** `. ./dev/start`
+- **Windows:** `.\dev\start.bat`
+
+## Code style
+
+- Org-wide Python style policies (imports, docstrings, typing, etc.) are summarized in the **[Conda Style Guide](https://github.com/conda/infrastructure/blob/main/infrastructure/STYLEGUIDE.md)** (`conda/infrastructure` on GitHub).
+- **This repo** configures formatting and lint with **[Ruff](https://docs.astral.sh/ruff/)** in **`pyproject.toml`** and **`.pre-commit-config.yaml`** (`ruff format`, `ruff check`). Hooks are **[prek](https://prek.j178.dev/)**-compatible (drop-in for **[pre-commit](https://pre-commit.com/)**); assume **prek** / **pre-commit** is already set up locally—this document does not cover installing or enabling hooks. CI enforces the same checks if a change bypasses hooks.
+
+## Changelog (`news/`)
+
+- Add **one file per change** under **`news/`** at the repo root. Use **`news/TEMPLATE`**. Do **not** edit **`CHANGELOG.md`** directly; releases fold in `news/` fragments.
+- **Filenames:** Prefer the **issue** number (not the PR number), plus a short slug, e.g. `14157-remove-conda-utils-unix-path-to-win`.
+- **Tone:** Read **`CHANGELOG.md`** for section headings, bullet style, and deprecation/removal wording.
+- **Sections:** Enhancements, Bug fixes, Deprecations, Docs, Other. Put **removals with Deprecations**, not under Other. One snippet may span multiple sections when one PR covers several kinds of changes.
+- **Bullets:** End each bullet with a GitHub reference in parentheses. Prefer an issue when there is one, e.g. `(#12345)`, `(#12345 via #12346)`. Use **imperative mood** (Add, Fix, Mark, Remove), matching recent entries.
+- **Deprecations / removals:** Follow existing Deprecations bullets in **`CHANGELOG.md`** (symbol paths, “pending deprecation”, target removal version, replacement when applicable).
+
+## Deprecation policy
+
+- **Releases ([CEP 8](https://conda.org/learn/ceps/cep-0008/)):** CalVer `YY.MM.MICRO`. Regular releases are roughly bi-monthly. **Deprecation releases** are **March (`YY.3.x`)** and **September (`YY.9.x`)**.
+- **Schedule ([CEP 9](https://conda.org/learn/ceps/cep-0009/)):** A feature goes **pending deprecation** → **deprecated** (in a **`YY.3.x`** or **`YY.9.x`** release, after pending was in at least **two regular** releases) → **removed** in the **next** deprecation release after that.
+- **`remove_in` in code and text:** Set removal to the **deprecation release** where the API will actually be removed (e.g. `27.3`). Keep **news** bullets and API warnings on the same version.
+
+## `conda.deprecations`
+
+Implement API and behavior deprecations with **`conda.deprecations`**: import **`deprecated`** from `conda.deprecations` (see **`conda/deprecations.py`**). The handler compares the running version to **`deprecate_in`** and **`remove_in`** for pending vs active warnings.
+
+Common uses: **`deprecated(...)`** (functions, methods, classes), **`.argument`**, **`.action`** (argparse), **`.module`**, **`.constant`**, **`.topic`**.
+
+## Tests
+
+- Prefer **clear names** and **small, focused** tests; the body should read as the spec.
+- Keep **docstrings short**; long prose drifts from the code.
+- Avoid **`assert expr, "message"`** — use a **`#` comment** above the line if needed.
+- Prefer **`pytest-mock`**’s **`mocker`** fixture over **`unittest.mock`**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Bootstrap and set up an environment for **development and testing** from the rep
 
 - **Unix / macOS:** `. ./dev/start`
 - **Windows:** `.\dev\start.bat`
+- **Dev Container:** Open the repo with **[Dev Containers](https://containers.dev/)** using **`.devcontainer/`** (e.g. VS Code). That gives a reproducible setup and avoids host **conda** / user configuration skewing tests (channel priority, etc.).
 
 ## Code style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,19 @@ Common uses: **`deprecated(...)`** (functions, methods, classes), **`.argument`*
 - Prefer **clear names** and **small, focused** tests; the body should read as the spec.
 - Keep **docstrings short**; long prose drifts from the code.
 - Avoid **`assert expr, "message"`** — use a **`#` comment** above the line if needed.
-- Prefer using **native and installed pytest fixtures**, e.g. **`monkeypatch`**.
-- Prefer to **reuse tests wide fixtures**, and implement local fixtures if useful.
-- Use **`pytest-mock`**’s **`mocker`** fixture instead of **`unittest.mock`**, if needed.
+- Prefer **native and installed pytest fixtures** (e.g. **`monkeypatch`** for **`setenv`**, **`chdir`**, etc.). **Reuse shared conda fixtures** before adding bespoke setup—see **Finding fixtures** below.
+- Use **`pytest-mock`**’s **`mocker`** instead of **`unittest.mock`** when you need mocks or patches (automatic teardown and idiomatic pytest usage).
+- **`mocker.spy`** is worth knowing for **call observation** or when swapping behavior is unnecessary—it often fits before **`mocker.patch`** or **`monkeypatch.setattr`**. **`monkeypatch`** is still the right tool for **`setenv`**, **`chdir`**, and similar—not attribute mocks.
 - Parameterize tests to reduce repetition.
 - Don't use section comments or other dividers to group code.
 - Don't use test classes to group tests; single functions are preferred.
+
+### Finding fixtures
+
+Do **not** maintain a name-by-name table here (it goes stale). Discover fixtures from code:
+
+- **`tests/conftest.py`** — registers **`pytest_plugins`** (e.g. **`conda.testing.fixtures`**, **`conda.testing.gateways.fixtures`**, **`conda.testing.notices.fixtures`**, **`tests.fixtures_package_server`**) and defines more fixtures in this file.
+- **`conda/testing/fixtures.py`**, **`conda/testing/gateways/fixtures.py`**, **`conda/testing/notices/fixtures.py`** — main shared implementations; search for **`@pytest.fixture`** to list names and behavior.
+- **Elsewhere** — additional fixtures may live in **subtree `conftest.py` files** or test modules; prefer reusing a shared fixture from **`conda.testing.*`** or **`tests/conftest.py`** when one fits.
+
+The **Writing tests** chapter under **`docs/source/dev-guide/writing-tests/`** has more context (e.g. **`pytest_plugins`** and the HTTP test server).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,11 @@ Bootstrap and set up an environment for **development and testing** from the rep
 
 ## Changelog (`news/`)
 
-- Add **one file per change** under **`news/`** at the repo root. Use **`news/TEMPLATE`**. Do **not** edit **`CHANGELOG.md`** directly; releases fold in `news/` fragments.
+- Add **one file per significant change** under **`news/`** at the repo root. Use a copy of **`news/TEMPLATE`** as the template. Do **not** edit **`CHANGELOG.md`** directly; releases fold in `news/` fragments.
 - **Filenames:** Prefer the **issue** number (not the PR number), plus a short slug, e.g. `14157-remove-conda-utils-unix-path-to-win`.
 - **Tone:** Read **`CHANGELOG.md`** for section headings, bullet style, and deprecation/removal wording.
 - **Sections:** Enhancements, Bug fixes, Deprecations, Docs, Other. Put **removals with Deprecations**, not under Other. One snippet may span multiple sections when one PR covers several kinds of changes.
-- **Bullets:** End each bullet with a GitHub reference in parentheses. Prefer an issue when there is one, e.g. `(#12345)`, `(#12345 via #12346)`. Use **imperative mood** (Add, Fix, Mark, Remove), matching recent entries.
+- **Bullets:** End each bullet with a GitHub reference in parentheses. Prefer an issue when there is one, e.g. `(#12345)`, `(#12345 via #12346)`. When "via" is used, the syntax is `#issue-number via #pr-number`. Several issues/PRs can be mentioned in the same parentheses; use commas to separate them. Use **imperative mood** (Add, Fix, Mark, Remove), matching recent entries.
 - **Deprecations / removals:** Follow existing Deprecations bullets in **`CHANGELOG.md`** (symbol paths, “pending deprecation”, target removal version, replacement when applicable).
 
 ## Deprecation policy
@@ -45,3 +45,4 @@ Common uses: **`deprecated(...)`** (functions, methods, classes), **`.argument`*
 - Use **`pytest-mock`**’s **`mocker`** fixture instead of **`unittest.mock`**, if needed.
 - Parameterize tests to reduce repetition.
 - Don't use section comments or other dividers to group code.
+- Don't use test classes to group tests; single functions are preferred.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ Bootstrap and set up an environment for **development and testing** from the rep
 - **Unix / macOS:** `. ./dev/start`
 - **Windows:** `.\dev\start.bat`
 - **Dev Container:** Open the repo with **[Dev Containers](https://containers.dev/)** using **`.devcontainer/`** (e.g. VS Code). That gives a reproducible setup and avoids host **conda** / user configuration skewing tests (channel priority, etc.).
+- When interacting with GitHub (e.g. repos, issues, pull requests etc), make use of the [GitHub CLI tool](https://cli.github.com/) to efficiently query the GitHub API.
+- When working with GitHub issues and pull requests, always follow the issue and pull request templates and other conventions native to the GitHub entity in question.
 
 ## Code style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code
+
+Repository conventions for contributors and coding agents: **[`AGENTS.md`](./AGENTS.md)** (repo root).


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

When agents are used we might as well tell them how to get started—this adds **`AGENTS.md`** at the repo root as a short, conda-specific checklist (humans can use it too).

#### Contents
- **Local development:** `dev/start` / `dev/start.bat`
- **Code style:** link to the org **[Conda Style Guide](https://github.com/conda/infrastructure/blob/main/infrastructure/STYLEGUIDE.md)**; **Ruff** + `.pre-commit-config.yaml`; hooks are **[prek](https://prek.j178.dev/)**-compatible (same config as **pre-commit**); assumes local hook setup is already done; CI still enforces if hooks are skipped
- **`news/`** changelog fragments (not direct **`CHANGELOG.md`** edits), filenames, tone, sections, references
- **Deprecation policy:** [CEP 8](https://conda.org/learn/ceps/cep-0008/) / [CEP 9](https://conda.org/learn/ceps/cep-0009/), **`YY.3.x`** / **`YY.9.x`**, aligning **`remove_in`** with news text
- **`conda.deprecations`** usage (`deprecated`, common helpers)
- **Tests:** self-documenting tests, short docstrings, no custom assert messages, prefer **`pytest-mock`** **`mocker`** over **`unittest.mock`**

#### Related
The style guide itself is being refreshed in https://github.com/conda/infrastructure/pull/1320 (Ruff-first org guidance, advisory framing). This file links to **`STYLEGUIDE.md`** on `main`; no hard dependency on that PR merging first, but reviewers may want both in mind.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
