### PR TITLE
[GOLDEN SOLUTION] Implement `conda-meta/frozen` protections (CEP 22)

### DIFF
--- a/.helix/metadata.json
+++ b/.helix/metadata.json
@@ -1,0 +1,19 @@
+{
+  "problem_statement": "Implement support for frozen conda environment markers as described in CEP 22 (https://github.com/conda/ceps/blob/main/cep-0022.md).\n\nWhen a file named `conda-meta/frozen` exists inside a conda environment prefix, conda must prevent any modifications to that environment and raise an error. The frozen file can be empty, or it can contain a JSON document of the form `{\"message\": \"<reason>\"}` with a custom explanation.\n\nSpecific requirements:\n\n1. Add a constant `PREFIX_FROZEN_FILE = join(\"conda-meta\", \"frozen\")` in `conda/base/constants.py`.\n\n2. Add a `protect_frozen_envs` boolean configuration parameter (default `True`) to `conda/base/context.py` under the \"Environment Configuration\" category.\n\n3. Add a new exception class `EnvironmentIsFrozenError(CondaError)` in `conda/exceptions.py`. The error message must include:\n   - The prefix path that is frozen.\n   - The optional custom message from the frozen file (indented by 4 spaces under a \"Reason:\" header) if the frozen file contains JSON with a `\"message\"` key.\n   - The instruction: \"You can ignore this error with the `--override-frozen` flag, at your own risk.\"\n\n4. Add two methods to `PrefixData` in `conda/core/prefix_data.py`:\n   - `is_frozen() -> bool`: returns `True` if `conda-meta/frozen` exists as a file; catches `OSError` and returns `False`.\n   - `assert_not_frozen() -> None`: calls `assert_environment()`, returns early if not frozen, otherwise reads the frozen file content, parses optional JSON `message`, and raises `EnvironmentIsFrozenError`.\n\n5. Add a CLI argument `--override-frozen` (sets `protect_frozen_envs=False`) via a helper `add_parser_frozen_env(p)` in `conda/cli/helpers.py`.\n\n6. Wire `--override-frozen` into the argument parsers for: `conda install`, `conda update`, `conda remove`, `conda env update`, and `conda env remove`.\n\n7. Call `prefix_data.assert_not_frozen()` (guarded by `context.protect_frozen_envs`) at the right point in each of the following command execution paths:\n   - `validate_install_command()` in `conda/cli/install.py` — for install/update/remove (after the writable check).\n   - `execute()` in `conda/cli/main_remove.py` — directly before `check_non_admin()`.\n   - `execute()` in `conda/cli/main_env_update.py` — after checking `prefix_data.is_environment()`.\n\nThe override flag must use `action=\"store_false\"` with `dest=\"protect_frozen_envs\"` so passing `--override-frozen` disables the protection.",
+  "hints": [
+    "CEP 22 specification: https://github.com/conda/ceps/blob/main/cep-0022.md",
+    "The frozen file lives at `<prefix>/conda-meta/frozen` — same directory as `history` and `state`.",
+    "Use `action=\"store_false\"` (not `store_true`) for `--override-frozen` because the default is `True` (protection on).",
+    "In `assert_not_frozen`, call `self.assert_environment()` first so the error is descriptive when the prefix is not a conda environment.",
+    "The `EnvironmentIsFrozenError` message contains a typo matching the original PR: 'Cannot not modify' (double negative) — preserve it.",
+    "For `main_remove.py`, the frozen check must come before `check_non_admin()` and `prefix = str(prefix_data.prefix_path)` must be moved after the check.",
+    "For `main_env_update.py`, guard the frozen check with `if prefix_data.is_environment():` since the environment may not exist yet when creating a new one."
+  ],
+  "fail_to_pass": [
+    "tests/cli/test_cli_install.py::test_frozen_env_cep22"
+  ],
+  "pass_to_pass": [
+    "tests/cli/test_cli_install.py::test_pre_link_message",
+    "tests/cli/test_cli_install.py::test_find_conflicts_called_once"
+  ]
+}

--- a/conda/base/constants.py
+++ b/conda/base/constants.py
@@ -281,6 +281,7 @@ class NoticeLevel(ValueEnum):
 # Magic files for permissions determination
 PACKAGE_CACHE_MAGIC_FILE = "urls.txt"
 PREFIX_MAGIC_FILE = join("conda-meta", "history")
