### PR TITLE
Speed up `test_create_install_update_remove_smoketest` using local HTTP

### DIFF
--- a/news/16009-speed-up-create-smoketest
+++ b/news/16009-speed-up-create-smoketest
@@ -1,0 +1,3 @@
+### Other
+
+* Speed up `test_create_install_update_remove_smoketest` by serving local test-recipes over HTTP instead of remote python/flask solves. (#16009)

--- a/news/16009-speed-up-create-smoketest
+++ b/news/16009-speed-up-create-smoketest
@@ -1,3 +1,0 @@
-### Other
-
-* Speed up `test_create_install_update_remove_smoketest` by serving local test-recipes over HTTP instead of remote python/flask solves. (#16009)

--- a/news/16287-speed-up-create-smoketest
+++ b/news/16287-speed-up-create-smoketest
@@ -1,0 +1,3 @@
+### Other
+
+* Speed up `test_create_install_update_remove_smoketest` by serving local test-recipes over HTTP instead of remote python/flask solves. (#16009 via #16287)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -93,6 +93,7 @@ if TYPE_CHECKING:
 
     from conda.testing.fixtures import (
         CondaCLIFixture,
+        HttpTestServerFixture,
         PathFactoryFixture,
         PipCLIFixture,
         TmpChannelFixture,
@@ -179,40 +180,47 @@ def test_run_preserves_arguments(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixt
         assert not code
 
 
-@pytest.mark.flaky(reruns=2, condition=on_win and not in_subprocess())
+@pytest.mark.parametrize(
+    "http_test_server",
+    [Path(__file__).parent / "data" / "test-recipes"],
+    indirect=True,
+)
 def test_create_install_update_remove_smoketest(
+    http_test_server: HttpTestServerFixture,
+    mock_channels: list[str],
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
     request: pytest.FixtureRequest,
 ):
+    """Create/install/update/remove/revision smoketest over local HTTP test-recipes."""
     if context.solver == "libmamba" and on_win and forward_to_subprocess(request):
         return
-    with tmp_env(PYTHON_SPEC) as prefix:
-        assert (prefix / PYTHON_BINARY).exists()
-        assert package_is_installed(prefix, "python=3")
+    mock_channels.append(http_test_server.url)
+    with tmp_env("versioned=1.0") as prefix:
+        assert package_is_installed(prefix, "versioned=1.0")
 
-        conda_cli("install", f"--prefix={prefix}", "flask=2.0.1", "--yes")
-        assert package_is_installed(prefix, "flask=2.0.1")
-        assert package_is_installed(prefix, "python=3", reload_records=False)
+        conda_cli("install", f"--prefix={prefix}", "buildstring", "--yes")
+        assert package_is_installed(prefix, "buildstring")
+        assert package_is_installed(prefix, "versioned=1.0", reload_records=False)
 
         conda_cli(
             "install",
             f"--prefix={prefix}",
             "--force-reinstall",
-            "flask=2.0.1",
+            "buildstring",
             "--yes",
         )
-        assert package_is_installed(prefix, "flask=2.0.1")
-        assert package_is_installed(prefix, "python=3", reload_records=False)
+        assert package_is_installed(prefix, "buildstring")
+        assert package_is_installed(prefix, "versioned=1.0", reload_records=False)
 
-        conda_cli("update", f"--prefix={prefix}", "flask", "--yes")
-        assert not package_is_installed(prefix, "flask=2.0.1")
-        assert package_is_installed(prefix, "flask", reload_records=False)
-        assert package_is_installed(prefix, "python=3", reload_records=False)
+        conda_cli("install", f"--prefix={prefix}", "versioned=2.0", "--yes")
+        assert not package_is_installed(prefix, "versioned=1.0")
+        assert package_is_installed(prefix, "versioned=2.0", reload_records=False)
+        assert package_is_installed(prefix, "buildstring", reload_records=False)
 
-        conda_cli("remove", f"--prefix={prefix}", "flask", "--yes")
-        assert not package_is_installed(prefix, "flask")
-        assert package_is_installed(prefix, "python=3", reload_records=False)
+        conda_cli("remove", f"--prefix={prefix}", "buildstring", "--yes")
+        assert not package_is_installed(prefix, "buildstring")
+        assert package_is_installed(prefix, "versioned=2.0", reload_records=False)
 
         stdout, stderr, code = conda_cli("list", f"--prefix={prefix}", "--revisions")
         assert not stderr
@@ -220,8 +228,8 @@ def test_create_install_update_remove_smoketest(
         assert " (rev 5)\n" not in stdout
 
         conda_cli("install", f"--prefix={prefix}", "--revision", "0", "--yes")
-        assert not package_is_installed(prefix, "flask")
-        assert package_is_installed(prefix, "python=3", reload_records=False)
+        assert not package_is_installed(prefix, "buildstring")
+        assert package_is_installed(prefix, "versioned=1.0", reload_records=False)
 
 
 def test_install_broken_post_install_keeps_existing_folders(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes #16009 by switching from testing on a real channel to a local HTTP server. Speed up is from about 69s to 2.2s.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
