### PR TITLE
Index exact-name PrefixGraph dependencies (B2)

### DIFF
--- a/conda/models/prefix_graph.py
+++ b/conda/models/prefix_graph.py
@@ -52,12 +52,9 @@ class PrefixGraph:
         self.graph = graph = {}
         self.spec_matches: dict[PrefixRecord, dict[MatchSpec, None]]
         self.spec_matches = spec_matches = {}
-        # Index records by package name so the parent-match inner loop
-        # iterates only the name-matching candidates instead of every
-        # record. MatchSpec(dep).name is always set; any record whose
-        # name doesn't match would have been filtered out by the
-        # original MatchSpec.match() anyway, just at O(N) per dep
-        # rather than O(1). See #15971 for the before/after benchmark.
+        # Index records by package name so exact-name dependencies only
+        # consider name-matching candidates. Non-exact names still scan
+        # every record. See #15971 for the before/after benchmark.
         by_name: dict[str, list[PrefixRecord]] = {}
         for rec in records:
             by_name.setdefault(rec.name, []).append(rec)
@@ -65,7 +62,9 @@ class PrefixGraph:
             parent_nodes: dict[PrefixRecord, None] = {}
             for dep in node.depends:
                 spec = MatchSpec(dep)
-                for candidate in by_name.get(spec.name, ()):
+                name = spec.get_exact_value("name")
+                candidates = records if name is None else by_name.get(name, ())
+                for candidate in candidates:
                     if spec.match(candidate):
                         parent_nodes[candidate] = None
             graph[node] = parent_nodes

--- a/conda/models/prefix_graph.py
+++ b/conda/models/prefix_graph.py
@@ -52,13 +52,22 @@ class PrefixGraph:
         self.graph = graph = {}
         self.spec_matches: dict[PrefixRecord, dict[MatchSpec, None]]
         self.spec_matches = spec_matches = {}
+        # Index records by package name so the parent-match inner loop
+        # iterates only the name-matching candidates instead of every
+        # record. MatchSpec(dep).name is always set; any record whose
+        # name doesn't match would have been filtered out by the
+        # original MatchSpec.match() anyway, just at O(N) per dep
+        # rather than O(1). See #15971 for the before/after benchmark.
+        by_name: dict[str, list[PrefixRecord]] = {}
+        for rec in records:
+            by_name.setdefault(rec.name, []).append(rec)
         for node in records:
-            parent_match_specs = tuple(MatchSpec(d) for d in node.depends)
-            parent_nodes = {
-                rec: None
-                for rec in records
-                if any(m.match(rec) for m in parent_match_specs)
-            }
+            parent_nodes: dict[PrefixRecord, None] = {}
+            for dep in node.depends:
+                spec = MatchSpec(dep)
+                for candidate in by_name.get(spec.name, ()):
+                    if spec.match(candidate):
+                        parent_nodes[candidate] = None
             graph[node] = parent_nodes
             matching_specs = dict.fromkeys(s for s in specs if s.match(node))
             if matching_specs:

--- a/news/15971-track-b-b2-prefix-graph
+++ b/news/15971-track-b-b2-prefix-graph
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Build a per-name candidate index in `PrefixGraph.__init__()` to replace the quadratic scan over all records. Speeds up transactions against large environments — ~50× at 1,000 records, far more at the scales where users notice it. (#15971)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/15971-track-b-b2-prefix-graph
+++ b/news/15971-track-b-b2-prefix-graph
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Build a per-name candidate index in `PrefixGraph.__init__()` to replace the quadratic scan over all records. Speeds up transactions against large environments — ~50× at 1,000 records, far more at the scales where users notice it. (#15971)
+* Build a per-name candidate index in `PrefixGraph.__init__()` to accelerate graph construction for large prefixes. (#15971)
 
 ### Bug fixes
 

--- a/tests/models/test_prefix_graph.py
+++ b/tests/models/test_prefix_graph.py
@@ -987,6 +987,18 @@ def test_general_graph_bfs_simple():
     assert backwards is None
 
 
+def test_prefix_graph_name_glob_dependency():
+    consumer = PackageRecord(
+        name="consumer", version="1", build="0", build_number=0, depends=["foo*"]
+    )
+    foo = PackageRecord(name="foo", version="1", build="0", build_number=0)
+    foobar = PackageRecord(name="foobar", version="1", build="0", build_number=0)
+
+    graph = PrefixGraph((consumer, foo, foobar))
+
+    assert graph.graph[consumer] == {foo: None, foobar: None}
+
+
 def test_general_graph_bfs_version():
     a = PackageRecord(
         name="a", version="1", build="0", build_number=0, depends=["b", "c", "d"]
@@ -1002,6 +1014,9 @@ def test_general_graph_bfs_version():
     g2 = PackageRecord(name="g", version="2", build="0", build_number=0)
     records = [a, b, c, d, e, f, g1, g2]
     graph = GeneralGraph(records)
+
+    assert graph.graph[c] == {g1: None}
+    assert graph.graph[d] == {f: None, g2: None}
 
     a_to_g1 = graph.breadth_first_search_by_name(MatchSpec("a"), MatchSpec("g=1"))
     assert a_to_g1 == [MatchSpec("a"), MatchSpec("c"), MatchSpec("g=1")]


### PR DESCRIPTION
### Description

Adds a per-name candidate index to `PrefixGraph.__init__()` for exact-name dependencies. Non-exact names, including globs, retain the full scan to preserve `MatchSpec` semantics.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Focused measurement

Synthetic DAG fixture:

| N | Repeated candidate scan | Name index | Speedup |
|---:|---:|---:|---:|
| 1,000 | 4.18 s | 78 ms | 53x |

The focused result measures the exact-name path. The earlier full-stack W3 figures were removed because they covered a superseded combination of Track B changes, rather than this PR in isolation.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests? Added coverage for globbed names and multiple same-name candidates in `GeneralGraph`.
- [x] Add / update outdated documentation? No user-facing docs change.
