### PR TITLE
Extract packages with a process pool (B8)

### DIFF
--- a/conda/_private/extract.py
+++ b/conda/_private/extract.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Lean package extraction helpers for subprocess workers."""
+
+from __future__ import annotations
+
+import os
+
+
+def extract_conda_package_archive(
+    source_full_path: str | os.PathLike,
+    destination_directory: str | os.PathLike,
+) -> None:
+    """Extract a conda package archive without importing conda runtime state."""
+    import conda_package_handling.api
+
+    conda_package_handling.api.extract(
+        os.fspath(source_full_path),
+        dest_dir=os.fspath(destination_directory),
+    )

--- a/conda/_private/extract.py
+++ b/conda/_private/extract.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 
 import os
 
+# This module is imported in each spawned extraction worker. Keep imports here
+# limited to the standard library; importing conda runtime state defeats the
+# process pool's startup benefit.
+
 
 def extract_conda_package_archive(
     source_full_path: str | os.PathLike,

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -186,6 +186,7 @@ MAX_CHANNEL_PRIORITY: Final = 10000
 
 CONDA_PACKAGE_EXTENSION_V1: Final = ".tar.bz2"
 CONDA_PACKAGE_EXTENSION_V2: Final = ".conda"
+CONDA_PACKAGE_EXTRACTOR_NAME: Final = "conda-package"
 
 PARTIAL_EXTENSION: Final = ".partial"
 """Suffix appended to package filenames during incomplete downloads."""

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -4,9 +4,15 @@
 
 from __future__ import annotations
 
+import multiprocessing
 import os
 from collections import defaultdict
-from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
+from concurrent.futures import (
+    CancelledError,
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+    as_completed,
+)
 from errno import EACCES, ENOENT, EPERM, EROFS
 from functools import partial
 from itertools import chain
@@ -18,12 +24,14 @@ from tarfile import ReadError
 from typing import TYPE_CHECKING
 
 from .. import CondaError, CondaMultiError, conda_signal_handler
+from .._private.extract import extract_conda_package_archive
 from ..auxlib.collection import first
 from ..auxlib.decorators import memoizemethod
 from ..auxlib.entity import ValidationError
 from ..base.constants import (
     CONDA_PACKAGE_EXTENSION_V1,
     CONDA_PACKAGE_EXTENSION_V2,
+    CONDA_PACKAGE_EXTRACTOR_NAME,
     PACKAGE_CACHE_MAGIC_FILE,
 )
 from ..base.context import context
@@ -35,7 +43,7 @@ from ..common.serialize import json
 from ..common.signals import signal_handler
 from ..common.terminal import is_tty, term_dumb
 from ..common.url import path_to_url
-from ..exceptions import NotWritableError, NoWritablePkgsDirError
+from ..exceptions import NotWritableError, NoWritablePkgsDirError, PluginError
 from ..gateways.disk.create import (
     create_package_cache_directory,
     write_as_json_to_file,
@@ -71,8 +79,15 @@ try:
     from conda_package_handling.api import THREADSAFE_EXTRACT
 except ImportError:
     THREADSAFE_EXTRACT = False
-# On the machines we tested, extraction doesn't get any faster after 3 threads
-EXTRACT_THREADS = min(os.cpu_count() or 1, 3) if THREADSAFE_EXTRACT else 1
+# The fallback thread pool is used for non-standard package extractor plugins
+# and debug mode. Built-in .conda/.tar.bz2 extraction normally runs in a
+# process pool below to avoid zstd's GIL bottleneck. See #15974.
+EXTRACT_THREADS = 2 if THREADSAFE_EXTRACT else 1
+EXTRACT_PROCESSES = min(os.cpu_count() or 1, 4) if THREADSAFE_EXTRACT else 1
+EXTRACT_PROCESS_EXTENSIONS = (
+    CONDA_PACKAGE_EXTENSION_V1,
+    CONDA_PACKAGE_EXTENSION_V2,
+)
 
 
 class PackageCacheType(type):
@@ -827,6 +842,39 @@ class ProgressiveFetchExtract:
             exceptions = []
             progress_bars = {}
             futures: list[Future] = []
+            extract_futures = {}
+            extract_actions = self.extract_actions
+            use_process_pool = (
+                bool(extract_actions) and EXTRACT_PROCESSES > 1 and not context.debug
+            )
+            if use_process_pool:
+                # Only bypass the plugin manager when every action resolves to
+                # conda's built-in extractor.
+                for extract_action in extract_actions:
+                    source_full_path = os.fspath(extract_action.source_full_path)
+                    if not source_full_path.lower().endswith(
+                        EXTRACT_PROCESS_EXTENSIONS
+                    ):
+                        use_process_pool = False
+                        break
+                    try:
+                        extractor = context.plugin_manager.get_package_extractor(
+                            source_full_path
+                        )
+                    except PluginError:
+                        use_process_pool = False
+                        break
+                    if extractor.name != CONDA_PACKAGE_EXTRACTOR_NAME:
+                        use_process_pool = False
+                        break
+
+            if use_process_pool:
+                extract_executor = ProcessPoolExecutor(
+                    max_workers=EXTRACT_PROCESSES,
+                    mp_context=multiprocessing.get_context("spawn"),
+                )
+            else:
+                extract_executor = ThreadPoolExecutor(EXTRACT_THREADS)
 
             cancelled_flag = False
 
@@ -841,7 +889,7 @@ class ProgressiveFetchExtract:
                 signal_handler(conda_signal_handler),
                 time_recorder("fetch_extract_execute"),
                 ThreadPoolExecutor(context.fetch_threads) as fetch_executor,
-                ThreadPoolExecutor(EXTRACT_THREADS) as extract_executor,
+                extract_executor,
             ):
                 for prec_or_spec, (
                     cache_action,
@@ -882,21 +930,58 @@ class ProgressiveFetchExtract:
                         prec_or_spec = completed_future.result()
 
                         cache_action, extract_action = self.paired_actions[prec_or_spec]
-                        extract_future = extract_executor.submit(
-                            do_extract_action,
-                            prec_or_spec,
-                            extract_action,
-                            progress_bars[prec_or_spec],
-                        )
-                        extract_future.add_done_callback(
-                            partial(
-                                done_callback,
-                                actions=(cache_action, extract_action),
-                                exceptions=exceptions,
-                                progress_bar=progress_bars[prec_or_spec],
-                                finish=True,
+                        progress_bar = progress_bars[prec_or_spec]
+                        actions = (cache_action, extract_action)
+                        if not extract_action:
+                            do_cleanup(actions)
+                            progress_bar.finish()
+                            progress_bar.refresh()
+                        elif use_process_pool:
+                            try:
+                                extract_action.verify()
+                                extract_action.prepare_extract()
+                                extract_future = extract_executor.submit(
+                                    extract_conda_package_archive,
+                                    extract_action.source_full_path,
+                                    extract_action.target_full_path,
+                                )
+                            except Exception as e:
+                                do_reverse(reversed(actions))
+                                exceptions.append(e)
+                            else:
+                                extract_futures[extract_future] = (
+                                    actions,
+                                    extract_action,
+                                    progress_bar,
+                                )
+                        else:
+                            extract_future = extract_executor.submit(
+                                do_extract_action,
+                                prec_or_spec,
+                                extract_action,
+                                progress_bar,
                             )
-                        )
+                            extract_futures[extract_future] = (
+                                actions,
+                                None,
+                                progress_bar,
+                            )
+                    for extract_future in as_completed(extract_futures):
+                        actions, process_extract_action, progress_bar = extract_futures[
+                            extract_future
+                        ]
+                        try:
+                            extract_future.result()
+                            if process_extract_action:
+                                process_extract_action.finish_extract()
+                                progress_bar.update_to(1.0)
+                        except Exception as e:
+                            do_reverse(reversed(actions))
+                            exceptions.append(e)
+                        else:
+                            do_cleanup(actions)
+                            progress_bar.finish()
+                            progress_bar.refresh()
                 except BaseException as e:
                     # We are interested in KeyboardInterrupt delivered to
                     # as_completed() while waiting, or any exception raised from

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -966,6 +966,20 @@ class ProgressiveFetchExtract:
                                 None,
                                 progress_bar,
                             )
+                except BaseException as e:
+                    # We are interested in KeyboardInterrupt delivered to
+                    # as_completed() while waiting, or any exception raised from
+                    # completed_future.result(). cancelled_flag is checked in the
+                    # progress callback to stop running transfers, shutdown() should
+                    # prevent new downloads from starting.
+                    cancelled_flag = True
+                    for future in futures:  # needed on top of .shutdown()
+                        future.cancel()
+                    # Has a Python >=3.9 cancel_futures= parameter that does not
+                    # replace the above loop:
+                    fetch_executor.shutdown(wait=False)
+                    exceptions.append(e)
+                finally:
                     for extract_future in as_completed(extract_futures):
                         actions, process_extract_action, progress_bar = extract_futures[
                             extract_future
@@ -982,19 +996,6 @@ class ProgressiveFetchExtract:
                             do_cleanup(actions)
                             progress_bar.finish()
                             progress_bar.refresh()
-                except BaseException as e:
-                    # We are interested in KeyboardInterrupt delivered to
-                    # as_completed() while waiting, or any exception raised from
-                    # completed_future.result(). cancelled_flag is checked in the
-                    # progress callback to stop running transfers, shutdown() should
-                    # prevent new downloads from starting.
-                    cancelled_flag = True
-                    for future in futures:  # needed on top of .shutdown()
-                        future.cancel()
-                    # Has a Python >=3.9 cancel_futures= parameter that does not
-                    # replace the above loop:
-                    fetch_executor.shutdown(wait=False)
-                    exceptions.append(e)
 
             for bar in progress_bars.values():
                 bar.close()

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -82,7 +82,8 @@ except ImportError:
 # The fallback thread pool is used for non-standard package extractor plugins
 # and debug mode. Built-in .conda/.tar.bz2 extraction normally runs in a
 # process pool below to avoid zstd's GIL bottleneck. See #15974.
-EXTRACT_THREADS = 2 if THREADSAFE_EXTRACT else 1
+# On the machines we tested, extraction doesn't get any faster after 3 threads.
+EXTRACT_THREADS = min(os.cpu_count() or 1, 3) if THREADSAFE_EXTRACT else 1
 EXTRACT_PROCESSES = min(os.cpu_count() or 1, 4) if THREADSAFE_EXTRACT else 1
 EXTRACT_PROCESS_EXTENSIONS = (
     CONDA_PACKAGE_EXTENSION_V1,
@@ -939,7 +940,7 @@ class ProgressiveFetchExtract:
                         elif use_process_pool:
                             try:
                                 extract_action.verify()
-                                extract_action.prepare_extract()
+                                extract_action._prepare_extract()
                                 extract_future = extract_executor.submit(
                                     extract_conda_package_archive,
                                     extract_action.source_full_path,
@@ -987,7 +988,7 @@ class ProgressiveFetchExtract:
                         try:
                             extract_future.result()
                             if process_extract_action:
-                                process_extract_action.finish_extract()
+                                process_extract_action._finish_extract()
                                 progress_bar.update_to(1.0)
                         except Exception as e:
                             do_reverse(reversed(actions))

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1466,10 +1466,14 @@ class ExtractPackageAction(PathAction):
         self._verified = True
 
     def execute(self, progress_update_callback=None):
-        # I hate inline imports, but I guess it's ok since we're importing from the conda.core
-        # The alternative is passing the the classes to ExtractPackageAction __init__
-        from .package_cache_data import PackageCacheData
+        self.prepare_extract()
+        context.plugin_manager.extract_package(
+            self.source_full_path,
+            self.target_full_path,
+        )
+        self.finish_extract()
 
+    def prepare_extract(self):
         log.log(
             TRACE, "extracting %s => %s", self.source_full_path, self.target_full_path
         )
@@ -1477,11 +1481,10 @@ class ExtractPackageAction(PathAction):
         if lexists(self.target_full_path):
             rm_rf(self.target_full_path)
 
-        # extract the package using the appropriate plugin
-        context.plugin_manager.extract_package(
-            self.source_full_path,
-            self.target_full_path,
-        )
+    def finish_extract(self):
+        # I hate inline imports, but I guess it's ok since we're importing from the conda.core
+        # The alternative is passing the the classes to ExtractPackageAction __init__
+        from .package_cache_data import PackageCacheData
 
         try:
             raw_index_json = read_index_json(self.target_full_path)

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -1466,14 +1466,14 @@ class ExtractPackageAction(PathAction):
         self._verified = True
 
     def execute(self, progress_update_callback=None):
-        self.prepare_extract()
+        self._prepare_extract()
         context.plugin_manager.extract_package(
             self.source_full_path,
             self.target_full_path,
         )
-        self.finish_extract()
+        self._finish_extract()
 
-    def prepare_extract(self):
+    def _prepare_extract(self):
         log.log(
             TRACE, "extracting %s => %s", self.source_full_path, self.target_full_path
         )
@@ -1481,7 +1481,7 @@ class ExtractPackageAction(PathAction):
         if lexists(self.target_full_path):
             rm_rf(self.target_full_path)
 
-    def finish_extract(self):
+    def _finish_extract(self):
         # I hate inline imports, but I guess it's ok since we're importing from the conda.core
         # The alternative is passing the the classes to ExtractPackageAction __init__
         from .package_cache_data import PackageCacheData

--- a/conda/plugins/package_extractors/conda.py
+++ b/conda/plugins/package_extractors/conda.py
@@ -10,6 +10,12 @@ from logging import getLogger
 from os.path import join
 from typing import TYPE_CHECKING
 
+from ..._private.extract import extract_conda_package_archive
+from ...base.constants import (
+    CONDA_PACKAGE_EXTENSION_V1,
+    CONDA_PACKAGE_EXTENSION_V2,
+    CONDA_PACKAGE_EXTRACTOR_NAME,
+)
 from ...common.compat import on_linux
 from ...gateways.disk.delete import path_is_clean
 from ..hookspec import hookimpl
@@ -50,9 +56,7 @@ def extract_conda_or_tarball(
             destination_directory,
         )
 
-    conda_package_handling.api.extract(
-        tarball_full_path, dest_dir=destination_directory
-    )
+    extract_conda_package_archive(tarball_full_path, destination_directory)
 
     if hasattr(conda_package_handling.api, "THREADSAFE_EXTRACT"):
         return  # indicates conda-package-handling 2.x, which implements --no-same-owner
@@ -70,7 +74,7 @@ def extract_conda_or_tarball(
 @hookimpl
 def conda_package_extractors():
     yield CondaPackageExtractor(
-        name="conda-package",
-        extensions=[".tar.bz2", ".conda"],
+        name=CONDA_PACKAGE_EXTRACTOR_NAME,
+        extensions=[CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2],
         extract=extract_conda_or_tarball,
     )

--- a/news/15974-track-b-b8-extract-threads
+++ b/news/15974-track-b-b8-extract-threads
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Extract built-in `.conda` and `.tar.bz2` package archives with a process pool so zstd decompression can run outside the GIL, while keeping package-cache metadata updates in the parent process. (#15974)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/15974-track-b-b8-extract-threads
+++ b/news/15974-track-b-b8-extract-threads
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Extract built-in `.conda` and `.tar.bz2` package archives with a process pool so zstd decompression can run outside the GIL, while keeping package-cache metadata updates in the parent process. (#15974)
+* Extract built-in `.conda` and `.tar.bz2` package archives with a process pool so zstd decompression can run outside the GIL, while keeping package-cache metadata updates in the parent process. (#15969 via #15974)
 
 ### Bug fixes
 

--- a/tests/_private/test_extract.py
+++ b/tests/_private/test_extract.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Verify the extraction worker module stays import-light."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_extract_module_does_not_import_runtime_state() -> None:
+    script = """\
+import sys
+import conda._private.extract
+
+for name in sorted(sys.modules):
+    print(name)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    imported = set(result.stdout.splitlines())
+    conda_modules = {
+        name for name in imported if name == "conda" or name.startswith("conda.")
+    }
+    assert conda_modules <= {
+        "conda",
+        "conda._private",
+        "conda._private.extract",
+        "conda._version",
+    }
+    assert not any(name.startswith("conda_package_handling") for name in imported)

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -137,9 +137,9 @@ def test_process_extract_finishes_when_later_fetch_fails(mocker):
     with pytest.raises(CondaMultiError, match="fetch failed"):
         pfe.execute()
 
