### PR TITLE
Ensure that `build_repodata_subset` partial is only applied to a solver's `__init__` function

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -444,8 +444,14 @@ class CondaPluginManager(pluggy.PluginManager):
         ):
             from ..gateways.shards import build_repodata_subset
 
-            return functools.partial(
-                solver_plugin.backend, build_repodata_subset=build_repodata_subset
+            new_init = functools.partialmethod(
+                solver_plugin.backend.__init__,
+                build_repodata_subset=build_repodata_subset,
+            )
+            return type(
+                f"Partial{solver_plugin.backend.__name__}",
+                (solver_plugin.backend,),
+                {"__init__": new_init},
             )
 
         return solver_plugin.backend

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -14,6 +14,7 @@ import pytest
 from packaging.version import Version
 
 from conda import plugins
+from conda.base.context import reset_context
 from conda.common.url import urlparse
 from conda.core import solve
 from conda.exceptions import CondaValueError, PluginError
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Any
 
+    from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
     from conda.plugins.manager import CondaPluginManager
@@ -168,6 +170,45 @@ def test_known_solver(plugin_manager: CondaPluginManager):
     """
     assert plugin_manager.load_plugins(VerboseSolverPlugin) == 1
     assert plugin_manager.get_solver_backend("verbose-classic") == VerboseSolver
+
+
+@pytest.mark.parametrize("use_shards", [True, False])
+def test_solver_with_repodata_subset(
+    use_shards: bool, plugin_manager: CondaPluginManager, monkeypatch: MonkeyPatch
+):
+    """
+    Cover getting a solver that uses sharded repodata api
+    """
+
+    class TestSolver(solve.Solver):
+        def __init__(
+            self,
+            build_repodata_subset=None,
+            *args,
+            **kwargs,
+        ):
+            return super().__init__(*args, **kwargs)
+
+        @staticmethod
+        def user_agent() -> str:
+            return "test-solver/1.0"
+
+    TestCondaSolver = plugins.types.CondaSolver(
+        name="test-classic",
+        backend=TestSolver,
+    )
+
+    class TestSolverPlugin:
+        @plugins.hookimpl
+        def conda_solvers(*args):
+            yield TestCondaSolver
+
+    monkeypatch.setenv("CONDA_REPODATA_USE_SHARDS", use_shards)
+    reset_context()
+
+    assert plugin_manager.load_plugins(TestSolverPlugin) == 1
+    solver = plugin_manager.get_solver_backend("test-classic")
+    assert solver.user_agent() == "test-solver/1.0"
 
 
 def test_get_canonical_name_object(plugin_manager: CondaPluginManager):

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -203,7 +203,7 @@ def test_solver_with_repodata_subset(
         def conda_solvers(*args):
             yield TestCondaSolver
 
-    monkeypatch.setenv("CONDA_REPODATA_USE_SHARDS", use_shards)
+    monkeypatch.setenv("CONDA_REPODATA_USE_SHARDS", str(use_shards))
     reset_context()
 
     assert plugin_manager.load_plugins(TestSolverPlugin) == 1


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Currently using the main branch of conda, the conda-rattler-solver [tests fail](https://github.com/conda-incubator/conda-rattler-solver/actions/runs/25753870477/job/75637093475?pr=53) with 
```
FAILED tests/test_user_agent.py::test_user_agent_conda_info[rattler] - AssertionError: assert 'conda-rattler-solver/0.0.7.dev10+g638ac7e6f' in 'conda/26.3.3.dev81 requests/2.34.0 CPython/3.10.20 Linux/6.17.0-1010-azure ubuntu/24.04.4 glibc/2.39 solver/rattler'
```

Inspecting conda, we can confirm that the main branch does not include the conda-rattler-solver version in the user agent.

```
$ conda info --json | jq .user_agent                                                                                                              
"conda/26.3.3.dev81 requests/2.33.1 CPython/3.10.20 Linux/6.17.4-76061704-generic pop/22.04 glibc/2.35 solver/rattler"
```

Previously it did (from commit 5a2724b95)
```
$ conda info --json | jq .user_agent                                                                                                                                                 
"conda/26.3.3.dev81 requests/2.33.1 CPython/3.10.20 Linux/6.17.4-76061704-generic pop/22.04 glibc/2.35 solver/rattler conda-rattler-solver/0.0.7.dev9+g46dc8bb7d py-rattler/0.23.2"
```

The root cause is conda getting caught in this exception in [`context.solver_user_agent`](https://github.com/conda/conda/blob/main/conda/base/context.py#L1113):
```
AttributeError("'functools.partial' object has no attribute 'user_agent'")
```


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
