### PR TITLE
Make `test_sorted_commands_in_error` less picky

### DIFF
--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -131,17 +131,13 @@ def test_sorted_commands_in_error(capsys):
         stderr = capsys.readouterr().err
         # ...but the suggestions here are sorted
 
-        # Linux Python 3.12.3 and possibly other 3.12 builds appear to use the
-        # quoted style:
-        old_style = "invalid choice: 'd' (choose from 'a', 'b', 'c')"
-        new_style = "invalid choice: 'd' (choose from a, b, c)"
-
-        if sys.version_info < (3, 12):
-            # FUTURE: Python 3.12+: remove this test case
-            assert old_style in stderr
-        elif sys.version_info[:2] == (3, 12):
-            assert old_style in stderr or new_style in stderr
-        else:
-            assert new_style in stderr
+        # See https://github.com/python/cpython/pull/144983 for context
+        # Some Python versions did not quote choices as a side-effect of a
+        # different fix in 3.12. This was reverted in 3.15 and backported.
+        # We could annotate which style is used in each version, but why bother:
+        # both are valid assertions for choice ordering.
+        quoted = "invalid choice: 'd' (choose from 'a', 'b', 'c')"
+        unquoted = "invalid choice: 'd' (choose from a, b, c)"
+        assert quoted in stderr or unquoted in stderr
     else:
         pytest.fail("Did not raise")

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib
-import sys
 from inspect import isclass, isfunction
 from logging import getLogger
 from typing import TYPE_CHECKING


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

xref https://github.com/python/cpython/pull/144983

Let's give up on matching quoting styles. Upstream couldn't decide for a while and either option is correct for our purposes.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
