### PR TITLE
Improve logging of menuinst exception

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -255,7 +255,7 @@ def make_menu(prefix, file_path, remove=False):
 
         from ...gateways.streams import stdoutlog
 
-        stdoutlog(f"menuinst Exception\n{format_exc()}")
+        stdoutlog(f"menuinst Exception for {file_path}:\n{format_exc()}")
 
 
 def create_hard_link_or_copy(src, dst):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

To help with https://github.com/conda/menuinst/issues/464, include the problematic path in the exception. Currently users can see for example (from https://github.com/conda/menuinst/issues/463):
```
...
Executing transaction:
...working...
menuinst\platforms\win.py:72: UserWarning: Quick launch menus are not available for system level installs
Terminal profiles are not available for system level installs
Terminal profiles are not available for system level installs
Terminal profiles are not available for system level installs
Terminal profiles are not available for system level installs
menuinst Exception
Traceback (most recent call last):
  File "conda\gateways\disk\create.py", line 241, in make_menu
  File "menuinst\api.py", line 191, in _install_adapter
  File "menuinst\utils.py", line 423, in wrapper_elevate
  File "menuinst\api.py", line 77, in install
  File "menuinst\platforms\win.py", line 162, in create
  File "menuinst\platforms\win.py", line 228, in _paths
KeyError: 'desktop'
done
```
Which makes it hard to tell what the problematic package actually is. At least printing the file path would make it easier (I hope!).

Not sure how to add a test easily for this so I didn't :see_no_evil: 

I don't think it's substantial enough for a news / changelog update or any doc updates, either.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
