### PR TITLE
Raise instead of crash when CONDA_SHLVL set but CONDA_PREFIX empty

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -354,6 +354,23 @@ class _Activator(metaclass=abc.ABCMeta):
         old_conda_shlvl = int(os.getenv("CONDA_SHLVL", "").strip() or 0)
         old_conda_prefix = os.getenv("CONDA_PREFIX")
 
+        if old_conda_shlvl > 0 and not old_conda_prefix:
+            # Symmetric to the CONDA_PREFIX_<n> guard in build_deactivate:
+            # CONDA_SHLVL claims an active env but CONDA_PREFIX is empty, so
+            # the upcoming _get_deactivate_scripts(old_conda_prefix) on the
+            # `not stack` branch would crash inside ntpath.join with
+            # "TypeError: expected str, bytes or os.PathLike object, not NoneType".
+            # That broken state usually comes from mixing shell-init blocks
+            # (e.g. cmd.exe + xonsh on Windows, see xonsh/xonsh#3676) or an
+            # interrupted deactivation.
+            raise ValueError(
+                "CONDA_SHLVL is %s but CONDA_PREFIX is empty. This indicates "
+                "a broken activation state, often caused by mixing shell-init "
+                "blocks across shells or an interrupted deactivation. Try "
+                "restarting your shell; if it persists, check your shell "
+                "profile for the conflicting init block." % old_conda_shlvl
+            )
+
         # if the prior active prefix is this prefix we are actually doing a reactivate
         if old_conda_prefix == prefix and old_conda_shlvl > 0:
             return self.build_reactivate()

--- a/news/3676-xonsh-build-activate-stack-guard
+++ b/news/3676-xonsh-build-activate-stack-guard
@@ -1,0 +1,24 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Raise a clear `ValueError` from `_build_activate_stack` when `CONDA_SHLVL`
+  is set but `CONDA_PREFIX` is empty, instead of crashing inside
+  `ntpath.join(None, …)` with `TypeError: expected str, bytes or os.PathLike
+  object, not NoneType`. This broken state is most often hit on Windows when
+  shell-init blocks for different shells fight with each other (e.g.
+  `cmd.exe` + `xonsh`). Reported via xonsh/xonsh#3676.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -693,6 +693,31 @@ def test_build_activate_shlvl_1(
     }
 
 
+def test_build_activate_raises_when_shlvl_set_but_prefix_unset(
+    monkeypatch: MonkeyPatch,
+    env_activate: tuple[str, str, str],
+):
+    """Regression test for the TypeError from `_get_deactivate_scripts(None)`.
+
+    With ``CONDA_SHLVL >= 1`` but ``CONDA_PREFIX`` unset, _build_activate_stack
+    used to fall through to ``self._get_deactivate_scripts(old_conda_prefix)``
+    on the ``not stack`` branch, which crashes inside ``ntpath.join(None, …)``
+    with ``TypeError: expected str, bytes or os.PathLike object, not NoneType``.
+    Reported via xonsh on Windows where conflicting init blocks (cmd.exe +
+    xonsh) leave the env partially activated — see xonsh/xonsh#3676.
+    """
+    prefix, _, _ = env_activate
+    monkeypatch.setenv("CONDA_SHLVL", "1")
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+
+    activator = PosixActivator()
+    with pytest.raises(
+        ValueError,
+        match=r"CONDA_SHLVL is 1 but CONDA_PREFIX is empty",
+    ):
+        activator.build_activate(prefix)
+
+
 @skip_unsupported_posix_path
 def test_build_stack_shlvl_1(
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
## Summary

When `CONDA_SHLVL >= 1` but `CONDA_PREFIX` is empty, the `not stack` branch of `_build_activate_stack` calls `_get_deactivate_scripts(None)`, which crashes inside `ntpath.join(None, …)` with:

```
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

The user just sees an unexpected stack trace instead of a hint about what's wrong.

`build_deactivate` already raises a clear `ValueError` for the analogous broken-state case (#15609 for `CONDA_PREFIX_<n>`). Mirror that here so `conda activate <env>` gives actionable diagnostics instead of a frame deep in `ntpath`.

This broken state is most commonly observed on Windows when shell-init blocks for `cmd.exe` and `xonsh` disagree about the active env — see [xonsh/xonsh#3676](https://github.com/xonsh/xonsh/issues/3676) for the user-facing report (open since 2020).