### PR TITLE
Cherry-pick: replace / with - for canary labels on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,9 @@ jobs:
               if not last_release.startswith(prefix):
                   envs["VERSION_OVERRIDE"] = f"{prefix}0"
 
+          # workaround for anaconda.org's 404 error when trying to install from a slash label
+          envs["ANACONDA_ORG_LABEL"] = envs["ANACONDA_ORG_LABEL"].replace("/", "-")
+
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 
       - name: Create & Upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,15 +101,15 @@ jobs:
           # e.g., `main` branch commits
           envs = {"ANACONDA_ORG_LABEL": "dev"}
 
+          _, name = "${{ github.repository }}".split("/")
+
           if "${{ github.event_name }}" == "pull_request":
-              # e.g., conda/conda/pr/123
-              envs["ANACONDA_ORG_LABEL"] = "${{ github.repository }}/pr/${{ github.event.number }}"
+              envs["ANACONDA_ORG_LABEL"] = f"{name}-pr-${{ github.event.number }}"
           elif "${{ env.REF_NAME }}".startswith("feature/"):
-              # e.g., conda/conda/feature/my-feature
-              envs["ANACONDA_ORG_LABEL"] = "${{ github.repository }}/${{ env.REF_NAME }}"
+              feature = "${{ env.REF_NAME }}".removeprefix("feature/")
+              envs["ANACONDA_ORG_LABEL"] = f"{name}-feature-{feature}"
           elif re.match(r"\d+(\.\d+)+\.x", "${{ env.REF_NAME }}"):
-              # e.g., conda/conda/rc/26.3.x
-              envs["ANACONDA_ORG_LABEL"] = f"${{ github.repository }}/rc/${{ env.REF_NAME }}"
+              envs["ANACONDA_ORG_LABEL"] = f"rc-{name}-${{ env.REF_NAME }}"
 
               # if no releases have occurred on this branch yet then `git describe --tag`
               # will misleadingly produce a version number relative to the last release
@@ -121,9 +121,6 @@ jobs:
               prefix = "${{ env.REF_NAME }}"[:-1]  # without x suffix
               if not last_release.startswith(prefix):
                   envs["VERSION_OVERRIDE"] = f"{prefix}0"
-
-          # workaround for anaconda.org's 404 error when trying to install from a slash label
-          envs["ANACONDA_ORG_LABEL"] = envs["ANACONDA_ORG_LABEL"].replace("/", "-")
 
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,18 +101,15 @@ jobs:
           # e.g., `main` branch commits
           envs = {"ANACONDA_ORG_LABEL": "dev"}
 
-          _, name = "${{ github.repository }}".split("/")
-
           if "${{ github.event_name }}" == "pull_request":
-              # e.g., conda-pr-123
-              envs["ANACONDA_ORG_LABEL"] = f"{name}-pr-${{ github.event.number }}"
+              # e.g., conda/conda/pr/123 -> conda-conda-pr-123
+              envs["ANACONDA_ORG_LABEL"] = "${{ github.repository }}/pr/${{ github.event.number }}"
           elif "${{ env.REF_NAME }}".startswith("feature/"):
-              # e.g., conda-feature-my-feature
-              feature = "${{ env.REF_NAME }}".removeprefix("feature/")
-              envs["ANACONDA_ORG_LABEL"] = f"{name}-feature-{feature}"
+              # e.g., conda/conda/feature/my-feature -> conda-conda-feature-my-feature
+              envs["ANACONDA_ORG_LABEL"] = "${{ github.repository }}/${{ env.REF_NAME }}"
           elif re.match(r"\d+(\.\d+)+\.x", "${{ env.REF_NAME }}"):
-              # e.g., rc-conda-26.5.x
-              envs["ANACONDA_ORG_LABEL"] = f"rc-{name}-${{ env.REF_NAME }}"
+              # e.g., conda/conda/rc/26.5.x -> conda-conda-rc-26.5.x
+              envs["ANACONDA_ORG_LABEL"] = f"${{ github.repository }}/rc/${{ env.REF_NAME }}"
 
               # if no releases have occurred on this branch yet then `git describe --tag`
               # will misleadingly produce a version number relative to the last release
@@ -124,6 +121,9 @@ jobs:
               prefix = "${{ env.REF_NAME }}"[:-1]  # without x suffix
               if not last_release.startswith(prefix):
                   envs["VERSION_OVERRIDE"] = f"{prefix}0"
+
+          # anaconda.org returns 404 for labels containing slashes
+          envs["ANACONDA_ORG_LABEL"] = envs["ANACONDA_ORG_LABEL"].replace("/", "-")
 
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,11 +104,14 @@ jobs:
           _, name = "${{ github.repository }}".split("/")
 
           if "${{ github.event_name }}" == "pull_request":
+              # e.g., conda-pr-123
               envs["ANACONDA_ORG_LABEL"] = f"{name}-pr-${{ github.event.number }}"
           elif "${{ env.REF_NAME }}".startswith("feature/"):
+              # e.g., conda-feature-my-feature
               feature = "${{ env.REF_NAME }}".removeprefix("feature/")
               envs["ANACONDA_ORG_LABEL"] = f"{name}-feature-{feature}"
           elif re.match(r"\d+(\.\d+)+\.x", "${{ env.REF_NAME }}"):
+              # e.g., rc-conda-26.5.x
               envs["ANACONDA_ORG_LABEL"] = f"rc-{name}-${{ env.REF_NAME }}"
 
               # if no releases have occurred on this branch yet then `git describe --tag`


### PR DESCRIPTION
### Description

Cherry-pick of #16105 to `main`. The canary build workflow (`build.yml`) runs from `main` even for release branch builds (via `workflow_run`), so the slash-to-dash fix is needed here too.

Without this, RC canary uploads use slash labels (e.g. `conda/conda/rc/26.5.x`) which anaconda.org returns 404 for.

### Checklist - did you ...

- [ ] ~Add a file to the `news` directory~ (CI-only change, no user-facing impact)
- [ ] ~Add / update necessary tests?~ (not applicable)
- [ ] ~Add / update outdated documentation?~ (not applicable)