### PR TITLE
Fix `--experimental` deprecation

### DIFF
--- a/conda/cli/conda_argparse.py
+++ b/conda/cli/conda_argparse.py
@@ -98,6 +98,7 @@ BUILTIN_COMMANDS = {
 
 def generate_pre_parser(**kwargs) -> ArgumentParser:
     pre_parser = ArgumentParser(
+        prog="conda",
         description="conda is a tool for managing and deploying applications,"
         " environments and packages.",
         **kwargs,

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -310,8 +310,8 @@ def add_parser_channels(p: ArgumentParser) -> _ArgumentGroup:
     channel_customization_options.add_argument(
         "--experimental",
         action=deprecated.action(
-            "26.3",
-            "26.5",
+            "26.9",
+            "27.3",
             _AppendAction,
             addendum="Deprecated: jlap and lock no longer supported.",
         ),

--- a/tests/cli/test_all_commands.py
+++ b/tests/cli/test_all_commands.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.cli.helpers import add_parser_environment_specifier
-from conda.deprecations import DeprecatedError, DeprecationHandler
 from conda.exceptions import ChannelDenied
 
 if TYPE_CHECKING:
@@ -87,115 +86,41 @@ def test_commands_with_plugin_backed_options(
     assert err_message in captured.err
 
 
-_FAKE_SPECIFIER = "yaml"
-"""
-A fake environment-specifier plugin name used as a valid choice in tests.
-"""
-
-_ENV_SPEC_FLAGS = pytest.mark.parametrize(
-    "flag", ["--environment-specifier", "--env-spec"]
+@pytest.mark.parametrize(
+    "flag",
+    ["--environment-specifier", "--env-spec"],
 )
-"""
-Parametrize over both flag aliases so both are covered.
-"""
-
-
-def _make_parser(mocker: MockerFixture, handler: DeprecationHandler) -> ArgumentParser:
-    """Return a fresh ArgumentParser with the environment-specifier arguments
-    registered, using the given *handler* as the ``deprecated`` singleton and
-    a single fake specifier choice so validation passes.
-
-    TODO: Remove test before 26.9.0 release
-    """
-    # Replace the module-level `deprecated` object so the action is built with
-    # the version embedded in *handler* rather than the real conda version.
-    mocker.patch("conda.cli.helpers.deprecated", handler)
-
+def test_env_spec_deprecation(mocker: MockerFixture, flag: str) -> None:
     # Provide a known valid choice so LazyChoicesAction does not reject it.
+    specifier = "yaml"
     mocker.patch(
         "conda.base.context.context.plugin_manager.get_environment_specifiers",
-        return_value=[_FAKE_SPECIFIER],
+        return_value=[specifier],
     )
 
     parser = ArgumentParser()
     add_parser_environment_specifier(parser)
-    return parser
 
+    with pytest.deprecated_call():
+        parser.parse_args([flag, specifier])
 
-@_ENV_SPEC_FLAGS
-def test_env_spec_deprecation_pending(mocker: MockerFixture, flag: str) -> None:
-    """
-    Before 26.5 the flag emits a ``PendingDeprecationWarning``.
-
-    TODO: Remove test before 26.9.0 release
-    """
-    parser = _make_parser(mocker, DeprecationHandler("26.3"))
-
-    with pytest.warns(PendingDeprecationWarning, match="pending deprecation"):
-        parser.parse_args([flag, _FAKE_SPECIFIER])
-
-
-@_ENV_SPEC_FLAGS
-def test_env_spec_deprecation_active(mocker: MockerFixture, flag: str) -> None:
-    """
-    From 26.9 onwards the flag emits a ``FutureWarning`` (active deprecation).
-
-    TODO: Remove test before 27.3.0 release
-    """
-    parser = _make_parser(mocker, DeprecationHandler("26.9"))
-
-    with pytest.warns(FutureWarning, match="deprecated"):
-        parser.parse_args([flag, _FAKE_SPECIFIER])
-
-
-def test_env_spec_deprecation_removal(mocker: MockerFixture) -> None:
-    """
-    At 27.3 the option should no longer exist: building the parser raises
-    ``DeprecatedError`` to alert developers that the dead code must be removed.
-
-    TODO: Remove test before  27.3.0 release
-    """
-    mocker.patch("conda.cli.helpers.deprecated", DeprecationHandler("27.3"))
-    mocker.patch(
-        "conda.base.context.context.plugin_manager.get_environment_specifiers",
-        return_value=[_FAKE_SPECIFIER],
-    )
-
-    parser = ArgumentParser()
-    with pytest.raises(DeprecatedError):
-        add_parser_environment_specifier(parser)
-
-
-def test_env_spec_no_warning_when_not_used(mocker: MockerFixture) -> None:
-    """
-    Passing ``--format`` (the replacement flag) must not trigger any
-    deprecation warning, even when the deprecated handler is at the active
-    version.
-
-    TODO: Remove before 27.3.0 release
-    """
-    parser = _make_parser(mocker, DeprecationHandler("26.9"))
-
-    # pytest.warns(None) would raise in newer pytest when *no* warning fires;
-    # use warnings.catch_warnings to assert silence instead.
+    # no deprecation warning when unused
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
-        # --format stores into the same dest; should not raise
-        parser.parse_args(["--format", _FAKE_SPECIFIER])
+        parser.parse_args(["--format", specifier])
 
 
 @pytest.mark.parametrize(
-    ("command"),
-    ("activate", "deactivate"),
+    "command",
+    ["activate", "deactivate"],
 )
 def test_activate_help_commands_exit_0_rc(
     conda_cli: CondaCLIFixture,
     command: str,
 ):
     """Ensure that conda returns a 0 error code when cli --help is called"""
-    with pytest.raises(SystemExit):
-        stdout, stderr, rc = conda_cli(command, "-h")
-        assert rc == 0, f"conda {command} failed ({rc}): {stderr}"
-        assert f"usage: conda {command}" in stdout
-        assert not re.search(r"\berror\b", stdout, re.IGNORECASE)
-        assert not re.search(r"\berror\b", stderr, re.IGNORECASE)
+    stdout, stderr, rc = conda_cli(command, "-h", raises=SystemExit)
+    assert rc == 0, f"conda {command} failed ({rc}): {stderr}"
+    assert f"usage: conda {command}" in stdout
+    assert not re.search(r"\berror\b", stdout, re.IGNORECASE)
+    assert not re.search(r"\berror\b", stderr, re.IGNORECASE)

--- a/tests/cli/test_all_commands.py
+++ b/tests/cli/test_all_commands.py
@@ -119,8 +119,8 @@ def test_activate_help_commands_exit_0_rc(
     command: str,
 ):
     """Ensure that conda returns a 0 error code when cli --help is called"""
-    stdout, stderr, rc = conda_cli(command, "-h", raises=SystemExit)
-    assert rc == 0, f"conda {command} failed ({rc}): {stderr}"
+    stdout, stderr, exc = conda_cli(command, "-h", raises=SystemExit)
+    assert exc.value.code == 0, f"conda {command} failed ({exc.value.code}): {stderr}"
     assert f"usage: conda {command}" in stdout
     assert not re.search(r"\berror\b", stdout, re.IGNORECASE)
     assert not re.search(r"\berror\b", stderr, re.IGNORECASE)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Resolves https://github.com/conda/conda/issues/16100

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~ Skipping news since this deprecation was in the last release (26.3.x)
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
