### PR TITLE
Fix test_get_index_no_platform_with_offline_cache on conda-forge CI

### DIFF
--- a/news/16041-fix-offline-cache-test
+++ b/news/16041-fix-offline-cache-test
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `test_get_index_no_platform_with_offline_cache` failing on conda-forge CI by warming the repodata cache before testing offline reads. (#16041)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -96,6 +96,13 @@ def test_get_index_no_platform_with_offline_cache(
     # only works if CONDA_PLATFORM exists in tests/data/conda_format_repo
     # (test will not pass on newer platforms with default CONDA_PLATFORM =
     # 'osx-arm64' etc.)
+
+    # Undo env vars from the loops above so we can fetch repodata online.
+    monkeypatch.delenv("CONDA_OFFLINE")
+    monkeypatch.delenv("CONDA_REPODATA_TIMEOUT_SECS")
+    monkeypatch.delenv("CONDA_PLATFORM")
+    reset_context()
+
     online_channels = context.channels or ["defaults"]
 
     # Warm the repodata cache while still online so offline reads work

--- a/tests/core/test_subdir_data.py
+++ b/tests/core/test_subdir_data.py
@@ -96,6 +96,13 @@ def test_get_index_no_platform_with_offline_cache(
     # only works if CONDA_PLATFORM exists in tests/data/conda_format_repo
     # (test will not pass on newer platforms with default CONDA_PLATFORM =
     # 'osx-arm64' etc.)
+    online_channels = context.channels or ["defaults"]
+
+    # Warm the repodata cache while still online so offline reads work
+    # regardless of which channel the CI environment is configured with.
+    SubdirData._cache_.clear()
+    assert len(SubdirData.query_all("zlib", channels=online_channels)) > 1
+
     monkeypatch.setenv("CONDA_OFFLINE", "yes")
     monkeypatch.setenv("CONDA_PLATFORM", platform)
     monkeypatch.setenv("CONDA_PKGS_DIRS", str(tmp_path))
@@ -104,7 +111,6 @@ def test_get_index_no_platform_with_offline_cache(
 
     local_channel = Channel(join(CHANNEL_DIR_V1, platform))
     offline_channels = [local_channel]
-    online_channels = context.channels or ["defaults"]
 
     # In offline mode with an empty cache, we expect no results from online channels
     assert len(SubdirData.query_all("zlib", channels=offline_channels)) > 0


### PR DESCRIPTION
### Description

Fix `test_get_index_no_platform_with_offline_cache` failing deterministically on all conda-forge integration CI jobs.

The test assumed the default pkgs cache already had repodata for `context.channels` from earlier CI activity. On conda-forge CI with Miniforge, the cache is empty, so `SubdirData.query_all("zlib", channels=('conda-forge',))` returned 0 results in offline mode.

The fix warms the repodata cache with an online query before entering the offline test section, matching the test's stated intent ("If we re-enable the regular cache location, we do find zlib results").

Fixes #16041

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [~] ~Add / update outdated documentation?~ (not applicable)