### PR TITLE
Optional py-rattler fast path for `PrefixGraph.__init__`

### DIFF
--- a/conda/models/_prefix_graph_rattler.py
+++ b/conda/models/_prefix_graph_rattler.py
@@ -1,0 +1,195 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Optional py-rattler fast path for PrefixGraph construction.
+
+Scope: this module is imported lazily from
+``conda.models.prefix_graph.PrefixGraph.__init__``. If py-rattler is
+not installed, ``try_build_graph`` returns ``None`` and the caller
+falls back to the pure-Python name-indexed path from #15971.
+
+Strategy:
+
+1. Convert the conda ``PrefixRecord`` inputs to ``rattler.PackageRecord``
+   once per call, caching the view on the conda record so repeat
+   PrefixGraph calls within one process skip the reconversion.
+2. Build adjacency using ``rattler.MatchSpec`` for dep parsing and
+   ``rattler.PackageRecord.matches`` for the match test. Both are
+   Rust-backed; parse is ~4x faster, match is ~5x faster than conda's
+   native implementations (measured in S18).
+3. Cache parsed ``rattler.MatchSpec`` by dep string within a single
+   call: real prefixes have significant dep-string repetition.
+4. Sort topologically with ``rattler.PackageRecord.sort_topologically``
+   on the rattler record list, then re-key the adjacency dict into
+   that order before returning.
+5. Spec matching (the ``specs`` argument of PrefixGraph) uses conda's
+   ``MatchSpec`` because callers hand us conda ``MatchSpec`` instances
+   built from sources we don't control, which may use conda grammar
+   rattler rejects.
+
+Returns ``(graph, spec_matches)`` in the same shape the pure-Python
+loop produces. Returns ``None`` for any error so conda's fallback
+keeps operating correctly; the fast path is strictly additive.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+try:
+    import rattler as _rattler
+except ImportError:
+    _rattler = None
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from .match_spec import MatchSpec
+    from .records import PrefixRecord
+
+_RATTLER_VIEW_ATTR = "_conda_prefix_graph_rattler_view"
+
+
+def is_available() -> bool:
+    return _rattler is not None
+
+
+def _to_rattler_record(rec) -> "Any | None":
+    cached = getattr(rec, _RATTLER_VIEW_ATTR, None)
+    if cached is not None:
+        return cached
+    try:
+        cached = _rattler.PackageRecord(
+            name=rec.name,
+            version=str(rec.version),
+            build=rec.build or "",
+            build_number=rec.build_number or 0,
+            subdir=rec.subdir,
+            noarch=_noarch_value(rec),
+            depends=list(rec.depends or ()),
+        )
+    except (ValueError, RuntimeError, TypeError, AttributeError):
+        return None
+    try:
+        setattr(rec, _RATTLER_VIEW_ATTR, cached)
+    except (AttributeError, TypeError):
+        pass
+    return cached
+
+
+def _noarch_value(rec) -> "str | None":
+    noarch = getattr(rec, "noarch", None)
+    if noarch is None:
+        if getattr(rec, "subdir", None) == "noarch":
+            return "generic"
+        return None
+    s = str(noarch).lower()
+    if s in ("python", "generic"):
+        return s
+    if s == "true":
+        return "generic"
+    return None
+
+
+def try_build_graph(
+    records: "tuple[PrefixRecord, ...]",
+    specs: "set[MatchSpec]",
+) -> "tuple[dict, dict] | None":
+    """Attempt the rattler-backed build. Returns (graph, spec_matches)
+    or ``None`` if the caller should use the pure-Python fallback.
+    """
+    if _rattler is None or not records:
+        return None
+
+    # Pre-convert every record. Abort to the fallback if any conversion
+    # fails so we don't produce a partial result.
+    rattler_recs: list = []
+    rec_to_rattler: dict[int, Any] = {}
+    rattler_to_conda: dict[tuple, Any] = {}
+    for rec in records:
+        rrec = _to_rattler_record(rec)
+        if rrec is None:
+            return None
+        rattler_recs.append(rrec)
+        rec_to_rattler[id(rec)] = rrec
+        # ``sort_topologically`` returns fresh ``PackageRecord`` instances
+        # so ``id(rrec)`` doesn't round-trip. Key the back-map by the
+        # identifying tuple which is unique within a prefix.
+        rattler_to_conda[_rec_identity(rrec)] = rec
+
+    by_name: dict[str, list[Any]] = {}
+    for rec in records:
+        by_name.setdefault(rec.name, []).append(rec)
+
+    spec_cache: dict[str, Any] = {}
+
+    def _rattler_spec(dep: str):
+        cached = spec_cache.get(dep)
+        if cached is not None:
+            return cached
+        try:
+            parsed = _rattler.MatchSpec(dep)
+        except (ValueError, RuntimeError, TypeError):
+            parsed = False
+        spec_cache[dep] = parsed
+        return parsed
+
+    graph: dict[Any, dict[Any, None]] = {}
+    unsorted_spec_matches: dict[Any, dict[Any, None]] = {}
+
+    for node in records:
+        parent_nodes: dict[Any, None] = {}
+        for dep in node.depends:
+            spec = _rattler_spec(dep)
+            if spec is False:
+                return None
+            name = _matchspec_name(spec)
+            candidates = by_name.get(name, ())
+            for candidate in candidates:
+                cand_rrec = rec_to_rattler[id(candidate)]
+                try:
+                    if spec.matches(cand_rrec):
+                        parent_nodes[candidate] = None
+                except (ValueError, RuntimeError, TypeError):
+                    return None
+        graph[node] = parent_nodes
+
+        if specs:
+            matching = {s: None for s in specs if s.match(node)}
+            if matching:
+                unsorted_spec_matches[node] = matching
+
+    try:
+        sorted_rattler = _rattler.PackageRecord.sort_topologically(rattler_recs)
+    except (ValueError, RuntimeError):
+        return None
+    sorted_graph: dict[Any, dict[Any, None]] = {}
+    for rrec in sorted_rattler:
+        conda_rec = rattler_to_conda.get(_rec_identity(rrec))
+        if conda_rec is None:
+            return None
+        sorted_graph[conda_rec] = graph[conda_rec]
+
+    return sorted_graph, unsorted_spec_matches
+
+
+def _rec_identity(rrec) -> tuple:
+    """Identity tuple used to round-trip a rattler record back to the
+    original conda record after ``sort_topologically`` returns fresh
+    instances. Unique within a prefix."""
+    name = rrec.name
+    name_str = getattr(name, "normalized", None) or str(name)
+    return (
+        name_str,
+        str(rrec.version),
+        rrec.build,
+        rrec.build_number,
+        rrec.subdir,
+    )
+
+
+def _matchspec_name(spec) -> str:
+    """Extract the plain package name from a rattler.MatchSpec."""
+    name_obj = spec.name
+    source = getattr(name_obj, "source", None)
+    if isinstance(source, str):
+        return source
+    return str(name_obj).split('"', 2)[1] if '"' in str(name_obj) else str(name_obj)

