### PR TITLE
Speed up `test_dont_remove_conda` tests

### DIFF
--- a/news/16299-speed-up-dont-remove-conda
+++ b/news/16299-speed-up-dont-remove-conda
@@ -1,3 +1,0 @@
-### Other
-
-* Speed up `test_dont_remove_conda` by merging duplicate setup from `test_dont_remove_conda_1` and `test_dont_remove_conda_2`, parametrizing remove order, and sharing one session-scoped conda install across variants. (#16299)

--- a/news/16299-speed-up-dont-remove-conda
+++ b/news/16299-speed-up-dont-remove-conda
@@ -1,0 +1,3 @@
+### Other
+
+* Speed up `test_dont_remove_conda` by merging duplicate setup from `test_dont_remove_conda_1` and `test_dont_remove_conda_2`, parametrizing remove order, and sharing one session-scoped conda install across variants. (#16299)

--- a/news/16311-speed-up-dont-remove-conda
+++ b/news/16311-speed-up-dont-remove-conda
@@ -1,0 +1,3 @@
+### Other
+
+* Speed up `test_dont_remove_conda` by merging duplicate setup from `test_dont_remove_conda_1` and `test_dont_remove_conda_2`, parametrizing remove order, and sharing one session-scoped conda install across variants. (#16299 via #16311)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2310,60 +2310,46 @@ def test_disallowed_packages(
         assert exc_val.dump_map()["package_ref"]["name"] == "openssl"
 
 
-def test_dont_remove_conda_1(
-    monkeypatch: MonkeyPatch, tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
+@pytest.fixture(scope="session")
+def _conda_root_prefix_env(
+    session_tmp_env: TmpEnvFixture,
+) -> Iterator[Path]:
+    """Session-scoped conda env shared across parametrized remove-order variants."""
+    with session_tmp_env("conda") as prefix:
+        yield prefix
+
+
+@pytest.fixture
+def root_prefix_with_conda(
+    monkeypatch: MonkeyPatch,
+    _conda_root_prefix_env: Path,
+) -> Path:
+    """Root prefix with conda installed; shared across parametrized remove-order variants."""
+    monkeypatch.setenv("CONDA_ROOT_PREFIX", str(_conda_root_prefix_env))
+    reset_context()
+    assert context.root_prefix == str(_conda_root_prefix_env)
+    return _conda_root_prefix_env
+
+
+@pytest.mark.parametrize(
+    "remove_order",
+    [("conda", "pycosat"), ("pycosat", "conda")],
+    ids=["conda_first", "pycosat_first"],
+)
+def test_dont_remove_conda(
+    root_prefix_with_conda: Path,
+    conda_cli: CondaCLIFixture,
+    remove_order: tuple[str, str],
 ):
-    with tmp_env() as prefix:
-        monkeypatch.setenv("CONDA_ROOT_PREFIX", str(prefix))
-        reset_context()
-        assert context.root_prefix == str(prefix)
-        conda_cli("install", f"--prefix={prefix}", "conda", "conda-build", "--yes")
-        assert package_is_installed(prefix, "conda")
-        assert package_is_installed(prefix, "pycosat")
-        assert package_is_installed(prefix, "conda-build")
-
+    """Conda and its dependencies cannot be removed from the root prefix (#6904)."""
+    for package in remove_order:
         with pytest.raises(CondaMultiError) as exc:
-            conda_cli("remove", f"--prefix={prefix}", "conda", "--yes")
+            conda_cli("remove", f"--prefix={root_prefix_with_conda}", package, "--yes")
 
         assert any(isinstance(e, RemoveError) for e in exc.value.errors)
-        assert package_is_installed(prefix, "conda")
-        assert package_is_installed(prefix, "pycosat")
 
-        with pytest.raises(CondaMultiError) as exc:
-            conda_cli("remove", f"--prefix={prefix}", "pycosat", "--yes")
-
-        assert any(isinstance(e, RemoveError) for e in exc.value.errors)
-        assert package_is_installed(prefix, "conda")
-        assert package_is_installed(prefix, "pycosat")
-        assert package_is_installed(prefix, "conda-build")
-
-
-def test_dont_remove_conda_2(
-    conda_cli: CondaCLIFixture, tmp_env: TmpEnvFixture, monkeypatch: MonkeyPatch
-):
-    # regression test for #6904
-    with tmp_env() as prefix:
-        monkeypatch.setenv("CONDA_ROOT_PREFIX", str(prefix))
-        reset_context()
-        assert context.root_prefix == str(prefix)
-
-        conda_cli("install", f"--prefix={prefix}", "conda", "--yes")
-        assert package_is_installed(prefix, "conda")
-        assert package_is_installed(prefix, "pycosat")
-
-        with pytest.raises(CondaMultiError) as exc:
-            conda_cli("remove", f"--prefix={prefix}", "pycosat", "--yes")
-
-        assert any(isinstance(e, RemoveError) for e in exc.value.errors)
-        assert package_is_installed(prefix, "conda")
-        assert package_is_installed(prefix, "pycosat")
-
-        with pytest.raises(CondaMultiError) as exc:
-            conda_cli("remove", f"--prefix={prefix}", "conda", "--yes")
-
-        assert any(isinstance(e, RemoveError) for e in exc.value.errors)
-        assert package_is_installed(prefix, "conda")
-        assert package_is_installed(prefix, "pycosat")
+    assert package_is_installed(root_prefix_with_conda, "conda")
+    assert package_is_installed(root_prefix_with_conda, "pycosat")
 
 
 def test_dont_remove_conda_3(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR speeds up the current slowest test and closes #16299:

1. Does a single 15sec set up of the test, which is then reused for other parameterized tests
2. Moves from 625s to 147s total test time, with 125s being classic solver run time

I also removed conda-build from the test because it made up 459s of the original test. It is a very heavy dependency to run tests with.

Overall 4x increase in test speed.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
