### PR TITLE
shards A: Add implementation from conda-libmamba-solver

### DIFF
--- a/conda/_private/README.md
+++ b/conda/_private/README.md
@@ -1,0 +1,6 @@
+`conda._private`. This directory should contain no `__init__.py` to avoid all
+side-effects for any submodules.
+
+If you are an API user, stop! This module has no stability guarantees. Symbols
+under `_conda` can be renamed or removed at any time. Instead, look for
+re-exported API under `conda.*`.

--- a/conda/_private/shards/__init__.py
+++ b/conda/_private/shards/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from . import cache, subset
+from .shards import (
+    ShardBase,
+    ShardLike,
+    Shards,
+    fetch_channels,
+    fetch_shards_index,
+)
+
+__all__ = [
+    "cache",
+    "subset",
+    "ShardBase",
+    "ShardLike",
+    "Shards",
+    "fetch_shards_index",
+    "fetch_channels",
+]

--- a/conda/_private/shards/cache.py
+++ b/conda/_private/shards/cache.py
@@ -1,0 +1,212 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Cache suitable for shards, not allowed to change because they are named
+after their own sha256 hash.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import msgpack
+import zstandard
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .typing import ShardDict
+
+log = logging.getLogger(__name__)
+
+SHARD_CACHE_NAME = "repodata_shards.db"
+ZSTD_MAX_SHARD_SIZE = (
+    2**20 * 16
+)  # maximum size necessary when compresed data has no size header
+
+
+@dataclass
+class AnnotatedRawShard:
+    def __init__(self, url: str, package: str, compressed_shard: bytes):
+        # prevent easy mistake of swapping url, package
+        if "://" not in url:
+            raise ValueError("url must contain '://'")
+        if "://" in package:
+            raise ValueError("package must not contain '://'")
+
+        self.url = url
+        self.package = package  # remove this field to avoid confusion?
+        self.compressed_shard = compressed_shard
+
+    url: str
+    package: str
+    compressed_shard: bytes
+
+
+def connect(dburi="cache.db"):
+    """
+    Get database connection.
+
+    dburi: uri-style sqlite database filename; accepts certain ?= parameters.
+    """
+    conn = sqlite3.connect(dburi, uri=True, timeout=30.0)
+    conn.row_factory = sqlite3.Row
+    with conn as c:
+        try:
+            mode = c.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+        except sqlite3.DatabaseError:
+            mode = None
+        if mode and mode.lower().startswith("wal"):
+            c.execute("PRAGMA synchronous = NORMAL")
+        c.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+class ShardCache:
+    """
+    Handle caching for individual shards (not the index of shards).
+    """
+
+    def __init__(self, base: Path, create=True):
+        """
+        base: directory and filename prefix for cache.
+        """
+        self.base = base
+        self.connect(create=create)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exec_tb):
+        self.close()
+
+    def close(self):
+        """
+        Clean up connection. ShardCache can no longer be used after close().
+        """
+        if self.conn:
+            self.conn.close()
+            self.conn = None
+
+    def copy(self):
+        """
+        Copy cache with new connection. Useful for threads.
+        """
+        return ShardCache(self.base, create=False)
+
+    def connect(self, create=True, retry=True):
+        """
+        Args:
+            create: if True, create table if not exists.
+            retry: remove cache, log warning, and retry on error.
+        """
+        global SHARD_CACHE_NAME
+
+        dburi = (self.base / SHARD_CACHE_NAME).as_uri()
+        self.conn = connect(dburi)
+        if not create:
+            return
+        try:
+            # this schema will also get confused if we merge packages into a single
+            # shard, but the package name should be advisory.
+            with self.conn as c:
+                c.execute(
+                    "CREATE TABLE IF NOT EXISTS shards ("
+                    "url TEXT PRIMARY KEY, package TEXT, shard BLOB, "
+                    "timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+                )
+        except sqlite3.DatabaseError as e:
+            # Python 3.11 adds sqlite_errorcode. This is meant to delete and
+            # retry on all DatabaseError for Python 3.10, but on Python 3.11+
+            # only retry on SQLITE_NOTADB. Other errors e.g. busy, locked, would
+            # propagate.
+            has_errorcode = hasattr(e, "sqlite_errorcode")
+            if retry and (
+                (not has_errorcode) or (e.sqlite_errorcode == sqlite3.SQLITE_NOTADB)
+            ):
+                log.warning("%s '%s'; remove and retry.", dburi, e)
+                try:
+                    self.remove_cache()
+                except OSError as e:
+                    # alternate filename if primary cannot be removed.
+                    log.warning("%s '%s'; use alternate filename.", dburi, e)
+                    SHARD_CACHE_NAME = "repodata_shards_1.db"
+                # pass False so that we only retry once:
+                return self.connect(create=create, retry=False)
+            raise
+
+    def insert(self, raw_shard: AnnotatedRawShard):
+        """
+        Args:
+            url: of shard
+            package: package name
+            raw_shard: msgpack.zst compressed shard data
+        """
+        # decompress and return shard for convenience, also to validate? unless
+        # caller would rather retrieve the shard from another thread.
+        with self.conn as c:
+            c.execute(
+                "INSERT OR IGNORE INTO SHARDS (url, package, shard) VALUES (?, ?, ?)",
+                (raw_shard.url, raw_shard.package, raw_shard.compressed_shard),
+            )
+
+    def retrieve(self, url) -> ShardDict | None:
+        with self.conn as c:
+            row = c.execute("SELECT shard FROM shards WHERE url = ?", (url,)).fetchone()
+            return (
+                msgpack.loads(
+                    zstandard.decompress(
+                        row["shard"], max_output_size=ZSTD_MAX_SHARD_SIZE
+                    )
+                )
+                if row
+                else None
+            )  # type: ignore
+
+    def retrieve_multiple(self, urls: list[str]) -> dict[str, ShardDict | None]:
+        """
+        Query database for cached shard urls.
+
+        Return a dict of urls in cache mapping to the Shard or None if not present.
+        """
+        if not urls:
+            return {}  # this optimization does not save a noticeable amount of time.
+
+        # In one test reusing the context saves difference between .006s and .01s
+        # We could make this a threadlocal.
+        dctx = zstandard.ZstdDecompressor()
+
+        query = f"SELECT url, shard FROM shards WHERE url IN ({','.join(('?',) * len(urls))}) ORDER BY url"
+        with self.conn as c:
+            result: dict[str, ShardDict | None] = {
+                row["url"]: msgpack.loads(
+                    dctx.decompress(row["shard"], max_output_size=ZSTD_MAX_SHARD_SIZE)
+                )
+                if row
+                else None
+                for row in c.execute(query, urls)  # type: ignore
+            }
+            return result
+
+    def clear_cache(self):
+        """
+        Truncate the database by removing all rows from tables
+        """
+        with self.conn as c:
+            c.execute("DELETE FROM shards")
+
+    def remove_cache(self):
+        """
+        Remove the sharded cache database.
+        """
+        self.close()
+        try:
+            (self.base / SHARD_CACHE_NAME).unlink()
+        except OSError:
+            # possibly workable on Windows
+            (self.base / SHARD_CACHE_NAME).rename(
+                self.base / f"{SHARD_CACHE_NAME}.conda_trash"
+            )

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -1,0 +1,827 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Models for sharded repodata, and to make monolithic repodata look like sharded
+repodata.
+"""
+
+from __future__ import annotations
+
+import abc
+import concurrent.futures
+import functools
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin, urlparse, urlunparse, uses_relative
+
+import msgpack
+import zstandard
+from libmambapy.bindings import specs
+
+import conda.exceptions
+from conda.base.context import context
+from conda.common.serialize import json
+from conda.core.subdir_data import SubdirData
+from conda.gateways.connection.session import get_session
+from conda.gateways.repodata import (
+    CACHE_CONTROL_KEY,
+    ETAG_KEY,
+    LAST_MODIFIED_KEY,
+    URL_KEY,
+    RepodataIsEmpty,
+    UnavailableInvalidChannel,
+    _add_http_value_to_dict,
+    conda_http_errors,
+)
+from conda.models.channel import Channel
+
+from . import cache
+
+log = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, KeysView
+
+    from requests import Response
+
+    from conda.gateways.repodata import RepodataCache
+
+    from .typing import PackageRecordDict, RepodataDict, ShardDict, ShardsIndexDict
+
+SHARDS_CONNECTIONS_DEFAULT = 10
+ZSTD_MAX_SHARD_SIZE = (
+    2**20 * 16
+)  # maximum size necessary when compressed data has no size header
+
+# Schemes that urljoin handles correctly (registered in urllib.parse.uses_relative)
+_URLJOIN_SAFE_SCHEMES = frozenset(uses_relative)
+
+
+def _safe_urljoin_with_slash(base_url: str, relative_url: str = "") -> str:
+    """
+    Join base_url with relative_url, ensuring proper handling of all URL schemes.
+
+    Python's urllib.parse.urljoin only handles schemes registered in
+    ``urllib.parse.uses_relative``. For unregistered schemes like ``s3://``,
+    it returns just ``"."`` instead of the resolved URL. This function falls
+    back to a scheme-swap workaround for those cases.
+
+    The result always ends with "/" to enable proper string concatenation with filenames.
+
+    See: https://github.com/conda/conda-libmamba-solver/issues/866
+    """
+    parsed = urlparse(base_url)
+
+    # For schemes that urljoin handles correctly, use the standard behavior
+    if parsed.scheme in _URLJOIN_SAFE_SCHEMES:
+        # Standard urljoin behavior: join with relative_url, then "." for trailing slash
+        result = urljoin(urljoin(base_url, relative_url), ".")
+        return result
+
+    # For unregistered schemes (e.g. s3://), urljoin drops the host.
+    # Work around that by temporarily swapping in https://, then restoring
+    # the original scheme on the result.
+    relative_parsed = urlparse(relative_url)
+    if not relative_parsed.scheme and parsed.scheme:
+        https_base_url = urlunparse(parsed._replace(scheme="https"))
+        joined_https = urljoin(urljoin(https_base_url, relative_url), ".")
+        result = urlunparse(urlparse(joined_https)._replace(scheme=parsed.scheme))
+    else:
+        result = urljoin(urljoin(base_url, relative_url), ".")
+
+    # Ensure trailing slash for proper concatenation
+    if not result.endswith("/"):
+        result += "/"
+
+    return result
+
+
+# For reference, the largest shard "conda-forge/linux-64/vim" is 2608283 bytes
+# or < 2**19*5 decompressed (486155 bytes compressed); the index is 575219 bytes
+# decompressed (514039 bytes compressed) and is mostly uncompressible hash data.
+
+
+def _shards_connections() -> int:
+    """
+    If context.repodata_threads is not set, find the size of the connection pool
+    in a typical https:// session. This should significantly reduce dropped
+    connections. We match requests' default 10.
+
+    Is this shared between all sessions? Or do we get a different pool for a
+    different get_session(url)?
+
+    Other adapters (file://, s3://) used in conda would have different
+    concurrency behavior;  we are not prepared to have separate threadpools per
+    connection type.
+    """
+    if context.repodata_threads is not None:
+        return context.repodata_threads
+    return SHARDS_CONNECTIONS_DEFAULT
+
+
+def ensure_hex_hash(record: PackageRecordDict):
+    """
+    Convert bytes checksums to hex; leave unchanged if already str.
+    """
+    for hash_type in "sha256", "md5":
+        if hash_value := record.get(hash_type):
+            if not isinstance(hash_value, str):
+                record[hash_type] = bytes(hash_value).hex()
+    return record
+
+
+@functools.cache
+def spec_to_package_name(spec: str) -> str:
+    """
+    Given a dependency spec, return the package name.
+    """
+    # Note: hope for no MatchSpec-without-name in repodata, although it is
+    # possible in the MatchSpec grammar.
+    parsed_spec = specs.MatchSpec.parse(spec)
+    name = str(parsed_spec.name)
+    return name
+
+
+def shard_mentioned_packages(
+    shard: ShardDict, extra: Iterable[str] = ()
+) -> Iterable[str]:
+    """
+    Return all dependency names mentioned in a shard, not including the shard's
+    own package name. Additional names can be injected via ``extra``.
+    """
+    unique_specs = set()
+    for package in (*shard["packages"].values(), *shard["packages.conda"].values()):
+        ensure_hex_hash(package)  # otherwise we could do this at serialization
+        for spec in (
+            *package.get("depends", ()),
+        ):  # , *package.get("constrains", ())):
+            if spec in unique_specs:
+                continue
+            unique_specs.add(spec)
+            name = spec_to_package_name(spec)
+            yield name  # not much improvement from only yielding unique names
+    yield from extra
+
+
+class ShardBase(abc.ABC):
+    """
+    Abstract base class for shard-like objects.
+
+    Defines the common interface for both sharded repodata (Shards)
+    and traditional repodata presented as shards (ShardLike).
+    """
+
+    url: str
+    repodata_no_packages: RepodataDict
+    visited: dict[str, ShardDict | None]
+    _base_url: str
+
+    @property
+    @abc.abstractmethod
+    def package_names(self) -> KeysView[str]:
+        """Return the names of all packages available in this shard collection."""
+        ...
+
+    @property
+    def base_url(self) -> str:
+        """
+        Return self.url joined with base_url from repodata, or self.url if no
+        base_url was present. Packages are found here.
+
+        Note base_url can be a relative or an absolute url.
+        Uses _safe_urljoin_with_slash to handle non-HTTP schemes (s3://, etc.).
+        """
+        return _safe_urljoin_with_slash(self.url, self._base_url)
+
+    def __contains__(self, package: str) -> bool:
+        """Check if a package is available in this shard collection."""
+        return package in self.package_names
+
+    @abc.abstractmethod
+    def shard_url(self, package: str) -> str:
+        """
+        Return shard URL for a given package. For monolithic repodata, should
+        not be fetched but is a unique identifier.
+
+        Raise KeyError if package is not in the index.
+        """
+        ...
+
+    @abc.abstractmethod
+    def shard_loaded(self, package: str) -> bool:
+        """
+        Return True if the given package's shard is in memory.
+        """
+        ...
+
+    def visit_package(self, package: str) -> ShardDict:
+        """
+        Return a shard that is already loaded in memory and mark as visited.
+        """
+        ...
+
+    def visit_shard(self, package: str, shard: ShardDict):
+        """
+        Store new shard data in the visited dict.
+        """
+        self.visited[package] = shard
+
+    @abc.abstractmethod
+    def fetch_shard(self, package: str) -> ShardDict:
+        """
+        Fetch an individual shard for the given package.
+        """
+        ...
+
+    @abc.abstractmethod
+    def fetch_shards(self, packages: Iterable[str]) -> dict[str, ShardDict]:
+        """
+        Fetch multiple shards in one go.
+        """
+        ...
+
+    def build_repodata(self) -> RepodataDict:
+        """
+        Return monolithic repodata including all visited shards.
+        """
+        repodata: RepodataDict = {
+            **self.repodata_no_packages,
+            "packages": {},
+            "packages.conda": {},
+        }
+        for _, shard in self.visited.items():
+            if shard is None:
+                continue  # recorded visited but not available shards
+            for package_group in ("packages", "packages.conda"):
+                repodata[package_group].update(shard[package_group])
+        return repodata
+
+
+class ShardLike(ShardBase):
+    """
+    Present a "classic" repodata.json as per-package shards.
+    """
+
+    def __init__(self, repodata: RepodataDict, url: str = ""):
+        """
+        url: must be unique for all ShardLike used together.
+        """
+        self.repodata_no_packages: RepodataDict = {
+            **repodata,
+            "packages": {},
+            "packages.conda": {},
+        }
+        all_packages = {
+            "packages": repodata.get("packages", {}),
+            "packages.conda": repodata.get("packages.conda", {}),
+        }
+        self.url = url
+
+        shards = defaultdict(lambda: {"packages": {}, "packages.conda": {}})
+
+        for group_name, group in all_packages.items():
+            for package, record in group.items():
+                name = record["name"]
+                shards[name][group_name][package] = record
+
+        # defaultdict behavior no longer wanted
+        self.shards: dict[str, ShardDict] = dict(shards)  # type: ignore
+
+        # used to write out repodata subset
+        self.visited: dict[str, ShardDict | None] = {}
+
+        # alternate location for packages, if not self.url
+        try:
+            base_url = self.repodata_no_packages["info"]["base_url"]
+            if not isinstance(base_url, str):
+                log.warning(
+                    'repodata["info"]["base_url"] was not a str, got %s',
+                    type(base_url),
+                )
+                raise TypeError()
+            self._base_url = base_url
+        except KeyError:
+            self._base_url = ""
+
+    def __repr__(self):
+        left, right = super().__repr__().split(maxsplit=1)
+        return f"{left} {self.url} {right}"
+
+    @property
+    def package_names(self) -> KeysView[str]:
+        return self.shards.keys()
+
+    def shard_url(self, package: str) -> str:
+        """
+        Return shard URL for a given package.
+
+        Raise KeyError if package is not in the index.
+        """
+        self.shards[package]
+        return f"{self.url}#{package}"
+
+    def shard_loaded(self, package: str) -> bool:
+        """
+        Return True if the given package's shard is in memory.
+        """
+        return package in self.shards
+
+    def visit_package(self, package: str) -> ShardDict:
+        """
+        Return a shard that is already in memory and mark as visited.
+        """
+        shard = self.fetch_shard(package)
+        if shard is None:
+            raise ValueError(f"Shard for package {package} is None")
+        return shard
+
+    def fetch_shard(self, package: str) -> ShardDict:
+        """
+        "Fetch" an individual shard.
+
+        Update self.visited with all not-None packages.
+
+        Raise KeyError if package is not in the index.
+        """
+        shard = self.shards[package]
+        self.visited[package] = shard
+        return shard
+
+    def fetch_shards(self, packages: Iterable[str]) -> dict[str, ShardDict]:
+        """
+        Fetch multiple shards in one go.
+
+        Update self.visited with all not-None packages.
+        """
+        return {package: self.fetch_shard(package) for package in packages}
+
+
+def _shards_base_url(url, shards_base_url) -> str:
+    """
+    Return shards_base_url joined with base_url and url.
+    Note shards_base_url can be a relative or an absolute url.
+    Uses _safe_urljoin_with_slash to handle non-HTTP schemes (s3://, etc.).
+    """
+    if shards_base_url and not shards_base_url.endswith("/"):
+        shards_base_url += "/"
+    return _safe_urljoin_with_slash(url, shards_base_url)
+
+
+class Shards(ShardBase):
+    """
+    Handle repodata_shards.msgpack.zst and individual per-package shards.
+    """
+
+    _shards_base_url: str
+    shards_cache: cache.ShardCache | None
+
+    def __init__(
+        self,
+        shards_index: ShardsIndexDict,
+        url: str,
+        cache_obj: cache.ShardCache | None = None,
+    ):
+        """
+        Args:
+            shards_index: raw parsed msgpack dict. Don't change it or base_url,
+            shards_base_url will be wrong.
+            url: URL of repodata_shards.msgpack.zst
+        """
+        self.shards_index = shards_index
+        self.url = url
+        self.shards_cache = cache_obj
+
+        # https://github.com/conda/conda-index/pull/209 ensures that sharded
+        # repodata will always include base_url, even if it is an empty string;
+        # rattler/pixi require these keys.
+        self._base_url = shards_index["info"]["base_url"]
+
+        # doesn't track changes to self.shards_index
+        self._shards_base_url = _shards_base_url(
+            self.url, self.shards_index["info"].get("shards_base_url", "")
+        )
+
+        # Use the channel's base URL to share session amongst subdir locations
+        channel_base_url = Channel(self.shards_base_url).base_url
+        self.session = get_session(channel_base_url)
+
+        self.repodata_no_packages = {
+            "info": shards_index["info"],
+            "packages": {},
+            "packages.conda": {},
+            "repodata_version": 2,
+        }
+
+        # used to write out repodata subset
+        # not used in traversal algorithm
+        self.visited: dict[str, ShardDict | None] = {}
+
+    @property
+    def package_names(self):
+        return self.packages_index.keys()
+
+    @property
+    def packages_index(self):
+        return self.shards_index["shards"]
+
+    @property
+    def shards_base_url(self) -> str:
+        """
+        Return self.url joined with shards_base_url.
+        Note shards_base_url can be a relative or an absolute url.
+        """
+        return self._shards_base_url
+
+    def shard_url(self, package: str) -> str:
+        """
+        Return shard URL for a given package.
+
+        Raise KeyError if package is not in the index.
+        """
+        shard_name = f"{bytes(self.packages_index[package]).hex()}.msgpack.zst"
+        # "Individual shards are stored under the URL <shards_base_url><sha256>.msgpack.zst"
+        return f"{self.shards_base_url}{shard_name}"
+
+    def shard_loaded(self, package: str) -> bool:
+        """
+        Return True if the given package's shard is in memory.
+        """
+        return package in self.visited
+
+    def visit_package(self, package: str) -> ShardDict:
+        """
+        Return a shard that is already in memory and mark as visited.
+        """
+        shard = self.visited[package]
+        return shard
+
+    def fetch_shard(self, package: str) -> ShardDict:
+        """
+        Fetch an individual shard for the given package.
+
+        Default implementation calls fetch_shards() with a single package.
+        Subclasses may override for more efficient single-fetch operations.
+
+        Raise KeyError if package is not in the index.
+        """
+        return self.fetch_shards([package])[package]
+
+    def fetch_shards(self, packages: Iterable[str]) -> dict[str, ShardDict]:
+        """
+        Return mapping of *package names* to Shard for given packages.
+
+        If a shard is already in self.visited, it is not fetched again.
+        """
+        results = {}
+
+        def fetch(s, url, package_to_fetch):
+            timeout = (
+                context.remote_connect_timeout_secs,
+                context.remote_read_timeout_secs,
+            )
+            response = s.get(url, timeout=timeout)
+            response.raise_for_status()
+            data = response.content
+
+            return cache.AnnotatedRawShard(
+                url=url, package=package_to_fetch, compressed_shard=data
+            )
+
+        packages = sorted(list(packages))
+        urls_packages = {}  # package shards to fetch
+        for package in packages:
+            if package in self.visited:
+                results[package] = self.visited[package]
+            else:
+                urls_packages[self.shard_url(package)] = package
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=_shards_connections()
+        ) as executor:
+            futures = {
+                executor.submit(fetch, self.session, url, package): (url, package)
+                for url, package in urls_packages.items()
+                if package not in results
+            }
+            for future in concurrent.futures.as_completed(futures):
+                log.debug(". %s", futures[future])
+                url, package = futures[future]
+                self._process_fetch_result(future, url, package, results)
+
+        self.visited.update(results)
+
+        return results
+
+    def _process_fetch_result(self, future, url, package, results):
+        """
+        Process a single fetched shard.
+        """
+        # Fail early if no cache to store the result.
+        if self.shards_cache is None:
+            raise ValueError("self.shards_cache is None")
+
+        with conda_http_errors(url, package):
+            fetch_result = future.result()
+
+        # Decompress and save record
+        results[fetch_result.package] = msgpack.loads(
+            zstandard.decompress(
+                fetch_result.compressed_shard, max_output_size=ZSTD_MAX_SHARD_SIZE
+            )
+        )
+        self.shards_cache.insert(fetch_result)
+
+
+def _repodata_shards(url, cache: RepodataCache) -> bytes:
+    """
+    Fetch shards index with cache.
+
+    Update cache state.
+
+    Return shards data, either newly fetched or from cache.
+
+    In offline mode, returns cached data even if expired. If no cache exists
+    in offline mode, raises RepodataIsEmpty to signal unavailability.
+    """
+    # In offline mode, return cached data if available, even if expired
+    if context.offline:
+        if cache.cache_path_shards.exists():
+            return cache.cache_path_shards.read_bytes()
+        else:
+            # In offline mode with no cache, signal that shards are not available.
+            # The caller (fetch_shards_index) catches RepodataIsEmpty and falls back to non-sharded repodata.
+            raise RepodataIsEmpty(url, status_code=404, response=None)
+
+    session = get_session(url)
+
+    state = cache.state
+    headers = {}
+    etag = state.etag
+    last_modified = state.mod
+    if etag:
+        headers["If-None-Match"] = str(etag)
+    if last_modified:
+        headers["If-Modified-Since"] = str(last_modified)
+    filename = "repodata_shards.msgpack.zst"
+
+    with conda_http_errors(url, filename):
+        timeout = (
+            context.remote_connect_timeout_secs,
+            context.remote_read_timeout_secs,
+        )
+        response: Response = session.get(
+            url, headers=headers, proxies=session.proxies, timeout=timeout
+        )
+        response.raise_for_status()
+        response_bytes = response.content
+
+    if response.status_code == 304:
+        # should we save cache-control to state here to put another n
+        # seconds on the "make a remote request" clock and/or touch cache
+        # mtime
+        #
+        # Hold the cache lock while reading: RepodataCache.replace() does
+        # unlink()+rename() under this same lock, so without it a concurrent
+        # writer can briefly remove the file between those two operations,
+        # causing FileNotFoundError on Windows.
+        with cache.lock("r+"):
+            return cache.cache_path_shards.read_bytes()
+
+    saved_fields = {URL_KEY: url}
+    for header, key in (
+        ("Etag", ETAG_KEY),
+        (
+            "Last-Modified",
+            LAST_MODIFIED_KEY,
+        ),
+        ("Cache-Control", CACHE_CONTROL_KEY),
+    ):
+        _add_http_value_to_dict(response, header, saved_fields, key)
+
+    state.update(saved_fields)
+
+    # should we return the response and let caller save cache data to state?
+    return response_bytes
+
+
+# Like conda.gateways.repodata.jlap.fetch. If this returns True, then we mark
+# shards as not supported; otherwise, we will check again next time.
+def _is_http_error_most_400_codes(status_code: str | int) -> bool:
+    """
+    Determine whether the `HTTPError` is an HTTP 400 error code (except for 416).
+    """
+    return (
+        isinstance(status_code, int) and 400 <= status_code < 500 and status_code != 416
+    )
+
+
+def fetch_shards_index(
+    sd: SubdirData, cache_obj: cache.ShardCache | None
+) -> Shards | None:
+    """
+    Check a SubdirData's URL for shards.
+
+    Return shards index bytes from cache or network.
+    Return None if not found; caller should fetch normal repodata.
+
+    TODO: If this function fails to retrieve the sharded repodata index file, it will
+          mark it is as not supporting this feature in cache. This can problematic
+          because sometimes server errors can happen which will lead it to wrongly
+          assuming the channel doesn't support sharding. We need to rethink our
+          logic for determining shard support.
+    """
+
+    fetch = sd.repo_fetch
+    repo_cache = fetch.repo_cache
+
+    # repo_cache.load_state() will clear the file on JSONDecodeError but cache.load()
+    # will raise the exception.
+    # repo_cache.load_state(
+    #     binary=True
+    # )  # won't succeed when .msgpack.zst is missing as it wants to compare the timestamp (returns empty state)
+
+    # Load state ourselves to avoid clearing when binary cached data is missing.
+    # If we fall back to monolithic repodata.json, the standard fetch code will
+    # load the state again in text mode.
+    try:
+        with repo_cache.lock("r+") as state_file:
+            # cannot use pathlib.read_text / write_text on any locked file, as
+            # it will release the lock early
+            state = json.loads(state_file.read())
+            repo_cache.state.update(state)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+
+    cache_state = repo_cache.state
+
+    if cache_state.should_check_format("shards"):
+        # look for shards index
+        shards_data = None
+        shards_index_url = f"{sd.url_w_subdir}/repodata_shards.msgpack.zst"
+
+        if not repo_cache.cache_path_shards.exists():
+            # avoid 304 not modified if we don't have the file
+            cache_state.etag = ""
+            cache_state.mod = ""
+        elif not repo_cache.stale():
+            # load from cache without network request
+            with repo_cache.lock("r+"):
+                shards_data = repo_cache.cache_path_shards.read_bytes()
+
+        # If we don't have shards_data yet, try fetching (repodata_shards handles offline mode)
+        if shards_data is None:
+            try:
+                shards_data = _repodata_shards(shards_index_url, repo_cache)
+                cache_state.set_has_format("shards", True)
+                # this will also set state["refresh_ns"] = time.time_ns(); we could
+                # call cache.refresh() if we got a 304 instead:
+                repo_cache.save(shards_data)
+            except UnavailableInvalidChannel as err:
+                # repodata_shards converts HTTP errors to conda errors.
+                # fetch repodata.json / repodata.json.zst instead
+                if _is_http_error_most_400_codes(err.status_code):
+                    cache_state.set_has_format("shards", False)
+                repo_cache.refresh()
+            except conda.exceptions.CondaHTTPError as err:
+                # repodata_shards converts HTTP errors to conda errors.
+                # fetch repodata.json / repodata.json.zst instead
+                if (
+                    hasattr(err._caused_by, "response")
+                    and hasattr(err._caused_by.response, "status_code")
+                    and _is_http_error_most_400_codes(
+                        err._caused_by.response.status_code
+                    )
+                ):
+                    cache_state.set_has_format("shards", False)
+                repo_cache.refresh()
+
+        if shards_data:
+            # basic parse (move into caller?)
+            shards_index: ShardsIndexDict = msgpack.loads(
+                zstandard.decompress(shards_data, max_output_size=ZSTD_MAX_SHARD_SIZE)
+            )  # type: ignore
+            shards = Shards(shards_index, shards_index_url, cache_obj)
+            return shards
+
+    return None
+
+
+def batch_retrieve_from_cache(sharded: list[Shards], packages: list[str]):
+    """
+    Given a list of Shards objects and a list of package names, fetch all URLs
+    from a shared local cache, and update Shards with those per-package shards.
+    Return the remaining URLs that must be fetched from the network.
+    """
+    sharded = [shardlike for shardlike in sharded if isinstance(shardlike, Shards)]
+
+    wanted = []
+    # XXX update batch_retrieve_from_cache to work with (Shards, package name)
+    # tuples instead of broadcasting across shards itself.
+    for shard in sharded:
+        for package_name in packages:
+            if package_name in shard:  # and not package_name in shard.visited
+                wanted.append((shard, package_name, shard.shard_url(package_name)))
+
+    log.debug("%d shards to fetch", len(wanted))
+
+    if not sharded:
+        log.debug("No sharded channels found.")
+        return wanted
+
+    shared_shard_cache = sharded[0].shards_cache
+    from_cache = shared_shard_cache.retrieve_multiple(
+        [shard_url for *_, shard_url in wanted]
+    )
+
+    # add fetched Shard objects to Shards objects visited dict
+    for shard, package, shard_url in wanted:
+        if from_cache_shard := from_cache.get(shard_url):
+            shard.visit_shard(package, from_cache_shard)
+
+    return wanted
+
+
+def batch_retrieve_from_network(wanted: list[tuple[Shards, str, str]]):
+    """
+    Given a list of (Shards, package name, shard URL) tuples, group by Shards and call fetch_shards
+    with a list of all URLs for that Shard.
+    """
+    shard_packages: dict[Shards, list[str]] = defaultdict(list)
+    for shard, package, _ in wanted:
+        shard_packages[shard].append(package)
+
+    # XXX it might be better to pull networking and Session() out of Shards(),
+    # so that we can e.g. use the same session for a Channel(); typically a
+    # noarch+arch pair of subdirs.
+    # Could we share a ThreadPoolExecutor and see better session utilization?
+    for shard, packages in shard_packages.items():
+        shard.fetch_shards(packages)
+
+
+def fetch_channels(url_to_channel: dict[str, Channel]) -> dict[str, ShardBase] | None:
+    """
+    Args:
+        url_to_channel: not modified, must already be expanded to subdirs.
+
+    Attempt to fetch the sharded index first and then fall back to retrieving a
+    traditional `repodata.json` file.
+
+    Returns:
+        A dict mapping channel URLs to `Shard` or `ShardLike` objects. None if
+        no channels have shards. This dict preserves the key order of the input
+        `url_to_channel`.
+    """
+    # copy incoming dict to retain order:
+    channel_data: dict[str, ShardBase | None] = {url: None for url in url_to_channel}
+
+    # The parallel version may reorder channels, does this matter?
+
+    non_sharded_channels = []
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=_shards_connections()
+    ) as executor:
+        futures = {
+            executor.submit(
+                fetch_shards_index, SubdirData(Channel(channel_url)), None
+            ): channel_url
+            for (channel_url, _) in url_to_channel.items()
+        }
+        futures_non_sharded = {}
+
+        for future in concurrent.futures.as_completed(futures):
+            channel_url = futures[future]
+            found = future.result()
+            if found:
+                channel_data[channel_url] = found
+            else:
+                non_sharded_channels.append((channel_url, Channel(channel_url)))
+
+        # If all are None then don't do ShardLike.
+        if all(value is None for value in channel_data.values()):
+            return None  # caller should interpret this as falling back to the older code path
+
+        # Latency penalty launching these requests here instead of when we
+        # non_sharded_channels.append(), but we want to leave a fallback to the
+        # non-sharded path open.
+        for channel_url, _ in non_sharded_channels:
+            futures_non_sharded[
+                executor.submit(
+                    SubdirData(Channel(channel_url)).repo_fetch.fetch_latest_parsed
+                )
+            ] = channel_url
+
+        for future in concurrent.futures.as_completed(futures_non_sharded):
+            channel_url = futures_non_sharded[future]
+            repodata_json, _ = future.result()
+            # the filename is not strictly repodata.json since we could have
+            # fetched the same data from repodata.json.zst; but makes the
+            # urljoin consistent with shards which end with
+            # /repodata_shards.msgpack.zst
+            url = f"{channel_url}/repodata.json"
+            found = ShardLike(repodata_json, url)
+            channel_data[channel_url] = found
+
+    return {url: shard for url, shard in channel_data.items() if shard is not None}

--- a/conda/_private/shards/subset.py
+++ b/conda/_private/shards/subset.py
@@ -1,0 +1,806 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Sharded repodata subsets.
+
+Traverse dependencies of installed and to-be-installed packages to generate a
+useful subset for the solver.
+
+The algorithm developed here is a direct result of the following CEP:
+
+- https://conda.org/learn/ceps/cep-0016 (Sharded Repodata)
+
+In this algorithm we treat a (channel, package name) as a node, its dependencies
+as edges. We then traverse all edges to discover all reachable (channel, package
+name) tuples. The solver should be able to find a solution with only this
+subset.
+
+This subset is overgenerous since the user is unlikely to want to install very
+old packages and their dependencies. If this is too slow, we could deploy
+heuristics that automatically ignore older package versions. We could also allow
+the user to configure minimum versions of common packages and ignore older
+versions and their dependencies, falling back to a full solve if unsatisfiable.
+
+We treat both sharded and monolithic repodata as if they were made up of
+per-package shards, computing a subset of both. This is because it is possible
+for the monolithic repodata to mention packages that exist in the true sharded
+repodata but would not be found by only traversing the shards.
+
+We treat all repodata as sharded, even if no actual sharded repodata has been
+found.
+
+## Example usage
+
+The following constructs several repodata (`noarch` and `linux-64`) from a
+single channel name and a list of root packages:
+
+``` from conda.models.channel import Channel from
+_conda.shards_subset import build_repodata_subset
+
+channel = Channel("conda-forge-sharded/linux-64") channel_data =
+build_repodata_subset(["python", "pandas"], [channel.url()]) repodata = {}
+
+for url in channel_data:
+    repodata[url] = channel_data.build_repodata()
+
+# ... this is what's fed to the solver ```
+
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import queue
+import sys
+import threading
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from pathlib import Path
+from queue import SimpleQueue
+from typing import TYPE_CHECKING
+
+import msgpack
+import zstandard
+
+import conda.gateways.repodata
+from conda.base.context import context
+
+from . import cache
+from .cache import AnnotatedRawShard
+from .shards import (
+    ZSTD_MAX_SHARD_SIZE,
+    Shards,
+    _shards_connections,
+    batch_retrieve_from_cache,
+    batch_retrieve_from_network,
+    fetch_channels,
+    shard_mentioned_packages,
+)
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator, Sequence
+    from queue import SimpleQueue as Queue
+    from typing import Literal, TypeVar
+
+    from conda.models.channel import Channel
+
+    from .cache import ShardCache
+    from .shards import ShardBase
+    from .typing import ShardDict
+
+# Waiting for worker threads to shutdown cleanly, or raise error.
+THREAD_WAIT_TIMEOUT = 5  # seconds
+REACHABLE_PIPELINED_MAX_TIMEOUTS = (
+    10  # number of times we can timeout waiting for shards
+)
+QUEUE_TIMEOUT = 1
+
+
+@dataclass(order=True)
+class Node:
+    distance: int = sys.maxsize
+    package: str = ""
+    channel: str = ""
+    visited: bool = False
+    shard_url: str = ""
+
+    def to_id(self) -> NodeId:
+        return NodeId(self.package, self.channel, self.shard_url)
+
+
+@dataclass(order=True, eq=True, frozen=True)
+class NodeId:
+    package: str
+    channel: str
+    shard_url: str = ""
+
+    def __hash__(self):
+        return hash((self.package, self.channel, self.shard_url))
+
+
+def _nodes_from_packages(
+    root_packages: list[str], shardlikes: Iterable[ShardBase]
+) -> Iterator[tuple[NodeId, Node]]:
+    """
+    Yield (NodeId, Node) for all root packages found in shardlikes.
+    """
+    for package in root_packages:
+        for shardlike in shardlikes:
+            if package in shardlike:
+                node = Node(
+                    0, package, shardlike.url, shard_url=shardlike.shard_url(package)
+                )
+                node_id = node.to_id()
+                yield node_id, node
+
+
+def filter_redundant_packages(repodata: ShardDict, use_only_tar_bz2=False) -> ShardDict:
+    """
+    Given repodata or a single shard, remove any .tar.bz2 packages that have a
+    .conda counterpart.
+
+    Return a shallow copy if use_only_tar_bz2==False, else unmodified input.
+    """
+    if use_only_tar_bz2:
+        return repodata
+
+    _tar_bz2 = ".tar.bz2"
+    _conda = ".conda"
+    _len_tar_bz2 = len(_tar_bz2)
+
+    legacy_packages = repodata.get("packages", {})
+    conda_packages = repodata.get("packages.conda", {})
+
+    return {
+        **repodata,
+        "packages": {
+            k: v
+            for k, v in legacy_packages.items()
+            if f"{k[:-_len_tar_bz2]}{_conda}" not in conda_packages
+        },
+    }
+
+
+@contextmanager
+def _install_shards_cache(shardlikes):
+    """
+    Add cache to shardlikes for duration of traversal, then remove and
+    close.
+    """
+    with cache.ShardCache(
+        Path(conda.gateways.repodata.create_cache_dir())
+    ) as cache_instance:
+        for shardlike in shardlikes:
+            if isinstance(shardlike, Shards):
+                shardlike.shards_cache = cache_instance
+        yield cache_instance
+        for shardlike in shardlikes:
+            if isinstance(shardlike, Shards):
+                shardlike.shards_cache = None
+
+
+@dataclass
+class RepodataSubset:
+    nodes: dict[NodeId, Node]
+    shardlikes: Sequence[ShardBase]
+    DEFAULT_STRATEGY = "pipelined"
+
+    def __init__(self, shardlikes: Iterable[ShardBase]):
+        self.nodes = {}
+        self.shardlikes = list(shardlikes)
+        self._use_only_tar_bz2 = context.use_only_tar_bz2
+        self._add_pip_as_python_dependency = context.add_pip_as_python_dependency
+
+    @classmethod
+    def has_strategy(cls, strategy: str) -> bool:
+        """
+        Return True if this class provides the named shard traversal strategy.
+        """
+        return hasattr(cls, f"reachable_{strategy}")
+
+    def neighbors(self, node: Node) -> Iterator[Node]:
+        """
+        Retrieve all unvisited neighbors of a node
+
+        Neighbors in the context are dependencies of a package
+        """
+        discovered = set()
+
+        for shardlike in self.shardlikes:
+            if node.package not in shardlike:
+                continue
+
+            # check that we don't fetch the same shard twice...
+            shard = shardlike.fetch_shard(
+                node.package
+            )  # XXX this is the only place that in-memory (repodata.json) shards are found for the first time
+
+            shard = filter_redundant_packages(shard, self._use_only_tar_bz2)
+            shardlike.visit_shard(node.package, shard)
+
+            # ensure solver has "pip" record if add_pip_as_python_dependency:
+            extra = (
+                ("pip",)
+                if self._add_pip_as_python_dependency and node.package == "python"
+                else ()
+            )
+            for package in shard_mentioned_packages(shard, extra=extra):
+                node_id = NodeId(package, shardlike.url)
+
+                if node_id not in self.nodes:
+                    self.nodes[node_id] = Node(
+                        node.distance + 1, package, shardlike.url
+                    )
+                    yield self.nodes[node_id]
+
+                    if package not in discovered:
+                        # now this is per package name, not per (name, channel) tuple
+                        discovered.add(package)
+
+    def outgoing(self, node: Node):
+        """
+        All nodes that can be reached by this node, plus cost.
+        """
+        # If we set a greater cost for sharded repodata than the repodata that
+        # is already in memory and tracked nodes as (channel, package) tuples,
+        # we might be able to find more shards-to-fetch-in-parallel more
+        # quickly. On the other hand our goal is that the big channels will all
+        # be sharded.
+        for n in self.neighbors(node):
+            yield n, 1
+
+    def reachable(self, root_packages, *, strategy=DEFAULT_STRATEGY) -> None:
+        """
+        Run named reachability strategy or the default.
+
+        Update `self.shardlikes` with reachable package records. Later,
+        [shardlike.build_repodata() for shardlike in shardlikes] can be used to
+        generate repodata.json-format subsets of each channel.
+        """
+        return getattr(self, f"reachable_{strategy}")(root_packages)
+
+    def reachable_bfs(self, root_packages):
+        """
+        Fetch all packages reachable from `root_packages`' by following
+        dependencies using the "breadth-first search" algorithm.
+
+        Update associated `self.shardlikes` to contain enough data to build a
+        repodata subset.
+        """
+        with _install_shards_cache(self.shardlikes):
+            return self._reachable_bfs(root_packages)
+
+    def _reachable_bfs(self, root_packages):
+        """
+        Inner reachable_bfs() implementation.
+        """
+        self.nodes = dict(_nodes_from_packages(root_packages, self.shardlikes))
+
+        node_queue = deque(self.nodes.values())
+        sharded = [s for s in self.shardlikes if isinstance(s, Shards)]
+
+        while node_queue:
+            # Batch fetch all nodes at current level
+            to_retrieve = {node.package for node in node_queue if not node.visited}
+            if to_retrieve:
+                not_in_cache = batch_retrieve_from_cache(sharded, sorted(to_retrieve))
+                batch_retrieve_from_network(not_in_cache)
+
+            # Process one level
+            level_size = len(node_queue)
+            for _ in range(level_size):
+                node = node_queue.popleft()
+                if node.visited:  # pragma: no cover
+                    continue  # we should never add visited nodes to node_queue
+                node.visited = True
+
+                for next_node, _ in self.outgoing(node):
+                    if not next_node.visited:
+                        node_queue.append(next_node)
+
+    def reachable_pipelined(self, root_packages):
+        """
+        Fetch all packages reachable from `root_packages`' by following
+        dependencies.
+
+        Build repodata subset using concurrent threads to follow dependencies,
+        fetch from cache, and fetch from network.
+        """
+
+        # In offline mode shards are retrieved from the cache database as usual,
+        # but cache misses are forwarded to offline_nofetch_thread returning
+        # empty shards.
+        if context.offline:
+            network_worker = offline_nofetch_thread
+        else:
+            network_worker = network_fetch_thread
+
+        # Ignore cache on shards object, use our own. Necessary if there are no
+        # sharded channels.
+        with cache.ShardCache(
+            Path(conda.gateways.repodata.create_cache_dir())
+        ) as cache_instance:
+            return self._reachable_pipelined(
+                root_packages, network_worker=network_worker, cache=cache_instance
+            )
+
+    def _reachable_pipelined(
+        self,
+        root_packages,
+        network_worker: Callable[
+            [
+                Queue[Sequence[NodeId] | None],
+                Queue[list[tuple[NodeId, ShardDict] | Exception]],
+                cache.ShardCache,
+                Sequence[ShardBase],
+            ],
+            None,
+        ],
+        cache: cache.ShardCache,
+    ):
+        """
+        Set up queues and threads for shard traversal with a configurable
+        network_worker. Called by reachable_pipelined()
+        """
+
+        cache_in_queue: SimpleQueue[list[NodeId] | None] = SimpleQueue()
+        shard_out_queue: SimpleQueue[list[tuple[NodeId, ShardDict]] | Exception] = (
+            SimpleQueue()
+        )
+        cache_miss_queue: SimpleQueue[list[NodeId] | None] = SimpleQueue()
+
+        cache_thread = threading.Thread(
+            target=cache_fetch_thread,
+            args=(cache_in_queue, shard_out_queue, cache_miss_queue, cache),
+            daemon=True,  # may have to set to False if we ever want to run in a subinterpreter
+        )
+
+        network_thread = threading.Thread(
+            target=network_worker,
+            args=(
+                cache_miss_queue,
+                shard_out_queue,
+                QueueCache(cache_in_queue),
+                self.shardlikes,
+            ),
+            daemon=True,
+        )
+
+        try:
+            cache_thread.start()
+            network_thread.start()
+            self._pipelined_traversal(
+                root_packages,
+                cache_in_queue,
+                shard_out_queue,
+                cache_thread,
+                network_thread,
+            )
+        finally:
+            cache_in_queue.put(None)
+            # These should finish almost immediately, but if not, raise an error:
+            cache_thread.join(THREAD_WAIT_TIMEOUT)
+            network_thread.join(THREAD_WAIT_TIMEOUT)
+
+    def _pipelined_traversal(
+        self,
+        root_packages,
+        cache_in_queue: Queue[list[NodeId] | None],
+        shard_out_queue: Queue[list[tuple[NodeId, ShardDict]] | Exception],
+        cache_thread: threading.Thread,
+        network_thread: threading.Thread,
+    ):
+        """
+        Run reachability algorithm given queues to submit and receive shards.
+        """
+        shardlikes_by_url = {s.url: s for s in self.shardlikes}
+        pending: set[NodeId] = set()
+        in_flight: set[NodeId] = set()
+        timeouts = 0
+
+        self.nodes = {}
+
+        # create start condition
+        parent_node = Node(0)
+        pending.update(self.visit_node(parent_node, root_packages))
+
+        def pump():
+            """
+            Find shards we already have and those we need. Submit those need to
+            cache_in_queue, those we have to shard_out_queue.
+            """
+            have, need = self.drain_pending(pending, shardlikes_by_url)
+            if need:
+                in_flight.update(need)
+                cache_in_queue.put(need)
+            if have:
+                in_flight.update(node_id for node_id, _ in have)
+                # All shards go through shard_out queue to be processed at
+                # shard_out_queue.get(). Whether they come from cache, network,
+                # or for repodata.json we "have" them (already in memory).
+                shard_out_queue.put(have)
+            return len(have) + len(need)
+
+        def log_timeout():
+            """
+            Log timeout information and raise TimeoutError if max timeouts
+            exceeded.
+            """
+            nonlocal timeouts
+            timeouts += 1
+            log.debug("Shard timeout %s", timeouts)
+            log.debug(
+                "in_flight: %s...", sorted(str(node_id) for node_id in in_flight)[:10]
+            )
+            log.debug("nodes: %d", len(self.nodes))
+            log.debug("cache_thread.is_alive(): %s", cache_thread.is_alive())
+            log.debug("network_thread.is_alive(): %s", network_thread.is_alive())
+            log.debug("shard_out_queue.qsize(): %s", shard_out_queue.qsize())
+            if network_thread.is_alive() and in_flight:
+                max_timeouts = int(
+                    context.remote_read_timeout_secs * (context.remote_max_retries + 1)
+                )
+            else:
+                max_timeouts = REACHABLE_PIPELINED_MAX_TIMEOUTS
+            if timeouts > max_timeouts:
+                raise TimeoutError("Timeout while fetching repodata shards.")
+
+        while True:
+            pump()
+            if not in_flight:  # pending is empty right after calling pump()
+                log.debug("All shards have finished processing.")
+                break
+
+            try:
+                new_shards = shard_out_queue.get(timeout=QUEUE_TIMEOUT)
+                if isinstance(
+                    new_shards, BaseException
+                ):  # error propagated from worker thread
+                    raise new_shards
+
+            except queue.Empty:
+                log_timeout()
+                continue
+
+            timeouts = 0
+            for node_id, shard in new_shards:
+                in_flight.remove(node_id)
+
+                # remove_legacy_packages if the ".conda" format is enabled /
+                # conda is not in ".tar.bz2 only" mode.
+                shard = filter_redundant_packages(shard, self._use_only_tar_bz2)
+
+                # add shard to appropriate ShardLike
+                parent_node = self.nodes[node_id]
+                shardlike = shardlikes_by_url[node_id.channel]
+                shardlike.visit_shard(node_id.package, shard)
+
+                # ensure solver has "pip" record if add_pip_as_python_dependency:
+                extra = (
+                    ("pip",)
+                    if self._add_pip_as_python_dependency
+                    and parent_node.package == "python"
+                    else ()
+                )
+                pending.update(
+                    self.visit_node(
+                        parent_node, shard_mentioned_packages(shard, extra=extra)
+                    )
+                )
+
+    def visit_node(
+        self, parent_node: Node, mentioned_packages: Iterable[str]
+    ) -> Iterable[NodeId]:
+        """Broadcast mentioned packages across channels. yield pending NodeId's."""
+        # NOTE we have visit for Nodes which is used in the graph traversal
+        # algorithm, and a separate visit for ShardBase which means "include
+        # this package in the output repodata".
+        for package in mentioned_packages:
+            for shardlike in self.shardlikes:
+                if package in shardlike:
+                    new_node_id = NodeId(
+                        package, shardlike.url, shardlike.shard_url(package)
+                    )
+                    if new_node_id not in self.nodes:
+                        new_node = Node(
+                            distance=parent_node.distance + 1,
+                            package=new_node_id.package,
+                            channel=new_node_id.channel,
+                            shard_url=new_node_id.shard_url,
+                        )
+                        self.nodes[new_node_id] = new_node
+                        yield new_node_id
+
+        parent_node.visited = True
+
+    def drain_pending(
+        self, pending: set[NodeId], shardlikes_by_url: dict[str, ShardBase]
+    ) -> tuple[list[tuple[NodeId, ShardDict]], list[NodeId]]:
+        """
+        Check pending for in-memory shards.
+        Clear pending.
+
+        Return a list of shards we have and shards we need to fetch.
+        """
+        shards_need = []
+        shards_have = []
+        for node_id in pending:
+            # we should already have these nodes.
+            shardlike = shardlikes_by_url[node_id.channel]
+            if shardlike.shard_loaded(node_id.package):  # for monolithic repodata
+                shards_have.append((node_id, shardlike.visit_package(node_id.package)))
+            else:
+                if self.nodes[node_id].visited:  # pragma: no cover
+                    log.debug("Skip visited, should not be reached")
+                    continue
+                shards_need.append(node_id)
+        pending.clear()
+        return shards_have, shards_need
+
+
+def build_repodata_subset(
+    root_packages: Iterable[str],
+    channels: dict[str, Channel],
+    algorithm: Literal["bfs", "pipelined"] = RepodataSubset.DEFAULT_STRATEGY,
+) -> dict[str, ShardBase] | None:
+    """
+    Retrieve all necessary information to build a repodata subset.
+
+    Params:
+        root_packages: iterable of installed and requested package names
+        channels: Channel objects; dict form preferred.
+        algorithm: desired traversal algorithm
+
+    Return:
+        None if there are no shards available, or a mapping of channel URL's to
+        ShardBase objects where build_repodata() returns the computed subset..
+    """
+    channel_data = fetch_channels(channels)
+    if channel_data is not None:
+        subset = RepodataSubset((*channel_data.values(),))
+        subset.reachable(root_packages, strategy=algorithm)
+        log.debug("%d (channel, package) nodes discovered", len(subset.nodes))
+
+    return channel_data
+
+
+# region workers
+
+if TYPE_CHECKING:
+    _T = TypeVar("_T")
+
+
+def combine_batches_until_none(
+    in_queue: Queue[Sequence[_T] | None],
+) -> Iterator[Sequence[_T]]:
+    """
+    Combine lists from in_queue until we see None. Yield combined lists.
+    """
+    running = True
+    while running:
+        try:
+            # Add timeout to prevent indefinite blocking if producer thread fails
+            batch = in_queue.get(timeout=QUEUE_TIMEOUT)
+            if batch is None:
+                break
+        except queue.Empty:
+            # If we timeout, continue waiting - producer might still send data
+            continue
+
+        node_ids = list(batch)
+        with suppress(queue.Empty):
+            while True:  # loop exits with break or queue.Empty exception
+                batch = in_queue.get_nowait()
+                if batch is None:
+                    # do the work but then quit
+                    running = False
+                    break
+                else:
+                    node_ids.extend(batch)
+        yield node_ids
+
+
+def exception_to_queue(func):
+    """
+    Decorator to send unhandled exceptions to the second argument out_queue.
+    """
+
+    @functools.wraps(func)
+    def wrapper(in_queue, out_queue, *args, **kwargs):
+        try:
+            return func(in_queue, out_queue, *args, **kwargs)
+        except BaseException as e:  # includes KeyboardInterrupt
+            in_queue.put(None)  # tell worker that we're done
+            out_queue.put(e)  # tell caller that we received an exception
+
+    return wrapper
+
+
+class QueueCache:
+    """
+    Implement insert() interface of .cache.ShardCache() as a queue, instead of
+    giving network thread direct access to the database.
+    """
+
+    def __init__(self, queue):
+        self.queue: Queue = queue
+
+    def insert(self, shard: AnnotatedRawShard):
+        self.queue.put([shard])
+
+    def copy(self):
+        return self  # used for threadsafety in ShardCache; not needed here
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return
+
+
+@exception_to_queue
+def cache_fetch_thread(
+    in_queue: Queue[Sequence[NodeId] | None],
+    shard_out_queue: Queue[Sequence[tuple[NodeId, ShardDict] | Exception]],
+    network_out_queue: Queue[Sequence[NodeId] | None],
+    cache: ShardCache,
+):
+    """
+    Fetch batches of shards from cache until in_queue sees None. Enqueue found
+    shards to shard_out_queue, and not found shards to network_out_queue.
+
+    When we see None on in_queue, send None to both out queues and exit.
+
+    Args:
+        in_queue: NodeId (URLs) to fetch.
+        shard_out_queue: fetched shards sent to queue.
+        network_out_queue: cache misses forwarded to queue. Same queue is
+            network_fetch_thread's in_queue.
+        cache: used to retrieve shards.
+    """
+    with cache.copy() as cache:
+        for batch in combine_batches_until_none(in_queue):
+            node_ids = []
+            for item in batch:
+                if isinstance(item, AnnotatedRawShard):
+                    # opens transaction; could do insertmany here or transaction scoped to loop
+                    cache.insert(item)
+                else:
+                    node_ids.append(item)
+            cached = cache.retrieve_multiple(
+                [node_id.shard_url for node_id in node_ids]
+            )
+
+            # should we add this into retrieve_multiple?
+            found: list[tuple[NodeId, ShardDict]] = []
+            not_found: list[NodeId] = []
+            for node_id in node_ids:
+                if shard := cached.get(node_id.shard_url):
+                    found.append((node_id, shard))
+                else:
+                    not_found.append(node_id)
+
+            # Might wake up the network thread by calling it first:
+            if not_found:
+                network_out_queue.put(not_found)
+            if found:
+                shard_out_queue.put(found)
+
+    network_out_queue.put(None)
+    # no shard_out_queue.put(None); this is during mainloop shutdown.
+
+
+@exception_to_queue
+def network_fetch_thread(
+    in_queue: Queue[Sequence[NodeId] | None],
+    shard_out_queue: Queue[list[tuple[NodeId, ShardDict] | Exception]],
+    cache: ShardCache,
+    shardlikes: Sequence[ShardBase],
+):
+    """
+    Fetch shards from the network that are received on in_queue, until we see
+    None.
+
+    Unhandled exceptions also go to shard_out_queue, and exit this thread.
+
+    Args:
+        in_queue: NodeId (URLs) to fetch.
+        shard_out_queue: fetched shards sent to queue.
+        cache: once shards are decoded they are stored in cache.
+        shardlikes: list of (network-only) shard index objects.
+    """
+    dctx = zstandard.ZstdDecompressor(max_window_size=ZSTD_MAX_SHARD_SIZE)
+    shardlikes_by_url = {s.url: s for s in shardlikes}
+
+    def fetch(s, url: str, node_id: NodeId):
+        timeout = (
+            context.remote_connect_timeout_secs,
+            context.remote_read_timeout_secs,
+        )
+        with s.get(url, timeout=timeout) as response:
+            response.raise_for_status()
+            data = response.content
+        return url, node_id, data
+
+    def submit(node_id: NodeId):
+        # this worker should only receive network node_id's:
+        shardlike = shardlikes_by_url[node_id.channel]
+        if not isinstance(shardlike, Shards):
+            raise TypeError("network_fetch_thread got non-network shardlike")
+        session = shardlike.session
+        url = shardlikes_by_url[node_id.channel].shard_url(node_id.package)
+        return executor.submit(fetch, session, url, node_id)
+
+    def handle_result(future: Future):
+        url, node_id, data = future.result()
+        log.debug("Fetch thread got %s (%s bytes)", url, len(data))
+        # Decompress and parse. If it decodes as
+        # msgpack.zst, insert into cache. Then put "known
+        # good" shard into out queue.
+        shard: ShardDict = msgpack.loads(
+            dctx.decompress(data, max_output_size=ZSTD_MAX_SHARD_SIZE)
+        )  # type: ignore[assign]
+        # We could send this back into the cache thread instead to
+        # serialize access to sqlite3 if lock contention becomes an issue.
+        cache.insert(AnnotatedRawShard(url, node_id.package, data))
+        shard_out_queue.put([(node_id, shard)])
+
+    def result_to_in_queue(future: Future):
+        # Simplify waiting by putting responses back into in_queue. This
+        # function is called in the ThreadPoolExecutor's thread, but we want to
+        # serialize result processing in the network_fetch_thread.
+
+        # Not in our signature; the caller doesn't need to know we are putting
+        # Future in here as well.
+        in_queue.put([future])  # type: ignore
+
+    with (
+        ThreadPoolExecutor(max_workers=_shards_connections()) as executor,
+        cache.copy() as cache,
+    ):
+        for node_ids_and_results in combine_batches_until_none(in_queue):
+            for node_id_or_result in node_ids_and_results:
+                if isinstance(node_id_or_result, Future):
+                    handle_result(node_id_or_result)
+                else:
+                    future = submit(node_id_or_result)
+                    future.add_done_callback(result_to_in_queue)
+
+        # TODO call executor.shutdown(cancel_futures=True) on error or otherwise
+        # prevent new HTTP requests from being started e.g. "skip" flag in
+        # fetch() function. Also possible to shutdown(wait=False).
+
+
+@exception_to_queue
+def offline_nofetch_thread(
+    in_queue: Queue[Sequence[NodeId] | None],
+    shard_out_queue: Queue[list[tuple[NodeId, ShardDict] | Exception]],
+    cache: ShardCache,
+    shardlikes: Sequence[ShardBase],
+):
+    """
+    For offline mode, where network requests are not allowed.
+    Pretend that every network request is an empty shard.
+    Don't save those to the cache.
+
+    Depending on how many shards are in sqlite3 and which packages were requested, the user may or may not get enough repodata for a solution.
+
+    Args:
+        in_queue: NodeId (URLs) to fetch.
+        shard_out_queue: fetched shards sent to queue.
+        cache: once shards are decoded they are stored in cache.
+        shardlikes: list of (network-only) shard index objects.
+    """
+
+    for node_ids in combine_batches_until_none(in_queue):
+        for node_id in node_ids:
+            shard: ShardDict = {"packages": {}, "packages.conda": {}}
+            shard_out_queue.put([(node_id, shard)])
+
+
+# endregion

--- a/conda/_private/shards/typing.py
+++ b/conda/_private/shards/typing.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+TypedDict declarations for shards.
+
+These are helpful for auto-complete, but do not validate at runtime and are not
+normative. They are intentionally not shared with another project (conda) to
+reduce coupling.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from typing import NotRequired
+
+
+class PackageRecordDict(TypedDict):
+    """
+    Basic package attributes that this module cares about.
+    """
+
+    name: str
+    version: str
+    build: str
+    build_number: int
+    sha256: NotRequired[str | bytes]
+    md5: NotRequired[str | bytes]
+    depends: list[str]
+    constrains: NotRequired[list[str]]
+    noarch: NotRequired[str]
+
+
+# in this style because "packages.conda" is not a Python identifier
+ShardDict = TypedDict(
+    "ShardDict",
+    {
+        "packages": dict[str, PackageRecordDict],
+        "packages.conda": dict[str, PackageRecordDict],
+    },
+)
+
+
+class RepodataInfoDict(TypedDict):
+    base_url: str  # where packages are stored
+    shards_base_url: str  # where shards are stored
+    subdir: str
+
+
+class RepodataDict(ShardDict):
+    """
+    Packages plus info.
+    """
+
+    info: RepodataInfoDict
+    repodata_version: int
+
+
+class ShardsIndexDict(TypedDict):
+    """
+    Shards index as deserialized from repodata_shards.msgpack.zst
+    """
+
+    info: RepodataInfoDict
+    version: int  # TODO conda-index currently uses 'repodata_version' here
+    shards: dict[str, bytes]

--- a/news/15906-repodata-subset
+++ b/news/15906-repodata-subset
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Port sharded repodata implementation from conda-libmamba-solver. (#15906)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,12 @@ dependencies = [
   "boltons >=23.0.0",
   "charset-normalizer",
   # Disabled due to conda-libmamba-solver not being available on PyPI
-  # "conda-libmamba-solver >=26.4.0",
+  # "conda-libmamba-solver >=26.4.1",
   "conda-package-handling >=2.2.0",
   "distro >=1.5.0",
   "frozendict >=2.4.2",
   "menuinst >=2",
+  "msgpack >=1.1.1",
   "packaging >=23.0",
   "platformdirs >=3.10.0",
   "pluggy >=1.6.0",
@@ -73,15 +74,19 @@ exclude_lines = [
 omit = [
   "*/site-packages/*",
   '*\site-packages\*',
+  "conda/_private/shards/typing.py",
   "conda/_vendor.py",
-  "conda/console.py",
   "conda/cli/activate.py",
   "conda/cli/main_package.py",
+  "conda/console.py",
   "conda/exports.py",
   "conda/gateways/connection/adapters/ftp.py",
   "conda/gateways/connection/adapters/s3.py",
   "tests/*",
   "utils/*",
+]
+partial_branches = [
+  "pragma: no branch",
 ]
 show_missing = true
 skip_covered = true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
     - distro >=1.5.0
     - frozendict >=2.4.2
     - menuinst >=2
+    - msgpack-python >=1.1.1
     - packaging >=23.0
     - platformdirs >=3.10.0
     - pluggy >=1.6.0

--- a/tests/shards/__init__.py
+++ b/tests/shards/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Sharded repodata tests
+"""

--- a/tests/shards/conftest.py
+++ b/tests/shards/conftest.py
@@ -1,0 +1,348 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Sharded repodata test fixtures and utilities.
+
+Adapted from conda-libmamba-solver/tests
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import tempfile
+import time
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, NamedTuple
+
+import msgpack
+import pytest
+import zstandard
+
+from conda._private.shards import cache, shards, subset
+from conda.base.context import context, reset_context
+from conda.models.channel import Channel, all_channel_urls
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+    from pathlib import Path
+
+    from conda._private.shards.typing import ShardDict, ShardsIndexDict
+
+# Test channel names
+CONDA_FORGE_WITH_SHARDS = "conda-forge"
+
+# Root packages (base environment approximation)
+ROOT_PACKAGES = [
+    "__archspec",
+    "__conda",
+    "__osx",
+    "__unix",
+    "bzip2",
+    "ca-certificates",
+    "expat",
+    "icu",
+    "libexpat",
+    "libffi",
+    "liblzma",
+    "libmpdec",
+    "libsqlite",
+    "libzlib",
+    "ncurses",
+    "openssl",
+    "pip",
+    "python",
+    "python_abi",
+    "readline",
+    "tk",
+    "twine",
+    "tzdata",
+    "xz",
+    "zlib",
+]
+
+# Fake repodata for testing shards
+FAKE_REPODATA: ShardDict = {
+    "info": {"subdir": "noarch", "base_url": "", "shards_base_url": ""},
+    "packages": {
+        "foo.tar.bz2": {
+            "name": "foo",
+            "version": "1",
+            "build": "0_a",
+            "build_number": 0,
+            "depends": ["bar", "baz"],
+        },
+        "bar.tar.bz2": {
+            "name": "bar",
+            "version": "1",
+            "build": "0_a",
+            "build_number": 0,
+            "depends": ["foo"],
+        },
+        "no-matching-conda.tar.bz2": {
+            "name": "foo",
+            "version": "0.1",
+            "build": "0_a",
+            "build_number": 0,
+        },
+    },
+    "packages.conda": {
+        "foo.conda": {
+            "name": "foo",
+            "version": "1",
+            "build": "0_a",
+            "build_number": 0,
+            "depends": ["bar", "baz"],
+            "constrains": ["splat<3"],
+            "sha256": hashlib.sha256().digest(),
+        },
+        "bar.conda": {
+            "name": "bar",
+            "version": "1",
+            "build": "0_a",
+            "build_number": 0,
+            "depends": ["foo"],
+            "constrains": ["splat<3"],
+            "sha256": hashlib.sha256().digest(),
+        },
+        "no-matching-tar-bz2.conda": {
+            "name": "foo",
+            "version": "2",
+            "build": "0_a",
+            "build_number": 0,
+            "depends": ["quux", "warble"],
+            "constrains": ["splat<3"],
+            "sha256": hashlib.sha256().digest(),
+        },
+    },
+    "repodata_version": 2,
+}
+
+
+@contextmanager
+def _timer(name: str, callback=None):
+    """
+    Print measured time with name as part of message. Call
+    callback(nanoseconds_elapsed) if given.
+    """
+    begin = time.monotonic_ns()
+    yield
+    end = time.monotonic_ns()
+    print(f"{name} took {(end - begin) / 1e9:0.6f}s")
+    if callback:
+        callback(end - begin)
+
+
+def ensure_hex_hash(repodata: dict):
+    """
+    Convert every hash in a repodata to hex. Copy repodata.
+    """
+    new_repodata = {**repodata}
+    for group in ("packages", "packages.conda"):
+        new_repodata[group] = {}
+        for name, record in repodata[group].items():
+            record = {**record}
+            new_repodata[group][name] = record
+            for hash_type in "sha256", "md5":
+                if hash_value := record.get(hash_type):
+                    if not isinstance(hash_value, str):
+                        record[hash_type] = bytes(hash_value).hex()
+    return new_repodata
+
+
+def shard_for_name(repodata: ShardDict, name: str) -> ShardDict:
+    """Extract shard containing only packages with given name."""
+    return {
+        group: {k: v for (k, v) in repodata[group].items() if v["name"] == name}
+        for group in ("packages", "packages.conda")
+    }
+
+
+def expand_channels(
+    channels: list[Channel], subdirs: Iterable[str] | None = None
+) -> dict[str, Channel]:
+    """
+    Expand channels list into a dict of subdir-aware channels.
+    Returns a mapping of channel URL strings to Channel objects.
+    """
+    # all_channel_urls is from conda.models.channel
+    channel_urls = all_channel_urls(
+        channels,
+        subdirs=subdirs or context.subdirs,
+    )
+    result = {}
+    for url_str in channel_urls:
+        result[url_str] = Channel(url_str)
+    return result
+
+
+# Create fake shards for testing
+FAKE_SHARD = shard_for_name(FAKE_REPODATA, "foo")
+FAKE_SHARD_2 = shard_for_name(FAKE_REPODATA, "bar")
+
+
+class ShardFactory:
+    """
+    Create http server shards in a temporary directory. Use this
+    class in the context of tests to generate multiple shard servers
+    that can be cleaned up after use.
+    """
+
+    def __init__(self, root: Path = tempfile.gettempdir()):
+        self.root = root
+        self._http_servers = []
+
+    def clean_up_http_servers(self):
+        """Shutdown all the servers created by this factory."""
+        for http in self._http_servers:
+            http.shutdown()
+        self._http_servers = []
+
+    def http_server_shards(
+        self, dir_name: str, finish_request_action: Callable | None = None
+    ) -> str:
+        """
+        Create a new http server serving shards from a temporary directory.
+
+        :param dir_name: The name of the directory to create the shards in.
+        :param finish_request_action: Optional callable after each request.
+        :return: The URL of the http server serving the shards.
+        """
+        from . import http_server as http_test_server
+
+        shards_repository = self.root / dir_name / "sharded_repo"
+        shards_repository.mkdir(parents=True, exist_ok=True)
+        noarch = shards_repository / "noarch"
+        noarch.mkdir(exist_ok=True)
+
+        foo_shard = zstandard.compress(msgpack.dumps(FAKE_SHARD))  # type: ignore
+        foo_shard_digest = hashlib.sha256(foo_shard).digest()
+        (noarch / f"{foo_shard_digest.hex()}.msgpack.zst").write_bytes(foo_shard)
+
+        bar_shard = zstandard.compress(msgpack.dumps(FAKE_SHARD_2))  # type: ignore
+        bar_shard_digest = hashlib.sha256(bar_shard).digest()
+        (noarch / f"{bar_shard_digest.hex()}.msgpack.zst").write_bytes(bar_shard)
+
+        # Create fake repodata_shards.msgpack.zst index
+        index: ShardsIndexDict = {
+            "info": {"subdir": "noarch", "base_url": "", "shards_base_url": ""},
+            "version": 1,
+            "shards": {
+                "foo": bytes.fromhex(foo_shard_digest.hex()),
+                "bar": bytes.fromhex(bar_shard_digest.hex()),
+            },
+        }
+        index_data = zstandard.compress(msgpack.dumps(index))  # type: ignore
+        (noarch / "repodata_shards.msgpack.zst").write_bytes(index_data)
+
+        def handler(request, base_path):
+            try:
+                http_test_server.request_handler(request, base_path)
+                if finish_request_action:
+                    finish_request_action(request)
+            except Exception:
+                if finish_request_action:
+                    finish_request_action(request)
+                raise
+
+        host = "127.0.0.1"
+        server = http_test_server.run_server(
+            handler, host, base_path=str(shards_repository)
+        )
+        self._http_servers.append(server)
+
+        return f"http://{host}:{server.server_port}"
+
+
+class MockCache(NamedTuple):
+    """Contain all the elements needed by mock_cache fixture."""
+
+    num_shards: int
+    shards: list[cache.AnnotatedRawShard]
+    cache_obj: cache.ShardCache
+
+
+@pytest.fixture
+def prepare_shards_test(monkeypatch: pytest.MonkeyPatch):
+    """
+    Reset token to avoid being logged in. Enable shards.
+    """
+    logging.basicConfig(level=logging.INFO)
+    for module in (shards, cache, subset):
+        module.log.setLevel(logging.DEBUG)
+
+    monkeypatch.setenv("CONDA_TOKEN", "")
+    monkeypatch.setenv("CONDA_PLUGINS_USE_SHARDED_REPODATA", "1")
+    reset_context()
+    # Note: _is_sharded_repodata_enabled() is from conda-libmamba-solver
+    # For now we just ensure the env var is set
+
+
+@pytest.fixture()
+def mock_cache(tmp_path: Path) -> Iterator[MockCache]:
+    """
+    Set up a mock shard cache that will be used by multiple benchmark tests.
+    """
+    num_fake_shards = 64
+    with cache.ShardCache(tmp_path) as cache_instance:
+        fake_shards = []
+
+        compressor = zstandard.ZstdCompressor(level=1)
+        for i in range(num_fake_shards):
+            fake_shard = {f"foo{i}": "bar"}
+            annotated_shard = cache.AnnotatedRawShard(
+                f"https://foo{i}",
+                f"foo{i}",
+                compressor.compress(msgpack.dumps(fake_shard)),  # type: ignore
+            )
+            cache_instance.insert(annotated_shard)
+            fake_shards.append(annotated_shard)
+
+        yield MockCache(
+            num_shards=num_fake_shards, shards=fake_shards, cache_obj=cache_instance
+        )
+
+
+@pytest.fixture
+def shard_cache_with_data(
+    mock_cache: MockCache,
+) -> tuple[cache.ShardCache, list[cache.AnnotatedRawShard]]:
+    """
+    ShardCache with some data already inserted.
+    """
+    return mock_cache.cache_obj, mock_cache.shards
+
+
+@pytest.fixture(scope="session")
+def http_server_shards(tmp_path_factory) -> Iterable[str]:
+    """
+    A shard repository with sharded repodata.
+    """
+    shard_factory = ShardFactory(tmp_path_factory.mktemp("sharded_repo"))
+    url = shard_factory.http_server_shards("http_server_shards")
+    yield url
+    shard_factory.clean_up_http_servers()
+
+
+@pytest.fixture
+def shard_factory(tmp_path_factory, request: pytest.FixtureRequest) -> ShardFactory:
+    """
+    Use ShardFactory to manage creating and cleaning up shards for testing.
+
+    Example:
+
+    ```
+    def test_something(shard_factory: ShardFactory):
+        server_one = shard_factory.http_server_shards("one")
+        server_two = shard_factory.http_server_shards("two")
+        ...
+    ```
+    """
+    shards_repository = tmp_path_factory.mktemp("sharded_repo")
+    factory = ShardFactory(shards_repository)
+
+    def close_servers():
+        factory.clean_up_http_servers()
+
+    request.addfinalizer(close_servers)
+    return factory

--- a/tests/shards/http_server.py
+++ b/tests/shards/http_server.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Custom HTTP server utilities for serving sharded repodata in tests.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import http.server
+import queue
+import socket
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from http.server import BaseHTTPRequestHandler
+
+
+def request_handler(request: BaseHTTPRequestHandler, base_path: str | Path) -> None:
+    """
+    Serve a file from the base_path directory based on the request path.
+
+    This is a simple file serving handler compatible with HTTP request handlers.
+    It serves files relative to base_path, returning 404 for missing files.
+
+    :param request: The HTTP request handler instance
+    :param base_path: The root directory to serve files from
+    """
+    base_path = Path(base_path).resolve()
+
+    # Get the requested file path
+    file_path = base_path / request.path.lstrip("/")
+    file_path = file_path.resolve()
+
+    # Security check: ensure the resolved path is still within base_path
+    try:
+        file_path.relative_to(base_path)
+    except ValueError:
+        # Path escape attempt detected
+        request.send_error(404, "Not Found")
+        return
+
+    # Check if file exists and is a file (not a directory)
+    if file_path.is_file():
+        try:
+            with open(file_path, "rb") as f:
+                file_data = f.read()
+                request.send_response(200)
+                request.send_header("Content-type", "application/octet-stream")
+                request.send_header("Content-Length", str(len(file_data)))
+                request.end_headers()
+                request.wfile.write(file_data)
+        except OSError:
+            request.send_error(500, "Internal Server Error")
+    else:
+        request.send_error(404, "Not Found")
+
+
+def run_server(
+    handler: Callable[[BaseHTTPRequestHandler, str], None],
+    host: str = "127.0.0.1",
+    base_path: str | Path | None = None,
+) -> http.server.ThreadingHTTPServer:
+    """
+    Run a custom HTTP server on a random port with a provided handler function.
+
+    The handler function is called for each request and receives:
+    - request: The HTTP request handler instance
+    - base_path: The base path provided to run_server
+
+    :param handler: Callable that handles HTTP requests
+    :param host: The host to bind to (default "127.0.0.1")
+    :param base_path: Base path to pass to the handler
+    :return: The running ThreadingHTTPServer instance
+    """
+    base_path = str(base_path) if base_path else ""
+
+    class CustomRequestHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            handler(self, base_path)
+
+        def log_message(self, format, *args):
+            # Suppress logging
+            pass
+
+    class DualStackServer(http.server.ThreadingHTTPServer):
+        daemon_threads = False
+        allow_reuse_address = True
+        request_queue_size = 64
+
+        def server_bind(self):
+            with contextlib.suppress(Exception):
+                self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            return super().server_bind()
+
+    def start_server(q: queue.Queue):
+        with DualStackServer((host, 0), CustomRequestHandler) as httpd:
+            q.put(httpd)
+            try:
+                httpd.serve_forever()
+            except KeyboardInterrupt:
+                pass
+
+    q: queue.Queue = queue.Queue()
+    thread = threading.Thread(target=start_server, args=(q,), daemon=True)
+    thread.start()
+
+    return q.get(timeout=1)

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -1,0 +1,196 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Minimal sharded repodata tests adapted from conda-libmamba-solver.
+
+Tests focus on core pipelined repodata subset functionality with
+code coverage tracking.
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+
+import pytest
+
+from conda._private.shards.shards import (
+    fetch_channels,
+)
+from conda._private.shards.subset import (
+    RepodataSubset,
+    build_repodata_subset,
+    filter_redundant_packages,
+)
+from conda.base.context import context, reset_context
+from conda.models.channel import Channel
+
+from .conftest import (
+    CONDA_FORGE_WITH_SHARDS,
+    FAKE_REPODATA,
+    ROOT_PACKAGES,
+    _timer,
+    ensure_hex_hash,
+    expand_channels,
+)
+
+# Minimal test scenarios for fast validation
+TESTING_SCENARIOS = [
+    {
+        "name": "python",
+        "packages": ["python"],
+        "prefetch_packages": [],
+        "channel": CONDA_FORGE_WITH_SHARDS,
+        "platform": "linux-64",
+    },
+    {
+        "name": "devops_automation",
+        "packages": ["ansible", "pyyaml", "jinja2"],
+        "prefetch_packages": ["python"],
+        "channel": CONDA_FORGE_WITH_SHARDS,
+        "platform": "linux-64",
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "root_packages", [ROOT_PACKAGES[:] + ["vaex"], []], ids=["complex", "empty"]
+)
+def test_build_repodata_subset_pipelined(
+    prepare_shards_test: None, root_packages: list[str], tmp_path
+):
+    """
+    Build repodata subset using a worker threads dependency traversal algorithm.
+
+    This is the minimal pipelined test adapted from conda-libmamba-solver.
+    """
+    channels = []
+    channels.append(Channel(CONDA_FORGE_WITH_SHARDS))
+
+    with _timer("fetch_channels()"):
+        channel_data = fetch_channels(expand_channels(channels))
+
+    def assert_quick(ns: int):
+        # Check that the 1 second queue timeout doesn't happen on an empty
+        # traversal.
+        if not root_packages:
+            assert (ns / 1e9) < 0.2, "Empty shard traversal should be quick."
+
+    with _timer("RepodataSubset.reachable_pipelined()", assert_quick):
+        subset = RepodataSubset((*channel_data.values(),))
+        subset.reachable_pipelined(root_packages)
+        print(f"{len(subset.nodes)} (channel, package) nodes discovered")
+
+    print(
+        "Channels:",
+        ",".join(urllib.parse.urlparse(url).path[1:] for url in channel_data),
+    )
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    TESTING_SCENARIOS,
+    ids=[scenario["name"] for scenario in TESTING_SCENARIOS],
+)
+def test_traversal_algorithms_match(conda_cli, scenario: dict):
+    """
+    Ensure that both BFS and pipelined algorithms return the same repodata subset.
+    """
+    channel = Channel(f"{scenario['channel']}/{scenario['platform']}")
+    channels = expand_channels([channel])
+
+    repodata_algorithm_map = {
+        "bfs": build_repodata_subset(scenario["packages"], channels, algorithm="bfs"),
+        "pipelined": build_repodata_subset(
+            scenario["packages"], channels, algorithm="pipelined"
+        ),
+    }
+
+    for subdir in repodata_algorithm_map["bfs"].keys():
+        repodatas = []
+
+        for algorithm, repodata_subset in repodata_algorithm_map.items():
+            repodatas.append(repodata_subset[subdir].build_repodata())
+
+        assert all(x == y for x, y in zip(repodatas, repodatas[1:]))
+
+
+@pytest.mark.parametrize("algorithm", ["bfs", "pipelined"])
+def test_build_repodata_subset_local_server(
+    http_server_shards, algorithm, monkeypatch, tmp_path
+):
+    """
+    Ensure we can fetch and build a valid repodata subset from our mock local server.
+    """
+    # Guarantee clean cache to avoid interference from previous tests
+    monkeypatch.setenv("CONDA_PKGS_DIRS", str(tmp_path))
+    reset_context()
+
+    channel = Channel.from_url(f"{http_server_shards}/noarch")
+    root_packages = ["foo"]
+
+    expected_repodata = ensure_hex_hash(FAKE_REPODATA)
+    expected_repodata = filter_redundant_packages(expected_repodata)  # type: ignore
+
+    channel_data = build_repodata_subset(
+        root_packages, {channel.url() or "": channel}, algorithm=algorithm
+    )
+
+    for shardlike in channel_data.values():
+        # expanded in fetch_channels() "channel.urls(True, context.subdirs)"
+        if "/noarch/" not in shardlike.url:
+            continue
+        actual_repodata = shardlike.build_repodata()
+
+        assert actual_repodata == expected_repodata, (
+            "actual",
+            actual_repodata,
+            "expected",
+            expected_repodata,
+        )
+
+
+def test_build_repodata_subset_no_shards(http_server_shards):
+    """
+    If no channel has repodata_shards.msgpack.zst, build_repodata_subset()
+    returns None.
+    """
+    channels = expand_channels([Channel(http_server_shards + "/notfound")])
+    assert build_repodata_subset([], channels) is None
+
+
+def test_build_repodata_subset(prepare_shards_test: None, tmp_path):
+    """
+    Build repodata subset and compute the size if it was serialized as repodata.json.
+    """
+    import json
+
+    # installed, plus what we want to add (twine)
+    root_packages = ROOT_PACKAGES[:]
+
+    channels = list(context.default_channels)
+    channels.append(Channel(CONDA_FORGE_WITH_SHARDS))
+    channel_dict = expand_channels(channels)
+
+    with _timer("build_repodata_subset()"):
+        channel_data = build_repodata_subset(root_packages, channel_dict)
+
+    # Measure size
+    repodata_size = 0
+    for _, shardlike in channel_data.items():
+        repodata = shardlike.build_repodata()
+        repodata_text = json.dumps(
+            repodata,
+            indent=0,
+            separators=(",", ":"),
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        repodata_size += len(repodata_text.encode("utf-8"))
+
+    assert len(channel_data), "no channel data"
+    print(f"Repodata subset would be {repodata_size} bytes as json")
+
+    print(
+        "Channels:",
+        ",".join(urllib.parse.urlparse(url).path[1:] for url in channel_data),
+    )


### PR DESCRIPTION
### Description

Part of #15906. Ports the sharded repodata implementation from conda-libmamba-solver into conda core.

- Add `conda/_private/shards/` package with the core sharding implementation (ShardBase, ShardLike, Shards classes)
- Add SQLite-backed shard cache (`cache.py`) for individual per-package shards
- Add pipelined and BFS traversal algorithms (`subset.py`) for dependency-driven repodata subsetting
- Add `QueueCache` to serialize SQLite writes through the cache thread (avoids lock contention)
- Add type definitions (`typing.py`) for shard data structures
- Add HTTP fetching with ETag/Last-Modified caching for the shards index
- Add `repodata_shards.msgpack.zst` index fetching integrated with `RepodataCache`
- Add `msgpack` as a new runtime dependency
- Add initial test suite with local HTTP server fixtures

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?