### PR TITLE
Batch codesign calls for osx-arm64 prefix rewrites (B9c)

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -64,6 +64,7 @@ from ..reporters import confirm_yn, get_spinner
 from ..resolve import MatchSpec
 from ..utils import get_comspec, human_bytes, wrap_subprocess_call
 from .package_cache_data import PackageCacheData
+from .portability import flush_pending_codesign
 from .path_actions import (
     AggregateCompileMultiPycAction,
     CompileMultiPycAction,
@@ -639,6 +640,13 @@ class UnlinkLinkTransaction:
                 )
                 log.debug("Verification error in action %s\n%s", axn, formatted_error)
                 error_results.append(error_result)
+
+        # Any osx-arm64 binary rewrites done in update_prefix() queued
+        # a codesign request rather than spawning a subprocess inline.
+        # Flush them all in one batched ``codesign`` invocation now, before
+        # execute() links the intermediates to their final paths. See
+        # #15975.
+        flush_pending_codesign()
         return error_results
 
     @staticmethod

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -64,7 +64,7 @@ from ..reporters import confirm_yn, get_spinner
 from ..resolve import MatchSpec
 from ..utils import get_comspec, human_bytes, wrap_subprocess_call
 from .package_cache_data import PackageCacheData
-from .portability import flush_pending_codesign
+from .portability import batch_codesign_calls
 from .path_actions import (
     AggregateCompileMultiPycAction,
     CompileMultiPycAction,
@@ -626,27 +626,23 @@ class UnlinkLinkTransaction:
             for axngroup in action_groups
         )
 
-        # run all per-action (per-package) verify methods
-        #   one of the more important of these checks is to verify that a file listed in
-        #   the packages manifest (i.e. info/files) is actually contained within the package
         error_results = []
