### PR TITLE
Linear-time sort in `diff_for_unlink_link_precs` (B1)

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1462,9 +1462,9 @@ def diff_for_unlink_link_precs(
         for prec in noarch_python_precs:
             _add_to_unlink_and_link(prec)
 
-    unlink_precs_tuple = (
+    unlink_precs_tuple = tuple(
         rec for rec in reversed(previous_records) if rec in unlink_precs
     )
-    link_precs_tuple = (rec for rec in final_precs if rec in link_precs)
+    link_precs_tuple = tuple(rec for rec in final_precs if rec in link_precs)
 
     return unlink_precs_tuple, link_precs_tuple

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1462,21 +1462,9 @@ def diff_for_unlink_link_precs(
         for prec in noarch_python_precs:
             _add_to_unlink_and_link(prec)
 
-    unlink_precs = tuple(
-        reversed(sorted(unlink_precs, key=_prec_order_key(previous_records)))
+    unlink_precs_tuple = (
+        rec for rec in reversed(previous_records) if rec in unlink_precs
     )
-    link_precs = tuple(sorted(link_precs, key=_prec_order_key(final_precs)))
-    return unlink_precs, link_precs
+    link_precs_tuple = (rec for rec in final_precs if rec in link_precs)
 
-
-def _prec_order_key(ordered_records: Sequence[PackageRecord]):
-    """Return a sort key that preserves the order of ``ordered_records``.
-
-    The obvious ``key=lambda x: ordered_records.index(x)`` is O(k) per
-    call (scans ``ordered_records`` linearly). When called from
-    ``sorted()`` that's O(k * n log n) per sort. For a 50k prefix with
-    2k unlink or link items, each sort was ~4M position scans.
-    Precomputing a dict lookup collapses that to O(n log n) total.
-    """
-    position = {rec: i for i, rec in enumerate(ordered_records)}
-    return position.__getitem__
+    return unlink_precs_tuple, link_precs_tuple

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -1463,7 +1463,20 @@ def diff_for_unlink_link_precs(
             _add_to_unlink_and_link(prec)
 
     unlink_precs = tuple(
-        reversed(sorted(unlink_precs, key=lambda x: previous_records.index(x)))
+        reversed(sorted(unlink_precs, key=_prec_order_key(previous_records)))
     )
-    link_precs = tuple(sorted(link_precs, key=lambda x: final_precs.index(x)))
+    link_precs = tuple(sorted(link_precs, key=_prec_order_key(final_precs)))
     return unlink_precs, link_precs
+
+
+def _prec_order_key(ordered_records: Sequence[PackageRecord]):
+    """Return a sort key that preserves the order of ``ordered_records``.
+
+    The obvious ``key=lambda x: ordered_records.index(x)`` is O(k) per
+    call (scans ``ordered_records`` linearly). When called from
+    ``sorted()`` that's O(k * n log n) per sort. For a 50k prefix with
+    2k unlink or link items, each sort was ~4M position scans.
+    Precomputing a dict lookup collapses that to O(n log n) total.
+    """
+    position = {rec: i for i, rec in enumerate(ordered_records)}
+    return position.__getitem__

--- a/news/15970-track-b-b1-diff-sort
+++ b/news/15970-track-b-b1-diff-sort
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Replace the quadratic position-scan in `diff_for_unlink_link_precs()` with a dict-keyed sort. Makes `conda install` and `conda update --all` against long-lived environments dramatically faster (~780× on a synthetic 50,000-record prefix). (#15970)
+* Replace the quadratic position-scan in `diff_for_unlink_link_precs()` with linear order restoration over the existing ordered record sequences. Makes `conda install` and `conda update --all` against long-lived environments dramatically faster (~780x on a synthetic 50,000-record prefix). (#15970)
 
 ### Bug fixes
 

--- a/news/15970-track-b-b1-diff-sort
+++ b/news/15970-track-b-b1-diff-sort
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Replace the quadratic position-scan in `diff_for_unlink_link_precs()` with a dict-keyed sort. Makes `conda install` and `conda update --all` against long-lived environments dramatically faster (~780× on a synthetic 50,000-record prefix). (#15970)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Replaces the quadratic order-restoration step in `diff_for_unlink_link_precs` (`conda/core/solve.py`) with a linear pass over the already-ordered record sequences.

The old code did:

- `sorted(unlink_precs, key=lambda x: previous_records.index(x))`
- `sorted(link_precs, key=lambda x: final_precs.index(x))`

Each `tuple.index` scans the ordered sequence, so restoring order for a 2,000-unlink/link transaction against a 50,000-record prefix does millions of repeated position scans.

This PR keeps `unlink_precs` / `link_precs` as sets, then restores order by filtering the source-of-truth ordered sequences directly:

- `previous_records` in reverse order for unlink records
- `final_precs` in forward order for link records

That preserves the same output order without sorting or per-record index lookups. No semantic change.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Focused measurement

Synthetic fixture with N=50,000 prefix records and k=2,000 unlink/link records:

| | Repeated index scan | Linear order restoration | Speedup |
|---|---:|---:|---:|
| `diff_for_unlink_link_precs` | 12.46 s | 15.9 ms | 782x |

At N=10,000 and k=400, the same focused benchmark measured a 215x speedup. These figures measure this function only. The earlier full-stack timing was removed because it covered a superseded combination of Track B changes rather than this PR in isolation.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests? Existing solve tests cover the semantics; happy to add a regression benchmark if desired.
- [x] Add / update outdated documentation? No user-facing docs change.