-    good_extract.finish_extract.assert_called_once_with()
+    good_extract._finish_extract.assert_called_once_with()
     good_extract.cleanup.assert_called_once_with()
-    bad_extract.finish_extract.assert_not_called()
+    bad_extract._finish_extract.assert_not_called()
 
 
 def test_ProgressiveFetchExtract_prefers_conda_v2_format(monkeypatch: MonkeyPatch):

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import datetime
 import json
+from concurrent.futures import ThreadPoolExecutor
 from os.path import abspath, basename, dirname, join
 from pathlib import Path
+from threading import Event
+from types import SimpleNamespace
 
 import pytest
 from pytest import MonkeyPatch
@@ -83,6 +86,60 @@ def fresh_zlib_records():
         PackageRecord.from_objects(zlib_tar_bz2_prec),
         PackageRecord.from_objects(zlib_conda_prec),
     )
+
+
+def test_process_extract_finishes_when_later_fetch_fails(mocker):
+    extracted = Event()
+    good = PackageRecord(name="good", version="1", build="0", build_number=0)
+    bad = PackageRecord(name="bad", version="1", build="0", build_number=0)
+    good_cache = mocker.MagicMock()
+    bad_cache = mocker.MagicMock()
+    good_extract = mocker.MagicMock(
+        source_full_path="/tmp/good.conda",
+        target_full_path="/tmp/good",
+    )
+    bad_extract = mocker.MagicMock(
+        source_full_path="/tmp/bad.conda",
+        target_full_path="/tmp/bad",
+    )
+    pfe = ProgressiveFetchExtract(())
+    pfe.paired_actions = {
+        good: (good_cache, good_extract),
+        bad: (bad_cache, bad_extract),
+    }
+    pfe._prepared = True
+
+    def cache_action(record, *args, **kwargs):
+        if record == bad:
+            assert extracted.wait(timeout=5)
+            raise OSError("fetch failed")
+        return record
+
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 2)
+    mocker.patch.object(package_cache_data, "do_cache_action", side_effect=cache_action)
+    mocker.patch.object(
+        package_cache_data,
+        "extract_conda_package_archive",
+        side_effect=lambda *args: extracted.set(),
+    )
+    mocker.patch.object(
+        package_cache_data,
+        "ProcessPoolExecutor",
+        side_effect=lambda **kwargs: ThreadPoolExecutor(kwargs["max_workers"]),
+    )
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_extractor",
+        return_value=SimpleNamespace(name="conda-package"),
+    )
+    mocker.patch.object(pfe, "_progress_bar", return_value=mocker.MagicMock())
+
+    with pytest.raises(CondaMultiError, match="fetch failed"):
+        pfe.execute()
+
+    good_extract.finish_extract.assert_called_once_with()
+    good_extract.cleanup.assert_called_once_with()
+    bad_extract.finish_extract.assert_not_called()
 
 
 def test_ProgressiveFetchExtract_prefers_conda_v2_format(monkeypatch: MonkeyPatch):

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -78,6 +78,13 @@ zlib_conda_prec = PackageRecord.from_objects(
 )
 
 
