### PR TITLE
Normalize structured guidance test style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Common uses: **`deprecated(...)`** (functions, methods, classes), **`.argument`*
 
 ## Tests
 
-- Prefer **clear names** and **small, focused** tests; the body should read as the spec.
+- Prefer **clear, snake_case names** and **small, focused** tests; the body should read as the spec.
 - Keep **docstrings short**; long prose drifts from the code.
 - Avoid **`assert expr, "message"`** when the message only repeats static explanation—use a **`#` comment** above the line if a reader needs a hint.
 - **Exit codes / subprocess output:** Bare **`assert rc == 0`** (or similar) is often too terse for CI; include **stderr** in the message (e.g. **`assert rc == 0, f"conda {subcommand} failed ({rc}): {stderr}"`**, or the same shape for **`pip install`** / **`python`** subprocess probes) so failures stay actionable.

--- a/tests/_private/test_exception_guidance.py
+++ b/tests/_private/test_exception_guidance.py
@@ -8,25 +8,25 @@ from conda import CondaError
 from conda._private.exception_guidance import ErrorGuidance, GuidanceHint
 
 
-def test_GuidanceHint() -> None:
+def test_guidance_hint() -> None:
     hint = GuidanceHint("Do the thing.", "do_the_thing")
     assert hint.text == "Do the thing."
     assert hint.hint_code == "do_the_thing"
 
 
-def test_ErrorGuidance_defaults() -> None:
+def test_error_guidance_defaults() -> None:
     g = ErrorGuidance(summary="S")
     assert g.summary == "S"
     assert g.cause is None
     assert g.hints == ()
 
 
-def test_ErrorGuidance_requires_at_least_one_field() -> None:
+def test_error_guidance_requires_at_least_one_field() -> None:
     with pytest.raises(ValueError, match="at least one of summary, cause, or hints"):
         ErrorGuidance()
 
 
-def test_ErrorGuidance_full() -> None:
+def test_error_guidance_full() -> None:
     g = ErrorGuidance(
         summary="Something went wrong.",
         cause="Because of reasons.",
@@ -40,7 +40,7 @@ def test_ErrorGuidance_full() -> None:
     assert len(g.hints) == 2
 
 
-def test_ErrorGuidance_frozen() -> None:
+def test_error_guidance_frozen() -> None:
     g = ErrorGuidance(summary="Test.")
 
     with pytest.raises(AttributeError):
@@ -126,7 +126,7 @@ def test_format_guidance_full() -> None:
     ]
 
 
