### PR TITLE
Backport: Fix tests for when plugins are installed in the test environment

### DIFF
--- a/tests/cli/test_startup_benchmarks.py
+++ b/tests/cli/test_startup_benchmarks.py
@@ -209,7 +209,7 @@ _MODULE_BUDGETS: dict[str, _BudgetSpec] = {
         "code": (
             "from conda.cli.conda_argparse import generate_parser\ngenerate_parser()"
         ),
-        "max_modules": 1200,
+        "max_modules": 1400,
     },
     "full_startup": {
         "code": (

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -12,6 +12,7 @@ from conda import CondaError, CondaMultiError
 from conda.base.constants import PACKAGE_CACHE_MAGIC_FILE
 from conda.base.context import context, reset_context
 from conda.common.compat import on_win
+from conda.common.path import strip_pkg_extension
 from conda.core import package_cache_data
 from conda.core.index import Index
 from conda.core.package_cache_data import (
@@ -139,11 +140,13 @@ def test_download_filename_from_url_basename():
     assert cache_action.target_package_basename == "idna-3.10-py3-none-any.whl"
     assert cache_action.target_package_basename != package_prec.fn
 
-    # The extract action uses strip_pkg_extension on the URL basename.
-    # Since .whl is not in KNOWN_EXTENSIONS (handled by conda-pypi plugin),
-    # the full filename is used as the extracted directory name.
     assert extract_action is not None
-    assert extract_action.target_extracted_dirname == "idna-3.10-py3-none-any.whl"
+    # Computed dynamically so the assertion holds regardless of which plugins
+    # (e.g. conda-pypi registering .whl) are installed in the test environment.
+    assert (
+        extract_action.target_extracted_dirname
+        == strip_pkg_extension(cache_action.target_package_basename)[0]
+    )
 
 
 def test_download_filename_strips_url_fragment():

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -149,6 +149,8 @@ def test_create_advanced_pip(
     assert package_is_installed(prefix, "xmltodict=0.10.2")
 
 
+# TODO: remove once https://github.com/conda/conda-lockfiles/issues/145 is fixed and released
+@pytest.mark.filterwarnings("ignore:.*yaml_safe.*:PendingDeprecationWarning")
 @pytest.mark.integration
 def test_create_empty_env(
     monkeypatch: MonkeyPatch,
@@ -402,6 +404,8 @@ def test_create_env_custom_platform(
         assert f"subdir: {platform}" in config.read_text()
 
 
+# TODO: remove once https://github.com/conda/conda-lockfiles/issues/145 is fixed and released
+@pytest.mark.filterwarnings("ignore:.*yaml_safe.*:PendingDeprecationWarning")
 @pytest.mark.integration
 def test_create_env_from_environment_yml_does_not_output_duplicate_warning(
     conda_cli: CondaCLIFixture,

--- a/tests/plugins/test_environment_export.py
+++ b/tests/plugins/test_environment_export.py
@@ -331,6 +331,18 @@ def test_exporter_error_conditions(
 
 def test_get_environment_exporters(plugin_manager_with_exporters: CondaPluginManager):
     """Test getting environment exporters mapping."""
+    exporters = {
+        exporter.name
+        for exporter in plugin_manager_with_exporters.get_environment_exporters()
+    }
+    assert "test-single-platform" in exporters
+    assert "test-multi-platform" in exporters
+
+
+def test_get_environment_exporters_disable_external_plugins(
+    plugin_manager_with_exporters: CondaPluginManager,
+):
+    plugin_manager_with_exporters.disable_external_plugins()
     assert {
         exporter.name
         for exporter in plugin_manager_with_exporters.get_environment_exporters()
@@ -339,8 +351,6 @@ def test_get_environment_exporters(plugin_manager_with_exporters: CondaPluginMan
         ENVIRONMENT_JSON_FORMAT,
         EXPLICIT_FORMAT,
         REQUIREMENTS_FORMAT,
-        "test-single-platform",
-        "test-multi-platform",
     }
 
 


### PR DESCRIPTION
### Description

Cherry-pick of 4ac5ebd9d from `main` into `26.5.x`.

Original PR: #16115

Fixes test failures in `26.5.x` CI when plugins are installed in the test environment.

### Checklist - did you ...

- [x] ~Add a file to the `news` directory~ (backport, news entry already on main)
- [x] ~Add / update necessary tests?~ (this IS the test fix)
- [x] ~Add / update outdated documentation?~ (not applicable)