### PR TITLE
Make conda env create an alias of conda create

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,11 @@ jobs:
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
+      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
+      # This should be removed next conda release.
+      - name: Upgrade conda-pypi
+        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
+
       - name: Conda Install
         run: >
           conda install
@@ -279,6 +284,11 @@ jobs:
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
+      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
+      # This should be removed next conda release.
+      - name: Upgrade conda-pypi
+        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
+
       - name: Conda Install
         run: >
           conda install
@@ -393,6 +403,11 @@ jobs:
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
+      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
+      # This should be removed next conda release.
+      - name: Upgrade conda-pypi
+        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
+
       - name: Conda Install
         run: >
           conda install
@@ -481,6 +496,11 @@ jobs:
       # Remove once miniforge ships c-l-s >=26.4.1.
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
+      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
+      # This should be removed next conda release.
+      - name: Upgrade conda-pypi
+        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
 
       - name: Conda Install
         run: >
@@ -639,6 +659,11 @@ jobs:
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
+      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
+      # This should be removed next conda release.
+      - name: Upgrade conda-pypi
+        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
+
       - name: Conda Install
         run: >
           conda install
@@ -739,6 +764,11 @@ jobs:
       # Remove once miniforge ships c-l-s >=26.4.1.
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
+      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
+      # This should be removed next conda release.
+      - name: Upgrade conda-pypi
+        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
 
       - name: Conda Install
         run: >
@@ -926,6 +956,11 @@ jobs:
       # Remove once miniforge ships c-l-s >=26.4.1.
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+
+      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
+      # This should be removed next conda release.
+      - name: Upgrade conda-pypi
+        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
 
       - name: Conda Install
         working-directory: conda

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -398,9 +398,12 @@ def install(args, parser, command="install"):
 
     defer_json = context.json and bool(env.external_packages)
 
-    conda_actions = handle_txn(
-        unlink_link_transaction, prefix, args, newenv, defer_json_success=defer_json
-    ) or {}
+    conda_actions = (
+        handle_txn(
+            unlink_link_transaction, prefix, args, newenv, defer_json_success=defer_json
+        )
+        or {}
+    )
 
     if env.external_packages and not context.dry_run and not context.download_only:
         from .. import CondaError

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -64,7 +64,6 @@ from .common import check_non_admin
 from .main_config import set_keys
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from typing import Any
 
 log = getLogger(__name__)
@@ -401,7 +400,7 @@ def install(args, parser, command="install"):
 
     conda_actions = handle_txn(
         unlink_link_transaction, prefix, args, newenv, defer_json_success=defer_json
-    )
+    ) or {}
 
     if env.external_packages and not context.dry_run and not context.download_only:
         from .. import CondaError
@@ -612,11 +611,6 @@ def handle_txn(
                 ("subdir", context.subdir),
                 path=Path(prefix, DEFAULT_CONDARC_FILENAME),
             )
-
-    follow_up_action_results = {}
-    for action in follow_up_actions:
-        result = action()
-        follow_up_action_results.update(result)
 
     if context.json:
         actions = unlink_link_transaction._make_legacy_action_groups()[0]

