### PR TITLE
Fix `test_sorted_commands_in_error`

### DIFF
--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib
-import sys
 from inspect import isclass, isfunction
 from logging import getLogger
 from typing import TYPE_CHECKING
@@ -20,7 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
 
-    from pytest import Subtests
+    from pytest import CaptureFixture, Subtests
 
     from conda.testing.fixtures import CondaCLIFixture
 
@@ -113,7 +112,7 @@ def test_imports(path: str, validate: Callable[[Any], bool]):
     assert validate(getattr(module, attr))
 
 
-def test_sorted_commands_in_error(capsys):
+def test_sorted_commands_in_error(capsys: CaptureFixture):
     p = ArgumentParser()
     sp = p.add_subparsers(
         metavar="COMMAND",
@@ -122,26 +121,25 @@ def test_sorted_commands_in_error(capsys):
         required=True,
     )
     # These are added in a non-alphabetical order...
-    sp.add_parser("c")
-    sp.add_parser("a")
-    sp.add_parser("b")
+    sp.add_parser("charlie")
+    sp.add_parser("alpha")
+    sp.add_parser("bravo")
     try:
-        p.parse_args(["d"])
+        p.parse_args(["delta"])
     except SystemExit:
         stderr = capsys.readouterr().err
         # ...but the suggestions here are sorted
 
-        # Linux Python 3.12.3 and possibly other 3.12 builds appear to use the
-        # quoted style:
-        old_style = "invalid choice: 'd' (choose from 'a', 'b', 'c')"
-        new_style = "invalid choice: 'd' (choose from a, b, c)"
-
-        if sys.version_info < (3, 12):
-            # FUTURE: Python 3.12+: remove this test case
-            assert old_style in stderr
-        elif sys.version_info[:2] == (3, 12):
-            assert old_style in stderr or new_style in stderr
-        else:
-            assert new_style in stderr
+        # some Pythons quote the choices:
+        #   invalid choice: 'delta' (choose from 'alpha', 'bravo', 'charlie')
+        # others don't:
+        #   invalid choice: 'delta' (choose from alpha, bravo, charlie)
+        assert (
+            stderr.index("invalid choice:")
+            < stderr.index("delta")
+            < stderr.index("alpha")
+            < stderr.index("bravo")
+            < stderr.index("charlie")
+        )
     else:
         pytest.fail("Did not raise")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Resolves #16133 

Latest Python 3.14 release changed how argparse choices are formatted.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
