### PR TITLE
Fix `conda doctor --fix` package reinstall step

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -93,6 +93,10 @@ def reinstall_packages(args, specs: list[str], **kwargs) -> int:
     args.prune = kwargs.get("prune", False)
     args.freeze_installed = kwargs.get("freeze_installed", False)
     args.solver_retries = kwargs.get("solver_retries", 0)
+    args.use_local = kwargs.get("use_local", False)
+    args.file = kwargs.get("file", [])
+    args.repodata_fns = kwargs.get("repodata_fns", None)
+    args.update_modifier = kwargs.get("update_modifier", NULL)
 
     return install(args, None)
 

--- a/news/16054-fix-conda-doctore-package-reinstall
+++ b/news/16054-fix-conda-doctore-package-reinstall
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix conda doctor --fix package reinstall step (#16054 via #15740)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/16054-fix-conda-doctore-package-reinstall
+++ b/news/16054-fix-conda-doctore-package-reinstall
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix conda doctor --fix package reinstall step (#16054 via #15740)
+* Fix conda doctor --fix package reinstall step (#15740 via #16054)
 
 ### Deprecations
 

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -242,3 +242,27 @@ def test_reinstall_packages_calls_install(tmp_path: Path, mocker: MockerFixture)
     call_args = mock_install.call_args
     assert call_args[0][0] is args  # First positional arg is args
     assert len(call_args[0]) >= 2  # Must have at least 2 positional args
+
+
+def test_reinstall_args(tmp_path: Path, mocker: MockerFixture):
+    """Test that reinstall_packages includes all required arguments when calling install."""
+
+    class EmptySolver:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def solve_for_transaction(self, *args, **kwargs):
+            pass
+
+    mock_solver = mocker.patch(
+        "conda.cli.install.context.plugin_manager.get_cached_solver_backend",
+        return_value=EmptySolver,
+    )
+    mock_handle_txn = mocker.patch("conda.cli.install.handle_txn", return_value=0)
+
+    # Create minimal args namespace with required attributes
+    args = Namespace(prefix=str(tmp_path), name=None, cmd="install")
+
+    reinstall_packages(args, ["some-package"], force_reinstall=True)
+    mock_solver.assert_called_once()
+    mock_handle_txn.assert_called_once()


### PR DESCRIPTION
### Description

This PR fixes the altered files conda doctor check that reinstalls broken packages. It does this by ensuring that `conda.cli.install.reinstall_packages` populates all required `args` before calling `conda.cli.install.install`.

fixes https://github.com/conda/conda/issues/15740

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

