### PR TITLE
Fix `JSONDecodeError` not caught when `simplejson` is installed

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -562,6 +562,7 @@ class UnavailableInvalidChannel(ChannelError):
         try:
             body = response.json()
         except (AttributeError, ValueError):
+            # ValueError covers both json.JSONDecodeError and simplejson.JSONDecodeError
             body = {}
         else:
             reason = body.get("reason") or reason
@@ -656,6 +657,7 @@ class CondaHTTPError(CondaError):
         try:
             body = response.json()
         except (AttributeError, ValueError):
+            # ValueError covers both json.JSONDecodeError and simplejson.JSONDecodeError
             body = {}
         else:
             reason = body.get("reason") or reason

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -26,7 +26,6 @@ from .base.constants import (
 from .common.compat import on_win
 from .common.io import dashlist
 from .common.iterators import groupby_to_dict as groupby
-from .common.serialize.json import JSONDecodeError
 from .common.serialize.json import dumps as json_dumps
 from .common.signals import get_signal_name
 from .common.url import join_url, maybe_unquote
@@ -562,7 +561,7 @@ class UnavailableInvalidChannel(ChannelError):
         # if response includes a valid json body we prefer the reason/message defined there
         try:
             body = response.json()
-        except (AttributeError, JSONDecodeError):
+        except (AttributeError, ValueError):
             body = {}
         else:
             reason = body.get("reason") or reason
@@ -656,7 +655,7 @@ class CondaHTTPError(CondaError):
         # if response includes a valid json body we prefer the reason/message defined there
         try:
             body = response.json()
-        except (AttributeError, JSONDecodeError):
+        except (AttributeError, ValueError):
             body = {}
         else:
             reason = body.get("reason") or reason

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -562,7 +562,8 @@ class UnavailableInvalidChannel(ChannelError):
         try:
             body = response.json()
         except (AttributeError, ValueError):
-            # ValueError covers both json.JSONDecodeError and simplejson.JSONDecodeError
+            # AttributeError: response has no .json method
+            # ValueError: covers both json.JSONDecodeError and simplejson.JSONDecodeError
             body = {}
         else:
             reason = body.get("reason") or reason
@@ -657,7 +658,8 @@ class CondaHTTPError(CondaError):
         try:
             body = response.json()
         except (AttributeError, ValueError):
-            # ValueError covers both json.JSONDecodeError and simplejson.JSONDecodeError
+            # AttributeError: response has no .json method
+            # ValueError: covers both json.JSONDecodeError and simplejson.JSONDecodeError
             body = {}
         else:
             reason = body.get("reason") or reason

--- a/news/fix-simplejson-decode-error
+++ b/news/fix-simplejson-decode-error
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix crash in `UnavailableInvalidChannel` and `CondaHTTPError` when `simplejson` is installed and a non-JSON HTTP error response is received. (#16136)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -577,6 +577,7 @@ def test_non_json_response_body(error_class: type) -> None:
     inherits from simplejson.JSONDecodeError (a ValueError), not from
     json.JSONDecodeError (stdlib).
     """
+
     class MockResponse:
         reason = "Not Found"
         headers = {}

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -561,6 +561,38 @@ def test_http_error_rfc_9457(monkeypatch: MonkeyPatch, capsys: CaptureFixture) -
     )
 
 
+@pytest.mark.parametrize(
+    "error_class",
+    [
+        json.JSONDecodeError,
+        ValueError,
+    ],
+)
+def test_non_json_response_body(error_class: type) -> None:
+    """UnavailableInvalidChannel and CondaHTTPError handle non-JSON responses.
+
+    Regression test for #16136: when simplejson is installed,
+    response.json() raises requests.exceptions.JSONDecodeError which
+    inherits from simplejson.JSONDecodeError (a ValueError), not from
+    json.JSONDecodeError (stdlib).
+    """
+    from conda.exceptions import CondaHTTPError, UnavailableInvalidChannel
+
+    class MockResponse:
+        reason = "Not Found"
+        headers = {}
+
+        def json(self):
+            raise error_class("bad", "", 0)
+
+    response = MockResponse()
+
+    exc = UnavailableInvalidChannel("test-channel", 404, response=response)
+    assert exc.status_code == 404
+
+    CondaHTTPError("msg", "https://x", 404, "Not Found", "0:01", response)
+
+
 def test_CommandNotFoundError_simple(
     monkeypatch: MonkeyPatch,
     capsys: CaptureFixture,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,6 +7,7 @@ from contextlib import nullcontext
 from unittest.mock import patch
 
 import pytest
+import requests
 from pytest import CaptureFixture, MonkeyPatch
 from pytest_mock import MockerFixture
 
@@ -567,6 +568,7 @@ def test_http_error_rfc_9457(monkeypatch: MonkeyPatch, capsys: CaptureFixture) -
     [
         json.JSONDecodeError,
         ValueError,
+        requests.exceptions.JSONDecodeError,
     ],
 )
 def test_non_json_response_body(error_class: type) -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,6 +30,7 @@ from conda.exceptions import (
     ProxyError,
     SharedLinkPathClobberError,
     TooManyArgumentsError,
+    UnavailableInvalidChannel,
     UnknownPackageClobberError,
     conda_exception_handler,
 )
@@ -576,8 +577,6 @@ def test_non_json_response_body(error_class: type) -> None:
     inherits from simplejson.JSONDecodeError (a ValueError), not from
     json.JSONDecodeError (stdlib).
     """
-    from conda.exceptions import CondaHTTPError, UnavailableInvalidChannel
-
     class MockResponse:
         reason = "Not Found"
         headers = {}


### PR DESCRIPTION
### Description

Fixes #16136.

PR #15866 replaced `from requests.compat import json` with `import json` (stdlib) in `conda/common/serialize/json.py` to speed up startup. This changed the `JSONDecodeError` re-exported from that module from `simplejson.JSONDecodeError` to `json.JSONDecodeError`.

When `simplejson` is installed, `requests` uses it internally, so `response.json()` raises `requests.exceptions.JSONDecodeError` which inherits from `simplejson.JSONDecodeError` -- not from `json.JSONDecodeError` (stdlib). These are two separate exception hierarchies that only share `ValueError` as a common ancestor.

This caused `UnavailableInvalidChannel.__init__` and `CondaHTTPError.__init__` to crash when handling non-JSON HTTP error responses (e.g. a 404 from a channel that doesn't support repodata shards).

The fix replaces `except (AttributeError, JSONDecodeError)` with `except (AttributeError, ValueError)` in both locations, since `ValueError` is the common ancestor of both JSON decode error types.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
  Not applicable -- internal exception handling fix with no user-facing API impact.