### PR TITLE
Ensure that on Windows reported conda anchor files report case sensitive paths

### DIFF
--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -773,6 +773,13 @@ def get_conda_anchor_files_and_records(
             if on_win:
                 fpath = fpath.replace("\\", "/")
             if matcher(fpath):
+                if on_win:
+                    fpath = re.sub(
+                        rf"{re.escape(site_packages_short_path)}",
+                        site_packages_short_path,
+                        fpath,
+                        flags=re.IGNORECASE,
+                    )
                 anchor_paths.append(fpath)
         if len(anchor_paths) > 1:
             anchor_path = max(anchor_paths, key=len)

--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -774,11 +774,9 @@ def get_conda_anchor_files_and_records(
                 fpath = fpath.replace("\\", "/")
             if matcher(fpath):
                 if on_win:
-                    fpath = re.sub(
-                        rf"{re.escape(site_packages_short_path)}",
-                        site_packages_short_path,
-                        fpath,
-                        flags=re.IGNORECASE,
+                    fpath = (
+                        site_packages_short_path
+                        + fpath[len(site_packages_short_path) :]
                     )
                 anchor_paths.append(fpath)
         if len(anchor_paths) > 1:

--- a/news/16052-case-insensitive-file-checking-on-windows
+++ b/news/16052-case-insensitive-file-checking-on-windows
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ensure that reported conda anchor files report case matched paths on Windows. (#16052 via #15983)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_prefix_data.py
+++ b/tests/core/test_prefix_data.py
@@ -327,7 +327,7 @@ def test_get_conda_anchor_files_and_records():
 
 
 def test_get_conda_anchor_files_and_records_case_sensitivity(monkeypatch: MonkeyPatch):
-    monkeypatch.setattr("conda.core.prefix_data.on_win", lambda: True)
+    monkeypatch.setattr("conda.core.prefix_data.on_win", True)
 
     @dataclass
     class DummyPythonRecord:

--- a/tests/core/test_prefix_data.py
+++ b/tests/core/test_prefix_data.py
@@ -27,6 +27,7 @@ from conda.testing.helpers import record
 from .. import PYTHON_SPEC
 
 if TYPE_CHECKING:
+    from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
     from conda.testing.fixtures import CondaCLIFixture, PipCLIFixture, TmpEnvFixture
@@ -323,6 +324,35 @@ def test_get_conda_anchor_files_and_records():
         )
         == valid_records
     )
+
+
+def test_get_conda_anchor_files_and_records_case_sensitivity(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr("conda.core.prefix_data.on_win", lambda: True)
+
+    @dataclass
+    class DummyPythonRecord:
+        files: list[str]
+
+    records = {
+        path: DummyPythonRecord([path])
+        for path in (
+            "lib/site-packages/spam.egg-info/PKG-INFO",
+            "Lib/site-packages/foo.dist-info/RECORD",
+            "lIb/site-packages/bar.egg-info",
+        )
+    }
+
+    expected_records_set = {
+        "Lib/site-packages/spam.egg-info/PKG-INFO",
+        "Lib/site-packages/foo.dist-info/RECORD",
+        "Lib/site-packages/bar.egg-info",
+    }
+
+    python_packages = get_conda_anchor_files_and_records(
+        "Lib/site-packages",
+        [*records.values()],
+    )
+    assert set(python_packages) == expected_records_set
 
 
 def test_corrupt_unicode_conda_meta_json():


### PR DESCRIPTION
### Description

This PR aims to fix an issue where installing scipy from conda-forge on windows reports being installed from pypi. Before this change:

```
H:\> conda create -n newenv scipy
 . . 

H:\>conda list -n newenv
. . .
scipy                      1.17.1                 pypi_0                 pypi

. . .
```

With this change
```
H:\> conda create -n newenv scipy
 . . 

H:\>conda list -n newenv
. . .
scipy                      1.17.1                 py314h9c5632b_0                  conda-forge

. . .
```

Other approaches might be to:
* ensure that the `files` entry for package records in `conda-meta` are case sensitive
* make the [check in the pypi prefix loader](https://github.com/conda/conda/blob/main/conda/plugins/prefix_data_loaders/pypi/__init__.py#L100) to be case insensitive

fixes https://github.com/conda/conda/issues/15983

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


