### PR TITLE
Add `conda_error_hints` plugin hook

### DIFF
--- a/conda/_private/exception_guidance.py
+++ b/conda/_private/exception_guidance.py
@@ -8,7 +8,7 @@ so that terminal and `--json` output share the same logical cause / hint structu
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from typing import TYPE_CHECKING
 
 from .. import CondaError
@@ -70,9 +70,11 @@ class ErrorGuidance:
         result["hint_codes"] = self.hint_codes
         return {k: v for k, v in result.items() if v}
 
-    @classmethod
-    def from_hints(cls, hints: Iterable[GuidanceHint]) -> ErrorGuidance | None:
-        """Create guidance from hints, deduplicating by ``hint_code``."""
+    @staticmethod
+    def _deduplicate_hints(
+        hints: Iterable[GuidanceHint],
+    ) -> tuple[GuidanceHint, ...]:
+        """Deduplicate hints by ``hint_code`` while preserving first wins order."""
         merged_hints = []
         seen_hint_codes = set()
         for hint in hints:
@@ -80,20 +82,28 @@ class ErrorGuidance:
                 continue
             seen_hint_codes.add(hint.hint_code)
             merged_hints.append(hint)
+        return tuple(merged_hints)
+
+    @classmethod
+    def from_hints(cls, hints: Iterable[GuidanceHint]) -> ErrorGuidance | None:
+        """Create guidance from hints, deduplicating by ``hint_code``."""
+        merged_hints = cls._deduplicate_hints(hints)
         if not merged_hints:
             return None
-        return cls(hints=tuple(merged_hints))
+        return cls(hints=merged_hints)
 
     def with_hints(self, hints: Iterable[GuidanceHint]) -> ErrorGuidance:
-        """Return this guidance with additional hints appended."""
-        guidance = ErrorGuidance.from_hints((*self.hints, *tuple(hints)))
-        if guidance is None or len(guidance.hints) == len(self.hints):
+        """Return this guidance with additional hints appended.
+
+        Existing hints keep priority when ``hint_code`` values collide.
+        """
+        hints = tuple(hints)
+        if not hints:
             return self
-        return ErrorGuidance(
-            summary=self.summary,
-            cause=self.cause,
-            hints=guidance.hints,
-        )
+        new_hints = self._deduplicate_hints((*self.hints, *hints))
+        if new_hints == self.hints:
+            return self
+        return replace(self, hints=new_hints)
 
     @classmethod
     def coerce(cls, value: Any) -> ErrorGuidance | None:

--- a/conda/_private/exception_guidance.py
+++ b/conda/_private/exception_guidance.py
@@ -92,7 +92,7 @@ class ErrorGuidance:
         hints = tuple(hints)
         if not hints:
             return self
-        guidance = ErrorGuidance.from_hints((*self.hints, *hints))
+        guidance = self.from_hints((*self.hints, *hints))
         if guidance is None or guidance.hints == self.hints:
             return self
         return replace(self, hints=guidance.hints)

--- a/conda/_private/exception_guidance.py
+++ b/conda/_private/exception_guidance.py
@@ -70,11 +70,9 @@ class ErrorGuidance:
         result["hint_codes"] = self.hint_codes
         return {k: v for k, v in result.items() if v}
 
-    @staticmethod
-    def _deduplicate_hints(
-        hints: Iterable[GuidanceHint],
-    ) -> tuple[GuidanceHint, ...]:
-        """Deduplicate hints by ``hint_code`` while preserving first wins order."""
+    @classmethod
+    def from_hints(cls, hints: Iterable[GuidanceHint]) -> ErrorGuidance | None:
+        """Create guidance from hints, deduplicating by ``hint_code``."""
         merged_hints = []
         seen_hint_codes = set()
         for hint in hints:
@@ -82,15 +80,9 @@ class ErrorGuidance:
                 continue
             seen_hint_codes.add(hint.hint_code)
             merged_hints.append(hint)
-        return tuple(merged_hints)
-
-    @classmethod
-    def from_hints(cls, hints: Iterable[GuidanceHint]) -> ErrorGuidance | None:
-        """Create guidance from hints, deduplicating by ``hint_code``."""
-        merged_hints = cls._deduplicate_hints(hints)
         if not merged_hints:
             return None
-        return cls(hints=merged_hints)
+        return cls(hints=tuple(merged_hints))
 
     def with_hints(self, hints: Iterable[GuidanceHint]) -> ErrorGuidance:
         """Return this guidance with additional hints appended.
@@ -100,10 +92,10 @@ class ErrorGuidance:
         hints = tuple(hints)
         if not hints:
             return self
-        new_hints = self._deduplicate_hints((*self.hints, *hints))
-        if new_hints == self.hints:
+        guidance = ErrorGuidance.from_hints((*self.hints, *hints))
+        if guidance is None or guidance.hints == self.hints:
             return self
-        return replace(self, hints=new_hints)
+        return replace(self, hints=guidance.hints)
 
     @classmethod
     def coerce(cls, value: Any) -> ErrorGuidance | None:

--- a/conda/_private/exception_guidance.py
+++ b/conda/_private/exception_guidance.py
@@ -71,6 +71,31 @@ class ErrorGuidance:
         return {k: v for k, v in result.items() if v}
 
     @classmethod
+    def from_hints(cls, hints: Iterable[GuidanceHint]) -> ErrorGuidance | None:
+        """Create guidance from hints, deduplicating by ``hint_code``."""
+        merged_hints = []
+        seen_hint_codes = set()
+        for hint in hints:
+            if hint.hint_code in seen_hint_codes:
+                continue
+            seen_hint_codes.add(hint.hint_code)
+            merged_hints.append(hint)
+        if not merged_hints:
+            return None
+        return cls(hints=tuple(merged_hints))
+
+    def with_hints(self, hints: Iterable[GuidanceHint]) -> ErrorGuidance:
+        """Return this guidance with additional hints appended."""
+        guidance = ErrorGuidance.from_hints((*self.hints, *tuple(hints)))
+        if guidance is None or len(guidance.hints) == len(self.hints):
+            return self
+        return ErrorGuidance(
+            summary=self.summary,
+            cause=self.cause,
+            hints=guidance.hints,
+        )
+
+    @classmethod
     def coerce(cls, value: Any) -> ErrorGuidance | None:
         """Coerce *value* to ``ErrorGuidance`` or ``None``.
 