+def fresh_zlib_records():
+    return (
+        PackageRecord.from_objects(zlib_tar_bz2_prec),
+        PackageRecord.from_objects(zlib_conda_prec),
+    )
+
+
 def test_ProgressiveFetchExtract_prefers_conda_v2_format(monkeypatch: MonkeyPatch):
     # force this to False, because otherwise tests fail when run with old conda-build
     # zlib is available in local "linux-64" subdir
@@ -277,8 +284,10 @@ def test_tar_bz2_in_pkg_cache_used_instead_of_conda_pkg(tmp_pkgs_dir: Path):
     Test that if a .tar.bz2 package is downloaded and extracted in a package cache, the
     complementary .conda package is not downloaded/extracted
     """
+    tar_bz2_prec, conda_prec = fresh_zlib_records()
+
     # Cache the .tar.bz2 file in the package cache and extract it
-    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe = ProgressiveFetchExtract((tar_bz2_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 1
     assert len(pfe.extract_actions) == 1
@@ -295,20 +304,20 @@ def test_tar_bz2_in_pkg_cache_used_instead_of_conda_pkg(tmp_pkgs_dir: Path):
     assert isfile(join(tmp_pkgs_dir, zlib_base_fn, "info", "repodata_record.json"))
 
     # Ensure second download/extract is a no-op
-    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe = ProgressiveFetchExtract((tar_bz2_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 0
     assert len(pfe.extract_actions) == 0
 
     # Now ensure download/extract for the complementary .conda package uses the cache
-    pfe = ProgressiveFetchExtract((zlib_conda_prec,))
+    pfe = ProgressiveFetchExtract((conda_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 0
     assert len(pfe.extract_actions) == 0
 
     # Now check urls.txt to make sure extensions are included.
     urls_text = tuple(yield_lines(join(tmp_pkgs_dir, "urls.txt")))
-    assert urls_text[0] == zlib_tar_bz2_prec.url
+    assert urls_text[0] == tar_bz2_prec.url
 
 
 @pytest.mark.integration
@@ -322,9 +331,10 @@ def test_tar_bz2_in_pkg_cache_doesnt_overwrite_conda_pkg(
     monkeypatch.setenv("CONDA_SEPARATE_FORMAT_CACHE", "True")
     reset_context()
     assert context.separate_format_cache
+    tar_bz2_prec, conda_prec = fresh_zlib_records()
 
     # Cache the .tar.bz2 file in the package cache and extract it
-    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe = ProgressiveFetchExtract((tar_bz2_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 1
     assert len(pfe.extract_actions) == 1
@@ -341,14 +351,14 @@ def test_tar_bz2_in_pkg_cache_doesnt_overwrite_conda_pkg(
     assert isfile(join(tmp_pkgs_dir, zlib_base_fn, "info", "repodata_record.json"))
 
     # Ensure second download/extract is a no-op
-    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe = ProgressiveFetchExtract((tar_bz2_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 0
     assert len(pfe.extract_actions) == 0
 
     # Now ensure download/extract for the complementary .conda package replaces the
     # extracted .tar.bz2
-    pfe = ProgressiveFetchExtract((zlib_conda_prec,))
+    pfe = ProgressiveFetchExtract((conda_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 1
     assert len(pfe.extract_actions) == 1
@@ -366,8 +376,8 @@ def test_tar_bz2_in_pkg_cache_doesnt_overwrite_conda_pkg(
 
     # Now check urls.txt to make sure extensions are included.
     urls_text = tuple(yield_lines(join(tmp_pkgs_dir, "urls.txt")))
-    assert urls_text[0] == zlib_tar_bz2_prec.url
-    assert urls_text[1] == zlib_conda_prec.url
+    assert urls_text[0] == tar_bz2_prec.url
+    assert urls_text[1] == conda_prec.url
 
 
 @pytest.mark.integration
@@ -381,9 +391,10 @@ def test_conda_pkg_in_pkg_cache_doesnt_overwrite_tar_bz2(
     monkeypatch.setenv("CONDA_SEPARATE_FORMAT_CACHE", "True")
     reset_context()
     assert context.separate_format_cache
+    tar_bz2_prec, conda_prec = fresh_zlib_records()
 
     # Cache the .conda file in the package cache and extract it
-    pfe = ProgressiveFetchExtract((zlib_conda_prec,))
+    pfe = ProgressiveFetchExtract((conda_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 1
     assert len(pfe.extract_actions) == 1
@@ -400,14 +411,14 @@ def test_conda_pkg_in_pkg_cache_doesnt_overwrite_tar_bz2(
     assert isfile(join(tmp_pkgs_dir, zlib_base_fn, "info", "repodata_record.json"))
 
     # Ensure second download/extract is a no-op
-    pfe = ProgressiveFetchExtract((zlib_conda_prec,))
+    pfe = ProgressiveFetchExtract((conda_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 0
     assert len(pfe.extract_actions) == 0
 
     # Now ensure download/extract for the complementary .conda package replaces the
     # extracted .tar.bz2
-    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe = ProgressiveFetchExtract((tar_bz2_prec,))
     pfe.prepare()
     assert len(pfe.cache_actions) == 1
     assert len(pfe.extract_actions) == 1


### PR DESCRIPTION
### Description

This updates B8 from a thread-cap-only change to Daniel's suggested process-pool approach for package extraction.

The motivating S8 fresh-cache trial used conda-tempo's documented package set (python=3.13 pandas scikit-learn jupyter). Four spawn-based process workers reduced the extraction phase from a 2.395 s serial median to 1.534 s, a 1.56x speedup. The full benchmark is recorded in the Track B report linked below.

Implementation details:

- Add conda._private.extract.extract_conda_package_archive as the lean built-in archive extraction helper.
- Keep filesystem preparation and package-cache metadata updates in the parent process.
- Use a spawn-based ProcessPoolExecutor only when every pending action uses conda's built-in extractor and process extraction is supported.
- Keep custom extractors, unsupported archive types, and debug mode on the existing thread path.
- Drain and finalize already-submitted extraction work even when a later fetch fails, so successful packages are not left extracted without their package-cache metadata.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the news directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
