### PR TITLE
Verify transaction actions in parallel (B6)

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -64,7 +64,7 @@ from ..reporters import confirm_yn, get_spinner
 from ..resolve import MatchSpec
 from ..utils import get_comspec, human_bytes, wrap_subprocess_call
 from .package_cache_data import PackageCacheData
-from .portability import batch_codesign_calls
+from .portability import batch_codesign_calls, codesign_paths
 from .path_actions import (
     AggregateCompileMultiPycAction,
     CompileMultiPycAction,
@@ -609,31 +609,9 @@ class UnlinkLinkTransaction:
         )
 
     @staticmethod
-    def _verify_individual_level(prefix_action_group):
-        all_actions = chain.from_iterable(
-            axngroup.actions
-            for action_groups in prefix_action_group
-            for axngroup in action_groups
-        )
-
-        error_results = []
-        with batch_codesign_calls():
-            # run all per-action (per-package) verify methods
-            #   one of the more important of these checks is to verify that a file listed in
-            #   the packages manifest (i.e. info/files) is actually contained within the package
-            for axn in all_actions:
-                if axn.verified:
-                    continue
-                error_result = axn.verify()
-                if error_result:
-                    formatted_error = "".join(
-                        format_exception_only(type(error_result), error_result)
-                    )
-                    log.debug(
-                        "Verification error in action %s\n%s", axn, formatted_error
-                    )
-                    error_results.append(error_result)
-        return error_results
+    def _verify_action(action):
+        with batch_codesign_calls(flush=False) as action_codesign_paths:
+            return action.verify(), action_codesign_paths
 
     @staticmethod
     def _verify_prefix_level(target_prefix_AND_prefix_action_group_tuple):
@@ -892,13 +870,28 @@ class UnlinkLinkTransaction:
         if transaction_exceptions:
             return transaction_exceptions
 
+        actions = tuple(
+            action
+            for prefix_action_group in prefix_action_groups.values()
+            for action_groups in prefix_action_group
+            for action_group in action_groups
+            for action in action_group.actions
+            if not action.verified
+        )
         exceptions = []
