### PR TITLE
Add conda_external_installers plugin hook, deprecate built-in pip installer

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -381,8 +381,7 @@ def install(args, parser, command="install"):
 
     if env.external_packages and not context.dry_run and not context.download_only:
         from .. import CondaError
-        from ..env.installers.base import get_installer
-        from ..env.pip_util import get_pip_workdir
+        from ..env.installers.base import get_installer, get_workdir
 
         external_envs = [
             (fpath, file_env)
@@ -393,13 +392,10 @@ def install(args, parser, command="install"):
             for installer_type, pkg_specs in file_env.external_packages.items():
                 try:
                     installer = get_installer(installer_type)
-                    if installer_type == "pip":
-                        workdir = get_pip_workdir(fpath)
-                        installer.install(
-                            prefix, list(pkg_specs), args, file_env, workdir=workdir
-                        )
-                    else:
-                        installer.install(prefix, list(pkg_specs), args, file_env)
+                    workdir = get_workdir(fpath)
+                    installer.install(
+                        prefix, list(pkg_specs), args, file_env, workdir=workdir
+                    )
                 except InvalidInstaller:
                     raise CondaError(
                         f"Unable to install package for {installer_type} from environment file {fpath}. "

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -102,8 +102,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..common.serialize import json
     from ..core.prefix_data import PrefixData
     from ..env.env import print_result
-    from ..env.installers.base import get_installer
-    from ..env.pip_util import get_pip_workdir
+    from ..env.installers.base import get_installer, get_workdir
     from ..exceptions import (
         CondaEnvException,
         InvalidInstaller,
@@ -190,15 +189,10 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         for installer_type, pkg_specs in env.external_packages.items():
             try:
                 installer = get_installer(installer_type)
-                if installer_type == "pip":
-                    workdir = get_pip_workdir(args.file)
-                    result[installer_type] = installer.install(
-                        prefix, pkg_specs, args, env, workdir=workdir
-                    )
-                else:
-                    result[installer_type] = installer.install(
-                        prefix, pkg_specs, args, env
-                    )
+                workdir = get_workdir(args.file)
+                result[installer_type] = installer.install(
+                    prefix, pkg_specs, args, env, workdir=workdir
+                )
             except InvalidInstaller:
                 raise CondaError(
                     dals(

--- a/conda/cli/main_env_update.py
+++ b/conda/cli/main_env_update.py
@@ -81,7 +81,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..base.context import context, determine_target_prefix
     from ..core.prefix_data import PrefixData
     from ..env.env import print_result
-    from ..env.installers.base import get_installer
+    from ..env.installers.base import get_installer, get_workdir
     from ..exceptions import (
         CondaEnvException,
         InvalidInstaller,
@@ -178,7 +178,10 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     # install all other external packages
     for installer_type, specs in env.external_packages.items():
         installer = installers[installer_type]
-        result[installer_type] = installer.install(prefix, specs, args, env)
+        workdir = get_workdir(args.file)
+        result[installer_type] = installer.install(
+            prefix, specs, args, env, workdir=workdir
+        )
 
     if env.variables:
         prefix_data.set_environment_env_vars(env.variables)

--- a/conda/env/env.py
+++ b/conda/env/env.py
@@ -429,9 +429,11 @@ class EnvironmentYaml:
         """Convert the ``Environment`` into a ``model.Environment`` object"""
         config = EnvironmentConfig(channels=tuple(self.channels))
 
-        external_packages = {}
-        if pip_dependencies := self.dependencies.get("pip"):
-            external_packages["pip"] = pip_dependencies
+        external_packages = {
+            key: specs
+            for key, specs in self.dependencies.items()
+            if key != "conda" and specs
+        }
 
         requested_packages = [
             MatchSpec(spec) for spec in self.dependencies.get("conda", [])

--- a/conda/env/installers/base.py
+++ b/conda/env/installers/base.py
@@ -3,16 +3,52 @@
 """Dynamic installer loading."""
 
 import importlib
+import os
 
 from ...exceptions import InvalidInstaller
 
 
+def get_workdir(file_path: str | None) -> str | None:
+    """
+    Return the directory of an environment file path, for resolving relative
+    paths in installer specs (e.g., ``-e ./local_pkg``).
+
+    Returns None for URLs or when no usable path is provided.
+    """
+    if not file_path:
+        return None
+    from ...gateways.connection.session import CONDA_SESSION_SCHEMES
+
+    url_scheme = file_path.split("://", 1)[0]
+    if url_scheme in CONDA_SESSION_SCHEMES:
+        return None
+    try:
+        workdir = os.path.dirname(os.path.abspath(file_path))
+        return workdir if os.access(workdir, os.W_OK) else None
+    except (AttributeError, TypeError):
+        return None
+
+
 def get_installer(name):
     """
-        Gets the installer for the given environment.
+    Gets the installer for the given environment.
+
+    Checks registered plugins first, then falls back to built-in modules.
+    The ``pip`` installer is only available via the plugin hook;
+    the built-in ``conda.env.installers.pip`` module is deprecated.
 
     Raises: InvalidInstaller if unable to load installer
     """
+    from ...base.context import context
+
+    plugin = context.plugin_manager.get_external_installer(name)
+    if plugin is not None:
+        return plugin
+
+    # pip requires the conda_external_installers plugin (provided by conda-pypi)
+    if name == "pip":
+        raise InvalidInstaller(name)
+
     try:
         return importlib.import_module(f"conda.env.installers.{name}")
     except ImportError:

--- a/conda/env/installers/pip.py
+++ b/conda/env/installers/pip.py
@@ -7,8 +7,15 @@ import os.path as op
 from logging import getLogger
 
 from ...auxlib.compat import Utf8NamedTemporaryFile
+from ...deprecations import deprecated
 from ...env.pip_util import get_pip_installed_packages, get_pip_workdir, pip_subprocess
 from ...reporters import get_spinner
+
+deprecated.module(
+    "26.9",
+    "27.3",
+    addendum="Use the conda_external_installers plugin hook instead.",
+)
 
 log = getLogger(__name__)
 

--- a/conda/env/pip_util.py
+++ b/conda/env/pip_util.py
@@ -13,11 +13,15 @@ from logging import getLogger
 
 from ..base.context import context
 from ..common.compat import on_win
+from ..deprecations import deprecated
 from ..exceptions import CondaEnvException
-from ..gateways.connection.session import CONDA_SESSION_SCHEMES
 from ..gateways.subprocess import any_subprocess
 
 log = getLogger(__name__)
+
+deprecated.module(
+    "26.9", "27.3", addendum="Use conda_external_installers plugin hook instead."
+)
 
 
 def get_pip_workdir(file_path: str | None) -> str | None:
@@ -27,16 +31,9 @@ def get_pip_workdir(file_path: str | None) -> str | None:
 
     Returns None for URLs or when no usable path is provided.
     """
-    if not file_path:
-        return None
-    url_scheme = file_path.split("://", 1)[0]
-    if url_scheme in CONDA_SESSION_SCHEMES:
-        return None
-    try:
-        workdir = os.path.dirname(os.path.abspath(file_path))
-        return workdir if os.access(workdir, os.W_OK) else None
-    except (AttributeError, TypeError):
-        return None
+    from .installers.base import get_workdir
+
+    return get_workdir(file_path)
 
 
 def pip_subprocess(args, prefix, cwd):

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
         CondaAuthHandler,
         CondaEnvironmentExporter,
         CondaEnvironmentSpecifier,
+        CondaExternalInstaller,
         CondaHealthCheck,
         CondaPackageExtractor,
         CondaPostCommand,
@@ -805,5 +806,42 @@ class CondaSpecs:
                 )
 
         :return: An iterable of :class:`~conda.plugins.types.CondaPackageExtractor` entries.
+        """
+        yield from ()
+
+    @_hookspec
+    def conda_external_installers(self) -> Iterable[CondaExternalInstaller]:
+        """
+        **EXPERIMENTAL**
+
+        Register external installers for non-conda package types.
+
+        External installers handle the installation of packages listed under
+        dict keys in the ``dependencies`` section of environment files (e.g., the
+        ``pip:`` section in ``environment.yml``). Plugins can override the built-in
+        installers or provide new ones.
+
+        **Example:**
+
+        .. code-block:: python
+
+            from conda import plugins
+
+
+            def install_pip_packages(prefix, specs, args, *_, **kwargs):
+                # Custom pip installation logic that converts wheels to conda packages
+                from my_plugin import convert_and_install
+
+                return convert_and_install(prefix, specs)
+
+
+            @plugins.hookimpl
+            def conda_external_installers():
+                yield plugins.types.CondaExternalInstaller(
+                    name="pip",
+                    install=install_pip_packages,
+                )
+
+        :return: An iterable of :class:`~conda.plugins.types.CondaExternalInstaller` entries.
         """
         yield from ()

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
         CondaAuthHandler,
         CondaEnvironmentExporter,
         CondaEnvironmentSpecifier,
+        CondaExternalInstaller,
         CondaHealthCheck,
         CondaPackageExtractor,
         CondaPluginWithAliases,
@@ -340,6 +341,11 @@ class CondaPluginManager(pluggy.PluginManager):
     def get_hook_results(
         self, name: Literal["environment_exporters"]
     ) -> list[CondaEnvironmentExporter]: ...
+
+    @overload
+    def get_hook_results(
+        self, name: Literal["external_installers"]
+    ) -> list[CondaExternalInstaller]: ...
 
     def get_hook_results(self, name, **kwargs):
         """
@@ -1051,6 +1057,19 @@ class CondaPluginManager(pluggy.PluginManager):
         for ext in self.get_package_extractors():
             if path_str.endswith(ext):
                 return ext
+        return None
+
+    def get_external_installer(self, name: str):
+        """
+        Get a registered external installer plugin by name or alias.
+
+        :param name: The installer name or alias (e.g., "pypi" or "pip").
+        :return: The matching CondaExternalInstaller plugin, or None if not found.
+        """
+        name = name.lower().strip()
+        for hook in self.get_hook_results("external_installers"):
+            if hook.name == name or name in hook.aliases:
+                return hook
         return None
 
 

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -801,3 +801,35 @@ class CondaPackageExtractor(CondaPlugin):
     name: str
     extensions: list[str]
     extract: PackageExtract
+
+
+@dataclass
+class CondaExternalInstaller(CondaPlugin):
+    """
+    **EXPERIMENTAL**
+
+    Return type to use when defining a conda external installer plugin hook.
+
+    External installers handle the installation of non-conda packages listed
+    in environment specification files (e.g., the ``pip:`` section in
+    ``environment.yml``). Each installer registers a name that corresponds to
+    the key used in the environment file's ``external_packages`` dict entries.
+
+    For details on how this is used, see
+    :meth:`~conda.plugins.hookspec.CondaSpecs.conda_external_installers`.
+
+    :param name: Primary installer name matching the environment file key
+                 (e.g., ``pypi`` for a PyPI installer).
+    :param aliases: Additional names that resolve to this installer
+                    (e.g., ``["pip"]`` for backwards compatibility).
+    :param install: Callable that installs the packages. Signature:
+                    ``install(prefix: str, specs: list[str], args: Namespace, env) -> list[str] | None``
+                    where ``prefix`` is the target environment path, ``specs`` is
+                    the list of package specifications, ``args`` is the CLI namespace,
+                    and ``env`` is the environment object. Returns a list of installed
+                    packages or None.
+    """
+
+    name: str
+    install: Callable
+    aliases: tuple[str, ...] = ()

--- a/news/external-installer-plugin-hook
+++ b/news/external-installer-plugin-hook
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Add `conda_external_installers` plugin hook for handling external package managers (e.g., pip/pypi, npm) in `environment.yml` files. (#14157)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.env.installers.pip` module as pending deprecation; use the `conda_external_installers` plugin hook instead (removal in 27.3). (#14157)
+* Mark `conda.env.pip_util` module as pending deprecation; use `conda.env.installers.base.get_workdir` and the `conda_external_installers` plugin hook instead (removal in 27.3). (#14157)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/env/support/example/environment_external_installer.yml
+++ b/tests/env/support/example/environment_external_installer.yml
@@ -1,0 +1,6 @@
+name: test
+dependencies:
+  - python
+  - pip
+  - pip:
+    - six

--- a/tests/env/support/example/environment_external_installer_multi.yml
+++ b/tests/env/support/example/environment_external_installer_multi.yml
@@ -1,0 +1,7 @@
+name: test
+dependencies:
+  - python
+  - pip
+  - pip:
+    - six
+    - colorama

--- a/tests/env/support/example/environment_external_installer_pinned.yml
+++ b/tests/env/support/example/environment_external_installer_pinned.yml
@@ -1,0 +1,6 @@
+name: test
+dependencies:
+  - python
+  - pip
+  - pip:
+    - six==1.16.0

--- a/tests/env/support/example/environment_npm.yml
+++ b/tests/env/support/example/environment_npm.yml
@@ -1,0 +1,5 @@
+name: test
+dependencies:
+  - nodejs
+  - npm:
+    - is-odd

--- a/tests/env/support/example/environment_unknown_installer.yml
+++ b/tests/env/support/example/environment_unknown_installer.yml
@@ -1,0 +1,5 @@
+name: test
+dependencies:
+  - python
+  - npm:
+    - express

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 from pathlib import Path
@@ -508,3 +509,145 @@ def test_export_and_recreate_environment(
         assert rc == 0, (
             f"conda env create --dry-run failed ({target_format=}): {stderr}"
         )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not importlib.util.find_spec("conda_pypi"),
+    reason="conda-pypi not installed",
+)
+@pytest.mark.parametrize(
+    "env_file,expected_packages",
+    [
+        ("example/environment_external_installer.yml", ["six"]),
+        ("example/environment_external_installer_multi.yml", ["six", "colorama"]),
+        ("example/environment_external_installer_pinned.yml", ["six=1.16.0"]),
+    ],
+)
+def test_create_external_installer(
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+    env_file: str,
+    expected_packages: list[str],
+):
+    """The conda_external_installers plugin hook installs pip: deps via conda-pypi."""
+    prefix = path_factory()
+
+    _, stderr, rc = conda_cli(
+        "env",
+        "create",
+        f"--prefix={prefix}",
+        "--file",
+        support_file(env_file),
+    )
+    assert rc == 0, f"conda env create failed: {stderr}"
+    assert prefix.exists()
+    assert package_is_installed(prefix, "python")
+    for pkg in expected_packages:
+        assert package_is_installed(prefix, pkg)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not importlib.util.find_spec("conda_pypi"),
+    reason="conda-pypi not installed",
+)
+def test_update_external_installer(
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+):
+    """conda env update adds pip: deps to an existing env via the plugin."""
+    prefix = path_factory()
+
+    _, stderr, rc = conda_cli(
+        "env",
+        "create",
+        f"--prefix={prefix}",
+        "--file",
+        support_file("example/environment_pinned.yml"),
+    )
+    assert rc == 0, f"conda env create failed: {stderr}"
+    assert not package_is_installed(prefix, "six")
+
+    _, stderr, rc = conda_cli(
+        "env",
+        "update",
+        f"--prefix={prefix}",
+        "--file",
+        support_file("example/environment_external_installer.yml"),
+    )
+    assert rc == 0, f"conda env update failed: {stderr}"
+    assert package_is_installed(prefix, "six")
+
+
+@pytest.mark.integration
+def test_create_unknown_installer_type_errors(
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+):
+    """Unknown installer key (e.g., npm:) raises a helpful error."""
+    from conda import CondaError
+
+    prefix = path_factory()
+
+    with pytest.raises(CondaError, match="Unable to install package for npm"):
+        conda_cli(
+            "env",
+            "create",
+            f"--prefix={prefix}",
+            "--file",
+            support_file("example/environment_unknown_installer.yml"),
+        )
+
+
+@pytest.fixture
+def npm_installer_plugin():
+    """Register a real npm external installer plugin into the live plugin manager."""
+    from conda import plugins as conda_plugins
+    from conda.base.context import context
+    from conda.plugins.types import CondaExternalInstaller
+
+    def npm_install(prefix, specs, args, *_, **kwargs):
+        npm_bin = Path(prefix) / ("Scripts" if on_win else "bin") / "npm"
+        result = subprocess.run(
+            [str(npm_bin), "install", *specs],
+            cwd=prefix,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"npm install failed ({result.returncode}): {result.stderr}"
+            )
+        return list(specs)
+
+    class NpmInstallerPlugin:
+        @conda_plugins.hookimpl
+        def conda_external_installers(self):
+            yield CondaExternalInstaller(name="npm", install=npm_install)
+
+    plugin = NpmInstallerPlugin()
+    context.plugin_manager.register(plugin)
+    yield
+    context.plugin_manager.unregister(plugin)
+
+
+@pytest.mark.integration
+def test_create_npm_installer(
+    npm_installer_plugin,
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+):
+    """A real npm external installer plugin can install packages from environment.yml."""
+    prefix = path_factory()
+
+    _, stderr, rc = conda_cli(
+        "env",
+        "create",
+        f"--prefix={prefix}",
+        "--file",
+        support_file("example/environment_npm.yml"),
+    )
+    assert rc == 0, f"conda env create failed: {stderr}"
+    assert package_is_installed(prefix, "nodejs")
+    assert (prefix / "node_modules" / "is-odd").exists()

--- a/tests/env/test_pip_util.py
+++ b/tests/env/test_pip_util.py
@@ -1,9 +1,13 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
+
 import pytest
 
-from conda.env.pip_util import get_pip_installed_packages
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", PendingDeprecationWarning)
+    from conda.env.pip_util import get_pip_installed_packages
 
 pip_output_attrs = """
 Collecting attrs

--- a/tests/plugins/test_external_installers.py
+++ b/tests/plugins/test_external_installers.py
@@ -1,0 +1,209 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from conda import plugins
+from conda.env.installers.base import get_installer
+from conda.exceptions import InvalidInstaller
+from conda.plugins.types import CondaExternalInstaller
+
+if TYPE_CHECKING:
+    from conda.plugins.manager import CondaPluginManager
+
+
+def _noop_install(prefix, specs, args, *_, **kwargs):
+    return None
+
+
+def _list_install(prefix, specs, args, *_, **kwargs):
+    return ["six-1.16.0"]
+
+
+def _raising_install(prefix, specs, args, *_, **kwargs):
+    raise RuntimeError("resolver failed")
+
+
+@pytest.fixture
+def pypi_installer_plugin() -> CondaExternalInstaller:
+    """A pypi external installer plugin with 'pip' as alias."""
+    return CondaExternalInstaller(
+        name="pypi",
+        install=_noop_install,
+        aliases=("pip",),
+    )
+
+
+@pytest.fixture
+def plugin_manager_with_installer(
+    pypi_installer_plugin: CondaExternalInstaller,
+    plugin_manager: CondaPluginManager,
+) -> CondaPluginManager:
+    """Plugin manager with a pypi external installer registered."""
+
+    class PyPIInstallerPlugin:
+        @plugins.hookimpl
+        def conda_external_installers(self):
+            yield pypi_installer_plugin
+
+    plugin_manager.register(PyPIInstallerPlugin())
+    return plugin_manager
+
+
+@pytest.mark.parametrize("query", ["pypi", "PYPI", "Pypi", "pip", "PIP", "Pip"])
+def test_get_external_installer_lookup(
+    plugin_manager_with_installer: CondaPluginManager,
+    pypi_installer_plugin: CondaExternalInstaller,
+    query: str,
+):
+    """Installer is found by name, alias, or case variant."""
+    assert (
+        plugin_manager_with_installer.get_external_installer(query)
+        is pypi_installer_plugin
+    )
+
+
+@pytest.mark.parametrize("query", ["pypi", "pip", "PIP", "Pypi"])
+def test_get_installer_resolves_plugin(
+    plugin_manager_with_installer: CondaPluginManager,
+    pypi_installer_plugin: CondaExternalInstaller,
+    query: str,
+):
+    """get_installer() resolves name/alias/case to plugin."""
+    assert get_installer(query) is pypi_installer_plugin
+
+
+@pytest.mark.parametrize("query", ["pip", "nonexistent", "npm"])
+def test_get_installer_raises_without_plugin(
+    plugin_manager: CondaPluginManager,
+    query: str,
+):
+    """get_installer() raises InvalidInstaller when no plugin handles the name."""
+    with pytest.raises(InvalidInstaller):
+        get_installer(query)
+
+
+@pytest.mark.parametrize("query", ["pip", "pypi", "unknown"])
+def test_get_external_installer_returns_none_when_missing(
+    plugin_manager: CondaPluginManager,
+    query: str,
+):
+    """Returns None when no plugin is registered."""
+    assert plugin_manager.get_external_installer(query) is None
+
+
+def test_get_installer_falls_back_to_builtin_module(
+    plugin_manager: CondaPluginManager,
+):
+    """Non-pip installers fall back to built-in modules."""
+    installer = get_installer("conda")
+    assert hasattr(installer, "install")
+    assert installer.__name__ == "conda.env.installers.conda"
+
+
+def test_multiple_installers_from_one_plugin(
+    plugin_manager: CondaPluginManager,
+):
+    """A single hook can yield multiple installers, each independently retrievable."""
+
+    class MultiInstallerPlugin:
+        @plugins.hookimpl
+        def conda_external_installers(self):
+            yield CondaExternalInstaller(
+                name="pypi", install=_noop_install, aliases=("pip",)
+            )
+            yield CondaExternalInstaller(name="npm", install=_list_install)
+
+    plugin_manager.register(MultiInstallerPlugin())
+
+    pypi = plugin_manager.get_external_installer("pypi")
+    npm = plugin_manager.get_external_installer("npm")
+    assert pypi is not None
+    assert npm is not None
+    assert pypi.name == "pypi"
+    assert npm.name == "npm"
+    assert plugin_manager.get_external_installer("pip").name == "pypi"
+
+
+def test_empty_aliases_only_reachable_by_name(
+    plugin_manager: CondaPluginManager,
+):
+    """Installer with no aliases is only found by primary name."""
+
+    class NoAliasPlugin:
+        @plugins.hookimpl
+        def conda_external_installers(self):
+            yield CondaExternalInstaller(name="custom", install=_noop_install)
+
+    plugin_manager.register(NoAliasPlugin())
+
+    assert plugin_manager.get_external_installer("custom") is not None
+    assert plugin_manager.get_external_installer("pip") is None
+    assert plugin_manager.get_external_installer("pypi") is None
+
+
+def test_install_returns_list(
+    plugin_manager: CondaPluginManager,
+):
+    """Install callable returning a list propagates the value."""
+
+    class ListPlugin:
+        @plugins.hookimpl
+        def conda_external_installers(self):
+            yield CondaExternalInstaller(
+                name="pypi", install=_list_install, aliases=("pip",)
+            )
+
+    plugin_manager.register(ListPlugin())
+    installer = get_installer("pip")
+    result = installer.install("/prefix", ["six"], None)
+    assert result == ["six-1.16.0"]
+
+
+def test_install_returns_none(
+    plugin_manager: CondaPluginManager,
+):
+    """Install callable returning None doesn't crash."""
+
+    class NonePlugin:
+        @plugins.hookimpl
+        def conda_external_installers(self):
+            yield CondaExternalInstaller(
+                name="pypi", install=_noop_install, aliases=("pip",)
+            )
+
+    plugin_manager.register(NonePlugin())
+    installer = get_installer("pip")
+    result = installer.install("/prefix", ["six"], None)
+    assert result is None
+
+
+def test_install_raises_exception(
+    plugin_manager: CondaPluginManager,
+):
+    """Exception from install callable bubbles up."""
+
+    class RaisingPlugin:
+        @plugins.hookimpl
+        def conda_external_installers(self):
+            yield CondaExternalInstaller(
+                name="pypi", install=_raising_install, aliases=("pip",)
+            )
+
+    plugin_manager.register(RaisingPlugin())
+    installer = get_installer("pip")
+    with pytest.raises(RuntimeError, match="resolver failed"):
+        installer.install("/prefix", ["six"], None)
+
+
+def test_pip_module_import_warns():
+    """Importing the deprecated pip module emits PendingDeprecationWarning."""
+    sys.modules.pop("conda.env.installers.pip", None)
+    sys.modules.pop("conda.env.pip_util", None)
+    with pytest.warns(PendingDeprecationWarning):
+        importlib.import_module("conda.env.installers.pip")


### PR DESCRIPTION
### Description

Introduces a new **experimental** `conda_external_installers` plugin hook that allows plugins to handle installation of non-conda packages listed in environment specification files (e.g., the `pip:` section in `environment.yml`).

**Motivation:** With `EXTERNALLY-MANAGED` (PEP 668) markers in conda environments, direct `pip install` calls break unless `PIP_BREAK_SYSTEM_PACKAGES` is set. This hook enables `conda-pypi` to intercept the `pip:` section, use pip only as a dependency resolver (dry-run), and install the resolved wheels through conda's package extractor — avoiding direct pip installs entirely.

**Changes:**

- Add `CondaExternalInstaller` dataclass to `conda.plugins.types` with `name`, `install`, and `aliases` fields
- Add `conda_external_installers` hook spec to `conda.plugins.hookspec`
- Add `get_external_installer()` to `CondaPluginManager` (matches by name or alias, case-insensitive)
- Update `get_installer()` in `conda.env.installers.base` to check plugins first; block the `importlib` fallback for `"pip"` (now only available via plugin)
- Add generic `get_workdir()` utility in `conda.env.installers.base` (replaces pip-specific `get_pip_workdir`)
- Generalize `to_environment_model()` to extract **all** non-`conda` dependency dict keys as `external_packages` (not just `pip`)
- Remove pip-specific branching from all call sites (`cli/install.py`, `cli/main_env_create.py`, `cli/main_env_update.py`)
- Deprecate `conda.env.installers.pip` module (26.9 → 27.3)
- Deprecate `conda.env.pip_util` module (26.9 → 27.3)

**Companion PR:** conda/conda-pypi#349

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

**Tests added:**

- `tests/plugins/test_external_installers.py` — 23 unit tests: parametrized lookup (name/alias/case), multi-installer registration, install callable contract (returns list, None, raises), deprecated module import warning
- `tests/env/test_create.py` — integration tests: parametrized `conda env create` (single/multi/pinned pip specs), `conda env update` with pip deps, unknown installer error, and a **real npm installer plugin** using `nodejs` from conda-forge