### PR TITLE
Remove pypi subcommand test from canary build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,7 +94,6 @@ test:
     - conda upgrade --help
     # plugin subcommands
     - conda doctor --help
-    - conda pypi --help
     - conda self --help
 
 about:


### PR DESCRIPTION
Follow up to #16082. I noticed our canary build was failing because we missed removing the subcommand check.

Closes #16084