### PR TITLE
Remove forward to subprocess for smoketest

### DIFF
--- a/news/16287-speed-up-create-smoketest
+++ b/news/16287-speed-up-create-smoketest
@@ -1,3 +1,3 @@
 ### Other
 
-* Speed up `test_create_install_update_remove_smoketest` by serving local test-recipes over HTTP instead of remote python/flask solves. (#16009 via #16287)
+* Speed up `test_create_install_update_remove_smoketest` by serving local test-recipes over HTTP instead of remote python/flask solves. (#16009 via #16287 and #16307)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -193,8 +193,6 @@ def test_create_install_update_remove_smoketest(
     request: pytest.FixtureRequest,
 ):
     """Create/install/update/remove/revision smoketest over local HTTP test-recipes."""
-    if context.solver == "libmamba" and on_win and forward_to_subprocess(request):
-        return
     mock_channels.append(http_test_server.url)
     with tmp_env("versioned=1.0") as prefix:
         assert package_is_installed(prefix, "versioned=1.0")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Follow-up to #16287, @kenodegard noticed that we could simplify this test further to remove forwarding the test to subprocess when on Windows and libmamba, now that the test should no longer be flaky.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
