### PR TITLE
Add iter_records_v3() to yield unique keys, return v3 repodata instead of existing Shards.iter_records() API

### DIFF
--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -336,25 +336,27 @@ class ShardBase(abc.ABC):
 
     def iter_records_v3(self) -> Iterable[tuple[tuple[str, str], dict]]:
         """
-        Yield ((filename, section), record) tuples for all packages in visited shards.
+        Yield ((key, section), record) tuples for all packages in visited
+        shards.
 
-        Section can be:
-        - "packages" for .tar.bz2 packages
-        - "packages.conda" for .conda packages
-        - "v3.whl", "v3.conda", "v3.tar.bz2" for v3 packages
+        Section can be: "packages" for .tar.bz2 packages, "packages.conda"
+        for .conda packages, "v3.whl", "v3.conda", "v3.tar.bz2" for v3 packages.
+
+        key is the same as the filename for "packages", "packages.conda" but is
+        different from the filename for v3 packages.
         """
         for shard in self.visited.values():
             if shard is None:
                 continue
             # Classic packages
             for package_group in ("packages", "packages.conda"):
-                for filename, record in shard.get(package_group, {}).items():
-                    yield (filename, package_group), record
+                for key, record in shard.get(package_group, {}).items():
+                    yield (key, package_group), record
             # v3 packages (iter_records() method depends on these coming last)
             for section_name, group in shard.get("v3", {}).items():
                 v3_section = f"v3.{section_name}"
-                for package_key, record in group.items():
-                    yield (package_key, v3_section), record
+                for key, record in group.items():
+                    yield (key, v3_section), record
 
 
 class ShardLike(ShardBase):

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -326,6 +326,8 @@ class ShardBase(abc.ABC):
     def iter_records(self) -> Iterable[tuple[str, dict]]:
         """
         Yield (filename, record) tuples for all packages in visited shards.
+        For v3 packages, appends the section name as an extension (e.g., '.whl')
+        to preserve the original package type information.
         """
         repodata = self.build_repodata()
         for package_group in ("packages", "packages.conda"):
@@ -333,8 +335,10 @@ class ShardBase(abc.ABC):
         for shard in self.visited.values():
             if shard is None:
                 continue
