### PR TITLE
Update test to account for changes in menuinst 2.5.0

### DIFF
--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -81,10 +81,10 @@ def package_is_installed(
         return prefix_recs[0]
 
 
-def get_shortcut_dir(prefix_for_unix=sys.prefix):
+def get_shortcut_dir(prefix=sys.prefix):
     if sys.platform == "win32":
-        # On Windows, .nonadmin has been historically created by constructor in sys.prefix
-        user_mode = "user" if Path(sys.prefix, ".nonadmin").is_file() else "system"
+        # menuinst 2.5.0+ checks .nonadmin in target_prefix or base_prefix
+        user_mode = "user" if Path(prefix, ".nonadmin").is_file() else "system"
         try:  # menuinst v2
             from menuinst.platforms.win_utils.knownfolders import dirs_src
 
@@ -101,7 +101,7 @@ def get_shortcut_dir(prefix_for_unix=sys.prefix):
     # on unix, .nonadmin is only created by menuinst v2 as needed on the target prefix
     # it might exist, or might not; if it doesn't, we try to create it
     # see https://github.com/conda/menuinst/issues/150
-    non_admin_file = Path(prefix_for_unix, ".nonadmin")
+    non_admin_file = Path(prefix, ".nonadmin")
     if non_admin_file.is_file():
         user_mode = "user"
     else:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1612,7 +1612,7 @@ def test_menuinst_v2(
     install = mocker.spy(menuinst, "install")
 
     (tmp_path / ".nonadmin").touch()
-    shortcut_root = Path(get_shortcut_dir(prefix_for_unix=tmp_path))
+    shortcut_root = Path(get_shortcut_dir(prefix=tmp_path))
 
     # shortcut_dirs are directories that need to be cleaned up
     # shortcut_files are files that need to be cleaned up


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Fixes `test_menuinst_v2` failing on Windows since menuinst 2.5.0.
The menuinst PR [conda/menuinst#454](https://github.com/conda/menuinst/pull/454) changed how the `elevate_as_needed` decorator determines shortcut mode on Windows (which is part of `menuinst` version `2.5.0`). When running as admin, it now checks for the file `.nonadmin` in `target_prefix` or `base_prefix` to decide between user/system mode. Previously it always used system mode for admin users and simply ignored `.nonadmin`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