--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -14,6 +14,7 @@ import os
 from logging import getLogger
 from os.path import abspath
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ..base.constants import (
     REPODATA_FN,
@@ -61,6 +62,10 @@ from ..reporters import confirm_yn, get_spinner
 from . import common
 from .common import check_non_admin
 from .main_config import set_keys
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
 
 log = getLogger(__name__)
 deprecated.constant(
@@ -135,7 +140,7 @@ def get_revision(arg, json=False):
         raise CondaValueError(f"expected revision number, not: '{arg}'", json)
 
 
-def get_index_args(args) -> dict[str, any]:
+def get_index_args(args) -> dict[str, Any]:
     """Returns a dict of args required for fetching an index
 
     Args:
@@ -607,6 +612,11 @@ def handle_txn(
                 ("subdir", context.subdir),
                 path=Path(prefix, DEFAULT_CONDARC_FILENAME),
             )
+
+    follow_up_action_results = {}
+    for action in follow_up_actions:
+        result = action()
+        follow_up_action_results.update(result)
 
     if context.json:
         actions = unlink_link_transaction._make_legacy_action_groups()[0]

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -115,7 +115,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     add_parser_platform(p)
 
     p.set_defaults(
-        func="conda.cli.main_create.execute",
+        func="conda.cli.main_env_create.execute",
         clone=False,
         override_channels=False,
         use_local=NULL,
@@ -123,138 +123,16 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         repodata_fns=None,
         yes=True
     )
-
     return p
 
 
 @notices
 def execute(args: Namespace, parser: ArgumentParser) -> int:
-    from ..auxlib.ish import dals
-    from ..base.context import context, determine_target_prefix
-    from ..common.serialize import json
-    from ..core.prefix_data import PrefixData
-    from ..env.env import print_result
-    from ..env.installers.base import get_installer
-    from ..env.pip_util import get_pip_workdir
-    from ..exceptions import (
-        CondaEnvException,
-        InvalidInstaller,
-        PlatformMismatchError,
-    )
-    from ..gateways.disk.delete import rm_rf
-    from .common import validate_file_exists
+    from .main_create import execute as create_execute
+    from ..common.constants import NULL
+    from ..exceptions import DryRunExit
 
-    # validate incoming arguments
-    validate_file_exists(args.file)
-
-    # detect the file format and get the env representation
-    spec_hook = context.plugin_manager.get_environment_specifier(
-        source=args.file,
-        name=context.environment_specifier,
-    )
-    spec = spec_hook.environment_spec(args.file)
-    if context.subdir not in spec.available_platforms:
-        raise PlatformMismatchError(
-            [(args.file, spec.available_platforms)], context.subdir
-        )
-    env = spec.env_for(context.subdir)
-
-    # FIXME conda code currently requires args to have a name or prefix
-    # don't overwrite name if it's given. gh-254
-    if args.prefix is None and args.name is None:
-        if env.name is None:  # requirements.txt won't populate Environment.name
-            msg = dals(
-                """
-                Unable to create environment
-                Please re-run this command with one of the following options:
-                * Provide an environment name via --name or -n
-                * Provide a path on disk via --prefix or -p
-                """
-            )
-            raise CondaEnvException(msg)
-        args.name = env.name
-
-    prefix = determine_target_prefix(context, args)
-    prefix_data = PrefixData(prefix)
-
-    if args.yes and not prefix_data.is_base() and prefix_data.exists():
-        rm_rf(prefix)
-
-    prefix_data.validate_path()
-    prefix_data.validate_name()
-
-    # TODO, add capability
-    # common.ensure_override_channels_requires_channel(args)
-    # channel_urls = args.channel or ()
-
-    result = {"conda": None, "pip": None}
-
-    args_packages = (
-        context.create_default_packages if not args.no_default_packages else []
-    )
-
-    if args.dry_run:
-        installer_type = "conda"
-        installer = get_installer(installer_type)
-
-        pkg_specs = [*env.requested_packages, *args_packages]
-
-        solved_env = installer.dry_run(pkg_specs, args, env)
-        if args.json:
-            print(json.dumps(solved_env.to_dict()))
-        else:
-            print(solved_env.to_yaml(), end="")
-
-    else:
-        if args_packages:
-            installer_type = "conda"
-            installer = get_installer(installer_type)
-            result[installer_type] = installer.install(prefix, args_packages, args, env)
-
-        # install conda packages
-        installer_type = "conda"
-        installer = get_installer(installer_type)
-        result[installer_type] = installer.install(
-            prefix, env.requested_packages, args, env
-        )
-
-        # install all other external packages
-        for installer_type, pkg_specs in env.external_packages.items():
-            try:
-                installer = get_installer(installer_type)
-                if installer_type == "pip":
-                    workdir = get_pip_workdir(args.file)
-                    result[installer_type] = installer.install(
-                        prefix, pkg_specs, args, env, workdir=workdir
-                    )
-                else:
-                    result[installer_type] = installer.install(
-                        prefix, pkg_specs, args, env
-                    )
-            except InvalidInstaller:
-                raise CondaError(
-                    dals(
-                        f"""
-                        Unable to install package for {installer_type}.
-
-                        Please double check and ensure your dependencies file has
-                        the correct spelling. You might also try installing the
-                        conda-env-{installer_type} package to see if provides
-                        the required installer.
-                        """
-                    )
-                )
-
-        if context.subdir != context._native_subdir():
-            set_keys(
-                ("subdir", context.subdir),
-                path=Path(prefix, DEFAULT_CONDARC_FILENAME),
-            )
-
-        if env.variables:
-            prefix_data.set_environment_env_vars(env.variables)
-
-        prefix_data.set_nonadmin()
-        print_result(args, prefix, result)
-
-    return 0
+    try:
+        return create_execute(args, parser)
+    except DryRunExit as e:
+        return 0

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -49,6 +49,7 @@ def epilog() -> str:
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
+    from ..common.constants import NULL
     from .helpers import (
         add_output_and_prompt_options,
         add_parser_default_packages,
@@ -89,13 +90,14 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     p.add_argument(
         "-f",
         "--file",
-        action="store",
+        nargs='*',
+        # action="store",
         help=(
             "Environment definition file (default: environment.yml). Standard "
             "filenames registered by the installed format plugins are "
             "auto-detected. Custom filenames require --format."
         ),
-        default="environment.yml",
+        default=["environment.yml"],
     )
 
     # Add name and prefix args
@@ -112,7 +114,15 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     add_parser_solver(p)
     add_parser_platform(p)
 
-    p.set_defaults(func="conda.cli.main_env_create.execute")
+    p.set_defaults(
+        func="conda.cli.main_create.execute",
+        clone=False,
+        override_channels=False,
+        use_local=NULL,
+        packages=[],
+        repodata_fns=None,
+        yes=True
+    )
 
     return p
 

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -10,11 +10,7 @@ from argparse import (
     Namespace,
     _SubParsersAction,
 )
-from pathlib import Path
 
-from .. import CondaError
-from ..cli.main_config import set_keys
-from ..common.configuration import DEFAULT_CONDARC_FILENAME
 from ..notices import notices
 
 
@@ -90,7 +86,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     p.add_argument(
         "-f",
         "--file",
-        nargs='*',
+        nargs="*",
         # action="store",
         help=(
             "Environment definition file (default: environment.yml). Standard "
@@ -121,18 +117,17 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         use_local=NULL,
         packages=[],
         repodata_fns=None,
-        yes=True
+        yes=True,
     )
     return p
 
 
 @notices
 def execute(args: Namespace, parser: ArgumentParser) -> int:
-    from .main_create import execute as create_execute
-    from ..common.constants import NULL
     from ..exceptions import DryRunExit
+    from .main_create import execute as create_execute
 
     try:
         return create_execute(args, parser)
-    except DryRunExit as e:
+    except DryRunExit:
         return 0

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -7,11 +7,8 @@ Creates new conda environments with the specified packages.
 
 from argparse import (
     ArgumentParser,
-    Namespace,
     _SubParsersAction,
 )
-
-from ..notices import notices
 
 
 def epilog() -> str:
@@ -111,7 +108,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     add_parser_platform(p)
 
     p.set_defaults(
-        func="conda.cli.main_env_create.execute",
+        func="conda.cli.main_create.execute",
         clone=False,
         override_channels=False,
         use_local=NULL,
@@ -120,14 +117,3 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         yes=True,
     )
     return p
-
-
-@notices
-def execute(args: Namespace, parser: ArgumentParser) -> int:
-    from ..exceptions import DryRunExit
-    from .main_create import execute as create_execute
-
-    try:
-        return create_execute(args, parser)
-    except DryRunExit:
-        return 0

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -84,7 +84,6 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         "-f",
         "--file",
         nargs="*",
-        # action="store",
         help=(
             "Environment definition file (default: environment.yml). Standard "
             "filenames registered by the installed format plugins are "

--- a/news/16210-make-conda-env-create-an-alias
+++ b/news/16210-make-conda-env-create-an-alias
@@ -1,0 +1,20 @@
+### Enhancements
+
+* pip related actions are included in output when `--json` output is specified for install related commands. (#16210)
+
+### Bug fixes
+
+* `conda env create` enforces not creating environments inside existing prefix's. (#16210)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Make `conda env create` an alias of `conda create`. (#15576 via #16210)
+* Make `conda env create --dry-run` and `conda create --dry-run` outputs consistent. (#16210)

--- a/news/16210-make-conda-env-create-an-alias
+++ b/news/16210-make-conda-env-create-an-alias
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* pip related actions are included in output when `--json` output is specified for install related commands. (#16210)
+* <news item>
 
 ### Bug fixes
 

--- a/news/16210-make-conda-env-create-an-alias
+++ b/news/16210-make-conda-env-create-an-alias
@@ -18,3 +18,4 @@
 
 * Make `conda env create` an alias of `conda create`. (#15576 via #16210)
 * Make `conda env create --dry-run` and `conda create --dry-run` outputs consistent. (#16210)
+* Bump`conda-pypi` dependency to `>=0.10.1`. (#16210)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,7 @@ requirements:
     # Plugins to bundle with conda
     - conda-libmamba-solver >=26.4.1
     - conda-lockfiles >=0.2.0
-    - conda-pypi >=0.9.0
+    - conda-pypi >=0.10.1
     - conda-self >=0.2.0
   run_constrained:
     - conda-build >=25.9

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -270,14 +270,14 @@ def test_create_valid_env_with_variables(
 
 @pytest.mark.integration
 def test_conda_env_create_empty_file(
-    conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture
+    conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture, tmp_path: Path,
 ):
     """Test the environment.yaml format, `conda env create --file=file_name.yml` where file_name.yml is empty."""
     tmp_file = path_factory(suffix=".yml")
     tmp_file.touch()
 
     with pytest.raises(EnvironmentSpecPluginSelectionError):
-        conda_cli("env", "create", "--format=cep-24", f"--file={tmp_file}")
+        conda_cli("env", "create", "--prefix", tmp_path, "--format=cep-24", f"--file={tmp_file}")
 
 
 @pytest.mark.integration

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -197,20 +197,14 @@ def test_create_dry_run_yaml(
 ):
     prefix = path_factory()
     create_env(ENVIRONMENT_CA_CERTIFICATES)
-    stdout, _, _ = conda_cli("env", "create", f"--prefix={prefix}", "--dry-run")
-    assert not PrefixData(prefix).is_environment()
+    with pytest.raises(DryRunExit):
+        stdout, _, rc = conda_cli("env", "create", f"--prefix={prefix}", "--dry-run")
+        assert rc == 0
+        assert not PrefixData(prefix).is_environment()
 
-    # Find line where the YAML output starts (stdout might change if plugins involved)
-    lines = stdout.splitlines()
-    for lineno, line in enumerate(lines):
-        if line.startswith("name:"):
-            break
-    else:
-        pytest.fail("Didn't find YAML data in output")
-
-    output = yaml.loads("\n".join(lines[lineno:]))
-    assert output["name"] == "env1"
-    assert len(output["dependencies"]) > 0
+        # Check that the output contains the expected package and prefix information
+        assert f"environment location: {prefix}" in stdout
+        assert "ca-certificates" in stdout
 
 
 @pytest.mark.integration
@@ -224,20 +218,21 @@ def test_create_dry_run_json(
     create_env(ENVIRONMENT_CA_CERTIFICATES, filename=str(env_file))
     assert env_file.is_file()
 
-    stdout, _, _ = conda_cli(
-        "env",
-        "create",
-        f"--file={env_file}",
-        f"--prefix={prefix}",
-        "--dry-run",
-        "--json",
-    )
-    assert not PrefixData(prefix).is_environment()
+    with pytest.raises(DryRunExit):
+        stdout, _, _ = conda_cli(
+            "env",
+            "create",
+            f"--file={env_file}",
+            f"--prefix={prefix}",
+            "--dry-run",
+            "--json",
+        )
+        assert not PrefixData(prefix).is_environment()
 
-    output = json.loads(stdout)
-    # assert that the name specified in the environment file matches output
-    assert output.get("name") == "env1"
-    assert len(output["dependencies"])
+        output = json.loads(stdout)
+        # assert that the name specified in the environment file matches output
+        assert output.get("name") == "env1"
+        assert len(output["dependencies"])
 
 
 @pytest.mark.integration
@@ -270,14 +265,23 @@ def test_create_valid_env_with_variables(
 
 @pytest.mark.integration
 def test_conda_env_create_empty_file(
-    conda_cli: CondaCLIFixture, path_factory: PathFactoryFixture, tmp_path: Path,
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+    tmp_path: Path,
 ):
     """Test the environment.yaml format, `conda env create --file=file_name.yml` where file_name.yml is empty."""
     tmp_file = path_factory(suffix=".yml")
     tmp_file.touch()
 
     with pytest.raises(EnvironmentSpecPluginSelectionError):
-        conda_cli("env", "create", "--prefix", tmp_path, "--format=cep-24", f"--file={tmp_file}")
+        conda_cli(
+            "env",
+            "create",
+            "--prefix",
+            tmp_path,
+            "--format=cep-24",
+            f"--file={tmp_file}",
+        )
 
 
 @pytest.mark.integration

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -206,9 +206,9 @@ def test_create_env_no_default_packages(
     tmp_envs_dir: Path,
 ):
     # use "cheap" packages with no dependencies
-    monkeypatch.setenv("CONDA_CREATE_DEFAULT_PACKAGES", "favicon,zlib")
+    monkeypatch.setenv("CONDA_CREATE_DEFAULT_PACKAGES", "favicon,imagesize")
     reset_context()
-    assert context.create_default_packages == ("favicon", "zlib")
+    assert context.create_default_packages == ("favicon", "imagesize")
 
     env_name = uuid4().hex[:8]
     prefix = tmp_envs_dir / env_name
@@ -223,7 +223,7 @@ def test_create_env_no_default_packages(
     assert package_is_installed(prefix, "python")
     assert package_is_installed(prefix, "pytz")
     assert not package_is_installed(prefix, "favicon")
-    assert not package_is_installed(prefix, "zlib")
+    assert not package_is_installed(prefix, "imagesize")
 
 
 @pytest.mark.integration

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -215,7 +215,7 @@ def test_create_env_no_default_packages(
 
     conda_cli(
         *("env", "create"),
-        *("--name", env_name),
+        *("--prefix", prefix),
         *("--file", support_file("env_with_dependencies.yml")),
         "--no-default-packages",
     )
@@ -347,7 +347,7 @@ def test_create_env_from_non_existent_plugin(
             conda_cli(
                 "env",
                 "create",
-                f"--prefix={prefix}/envs",
+                f"--prefix={prefix}",
                 "--file",
                 support_file("example/environment_pinned.yml"),
             )

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -14,7 +14,11 @@ from conda.base.context import context, reset_context
 from conda.common.compat import on_win
 from conda.common.configuration import DEFAULT_CONDARC_FILENAME
 from conda.core.prefix_data import PrefixData
-from conda.exceptions import CondaValueError, EnvironmentSpecPluginSelectionError
+from conda.exceptions import (
+    CondaValueError,
+    DryRunExit,
+    EnvironmentSpecPluginSelectionError,
+)
 from conda.testing.integration import package_is_installed
 
 from . import remote_support_file, support_file
@@ -501,14 +505,15 @@ def test_export_and_recreate_environment(
 
         # recreate the environment
         recreate_prefix = path_factory()
-        _, stderr, rc = conda_cli(
-            "env",
-            "create",
-            f"--prefix={recreate_prefix}",
-            f"--format={target_format}",
-            f"--file={env_file_path}",
-            "--dry-run",
-        )
-        assert rc == 0, (
-            f"conda env create --dry-run failed ({target_format=}): {stderr}"
-        )
+        with pytest.raises(DryRunExit):
+            _, stderr, rc = conda_cli(
+                "env",
+                "create",
+                f"--prefix={recreate_prefix}",
+                f"--format={target_format}",
+                f"--file={env_file_path}",
+                "--dry-run",
+            )
+            assert rc == 0, (
+                f"conda env create --dry-run failed ({target_format=}): {stderr}"
+            )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes: https://github.com/conda/conda/issues/15576
This pr updates `conda env create` an alias of `conda env`.  ~This should not impact any user facing features of `conda env create`.~

A couple of things this depends on:
* [x] currently conda-pypi post install hooks will try to read environment files. However this does not support remote env files. conda env allows for environment files to be remote.
  * fix: https://github.com/conda/conda-pypi/pull/408
  * will need a release of conda-pypi: https://github.com/conda/conda-pypi/issues/411
* [x] bug fix: pip related actions are included in the json summary, for example when running `conda create . . . --json`. Some possible solutions:
  * https://github.com/conda/conda/pull/16269
  * https://github.com/conda/conda/pull/16270

### A couple of user facing changes:

A few user facing changes are required to make `conda create` and `conda env create` consistent. Some of these changes are not strictly required. Alternative solutions will also be listed.

#### Make `conda create` and `conda env create` dry run output consistent. 

Now they both 
  * have a return code 0 - not a change in behaviour
  * raise a `DryRunExit` - previously `conda env create` would not output any error codes
  * output the same actions report - previously `conda env create` would return a yaml report with all the packages it would have installed.

*Rationale*: This makes `conda env create` more consistent with the behaviour of `conda create` and other existing conda commands. However, this is a breaking change.

*Alternatives*: `conda env create` could keep the existing behaviour.

#### `conda env create` enforces not creating environments inside already existing prefix's 

*Rationale*: This makes `conda env create` more consistent with the behaviour of `conda create`.

*Alternatives*: `conda env create` could keep the existing behaviour.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
