### PR TITLE
Make activate/deactivate return code 0 

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -87,7 +87,7 @@ class ArgumentError(CondaError):
 
 
 class Help(CondaError):
-    pass
+    return_code = 0
 
 
 class ActivateHelp(Help):

--- a/conda/shell/condabin/_conda_activate.bat
+++ b/conda/shell/condabin/_conda_activate.bat
@@ -36,6 +36,16 @@ IF NOT EXIST "%__conda_tmp%" (
     ENDLOCAL & EXIT /B 2
 )
 
+:: Check if -h or --help is passed. If so, no need to do activation steps, exit early
+FOR %%A IN (%*) DO (
+    IF "%%A"=="-h" (
+        ENDLOCAL & EXIT /B 0
+    )
+    IF "%%A"=="--help" (
+        ENDLOCAL & EXIT /B 0
+    )
+)
+
 :: Check if conda produced output
 FOR /F "delims=" %%T IN (%__conda_tmp%) DO (
     :: T = "%TEMP%\<uuid>.env"

--- a/news/15958-make-activate-help-command-return-0
+++ b/news/15958-make-activate-help-command-return-0
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Update the `conda activate`/`conda deactivate` commands return a 0 exit code when run with the `-h`/`--help` flag. (#15826 via #15958)
+* Make the windows (bat activator) recognize the `-h`/`--help` flags. (#15826 via #15958)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_all_commands.py
+++ b/tests/cli/test_all_commands.py
@@ -7,6 +7,7 @@ circumstance.
 
 from __future__ import annotations
 
+import re
 import warnings
 from argparse import ArgumentParser
 from typing import TYPE_CHECKING
@@ -181,3 +182,20 @@ def test_env_spec_no_warning_when_not_used(mocker: MockerFixture) -> None:
         warnings.simplefilter("error", FutureWarning)
         # --format stores into the same dest; should not raise
         parser.parse_args(["--format", _FAKE_SPECIFIER])
+
+
+@pytest.mark.parametrize(
+    ("command"),
+    ("activate", "deactivate"),
+)
+def test_activate_help_commands_exit_0_rc(
+    conda_cli: CondaCLIFixture,
+    command: str,
+):
+    """Ensure that conda returns a 0 error code when cli --help is called"""
+    with pytest.raises(SystemExit):
+        out, err, rc = conda_cli(command, "-h")
+        assert rc == 0
+        assert f"usage: conda {command}" in out
+        assert not re.search(r"\berror\b", out, re.IGNORECASE)
+        assert not re.search(r"\berror\b", err, re.IGNORECASE)

--- a/tests/shell/test_cmd_exe.py
+++ b/tests/shell/test_cmd_exe.py
@@ -140,6 +140,15 @@ def test_cmd_exe_activate_error(shell: Shell) -> None:
 
         sh.sendline("conda activate -h blah blah")
         sh.expect("usage: conda activate")
+        sh.assert_env_var("errorlevel", "0", True)
+
+
+@PARAMETRIZE_CMD_EXE
+def test_cmd_exe_deactivate_help(shell: Shell) -> None:
+    with shell.interactive() as sh:
+        sh.sendline("conda deactivate -h")
+        sh.expect("usage: conda deactivate")
+        sh.assert_env_var("errorlevel", "0", True)
 
 
 @PARAMETRIZE_CMD_EXE


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

With this change, when a user executes a command to get the help output from activate/deactivate, conda will raise an error and have a 0 return code. Previsouly conda would raise and error and produce a 1 return code.

For example:

on linux
```
$ conda activate -h  

ActivateHelp: usage: conda activate [-h] [--[no-]stack] [env_name_or_prefix]

Activate a conda environment.

Options:

positional arguments:
  env_name_or_prefix    The environment name or prefix to activate. If the
                        prefix is a relative path, it must start with './'
                        (or '.\' on Windows).

optional arguments:
  -h, --help            Show this help message and exit.
  --stack               Stack the environment being activated on top of the
                        previous active environment, rather replacing the
                        current active environment with a new one. Currently,
                        only the PATH environment variable is stacked. This
                        may be enabled implicitly by the 'auto_stack'
                        configuration variable.
  --no-stack            Do not stack the environment. Overrides 'auto_stack'
                        setting.


$ echo $?           
0
```

on windows (cmd)
```
> conda activate -h

ActivateHelp: usage: conda activate [-h] [--[no-]stack] [env_name_or_prefix]

Activate a conda environment.

Options:

positional arguments:
  env_name_or_prefix    The environment name or prefix to activate. If the
                        prefix is a relative path, it must start with './'
                        (or '.\' on Windows).

optional arguments:
  -h, --help            Show this help message and exit.
  --stack               Stack the environment being activated on top of the
                        previous active environment, rather replacing the
                        current active environment with a new one. Currently,
                        only the PATH environment variable is stacked. This
                        may be enabled implicitly by the 'auto_stack'
                        configuration variable.
  --no-stack            Do not stack the environment. Overrides 'auto_stack'
                        setting.

> echo %errorlevel%
0
```

fixes: https://github.com/conda/conda/issues/15826

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