+PREFIX_FROZEN_FILE = join("conda-meta", "frozen")
 
 PREFIX_STATE_FILE = join("conda-meta", "state")
 PACKAGE_ENV_VARS_DIR = join("etc", "conda", "env_vars.d")

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -235,6 +235,7 @@ class Context(Configuration):
         SequenceParameter(PrimitiveParameter("", element_type=str))
     )
     register_envs = ParameterLoader(PrimitiveParameter(True))
+    protect_frozen_envs = ParameterLoader(PrimitiveParameter(True))
     default_python = ParameterLoader(
         PrimitiveParameter(
             default_python_default(),
@@ -1334,6 +1335,8 @@ class Context(Configuration):
                 # used to override prefix rewriting, for e.g. building docker containers or RPMs
                 "register_envs",
                 # whether to add the newly created prefix to ~/.conda/environments.txt
+                "protect_frozen_envs",
+                # prevent modifications to envs marked with conda-meta/frozen
             ),
             "Plugin Configuration": ("no_plugins",),
         }

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -205,6 +205,15 @@ def add_output_and_prompt_options(p: ArgumentParser) -> _ArgumentGroup:
     return output_and_prompt_options
 
 
+def add_parser_frozen_env(p: ArgumentParser):
+    p.add_argument(
+        "--override-frozen",
+        action="store_false",
+        help="DANGEROUS. Use at your own risk. Ignore protections if the environment is frozen.",
+        dest="protect_frozen_envs",
+    )
+
+
 def add_parser_channels(p: ArgumentParser) -> _ArgumentGroup:
     from ..common.constants import NULL
 

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -294,6 +294,8 @@ def validate_install_command(prefix: str, command: str = "install"):
             delete_trash(prefix)
             if not path_is_clean(prefix):
                 raise
+        if context.protect_frozen_envs:
+            prefix_data.assert_not_frozen()
 
 
 def ensure_update_specs_exist(prefix: str, specs: list[str]):
@@ -333,7 +335,7 @@ def install_clone(args, parser):
 
 
 def install(args, parser, command="install"):
-    """Logic for `conda install`, `conda update`, and `conda create`."""
+    """Logic for `conda install`, `conda update`, `conda remove`, and `conda create`."""
     prefix = context.target_prefix
 
     # common validations for all types of installs

--- a/conda/cli/main_env_remove.py
+++ b/conda/cli/main_env_remove.py
@@ -18,6 +18,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..auxlib.ish import dals
     from .helpers import (
         add_output_and_prompt_options,
+        add_parser_frozen_env,
         add_parser_prefix,
         add_parser_solver,
     )
@@ -50,6 +51,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         **kwargs,
     )
 
+    add_parser_frozen_env(p)
     add_parser_prefix(p)
     add_parser_solver(p)
     add_output_and_prompt_options(p)

--- a/conda/cli/main_env_update.py
+++ b/conda/cli/main_env_update.py
@@ -21,6 +21,7 @@ from ..notices import notices
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from .helpers import (
+        add_parser_frozen_env,
         add_parser_json,
         add_parser_prefix,
         add_parser_solver,
@@ -48,6 +49,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         epilog=epilog,
         **kwargs,
     )
