### PR TITLE
Bump conda-libmamba-solver to >=26.4.1

### DIFF
--- a/news/bump-libmamba-solver
+++ b/news/bump-libmamba-solver
@@ -1,0 +1,3 @@
+### Other
+
+* Bump `conda-libmamba-solver` minimum version to `>=26.4.1`. (#16043)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ requirements:
     - truststore >=0.8.0           # [py>=310]
     - zstandard >=0.15
     # Plugins to bundle with conda
-    - conda-libmamba-solver >=26.4.0
+    - conda-libmamba-solver >=26.4.1
     - conda-pypi >=0.8.0
   run_constrained:
     - conda-build >=25.9

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ archspec >=0.2.3
 boltons >=23.0.0
 charset-normalizer
 conda-forge::pytest-codspeed >=3.0.0
-conda-libmamba-solver >=26.4.0
+conda-libmamba-solver >=26.4.1
 conda-package-handling >=2.2.0
 distro >=1.5.0
 frozendict >=2.4.2


### PR DESCRIPTION
### What was this PR about?

Bump the minimum `conda-libmamba-solver` version from `>=26.4.0` to `>=26.4.1` in both `recipe/meta.yaml` and `tests/requirements.txt` to pick up fixes needed for CI stability.

### Checklist - did you ...

- [x] Add a [news](news/TEMPLATE) file?
- ~[ ] Add / update tests?~
- ~[ ] Add / update relevant documentation?~