### PR TITLE
Fix stale negative shard cache rechecks

### DIFF
--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -595,7 +595,7 @@ def _repodata_shards(url, cache: RepodataCache) -> bytes:
 # shards as not supported; otherwise, we will check again next time.
 
 
-def fetch_shards_index(sd: SubdirData) -> Shards | None:
+def fetch_shards_index(sd: SubdirData, *, force: bool = False) -> Shards | None:
     """
     Check a SubdirData's URL for shards.
 
@@ -632,7 +632,7 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
 
     cache_state = repo_cache.state
 
-    if cache_state.should_check_format("shards"):
+    if force or cache_state.should_check_format("shards"):
         # look for shards index
         shards_data = None
         shards_index_url = f"{sd.url_w_subdir}/{REPODATA_SHARDS_FN}"
@@ -757,11 +757,28 @@ def fetch_channels(url_to_channel: dict[str, Channel]) -> dict[str, ShardBase] |
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=_shards_connections()
     ) as executor:
+        subdir_data = {
+            channel_url: SubdirData(Channel(channel_url))
+            for channel_url in url_to_channel
+        }
+        fallback_recheck_channels = set()
+        for channel_url, sd in subdir_data.items():
+            repo_cache = sd.repo_cache
+            try:
+                with repo_cache.lock("r+") as state_file:
+                    repo_cache.state.update(json.loads(state_file.read()))
+            except (FileNotFoundError, json.JSONDecodeError):
+                pass
+
+            if (
+                not repo_cache.state.should_check_format("shards")
+                and not repo_cache.cache_path_json.exists()
+            ):
+                fallback_recheck_channels.add(channel_url)
+
         futures = {
-            executor.submit(
-                fetch_shards_index, SubdirData(Channel(channel_url))
-            ): channel_url
-            for (channel_url, _) in url_to_channel.items()
+            executor.submit(fetch_shards_index, sd): channel_url
+            for channel_url, sd in subdir_data.items()
         }
         futures_non_sharded = {}
 
@@ -773,9 +790,30 @@ def fetch_channels(url_to_channel: dict[str, Channel]) -> dict[str, ShardBase] |
             else:
                 non_sharded_channels.append((channel_url, Channel(channel_url)))
 
-        # If all are None then don't do ShardLike.
+        # If every channel appears non-sharded because of cached negative shard
+        # state, recheck channels that also have no classic cache before sending
+        # the caller down a repodata.json fallback path.
         if all(value is None for value in channel_data.values()):
-            return None  # caller should interpret this as falling back to the older code path
+            retry_futures = {
+                executor.submit(
+                    fetch_shards_index, subdir_data[channel_url], force=True
+                ): channel_url
+                for channel_url in fallback_recheck_channels
+            }
+            for future in concurrent.futures.as_completed(retry_futures):
+                channel_url = retry_futures[future]
+                found = future.result()
+                if found:
+                    channel_data[channel_url] = found
+
+            if all(value is None for value in channel_data.values()):
+                return None  # caller should interpret this as falling back to the older code path
+
+            non_sharded_channels = [
+                (channel_url, channel)
+                for channel_url, channel in non_sharded_channels
+                if channel_data[channel_url] is None
+            ]
 
         # Latency penalty launching these requests here instead of when we
         # non_sharded_channels.append(), but we want to leave a fallback to the

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -632,10 +632,7 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
 
     cache_state = repo_cache.state
 
-    if (
-        cache_state.should_check_format("shards")
-        or not repo_cache.cache_path_json.exists()
-    ):
+    if cache_state.should_check_format("shards"):
         # look for shards index
         shards_data = None
         shards_index_url = f"{sd.url_w_subdir}/{REPODATA_SHARDS_FN}"

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -595,7 +595,7 @@ def _repodata_shards(url, cache: RepodataCache) -> bytes:
 # shards as not supported; otherwise, we will check again next time.
 
 
-def fetch_shards_index(sd: SubdirData, *, force: bool = False) -> Shards | None:
+def fetch_shards_index(sd: SubdirData) -> Shards | None:
     """
     Check a SubdirData's URL for shards.
 
@@ -632,7 +632,10 @@ def fetch_shards_index(sd: SubdirData, *, force: bool = False) -> Shards | None:
 
     cache_state = repo_cache.state
 
-    if force or cache_state.should_check_format("shards"):
+    if (
+        cache_state.should_check_format("shards")
+        or not repo_cache.cache_path_json.exists()
+    ):
         # look for shards index
         shards_data = None
         shards_index_url = f"{sd.url_w_subdir}/{REPODATA_SHARDS_FN}"
