### PR TITLE
Adding conda-self and conda-lockfiles to canary build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,7 @@ requirements:
     - conda-libmamba-solver >=26.4.1
     - conda-pypi >=0.8.0
     - conda-lockfiles >=0.2.0
+    - conda-self >=0.2.0
     - conda-spawn >=0.1.0
   run_constrained:
     - conda-build >=25.9
@@ -96,6 +97,7 @@ test:
     - conda doctor --help
     - conda pypi --help
     - conda spawn --help
+    - conda self --help
 
 about:
   home: https://conda.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,8 @@ requirements:
     # Plugins to bundle with conda
     - conda-libmamba-solver >=26.4.0
     - conda-pypi >=0.8.0
+    - conda-lockfiles >=0.2.0
+    - conda-spawn >=0.1.0
   run_constrained:
     - conda-build >=25.9
     # minimum version when conda-content-trust plugin is installed
@@ -92,6 +94,8 @@ test:
     - conda upgrade --help
     # plugin subcommands
     - conda doctor --help
+    - conda pypi --help
+    - conda spawn --help
 
 about:
   home: https://conda.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,6 @@ requirements:
     - conda-pypi >=0.8.0
     - conda-lockfiles >=0.2.0
     - conda-self >=0.2.0
-    - conda-spawn >=0.1.0
   run_constrained:
     - conda-build >=25.9
     # minimum version when conda-content-trust plugin is installed
@@ -96,7 +95,6 @@ test:
     # plugin subcommands
     - conda doctor --help
     - conda pypi --help
-    - conda spawn --help
     - conda self --help
 
 about:


### PR DESCRIPTION
### Description

This adds `conda-self` and `conda-lockfiles` as a dependencies included in canary builds.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