-        for axn in all_actions:
-            if axn.verified:
-                continue
-            error_result = axn.verify()
-            if error_result:
-                formatted_error = "".join(
-                    format_exception_only(type(error_result), error_result)
-                )
-                log.debug("Verification error in action %s\n%s", axn, formatted_error)
-                error_results.append(error_result)
-
-        # Any osx-arm64 binary rewrites done in update_prefix() queued
-        # a codesign request rather than spawning a subprocess inline.
-        # Flush them all in one batched ``codesign`` invocation now, before
-        # execute() links the intermediates to their final paths. See
-        # #15975.
-        flush_pending_codesign()
+        with batch_codesign_calls():
+            # run all per-action (per-package) verify methods
+            #   one of the more important of these checks is to verify that a file listed in
+            #   the packages manifest (i.e. info/files) is actually contained within the package
+            for axn in all_actions:
+                if axn.verified:
+                    continue
+                error_result = axn.verify()
+                if error_result:
+                    formatted_error = "".join(
+                        format_exception_only(type(error_result), error_result)
+                    )
+                    log.debug(
+                        "Verification error in action %s\n%s", axn, formatted_error
+                    )
+                    error_results.append(error_result)
         return error_results
 
     @staticmethod

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -140,7 +140,8 @@ def _run_codesign(paths: list[str]) -> None:
     for i in range(0, len(paths), chunk_size):
         subprocess.run(
             ["/usr/bin/codesign", "-s", "-", "-f", *paths[i : i + chunk_size]],
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
 
 

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -9,8 +9,10 @@ import re
 import struct
 import subprocess
 import threading
+from contextlib import contextmanager
 from logging import getLogger
 from os.path import basename, realpath
+from typing import TYPE_CHECKING
 
 from ..auxlib.ish import dals
 from ..base.constants import PREFIX_PLACEHOLDER
@@ -21,6 +23,9 @@ from ..gateways.disk.update import CancelOperation, update_file_in_place_as_bina
 from ..models.enums import FileMode
 
 log = getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 # three capture groups: whole_shebang, executable, options
@@ -118,45 +123,16 @@ def update_prefix(
     updated = update_file_in_place_as_binary(realpath(path), _update_prefix)
 
     if updated and mode == FileMode.binary and subdir == "osx-arm64" and on_mac:
-        # Apple arm64 needs signed executables. Historically we spawned a
-        # codesign subprocess per file here — for a fresh scientific-Python
-        # install that's ~190 codesign invocations, each paying a
-        # fork/exec/startup cost (profiling shows ~9 s of wall time from
-        # 186 subprocess calls in the W2 workload). ``codesign`` accepts
-        # multiple paths in a single invocation, so instead of running one
-        # per file we queue the paths here and flush them as a batch at
-        # the end of the verify phase. See #15975.
-        _enqueue_codesign(realpath(path))
+        _codesign_or_enqueue(realpath(path))
 
 
-_pending_codesign_paths: list[str] = []
-_pending_codesign_lock = threading.Lock()
+_codesign_batch_state = threading.local()
 
 
-def _enqueue_codesign(path: str) -> None:
-    """Queue a path for the next :func:`flush_pending_codesign` call."""
-    with _pending_codesign_lock:
-        _pending_codesign_paths.append(path)
-
-
-def flush_pending_codesign() -> None:
-    """Run ``codesign`` on all paths queued by :func:`update_prefix`.
-
-    ``codesign`` accepts multiple paths per invocation, so a
-    whole-transaction's worth of osx-arm64 binary rewrites can be
-    re-signed with a single fork/exec instead of one per file.
-    Called at the end of ``_verify_individual_level`` so the signatures
-    are in place before ``execute()`` links the intermediates.
-
-    Chunks the file list to stay safely under the kernel's
-    ``MAX_ARG_STRLEN`` / ``ARG_MAX`` limits. Failures (non-zero exit)
-    are ignored, matching the per-file behaviour this replaced.
-    """
-    with _pending_codesign_lock:
-        paths = list(_pending_codesign_paths)
-        _pending_codesign_paths.clear()
+def _run_codesign(paths: list[str]) -> None:
     if not paths:
         return
+
     # macOS Darwin has ARG_MAX ~ 1 MB; per-path cost is typically
     # 100-200 bytes of fully-qualified realpath. 500-path chunks stay
     # well under the cap.
@@ -166,6 +142,42 @@ def flush_pending_codesign() -> None:
             ["/usr/bin/codesign", "-s", "-", "-f", *paths[i : i + chunk_size]],
             capture_output=True,
         )
+
+
+def _codesign_or_enqueue(path: str) -> None:
+    paths = getattr(_codesign_batch_state, "paths", None)
+    if paths is None:
+        _run_codesign([path])
+    else:
+        paths.append(path)
+
+
+@contextmanager
+def batch_codesign_calls() -> Iterator[None]:
+    """Batch osx-arm64 ``codesign`` calls made by :func:`update_prefix`.
+
+    Direct ``update_prefix`` callers keep the old immediate-signing behavior.
+    Transaction verification wraps prefix rewrites in this context so the
+    rewritten intermediates can be signed with fewer subprocesses before they
+    are linked into the target prefix. See #15975.
+    """
+    parent_paths = getattr(_codesign_batch_state, "paths", None)
+    paths: list[str] = []
+    _codesign_batch_state.paths = paths
+    succeeded = False
+    try:
+        yield
+        succeeded = True
+    finally:
+        if parent_paths is None:
+            delattr(_codesign_batch_state, "paths")
+        else:
+            _codesign_batch_state.paths = parent_paths
+        if succeeded:
+            if parent_paths is None:
+                _run_codesign(paths)
+            else:
+                parent_paths.extend(paths)
 
 
 def replace_prefix(

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -8,6 +8,7 @@ import os
 import re
 import struct
 import subprocess
+import threading
 from logging import getLogger
 from os.path import basename, realpath
 
@@ -117,9 +118,53 @@ def update_prefix(
     updated = update_file_in_place_as_binary(realpath(path), _update_prefix)
 
     if updated and mode == FileMode.binary and subdir == "osx-arm64" and on_mac:
-        # Apple arm64 needs signed executables
+        # Apple arm64 needs signed executables. Historically we spawned a
+        # codesign subprocess per file here — for a fresh scientific-Python
+        # install that's ~190 codesign invocations, each paying a
+        # fork/exec/startup cost (profiling shows ~9 s of wall time from
+        # 186 subprocess calls in the W2 workload). ``codesign`` accepts
+        # multiple paths in a single invocation, so instead of running one
+        # per file we queue the paths here and flush them as a batch at
+        # the end of the verify phase. See #15975.
+        _enqueue_codesign(realpath(path))
+
+
+_pending_codesign_paths: list[str] = []
+_pending_codesign_lock = threading.Lock()
+
+
+def _enqueue_codesign(path: str) -> None:
+    """Queue a path for the next :func:`flush_pending_codesign` call."""
+    with _pending_codesign_lock:
+        _pending_codesign_paths.append(path)
+
+
+def flush_pending_codesign() -> None:
+    """Run ``codesign`` on all paths queued by :func:`update_prefix`.
+
+    ``codesign`` accepts multiple paths per invocation, so a
+    whole-transaction's worth of osx-arm64 binary rewrites can be
+    re-signed with a single fork/exec instead of one per file.
+    Called at the end of ``_verify_individual_level`` so the signatures
+    are in place before ``execute()`` links the intermediates.
+
+    Chunks the file list to stay safely under the kernel's
+    ``MAX_ARG_STRLEN`` / ``ARG_MAX`` limits. Failures (non-zero exit)
+    are ignored, matching the per-file behaviour this replaced.
+    """
+    with _pending_codesign_lock:
+        paths = list(_pending_codesign_paths)
+        _pending_codesign_paths.clear()
+    if not paths:
+        return
+    # macOS Darwin has ARG_MAX ~ 1 MB; per-path cost is typically
+    # 100-200 bytes of fully-qualified realpath. 500-path chunks stay
+    # well under the cap.
+    chunk_size = 500
+    for i in range(0, len(paths), chunk_size):
         subprocess.run(
-            ["/usr/bin/codesign", "-s", "-", "-f", realpath(path)], capture_output=True
+            ["/usr/bin/codesign", "-s", "-", "-f", *paths[i : i + chunk_size]],
+            capture_output=True,
         )
 
 

--- a/news/15975-track-b-b9c-codesign-batch
+++ b/news/15975-track-b-b9c-codesign-batch
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Batch per-file `codesign` invocations on osx-arm64 into a single end-of-transaction call. Cuts `conda install` / `conda update` time on macOS by roughly 15–30% for packages with many prefix-replaced binaries. No effect on other platforms. (#15975)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_portability.py
+++ b/tests/core/test_portability.py
@@ -7,10 +7,11 @@ import pytest
 
 from conda.auxlib.ish import dals
 from conda.base.constants import PREFIX_PLACEHOLDER
-from conda.common.compat import on_win
+from conda.common.compat import on_mac, on_win
 from conda.core.portability import (
     MAX_SHEBANG_LENGTH,
     SHEBANG_REGEX,
+    batch_codesign_calls,
     replace_long_shebang,
     update_prefix,
 )
@@ -148,3 +149,63 @@ def test_escaped_prefix_replaced_only_shebang(tmp_path):
                 assert line.startswith("#!/usr/bin/env python")
             elif i == 1:
                 assert new_prefix in line
+
+
+@pytest.mark.skipif(not on_mac, reason="codesign is macOS-only")
+def test_update_prefix_batches_osx_arm64_codesign(tmp_path, mocker):
+    placeholder = "/some-placeholder"
+    new_prefix = "/usr/local"
+
+    def write_binary(name):
+        path = tmp_path / name
+        path.write_bytes(b"\x7fMach-O.../some-placeholder/bin/tool\0")
+        return path
+
+    codesign = mocker.patch("conda.core.portability.subprocess.run")
+    direct = write_binary("direct")
+
+    update_prefix(
+        direct,
+        new_prefix,
+        placeholder=placeholder,
+        mode=FileMode.binary,
+        subdir="osx-arm64",
+    )
+
+    codesign.assert_called_once_with(
+        ["/usr/bin/codesign", "-s", "-", "-f", os.path.realpath(direct)],
+        capture_output=True,
+    )
+
+    codesign.reset_mock()
+    first = write_binary("first")
+    second = write_binary("second")
+
+    with batch_codesign_calls():
+        update_prefix(
+            first,
+            new_prefix,
+            placeholder=placeholder,
+            mode=FileMode.binary,
+            subdir="osx-arm64",
+        )
+        update_prefix(
+            second,
+            new_prefix,
+            placeholder=placeholder,
+            mode=FileMode.binary,
+            subdir="osx-arm64",
+        )
+        codesign.assert_not_called()
+
+    codesign.assert_called_once_with(
+        [
+            "/usr/bin/codesign",
+            "-s",
+            "-",
+            "-f",
+            os.path.realpath(first),
+            os.path.realpath(second),
+        ],
+        capture_output=True,
+    )

--- a/tests/core/test_portability.py
+++ b/tests/core/test_portability.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import os
 import re
+import subprocess
 
 import pytest
 
@@ -174,7 +175,8 @@ def test_update_prefix_batches_osx_arm64_codesign(tmp_path, mocker):
 
     codesign.assert_called_once_with(
         ["/usr/bin/codesign", "-s", "-", "-f", os.path.realpath(direct)],
-        capture_output=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
     codesign.reset_mock()
@@ -207,5 +209,6 @@ def test_update_prefix_batches_osx_arm64_codesign(tmp_path, mocker):
             os.path.realpath(first),
             os.path.realpath(second),
         ],
-        capture_output=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )


### PR DESCRIPTION
### Description

On osx-arm64, `update_prefix` signs every rewritten binary with `/usr/bin/codesign -s - -f <path>`. Phase-1 profiling of a W2 macOS install found 186 `subprocess.communicate` calls totaling 9.47 s, from per-package `codesign` process startup rather than bytecode compilation.

This PR queues codesign paths while transaction actions are verified, then flushes the batch through `batch_codesign_calls()` as `codesign -s - -f <path1> <path2> ...`. Direct `update_prefix()` callers still sign immediately. Each rewritten binary still gets the same ad-hoc signature, with fewer subprocess launches. Linux and Windows do not enter this path.

Stack interaction: B6 (#15973) now maps individual action verification directly across the shared verification executor and removes `_verify_individual_level`. After B6 lands, this PR must move the codesign queue to parent-visible transaction state before rebasing; a thread-local batch context does not propagate into executor workers.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Measured mechanism

The profiled W2 install had 186 rewritten binaries. This PR reduces that work from 186 `codesign` subprocess invocations to one batched invocation while preserving the per-binary signature operation.

The earlier end-to-end timing was removed because it was taken on a superseded stack before the B6 interaction above was resolved. This PR does not claim a current standalone install-time speedup until it is rebased and remeasured.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the news directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? No user-facing documentation change.
