### PR TITLE
Validate MatchSpec package names against CEP-26

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -102,6 +102,13 @@ _NAME_VERSION_RE: re.Pattern[str] = re.compile(
     """,
     re.VERBOSE,
 )
+# CEP-26 package name validation (distributable and virtual)
+_CEP26_NAME_RE: re.Pattern[str] = re.compile(
+    r"^(([a-z0-9])|([a-z0-9_](?!_)))[._-]?([a-z0-9]+(\.|-|_|$))*$"
+)
+_CEP26_VIRTUAL_NAME_RE: re.Pattern[str] = re.compile(
+    r"^__[a-z0-9][._-]?([a-z0-9]+(\.|-|_|$))*$"
+)
 _VERSION_BUILD_RE: re.Pattern[str] = re.compile(
     r"""
     ((?:.+?)[^><!,|]?)      # version (non-greedy, not ending in operator)
@@ -113,6 +120,27 @@ _VERSION_BUILD_RE: re.Pattern[str] = re.compile(
     """,
     re.VERBOSE,
 )
+
+
+def _validate_package_name(name: str, original_spec_str: str) -> None:
+    """Validate a package name against CEP-26 rules.
+
+    Glob patterns (containing *) are not validated.
+    Names are lowercased before checking since conda normalizes case.
+    """
+    if "*" in name:
+        return
+    normalized = name.lower()
+    if invalid := re.findall(r"[^a-z0-9._-]", normalized):
+        raise InvalidMatchSpec(
+            original_spec_str,
+            f"package name contains invalid characters ({''.join(dict.fromkeys(invalid))})",
+        )
+    if not (_CEP26_NAME_RE.match(normalized) or _CEP26_VIRTUAL_NAME_RE.match(normalized)):
+        raise InvalidMatchSpec(
+            original_spec_str,
+            "invalid package name",
+        )
 
 
 class MatchSpecType(type):
@@ -915,11 +943,7 @@ def _parse_spec_str(spec_str):
             raise InvalidMatchSpec(
                 original_spec_str, f"no package name found in '{spec_str}'"
             )
-        if "'" in name or '"' in name:
-            raise InvalidMatchSpec(
-                original_spec_str,
-                "package name contains invalid quote characters",
-            )
+        _validate_package_name(name, original_spec_str)
     else:
         raise InvalidMatchSpec(original_spec_str, "no package name found")
 
@@ -1144,11 +1168,7 @@ def _parse_spec_str_v3(spec_str):
             raise InvalidMatchSpec(
                 original_spec_str, f"no package name found in '{spec_str}'"
             )
-        if "'" in name or '"' in name:
-            raise InvalidMatchSpec(
-                original_spec_str,
-                "package name contains invalid quote characters",
-            )
+        _validate_package_name(name, original_spec_str)
     else:
         raise InvalidMatchSpec(original_spec_str, "no package name found")
 

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -915,6 +915,11 @@ def _parse_spec_str(spec_str):
             raise InvalidMatchSpec(
                 original_spec_str, f"no package name found in '{spec_str}'"
             )
+        if "'" in name or '"' in name:
+            raise InvalidMatchSpec(
+                original_spec_str,
+                "package name contains invalid quote characters",
+            )
     else:
         raise InvalidMatchSpec(original_spec_str, "no package name found")
 
@@ -1138,6 +1143,11 @@ def _parse_spec_str_v3(spec_str):
         if name is None:
             raise InvalidMatchSpec(
                 original_spec_str, f"no package name found in '{spec_str}'"
+            )
+        if "'" in name or '"' in name:
+            raise InvalidMatchSpec(
+                original_spec_str,
+                "package name contains invalid quote characters",
             )
     else:
         raise InvalidMatchSpec(original_spec_str, "no package name found")

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -136,7 +136,9 @@ def _validate_package_name(name: str, original_spec_str: str) -> None:
             original_spec_str,
             f"package name contains invalid characters ({''.join(dict.fromkeys(invalid))})",
         )
-    if not (_CEP26_NAME_RE.match(normalized) or _CEP26_VIRTUAL_NAME_RE.match(normalized)):
+    if not (
+        _CEP26_NAME_RE.match(normalized) or _CEP26_VIRTUAL_NAME_RE.match(normalized)
+    ):
         raise InvalidMatchSpec(
             original_spec_str,
             "invalid package name",

--- a/news/16087-quoted-names
+++ b/news/16087-quoted-names
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Reject package names containing quote characters in `MatchSpec` with a clear error message. (#16087)
+* Validate `MatchSpec` package names against CEP-26 rules, rejecting names with invalid characters or structure. (#16087)
 
 ### Deprecations
 

--- a/news/16087-quoted-names
+++ b/news/16087-quoted-names
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Reject package names containing quote characters in `MatchSpec` with a clear error message. (#16087)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -656,6 +656,22 @@ def test_invalid_match_spec():
         str(MatchSpec("!xyz 1.3"))
 
 
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "'package'",
+        '"package"',
+        "'package==3'",
+        '"package==3"',
+        "'package'>=1.0",
+    ],
+)
+def test_quoted_name_rejected(spec):
+    """Quote characters in package names must raise InvalidMatchSpec (CEP-26)."""
+    with pytest.raises(InvalidMatchSpec, match="quote"):
+        MatchSpec(spec)
+
+
 def cb_form(spec_str):
     return MatchSpec(spec_str).conda_build_form()
 

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -661,10 +661,7 @@ def test_invalid_match_spec():
     [
         ("'package'", "invalid characters"),
         ('"package"', "invalid characters"),
-        ("'package==3'", "invalid characters"),
-        ('"package==3"', "invalid characters"),
-        ("'package'>=1.0", "invalid characters"),
-        ("pack@ge>=1.0", "invalid characters"),
+        ("pack@ge", "invalid characters"),
         ("pkg..name", "invalid package name"),
         ("pkg--name", "invalid package name"),
         (".pkg", "invalid package name"),

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -657,19 +657,45 @@ def test_invalid_match_spec():
 
 
 @pytest.mark.parametrize(
-    "spec",
+    "spec,match",
     [
-        "'package'",
-        '"package"',
-        "'package==3'",
-        '"package==3"',
-        "'package'>=1.0",
+        ("'package'", "invalid characters"),
+        ('"package"', "invalid characters"),
+        ("'package==3'", "invalid characters"),
+        ('"package==3"', "invalid characters"),
+        ("'package'>=1.0", "invalid characters"),
+        ("pack@ge>=1.0", "invalid characters"),
+        ("pkg..name", "invalid package name"),
+        ("pkg--name", "invalid package name"),
+        (".pkg", "invalid package name"),
+        ("-pkg", "invalid package name"),
     ],
 )
-def test_quoted_name_rejected(spec):
-    """Quote characters in package names must raise InvalidMatchSpec (CEP-26)."""
-    with pytest.raises(InvalidMatchSpec, match="quote"):
+def test_invalid_package_name_rejected(spec, match):
+    """Invalid package names must raise InvalidMatchSpec (CEP-26)."""
+    with pytest.raises(InvalidMatchSpec, match=match):
         MatchSpec(spec)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "numpy",
+        "my-package",
+        "my_package",
+        "my.package",
+        "r-base",
+        "python-dateutil",
+        "_openmp_mutex",
+        "_pkg",
+        "__glibc",
+        "__unix",
+    ],
+)
+def test_valid_package_names(spec):
+    """Valid CEP-26 package names must be accepted."""
+    ms = MatchSpec(spec)
+    assert ms.name == spec
 
 
 def cb_form(spec_str):
@@ -1914,16 +1940,8 @@ def test_kv_regex_does_not_hang_on_channel_urls():
 @pytest.mark.parametrize(
     "spec,message",
     [
-        pytest.param(
-            "package[build",
-            None,
-            marks=pytest.mark.xfail(reason="We are not banning bad names", strict=True),
-        ),
-        pytest.param(
-            "package[build=",
-            None,
-            marks=pytest.mark.xfail(reason="We are not banning bad names", strict=True),
-        ),
+        ("package[build", "invalid characters"),
+        ("package[build=", "invalid characters"),
         ("package[build=]", "a key or a value is missing"),
         ("package[build=value, build=again]", "key can only be specified once"),
         ("package[build]", "No key-value pairs found in square brackets"),


### PR DESCRIPTION
### Description

Validate `MatchSpec` package names against CEP-26 rules instead of only rejecting quote characters. Uses a layered approach:

1. Lowercase the name (conda normalizes case at match time)
2. Check for invalid characters with a specific error listing them (e.g. `"package name contains invalid characters ('@)"`)
3. Validate against the full CEP-26 regex for both distributable (`^(([a-z0-9])|([a-z0-9_](?!_)))[._-]?([a-z0-9]+(\.|-|_|$))*$`) and virtual (`^__[a-z0-9]...`) package names
4. Skip validation for glob patterns (containing `*`)

Two previously-xfailing test cases (`"We are not banning bad names"` from #15443) now pass since the CEP-26 regex catches `[` as an invalid character.

Closes #16087

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ Not applicable.