-            for group in shard.get("v3", {}).values():
-                yield from group.items()
+            for section_name, group in shard.get("v3", {}).items():
+                for package_key, record in group.items():
+                    # Append section name as extension to preserve package type
+                    yield f"{package_key}.{section_name}", record
 
 
 class ShardLike(ShardBase):

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -720,11 +720,13 @@ def batch_retrieve_from_cache(
     for shardlike in sharded:
         for package_name in packages:
             if package_name in shardlike:  # and not package_name in shardlike.visited
-                wanted.append((
-                    shardlike,
-                    package_name,
-                    shardlike.shard_url(package_name),
-                ))
+                wanted.append(
+                    (
+                        shardlike,
+                        package_name,
+                        shardlike.shard_url(package_name),
+                    )
+                )
 
     log.debug("%d shards to fetch", len(wanted))
 

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -309,7 +309,9 @@ class ShardBase(abc.ABC):
         """
         Return monolithic repodata including all visited shards.
 
-        Prefer iter_records() over this method.
+        Does not return "v3" repodata.
+
+        Prefer iter_records_v3() over this method.
         """
         repodata: RepodataDict = {
             **self.repodata_no_packages,
@@ -323,7 +325,16 @@ class ShardBase(abc.ABC):
                 repodata[package_group].update(shard[package_group])
         return repodata
 
-    def iter_records(self) -> Iterable[tuple[tuple[str, str], dict]]:
+    def iter_records(self) -> Iterable[tuple[str, dict]]:
+        """
+        Yield (filename, record) tuples for all packages in visited shards.
+        """
+        for (filename, section), record in self.iter_records_v3():
+            if section not in ("packages", "packages.conda"):
+                continue
+            yield filename, record
+
+    def iter_records_v3(self) -> Iterable[tuple[tuple[str, str], dict]]:
         """
         Yield ((filename, section), record) tuples for all packages in visited shards.
 
@@ -339,7 +350,7 @@ class ShardBase(abc.ABC):
             for package_group in ("packages", "packages.conda"):
                 for filename, record in shard.get(package_group, {}).items():
                     yield (filename, package_group), record
-            # v3 packages
+            # v3 packages (iter_records() method depends on these coming last)
             for section_name, group in shard.get("v3", {}).items():
                 v3_section = f"v3.{section_name}"
                 for package_key, record in group.items():
@@ -707,9 +718,11 @@ def batch_retrieve_from_cache(
     for shardlike in sharded:
         for package_name in packages:
             if package_name in shardlike:  # and not package_name in shardlike.visited
-                wanted.append(
-                    (shardlike, package_name, shardlike.shard_url(package_name))
-                )
+                wanted.append((
+                    shardlike,
+                    package_name,
+                    shardlike.shard_url(package_name),
+                ))
 
     log.debug("%d shards to fetch", len(wanted))
 

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -323,22 +323,27 @@ class ShardBase(abc.ABC):
                 repodata[package_group].update(shard[package_group])
         return repodata
 
-    def iter_records(self) -> Iterable[tuple[str, dict]]:
+    def iter_records(self) -> Iterable[tuple[tuple[str, str], dict]]:
         """
-        Yield (filename, record) tuples for all packages in visited shards.
-        For v3 packages, appends the section name as an extension (e.g., '.whl')
-        to preserve the original package type information.
+        Yield ((filename, section), record) tuples for all packages in visited shards.
+
+        Section can be:
+        - "packages" for .tar.bz2 packages
+        - "packages.conda" for .conda packages
+        - "v3.whl", "v3.conda", "v3.tar.bz2" for v3 packages
         """
-        repodata = self.build_repodata()
-        for package_group in ("packages", "packages.conda"):
-            yield from repodata.get(package_group, {}).items()
         for shard in self.visited.values():
             if shard is None:
                 continue
+            # Classic packages
+            for package_group in ("packages", "packages.conda"):
+                for filename, record in shard.get(package_group, {}).items():
+                    yield (filename, package_group), record
+            # v3 packages
             for section_name, group in shard.get("v3", {}).items():
+                v3_section = f"v3.{section_name}"
                 for package_key, record in group.items():
-                    # Append section name as extension to preserve package type
-                    yield f"{package_key}.{section_name}", record
+                    yield (package_key, v3_section), record
 
 
 class ShardLike(ShardBase):

--- a/conda/_private/shards/typing.py
+++ b/conda/_private/shards/typing.py
@@ -38,6 +38,7 @@ ShardDict = TypedDict(
     {
         "packages": dict[str, PackageRecordDict],
         "packages.conda": dict[str, PackageRecordDict],
+        "v3": NotRequired[dict[str, dict[str, PackageRecordDict]]],
     },
 )
 

--- a/conda/_private/shards/typing.py
+++ b/conda/_private/shards/typing.py
@@ -33,14 +33,17 @@ class PackageRecordDict(TypedDict):
 
 
 # in this style because "packages.conda" is not a Python identifier
-ShardDict = TypedDict(
-    "ShardDict",
+_ShardDictBase = TypedDict(
+    "_ShardDictBase",
     {
         "packages": dict[str, PackageRecordDict],
         "packages.conda": dict[str, PackageRecordDict],
-        "v3": NotRequired[dict[str, dict[str, PackageRecordDict]]],
     },
 )
+
+
+class ShardDict(_ShardDictBase, total=False):
+    v3: dict[str, dict[str, PackageRecordDict]]
 
 
 class RepodataInfoDict(TypedDict):

--- a/conda/gateways/shards/typing.py
+++ b/conda/gateways/shards/typing.py
@@ -25,12 +25,14 @@ class Shards(typing.Protocol):
 
     def iter_records_v3(self) -> Iterable[tuple[tuple[str, str], dict]]:
         """
-        Yield ((filename, section), record) tuples for all packages in visited shards.
+        Yield ((key, section), record) tuples for all packages in visited
+        shards.
 
-        Section can be:
-        - "packages" for .tar.bz2 packages
-        - "packages.conda" for .conda packages
-        - "v3.whl", "v3.conda", "v3.tar.bz2" for v3 packages
+        Section can be: "packages" for .tar.bz2 packages, "packages.conda"
+        for .conda packages, "v3.whl", "v3.conda", "v3.tar.bz2" for v3 packages.
+
+        key is the same as the filename for "packages", "packages.conda" but is
+        different from the filename for v3 packages.
         """
 
 

--- a/conda/gateways/shards/typing.py
+++ b/conda/gateways/shards/typing.py
@@ -18,7 +18,12 @@ class Shards(typing.Protocol):
     def __contains__(self, package: str) -> bool:
         """Check if a package is available in this shard collection."""
 
-    def iter_records(self) -> Iterator[tuple[tuple[str, str], dict]]:
+    def iter_records(self) -> Iterator[tuple[str, dict]]:
+        """
+        Yield (filename, record) tuples for all packages in visited shards.
+        """
+
+    def iter_records_v3(self) -> Iterable[tuple[tuple[str, str], dict]]:
         """
         Yield ((filename, section), record) tuples for all packages in visited shards.
 

--- a/conda/gateways/shards/typing.py
+++ b/conda/gateways/shards/typing.py
@@ -18,11 +18,14 @@ class Shards(typing.Protocol):
     def __contains__(self, package: str) -> bool:
         """Check if a package is available in this shard collection."""
 
-    def iter_records(self) -> Iterator[tuple[str, dict]]:
+    def iter_records(self) -> Iterator[tuple[tuple[str, str], dict]]:
         """
-        Yield (filename, record) tuples for all packages in visited shards.
-        For v3 packages, the filename includes the section name as an extension
-        (e.g., '.whl') to preserve package type information.
+        Yield ((filename, section), record) tuples for all packages in visited shards.
+
+        Section can be:
+        - "packages" for .tar.bz2 packages
+        - "packages.conda" for .conda packages
+        - "v3.whl", "v3.conda", "v3.tar.bz2" for v3 packages
         """
 
 

--- a/conda/gateways/shards/typing.py
+++ b/conda/gateways/shards/typing.py
@@ -21,6 +21,8 @@ class Shards(typing.Protocol):
     def iter_records(self) -> Iterator[tuple[str, dict]]:
         """
         Yield (filename, record) tuples for all packages in visited shards.
+        For v3 packages, the filename includes the section name as an extension
+        (e.g., '.whl') to preserve package type information.
         """
 
 

--- a/news/shards-v3-unique-keys
+++ b/news/shards-v3-unique-keys
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* In v3 sharded repodata, yield unique keys from `Shards.iter_records()`
+  by appending section name (package extension) to keys. (`iter_records()`
+  yields key, value pairs). #16099
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/shards-v3-unique-keys
+++ b/news/shards-v3-unique-keys
@@ -5,8 +5,7 @@
 ### Bug fixes
 
 * In v3 sharded repodata, yield unique keys from `Shards.iter_records()`
-  by yielding (package, section_name) keys from (`iter_records()`
-  yields key, value pairs). #16099
+  by yielding (package, section_name) keys from `iter_records()`. #16099
 
 ### Deprecations
 

--- a/news/shards-v3-unique-keys
+++ b/news/shards-v3-unique-keys
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 * In v3 sharded repodata, yield unique keys from `Shards.iter_records()`
-  by appending section name (package extension) to keys. (`iter_records()`
+  by yielding (package, section_name) keys from (`iter_records()`
   yields key, value pairs). #16099
 
 ### Deprecations

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -489,15 +489,13 @@ def test_shards_base_url():
 
 
 def test_shard_mentioned_packages_2():
-    assert set(shard_mentioned_packages(FAKE_SHARD)) == set(
-        (
-            "bar",
-            "baz",
-            "quux",
-            # "splat", # omit constrains
-            "warble",
-        )
-    )
+    assert set(shard_mentioned_packages(FAKE_SHARD)) == set((
+        "bar",
+        "baz",
+        "quux",
+        # "splat", # omit constrains
+        "warble",
+    ))
 
     # check that the bytes hash was converted to hex
     assert (
@@ -531,15 +529,13 @@ def _v3_shard(groups: dict) -> dict:
 
 
 def test_shard_mentioned_packages_v3_depends():
-    shard = _v3_shard(
-        {
-            "conda": {
-                "cpython-3.12.0-0": {
-                    "depends": ["openssl >=3", "libffi >=3.4"],
-                },
-            }
+    shard = _v3_shard({
+        "conda": {
+            "cpython-3.12.0-0": {
+                "depends": ["openssl >=3", "libffi >=3.4"],
+            },
         }
-    )
+    })
     names = list(shard_mentioned_packages(shard, repodata_version=3))
     assert "openssl" in names
     assert "libffi" in names
@@ -547,14 +543,12 @@ def test_shard_mentioned_packages_v3_depends():
 
 def test_shard_mentioned_packages_v3_deduplication_within_v3():
     # two records in the same v3 group share a dep spec
-    shard = _v3_shard(
-        {
-            "whl": {
-                "pkgA-1.0-py3_none_any_0": {"depends": ["openssl >=3"]},
-                "pkgA-2.0-py3_none_any_0": {"depends": ["openssl >=3"]},
-            }
+    shard = _v3_shard({
+        "whl": {
+            "pkgA-1.0-py3_none_any_0": {"depends": ["openssl >=3"]},
+            "pkgA-2.0-py3_none_any_0": {"depends": ["openssl >=3"]},
         }
-    )
+    })
     names = list(shard_mentioned_packages(shard, repodata_version=3))
     assert names.count("openssl") == 1
 
@@ -952,9 +946,11 @@ def test_shardlike():
 
 
 def test_iter_records_classic():
-    shardlike = ShardLike(
-        {"packages": {}, "packages.conda": {}, "info": {"base_url": ""}}
-    )
+    shardlike = ShardLike({
+        "packages": {},
+        "packages.conda": {},
+        "info": {"base_url": ""},
+    })
     shardlike.visit_shard(
         "mypkg",
         {
@@ -962,15 +958,17 @@ def test_iter_records_classic():
             "packages.conda": {"mypkg-1.0-0.conda": {"name": "mypkg"}},
         },
     )
-    records = {(fn, sec): rec for (fn, sec), rec in shardlike.iter_records()}
-    assert ("mypkg-1.0-0.tar.bz2", "packages") in records
-    assert ("mypkg-1.0-0.conda", "packages.conda") in records
+    records = dict(shardlike.iter_records())
+    assert "mypkg-1.0-0.tar.bz2" in records
+    assert "mypkg-1.0-0.conda" in records
 
 
 def test_iter_records_v3():
-    shardlike = ShardLike(
-        {"packages": {}, "packages.conda": {}, "info": {"base_url": ""}}
-    )
+    shardlike = ShardLike({
+        "packages": {},
+        "packages.conda": {},
+        "info": {"base_url": ""},
+    })
     shardlike.visit_shard(
         "mypkg",
         {
@@ -988,7 +986,7 @@ def test_iter_records_v3():
     )
     # None entries in visited must not raise
     shardlike.visited["ghost"] = None
-    records = {(fn, sec): rec for (fn, sec), rec in shardlike.iter_records()}
+    records = dict(shardlike.iter_records_v3())
     assert ("mypkg-1.0-0.conda", "packages.conda") in records
     assert ("mypkg-1.0-py312_none_any_0", "v3.whl") in records
     assert records[("mypkg-1.0-py312_none_any_0", "v3.whl")]["name"] == "mypkg"
@@ -1124,9 +1122,9 @@ def test_shard_cache_multiple_profile(retrieval_type, mock_cache: MockCache):
     `shards_cache.retrieve_multiple should be faster than `shards_cache.retrieve`.
     """
     if retrieval_type == "retrieve_multiple":
-        retrieved = mock_cache.cache.retrieve_multiple(
-            [shard.url for shard in mock_cache.shards]
-        )
+        retrieved = mock_cache.cache.retrieve_multiple([
+            shard.url for shard in mock_cache.shards
+        ])
         assert len(retrieved) == mock_cache.num_shards
 
     elif retrieval_type == "retrieve_single":

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -990,8 +990,8 @@ def test_iter_records_v3():
     shardlike.visited["ghost"] = None
     records = dict(shardlike.iter_records())
     assert "mypkg-1.0-0.conda" in records
-    assert "mypkg-1.0-py312_none_any_0" in records
-    assert records["mypkg-1.0-py312_none_any_0"]["name"] == "mypkg"
+    assert "mypkg-1.0-py312_none_any_0.whl" in records
+    assert records["mypkg-1.0-py312_none_any_0.whl"]["name"] == "mypkg"
 
 
 def test_shardlike_repr():

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -489,13 +489,15 @@ def test_shards_base_url():
 
 
 def test_shard_mentioned_packages_2():
-    assert set(shard_mentioned_packages(FAKE_SHARD)) == set((
-        "bar",
-        "baz",
-        "quux",
-        # "splat", # omit constrains
-        "warble",
-    ))
+    assert set(shard_mentioned_packages(FAKE_SHARD)) == set(
+        (
+            "bar",
+            "baz",
+            "quux",
+            # "splat", # omit constrains
+            "warble",
+        )
+    )
 
     # check that the bytes hash was converted to hex
     assert (
@@ -529,13 +531,15 @@ def _v3_shard(groups: dict) -> dict:
 
 
 def test_shard_mentioned_packages_v3_depends():
-    shard = _v3_shard({
-        "conda": {
-            "cpython-3.12.0-0": {
-                "depends": ["openssl >=3", "libffi >=3.4"],
-            },
+    shard = _v3_shard(
+        {
+            "conda": {
+                "cpython-3.12.0-0": {
+                    "depends": ["openssl >=3", "libffi >=3.4"],
+                },
+            }
         }
-    })
+    )
     names = list(shard_mentioned_packages(shard, repodata_version=3))
     assert "openssl" in names
     assert "libffi" in names
@@ -543,12 +547,14 @@ def test_shard_mentioned_packages_v3_depends():
 
 def test_shard_mentioned_packages_v3_deduplication_within_v3():
     # two records in the same v3 group share a dep spec
-    shard = _v3_shard({
-        "whl": {
-            "pkgA-1.0-py3_none_any_0": {"depends": ["openssl >=3"]},
-            "pkgA-2.0-py3_none_any_0": {"depends": ["openssl >=3"]},
+    shard = _v3_shard(
+        {
+            "whl": {
+                "pkgA-1.0-py3_none_any_0": {"depends": ["openssl >=3"]},
+                "pkgA-2.0-py3_none_any_0": {"depends": ["openssl >=3"]},
+            }
         }
-    })
+    )
     names = list(shard_mentioned_packages(shard, repodata_version=3))
     assert names.count("openssl") == 1
 
@@ -946,11 +952,13 @@ def test_shardlike():
 
 
 def test_iter_records_classic():
-    shardlike = ShardLike({
-        "packages": {},
-        "packages.conda": {},
-        "info": {"base_url": ""},
-    })
+    shardlike = ShardLike(
+        {
+            "packages": {},
+            "packages.conda": {},
+            "info": {"base_url": ""},
+        }
+    )
     shardlike.visit_shard(
         "mypkg",
         {
@@ -964,11 +972,13 @@ def test_iter_records_classic():
 
 
 def test_iter_records_v3():
-    shardlike = ShardLike({
-        "packages": {},
-        "packages.conda": {},
-        "info": {"base_url": ""},
-    })
+    shardlike = ShardLike(
+        {
+            "packages": {},
+            "packages.conda": {},
+            "info": {"base_url": ""},
+        }
+    )
     shardlike.visit_shard(
         "mypkg",
         {
@@ -1122,9 +1132,9 @@ def test_shard_cache_multiple_profile(retrieval_type, mock_cache: MockCache):
     `shards_cache.retrieve_multiple should be faster than `shards_cache.retrieve`.
     """
     if retrieval_type == "retrieve_multiple":
-        retrieved = mock_cache.cache.retrieve_multiple([
-            shard.url for shard in mock_cache.shards
-        ])
+        retrieved = mock_cache.cache.retrieve_multiple(
+            [shard.url for shard in mock_cache.shards]
+        )
         assert len(retrieved) == mock_cache.num_shards
 
     elif retrieval_type == "retrieve_single":

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -962,9 +962,9 @@ def test_iter_records_classic():
             "packages.conda": {"mypkg-1.0-0.conda": {"name": "mypkg"}},
         },
     )
-    records = dict(shardlike.iter_records())
-    assert "mypkg-1.0-0.tar.bz2" in records
-    assert "mypkg-1.0-0.conda" in records
+    records = {(fn, sec): rec for (fn, sec), rec in shardlike.iter_records()}
+    assert ("mypkg-1.0-0.tar.bz2", "packages") in records
+    assert ("mypkg-1.0-0.conda", "packages.conda") in records
 
 
 def test_iter_records_v3():
@@ -988,10 +988,10 @@ def test_iter_records_v3():
     )
     # None entries in visited must not raise
     shardlike.visited["ghost"] = None
-    records = dict(shardlike.iter_records())
-    assert "mypkg-1.0-0.conda" in records
-    assert "mypkg-1.0-py312_none_any_0.whl" in records
-    assert records["mypkg-1.0-py312_none_any_0.whl"]["name"] == "mypkg"
+    records = {(fn, sec): rec for (fn, sec), rec in shardlike.iter_records()}
+    assert ("mypkg-1.0-0.conda", "packages.conda") in records
+    assert ("mypkg-1.0-py312_none_any_0", "v3.whl") in records
+    assert records[("mypkg-1.0-py312_none_any_0", "v3.whl")]["name"] == "mypkg"
 
 
 def test_shardlike_repr():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

When iterating over (key, package record) in an individual Shards representing one channel, it would be better if each channel had unique keys. Append extension (section name) to each key in "v3".

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
