### PR TITLE
shards: update network thread test

### DIFF
--- a/tests/shards/test_shards_subset.py
+++ b/tests/shards/test_shards_subset.py
@@ -491,7 +491,9 @@ def test_shards_network_thread(http_server_shards, shard_cache_with_data, monkey
     Test network retrieval thread, meant to be chained after the sqlite3 thread
     by having network_in_queue = sqlite3 thread's network_out_queue.
     """
-    monkeypatch.setattr(shards_subset, "QUEUE_TIMEOUT", 0.01)
+    # Timeout allows us to finish `with suppress(Empty)` loop more quickly, but
+    # a too-short timeout can cause failures.
+    monkeypatch.setattr(shards_subset, "QUEUE_TIMEOUT", 0.05)
 
     cache, fake_shards = shard_cache_with_data
     channel = Channel.from_url(f"{http_server_shards}/noarch")
@@ -507,8 +509,6 @@ def test_shards_network_thread(http_server_shards, shard_cache_with_data, monkey
     network_in_queue: SimpleQueue[list[NodeId] | None] = SimpleQueue()
     shard_out_queue: SimpleQueue[list[tuple[NodeId, ShardDict]]] = SimpleQueue()
 
-    # this kind of thread can crash, and we don't hear back without our own
-    # handling.
     network_thread = threading.Thread(
         target=shards_subset.network_fetch_thread,
         args=(network_in_queue, shard_out_queue, cache, [found, invalid_shardlike]),
@@ -524,6 +524,8 @@ def test_shards_network_thread(http_server_shards, shard_cache_with_data, monkey
 
     network_thread.start()
 
+    urls = {}
+
     with suppress(Empty):
         while batch := shard_out_queue.get(timeout=shards_subset.QUEUE_TIMEOUT):
             for url, shard in batch:
@@ -534,13 +536,35 @@ def test_shards_network_thread(http_server_shards, shard_cache_with_data, monkey
                     ("foo.tar.bz2", "bar.tar.bz2")
                 )
 
-    # Worker produces TypeError if non-network NodeId is sent and one of the
-    # shardlikes has its url. (If no shardlike has NodeId's url, it produces
-    # KeyError).
+                urls[url] = shard
+
+    assert len(urls) == 2
+
+    # Expect TypeError if non-network NodeId is sent and one of the shardlikes
+    # has its url. The worker thread will find that "nope" belongs to
+    # invalid_shardlike: ShardLike (not Shards() type) and produce TypeError.
     network_in_queue.put([NodeId("nope", invalid_shardlike.url)])
-    assert isinstance(
-        shard_out_queue.get(timeout=shards_subset.QUEUE_TIMEOUT), TypeError
+    assert isinstance(shard_out_queue.get(timeout=1), TypeError)
+
+    # Thread exits after exception.
+    assert not network_thread.is_alive()
+
+    # The network_in_queue() has an unnecessary None from its exception handler,
+    # telling network_fetch_thread to quit but it already quit due to the
+    # exception.
+    assert network_in_queue.get() is None
+
+    # New thread to test KeyError (invalid_shardlikes not in input args)
+    network_thread = threading.Thread(
+        target=shards_subset.network_fetch_thread,
+        args=(network_in_queue, shard_out_queue, cache, [found]),
+        daemon=False,
     )
+
+    network_thread.start()
+
+    network_in_queue.put([NodeId("nope", invalid_shardlike.url)])
+    assert isinstance(shard_out_queue.get(timeout=1), KeyError)
 
     # Terminate with sentinel
     network_in_queue.put(None)

--- a/tests/shards/test_shards_subset.py
+++ b/tests/shards/test_shards_subset.py
@@ -569,7 +569,8 @@ def test_shards_network_thread(http_server_shards, shard_cache_with_data, monkey
     # Terminate with sentinel
     network_in_queue.put(None)
 
-    network_thread.join(0)
+    network_thread.join(1)
+    assert not network_thread.is_alive()
 
 
 # endregion


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Update network threads test.

The short timeout is useful in the first part of the test because we pull from the output queue until it's empty; and we don't want to wait 1 second. Alternatively we could submit the shards and a None so that this thread would terminate on its own.

The short timeout isn't useful in the second part of the test and was causing failure. Instead, use a 1 second timeout. We will always get an item from the queue instead of timing out if the test passes.

Added a third part of the test to generate `KeyError` in the thread.

Fix #15906 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
