### PR TITLE
Fix menuinst v2 shortcut dir helper

### DIFF
--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -83,8 +83,16 @@ def package_is_installed(
 
 def get_shortcut_dir(prefix_for_unix=sys.prefix):
     if sys.platform == "win32":
-        # On Windows, .nonadmin has been historically created by constructor in sys.prefix
-        user_mode = "user" if Path(sys.prefix, ".nonadmin").is_file() else "system"
+        # On Windows, .nonadmin has historically been created by constructor
+        # in sys.prefix. Newer menuinst versions also honor the target prefix.
+        user_mode = (
+            "user"
+            if (
+                Path(prefix_for_unix, ".nonadmin").is_file()
+                or Path(sys.prefix, ".nonadmin").is_file()
+            )
+            else "system"
+        )
         try:  # menuinst v2
             from menuinst.platforms.win_utils.knownfolders import dirs_src
 


### PR DESCRIPTION
### Description

Fix the Windows shortcut path helper used by `test_menuinst_v2`.

The linked failure in https://github.com/conda/conda/actions/runs/27038505373/job/80065591266 comes from `tests/test_create.py::test_menuinst_v2[libmamba]` on Windows. The test creates `.nonadmin` in the target prefix, and menuinst 2.5 uses that marker to install shortcuts into the user Start Menu. `get_shortcut_dir()` still only looked at `sys.prefix/.nonadmin` on Windows, so the test could assert system Start Menu paths while menuinst created user Start Menu paths.

This updates the helper to consider the supplied prefix on Windows while preserving the historical `sys.prefix` fallback.

### Checklist - did you ...

- [x] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~ Test helper fix only.
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ Not applicable.

Validation:

- `CONDA_TEST_SOLVERS=libmamba python -m pytest tests/test_create.py::test_menuinst_v2 -q`
- `ruff format --check conda/testing/integration.py`
- `ruff check conda/testing/integration.py`
