### PR TITLE
Deprecate unused functions in `conda.common.io`

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -135,7 +135,7 @@ class SwallowBrokenPipe(ContextDecorator):
 swallow_broken_pipe = SwallowBrokenPipe()
 
 
-class CaptureTarget(Enum):
+class _CaptureTarget(Enum):
     """Constants used for contextmanager captured.
 
     Used similarly like the constants PIPE, STDOUT for stdlib's subprocess.Popen.
@@ -143,6 +143,9 @@ class CaptureTarget(Enum):
 
     STRING = -1
     STDOUT = -2
+
+
+deprecated.constant("26.9", "27.3", "CaptureTarget", _CaptureTarget)
 
 
 @contextmanager
@@ -220,8 +223,8 @@ def env_unmodified(
 @contextmanager
 @deprecated("26.9", "27.3")
 def captured(
-    stdout: CaptureTarget | None | Any = CaptureTarget.STRING,
-    stderr: CaptureTarget | None | Any = CaptureTarget.STRING,
+    stdout: _CaptureTarget | None | Any = _CaptureTarget.STRING,
+    stderr: _CaptureTarget | None | Any = _CaptureTarget.STRING,
 ) -> Generator[Any, None, None]:
     r"""Capture outputs of sys.stdout and sys.stderr.
 
