### PR TITLE
Move conda-pypi from run to run_constrained

### DIFF
--- a/news/15987-add-conda-pypi-dependency
+++ b/news/15987-add-conda-pypi-dependency
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Require `conda-pypi >=0.8.0` in the conda recipe. (#15987)
+* Add `conda-pypi >=0.8.0` to `run_constrained` in the conda recipe. (#15987)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,14 +56,13 @@ requirements:
     - tqdm >=4
     - truststore >=0.8.0           # [py>=310]
     - zstandard >=0.15
-    # Plugins to bundle with conda
     - conda-libmamba-solver >=26.4.0
-    - conda-pypi >=0.8.0
   run_constrained:
     - conda-build >=25.9
     # minimum version when conda-content-trust plugin is installed
     - conda-content-trust >=0.3.0
     - conda-env >=2.6
+    - conda-pypi >=0.8.0
 
 test:
   imports:


### PR DESCRIPTION
### Description

Move `conda-pypi >=0.8.0` from `run` to `run_constrained` in `recipe/meta.yaml` and update the news fragment to reflect the change.

`conda-pypi` was added as a hard `run` dependency in #15987. However, the `conda_external_installers` plugin hook (#16035) has not landed on main yet, so conda-pypi's headline feature (handling `pip:` sections natively) is not available. After discussion in #16039, the decision is to move to `run_constrained` — following the existing pattern for `conda-content-trust` and `conda-env`: "if you install it, here's the version floor." Hard bundling is deferred until the hook lands.

Phase 0 of the native wheel support roadmap (#13863).

Closes #16039

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [~] ~Add / update necessary tests?~ (recipe-only change, no code changes)
- [~] ~Add / update outdated documentation?~ (not applicable)