### PR TITLE
Fix notices ImportError after in-place base Python update

### DIFF
--- a/conda/notices/core.py
+++ b/conda/notices/core.py
@@ -128,6 +128,12 @@ def notices(func):
 
             if channel_notice_set is not None:
                 try:
+                    # Load display deps before the command: upgrading/downgrading base
+                    # python rewrites site-packages under the running interpreter, so
+                    # display_notices() must not be the first import of views.
+                    # see https://github.com/conda/conda/issues/16126
+                    from . import cache, views  # noqa: F401
+
                     return_value = func(*args, **kwargs)
                     display_notices(channel_notice_set)
 

--- a/news/16126-fix-notices-import-after-python-update.md
+++ b/news/16126-fix-notices-import-after-python-update.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Fix channel notices display failing with `ImportError` when a decorated command replaces base `python` while conda is still running on the previous interpreter. Pre-import `conda.notices.views` before the command so post-command display does not load modules from rewritten `site-packages`. (#16126 via #16142)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

- Fixes a regression from deferred imports in `conda.notices` (#15879) where `display_notices()` imported `views` only after the wrapped command finished.
- When a transaction replaces base `python`, `site-packages` under the running interpreter can change on disk; post-command imports of `views` then fail with `ImportError` even though the install succeeded:
  - #16126
  - #16135
- Pre-import `views` (and `cache`) in the `@notices` decorator before running the command so modules stay in `sys.modules` for the post-command display step.

Closes #16126

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
