### PR TITLE
CI: upgrade conda-libmamba-solver in base before test deps install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,6 +129,11 @@ jobs:
           pkgs-dirs: D:\conda_pkgs_dir
           installation-dir: D:\conda
 
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
       - name: Conda Install
         run: >
           conda install
@@ -269,6 +274,11 @@ jobs:
           miniconda-version: ${{ matrix.default-channel == 'defaults' && 'latest' || null }}
           miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
 
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
       - name: Conda Install
         run: >
           conda install
@@ -378,6 +388,11 @@ jobs:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
 
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
       - name: Conda Install
         run: >
           conda install
@@ -446,6 +461,11 @@ jobs:
         with:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
+
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
       - name: Conda Install
         run: >
@@ -599,6 +619,11 @@ jobs:
           condarc-file: .github/condarc-defaults
           run-post: false  # skip post cleanup
 
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
       - name: Conda Install
         run: >
           conda install
@@ -694,6 +719,11 @@ jobs:
           run-post: false  # skip post cleanup
           miniconda-version: ${{ matrix.default-channel == 'defaults' && 'latest' || null }}
           miniforge-version: ${{ matrix.default-channel == 'conda-forge' && 'latest' || null }}
+
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
       - name: Conda Install
         run: >
@@ -869,6 +899,11 @@ jobs:
         with:
           condarc-file: conda/.github/condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
+
+      # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
+      # Remove once miniforge ships c-l-s >=26.4.1.
+      - name: Upgrade conda-libmamba-solver
+        run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
       - name: Conda Install
         working-directory: conda


### PR DESCRIPTION
### Description

Miniforge currently ships conda-libmamba-solver 26.4.0, which has a sqlite database locking bug in `shards_cache.py` (`sqlite3.OperationalError: database is locked`). The base conda that resolves test dependencies crashes before the test environment can even be set up.

Example failure: https://github.com/conda/conda/actions/runs/25867286560/job/76012696400?pr=16096

The `>=26.4.1` pin in `tests/requirements.txt` only upgrades c-l-s *into* the env, but the solver *doing the resolving* is still the base 26.4.0 from the installer.

This adds a `conda install -n base --yes "conda-libmamba-solver>=26.4.1"` step after each `setup-miniconda` and before the main `conda install` in all seven test jobs.

Temporary workaround until miniforge ships c-l-s >=26.4.1 (conda-forge/miniforge#878).

Relates to #16083.

### Checklist - did you ...

- [ ] ~Add a file to the `news` directory~ (CI-only change, no user-facing impact)
- [ ] ~Add / update necessary tests?~ (CI workflow change)
- [ ] ~Add / update outdated documentation?~ (not applicable)