--- a/conda/models/_prefix_graph_rattler.py
+++ b/conda/models/_prefix_graph_rattler.py
@@ -30,6 +30,7 @@ Returns ``(graph, spec_matches)`` in the same shape the pure-Python
 loop produces. Returns ``None`` for any error so conda's fallback
 keeps operating correctly; the fast path is strictly additive.
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -52,7 +53,7 @@ def is_available() -> bool:
     return _rattler is not None
 
 
-def _to_rattler_record(rec) -> "Any | None":
+def _to_rattler_record(rec) -> Any | None:
     cached = getattr(rec, _RATTLER_VIEW_ATTR, None)
     if cached is not None:
         return cached
@@ -75,7 +76,7 @@ def _to_rattler_record(rec) -> "Any | None":
     return cached
 
 
-def _noarch_value(rec) -> "str | None":
+def _noarch_value(rec) -> str | None:
     noarch = getattr(rec, "noarch", None)
     if noarch is None:
         if getattr(rec, "subdir", None) == "noarch":
@@ -90,9 +91,9 @@ def _noarch_value(rec) -> "str | None":
 
 
 def try_build_graph(
-    records: "tuple[PrefixRecord, ...]",
-    specs: "set[MatchSpec]",
-) -> "tuple[dict, dict] | None":
+    records: tuple[PrefixRecord, ...],
+    specs: set[MatchSpec],
+) -> tuple[dict, dict] | None:
     """Attempt the rattler-backed build. Returns (graph, spec_matches)
     or ``None`` if the caller should use the pure-Python fallback.
     """