-def test_ErrorGuidance_hint_codes_property() -> None:
+def test_error_guidance_hint_codes_property() -> None:
     g = ErrorGuidance(
         hints=(
             GuidanceHint("h1", "code1"),
@@ -136,12 +136,12 @@ def test_ErrorGuidance_hint_codes_property() -> None:
     assert g.hint_codes == ("code1", "code2")
 
 
-def test_ErrorGuidance_hint_codes_empty() -> None:
+def test_error_guidance_hint_codes_empty() -> None:
     g = ErrorGuidance(summary="S")
     assert g.hint_codes == ()
 
 
-def test_ErrorGuidance_json() -> None:
+def test_error_guidance_json() -> None:
     g = ErrorGuidance(
         summary="S",
         cause="C",
@@ -162,7 +162,7 @@ def test_ErrorGuidance_json() -> None:
     }
 
 
-def test_ErrorGuidance_json_no_hints() -> None:
+def test_error_guidance_json_no_hints() -> None:
     g = ErrorGuidance(summary="S")
     assert g.__json__() == {"summary": "S"}
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -39,6 +39,7 @@ from conda.exceptions import (
     conda_exception_handler,
     print_conda_exception,
 )
+from conda.models.match_spec import MatchSpec
 
 
 def _raise_helper(exception):
@@ -942,7 +943,7 @@ def test_BinaryPrefixReplacementError(
     )
 
 
-def test_RemoveError_with_guidance() -> None:
+def test_remove_error_with_guidance() -> None:
     exc = RemoveError(
         "legacy message",
         guidance={
@@ -964,12 +965,12 @@ def test_RemoveError_with_guidance() -> None:
     assert exc.guidance.hints[0].hint_code == hint_code
 
 
-def test_RemoveError_without_guidance() -> None:
+def test_remove_error_without_guidance() -> None:
     exc = RemoveError("legacy message")
     assert exc.guidance is None
 
 
-def test_RemoveError_guidance_in_dump_map() -> None:
+def test_remove_error_guidance_in_dump_map() -> None:
     exc = RemoveError(
         "legacy message",
         guidance={
@@ -991,12 +992,12 @@ def test_RemoveError_guidance_in_dump_map() -> None:
     }
 
 
-def test_RemoveError_without_guidance_dump_map_no_key() -> None:
+def test_remove_error_without_guidance_dump_map_no_key() -> None:
     exc = RemoveError("legacy message")
     assert "guidance" not in exc.dump_map()
 
 
-def test_RemoveError_str_unchanged_with_guidance() -> None:
+def test_remove_error_str_unchanged_with_guidance() -> None:
     """__str__ should remain the legacy message, not the guidance."""
     exc = RemoveError(
         (message := "legacy message"),
@@ -1064,59 +1065,61 @@ def test_print_conda_exception_without_guidance(
     )
 
 
-def test_PackagesNotFoundError_guidance_for_bulk_missing(
+@pytest.mark.parametrize(
+    "packages, has_guidance",
+    (
+        pytest.param([f"pkg{i}" for i in range(5)], True, id="bulk-missing"),
+        pytest.param(["single-pkg"], False, id="few-missing"),
+    ),
+)
+def test_packages_not_found_error_guidance(
     monkeypatch: MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("CONDA_USE_ONLY_TAR_BZ2", "false")
-    reset_context()
-    assert not context.use_only_tar_bz2
-
-    pkgs = [f"pkg{i}" for i in range(5)]
-    exc = PackagesNotFoundError(
-        pkgs,
-        channel_urls=["https://repo.anaconda.org/pkgs/main"],
-    )
-    assert exc.guidance is not None
-    assert "Many packages are unavailable" in exc.guidance.summary
-    assert exc.guidance.hints[0].hint_code == "check_channel_config"
-
-
-def test_PackagesNotFoundError_no_guidance_for_few_packages(
-    monkeypatch: MonkeyPatch,
+    packages: list[str],
+    has_guidance: bool,
 ) -> None:
     monkeypatch.setenv("CONDA_USE_ONLY_TAR_BZ2", "false")
     reset_context()
     assert not context.use_only_tar_bz2
 
     exc = PackagesNotFoundError(
-        ["single-pkg"],
+        packages,
         channel_urls=["https://repo.anaconda.org/pkgs/main"],
     )
-    assert exc.guidance is None
+    assert (exc.guidance is not None) is has_guidance
+    if has_guidance:
+        assert "Many packages are unavailable" in exc.guidance.summary
+        assert exc.guidance.hints[0].hint_code == "check_channel_config"
 
 
-def test_UnsatisfiableError_guidance() -> None:
+def test_unsatisfiable_error_guidance() -> None:
     exc = UnsatisfiableError({})
     assert exc.guidance is not None
     assert "could not find a compatible set" in exc.guidance.summary
 
 
-def test_UnsatisfiableError_bad_deps_requires_conflict_map() -> None:
-    from conda.models.match_spec import MatchSpec
-
-    with pytest.raises(AttributeError, match="items"):
-        UnsatisfiableError([[MatchSpec("foo=99")]])
-
-
-def test_UnsatisfiableError_bad_deps_accepts_conflict_map() -> None:
-    UnsatisfiableError(
-        {
-            "python": set(),
-            "request_conflict_with_history": set(),
-            "direct": set(),
-            "virtual_package": set(),
-        }
-    )
+@pytest.mark.parametrize(
+    "bad_deps, raises",
+    (
+        pytest.param([[MatchSpec("foo=99")]], AttributeError, id="list"),
+        pytest.param(
+            {
+                "python": set(),
+                "request_conflict_with_history": set(),
+                "direct": set(),
+                "virtual_package": set(),
+            },
+            None,
+            id="conflict-map",
+        ),
+    ),
+)
+def test_unsatisfiable_error_bad_deps_shape(
+    bad_deps: object,
+    raises: type[Exception] | None,
+) -> None:
+    raises_context = pytest.raises(raises, match="items") if raises else nullcontext()
+    with raises_context:
+        UnsatisfiableError(bad_deps)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("use_only_tar_bz2", [True, False])


### PR DESCRIPTION
### Description

Follow-up to #16160 that keeps the new structured guidance tests aligned with the repo's test style conventions.

This PR:
- moves the `MatchSpec` test import to module scope
- renames the newly added structured guidance tests to snake_case
- documents snake_case test function names in `AGENTS.md`
- parameterizes the repeated `PackagesNotFoundError` and `UnsatisfiableError` shape tests

### Checklist - did you ...

- [x] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
