### PR TITLE
Ensure auth headers are set when fetching sharded repodata

### DIFF
--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -657,7 +657,7 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
     if cache_state.should_check_format("shards"):
         # look for shards index
         shards_data = None
-        shards_index_url = f"{sd.url_w_subdir}/{REPODATA_SHARDS_FN}"
+        shards_index_url = f"{sd.url_w_credentials}/{REPODATA_SHARDS_FN}"
 
         if not repo_cache.cache_path_shards.exists():
             # avoid 304 not modified if we don't have the file

--- a/news/16273-apply-channel-auth-to-shard-repodata-fetch
+++ b/news/16273-apply-channel-auth-to-shard-repodata-fetch
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ensure auth headers are set when fetching sharded repodata. (#16250 via #16273)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -381,6 +381,46 @@ def test_fetch_shards_index_mark_unavailable(monkeypatch, tmp_path, error_code):
         assert mock_session.get_count == get_count
 
 
+def test_fetch_shards_index_uses_credentials(monkeypatch, tmp_path):
+    """
+    Regression test: fetch_shards_index must include credentials in the request
+    if provided in the channel url. This way, auth tokens are included in the
+    request URL for sharded repodata.
+    """
+    monkeypatch.setenv("CONDA_PKGS_DIRS", str(tmp_path))
+    reset_context()
+
+    captured_urls = []
+
+    class MockSession:
+        proxies = None
+
+        def __call__(self, *args):
+            return self
+
+        def get(self, url, *args, **kwargs):
+            captured_urls.append(url)
+            request = Request("GET", url).prepare()
+            response = Response()
+            response.request = request
+            response.url = url
+            response.status_code = 404
+            return response
+
+    monkeypatch.setattr(shards, "get_session", MockSession())
+
+    # Channel with a token embedded in the URL
+    channel = Channel("http://token:mytoken@localhost/mock/noarch")
+    subdir_data = SubdirData(channel)
+
+    assert "mytoken" in subdir_data.url_w_credentials
+
+    fetch_shards_index(subdir_data)
+
+    assert len(captured_urls) == 1
+    assert "mytoken" in captured_urls[0]
+
+
 def test_fetch_shards_error(http_server_shards, empty_shards_cache):
     channel = Channel.from_url(f"{http_server_shards}/noarch")
     subdir_data = SubdirData(channel)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This change makes the shards repodata fetching include the appropriate auth headers when auth tokens are provided in the set of conda channels.

#### Test it out

You can manually test this by setting up a local server and inspecting the traffic conda sends when it is fetching repodata.

##### Setup the server

An example server script that will include all header information: https://gist.github.com/mdonkers/63e115cc0c79b4f6b8b3a6b797e485c7

```
$ python server.py 8000
```

##### conda config
Update the condarc (sharded repodata enabled by default)
```
channels:
  - http://token:token@localhost:8000
solver: rattler
```

##### Test it out
Try running an install
```
$ conda install python
```

Notice the logging from the server. On the main branch:
```
INFO:root:GET request,
Path: /noarch/repodata_shards.msgpack.zst
Headers:
Host: localhost:8000
User-Agent: conda/26.5.3.dev38 requests/2.34.2 CPython/3.10.20 Linux/6.17.4-76061704-generic pop/22.04 glibc/2.35 solver/rattler conda-rattler-solver/0.1.1 py-rattler/0.25.0
Accept-Encoding: gzip, deflate, br, zstd
Accept: */*
Connection: keep-alive
```

With this change, notice the additional `Authorization` header
```
127.0.0.1 - - [23/Jun/2026 14:24:49] "GET /linux-64/repodata_shards.msgpack.zst HTTP/1.1" 200 -
INFO:root:GET request,
Path: /noarch/repodata_shards.msgpack.zst
Headers:
Host: localhost:8000
User-Agent: conda/26.5.3.dev38 requests/2.34.2 CPython/3.10.20 Linux/6.17.4-76061704-generic pop/22.04 glibc/2.35 solver/rattler conda-rattler-solver/0.1.1 py-rattler/0.25.0
Accept-Encoding: gzip, deflate, br, zstd
Accept: */*
Connection: keep-alive
Authorization: Basic dG9rZW46dG9rZW4= 
```


fixes https://github.com/conda/conda/issues/16250

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
