### PR TITLE
fix CondaError.__str__() raising on interpolation with empty kwargs

### DIFF
--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -107,6 +107,8 @@ class CondaError(Exception):
         return f"{self.__class__.__name__}: {self}"
 
     def __str__(self) -> str:
+        if not self._kwargs:
+            return str(self.message)
         try:
             return str(self.message) % self._kwargs
         except Exception:

--- a/news/16263-condaerror-formatting
+++ b/news/16263-condaerror-formatting
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Avoid crash when trying to format a CondaError with a message that has already been formatted. (#16263)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -12,6 +12,7 @@ import requests
 from pytest import CaptureFixture, MonkeyPatch
 from pytest_mock import MockerFixture
 
+from conda import CondaError
 from conda.auxlib.collection import AttrDict
 from conda.base.constants import PathConflict
 from conda.base.context import context, reset_context
@@ -1213,3 +1214,11 @@ def test_platform_mismatch_error_message(
     message = str(PlatformMismatchError(sources, subdir))
     for fragment in expected_fragments:
         assert fragment in message
+
+
+def test_CondaError_interpolation_no_kwargs() -> None:
+    """__str__ should not raise if trying to interpolate a string with no kwargs."""
+    message = "a message with %T"
+    exc = CondaError(message=message)
+    assert str(exc) == message
+    assert repr(exc) == "CondaError: " + message


### PR DESCRIPTION
### Description

`conda env create` crashes with `ValueError: unsupported format character` while rendering an error, hiding the actual failure, when a failed pre-/post-link script's output contains a literal %.
 
 Cause can be traced to double %-formatting
 
1. On a failed post-link script, run_script builds the error message by interpolating the captured script output: [conda/core/link.py:1699](https://github.com/conda/conda/blob/main/conda/core/link.py#L1699) 

 2. LinkError(message) passes only a positional message and no kwargs. So CondaError._kwargs == {}, and the message is already fully interpolated.
 
 3. When the error is rendered, [`CondaError.__str__`](https://github.com/conda/conda/blob/main/conda/__init__.py#L109) runs `str(self.message) % self._kwargs`, so tries a second %-format over the message string. If  the embedded script output contains a literal %, it's parsed as a format string and raises the `ValueError: unsupported format character 'T'`.
 
4. The except block in __str__ re-raises, and the original error (link error during R CMD INSTALL) is lost.

Any failed pre-/post-link script whose stdout/stderr contains a % crashes conda and suppresses the real cause. 

The original bug and repro is documented in #16263 - found while installing `bioconductor-singlecellmultimodal`  (the post-link runs curl, whose progress output contains %).

Fixes #16263.

### Checklist 
- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?