### PR TITLE
Update canary label comments to show resolved formats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,13 +102,13 @@ jobs:
           envs = {"ANACONDA_ORG_LABEL": "dev"}
 
           if "${{ github.event_name }}" == "pull_request":
-              # e.g., conda/conda/pr/123
+              # e.g., conda/conda/pr/123 -> conda-conda-pr-123
               envs["ANACONDA_ORG_LABEL"] = "${{ github.repository }}/pr/${{ github.event.number }}"
           elif "${{ env.REF_NAME }}".startswith("feature/"):
-              # e.g., conda/conda/feature/my-feature
+              # e.g., conda/conda/feature/my-feature -> conda-conda-feature-my-feature
               envs["ANACONDA_ORG_LABEL"] = "${{ github.repository }}/${{ env.REF_NAME }}"
           elif re.match(r"\d+(\.\d+)+\.x", "${{ env.REF_NAME }}"):
-              # e.g., conda/conda/rc/26.3.x
+              # e.g., conda/conda/rc/26.5.x -> conda-conda-rc-26.5.x
               envs["ANACONDA_ORG_LABEL"] = f"${{ github.repository }}/rc/${{ env.REF_NAME }}"
 
               # if no releases have occurred on this branch yet then `git describe --tag`


### PR DESCRIPTION
### Description

Update inline comments in `build.yml` to show the resolved label formats after the `replace("/", "-")` step. This keeps the comments on `26.5.x` in sync with `main` (#16106).

Merging this will also trigger a fresh Tests run on `26.5.x`, which will trigger the first RC canary build with the working dash-separated labels.

### Checklist - did you ...

- [ ] ~Add a file to the `news` directory~ (comment-only change)
- [ ] ~Add / update necessary tests?~ (not applicable)
- [ ] ~Add / update outdated documentation?~ (not applicable)