### PR TITLE
`conda activate/deactivate --help` powershell should not raise an error

### DIFF
--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -65,13 +65,12 @@ function Enter-CondaEnvironment {
 
         [Parameter(Position=0)][string]$Name,
 
-        [Parameter(Mandatory=$false)]
-        [switch]$Help = $False
+        [Parameter(Mandatory=$false)][switch]$Help = $False
     );
 
     begin {
         # Includes if the user provides the flags -h/-help
-        If ($Help) {
+        If ($Help -or  ($Name -contains "--help")) {
             & $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate --help;
         } else {
             If ($Stack) {
@@ -81,9 +80,7 @@ function Enter-CondaEnvironment {
             }
 
             Write-Verbose "[conda shell.powershell activate $Name]`n$activateCommand";
-            if (!($Name -contains "--help")) {
-                Invoke-Expression -Command $activateCommand;
-            }
+            Invoke-Expression -Command $activateCommand;
         }
     }
 
@@ -106,28 +103,24 @@ function Enter-CondaEnvironment {
 function Exit-CondaEnvironment {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$false)]
-        [switch]$Help = $False,
+        [Parameter(Mandatory=$false)][switch]$Help = $False,
 
         [Parameter(Position=0)][string]$Arg
     );
 
     begin {
         # Includes if the user provides the flags -h/-help
-        If ($Help) {
+        If ($Help -or  ($Name -contains "--help")) {
             & $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell deactivate --help;
         } else {
             $deactivateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell deactivate $Arg | Out-String);
-
-            if (!($Arg -contains "--help")) {
-                # If deactivate returns an empty string, we have nothing more to do,
-                # so return early.
-                if ($deactivateCommand.Trim().Length -eq 0) {
-                    return;
-                }
-                Write-Verbose "[conda shell.powershell deactivate]`n$deactivateCommand";
-                Invoke-Expression -Command $deactivateCommand;
+            # If deactivate returns an empty string, we have nothing more to do,
+            # so return early.
+            if ($deactivateCommand.Trim().Length -eq 0) {
+                return;
             }
+            Write-Verbose "[conda shell.powershell deactivate]`n$deactivateCommand";
+            Invoke-Expression -Command $deactivateCommand;
         }
     }
     process {}

--- a/conda/shell/condabin/Conda.psm1
+++ b/conda/shell/condabin/Conda.psm1
@@ -62,18 +62,29 @@ function Enter-CondaEnvironment {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$false)][switch]$Stack,
-        [Parameter(Position=0)][string]$Name
+
+        [Parameter(Position=0)][string]$Name,
+
+        [Parameter(Mandatory=$false)]
+        [switch]$Help = $False
     );
 
     begin {
-        If ($Stack) {
-            $activateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate --stack $Name | Out-String);
-        } Else {
-            $activateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate $Name | Out-String);
-        }
+        # Includes if the user provides the flags -h/-help
+        If ($Help) {
+            & $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate --help;
+        } else {
+            If ($Stack) {
+                $activateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate --stack $Name | Out-String);
+            } Else {
+                $activateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell activate $Name | Out-String);
+            }
 
-        Write-Verbose "[conda shell.powershell activate $Name]`n$activateCommand";
-        Invoke-Expression -Command $activateCommand;
+            Write-Verbose "[conda shell.powershell activate $Name]`n$activateCommand";
+            if (!($Name -contains "--help")) {
+                Invoke-Expression -Command $activateCommand;
+            }
+        }
     }
 
     process {}
