### PR TITLE
bugfix: MatchSpec parsing error fix (`AttributeError`)

### DIFF
--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -394,7 +394,10 @@ class MatchSpec(metaclass=MatchSpecType):
         return True
 
     def _match_individual(self, record, field_name, match_component):
-        val = getattr(record, field_name)
+        # Use getattr with a default of None so that MatchSpec fields that are
+        # not yet present on PackageRecord (e.g. "extras") do not raise
+        # AttributeError and instead evaluate as a non-match.  See GH-16016.
+        val = getattr(record, field_name, None)
         try:
             return match_component.match(val)
         except AttributeError:

--- a/conda/models/match_spec.py
+++ b/conda/models/match_spec.py
@@ -297,7 +297,7 @@ class MatchSpec(metaclass=MatchSpecType):
         "license_family",
         "fn",
         "when",  # str
-        "extras",  # str | list[str]
+        "extras",  # str | list[str] — names of requested extras; matched against dict[str, list[str]] keys on PackageRecord
         "flags",  # str | list[str]
     )
     FIELD_NAMES_SET = frozenset(FIELD_NAMES)
@@ -1574,6 +1574,31 @@ class ListOfStrMatch(MatchInterface):
         return self._raw_value
 
 
+class ExtrasMatch(ListOfStrMatch):
+    """Matcher for the ``extras`` bracket field.
+
+    The MatchSpec stores the *requested* extra names as a tuple of strings.
+    A PackageRecord stores ``extras`` as a ``dict[str, list[str]]`` mapping each
+    extra-group name to its dependency strings.
+
+    A record matches when every requested extra name is a key in the record's
+    extras dict (subset check).  A record with ``extras=None`` or an empty dict
+    never matches a non-empty extras spec.
+    """
+
+    def match(self, other):
+        if not self._raw_value:
+            # empty spec matches everything
+            return True
+        if not other:
+            return False
+        if isinstance(other, dict):
+            return all(k in other for k in self._raw_value)
+        # fall back: treat other as a flat iterable of strings (e.g. old-style records)
+        other_set = set(self._convert(other))
+        return all(k in other_set for k in self._raw_value)
+
+
 class ChannelMatch(GlobStrMatch):
     def __init__(self, value):
         self._re_match = None