-        for exc in self.verify_executor.map(
-            UnlinkLinkTransaction._verify_individual_level,
-            prefix_action_groups.values(),
+        pending_codesign_paths = []
+        for action, (exc, action_codesign_paths) in zip(
+            actions,
+            self.verify_executor.map(UnlinkLinkTransaction._verify_action, actions),
         ):
+            pending_codesign_paths.extend(action_codesign_paths)
             if exc:
-                exceptions.extend(exc)
+                formatted_error = "".join(format_exception_only(type(exc), exc))
+                log.debug(
+                    "Verification error in action %s\n%s", action, formatted_error
+                )
+                exceptions.append(exc)
+        codesign_paths(pending_codesign_paths)
         for exc in self.verify_executor.map(
             UnlinkLinkTransaction._verify_prefix_level, prefix_action_groups.items()
         ):

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -25,7 +25,7 @@ from ..models.enums import FileMode
 log = getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
 
 
 # three capture groups: whole_shebang, executable, options
@@ -135,7 +135,9 @@ def update_prefix(
 _codesign_batch_state = threading.local()
 
 
-def _run_codesign(paths: list[str]) -> None:
+def codesign_paths(paths: Iterable[str]) -> None:
+    """Ad-hoc sign paths in command-line-sized batches."""
+    paths = list(paths)
     if not paths:
         return
 
@@ -154,26 +156,27 @@ def _run_codesign(paths: list[str]) -> None:
 def _codesign_or_enqueue(path: str) -> None:
     paths = getattr(_codesign_batch_state, "paths", None)
     if paths is None:
-        _run_codesign([path])
+        codesign_paths([path])
     else:
         paths.append(path)
 
 
 @contextmanager
-def batch_codesign_calls() -> Iterator[None]:
+def batch_codesign_calls(*, flush: bool = True) -> Iterator[list[str]]:
     """Batch osx-arm64 ``codesign`` calls made by :func:`update_prefix`.
 
     Direct ``update_prefix`` callers keep the old immediate-signing behavior.
     Transaction verification wraps prefix rewrites in this context so the
     rewritten intermediates can be signed with fewer subprocesses before they
-    are linked into the target prefix. See #15975.
+    are linked into the target prefix. Executor workers can disable flushing
+    and return their collected paths to the parent thread. See #15975.
     """
     parent_paths = getattr(_codesign_batch_state, "paths", None)
     paths: list[str] = []
     _codesign_batch_state.paths = paths
     succeeded = False
     try:
-        yield
+        yield paths
         succeeded = True
     finally:
         if parent_paths is None:
@@ -182,7 +185,8 @@ def batch_codesign_calls() -> Iterator[None]:
             _codesign_batch_state.paths = parent_paths
         if succeeded:
             if parent_paths is None:
-                _run_codesign(paths)
+                if flush:
+                    codesign_paths(paths)
             else:
                 parent_paths.extend(paths)
 

--- a/news/15973-track-b-b6-verify-parallel
+++ b/news/15973-track-b-b6-verify-parallel
@@ -1,0 +1,19 @@
+### Enhancements
+
+* `_verify_individual_level()` now parallelises across `CONDA_VERIFY_THREADS` workers when the user sets it above 1 (default unchanged). On fast disks this roughly halves the verify phase for packages with many prefix-replaced files. (#15973)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/15973-track-b-b6-verify-parallel
+++ b/news/15973-track-b-b6-verify-parallel
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* `_verify_individual_level()` now parallelises across `CONDA_VERIFY_THREADS` workers when the user sets it above 1 (default unchanged). On fast disks this roughly halves the verify phase for packages with many prefix-replaced files. (#15973)
+* Verify individual transaction actions across the shared `verify_threads` executor when configured above 1. (#15969 via #15973)
 
 ### Bug fixes
 

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -1,9 +1,15 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
+from pathlib import Path
+
+from conda.base.context import reset_context
 from conda.core import link
 from conda.core.path_actions import RemoveLinkedPackageRecordAction
-from conda.models.records import PackageRecord, PrefixRecord
+from conda.models.channel import Channel
+from conda.models.enums import FileMode, PathEnum
+from conda.models.package_info import PackageInfo
+from conda.models.records import PackageRecord, PathDataV1, PathsData, PrefixRecord
 
 
 def test_make_unlink_actions_uses_prefix_record_json_filename_for_conda_meta():
@@ -31,6 +37,87 @@ def test_make_unlink_actions_uses_prefix_record_json_filename_for_conda_meta():
         remove_record_action.target_short_path
         == "conda-meta/idna-3.10-py3_none_any_0.json"
     )
+
+
+def test_verify_uses_parallel_prefix_rewrite_actions(tmp_path, mocker, monkeypatch):
+    source_dir = tmp_path / "pkgs"
+    prefix_placeholder = "/" + "placeholder" * 30
+    path_data = []
+    (source_dir / "info").mkdir(parents=True)
+    (source_dir / "info" / "index.json").write_text("{}", encoding="utf-8")
+    for index in range(4):
+        source_short_path = f"bin/tool-{index}"
+        source_path = source_dir / "bin" / f"tool-{index}"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_bytes(
+            b"\x7fELF..." + prefix_placeholder.encode() + b"/bin/python\0"
+        )
+        path_data.append(
+            PathDataV1(
+                _path=source_short_path,
+                path_type=PathEnum.hardlink,
+                prefix_placeholder=prefix_placeholder,
+                file_mode=FileMode.binary,
+            )
+        )
+    repodata_record = PackageRecord(
+        build=0,
+        build_number=0,
+        name="test-prefix-replace",
+        version=0,
+        channel="defaults",
+        subdir="linux-64",
+        fn="test-prefix-replace-0-0.conda",
+        md5="0123456789",
+    )
+    package_info = PackageInfo(
+        extracted_package_dir=str(source_dir),
+        package_tarball_full_path=str(source_dir / "test-prefix-replace-0-0.conda"),
+        channel=Channel("defaults"),
+        repodata_record=repodata_record,
+        url="https://example.invalid/test-prefix-replace-0-0.conda",
+        package_metadata=None,
+        paths_data=PathsData(paths_version=1, paths=path_data),
+    )
+    target_prefix = str(tmp_path / "prefix")
+    link_prec = package_info.repodata_record
+    setup = link.PrefixSetup(
+        target_prefix,
+        (),
+        (link_prec,),
+        (),
+        (),
+        (),
+    )
+    mocker.patch(
+        "conda.core.link.PackageCacheData.get_entry_to_link", return_value=object()
+    )
+    mocker.patch("conda.core.package_cache_data.ProgressiveFetchExtract.execute")
+    mocker.patch("conda.core.link.read_package_info", return_value=package_info)
+    monkeypatch.setenv("CONDA_VERIFY_THREADS", "2")
+    reset_context()
+
+    transaction = link.UnlinkLinkTransaction(setup)
+
+    transaction.verify()
+
+    link_actions = tuple(
+        action
+        for action_group in transaction.prefix_action_groups[
+            target_prefix
+        ].link_action_groups
+        for action in action_group.actions
+        if getattr(action, "prefix_placeholder", None)
+    )
+    assert len(link_actions) == 4
+    for action in link_actions:
+        assert action.verified
+        assert action.prefix_path_data.file_mode == FileMode.binary
+        assert Path(action.intermediate_path).exists()
+        assert (
+            bytes(target_prefix, encoding="utf-8")
+            in Path(action.intermediate_path).read_bytes()
+        )
 
 
 def test_calculate_change_report_revised_variant():

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -2,10 +2,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from pathlib import Path
+from threading import Lock, get_ident
+from time import sleep
 
 from conda.base.context import reset_context
 from conda.core import link
-from conda.core.path_actions import RemoveLinkedPackageRecordAction
+from conda.core.path_actions import (
+    PrefixReplaceLinkAction,
+    RemoveLinkedPackageRecordAction,
+)
 from conda.models.channel import Channel
 from conda.models.enums import FileMode, PathEnum
 from conda.models.package_info import PackageInfo
@@ -40,6 +45,16 @@ def test_make_unlink_actions_uses_prefix_record_json_filename_for_conda_meta():
 
 
 def test_verify_uses_parallel_prefix_rewrite_actions(tmp_path, mocker, monkeypatch):
+    worker_threads = set()
+    worker_threads_lock = Lock()
+    original_verify = PrefixReplaceLinkAction.verify
+
+    def tracked_verify(action):
+        with worker_threads_lock:
+            worker_threads.add(get_ident())
+        sleep(0.05)
+        return original_verify(action)
+
     source_dir = tmp_path / "pkgs"
     prefix_placeholder = "/" + "placeholder" * 30
     path_data = []
@@ -66,7 +81,7 @@ def test_verify_uses_parallel_prefix_rewrite_actions(tmp_path, mocker, monkeypat
         name="test-prefix-replace",
         version=0,
         channel="defaults",
-        subdir="linux-64",
+        subdir="osx-arm64",
         fn="test-prefix-replace-0-0.conda",
         md5="0123456789",
     )
@@ -94,6 +109,15 @@ def test_verify_uses_parallel_prefix_rewrite_actions(tmp_path, mocker, monkeypat
     )
     mocker.patch("conda.core.package_cache_data.ProgressiveFetchExtract.execute")
     mocker.patch("conda.core.link.read_package_info", return_value=package_info)
+    mocker.patch.object(
+        PrefixReplaceLinkAction,
+        "verify",
+        autospec=True,
+        side_effect=tracked_verify,
+    )
+    monkeypatch.setattr("conda.core.portability.on_mac", True)
+    immediate_codesign = mocker.patch("conda.core.portability.codesign_paths")
+    batched_codesign = mocker.patch("conda.core.link.codesign_paths")
     monkeypatch.setenv("CONDA_VERIFY_THREADS", "2")
     reset_context()
 
@@ -110,6 +134,11 @@ def test_verify_uses_parallel_prefix_rewrite_actions(tmp_path, mocker, monkeypat
         if getattr(action, "prefix_placeholder", None)
     )
     assert len(link_actions) == 4
+    assert len(worker_threads) == 2
+    immediate_codesign.assert_not_called()
+    batched_codesign.assert_called_once_with(
+        [str(Path(action.intermediate_path).resolve()) for action in link_actions]
+    )
     for action in link_actions:
         assert action.verified
         assert action.prefix_path_data.file_mode == FileMode.binary


### PR DESCRIPTION
### Description

Transaction verification already owns a shared executor sized by `verify_threads`, but B6 previously fanned out only by prefix and then created a second executor for the actions inside each prefix. A normal install usually has one target prefix, so that shape either stayed serial or created nested pools.

This PR now flattens all unverified transaction actions into one ordered stream and maps their `verify()` calls directly across the existing executor. Prefix-level checks reuse the same executor after individual verification completes.

Since B9c (#15975) now batches codesign calls during verification, each executor worker returns its queued signing paths to the parent, which flushes one batch before prefix-level verification. This keeps batching effective without sharing thread-local state.

The default remains one verification worker. Setting `verify_threads` or `CONDA_VERIFY_THREADS` above one enables parallel action verification while preserving deterministic result ordering.

This removes `_verify_individual_level` and avoids a nested executor.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the news directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? The existing `verify_threads` setting now controls action verification directly.
