### PR TITLE
Fix ValueError for prefix records with unknown package extensions

### DIFF
--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -480,8 +480,10 @@ class PrefixData(metaclass=PrefixDataType):
         if not ext and fn.endswith(".dist-info"):
             stripped = fn[: -len(".dist-info")]
         elif not ext:
-            raise ValueError(
-                f"Attempted to make prefix record for unknown package type: {fn}"
+            # Unknown extension (e.g. .whl from conda-pypi without the plugin loaded).
+            # Fall back to the name-version-build convention used by _load_single_record.
+            stripped = (
+                f"{prefix_record.name}-{prefix_record.version}-{prefix_record.build}"
             )
         return stripped + ".json"
 

--- a/news/16131-unknown-pkg-extension
+++ b/news/16131-unknown-pkg-extension
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `ValueError` when inserting or removing prefix records with unrecognized package extensions (e.g. `.whl` from `conda-pypi`), which broke the Miniconda uninstall workflow when using an older `conda-standalone`. (#16131)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_prefix_data.py
+++ b/tests/core/test_prefix_data.py
@@ -466,6 +466,30 @@ def test_no_tokens_dumped(empty_env: Path, remove_auth: bool):
         assert "/t/some-fake-token/" in json_content
 
 
+def test_insert_and_remove_unknown_extension(empty_env: Path):
+    """Packages with unrecognized extensions (e.g. .whl from conda-pypi) can
+    be inserted and removed without raising."""
+    pkg_record = PrefixRecord(
+        name="httpx",
+        version="1.0",
+        build="py3_none_any_0",
+        build_number=0,
+        depends=[],
+        channel="conda-pypi",
+        fn="httpx-1.0-py3_none_any_0.whl",
+        url="https://repo.anaconda.cloud/repo/conda-pypi/noarch/httpx-1.0-py3_none_any_0.whl",
+    )
+    pd = PrefixData(empty_env)
+    pd.insert(pkg_record)
+
+    json_path = empty_env / "conda-meta" / "httpx-1.0-py3_none_any_0.json"
+    assert json_path.exists()
+    assert pd.get("httpx") == pkg_record
+
+    pd.remove("httpx")
+    assert not json_path.exists()
+
+
 @pytest.mark.parametrize(
     "prefix1,prefix2,equals",
     [


### PR DESCRIPTION
### Description

Fixes #16131

When a package has an unrecognized file extension (e.g. `.whl` from `conda-pypi`), `PrefixData._get_json_fn` raised a `ValueError`. This breaks the Miniconda uninstall workflow because the embedded `conda-standalone` (`_conda`) uses an older conda version that doesn't have the `conda-pypi` plugin registered, so it can't recognize `.whl` as a valid package extension.

The fix: instead of raising, fall back to deriving the `conda-meta` JSON filename from the record's `name`, `version`, and `build` fields -- the same `name-version-build.json` convention that `_load_single_record` already relies on when reading.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?