### PR TITLE
Fix flaky `test_notices_shown_after_previous_command_error` on Windows

### DIFF
--- a/conda/notices/cache.py
+++ b/conda/notices/cache.py
@@ -176,10 +176,36 @@ def get_viewed_channel_notice_ids(
 
 def clear_cache() -> None:
     """
-    Removes all files in notices cache
+    Invalidate the notices cache so notices will be retrieved and displayed
+    on the next command invocation.
+
+    For the ``notices.cache`` file we rewind its mtime into the past instead
+    of removing it. On Windows the file can be transiently locked (e.g. by
+    antivirus or lingering file handles), in which case ``unlink()`` raises
+    ``PermissionError`` and the cache would otherwise remain with a recent
+    ``touch()``-ed mtime, suppressing notices on subsequent runs.
+
+    Per-channel cached response files are still removed when possible, but
+    any ``OSError`` raised while unlinking them is ignored for the same
+    reason.
     """
     cache_dir = Path(get_notices_cache_dir())
+    notices_cache = cache_dir / NOTICES_CACHE_FN
 
     for cache_file in cache_dir.iterdir():
-        if cache_file.is_file():
-            cache_file.unlink()
+        if not cache_file.is_file():
+            continue
+        if cache_file == notices_cache:
+            try:
+                with open(cache_file, "w") as fp:
+                    fp.write("")
+                stat = cache_file.stat()
+                past_mtime = stat.st_mtime - NOTICES_DECORATOR_DISPLAY_INTERVAL
+                os.utime(cache_file, (stat.st_atime, past_mtime))
+            except OSError:
+                pass
+        else:
+            try:
+                cache_file.unlink()
+            except OSError:
+                pass

--- a/news/15796-notices-cache-windows-unlink
+++ b/news/15796-notices-cache-windows-unlink
@@ -1,0 +1,24 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Make `conda.notices.cache.clear_cache()` robust against transient Windows
+  file locks. It now rewinds `notices.cache`'s mtime instead of deleting the
+  file (which could silently fail with `PermissionError`), and ignores
+  `OSError` when removing per-channel response caches. This fixes flaky
+  behavior of `tests/cli/test_main_notices.py::test_notices_shown_after_previous_command_error`
+  on Windows. (#15796, #15817, #15839)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/notices/test_cache.py
+++ b/tests/notices/test_cache.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from conda.notices import cache as notices_cache
+from conda.notices import core as notices_core
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+@pytest.fixture
+def channel_response_cache(notices_cache_dir: Path) -> Path:
+    """Create a dummy per-channel response cache file inside ``notices_cache_dir``."""
+    path = notices_cache_dir / "chan.json"
+    path.write_text("{}")
+    return path
+
+
+@pytest.fixture
+def notices_cache_file(notices_cache_dir: Path) -> Path:
+    """Ensure the ``notices.cache`` file exists and return its path."""
+    return notices_cache.get_notices_cache_file()
+
+
+@pytest.mark.parametrize(
+    "viewed_ids",
+    [(), ("some-id-1", "some-id-2")],
+    ids=["empty", "with-viewed-ids"],
+)
+def test_clear_cache_invalidates_notices_cache(
+    notices_cache_file: Path, viewed_ids: tuple[str, ...]
+) -> None:
+    """``clear_cache()`` must leave ``notices.cache`` empty and looking expired."""
+    notices_cache_file.write_text("\n".join(viewed_ids))
+    notices_cache_file.touch()
+    assert not notices_core.is_channel_notices_cache_expired()
+
+    notices_cache.clear_cache()
+
+    assert notices_cache_file.is_file()
+    assert notices_cache_file.read_text() == ""
+    assert notices_core.is_channel_notices_cache_expired()
+
+
+def test_clear_cache_removes_channel_response_caches(
+    notices_cache_file: Path,
+    channel_response_cache: Path,
+) -> None:
+    """Per-channel response cache files are removed by ``clear_cache()``."""
+    assert channel_response_cache.is_file()
+    notices_cache.clear_cache()
+    assert not channel_response_cache.exists()
+
+
+@pytest.mark.parametrize(
+    "failing_target",
+    ["channel_response_cache", "notices_cache"],
+)
+def test_clear_cache_survives_os_error(
+    notices_cache_file: Path,
+    channel_response_cache: Path,
+    monkeypatch: MonkeyPatch,
+    failing_target: str,
+) -> None:
+    """
+    ``clear_cache()`` must tolerate ``OSError`` from either the per-channel
+    unlink or the ``notices.cache`` rewrite (e.g. Windows file locks from
+    antivirus scanners or lingering handles).
+    """
+    if failing_target == "channel_response_cache":
+        original_unlink = Path.unlink
+
+        def fake_unlink(self: Path, *args, **kwargs):
+            if self == channel_response_cache:
+                raise PermissionError("simulated Windows lock")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", fake_unlink)
+    else:
+
+        def fake_open(*args, **kwargs):
+            raise PermissionError("simulated Windows lock")
+
+        monkeypatch.setattr("conda.notices.cache.open", fake_open, raising=False)
+
+    notices_cache.clear_cache()
+
+    if failing_target == "channel_response_cache":
+        assert notices_core.is_channel_notices_cache_expired()


### PR DESCRIPTION
### Description

`tests/cli/test_main_notices.py::test_notices_shown_after_previous_command_error` keeps [failing intermittently on Windows][run] despite #15799. That PR landed with the honest caveat _"Not entirely sure why this test is flaky"_ and has since reappeared across #15796, #15817, #15839 and most recently #15953.

#### Root cause

`clear_cache()` calls `cache_file.unlink()` in a loop. On Windows, a lingering file handle (antivirus, just-closed `Path.touch()`, `ThreadPoolExecutor` workers in `conda/notices/fetch.py`) intermittently turns that into a `PermissionError`, which the caller in `conda/notices/core.py` silently swallows with `except OSError: pass`.

When that happens, `notices.cache` survives with the `touch()`-ed mtime from the first `conda create` call. `get_notices_cache_file()` only rewinds the mtime when the file is missing, so on the second call `is_channel_notices_cache_expired()` sees a fresh mtime, returns `False`, and the decorator skips retrieval entirely — no spinner, no `"Test One"`, assertion fails.

POSIX allows unlinking open files, which is why the flake is Windows-only.

#### Fix

Make `clear_cache()` do what its one caller actually wants (_invalidate the cache_) instead of depending on `unlink()` succeeding:

| Before | After |
| --- | --- |
| `unlink()` every file in the cache dir | Rewind `notices.cache` mtime + truncate; `unlink()` per-channel caches |
| One unwrapped `unlink()` loop | `OSError` caught per-file, one lock doesn't break the others |
| Post-condition depends on the FS | Post-condition self-heals: `notices.cache` always looks expired afterwards |

The rewind reuses the same `os.utime(..., mtime - NOTICES_DECORATOR_DISPLAY_INTERVAL)` trick `get_notices_cache_file()` already uses.

#### Tests

New `tests/notices/test_cache.py` covers the happy path and both lock-failure branches via `monkeypatch`. No `mocker`, no `unittest.mock`.

Closes #15796. Closes #15817. Closes #15839.

### Checklist - did you ...

- [x] Add a file to the `news` directory (using the template) for the next release's release notes? (`news/15796-notices-cache-windows-unlink`)
- [x] Add / update necessary tests? (`tests/notices/test_cache.py`)
- [x] ~Add / update outdated documentation?~ (internal behavior only)

[run]: https://github.com/conda/conda/actions/runs/24876745641/job/72835034427