--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -1738,17 +1738,38 @@ def print_conda_exception(exc_val: CondaError, exc_tb: TracebackType | None = No
     rc = getattr(exc_val, "return_code", None)
     if context.debug or (not isinstance(exc_val, DryRunExit) and context.info):
         print(_format_exc(exc_val, exc_tb), file=sys.stderr)
-    elif context.json:
+        return
+
+    if context.json:
         if isinstance(exc_val, DryRunExit):
             return
+
+    guidance = exc_val.guidance
+    try:
+        plugin_hints = context.plugin_manager.get_error_hints(exc_val)
+    except BaseException:
+        log.debug("Failed to collect error hint plugins", exc_info=True)
+        plugin_hints = ()
+    if guidance is not None:
+        guidance = guidance.with_hints(plugin_hints)
+    elif plugin_hints:
+        from ._private.exception_guidance import ErrorGuidance
+
+        guidance = ErrorGuidance.from_hints(plugin_hints)
+
+    if context.json:
         from .gateways.streams import stderr, stdout
 
-        exc_json = json_dumps(exc_val.dump_map(), sort_keys=True)
+        error_map = exc_val.dump_map()
+        if guidance is not None:
+            error_map["guidance"] = guidance.__json__()
+        else:
+            error_map.pop("guidance", None)
+        exc_json = json_dumps(error_map, sort_keys=True)
         (stdout if rc else stderr)(f"{exc_json}\n")
     else:
         from .gateways.streams import stderr
 
-        guidance = getattr(exc_val, "_guidance", None)
         if guidance is not None:
             stderr(f"\n{guidance.format(exc_val)}\n")
         else:

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -658,8 +658,8 @@ class CondaSpecs:
             def conda_error_hints(error):
                 if isinstance(error, PackagesNotFoundInChannelsError):
                     yield plugins.types.CondaErrorHint(
+                        name="check_expected_channel",
                         text="Check whether the package exists on your expected channel.",
-                        hint_code="check_expected_channel",
                     )
 
         Returns:

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -20,10 +20,12 @@ from ..deprecations import deprecated
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from .. import CondaError
     from .types import (
         CondaAuthHandler,
         CondaEnvironmentExporter,
         CondaEnvironmentSpecifier,
+        CondaErrorHint,
         CondaExceptionObserver,
         CondaHealthCheck,
         CondaPackageExtractor,
@@ -625,6 +627,42 @@ class CondaSpecs:
         yield from ()
 
     @_hookspec
+    def conda_error_hints(self, error: CondaError) -> Iterable[CondaErrorHint]:
+        """
+        Register user-facing hints for expected conda errors.
+
+        This hook is invoked while rendering a :class:`conda.CondaError`.
+        Plugins receive the current error and yield structured
+        :class:`~conda.plugins.types.CondaErrorHint` objects that conda appends
+        to the error's existing guidance. Plugins should not print directly from
+        this hook.
+
+        Use this hook for user-facing next steps. Use
+        :meth:`~conda.plugins.hookspec.CondaSpecs.conda_exception_observers`
+        for telemetry, logging, demand tracking, or other side effects.
+
+        **Example:**
+
+        .. code-block:: python
+
+            from conda import plugins
+            from conda.exceptions import PackagesNotFoundInChannelsError
+
+
+            @plugins.hookimpl
+            def conda_error_hints(error):
+                if isinstance(error, PackagesNotFoundInChannelsError):
+                    yield plugins.types.CondaErrorHint(
+                        text="Check whether the package exists on your expected channel.",
+                        hint_code="check_expected_channel",
+                    )
+
+        Returns:
+            An iterable of :class:`~conda.plugins.types.CondaErrorHint` entries.
+        """
+        yield from ()
+
+    @_hookspec
     def conda_prefix_data_loaders() -> Iterable[CondaPrefixDataLoader]:
         """
         Register new loaders for PrefixData
@@ -858,12 +896,16 @@ class CondaSpecs:
 
         .. code-block:: python
 
+            import logging
+
             from conda import plugins
+
+            log = logging.getLogger(__name__)
 
 
             def report_missing(event):
-                print(f"Missing packages: {event.exc_value.packages}")
-                print(f"Command was: {' '.join(event.argv)}")
+                log.info("Missing packages: %s", event.exc_value.packages)
+                log.info("Command was: %s", " ".join(event.argv))
 
 
             @plugins.hookimpl

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -637,6 +637,11 @@ class CondaSpecs:
         to the error's existing guidance. Plugins should not print directly from
         this hook.
 
+        Conda invokes implementations in deterministic plugin-name order and
+        preserves the hint order yielded by each plugin. Existing core guidance
+        hints win when a plugin yields the same ``hint_code``. Hook wrappers are
+        skipped so conda can isolate failures per implementation.
+
         Use this hook for user-facing next steps. Use
         :meth:`~conda.plugins.hookspec.CondaSpecs.conda_exception_observers`
         for telemetry, logging, demand tracking, or other side effects.

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -658,8 +658,8 @@ class CondaSpecs:
             def conda_error_hints(error):
                 if isinstance(error, PackagesNotFoundInChannelsError):
                     yield plugins.types.CondaErrorHint(
-                        name="check_expected_channel",
                         text="Check whether the package exists on your expected channel.",
+                        hint_code="check_expected_channel",
                     )
 
         Returns:

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -660,13 +660,17 @@ class CondaPluginManager(pluggy.PluginManager):
 
         Each hook implementation is invoked independently so a faulty plugin
         cannot prevent other plugins from contributing hints during error
-        rendering.
+        rendering. Implementations are invoked in deterministic plugin-name
+        order, while preserving the hint order yielded by each plugin.
         """
         from .._private.exception_guidance import GuidanceHint
 
         hook = self.hook.conda_error_hints
         hints = []
-        for hookimpl in hook.get_hookimpls():
+        for hookimpl in sorted(
+            hook.get_hookimpls(),
+            key=lambda hookimpl: str(hookimpl.plugin_name),
+        ):
             if hookimpl.hookwrapper or hookimpl.wrapper:
                 log.debug(
                     "Skipping wrapper implementation for `conda_error_hints`: %r",

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -663,8 +663,6 @@ class CondaPluginManager(pluggy.PluginManager):
         rendering. Implementations are invoked in deterministic plugin-name
         order, while preserving the hint order yielded by each plugin.
         """
-        from .._private.exception_guidance import GuidanceHint
-
         hook = self.hook.conda_error_hints
         hints = []
         for hookimpl in sorted(
@@ -685,7 +683,7 @@ class CondaPluginManager(pluggy.PluginManager):
                     continue
                 for hint in hook_result:
                     if isinstance(hint, CondaErrorHint):
-                        hints.append(GuidanceHint(text=hint.text, hint_code=hint.name))
+                        hints.append(hint)
                     else:
                         log.debug(
                             "Invalid error hint from plugin %r: expected "

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -53,7 +53,7 @@ from . import (
 from .config import PluginConfig
 from .hookspec import CondaSpecs
 from .subcommands.doctor import health_checks
-from .types import CondaExceptionEvent
+from .types import CondaErrorHint, CondaExceptionEvent
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -63,6 +63,8 @@ if TYPE_CHECKING:
     from pluggy import HookImpl
     from requests.auth import AuthBase
 
+    from .. import CondaError
+    from .._private.exception_guidance import GuidanceHint
     from ..common.path import PathType
     from ..core.path_actions import Action
     from ..core.solve import Solver
@@ -651,6 +653,51 @@ class CondaPluginManager(pluggy.PluginManager):
             hook.name: hook.value
             for hook in self.get_hook_results("request_headers", host=host, path=path)
         }
+
+    def get_error_hints(self, error: CondaError) -> tuple[GuidanceHint, ...]:
+        """
+        Return plugin-provided guidance hints for a conda error.
+
+        Each hook implementation is invoked independently so a faulty plugin
+        cannot prevent other plugins from contributing hints during error
+        rendering.
+        """
+        from .._private.exception_guidance import GuidanceHint
+
+        hook = self.hook.conda_error_hints
+        hints = []
+        for hookimpl in hook.get_hookimpls():
+            if hookimpl.hookwrapper or hookimpl.wrapper:
+                log.debug(
+                    "Skipping wrapper implementation for `conda_error_hints`: %r",
+                    hookimpl.plugin_name,
+                )
+                continue
+
+            try:
+                kwargs = {"error": error} if "error" in hookimpl.argnames else {}
+                hook_result = hookimpl.function(**kwargs)
+                if hook_result is None:
+                    continue
+                for hint in hook_result:
+                    if isinstance(hint, CondaErrorHint):
+                        hints.append(
+                            GuidanceHint(text=hint.text, hint_code=hint.hint_code)
+                        )
+                    else:
+                        log.debug(
+                            "Invalid error hint from plugin %r: expected "
+                            "CondaErrorHint, got %s",
+                            hookimpl.plugin_name,
+                            type(hint).__name__,
+                        )
+            except BaseException:
+                log.debug(
+                    "Error hints plugin %r failed",
+                    hookimpl.plugin_name,
+                    exc_info=True,
+                )
+        return tuple(hints)
 
     def get_prefix_data_loaders(self) -> Iterable[CondaPrefixDataLoaderCallable]:
         for hook in self.get_hook_results("prefix_data_loaders"):

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -685,9 +685,7 @@ class CondaPluginManager(pluggy.PluginManager):
                     continue
                 for hint in hook_result:
                     if isinstance(hint, CondaErrorHint):
-                        hints.append(
-                            GuidanceHint(text=hint.text, hint_code=hint.hint_code)
-                        )
+                        hints.append(GuidanceHint(text=hint.text, hint_code=hint.name))
                     else:
                         log.debug(
                             "Invalid error hint from plugin %r: expected "

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, overload
 
 from requests.auth import AuthBase  # noqa: TID253
 
+from .._private.exception_guidance import GuidanceHint as _GuidanceHint
 from ..auxlib import NULL
 from ..auxlib.type_coercion import maybecall
 from ..base.constants import APP_NAME
@@ -570,8 +571,8 @@ class CondaRequestHeader(CondaPlugin):
     value: str
 
 
-@dataclass
-class CondaErrorHint(CondaPlugin):
+@dataclass(frozen=True)
+class CondaErrorHint(_GuidanceHint):
     """
     Return type to use when defining a conda error hints plugin hook.
 
@@ -579,17 +580,12 @@ class CondaErrorHint(CondaPlugin):
     :meth:`~conda.plugins.hookspec.CondaSpecs.conda_error_hints`.
 
     Args:
-        name: Stable machine-readable hint code. Use snake_case.
         text: Human-readable description of the action to take.
+        hint_code: Stable machine-readable identifier. Use snake_case.
     """
 
-    name: str
     text: str
-
-    @property
-    def hint_code(self) -> str:
-        """Alias for ``name`` used by structured guidance output."""
-        return self.name
+    hint_code: str
 
 
 @dataclass

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -570,8 +570,8 @@ class CondaRequestHeader(CondaPlugin):
     value: str
 
 
-@dataclass(frozen=True)
-class CondaErrorHint:
+@dataclass
+class CondaErrorHint(CondaPlugin):
     """
     Return type to use when defining a conda error hints plugin hook.
 
@@ -579,12 +579,17 @@ class CondaErrorHint:
     :meth:`~conda.plugins.hookspec.CondaSpecs.conda_error_hints`.
 
     Args:
+        name: Stable machine-readable hint code. Use snake_case.
         text: Human-readable description of the action to take.
-        hint_code: Stable machine-readable identifier. Use snake_case.
     """
 
+    name: str
     text: str
-    hint_code: str
+
+    @property
+    def hint_code(self) -> str:
+        """Alias for ``name`` used by structured guidance output."""
+        return self.name
 
 
 @dataclass

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -570,6 +570,23 @@ class CondaRequestHeader(CondaPlugin):
     value: str
 
 
+@dataclass(frozen=True)
+class CondaErrorHint:
+    """
+    Return type to use when defining a conda error hints plugin hook.
+
+    For details on how this is used, see
+    :meth:`~conda.plugins.hookspec.CondaSpecs.conda_error_hints`.
+
+    Args:
+        text: Human-readable description of the action to take.
+        hint_code: Stable machine-readable identifier. Use snake_case.
+    """
+
+    text: str
+    hint_code: str
+
+
 @dataclass
 class CondaPreTransactionAction(CondaPlugin):
     """

--- a/docs/source/dev-guide/plugins/error_hints.rst
+++ b/docs/source/dev-guide/plugins/error_hints.rst
@@ -23,8 +23,8 @@ Example
    def conda_error_hints(error):
        if isinstance(error, PackagesNotFoundInChannelsError):
            yield plugins.types.CondaErrorHint(
-               name="check_expected_channel",
                text="Check whether the package exists on your expected channel.",
+               hint_code="check_expected_channel",
            )
 
 With that plugin installed, conda appends the hint to the normal terminal
@@ -67,8 +67,6 @@ preserves the order yielded by each implementation, and appends plugin hints
 after core guidance hints. If two hints use the same ``hint_code``, the first
 hint wins, so core guidance takes priority over plugin guidance. Hook wrappers
 are skipped for this hook so conda can isolate failures per implementation.
-The hint object's ``name`` is rendered as ``guidance.hints[].hint_code`` in
-``--json`` output.
 
 Error hints vs. exception observers
 -----------------------------------

--- a/docs/source/dev-guide/plugins/error_hints.rst
+++ b/docs/source/dev-guide/plugins/error_hints.rst
@@ -62,6 +62,12 @@ rendering expected errors. If one plugin raises or yields an invalid hint,
 conda logs the plugin failure at DEBUG level and continues rendering the
 original error plus any other valid hints.
 
+Hint order is deterministic: conda invokes implementations by plugin name,
+preserves the order yielded by each implementation, and appends plugin hints
+after core guidance hints. If two hints use the same ``hint_code``, the first
+hint wins, so core guidance takes priority over plugin guidance. Hook wrappers
+are skipped for this hook so conda can isolate failures per implementation.
+
 Error hints vs. exception observers
 -----------------------------------
 

--- a/docs/source/dev-guide/plugins/error_hints.rst
+++ b/docs/source/dev-guide/plugins/error_hints.rst
@@ -1,0 +1,87 @@
+===========
+Error Hints
+===========
+
+The ``conda_error_hints`` plugin hook allows plugins to contribute structured
+next-step hints while conda renders a :class:`conda.CondaError`.
+
+This hook is for user-facing remediation, not telemetry. Plugins should yield
+:class:`~conda.plugins.types.CondaErrorHint` objects and should not print
+directly. Conda appends the yielded hints to the error's existing guidance so
+terminal and ``--json`` output stay consistent.
+
+Example
+-------
+
+.. code-block:: python
+
+   from conda import plugins
+   from conda.exceptions import PackagesNotFoundInChannelsError
+
+
+   @plugins.hookimpl
+   def conda_error_hints(error):
+       if isinstance(error, PackagesNotFoundInChannelsError):
+           yield plugins.types.CondaErrorHint(
+               text="Check whether the package exists on your expected channel.",
+               hint_code="check_expected_channel",
+           )
+
+With that plugin installed, conda appends the hint to the normal terminal
+guidance output:
+
+.. code-block:: text
+
+   PackagesNotFoundInChannelsError: The following packages are not available
+   from current channels:
+     - missing-package
+
+   Next steps:
+     - (check_expected_channel) Check whether the package exists on your expected channel.
+
+The same hint is included in ``--json`` output:
+
+.. code-block:: json
+
+   {
+     "error": "...",
+     "exception_name": "PackagesNotFoundInChannelsError",
+     "guidance": {
+       "hints": [
+         {
+           "hint_code": "check_expected_channel",
+           "text": "Check whether the package exists on your expected channel."
+         }
+       ],
+       "hint_codes": ["check_expected_channel"]
+     }
+   }
+
+Conda invokes each ``conda_error_hints`` implementation independently while
+rendering expected errors. If one plugin raises or yields an invalid hint,
+conda logs the plugin failure at DEBUG level and continues rendering the
+original error plus any other valid hints.
+
+Error hints vs. exception observers
+-----------------------------------
+
+Use ``conda_error_hints`` when a plugin wants to add user-facing next steps to
+an expected :class:`conda.CondaError`. Hints are part of conda's normal error
+guidance model: conda controls ordering, deduplicates by ``hint_code``, renders
+them in the terminal ``Next steps`` section, and includes them in ``--json``
+under ``guidance.hints`` and ``guidance.hint_codes``.
+
+Use :doc:`exception_observers` when a plugin needs to observe failures for
+telemetry, logging, demand tracking, or other side effects. Observers are
+fire-and-forget callbacks modelled after :func:`sys.excepthook`: their return
+value is ignored, and they should not mutate exceptions or print user-facing
+messages.
+
+API reference
+-------------
+
+.. autoapiclass:: conda.plugins.types.CondaErrorHint
+   :members:
+   :undoc-members:
+
+.. autoapifunction:: conda.plugins.hookspec.CondaSpecs.conda_error_hints

--- a/docs/source/dev-guide/plugins/error_hints.rst
+++ b/docs/source/dev-guide/plugins/error_hints.rst
@@ -23,8 +23,8 @@ Example
    def conda_error_hints(error):
        if isinstance(error, PackagesNotFoundInChannelsError):
            yield plugins.types.CondaErrorHint(
+               name="check_expected_channel",
                text="Check whether the package exists on your expected channel.",
-               hint_code="check_expected_channel",
            )
 
 With that plugin installed, conda appends the hint to the normal terminal
@@ -67,6 +67,8 @@ preserves the order yielded by each implementation, and appends plugin hints
 after core guidance hints. If two hints use the same ``hint_code``, the first
 hint wins, so core guidance takes priority over plugin guidance. Hook wrappers
 are skipped for this hook so conda can isolate failures per implementation.
+The hint object's ``name`` is rendered as ``guidance.hints[].hint_code`` in
+``--json`` output.
 
 Error hints vs. exception observers
 -----------------------------------

--- a/docs/source/dev-guide/plugins/index.rst
+++ b/docs/source/dev-guide/plugins/index.rst
@@ -98,6 +98,7 @@ For examples of how to use other plugin hooks, please read their respective docu
    :maxdepth: 1
 
    auth_handlers
+   error_hints
    environment_exporters
    environment_specifiers
    exception_observers

--- a/news/16290-error-hints-plugin-hook
+++ b/news/16290-error-hints-plugin-hook
@@ -1,0 +1,11 @@
+### Enhancements
+
+* Add a ``conda_error_hints`` plugin hook for appending structured guidance hints to ``CondaError`` output. (#16290)
+
+### Bug fixes
+
+### Deprecations
+
+### Docs
+
+### Other

--- a/news/16290-error-hints-plugin-hook
+++ b/news/16290-error-hints-plugin-hook
@@ -1,11 +1,3 @@
 ### Enhancements
 
 * Add a ``conda_error_hints`` plugin hook for appending structured guidance hints to ``CondaError`` output. (#16290)
-
-### Bug fixes
-
-### Deprecations
-
-### Docs
-
-### Other

--- a/tests/_private/test_exception_guidance.py
+++ b/tests/_private/test_exception_guidance.py
@@ -167,6 +167,60 @@ def test_ErrorGuidance_json_no_hints() -> None:
     assert g.__json__() == {"summary": "S"}
 
 
+def test_ErrorGuidance_from_hints_deduplicates_first_wins() -> None:
+    guidance = ErrorGuidance.from_hints(
+        (
+            GuidanceHint("Core step.", "step"),
+            GuidanceHint("Plugin replacement.", "step"),
+            GuidanceHint("Plugin step.", "plugin_step"),
+        )
+    )
+
+    assert guidance is not None
+    assert guidance.hints == (
+        GuidanceHint("Core step.", "step"),
+        GuidanceHint("Plugin step.", "plugin_step"),
+    )
+
+
+def test_ErrorGuidance_with_hints_empty_returns_self() -> None:
+    guidance = ErrorGuidance(summary="S")
+
+    assert guidance.with_hints(()) is guidance
+
+
+def test_ErrorGuidance_with_hints_appends_after_existing() -> None:
+    guidance = ErrorGuidance(
+        summary="S",
+        hints=(GuidanceHint("Core step.", "core_step"),),
+    )
+
+    updated = guidance.with_hints((GuidanceHint("Plugin step.", "plugin_step"),))
+
+    assert updated is not guidance
+    assert updated.hints == (
+        GuidanceHint("Core step.", "core_step"),
+        GuidanceHint("Plugin step.", "plugin_step"),
+    )
+
+
+def test_ErrorGuidance_with_hints_compares_result_not_length() -> None:
+    guidance = ErrorGuidance(
+        hints=(
+            GuidanceHint("Core step.", "core_step"),
+            GuidanceHint("Duplicate core step.", "core_step"),
+        ),
+    )
+
+    updated = guidance.with_hints((GuidanceHint("Plugin step.", "plugin_step"),))
+
+    assert updated is not guidance
+    assert updated.hints == (
+        GuidanceHint("Core step.", "core_step"),
+        GuidanceHint("Plugin step.", "plugin_step"),
+    )
+
+
 def test_coerce_guidance_none() -> None:
     assert ErrorGuidance.coerce(None) is None
 

--- a/tests/plugins/test_error_hints.py
+++ b/tests/plugins/test_error_hints.py
@@ -25,12 +25,12 @@ class ErrorHintsPlugin:
     ) -> Iterator[plugins.types.CondaErrorHint]:
         self.calls.append(error)
         yield plugins.types.CondaErrorHint(
-            name="first_hint",
             text="First hint.",
+            hint_code="first_hint",
         )
         yield plugins.types.CondaErrorHint(
-            name="second_hint",
             text="Second hint.",
+            hint_code="second_hint",
         )
 
 
@@ -42,8 +42,8 @@ class InvalidHintPlugin:
     def conda_error_hints(self, error: CondaError):
         yield self.invalid_hint
         yield plugins.types.CondaErrorHint(
-            name="still_valid",
             text="Still valid.",
+            hint_code="still_valid",
         )
 
 
@@ -52,8 +52,8 @@ class ExplodingHintPlugin:
     def conda_error_hints(self, error: CondaError):
         raise RuntimeError("plugin bug")
         yield plugins.types.CondaErrorHint(
-            name="unreachable",
             text="unreachable",
+            hint_code="unreachable",
         )
 
 
@@ -65,8 +65,8 @@ class NamedErrorHintPlugin:
     @plugins.hookimpl
     def conda_error_hints(self, error: CondaError):
         yield plugins.types.CondaErrorHint(
-            name=self.hint_code,
             text=self.text,
+            hint_code=self.hint_code,
         )
 
 
@@ -76,20 +76,21 @@ def test_get_error_hints(plugin_manager: CondaPluginManager):
     plugin_manager.register(plugin)
 
     assert plugin_manager.get_error_hints(error) == (
-        GuidanceHint("First hint.", "first_hint"),
-        GuidanceHint("Second hint.", "second_hint"),
+        plugins.types.CondaErrorHint("First hint.", "first_hint"),
+        plugins.types.CondaErrorHint("Second hint.", "second_hint"),
     )
     assert plugin.calls == [error]
 
 
-def test_CondaErrorHint_uses_name_as_hint_code() -> None:
+def test_CondaErrorHint_reuses_guidance_hint() -> None:
     hint = plugins.types.CondaErrorHint(
-        name="  MY_HINT  ",
         text="Do the thing.",
+        hint_code="do_the_thing",
     )
 
-    assert hint.name == "my_hint"
-    assert hint.hint_code == "my_hint"
+    assert isinstance(hint, GuidanceHint)
+    assert not isinstance(hint, plugins.types.CondaPlugin)
+    assert hint.hint_code == "do_the_thing"
 
 
 def test_get_error_hints_orders_plugins_by_plugin_name(
@@ -105,8 +106,8 @@ def test_get_error_hints_orders_plugins_by_plugin_name(
     )
 
     assert plugin_manager.get_error_hints(CondaError("boom")) == (
-        GuidanceHint("First plugin.", "first_plugin"),
-        GuidanceHint("Second plugin.", "second_plugin"),
+        plugins.types.CondaErrorHint("First plugin.", "first_plugin"),
+        plugins.types.CondaErrorHint("Second plugin.", "second_plugin"),
     )
 
 
@@ -125,7 +126,7 @@ def test_get_error_hints_ignores_invalid_hints(
     plugin_manager.register(InvalidHintPlugin(invalid_hint))
 
     assert plugin_manager.get_error_hints(CondaError("boom")) == (
-        GuidanceHint("Still valid.", "still_valid"),
+        plugins.types.CondaErrorHint("Still valid.", "still_valid"),
     )
 
 
@@ -136,6 +137,6 @@ def test_get_error_hints_swallow_plugin_failures(
     plugin_manager.register(ErrorHintsPlugin())
 
     assert plugin_manager.get_error_hints(CondaError("boom")) == (
-        GuidanceHint("First hint.", "first_hint"),
-        GuidanceHint("Second hint.", "second_hint"),
+        plugins.types.CondaErrorHint("First hint.", "first_hint"),
+        plugins.types.CondaErrorHint("Second hint.", "second_hint"),
     )

--- a/tests/plugins/test_error_hints.py
+++ b/tests/plugins/test_error_hints.py
@@ -45,6 +45,16 @@ class ExplodingHintPlugin:
         yield plugins.types.CondaErrorHint("unreachable", "unreachable")
 
 
+class NamedErrorHintPlugin:
+    def __init__(self, text: str, hint_code: str):
+        self.text = text
+        self.hint_code = hint_code
+
+    @plugins.hookimpl
+    def conda_error_hints(self, error: CondaError):
+        yield plugins.types.CondaErrorHint(self.text, self.hint_code)
+
+
 def test_get_error_hints(plugin_manager: CondaPluginManager):
     plugin = ErrorHintsPlugin()
     error = CondaError("boom")
@@ -55,6 +65,24 @@ def test_get_error_hints(plugin_manager: CondaPluginManager):
         GuidanceHint("Second hint.", "second_hint"),
     )
     assert plugin.calls == [error]
+
+
+def test_get_error_hints_orders_plugins_by_plugin_name(
+    plugin_manager: CondaPluginManager,
+):
+    plugin_manager.register(
+        NamedErrorHintPlugin("Second plugin.", "second_plugin"),
+        name="z-plugin",
+    )
+    plugin_manager.register(
+        NamedErrorHintPlugin("First plugin.", "first_plugin"),
+        name="a-plugin",
+    )
+
+    assert plugin_manager.get_error_hints(CondaError("boom")) == (
+        GuidanceHint("First plugin.", "first_plugin"),
+        GuidanceHint("Second plugin.", "second_plugin"),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/test_error_hints.py
+++ b/tests/plugins/test_error_hints.py
@@ -24,8 +24,14 @@ class ErrorHintsPlugin:
         self, error: CondaError
     ) -> Iterator[plugins.types.CondaErrorHint]:
         self.calls.append(error)
-        yield plugins.types.CondaErrorHint("First hint.", "first_hint")
-        yield plugins.types.CondaErrorHint("Second hint.", "second_hint")
+        yield plugins.types.CondaErrorHint(
+            name="first_hint",
+            text="First hint.",
+        )
+        yield plugins.types.CondaErrorHint(
+            name="second_hint",
+            text="Second hint.",
+        )
 
 
 class InvalidHintPlugin:
@@ -35,14 +41,20 @@ class InvalidHintPlugin:
     @plugins.hookimpl
     def conda_error_hints(self, error: CondaError):
         yield self.invalid_hint
-        yield plugins.types.CondaErrorHint("Still valid.", "still_valid")
+        yield plugins.types.CondaErrorHint(
+            name="still_valid",
+            text="Still valid.",
+        )
 
 
 class ExplodingHintPlugin:
     @plugins.hookimpl
     def conda_error_hints(self, error: CondaError):
         raise RuntimeError("plugin bug")
-        yield plugins.types.CondaErrorHint("unreachable", "unreachable")
+        yield plugins.types.CondaErrorHint(
+            name="unreachable",
+            text="unreachable",
+        )
 
 
 class NamedErrorHintPlugin:
@@ -52,7 +64,10 @@ class NamedErrorHintPlugin:
 
     @plugins.hookimpl
     def conda_error_hints(self, error: CondaError):
-        yield plugins.types.CondaErrorHint(self.text, self.hint_code)
+        yield plugins.types.CondaErrorHint(
+            name=self.hint_code,
+            text=self.text,
+        )
 
 
 def test_get_error_hints(plugin_manager: CondaPluginManager):
@@ -65,6 +80,16 @@ def test_get_error_hints(plugin_manager: CondaPluginManager):
         GuidanceHint("Second hint.", "second_hint"),
     )
     assert plugin.calls == [error]
+
+
+def test_CondaErrorHint_uses_name_as_hint_code() -> None:
+    hint = plugins.types.CondaErrorHint(
+        name="  MY_HINT  ",
+        text="Do the thing.",
+    )
+
+    assert hint.name == "my_hint"
+    assert hint.hint_code == "my_hint"
 
 
 def test_get_error_hints_orders_plugins_by_plugin_name(

--- a/tests/plugins/test_error_hints.py
+++ b/tests/plugins/test_error_hints.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from conda import CondaError, plugins
+from conda._private.exception_guidance import GuidanceHint
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from conda.plugins.manager import CondaPluginManager
+
+
+class ErrorHintsPlugin:
+    def __init__(self):
+        self.calls = []
+
+    @plugins.hookimpl
+    def conda_error_hints(
+        self, error: CondaError
+    ) -> Iterator[plugins.types.CondaErrorHint]:
+        self.calls.append(error)
+        yield plugins.types.CondaErrorHint("First hint.", "first_hint")
+        yield plugins.types.CondaErrorHint("Second hint.", "second_hint")
+
+
+class InvalidHintPlugin:
+    def __init__(self, invalid_hint):
+        self.invalid_hint = invalid_hint
+
+    @plugins.hookimpl
+    def conda_error_hints(self, error: CondaError):
+        yield self.invalid_hint
+        yield plugins.types.CondaErrorHint("Still valid.", "still_valid")
+
+
+class ExplodingHintPlugin:
+    @plugins.hookimpl
+    def conda_error_hints(self, error: CondaError):
+        raise RuntimeError("plugin bug")
+        yield plugins.types.CondaErrorHint("unreachable", "unreachable")
+
+
+def test_get_error_hints(plugin_manager: CondaPluginManager):
+    plugin = ErrorHintsPlugin()
+    error = CondaError("boom")
+    plugin_manager.register(plugin)
+
+    assert plugin_manager.get_error_hints(error) == (
+        GuidanceHint("First hint.", "first_hint"),
+        GuidanceHint("Second hint.", "second_hint"),
+    )
+    assert plugin.calls == [error]
+
+
+@pytest.mark.parametrize(
+    "invalid_hint",
+    [
+        object(),
+        {"text": "Dict hint.", "hint_code": "dict_hint"},
+        GuidanceHint("Internal hint.", "internal_hint"),
+    ],
+)
+def test_get_error_hints_ignores_invalid_hints(
+    plugin_manager: CondaPluginManager,
+    invalid_hint,
+):
+    plugin_manager.register(InvalidHintPlugin(invalid_hint))
+
+    assert plugin_manager.get_error_hints(CondaError("boom")) == (
+        GuidanceHint("Still valid.", "still_valid"),
+    )
+
+
+def test_get_error_hints_swallow_plugin_failures(
+    plugin_manager: CondaPluginManager,
+):
+    plugin_manager.register(ExplodingHintPlugin())
+    plugin_manager.register(ErrorHintsPlugin())
+
+    assert plugin_manager.get_error_hints(CondaError("boom")) == (
+        GuidanceHint("First hint.", "first_hint"),
+        GuidanceHint("Second hint.", "second_hint"),
+    )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1055,12 +1055,12 @@ def test_print_conda_exception_with_plugin_hints(
         def conda_error_hints(self, error):
             if isinstance(error, RemoveError):
                 yield plugins.types.CondaErrorHint(
-                    name="do_the_thing",
                     text="Duplicate.",
+                    hint_code="do_the_thing",
                 )
                 yield plugins.types.CondaErrorHint(
-                    name="plugin_step",
                     text="Plugin step.",
+                    hint_code="plugin_step",
                 )
 
     plugin_manager.register(PluginHints())
@@ -1111,8 +1111,8 @@ def test_print_conda_exception_with_plugin_hints_json(
         def conda_error_hints(self, error):
             if isinstance(error, RemoveError):
                 yield plugins.types.CondaErrorHint(
-                    name="plugin_step",
                     text="Plugin step.",
+                    hint_code="plugin_step",
                 )
 
     plugin_manager.register(PluginHints())
@@ -1160,8 +1160,8 @@ def test_PackagesNotFoundInChannelsError_plugin_hint(
                 assert error.packages == ("missing-pkg",)
                 assert error.channel_urls == ("https://repo.example.com",)
                 yield plugins.types.CondaErrorHint(
-                    name="anaconda_channel_suggestion",
                     text="Try installing from the recommended channel.",
+                    hint_code="anaconda_channel_suggestion",
                 )
 
     plugin_manager.register(ChannelGuidePlugin())
@@ -1202,8 +1202,8 @@ def test_exception_observers_do_not_contribute_error_hints(
         def conda_exception_observers(self):
             def observer(event):
                 return plugins.types.CondaErrorHint(
-                    name="observer_hint",
                     text="Observer hint.",
+                    hint_code="observer_hint",
                 )
 
             yield plugins.types.CondaExceptionObserver(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -12,7 +12,7 @@ import requests
 from pytest import CaptureFixture, MonkeyPatch
 from pytest_mock import MockerFixture
 
-from conda import CondaError
+from conda import CondaError, plugins
 from conda.auxlib.collection import AttrDict
 from conda.base.constants import PathConflict
 from conda.base.context import context, reset_context
@@ -29,6 +29,7 @@ from conda.exceptions import (
     InvalidInstaller,
     KnownPackageClobberError,
     PackagesNotFoundError,
+    PackagesNotFoundInChannelsError,
     PathNotFoundError,
     PlatformMismatchError,
     ProxyError,
@@ -1042,6 +1043,176 @@ def test_print_conda_exception_with_guidance(
             "",
         )
     )
+
+
+def test_print_conda_exception_with_plugin_hints(
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture,
+    plugin_manager,
+) -> None:
+    class PluginHints:
+        @plugins.hookimpl
+        def conda_error_hints(self, error):
+            if isinstance(error, RemoveError):
+                yield plugins.types.CondaErrorHint("Duplicate.", "do_the_thing")
+                yield plugins.types.CondaErrorHint("Plugin step.", "plugin_step")
+
+    plugin_manager.register(PluginHints())
+    monkeypatch.setenv("CONDA_JSON", "no")
+    reset_context()
+    assert not context.json
+
+    summary = "Guidance summary."
+    cause = "Root cause."
+    text = "Do the thing."
+    exc = RemoveError(
+        "legacy message",
+        guidance={
+            "summary": summary,
+            "cause": cause,
+            "hints": [
+                {
+                    "text": text,
+                    "hint_code": "do_the_thing",
+                }
+            ],
+        },
+    )
+    print_conda_exception(exc)
+    stderr = capsys.readouterr().err
+    assert stderr == "\n".join(
+        (
+            "",
+            f"RemoveError: {summary}",
+            "",
+            f"Cause: {cause}",
+            "Next steps:",
+            f"  - (do_the_thing) {text}",
+            "  - (plugin_step) Plugin step.",
+            "",
+            "",
+        )
+    )
+
+
+def test_print_conda_exception_with_plugin_hints_json(
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture,
+    plugin_manager,
+) -> None:
+    class PluginHints:
+        @plugins.hookimpl
+        def conda_error_hints(self, error):
+            if isinstance(error, RemoveError):
+                yield plugins.types.CondaErrorHint("Plugin step.", "plugin_step")
+
+    plugin_manager.register(PluginHints())
+    monkeypatch.setenv("CONDA_JSON", "yes")
+    reset_context()
+    assert context.json
+
+    exc = RemoveError(
+        "legacy message",
+        guidance={
+            "summary": "Guidance summary.",
+            "hints": [
+                {
+                    "text": "Do the thing.",
+                    "hint_code": "do_the_thing",
+                }
+            ],
+        },
+    )
+    print_conda_exception(exc)
+    stdout, stderr = capsys.readouterr()
+    json_obj = json.loads(stdout)
+    assert not stderr
+    assert json_obj["guidance"]["hints"] == [
+        {"text": "Do the thing.", "hint_code": "do_the_thing"},
+        {"text": "Plugin step.", "hint_code": "plugin_step"},
+    ]
+    assert json_obj["guidance"]["hint_codes"] == ["do_the_thing", "plugin_step"]
+
+
+@pytest.mark.parametrize(
+    "json_output",
+    [pytest.param(False, id="terminal"), pytest.param(True, id="json")],
+)
+def test_PackagesNotFoundInChannelsError_plugin_hint(
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture,
+    plugin_manager,
+    json_output: bool,
+) -> None:
+    class ChannelGuidePlugin:
+        @plugins.hookimpl
+        def conda_error_hints(self, error):
+            if isinstance(error, PackagesNotFoundInChannelsError):
+                assert error.packages == ("missing-pkg",)
+                assert error.channel_urls == ("https://repo.example.com",)
+                yield plugins.types.CondaErrorHint(
+                    "Try installing from the recommended channel.",
+                    "anaconda_channel_suggestion",
+                )
+
+    plugin_manager.register(ChannelGuidePlugin())
+    monkeypatch.setenv("CONDA_JSON", "yes" if json_output else "no")
+    reset_context()
+    assert context.json is json_output
+
+    exc = PackagesNotFoundInChannelsError(
+        ["missing-pkg"],
+        ["https://repo.example.com"],
+    )
+    print_conda_exception(exc)
+    stdout, stderr = capsys.readouterr()
+    if json_output:
+        json_obj = json.loads(stdout)
+        assert not stderr
+        assert json_obj["guidance"]["hints"] == [
+            {
+                "text": "Try installing from the recommended channel.",
+                "hint_code": "anaconda_channel_suggestion",
+            }
+        ]
+        assert json_obj["guidance"]["hint_codes"] == ["anaconda_channel_suggestion"]
+    else:
+        assert not stdout
+        assert "PackagesNotFoundInChannelsError:" in stderr
+        assert "Next steps:" in stderr
+        assert "(anaconda_channel_suggestion)" in stderr
+
+
+def test_exception_observers_do_not_contribute_error_hints(
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture,
+    plugin_manager,
+) -> None:
+    class HintReturningObserver:
+        @plugins.hookimpl
+        def conda_exception_observers(self):
+            def observer(event):
+                return plugins.types.CondaErrorHint(
+                    "Observer hint.",
+                    "observer_hint",
+                )
+
+            yield plugins.types.CondaExceptionObserver(
+                name="hint-returning-observer",
+                hook=observer,
+                watch_for={"RemoveError"},
+            )
+
+    plugin_manager.register(HintReturningObserver())
+    monkeypatch.setenv("CONDA_JSON", "no")
+    reset_context()
+    assert not context.json
+
+    conda_exception_handler(_raise_helper, RemoveError("legacy message"))
+    stdout, stderr = capsys.readouterr()
+    assert not stdout
+    assert "observer_hint" not in stderr
+    assert stderr == "\n".join(("", "RemoveError: legacy message", "", ""))
 
 
 def test_print_conda_exception_without_guidance(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1054,8 +1054,14 @@ def test_print_conda_exception_with_plugin_hints(
         @plugins.hookimpl
         def conda_error_hints(self, error):
             if isinstance(error, RemoveError):
-                yield plugins.types.CondaErrorHint("Duplicate.", "do_the_thing")
-                yield plugins.types.CondaErrorHint("Plugin step.", "plugin_step")
+                yield plugins.types.CondaErrorHint(
+                    name="do_the_thing",
+                    text="Duplicate.",
+                )
+                yield plugins.types.CondaErrorHint(
+                    name="plugin_step",
+                    text="Plugin step.",
+                )
 
     plugin_manager.register(PluginHints())
     monkeypatch.setenv("CONDA_JSON", "no")
@@ -1104,7 +1110,10 @@ def test_print_conda_exception_with_plugin_hints_json(
         @plugins.hookimpl
         def conda_error_hints(self, error):
             if isinstance(error, RemoveError):
-                yield plugins.types.CondaErrorHint("Plugin step.", "plugin_step")
+                yield plugins.types.CondaErrorHint(
+                    name="plugin_step",
+                    text="Plugin step.",
+                )
 
     plugin_manager.register(PluginHints())
     monkeypatch.setenv("CONDA_JSON", "yes")
@@ -1151,8 +1160,8 @@ def test_PackagesNotFoundInChannelsError_plugin_hint(
                 assert error.packages == ("missing-pkg",)
                 assert error.channel_urls == ("https://repo.example.com",)
                 yield plugins.types.CondaErrorHint(
-                    "Try installing from the recommended channel.",
-                    "anaconda_channel_suggestion",
+                    name="anaconda_channel_suggestion",
+                    text="Try installing from the recommended channel.",
                 )
 
     plugin_manager.register(ChannelGuidePlugin())
@@ -1193,8 +1202,8 @@ def test_exception_observers_do_not_contribute_error_hints(
         def conda_exception_observers(self):
             def observer(event):
                 return plugins.types.CondaErrorHint(
-                    "Observer hint.",
-                    "observer_hint",
+                    name="observer_hint",
+                    text="Observer hint.",
                 )
 
             yield plugins.types.CondaExceptionObserver(


### PR DESCRIPTION
### Description

Refs #16290.

Adds a `conda_error_hints` plugin hook so plugins can contribute structured next-step hints for expected `CondaError` failures.

Plugin hooks yield public `CondaErrorHint` objects, which conda translates into the existing `GuidanceHint` model, merges after core guidance hints, deduplicates by `hint_code`, and renders through the existing terminal and JSON guidance paths.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?