@@ -277,7 +280,7 @@ def captured(
     # sys.stdout.write(bytes('bytes out', encoding='utf-8'))
     # sys.stdout.write(str('str out'))
     saved_stdout, saved_stderr = sys.stdout, sys.stderr
-    if stdout == CaptureTarget.STRING:
+    if stdout == _CaptureTarget.STRING:
         outfile = StringIO()
         outfile.old_write = outfile.write
         outfile.write = partial(write_wrapper, outfile)
@@ -286,12 +289,12 @@ def captured(
         outfile = stdout
         if outfile is not None:
             sys.stdout = outfile
-    if stderr == CaptureTarget.STRING:
+    if stderr == _CaptureTarget.STRING:
         errfile = StringIO()
         errfile.old_write = errfile.write
         errfile.write = partial(write_wrapper, errfile)
         sys.stderr = errfile
-    elif stderr == CaptureTarget.STDOUT:
+    elif stderr == _CaptureTarget.STDOUT:
         sys.stderr = errfile = outfile
     else:
         errfile = stderr
@@ -302,13 +305,13 @@ def captured(
     try:
         yield c
     finally:
-        if stdout == CaptureTarget.STRING:
+        if stdout == _CaptureTarget.STRING:
             c.stdout = outfile.getvalue()
         else:
             c.stdout = outfile
-        if stderr == CaptureTarget.STRING:
+        if stderr == _CaptureTarget.STRING:
             c.stderr = errfile.getvalue()
-        elif stderr == CaptureTarget.STDOUT:
+        elif stderr == _CaptureTarget.STDOUT:
             c.stderr = None
         else:
             c.stderr = errfile

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -332,6 +332,7 @@ def argv(args_list: list[str]) -> Generator[None, None, None]:
 
 
 @contextmanager
+@deprecated("26.9", "27.3")
 def disable_logger(logger_name: str) -> Generator[None, None, None]:
     """Temporarily disable a logger by setting its level above CRITICAL.
 

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -317,6 +317,7 @@ def captured(
 
 
 @contextmanager
+@deprecated("26.9", "27.3")
 def argv(args_list: list[str]) -> Generator[None, None, None]:
     """Temporarily replace sys.argv with the given list.
 

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -355,6 +355,7 @@ def disable_logger(logger_name: str) -> Generator[None, None, None]:
 
 
 @contextmanager
+@deprecated("26.9", "27.3")
 def stderr_log_level(
     level: int,
     logger_name: str | None = None,

--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -218,6 +218,7 @@ def env_unmodified(
 
 
 @contextmanager
+@deprecated("26.9", "27.3")
 def captured(
     stdout: CaptureTarget | None | Any = CaptureTarget.STRING,
     stderr: CaptureTarget | None | Any = CaptureTarget.STRING,

--- a/conda/gateways/logging.py
+++ b/conda/gateways/logging.py
@@ -189,6 +189,11 @@ def set_all_logger_level(level=DEBUG):
     )
 
 
+@deprecated(
+    "26.9",
+    "27.3",
+    addendum="Attach a ``logging.FileHandler`` to the desired logger instead.",
+)
 @cache
 def set_file_logging(logger_name=None, level=DEBUG, path=None):
     if path is None:

--- a/conda/testing/helpers.py
+++ b/conda/testing/helpers.py
@@ -23,6 +23,7 @@ from ..common.io import captured as common_io_captured
 from ..common.serialize import json
 from ..core.prefix_data import PrefixData
 from ..core.subdir_data import SubdirData
+from ..deprecations import deprecated
 from ..gateways.disk.delete import rm_rf
 from ..gateways.disk.read import lexists
 from ..history import History
@@ -60,6 +61,7 @@ def raises(exception, func, string=None):
 
 
 @contextmanager
+@deprecated("26.9", "27.3", addendum="Use pytest's `capsys` fixture instead.")
 def captured(disallow_stderr=True):
     # same as common.io.captured but raises Exception if unexpected output was written to stderr
     try:

--- a/docs/source/dev-guide/deep-dives/logging.md
+++ b/docs/source/dev-guide/deep-dives/logging.md
@@ -36,10 +36,6 @@ Historically, additional loggers were used for user-facing CLI text to stdout/st
 
 The `auxlib` logger a remnant from before the auxlib code was completely absorbed into conda.
 
-## Potential effect on other loggers
-
-There are three other functions that use {func}`logging.getLogger` and hence might affect other loggers. They are {func}`conda.gateways.logging.set_file_logging` that is never used in the code base and the context managers {func}`conda.common.io.disable_logger` and {func}`conda.common.io.stderr_log_level`, which are only used in testing.
-
 ## Root logger in auxlib
 
 In {mod}`conda.auxlib.logz`, the root logger is modified.

--- a/news/16004-deprecate-common-io-capture-helpers
+++ b/news/16004-deprecate-common-io-capture-helpers
@@ -1,0 +1,24 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.common.io.CaptureTarget` as pending deprecation for removal in 27.3. (#16004)
+* Mark `conda.common.io.captured` as pending deprecation for removal in 27.3. (#16004)
+* Mark `conda.common.io.argv` as pending deprecation for removal in 27.3. (#16004)
+* Mark `conda.common.io.disable_logger` as pending deprecation for removal in 27.3. (#16004)
+* Mark `conda.common.io.stderr_log_level` as pending deprecation for removal in 27.3. (#16004)
+* Mark `conda.testing.helpers.captured` as pending deprecation for removal in 27.3. In tests, prefer pytest's `capsys` fixture instead. (#16004)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/16004-deprecate-common-io-capture-helpers
+++ b/news/16004-deprecate-common-io-capture-helpers
@@ -14,6 +14,7 @@
 * Mark `conda.common.io.disable_logger` as pending deprecation for removal in 27.3. (#16004)
 * Mark `conda.common.io.stderr_log_level` as pending deprecation for removal in 27.3. (#16004)
 * Mark `conda.testing.helpers.captured` as pending deprecation for removal in 27.3. In tests, prefer pytest's `capsys` fixture instead. (#16004)
+* Mark `conda.gateways.logging.set_file_logging` as pending deprecation for removal in 27.3. (#16004)
 
 ### Docs
 

--- a/tests/cli/test_main_remove.py
+++ b/tests/cli/test_main_remove.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.base.context import context, reset_context
-from conda.common.io import stderr_log_level
 from conda.exceptions import (
     CondaEnvException,
     DryRunExit,
@@ -18,10 +17,7 @@ from conda.exceptions import (
     PackagesNotFoundInPrefixError,
 )
 from conda.gateways.disk.delete import path_is_clean
-from conda.testing.integration import (
-    TEST_LOG_LEVEL,
-    package_is_installed,
-)
+from conda.testing.integration import package_is_installed
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -31,8 +27,6 @@ if TYPE_CHECKING:
     from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 
 log = getLogger(__name__)
-stderr_log_level(TEST_LOG_LEVEL, "conda")
-stderr_log_level(TEST_LOG_LEVEL, "requests")
 
 
 def test_remove_all(

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -7,23 +7,25 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 from logging import DEBUG, NOTSET, WARN, getLogger
+from typing import TYPE_CHECKING
 
 import pytest
 
-from conda.common.io import (
-    CaptureTarget,
-    ThreadLimitedThreadPoolExecutor,
-    attach_stderr_handler,
-    captured,
-)
+from conda.common.io import ThreadLimitedThreadPoolExecutor, attach_stderr_handler
+
+if TYPE_CHECKING:
+    from pytest import CaptureFixture
 
 
 def test_captured():
+    with pytest.deprecated_call():
+        from conda.common.io import CaptureTarget, captured
+
     stdout_text = "stdout text"
     stderr_text = "stderr text"
 
     def print_captured(*args, **kwargs):
-        with captured(*args, **kwargs) as c:
+        with pytest.deprecated_call(), captured(*args, **kwargs) as c:
             print(stdout_text, end="")
             print(stderr_text, end="", file=sys.stderr)
         return c
@@ -48,7 +50,7 @@ def test_captured():
     assert caller_stdout.getvalue() == stdout_text
     assert caller_stderr.getvalue() == stderr_text
 
-    with captured() as outer_c:
+    with pytest.deprecated_call(), captured() as outer_c:
         inner_c = print_captured(None, None)
     assert inner_c.stdout is None
     assert inner_c.stderr is None
@@ -56,7 +58,7 @@ def test_captured():
     assert outer_c.stderr == stderr_text
 
 
-def test_attach_stderr_handler():
+def test_attach_stderr_handler(capsys: CaptureFixture):
     name = "abbacadabba"
     logr = getLogger(name)
     assert len(logr.handlers) == 0
@@ -64,34 +66,34 @@ def test_attach_stderr_handler():
 
     debug_message = "debug message 1329-485"
 
-    with captured() as c:
-        attach_stderr_handler(WARN, name)
-        logr.warning("test message")
-        logr.debug(debug_message)
+    attach_stderr_handler(WARN, name)
+    logr.warning("test message")
+    logr.debug(debug_message)
+    stdout, stderr = capsys.readouterr()
 
     assert len(logr.handlers) == 1
     assert logr.handlers[0].name == "stderr"
     assert logr.handlers[0].level is WARN
     assert logr.level is NOTSET
     assert logr.getEffectiveLevel() is WARN
-    assert c.stdout == ""
-    assert "test message" in c.stderr
-    assert debug_message not in c.stderr
+    assert stdout == ""
+    assert "test message" in stderr
+    assert debug_message not in stderr
 
     # round two, with debug
-    with captured() as c:
-        attach_stderr_handler(DEBUG, name)
-        logr.warning("test message")
-        logr.debug(debug_message)
-        logr.info("info message")
+    attach_stderr_handler(DEBUG, name)
+    logr.warning("test message")
+    logr.debug(debug_message)
+    logr.info("info message")
+    stdout, stderr = capsys.readouterr()
 
     assert len(logr.handlers) == 1
     assert logr.handlers[0].name == "stderr"
     assert logr.handlers[0].level is DEBUG
     assert logr.level is DEBUG
-    assert c.stdout == ""
-    assert "test message" in c.stderr
-    assert debug_message in c.stderr
+    assert stdout == ""
+    assert "test message" in stderr
+    assert debug_message in stderr
 
 
 @pytest.mark.parametrize(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -34,7 +34,6 @@ from conda.base.constants import (
 from conda.base.context import context, reset_context
 from conda.common.compat import on_linux, on_mac, on_win
 from conda.common.configuration import DEFAULT_CONDARC_FILENAME
-from conda.common.io import stderr_log_level
 from conda.common.iterators import groupby_to_dict as groupby
 from conda.common.path import (
     BIN_DIRECTORY,
@@ -75,7 +74,6 @@ from conda.resolve import Resolve
 from conda.testing.helpers import CHANNEL_DIR_V2, forward_to_subprocess, in_subprocess
 from conda.testing.integration import (
     PYTHON_BINARY,
-    TEST_LOG_LEVEL,
     get_shortcut_dir,
     package_is_installed,
     which_or_where,
@@ -100,8 +98,6 @@ if TYPE_CHECKING:
     )
 
 log = getLogger(__name__)
-stderr_log_level(TEST_LOG_LEVEL, "conda")
-stderr_log_level(TEST_LOG_LEVEL, "requests")
 
 pytestmark = [
     # all tests in this file are integration tests


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Found more unused code that we can deprecate:

* `conda.common.io.CaptureTarget`
* `conda.common.io.captured`
* `conda.common.io.argv`
* `conda.common.io.disable_logger`
* `conda.common.io.stderr_log_level`
* `conda.testing.helpers.captured`

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
