### PR TITLE
Backport menuinst v2 shortcut dir helper to 26.5.x

### DIFF
--- a/conda/testing/integration.py
+++ b/conda/testing/integration.py
@@ -83,8 +83,16 @@ def package_is_installed(
 
 def get_shortcut_dir(prefix_for_unix=sys.prefix):
     if sys.platform == "win32":
-        # On Windows, .nonadmin has been historically created by constructor in sys.prefix
-        user_mode = "user" if Path(sys.prefix, ".nonadmin").is_file() else "system"
+        # On Windows, .nonadmin has historically been created by constructor
+        # in sys.prefix. Newer menuinst versions also honor the target prefix.
+        user_mode = (
+            "user"
+            if (
+                Path(prefix_for_unix, ".nonadmin").is_file()
+                or Path(sys.prefix, ".nonadmin").is_file()
+            )
+            else "system"
+        )
         try:  # menuinst v2
             from menuinst.platforms.win_utils.knownfolders import dirs_src
 


### PR DESCRIPTION
### Description

Backport #16207 to `26.5.x`.

The Windows failures seen in #16184 are `tests/test_create.py::test_menuinst_v2[libmamba]` failures. The test creates `.nonadmin` in the target prefix, and newer menuinst versions honor that marker when choosing the user Start Menu location. The helper on `26.5.x` still only checked `sys.prefix/.nonadmin`, so the test could assert the system Start Menu path while menuinst created shortcuts in the user Start Menu path.

This backports the merged main-branch helper fix from #16207: on Windows, `get_shortcut_dir()` now considers the supplied target prefix marker while preserving the historical `sys.prefix` fallback.

### Checklist - did you ...

- [x] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release release notes?~ Test helper backport only.
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ Not applicable.
