### PR TITLE
Skip concurrent sqlite writer test on macOS Intel

### DIFF
--- a/tests/shards/test_cache.py
+++ b/tests/shards/test_cache.py
@@ -4,11 +4,14 @@
 
 from __future__ import annotations
 
+import platform
 import threading
 
+import pytest
 import zstandard
 
 from conda._private.shards.cache import AnnotatedRawShard, ShardCache
+from conda.common.compat import on_mac
 
 
 class TestCacheWALMode:
@@ -76,6 +79,10 @@ class TestCacheWALMode:
         # No sqlite3.OperationalError from either thread
         assert errors == []
 
+    @pytest.mark.skipif(
+        on_mac and platform.machine() == "x86_64",
+        reason="concurrent sqlite writes segfault on macOS Intel (#16083)",
+    )
     def test_shards_cache_concurrent_multiple_writers(self, tmp_path):
         """Multiple concurrent writers must not raise OperationalError."""
         import msgpack


### PR DESCRIPTION
### Description

Skip `test_shards_cache_concurrent_multiple_writers` on macOS Intel (osx-64) where it causes a native segfault in the sqlite WAL writer lock mechanism during concurrent writes.

The test was added in #16058 and creates 3 writer threads doing 50 concurrent INSERTs to the same WAL-mode sqlite database. On `macos-15-intel` runners (Python 3.10, libsqlite 3.53.1), this triggers a non-deterministic race condition that kills the entire pytest process -- all subsequent test results are lost.

The crash is platform-specific (macOS ARM64, Linux, and Windows are unaffected) and cannot be caught with `xfail` since it's a native segfault. The single reader+writer concurrent test continues to validate WAL mode concurrency on all platforms.

Refs: #16083

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     ~Not applicable -- test-only change with no user-facing impact.~
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ Not applicable.