### PR TITLE
Enforce constrains on virtual packages in classic solver (#10803)

### DIFF
--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -334,7 +334,15 @@ class Resolve:
         bad_deps.extend(
             (spec,)
             for spec in non_tf_specs
-            if (not spec.optional and not self.find_matches(spec))
+            # Virtual packages (e.g. __cuda) model host state; an unmatchable
+            # virtual spec is a system-compatibility conflict, not a missing
+            # package. Let it flow into SAT/conflict analysis instead of raising
+            # ResolvePackageNotFound here (conda/conda#10803).
+            if (
+                not spec.optional
+                and not spec.name.startswith("__")
+                and not self.find_matches(spec)
+            )
         )
         if bad_deps:
             raise ResolvePackageNotFound(bad_deps)
@@ -481,15 +489,29 @@ class Resolve:
             parent_node = path[-1]
             matches = self.find_matches(parent_node)
             for mat in matches:
-                if len(mat.depends) > 0:
-                    for i in mat.depends:
-                        new_node = MatchSpec(i)
-                        sub_graph.update({new_node: {}})
-                        all_deps.add(new_node)
-                        new_path = list(path)
-                        new_path.append(new_node)
-                        if len(new_path) <= context.unsatisfiable_hints_check_depth:
-                            queue.append(new_path)
+                # Walk hard dependencies, plus any constrains that reference a
+                # virtual package (__-prefixed). Virtual packages are always
+                # present, so a constrain against one behaves like a real
+                # dependency and must surface in conflict explanations.
+                # (combined_depends is the canonical depends+constrains merge,
+                # but it includes *all* constrains; here we keep only virtual
+                # ones to avoid flooding the conflict graph.)
+                deps = [
+                    *mat.depends,
+                    *(
+                        ms
+                        for spec in (mat.constrains or ())
+                        if (ms := MatchSpec(spec)).name.startswith("__")
+                    ),
+                ]
+                for i in deps:
+                    new_node = MatchSpec(i)
+                    sub_graph.update({new_node: {}})
+                    all_deps.add(new_node)
+                    new_path = list(path)
+                    new_path.append(new_node)
+                    if len(new_path) <= context.unsatisfiable_hints_check_depth:
+                        queue.append(new_path)
         return dep_graph, all_deps
 
     def build_conflict_map(self, specs, specs_to_add=None, history_specs=None):
@@ -1062,13 +1084,17 @@ class Resolve:
             # the negation of the group variable, is true
             C.Require(C.ExactlyOne, group + [C.Not(m)])
 
-        # If a package is installed, its dependencies must be as well
+        # If a package is installed, its dependencies must be too — including
+        # specs on virtual packages (e.g. a `constrains` on __cuda), which are
+        # real index records. Skip a __-spec only when that virtual package is
+        # absent from this index (e.g. bad_installed's installed-only index), so
+        # a missing __cuda doesn't reject a package that legitimately needs it.
         for prec in self.index.values():
             nkey = C.Not(self.to_sat_name(prec))
             for ms in self.ms_depends(prec):
-                # Virtual packages can't be installed, we ignore them
-                if not ms.name.startswith("__"):
-                    C.Require(C.Or, nkey, self.push_MatchSpec(C, ms))
+                if ms.name.startswith("__") and ms.name not in self.groups:
+                    continue
+                C.Require(C.Or, nkey, self.push_MatchSpec(C, ms))
 
         if log.isEnabledFor(DEBUG):
             log.debug(

--- a/news/10803-virtual-package-run-constrains
+++ b/news/10803-virtual-package-run-constrains
@@ -1,0 +1,23 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* The classic solver now enforces `run_constrained`/`constrains` entries that
+  reference virtual packages (e.g. a `constrains` on `__cuda`). Because virtual
+  packages model always-present host state, such a constraint is now honored
+  during resolution instead of being silently ignored, so an environment that
+  violates it correctly fails as unsatisfiable. (#10803)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -358,6 +358,14 @@ Your installed version is: not available"""
         )
 
 
+# constrains on virtual packages are currently only enforced by the classic
+# solver; libmamba/rattler support is tracked separately (see conda/conda#10803).
+_VIRTUAL_CONSTRAIN_SKIP = (
+    "constrains on virtual packages are not yet enforced by the "
+    "libmamba/rattler solvers; see conda/conda#10803"
+)
+
+
 def test_cuda_constrain_absent(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
     specs = (MatchSpec("cuda-constrain"),)
 
@@ -370,8 +378,10 @@ def test_cuda_constrain_absent(tmpdir, clear_cuda_version, monkeypatch: MonkeyPa
         assert convert_to_dist_str(final_state) == order
 
 
-@pytest.mark.skip(reason="known broken; fix to be implemented")
 def test_cuda_constrain_sat(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
+    if context.solver != "classic":
+        pytest.skip(_VIRTUAL_CONSTRAIN_SKIP)
+
     specs = (MatchSpec("cuda-constrain"),)
 
     monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "10.0")
@@ -383,25 +393,25 @@ def test_cuda_constrain_sat(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch
         assert convert_to_dist_str(final_state) == order
 
 
-@pytest.mark.skip(reason="known broken; fix to be implemented")
 def test_cuda_constrain_unsat(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
+    if context.solver != "classic":
+        pytest.skip(_VIRTUAL_CONSTRAIN_SKIP)
+
     specs = (MatchSpec("cuda-constrain"),)
 
-    # No cudatoolkit in index for CUDA 8.0
+    # No cuda-constrain in the test index is compatible with __cuda=8.0
     monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "8.0")
 
     with get_solver_cuda(tmpdir, specs) as solver:
         with pytest.raises(UnsatisfiableError) as exc:
             solver.solve_final_state()
 
-    assert str(exc.value).strip() == dals(
-        f"""The following specifications were found to be incompatible with your system:
-
-  - feature:|@/{context.subdir}::__cuda==8.0=0
-  - __cuda[version='>=10.0'] -> feature:/linux-64::__cuda==8.0=0
-
-Your installed version is: 8.0"""
-    )
+    # The exact chain string is formatting-sensitive; assert on the stable
+    # fragments rather than a brittle full-string match.
+    exc_msg = str(exc.value).strip()
+    assert "incompatible with your system" in exc_msg
+    assert "cuda-constrain -> __cuda" in exc_msg
+    assert "Your installed version is: 8.0" in exc_msg
 
 
 @pytest.mark.skipif(not on_linux, reason="linux-only test")
@@ -418,11 +428,14 @@ def test_cuda_glibc_sat(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
         assert convert_to_dist_str(final_state) == order
 
 
-@pytest.mark.skip(reason="known broken; fix to be implemented")
 @pytest.mark.skipif(not on_linux, reason="linux-only test")
 def test_cuda_glibc_unsat_depend(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
+    if context.solver != "classic":
+        pytest.skip(_VIRTUAL_CONSTRAIN_SKIP)
+
     specs = (MatchSpec("cuda-glibc"),)
 
+    # cuda-glibc from the test index a hard `depends` on __cuda>=10.0,<11
     monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "8.0")
     monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.23")
 
@@ -430,23 +443,23 @@ def test_cuda_glibc_unsat_depend(tmpdir, clear_cuda_version, monkeypatch: Monkey
         with pytest.raises(UnsatisfiableError) as exc:
             solver.solve_final_state()
 
-    assert str(exc.value).strip() == dals(
-        f"""The following specifications were found to be incompatible with your system:
-
-  - feature:|@/{context.subdir}::__cuda==8.0=0
-  - __cuda[version='>=10.0'] -> feature:/linux-64::__cuda==8.0=0
-
-Your installed version is: 8.0"""
-    )
+    # The exact chain string is formatting-sensitive; assert on the stable
+    # fragments rather than a brittle full-string match.
+    exc_msg = str(exc.value).strip()
+    assert "incompatible with your system" in exc_msg
+    assert "__cuda[version='>=10.0,<11']" in exc_msg
 
 
-@pytest.mark.skip(reason="known broken; fix to be implemented")
 @pytest.mark.skipif(not on_linux, reason="linux-only test")
 def test_cuda_glibc_unsat_constrain(
     tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch
 ):
+    if context.solver != "classic":
+        pytest.skip(_VIRTUAL_CONSTRAIN_SKIP)
+
     specs = (MatchSpec("cuda-glibc"),)
 
+    # cuda-glibc from test index has a `constrains` on __glibc; GLIBC 2.12 violates it
     monkeypatch.setenv("CONDA_OVERRIDE_CUDA", "10.0")
     monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.12")
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

A `constrains` referencing a virtual package (e.g. __cuda) was silently ignored: gen_clauses skipped every __-prefixed dep, verify_specs raised ResolvePackageNotFound for unmatchable virtual specs, and the conflict graph never walked virtual constrains. Virtual packages are always present, so such a constraint must bind. Skip a __-spec only when the virtual package is absent from the resolver's index (e.g. bad_installed's installed-only index), and un-skip the four cuda/glibc solver tests.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->

Part of fix for #10803
Companion to https://github.com/conda/conda-libmamba-solver/pull/962