### PR TITLE
Use os.path.splitext to get win destination trash file

### DIFF
--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -19,6 +19,7 @@ from os.path import (
     join,
     normpath,
     split,
+    splitext,
 )
 from subprocess import STDOUT, CalledProcessError, check_output
 
@@ -160,7 +161,7 @@ def unlink_or_rename_to_trash(path):
                     dest_fn = path + ".conda_trash"
                     counter = 1
                     while isfile(dest_fn):
-                        dest_fn = dest_fn.splitext[0] + f".conda_trash_{counter}"
+                        dest_fn = splitext(dest_fn)[0] + f".conda_trash_{counter}"
                         counter += 1
                     out = "< empty >"
                     try:

--- a/news/16315-dont-use-splitext-on-string
+++ b/news/16315-dont-use-splitext-on-string
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix windows `AttributeError` at runtime for for `.splitext` method. Use `os.path.splitext` to get the filename from strings instead. (#15760 via #16315)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/16315-dont-use-splitext-on-string
+++ b/news/16315-dont-use-splitext-on-string
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix windows `AttributeError` at runtime for for `.splitext` method. Use `os.path.splitext` to get the filename from strings instead. (#15760 via #16315)
+* Fix Windows runtime `AttributeError` from calling `.splitext` on strings. Use `os.path.splitext` instead. (#15760 via #16315)
 
 ### Deprecations
 

--- a/tests/gateways/disk/test_delete.py
+++ b/tests/gateways/disk/test_delete.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import os
 from errno import ENOENT
 from os.path import isdir, isfile, join, lexists
+from typing import TYPE_CHECKING
 
 import pytest
 
 from conda.common.compat import on_win
 from conda.gateways.disk.create import TemporaryDirectory, create_link, mkdir_p
-from conda.gateways.disk.delete import backoff_rmdir, rm_rf
+from conda.gateways.disk.delete import backoff_rmdir, rm_rf, unlink_or_rename_to_trash
 from conda.gateways.disk.link import islink, symlink
 from conda.gateways.disk.permissions import make_read_only
 from conda.gateways.disk.test import softlink_supported
@@ -18,6 +19,9 @@ from conda.gateways.disk.update import touch
 from conda.models.enums import LinkType
 
 from .test_permissions import _try_open, tempdir
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def _write_file(path, content):
@@ -167,3 +171,39 @@ def test_try_rmdir_all_empty_doesnt_exist():
         assert isdir(td)
         rm_rf(td)
         assert not isdir(td)
+
+
+def test_unlink_to_rename_to_trash_win_fallback(
+    mocker: MockerFixture,
+):
+    """
+    Test fix for bug: https://github.com/conda/conda/issues/15760
+    """
+    test_path = "idontexist"
+    mocker.patch(
+        "conda.gateways.disk.delete.os.unlink",
+        side_effect=OSError(),
+    )
+    mocker.patch(
+        "conda.gateways.disk.delete.os.rename",
+        side_effect=OSError(),
+    )
+    mocker.patch("conda.gateways.disk.delete.on_win", True)
+    mocker.patch("conda.gateways.disk.delete.exists", return_value=True)
+
+    # Return True on the first isfile check so the while-loop body executes,
+    # then False to exit the loop.
+    mocker.patch(
+        "conda.gateways.disk.delete.isfile",
+        side_effect=[True, False],
+    )
+    mock_check_output = mocker.patch(
+        "conda.gateways.disk.delete.check_output",
+        return_value=b"",
+    )
+
+    unlink_or_rename_to_trash(test_path)
+
+    # The counter suffix must have been applied; dest filename should end with .conda_trash_1
+    call_args = mock_check_output.call_args[0][0]
+    assert call_args[-1].endswith(".conda_trash_1")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Python strings do not have a `.splitext` function. This funciton is available in the `os.path` module. This pattern is used elsewhere in conda code, for example https://github.com/conda/conda/blob/main/conda/core/subdir_data.py#L327.

fixes https://github.com/conda/conda/issues/15760

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
