### PR TITLE
Disable test_dont_remove_conda_3 for solvers not included in conda

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2366,6 +2366,11 @@ def test_dont_remove_conda_3(
     upgrades a dependency) it could produce spurious RemoveError, blocking
     further use of conda.
     """
+    if context.solver != "libmamba" or context.solver != "classic":
+        pytest.skip(
+            "This test can only be run with solvers that come shipped with conda"
+        )
+
     with tmp_env("conda", "conda-pypi") as prefix:
         monkeypatch.setenv("CONDA_ROOT_PREFIX", str(prefix))
         monkeypatch.setenv("CONDA_PREFIX", str(prefix))


### PR DESCRIPTION


### Description
This test uses a conda that is installed into a test environment. Only libmamba solver and the classic solver will be available in this environment. Skip the test for all other solvers.

Fixes c-r-s tests, for example https://github.com/conda/conda-rattler-solver/actions/runs/25950130711/job/76286263956?pr=61

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