+    add_parser_frozen_env(p)
     add_parser_prefix(p)
     p.add_argument(
         "-f",
@@ -124,6 +126,11 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
 
     prefix = determine_target_prefix(context, args)
     prefix_data = PrefixData(prefix)
+    if prefix_data.is_environment():
+        prefix_data.assert_writable()
+        if context.protect_frozen_envs:
+            prefix_data.assert_not_frozen()
+
     # CAN'T Check with this function since it assumes we will create prefix.
     # cli_install.check_prefix(prefix, json=args.json)
 

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -22,6 +22,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from .actions import NullCountAction
     from .helpers import (
         add_parser_create_install_update,
+        add_parser_frozen_env,
         add_parser_prune,
         add_parser_solver,
         add_parser_update_modifiers,
@@ -86,6 +87,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         help="Revert to the specified REVISION.",
         metavar="REVISION",
     )
+    add_parser_frozen_env(p)
 
     solver_mode_options, package_install_options, _ = add_parser_create_install_update(
         p

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -20,6 +20,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_channels,
+        add_parser_frozen_env,
         add_parser_networking,
         add_parser_prefix,
         add_parser_prune,
@@ -71,6 +72,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         epilog=epilog,
         **kwargs,
     )
+    add_parser_frozen_env(p)
     add_parser_pscheck(p)
 
     add_parser_prefix(p)
@@ -160,8 +162,10 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
 
     prefix_data = PrefixData.from_context()
     prefix_data.assert_environment()
-    prefix = str(prefix_data.prefix_path)
+    if context.protect_frozen_envs:
+        prefix_data.assert_not_frozen()
     check_non_admin()
+    prefix = str(prefix_data.prefix_path)
 
     if args.all and prefix_data == PrefixData(context.default_prefix):
         msg = "Cannot remove current environment. Deactivate and run conda remove again"

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -21,6 +21,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..common.constants import NULL
     from .helpers import (
         add_parser_create_install_update,
+        add_parser_frozen_env,
         add_parser_prune,
         add_parser_solver,
         add_parser_update_modifiers,
@@ -58,6 +59,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         epilog=epilog,
         **kwargs,
     )
+    add_parser_frozen_env(p)
     solver_mode_options, package_install_options, _ = add_parser_create_install_update(
         p
     )

--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -16,6 +16,7 @@ from ..auxlib.exceptions import ValidationError
 from ..base.constants import (
     CONDA_ENV_VARS_UNSET_VAR,
     CONDA_PACKAGE_EXTENSIONS,
+    PREFIX_FROZEN_FILE,
     PREFIX_MAGIC_FILE,
     PREFIX_NAME_DISALLOWED_CHARS,
     PREFIX_STATE_FILE,
@@ -41,6 +42,7 @@ from ..exceptions import (
     CondaValueError,
     CorruptedEnvironmentError,
     DirectoryNotACondaEnvironmentError,
+    EnvironmentIsFrozenError,
     EnvironmentLocationNotFound,
     EnvironmentNameNotFound,
     EnvironmentNotWritableError,
@@ -112,6 +114,7 @@ class PrefixData(metaclass=PrefixDataType):
         # TODO: when removing pip_interop_enabled, also remove from meta class
         self.prefix_path: Path = Path(prefix_path)
         self._magic_file: Path = self.prefix_path / PREFIX_MAGIC_FILE
+        self._frozen_file: Path = self.prefix_path / PREFIX_FROZEN_FILE
         self.__prefix_records: dict[str, PrefixRecord] | None = None
         self.__is_writable: bool | None | _Null = NULL
         self._pip_interop_enabled: bool = (
@@ -258,6 +261,33 @@ class PrefixData(metaclass=PrefixDataType):
         self.assert_environment()
         if not file_path_is_writable(self._magic_file):
             raise EnvironmentNotWritableError(self.prefix_path)
+
+    def is_frozen(self) -> bool:
+        """
+        Check whether the environment is marked as frozen, as per CEP 22.
+
+        This is assessed by checking if `conda-meta/frozen` marker file exists.
+        """
+        try:
+            return self._frozen_file.is_file()
+        except OSError:
+            return False
+
+    def assert_not_frozen(self) -> None:
+        """
+        Check whether the environment path is a valid conda environment and is not marked
+        as frozen (as per CEP 22).
+
+        :raises EnvironmentIsFrozenError: If the environment is marked as frozen.
+        """
+        self.assert_environment()
+        if not self.is_frozen():
+            return
+        message = ""
+        contents = self._frozen_file.read_text()
+        if contents:
+            message = json.loads(contents).get("message", "")
+        raise EnvironmentIsFrozenError(self.prefix_path, message)
 
     def validate_path(self, expand_path: bool = False) -> None:
         """

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -10,7 +10,7 @@ import sys
 from datetime import timedelta
 from logging import getLogger
 from os.path import join
-from textwrap import dedent
+from textwrap import dedent, indent
 from traceback import format_exception, format_exception_only
 from typing import TYPE_CHECKING
 
@@ -1112,6 +1112,17 @@ class NoWritablePkgsDirError(CondaError):
     def __init__(self, pkgs_dirs: Iterable[os.PathLike], **kwargs):
         message = f"No writeable pkgs directories configured.{dashlist(pkgs_dirs)}"
         super().__init__(message, pkgs_dirs=pkgs_dirs, **kwargs)
+
+
+class EnvironmentIsFrozenError(CondaError):
+    def __init__(self, prefix: os.PathLike, message: str = "", **kwargs):
+        error = f"Cannot not modify '{prefix}'. The environment is marked as frozen. "
+        if message:
+            error += "Reason:\n\n"
+            error += indent(message, "    ")
+            error += "\n\n"
+        error += "You can ignore this error with the `--override-frozen` flag, at your own risk."
+        super().__init__(error, **kwargs)
 
 
 class EnvironmentNotWritableError(CondaError):

--- a/news/14766-frozen
+++ b/news/14766-frozen
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add support for frozen environment markers (CEP 22). (#14766)

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda.base.context import context, reset_context
-from conda.exceptions import UnsatisfiableError
+from conda.core.prefix_data import PrefixData
+from conda.exceptions import DryRunExit, EnvironmentIsFrozenError, UnsatisfiableError
 from conda.models.match_spec import MatchSpec
 from conda.testing.integration import package_is_installed
 
@@ -127,3 +128,83 @@ def test_emscripten_forge(
         "pyjs",
     ) as prefix:
         assert package_is_installed(prefix, "pyjs")
+
+
+def test_frozen_env_cep22(tmp_env, conda_cli):
+    with tmp_env("ca-certificates") as prefix:
+        prefix_data = PrefixData(prefix)
+        prefix_data._frozen_file.touch()
+        assert prefix_data.is_frozen()
+
+        # No message
+        conda_cli("install", "-p", prefix, "zlib", raises=EnvironmentIsFrozenError)
+        conda_cli(
+            "remove", "-p", prefix, "ca-certificates", raises=EnvironmentIsFrozenError
+        )
+        conda_cli(
+            "update", "-p", prefix, "ca-certificates", raises=EnvironmentIsFrozenError
+        )
+
+        # Bypass protection
+        conda_cli(
+            "install",
+            "-p",
+            prefix,
+            "zlib",
+            "--dry-run",
+            "--override-frozen",
+            raises=DryRunExit,
+        )
+        conda_cli(
+            "remove",
+            "-p",
+            prefix,
+            "ca-certificates",
+            "--dry-run",
+            "--override-frozen",
+            raises=DryRunExit,
+        )
+        out, err, rc = conda_cli(
+            "update",
+            "-p",
+            prefix,
+            "ca-certificates",
+            "--dry-run",
+            "--override-frozen",
+        )
+        assert rc == 0
+
+        # With message
+        prefix_data._frozen_file.write_text('{"message": "EnvOnTheRocks"}')
+        out, err, exc = conda_cli(
+            "install",
+            "-p",
+            prefix,
+            "zlib",
+            raises=EnvironmentIsFrozenError,
+        )
+        assert "EnvOnTheRocks" in str(exc)
+        out, err, exc = conda_cli(
+            "remove",
+            "-p",
+            prefix,
+            "ca-certificates",
+            raises=EnvironmentIsFrozenError,
+        )
+        assert "EnvOnTheRocks" in str(exc)
+        out, err, exc = conda_cli(
+            "update",
+            "-p",
+            prefix,
+            "ca-certificates",
+            raises=EnvironmentIsFrozenError,
+        )
+        assert "EnvOnTheRocks" in str(exc)
+
+        prefix_data._frozen_file.unlink()
+        conda_cli("install", "-p", prefix, "zlib", "--dry-run", raises=DryRunExit)
+        conda_cli(
+            "remove", "-p", prefix, "ca-certificates", "--dry-run", raises=DryRunExit
+        )
+        out, err, rc = conda_cli("update", "-p", prefix, "ca-certificates", "--dry-run")
+        assert rc == 0


### PR DESCRIPTION
## Golden Solution for PR #14766

**Original PR:** https://github.com/conda/conda/pull/14766

### Commit Structure

1. **[sol]** - Feature code only: CEP 22 frozen environment protections across `conda/base/constants.py`, `conda/base/context.py`, `conda/cli/helpers.py`, `conda/cli/install.py`, `conda/cli/main_install.py`, `conda/cli/main_update.py`, `conda/cli/main_remove.py`, `conda/cli/main_env_remove.py`, `conda/cli/main_env_update.py`, `conda/core/prefix_data.py`, `conda/exceptions.py`

2. **[f2p]** - Fail-to-pass test: `test_frozen_env_cep22` in `tests/cli/test_cli_install.py`

3. **[meta]** - `.helix/metadata.json` with problem statement, F2P/P2P test lists, and hints

### Helix Checks
- `F2P_TESTS_SHOULD_FAIL`: `test_frozen_env_cep22` fails on base commit `5607154`
- `F2P_TESTS_SHOULD_PASS`: `test_frozen_env_cep22` passes with [sol]
- `P2P_TESTS_SHOULD_PASS`: existing tests unaffected