### PR TITLE
Enable docs updates with dependabot

### DIFF
--- a/.github/template-files/config.yml
+++ b/.github/template-files/config.yml
@@ -42,10 +42,12 @@ conda/infrastructure:
   # [optional] dependabot — pick ONE variant
   # - src: templates/dependabot/github-actions.yml
   #   dst: .github/dependabot.yml
-  - src: templates/dependabot/github-actions-with-pre-commit.yml
-    dst: .github/dependabot.yml
+  # - src: templates/dependabot/github-actions-with-pre-commit.yml
+  #   dst: .github/dependabot.yml
   # - src: templates/dependabot/github-actions-with-docs-pip.yml
   #   dst: .github/dependabot.yml
+  - src: templates/dependabot/github-actions-with-pre-commit-docs-conda.yml
+    dst: .github/dependabot.yml
   # - src: templates/dependabot/github-actions-full.yml
   #   dst: .github/dependabot.yml
 

--- a/news/16251-infrastructure-dependabot
+++ b/news/16251-infrastructure-dependabot
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Enable infrastructure-managed Dependabot configuration via conda/infrastructure templates. (#16251)
+* Enable infrastructure-managed Dependabot configuration via conda/infrastructure templates. (#16251, #16271)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Previously conda had a docs update section in dependabot with a pip section which wasn't causing any updates. This PR goes with https://github.com/conda/infrastructure/pull/1369 to enable conda ecosystem updates to our docs for the environment.yaml.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
