### PR TITLE
Handle urljoin() special-case in sharded repodata

### DIFF
--- a/_conda/shards/cache.py
+++ b/_conda/shards/cache.py
@@ -35,8 +35,10 @@ ZSTD_MAX_SHARD_SIZE = (
 class AnnotatedRawShard:
     def __init__(self, url: str, package: str, compressed_shard: bytes):
         # prevent easy mistake of swapping url, package
-        assert "://" in url
-        assert "://" not in package
+        if "://" not in url:
+            raise ValueError("url must contain '://'")
+        if "://" in package:
+            raise ValueError("package must not contain '://'")
 
         self.url = url
         self.package = package  # remove this field to avoid confusion?

--- a/_conda/shards/misc.py
+++ b/_conda/shards/misc.py
@@ -70,23 +70,34 @@ def _safe_urljoin_with_slash(base_url: str, relative_url: str = "") -> str:
     See: https://github.com/conda/conda-libmamba-solver/issues/866
     """
     parsed = urlparse(base_url)
+    relative_parsed = urlparse(relative_url)
 
     # For schemes that urljoin handles correctly, use the standard behavior
     if parsed.scheme in _URLJOIN_SAFE_SCHEMES:
-        # Standard urljoin behavior: join with relative_url, then "." for trailing slash
-        result = urljoin(urljoin(base_url, relative_url), ".")
-        return result
-
-    # For unregistered schemes (e.g. s3://), urljoin drops the host.
-    # Work around that by temporarily swapping in https://, then restoring
-    # the original scheme on the result.
-    relative_parsed = urlparse(relative_url)
-    if not relative_parsed.scheme and parsed.scheme:
-        https_base_url = urlunparse(parsed._replace(scheme="https"))
-        joined_https = urljoin(urljoin(https_base_url, relative_url), ".")
-        result = urlunparse(urlparse(joined_https)._replace(scheme=parsed.scheme))
+        # Standard urljoin behavior: join with relative_url
+        # If relative_url is absolute (has a scheme), it will override base_url entirely
+        # Otherwise, treat last segment as filename and strip it with "."
+        if relative_parsed.scheme:
+            # Absolute URL: use as-is (the trailing slash will be added at the end)
+            result = relative_url
+        else:
+            # Relative URL: join and normalize to directory by appending "."
+            result = urljoin(urljoin(base_url, relative_url), ".")
     else:
-        result = urljoin(urljoin(base_url, relative_url), ".")
+        # For unregistered schemes (e.g. s3://), urljoin drops the host.
+        # Work around that by temporarily swapping in https://, then restoring
+        # the original scheme on the result.
+        if relative_parsed.scheme:
+            # Absolute URL with same scheme: override base_url
+            result = relative_url
+        elif not relative_parsed.scheme and parsed.scheme:
+            # Relative URL: use scheme-swap workaround
+            https_base_url = urlunparse(parsed._replace(scheme="https"))
+            joined_https = urljoin(urljoin(https_base_url, relative_url), ".")
+            result = urlunparse(urlparse(joined_https)._replace(scheme=parsed.scheme))
+        else:
+            # Fallback for edge cases
+            result = urljoin(urljoin(base_url, relative_url), ".")
 
     # Ensure trailing slash for proper concatenation
     if not result.endswith("/"):

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -1159,6 +1159,18 @@ def test_repodata_shards_sends_etag(monkeypatch, tmp_path):
         ("s3://bucket-name/linux-64", ".", "s3://bucket-name/"),
         ("file:///path/to/channel/linux-64", "", "file:///path/to/channel/"),
         ("ftp://ftp.example.com/pub/linux-64", "", "ftp://ftp.example.com/pub/"),
+        # requires final "append /" check, second URL is absolute overriding first URL.
+        (
+            "s3://bucket-name/linux-64",
+            "s3://bucket-name/noslash",
+            "s3://bucket-name/noslash/",
+        ),
+        # requires final "append /" check, second URL also ends with /
+        (
+            "s3://bucket-name/linux-64",
+            "s3://bucket-name/slash/",
+            "s3://bucket-name/slash/",
+        ),
     ],
 )
 def test_safe_urljoin_with_slash(base_url, relative_url, expected):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

While working on code coverage for shards, I noticed an issue with `urljoin("s3://one", "s3://two")` returning "." instead of "s3://two". This PR covers that case, but we have to parse both URLs.

Since `urljoin()` is slow, it's a shame that we have to call it so many times to perform this operation. However we also try to only call it once per repodata which is what the "always end in '/'" is about. If we have to call it once per file, that causes a performance problem.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