@@ -761,21 +764,6 @@ def fetch_channels(url_to_channel: dict[str, Channel]) -> dict[str, ShardBase] |
             channel_url: SubdirData(Channel(channel_url))
             for channel_url in url_to_channel
         }
-        fallback_recheck_channels = set()
-        for channel_url, sd in subdir_data.items():
-            repo_cache = sd.repo_cache
-            try:
-                with repo_cache.lock("r+") as state_file:
-                    repo_cache.state.update(json.loads(state_file.read()))
-            except (FileNotFoundError, json.JSONDecodeError):
-                pass
-
-            if (
-                not repo_cache.state.should_check_format("shards")
-                and not repo_cache.cache_path_json.exists()
-            ):
-                fallback_recheck_channels.add(channel_url)
-
         futures = {
             executor.submit(fetch_shards_index, sd): channel_url
             for channel_url, sd in subdir_data.items()
@@ -790,30 +778,8 @@ def fetch_channels(url_to_channel: dict[str, Channel]) -> dict[str, ShardBase] |
             else:
                 non_sharded_channels.append((channel_url, Channel(channel_url)))
 
-        # If every channel appears non-sharded because of cached negative shard
-        # state, recheck channels that also have no classic cache before sending
-        # the caller down a repodata.json fallback path.
         if all(value is None for value in channel_data.values()):
-            retry_futures = {
-                executor.submit(
-                    fetch_shards_index, subdir_data[channel_url], force=True
-                ): channel_url
-                for channel_url in fallback_recheck_channels
-            }
-            for future in concurrent.futures.as_completed(retry_futures):
-                channel_url = retry_futures[future]
-                found = future.result()
-                if found:
-                    channel_data[channel_url] = found
-
-            if all(value is None for value in channel_data.values()):
-                return None  # caller should interpret this as falling back to the older code path
-
-            non_sharded_channels = [
-                (channel_url, channel)
-                for channel_url, channel in non_sharded_channels
-                if channel_data[channel_url] is None
-            ]
+            return None  # caller should interpret this as falling back to the older code path
 
         # Latency penalty launching these requests here instead of when we
         # non_sharded_channels.append(), but we want to leave a fallback to the

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -485,12 +485,16 @@ class RepodataState(UserDict):
     def should_check_format(self, format: str) -> bool:
         """Return True if named format should be attempted."""
         has, when = self.has_format(format)
-        return (
+        should_check = (
             has is True
             or isinstance(when, datetime.datetime)
             and datetime.datetime.now(tz=datetime.timezone.utc) - when
             > CHECK_ALTERNATE_FORMAT_INTERVAL
         )
+        # Always check for shards if json has not been cached:
+        if format == "shards" and not should_check:
+            should_check = not self.cache_path_json.exists()
+        return should_check
 
     def __contains__(self, key: str) -> bool:
         key = self._aliased.get(key, key)

--- a/news/conda-pypi-397-recheck-shards-without-classic-cache.md
+++ b/news/conda-pypi-397-recheck-shards-without-classic-cache.md
@@ -1,3 +1,3 @@
 ### Bug fixes
 
-* Fix sharded repodata fetching to recheck shards when a cached negative shard-format result has no classic repodata cache to fall back to, avoiding stale-cache failures for shards-only channels. (#16183)
+* If shards were not found on a channel, conda would cache the not-found response, which can break shards-only channels. Instead, always check for sharded repodata if classic repodata has not been cached. (#16183)

--- a/news/conda-pypi-397-recheck-shards-without-classic-cache.md
+++ b/news/conda-pypi-397-recheck-shards-without-classic-cache.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Fix sharded repodata fetching to recheck shards when a cached negative shard-format result has no classic repodata cache to fall back to, avoiding stale-cache failures for shards-only channels. (#16183)

--- a/tests/shards/conftest.py
+++ b/tests/shards/conftest.py
@@ -186,6 +186,53 @@ FAKE_SHARD = shard_for_name(FAKE_REPODATA, "foo")
 FAKE_SHARD_2 = shard_for_name(FAKE_REPODATA, "bar")
 
 
+def write_shards_repository(shards_repository: Path) -> None:
+    shards_repository.mkdir(parents=True, exist_ok=True)
+    noarch = shards_repository / "noarch"
+    noarch.mkdir(exist_ok=True)
+
+    foo_shard = zstandard.compress(msgpack.dumps(FAKE_SHARD))  # type: ignore
+    foo_shard_digest = hashlib.sha256(foo_shard).digest()
+    (noarch / f"{foo_shard_digest.hex()}.msgpack.zst").write_bytes(foo_shard)
+
+    bar_shard = zstandard.compress(msgpack.dumps(FAKE_SHARD_2))  # type: ignore
+    bar_shard_digest = hashlib.sha256(bar_shard).digest()
+    (noarch / f"{bar_shard_digest.hex()}.msgpack.zst").write_bytes(bar_shard)
+
+    # Create fake malformed shards to test error handling
+    malformed = {"follows_schema": False}
+    bad_schema = zstandard.compress(msgpack.dumps(malformed))  # type: ignore
+    malformed_digest = hashlib.sha256(bad_schema).digest()
+    (noarch / f"{malformed_digest.hex()}.msgpack.zst").write_bytes(bad_schema)
+
+    not_zstd = b"not zstd"
+    (noarch / f"{hashlib.sha256(not_zstd).digest().hex()}.msgpack.zst").write_bytes(
+        not_zstd
+    )
+
+    not_msgpack = zstandard.compress(b"not msgpack")
+    (noarch / f"{hashlib.sha256(not_msgpack).digest().hex()}.msgpack.zst").write_bytes(
+        not_msgpack
+    )
+
+    # Create fake repodata_shards.msgpack.zst index
+    fake_shards: ShardsIndexDict = {
+        "info": {"subdir": "noarch", "base_url": "", "shards_base_url": ""},
+        "version": 1,
+        "shards": {
+            "foo": foo_shard_digest,
+            "bar": bar_shard_digest,
+            "wrong_package_name": foo_shard_digest,
+            "fake_package": b"",
+            "malformed": malformed_digest,
+            "not_zstd": hashlib.sha256(not_zstd).digest(),
+            "not_msgpack": hashlib.sha256(not_msgpack).digest(),
+        },
+    }
+    index_data = zstandard.compress(msgpack.dumps(fake_shards))  # type: ignore
+    (noarch / "repodata_shards.msgpack.zst").write_bytes(index_data)
+
+
 def _run_test_server(
     directory: str, finish_request_action: Callable | None = None
 ) -> http.server.ThreadingHTTPServer:
@@ -283,50 +330,7 @@ class ShardFactory:
         :return: The URL of the http server serving the shards.
         """
         shards_repository = self.root / dir_name / "sharded_repo"
-        shards_repository.mkdir(parents=True, exist_ok=True)
-        noarch = shards_repository / "noarch"
-        noarch.mkdir(exist_ok=True)
-
-        foo_shard = zstandard.compress(msgpack.dumps(FAKE_SHARD))  # type: ignore
-        foo_shard_digest = hashlib.sha256(foo_shard).digest()
-        (noarch / f"{foo_shard_digest.hex()}.msgpack.zst").write_bytes(foo_shard)
-
-        bar_shard = zstandard.compress(msgpack.dumps(FAKE_SHARD_2))  # type: ignore
-        bar_shard_digest = hashlib.sha256(bar_shard).digest()
-        (noarch / f"{bar_shard_digest.hex()}.msgpack.zst").write_bytes(bar_shard)
-
-        # Create fake malformed shards to test error handling
-        malformed = {"follows_schema": False}
-        bad_schema = zstandard.compress(msgpack.dumps(malformed))  # type: ignore
-        malformed_digest = hashlib.sha256(bad_schema).digest()
-        (noarch / f"{malformed_digest.hex()}.msgpack.zst").write_bytes(bad_schema)
-
-        not_zstd = b"not zstd"
-        (noarch / f"{hashlib.sha256(not_zstd).digest().hex()}.msgpack.zst").write_bytes(
-            not_zstd
-        )
-
-        not_msgpack = zstandard.compress(b"not msgpack")
-        (
-            noarch / f"{hashlib.sha256(not_msgpack).digest().hex()}.msgpack.zst"
-        ).write_bytes(not_msgpack)
-
-        # Create fake repodata_shards.msgpack.zst index
-        fake_shards: ShardsIndexDict = {
-            "info": {"subdir": "noarch", "base_url": "", "shards_base_url": ""},
-            "version": 1,
-            "shards": {
-                "foo": foo_shard_digest,
-                "bar": bar_shard_digest,
-                "wrong_package_name": foo_shard_digest,
-                "fake_package": b"",
-                "malformed": malformed_digest,
-                "not_zstd": hashlib.sha256(not_zstd).digest(),
-                "not_msgpack": hashlib.sha256(not_msgpack).digest(),
-            },
-        }
-        index_data = zstandard.compress(msgpack.dumps(fake_shards))  # type: ignore
-        (noarch / "repodata_shards.msgpack.zst").write_bytes(index_data)
+        write_shards_repository(shards_repository)
 
         httpd = _run_test_server(
             str(shards_repository), finish_request_action=finish_request_action

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -361,7 +361,10 @@ def test_fetch_shards_index_mark_unavailable(monkeypatch, tmp_path, error_code):
     # load json directly due to issues with repo_cache API, also
     # fetch_shards_index gets a different repo_cache instance:
     repo_cache.state.update(json.loads(repo_cache.cache_path_state.read_text()))
-    assert repo_cache.state.should_check_format("shards") == expect_should_check_shards
+    # Always check for shards if json has not been cached:
+    assert repo_cache.state.should_check_format("shards") == (
+        expect_should_check_shards or not repo_cache.cache_path_json.exists()
+    )
     assert mock_session.get_count == 1
 
     # Without classic repodata cache, retry should still check shards before
@@ -965,7 +968,11 @@ def test_shardlike():
 
 def test_iter_records_classic():
     shardlike = ShardLike(
-        {"packages": {}, "packages.conda": {}, "info": {"base_url": ""}}
+        {
+            "packages": {},
+            "packages.conda": {},
+            "info": {"base_url": ""},
+        }
     )
     shardlike.visit_shard(
         "mypkg",
@@ -981,7 +988,11 @@ def test_iter_records_classic():
 
 def test_iter_records_v3():
     shardlike = ShardLike(
-        {"packages": {}, "packages.conda": {}, "info": {"base_url": ""}}
+        {
+            "packages": {},
+            "packages.conda": {},
+            "info": {"base_url": ""},
+        }
     )
     shardlike.visit_shard(
         "mypkg",

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -364,11 +364,23 @@ def test_fetch_shards_index_mark_unavailable(monkeypatch, tmp_path, error_code):
     assert repo_cache.state.should_check_format("shards") == expect_should_check_shards
     assert mock_session.get_count == 1
 
-    # assert that retry skips over shards without trying to GET
+    # Without classic repodata cache, retry should still check shards before
+    # falling back to a cache path that is not available.
     get_count = mock_session.get_count
     second_try = fetch_shards_index(subdir_data)
     assert second_try is None
-    assert mock_session.get_count == get_count + expect_should_check_shards
+    assert mock_session.get_count == get_count + 1
+
+    if not expect_should_check_shards:
+        repo_cache.state.update(json.loads(repo_cache.cache_path_state.read_text()))
+        repo_cache.save("{}")
+
+        # With classic repodata cache available, cached negative shard state can
+        # safely skip the shard check.
+        get_count = mock_session.get_count
+        third_try = fetch_shards_index(subdir_data)
+        assert third_try is None
+        assert mock_session.get_count == get_count
 
 
 def test_fetch_shards_error(http_server_shards, empty_shards_cache):

--- a/tests/shards/test_shards_subset.py
+++ b/tests/shards/test_shards_subset.py
@@ -46,9 +46,11 @@ from .conftest import (
     CONDA_FORGE_WITH_SHARDS,
     FAKE_REPODATA,
     ROOT_PACKAGES,
+    _run_test_server,
     _timer,
     ensure_hex_hash,
     expand_channels,
+    write_shards_repository,
 )
 
 if TYPE_CHECKING:
@@ -191,6 +193,66 @@ def test_build_repodata_subset_no_shards(http_server_shards):
     """
     channels = expand_channels([Channel(http_server_shards + "/notfound")])
     assert build_repodata_subset([], channels) is None
+
+
+@pytest.mark.parametrize(
+    "has_classic_cache",
+    [False, True],
+    ids=["without-classic-cache", "with-classic-cache"],
+)
+def test_fetch_channels_rechecks_shards_when_needed(
+    monkeypatch, tmp_path, has_classic_cache
+):
+    """
+    A cached `has_shards: false` result should only be honored when there is
+    classic repodata cache to fall back to.
+    """
+    monkeypatch.setenv("CONDA_PKGS_DIRS", str(tmp_path / "pkgs"))
+    monkeypatch.setenv("CONDA_SUBDIR", "osx-arm64")
+    reset_context()
+
+    channel_root = tmp_path / "channel"
+    channel_root.mkdir()
+    httpd = _run_test_server(str(channel_root))
+    try:
+        host, port = httpd.socket.getsockname()[:2]
+        url_host = f"[{host}]" if ":" in host else host
+        channel_url = f"http://{url_host}:{port}/"
+        channels = expand_channels(
+            [Channel(channel_url)], subdirs=("osx-arm64", "noarch")
+        )
+        noarch_url = next(url for url in channels if url.endswith("/noarch"))
+        noarch_cache = SubdirData(Channel(noarch_url)).repo_cache
+
+        assert fetch_channels(channels) is None
+        assert not noarch_cache.cache_path_json.exists()
+        with noarch_cache.lock("r+") as state_file:
+            noarch_cache_state = json.load(state_file)
+            assert noarch_cache_state["has_shards"]["value"] is False
+
+        if has_classic_cache:
+            noarch_cache.state.update(noarch_cache_state)
+            noarch_cache.save(
+                json.dumps(
+                    {
+                        "info": {"subdir": "noarch"},
+                        "packages": {},
+                        "packages.conda": {},
+                        "repodata_version": 2,
+                    }
+                )
+            )
+
+        write_shards_repository(channel_root)
+
+        channel_data = fetch_channels(channels)
+        if has_classic_cache:
+            assert channel_data is None
+        else:
+            assert channel_data is not None
+            assert isinstance(channel_data[noarch_url], Shards)
+    finally:
+        httpd.shutdown()
 
 
 @pytest.mark.integration

--- a/tests/shards/test_shards_subset.py
+++ b/tests/shards/test_shards_subset.py
@@ -255,6 +255,64 @@ def test_fetch_channels_rechecks_shards_when_needed(
         httpd.shutdown()
 
 
+def test_fetch_channels_rechecks_stale_shards_in_mixed_channels(monkeypatch, tmp_path):
+    """
+    A stale negative shard result should be rechecked even when another channel
+    already has shards.
+    """
+    monkeypatch.setenv("CONDA_PKGS_DIRS", str(tmp_path / "pkgs"))
+    monkeypatch.setenv("CONDA_SUBDIR", "osx-arm64")
+    reset_context()
+
+    stale_channel_root = tmp_path / "stale-channel"
+    other_channel_root = tmp_path / "other-channel"
+    stale_channel_root.mkdir()
+    other_channel_root.mkdir()
+
+    stale_httpd = _run_test_server(str(stale_channel_root))
+    other_httpd = _run_test_server(str(other_channel_root))
+    try:
+
+        def channel_url(httpd):
+            host, port = httpd.socket.getsockname()[:2]
+            url_host = f"[{host}]" if ":" in host else host
+            return f"http://{url_host}:{port}/"
+
+        stale_channel_url = channel_url(stale_httpd)
+        stale_channels = expand_channels(
+            [Channel(stale_channel_url)], subdirs=("osx-arm64", "noarch")
+        )
+        assert fetch_channels(stale_channels) is None
+
+        write_shards_repository(stale_channel_root)
+        write_shards_repository(other_channel_root)
+
+        other_channel_url = channel_url(other_httpd)
+        channels = expand_channels(
+            [Channel(stale_channel_url), Channel(other_channel_url)],
+            subdirs=("osx-arm64", "noarch"),
+        )
+        stale_noarch_url = next(
+            url
+            for url in channels
+            if url.startswith(stale_channel_url.rstrip("/")) and url.endswith("/noarch")
+        )
+        other_noarch_url = next(
+            url
+            for url in channels
+            if url.startswith(other_channel_url.rstrip("/")) and url.endswith("/noarch")
+        )
+
+        channel_data = fetch_channels(channels)
+
+        assert channel_data is not None
+        assert isinstance(channel_data[stale_noarch_url], Shards)
+        assert isinstance(channel_data[other_noarch_url], Shards)
+    finally:
+        stale_httpd.shutdown()
+        other_httpd.shutdown()
+
+
 @pytest.mark.integration
 def test_build_repodata_subset(prepare_shards_test: None, tmp_path):
     """


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes #16183.
Refs conda/conda-pypi#397.

This updates shard format probing so cached `has_shards: false` results are only trusted when classic `repodata.json` is already cached as a fallback. If the classic cache is absent, conda now rechecks sharded repodata instead of sending shards-only channels down a missing `repodata.json` fallback path.

The cache decision now lives in `RepodataState.should_check_format("shards")`, so `fetch_shards_index()` consistently reuses that state-level rule.

The failure was exposed by `conda-pypi`, which serves `noarch/repodata_shards.msgpack.zst` but not classic `noarch/repodata.json`. Users with stale `has_shards: false` cache state could see `UnavailableInvalidChannel: HTTP 404` even after shard metadata was available.

The tests cover the shards-only stale-cache path, the classic-cache fallback path, and the mixed-channel case. They also factor the local shard repository writer into a shared helper so the new regression tests reuse the existing shard fixture setup.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