@@ -1645,5 +1670,5 @@ _implementors = {
     # TODO: These needs their own classes for matching and merging
     "when": CaseInsensitiveStrMatch,  # FIXME: Merge should be possible, matching is not
     "flags": ListOfStrMatch,  # FIXME: Must accept globs too, unordered subsets
-    "extras": ListOfStrMatch,  # FIXME: We are matching dicts on keys only
+    "extras": ExtrasMatch,  # subset check: requested extra names must be keys in record's extras dict
 }

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -26,6 +26,7 @@ from ..auxlib.entity import (
     DictSafeMixin,
     Entity,
     EnumField,
+    Field,
     IntegerField,
     ListField,
     NumberField,
@@ -118,6 +119,44 @@ class _FeaturesField(ListField):
             return " ".join(val)
         else:
             return val or ()  # default value is (), and default_in_dump=False
+
+
+class _ExtrasField(Field):
+    """Field for ``extras``: stores ``dict[str, list[str]]`` (PEP 508 extras groups).
+
+    On the record the value is ``None`` when not set (and therefore omitted from
+    serialization when *default_in_dump=False*), or a plain ``dict`` mapping each
+    extra-group name to its list of dependency strings.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(default=None, nullable=True, **kwargs)
+
+    def box(self, instance, instance_type, val):
+        if val is None:
+            return None
+        if isinstance(val, dict):
+            return {k: list(v) for k, v in val.items()}
+        raise ValueError(
+            f"extras must be a dict[str, list[str]], got {type(val).__name__!r}"
+        )
+
+    def unbox(self, instance, instance_type, val):
+        return val
+
+    def dump(self, instance, instance_type, val):
+        if val is None:
+            return None
+        return {k: list(v) for k, v in val.items()}
+
+    def validate(self, instance, val):
+        if val is None:
+            return val
+        if not isinstance(val, dict):
+            raise ValueError(
+                f"extras must be a dict[str, list[str]], got {type(val).__name__!r}"
+            )
+        return val
 
 
 class ChannelField(ComposableField):
@@ -410,7 +449,7 @@ class PackageRecord(DictSafeMixin, Entity):
     constrains = ListField(str, default=())
 
     flags = ListField(str, default=(), required=False, default_in_dump=False)
-    extras = ListField(str, default=(), required=False, default_in_dump=False)
+    extras = _ExtrasField(required=False, default_in_dump=False)
 
     track_features = _FeaturesField(required=False, default=(), default_in_dump=False)
     features = _FeaturesField(required=False, default=(), default_in_dump=False)

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -410,6 +410,7 @@ class PackageRecord(DictSafeMixin, Entity):
     constrains = ListField(str, default=())
 
     flags = ListField(str, default=(), required=False, default_in_dump=False)
+    extras = ListField(str, default=(), required=False, default_in_dump=False)
 
     track_features = _FeaturesField(required=False, default=(), default_in_dump=False)
     features = _FeaturesField(required=False, default=(), default_in_dump=False)

--- a/news/16104-bugfix-for-matchspec-extras
+++ b/news/16104-bugfix-for-matchspec-extras
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Addresses a bug found in MatchSpec parsing where accessing `MatchSpec.extras` resulted in an `AttributeError` (#16104)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -35,6 +35,9 @@ def m(string) -> str:
 
 
 def DPkg(s, **kwargs):
+    """
+    Mock for creating Dist and PackageRecord objects.
+    """
     d = Dist(s)
     return PackageRecord(
         fn=d.to_filename(),
@@ -1818,6 +1821,37 @@ def test_extras_specs_match(match_spec_v3):
     assert MatchSpec("pkg[extras=[a, b]]").match(record)
     assert not MatchSpec("pkg[extras=[a, b, c]]").match(record)
     assert not MatchSpec("pkg[extras=c]").match(record)
+
+
+def test_package_record_extras_field_default(match_spec_v3):
+    """PackageRecord must expose an extras attribute that defaults to empty (GH-16016)."""
+    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2")
+    assert hasattr(rec, "extras")
+    assert rec.extras == () or rec.extras == []
+
+
+def test_package_record_extras_not_in_dump_when_empty(match_spec_v3):
+    """Empty extras must not appear in the serialized record (GH-16016)."""
+    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2")
+    assert "extras" not in rec.dist_fields_dump()
+
+
+def test_match_extras_no_attribute_error_on_plain_record(match_spec_v3):
+    """MatchSpec with extras must not raise AttributeError on a plain PackageRecord (GH-16016)."""
+    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2")
+    assert MatchSpec("pkg[extras=foo]").match(rec) is False
+
+
+def test_match_extras_record_with_matching_extras(match_spec_v3):
+    """A PackageRecord carrying matching extras must match the spec (GH-16016)."""
+    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2", extras=["group1"])
+    assert MatchSpec("pkg[extras=group1]").match(rec) is True
+
+
+def test_match_extras_record_with_non_matching_extras(match_spec_v3):
+    """A PackageRecord whose extras differ from the spec must not match (GH-16016)."""
+    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2", extras=["group1"])
+    assert MatchSpec("pkg[extras=other]").match(rec) is False
 
 
 def test_flags_specs(match_spec_v3):

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -1811,23 +1811,20 @@ def test_extras_specs_merge(match_spec_v3):
         MatchSpec.merge(["pkg[extras=[a]]", "pkg[extras=[b]]"], union=True)
 
 
-@pytest.mark.xfail(reason="Pending implementation")
 def test_extras_specs_match(match_spec_v3):
-    """
-    Extras match via 'set.issubset' on the dictionary keys
-    """
-    record = {"name": "pkg", "extras-depends": {"a": [], "b": []}}
-    assert MatchSpec("pkg[extras=a]").match()
-    assert MatchSpec("pkg[extras=[a, b]]").match(record)
-    assert not MatchSpec("pkg[extras=[a, b, c]]").match(record)
-    assert not MatchSpec("pkg[extras=c]").match(record)
+    """Extras match via subset check on the record's extras dict keys."""
+    rec_ab = DPkg("defaults::pkg-1.0-py313_0.tar.bz2", extras={"a": [], "b": []})
+    assert MatchSpec("pkg[extras=a]").match(rec_ab)
+    assert MatchSpec("pkg[extras=[a, b]]").match(rec_ab)
+    assert not MatchSpec("pkg[extras=[a, b, c]]").match(rec_ab)
+    assert not MatchSpec("pkg[extras=c]").match(rec_ab)
 
 
 def test_package_record_extras_field_default(match_spec_v3):
-    """PackageRecord must expose an extras attribute that defaults to empty (GH-16016)."""
+    """PackageRecord must expose an extras attribute that defaults to None when not set (GH-16016)."""
     rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2")
     assert hasattr(rec, "extras")
-    assert rec.extras == () or rec.extras == []
+    assert rec.extras is None
 
 
 def test_package_record_extras_not_in_dump_when_empty(match_spec_v3):
@@ -1844,13 +1841,13 @@ def test_match_extras_no_attribute_error_on_plain_record(match_spec_v3):
 
 def test_match_extras_record_with_matching_extras(match_spec_v3):
     """A PackageRecord carrying matching extras must match the spec (GH-16016)."""
-    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2", extras=["group1"])
+    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2", extras={"group1": []})
     assert MatchSpec("pkg[extras=group1]").match(rec) is True
 
 
 def test_match_extras_record_with_non_matching_extras(match_spec_v3):
     """A PackageRecord whose extras differ from the spec must not match (GH-16016)."""
-    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2", extras=["group1"])
+    rec = DPkg("defaults::pkg-1.0-py313_0.tar.bz2", extras={"group1": []})
     assert MatchSpec("pkg[extras=other]").match(rec) is False
 
 


### PR DESCRIPTION
### Description

This fixes an error encountered during [QA testing](https://github.com/conda/conda/issues/16016) for release 26.5.0 Scenario 8.

xref: #16073

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