--- a/conda/models/_prefix_graph_rattler.py
+++ b/conda/models/_prefix_graph_rattler.py
@@ -18,9 +18,9 @@ Strategy:
    native implementations (measured in S18).
 3. Cache parsed ``rattler.MatchSpec`` by dep string within a single
    call: real prefixes have significant dep-string repetition.
-4. Sort topologically with ``rattler.PackageRecord.sort_topologically``
-   on the rattler record list, then re-key the adjacency dict into
-   that order before returning.
+4. Return the unsorted conda-shaped adjacency dict and let
+   ``PrefixGraph._toposort()`` keep conda's stable ordering and
+   special-case edge handling.
 5. Spec matching (the ``specs`` argument of PrefixGraph) uses conda's
    ``MatchSpec`` because callers hand us conda ``MatchSpec`` instances
    built from sources we don't control, which may use conda grammar
@@ -102,19 +102,12 @@ def try_build_graph(
 
     # Pre-convert every record. Abort to the fallback if any conversion
     # fails so we don't produce a partial result.
-    rattler_recs: list = []
     rec_to_rattler: dict[int, Any] = {}
-    rattler_to_conda: dict[tuple, Any] = {}
     for rec in records:
         rrec = _to_rattler_record(rec)
         if rrec is None:
             return None
-        rattler_recs.append(rrec)
         rec_to_rattler[id(rec)] = rrec
-        # ``sort_topologically`` returns fresh ``PackageRecord`` instances
-        # so ``id(rrec)`` doesn't round-trip. Key the back-map by the
-        # identifying tuple which is unique within a prefix.
-        rattler_to_conda[_rec_identity(rrec)] = rec
 
     by_name: dict[str, list[Any]] = {}
     for rec in records:
@@ -158,33 +151,7 @@ def try_build_graph(
             if matching:
                 unsorted_spec_matches[node] = matching
 
-    try:
-        sorted_rattler = _rattler.PackageRecord.sort_topologically(rattler_recs)
-    except (ValueError, RuntimeError):
-        return None
-    sorted_graph: dict[Any, dict[Any, None]] = {}
-    for rrec in sorted_rattler:
-        conda_rec = rattler_to_conda.get(_rec_identity(rrec))
-        if conda_rec is None:
-            return None
-        sorted_graph[conda_rec] = graph[conda_rec]
-
-    return sorted_graph, unsorted_spec_matches
-
-
-def _rec_identity(rrec) -> tuple:
-    """Identity tuple used to round-trip a rattler record back to the
-    original conda record after ``sort_topologically`` returns fresh
-    instances. Unique within a prefix."""
-    name = rrec.name
-    name_str = getattr(name, "normalized", None) or str(name)
-    return (
-        name_str,
-        str(rrec.version),
-        rrec.build,
-        rrec.build_number,
-        rrec.subdir,
-    )
+    return graph, unsorted_spec_matches
 
 
 def _matchspec_name(spec) -> str:

--- a/conda/models/prefix_graph.py
+++ b/conda/models/prefix_graph.py
@@ -52,13 +52,22 @@ class PrefixGraph:
         self.graph = graph = {}
         self.spec_matches: dict[PrefixRecord, dict[MatchSpec, None]]
         self.spec_matches = spec_matches = {}
+        # Index records by package name so the parent-match inner loop
+        # iterates only the name-matching candidates instead of every
+        # record. MatchSpec(dep).name is always set; any record whose
+        # name doesn't match would have been filtered out by the
+        # original MatchSpec.match() anyway, just at O(N) per dep
+        # rather than O(1). See #15971 for the before/after benchmark.
+        by_name: dict[str, list[PrefixRecord]] = {}
+        for rec in records:
+            by_name.setdefault(rec.name, []).append(rec)
         for node in records:
-            parent_match_specs = tuple(MatchSpec(d) for d in node.depends)
-            parent_nodes = {
-                rec: None
-                for rec in records
-                if any(m.match(rec) for m in parent_match_specs)
-            }
+            parent_nodes: dict[PrefixRecord, None] = {}
+            for dep in node.depends:
+                spec = MatchSpec(dep)
+                for candidate in by_name.get(spec.name, ()):
+                    if spec.match(candidate):
+                        parent_nodes[candidate] = None
             graph[node] = parent_nodes
             matching_specs = dict.fromkeys(s for s in specs if s.match(node))
             if matching_specs:

--- a/conda/models/prefix_graph.py
+++ b/conda/models/prefix_graph.py
@@ -52,6 +52,19 @@ class PrefixGraph:
         self.graph = graph = {}
         self.spec_matches: dict[PrefixRecord, dict[MatchSpec, None]]
         self.spec_matches = spec_matches = {}
+
+        # Optional py-rattler fast path. Delegates adjacency build and
+        # toposort to rattler's Rust implementation when available.
+        # Returns None if rattler is missing, can't parse a spec, or
+        # hits an edge case; in every such case we fall through to the
+        # pure-Python loop below.
+        from ._prefix_graph_rattler import try_build_graph
+
+        fast = try_build_graph(records, specs)
+        if fast is not None:
+            self.graph, self.spec_matches = fast
+            return
+
         # Index records by package name so the parent-match inner loop
         # iterates only the name-matching candidates instead of every
         # record. MatchSpec(dep).name is always set; any record whose

--- a/conda/models/prefix_graph.py
+++ b/conda/models/prefix_graph.py
@@ -53,8 +53,8 @@ class PrefixGraph:
         self.spec_matches: dict[PrefixRecord, dict[MatchSpec, None]]
         self.spec_matches = spec_matches = {}
 
-        # Optional py-rattler fast path. Delegates adjacency build and
-        # toposort to rattler's Rust implementation when available.
+        # Optional py-rattler fast path. Delegates dependency parsing
+        # and parent matching to rattler's Rust implementation when available.
         # Returns None if rattler is missing, can't parse a spec, or
         # hits an edge case; in every such case we fall through to the
         # pure-Python loop below.
@@ -63,6 +63,7 @@ class PrefixGraph:
         fast = try_build_graph(records, specs)
         if fast is not None:
             self.graph, self.spec_matches = fast
+            self._toposort()
             return
 
         # Index records by package name so the parent-match inner loop

--- a/news/15971-track-b-b2-prefix-graph
+++ b/news/15971-track-b-b2-prefix-graph
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Build a per-name candidate index in `PrefixGraph.__init__()` to replace the quadratic scan over all records. Speeds up transactions against large environments — ~50× at 1,000 records, far more at the scales where users notice it. (#15971)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/15980-prefix-graph-rattler-fast-path
+++ b/news/15980-prefix-graph-rattler-fast-path
@@ -1,0 +1,19 @@
+### Enhancements
+
+* When `py-rattler` is installed, `PrefixGraph.__init__` delegates its adjacency build and topological sort to rattler's Rust implementation. Falls back to the existing pure-Python name-indexed loop when rattler isn't present, so the behaviour is unchanged for installs that don't have it. Saves several minutes on `conda install` / `conda update` against very large prefixes (~30× speedup at 50 000 installed records). (#15980)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/15980-prefix-graph-rattler-fast-path
+++ b/news/15980-prefix-graph-rattler-fast-path
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* When `py-rattler` is installed, `PrefixGraph.__init__` delegates its adjacency build and topological sort to rattler's Rust implementation. Falls back to the existing pure-Python name-indexed loop when rattler isn't present, so the behaviour is unchanged for installs that don't have it. Saves several minutes on `conda install` / `conda update` against very large prefixes (~30× speedup at 50 000 installed records). (#15980)
+* When `py-rattler` is installed, `PrefixGraph.__init__` delegates dependency parsing and parent matching to rattler's Rust implementation while preserving conda's existing topological ordering. Falls back to the existing pure-Python name-indexed loop when rattler isn't present. (#15980)
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

Draft PR, logically stacked on top of #15971. **Do not merge before #15971 lands** unless we intentionally want this PR to carry the B2 name-indexed fallback as well.

This PR adds a rattler-backed fast path inside `PrefixGraph.__init__` for the expensive dependency parsing and parent-matching part of graph construction.

The dependency story has changed since this branch was opened: `conda-rattler-solver` depends on `py-rattler >=0.25.0,<0.26.0a0`, and conda runtimes that include the rattler solver are therefore expected to have the `rattler` Python module available. That makes this less of an optional-dependency experiment and more of a potential large-prefix fast path using bindings that conda is already carrying.

Current implementation:

- Convert each conda `PrefixRecord` to a `rattler.PackageRecord` once per call, caching the converted view on the conda record where possible.
- Parse dependency strings with `rattler.MatchSpec`, using a per-call dedup cache for repeated dependency strings.
- Match candidates with `rattler.PackageRecord.matches` after narrowing candidates through the same by-name index introduced in #15971.
- Return the conda-shaped adjacency dict and `spec_matches`, then call `PrefixGraph._toposort()` so conda keeps its existing stable topological ordering and special-case edge handling.

The fallback still matters. Minimal/PyPI-style installs may not have the solver plugin dependency set, and rattler can still reject specs or records that conda accepts. If `rattler` is missing, cannot parse a spec, cannot convert a record, or hits an edge case, the fast path returns `None` and the caller falls back to the pure-Python name-indexed loop from #15971.

Full research context and the S19 / W5 benchmark writeups live in the research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md#w5-conda-install-real-pkg-against-realistic-bench_big-end-to-end

### Numbers

Measured on `conda install -c conda-forge -y --dry-run requests` against a realistic synthetic prefix (exponential dep fan-out, version-constrained dep lines, mixed subdirs) using the fixture from https://github.com/jezdez/conda-tempo/blob/main/bench/seed_big_prefix.py:

| Prefix size (N) | #15971 only | with rattler fast path | speedup |
|---:|---:|---:|---:|
| 1,000 | 1.75 s | 1.90 s | 0.92x |
| 5,000 | 4.71 s | 2.95 s | 1.6x |
| 10,000 | 12.60 s | 4.11 s | 3.1x |
| 50,000 | 628.8 s | 21.3 s | **29.5x** |

At N=50,000, installing anything into a long-lived prefix drops from roughly 10 minutes to 21 seconds in the original W5 experiment. The current branch has since been adjusted to preserve conda's `_toposort()` ordering after the rattler-backed adjacency build, so these numbers should be rerun before the PR leaves draft.

The small-prefix result matters more now that `rattler` is expected to be available in normal conda runtimes: at N=1,000 the fast path regressed slightly in W5, and CodSpeed reported regressions on small update benchmarks. The July 2026 review conclusion is that the current always-try-rattler shape should not leave draft. The next shippable variant should gate the rattler path before any record conversion, starting conservatively at `len(records) >= 10_000`; N=5,000 can be reconsidered only after fresh W5 and CodSpeed-style reruns show that the current `_toposort()`-preserving implementation is still safely positive there.

### Remaining work before ready for review

1. **Threshold / activation policy**. Implement a pre-conversion large-prefix gate, initially `len(records) >= 10_000`, so common small-prefix operations continue through the #15971 pure-Python path. Revisit a lower 5,000-record gate only with fresh benchmark evidence.
2. **Benchmark rerun**. Rerun W5 with the current implementation that preserves conda's `_toposort()` ordering, plus small-prefix/CodSpeed-style workloads that previously showed regressions.
3. **Grammar coverage**. rattler's `MatchSpec` parser is stricter than conda's; it rejects a handful of bracket-key syntaxes that conda silently accepts (for example, `python[extras=['dev','test']]`). The fallback handles this transparently, but a compatibility sweep across real conda-forge / conda-channel specs would build confidence.
4. **Test coverage**. Add CI tests that exercise both paths and assert equivalent graph output, plus fallback behavior when rattler is unavailable or rejects a spec.

Tracking epic: conda/conda#15969.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests? Manual correctness checks only at this stage; CI test pending, see remaining work item 4.
- [x] Add / update outdated documentation? No user-facing docs change; the feature is invisible to callers of `PrefixGraph`.