@@ -94,18 +105,30 @@ function Enter-CondaEnvironment {
 #>
 function Exit-CondaEnvironment {
     [CmdletBinding()]
-    param();
+    param(
+        [Parameter(Mandatory=$false)]
+        [switch]$Help = $False,
+
+        [Parameter(Position=0)][string]$Arg
+    );
 
     begin {
-        $deactivateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell deactivate | Out-String);
+        # Includes if the user provides the flags -h/-help
+        If ($Help) {
+            & $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell deactivate --help;
+        } else {
+            $deactivateCommand = (& $Env:CONDA_EXE $Env:_CE_M $Env:_CE_CONDA shell.powershell deactivate $Arg | Out-String);
 
-        # If deactivate returns an empty string, we have nothing more to do,
-        # so return early.
-        if ($deactivateCommand.Trim().Length -eq 0) {
-            return;
+            if (!($Arg -contains "--help")) {
+                # If deactivate returns an empty string, we have nothing more to do,
+                # so return early.
+                if ($deactivateCommand.Trim().Length -eq 0) {
+                    return;
+                }
+                Write-Verbose "[conda shell.powershell deactivate]`n$deactivateCommand";
+                Invoke-Expression -Command $deactivateCommand;
+            }
         }
-        Write-Verbose "[conda shell.powershell deactivate]`n$deactivateCommand";
-        Invoke-Expression -Command $deactivateCommand;
     }
     process {}
     end {}
@@ -157,7 +180,7 @@ function Invoke-Conda() {
                 Enter-CondaEnvironment @OtherArgs;
             }
             "^deactivate$" {
-                Exit-CondaEnvironment;
+                Exit-CondaEnvironment @OtherArgs;
             }
 
             # Run the command, then reactivate so activate.ps1 runs and env vars

--- a/news/15978-dont-raise-errors-running-activate-help-from-ps
+++ b/news/15978-dont-raise-errors-running-activate-help-from-ps
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Make the windows powershell activator recognize the `-h`/`--help` flags. (#15978)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/shell/test_powershell.py
+++ b/tests/shell/test_powershell.py
@@ -145,3 +145,39 @@ def test_powershell_PATH_management(
         sh.expect_exact("Alias")
         sh.sendline(f'conda create -yqp "{prefix}" bzip2')
         sh.expect(r"Executing transaction: ...working... done.*\n")
+
+
+@PARAMETRIZE_POWERSHELL
+def test_powershell_activate_help(shell: Shell) -> None:
+    with shell.interactive() as sh:
+        sh.assert_env_var("CONDA_SHLVL", "0")
+        # Check -h flag
+        sh.sendline("Enter-CondaEnvironment -h")
+        sh.sendline("$LASTEXITCODE")
+        sh.expect("0")
+        sh.assert_env_var("CONDA_SHLVL", "0")
+        # Check --help flag
+        sh.sendline("Ender-CondaEnvironment --help")
+        sh.sendline("$LASTEXITCODE")
+        sh.expect("0")
+        sh.assert_env_var("CONDA_SHLVL", "0")
+
+
+@PARAMETRIZE_POWERSHELL
+def test_powershell_deactivate_help(
+    shell_wrapper_integration: tuple[str, str, str], shell: Shell
+) -> None:
+    prefix, _, _ = shell_wrapper_integration
+    with shell.interactive() as sh:
+        sh.sendline(f'conda activate "{prefix}"')
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        # Check -h flag
+        sh.sendline("Exit-CondaEnvironment -h")
+        sh.sendline("$LASTEXITCODE")
+        sh.expect("0")
+        sh.assert_env_var("CONDA_SHLVL", "1")
+        # Check --help flag
+        sh.sendline("Exit-CondaEnvironment --help")
+        sh.sendline("$LASTEXITCODE")
+        sh.expect("0")
+        sh.assert_env_var("CONDA_SHLVL", "1")

--- a/tests/shell/test_powershell.py
+++ b/tests/shell/test_powershell.py
@@ -157,7 +157,7 @@ def test_powershell_activate_help(shell: Shell) -> None:
         sh.expect("0")
         sh.assert_env_var("CONDA_SHLVL", "0")
         # Check --help flag
-        sh.sendline("Ender-CondaEnvironment --help")
+        sh.sendline("Enter-CondaEnvironment --help")
         sh.sendline("$LASTEXITCODE")
         sh.expect("0")
         sh.assert_env_var("CONDA_SHLVL", "0")


### PR DESCRIPTION


### Description

Previously in powershell conda activate and deactivate commands would produce some error when supplying the help flag either by `-h` or `--help`. This PR fixes the powershell activation scripts to accept both the `-h` and `--help` flags.

follow up to https://github.com/conda/conda/pull/15958

#### `conda activate -h`

**Previously**
```
Enter-CondaEnvironment : A parameter cannot be found that matches parameter name 'h'.
At C:\vagrant\conda\conda\shell\condabin\Conda.psm1:157 char:40
+                 Enter-CondaEnvironment @OtherArgs;
+                                        ~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Enter-CondaEnvironment], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Enter-CondaEnvironment
 
```

**Now**
```
ActivateHelp: usage: conda activate [-h] [--[no-]stack] [env_name_or_prefix]

Activate a conda environment.

Options:

positional arguments:
  env_name_or_prefix    The environment name or prefix to activate. If the
                        prefix is a relative path, it must start with './'
                        (or '.\' on Windows).

optional arguments:
  -h, --help            Show this help message and exit.
  --stack               Stack the environment being activated on top of the
                        previous active environment, rather replacing the
                        current active environment with a new one. Currently,
                        only the PATH environment variable is stacked. This
                        may be enabled implicitly by the 'auto_stack'
                        configuration variable.
  --no-stack            Do not stack the environment. Overrides 'auto_stack'
                        setting.



```

#### `conda activate --help`
**Previously**
```
 ActivateHelp: usage: conda activate [-h] [--[no-]stack] [env_name_or_prefix]

Activate a conda environment.

Options:

positional arguments:
  env_name_or_prefix    The environment name or prefix to activate. If the
                        prefix is a relative path, it must start with './'
                        (or '.\' on Windows).

optional arguments:
  -h, --help            Show this help message and exit.
  --stack               Stack the environment being activated on top of the
                        previous active environment, rather replacing the
                        current active environment with a new one. Currently,
                        only the PATH environment variable is stacked. This
                        may be enabled implicitly by the 'auto_stack'
                        configuration variable.
  --no-stack            Do not stack the environment. Overrides 'auto_stack'
                        setting.


Invoke-Expression : Cannot bind argument to parameter 'Command' because it is an empty string.
At C:\vagrant\conda\conda\shell\condabin\Conda.psm1:76 char:36
+         Invoke-Expression -Command $activateCommand;
+                                    ~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Invoke-Expression], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.InvokeExpressionCommand

```

**Now**
```
ActivateHelp: usage: conda activate [-h] [--[no-]stack] [env_name_or_prefix]

Activate a conda environment.

Options:

positional arguments:
  env_name_or_prefix    The environment name or prefix to activate. If the
                        prefix is a relative path, it must start with './'
                        (or '.\' on Windows).

optional arguments:
  -h, --help            Show this help message and exit.
  --stack               Stack the environment being activated on top of the
                        previous active environment, rather replacing the
                        current active environment with a new one. Currently,
                        only the PATH environment variable is stacked. This
                        may be enabled implicitly by the 'auto_stack'
                        configuration variable.
  --no-stack            Do not stack the environment. Overrides 'auto_stack'
                        setting.
```

#### `conda deactivate -h`

**Previously**
```
# does not output, deactivates the current environment

```
**Now**
```
DeactivateHelp: usage: conda deactivate [-h]

Deactivate the current active conda environment.

Options:

optional arguments:
  -h, --help            Show this help message and exit.

```

#### `conda deactivate --help`

**Previously**
```
# does not output, deactivates the current environment
```

**Now**
```
DeactivateHelp: usage: conda deactivate [-h]

Deactivate the current active conda environment.

Options:

optional arguments:
  -h, --help            Show this help message and exit.

```


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
