### PR TITLE
Add conda dependency removal coverage with reverse dependents

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2358,7 +2358,6 @@ def test_dont_remove_conda_dependency_with_dependent_packages(
     conda_cli: CondaCLIFixture,
 ):
     """Removing a conda dependency is blocked even when dependents would be unlinked."""
-    assert test_recipes_channel.is_dir()
     conda_cli(
         "install",
         f"--prefix={root_prefix_with_conda}",
@@ -2393,6 +2392,7 @@ def test_dont_remove_conda_dependency_with_dependent_packages(
             )
 
         assert any(isinstance(e, RemoveError) for e in exc.value.errors)
+        assert package_is_installed(root_prefix_with_conda, "conda")
         assert package_is_installed(root_prefix_with_conda, "dependency")
         assert package_is_installed(root_prefix_with_conda, "dependent")
         assert package_is_installed(root_prefix_with_conda, "another_dependent")
@@ -2400,6 +2400,18 @@ def test_dont_remove_conda_dependency_with_dependent_packages(
         conda_record["depends"] = original_depends
         conda_meta.write_text(json.dumps(conda_record))
         PrefixData._cache_.clear()
+        cleanup_packages = [
+            package
+            for package in ("another_dependent", "dependent", "dependency")
+            if package_is_installed(root_prefix_with_conda, package)
+        ]
+        if cleanup_packages:
+            conda_cli(
+                "remove",
+                f"--prefix={root_prefix_with_conda}",
+                *cleanup_packages,
+                "--yes",
+            )
 
 
 def test_dont_remove_conda_3(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2352,6 +2352,56 @@ def test_dont_remove_conda(
     assert package_is_installed(root_prefix_with_conda, "pycosat")
 
 
+def test_dont_remove_conda_dependency_with_dependent_packages(
+    root_prefix_with_conda: Path,
+    test_recipes_channel: Path,
+    conda_cli: CondaCLIFixture,
+):
+    """Removing a conda dependency is blocked even when dependents would be unlinked."""
+    assert test_recipes_channel.is_dir()
+    conda_cli(
+        "install",
+        f"--prefix={root_prefix_with_conda}",
+        "another_dependent",
+        "--yes",
+    )
+    assert package_is_installed(root_prefix_with_conda, "dependency")
+    assert package_is_installed(root_prefix_with_conda, "dependent")
+    assert package_is_installed(root_prefix_with_conda, "another_dependent")
+
+    # Model a conda dependency that also has installed reverse dependencies.
+    conda_prec = PrefixData(root_prefix_with_conda).reload().get("conda")
+    conda_meta = (
+        root_prefix_with_conda
+        / "conda-meta"
+        / f"{conda_prec.name}-{conda_prec.version}-{conda_prec.build}.json"
+    )
+    assert conda_meta.is_file()
+    conda_record = json.loads(conda_meta.read_text())
+    original_depends = conda_record["depends"]
+    conda_record["depends"] = [*original_depends, "dependency"]
+    conda_meta.write_text(json.dumps(conda_record))
+    PrefixData._cache_.clear()
+
+    try:
+        with pytest.raises(CondaMultiError) as exc:
+            conda_cli(
+                "remove",
+                f"--prefix={root_prefix_with_conda}",
+                "dependency",
+                "--yes",
+            )
+
+        assert any(isinstance(e, RemoveError) for e in exc.value.errors)
+        assert package_is_installed(root_prefix_with_conda, "dependency")
+        assert package_is_installed(root_prefix_with_conda, "dependent")
+        assert package_is_installed(root_prefix_with_conda, "another_dependent")
+    finally:
+        conda_record["depends"] = original_depends
+        conda_meta.write_text(json.dumps(conda_record))
+        PrefixData._cache_.clear()
+
+
 def test_dont_remove_conda_3(
     conda_cli: CondaCLIFixture,
     tmp_env: TmpEnvFixture,

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2314,7 +2314,7 @@ def test_disallowed_packages(
 def _conda_root_prefix_env(
     session_tmp_env: TmpEnvFixture,
 ) -> Iterator[Path]:
-    """Session-scoped conda env shared across parametrized remove-order variants."""
+    """Session-scoped conda env shared by the don't-remove-conda tests."""
     with session_tmp_env("conda") as prefix:
         yield prefix
 
@@ -2324,7 +2324,7 @@ def root_prefix_with_conda(
     monkeypatch: MonkeyPatch,
     _conda_root_prefix_env: Path,
 ) -> Path:
-    """Root prefix with conda installed; shared across parametrized remove-order variants."""
+    """Root prefix with conda installed; local to the don't-remove-conda tests."""
     monkeypatch.setenv("CONDA_ROOT_PREFIX", str(_conda_root_prefix_env))
     reset_context()
     assert context.root_prefix == str(_conda_root_prefix_env)
@@ -2358,6 +2358,8 @@ def test_dont_remove_conda_dependency_with_dependent_packages(
     conda_cli: CondaCLIFixture,
 ):
     """Removing a conda dependency is blocked even when dependents would be unlinked."""
+    # The session-scoped prefix is local to this test group, so these lightweight
+    # packages can remain installed for later parametrized runs.
     conda_cli(
         "install",
         f"--prefix={root_prefix_with_conda}",
@@ -2400,18 +2402,6 @@ def test_dont_remove_conda_dependency_with_dependent_packages(
         conda_record["depends"] = original_depends
         conda_meta.write_text(json.dumps(conda_record))
         PrefixData._cache_.clear()
-        cleanup_packages = [
-            package
-            for package in ("another_dependent", "dependent", "dependency")
-            if package_is_installed(root_prefix_with_conda, package)
-        ]
-        if cleanup_packages:
-            conda_cli(
-                "remove",
-                f"--prefix={root_prefix_with_conda}",
-                *cleanup_packages,
-                "--yes",
-            )
 
 
 def test_dont_remove_conda_3(


### PR DESCRIPTION
### Description

Adds root-prefix CLI coverage for the conda dependency removal guard when a conda dependency also has installed reverse dependents.

#16311 removed the expensive `conda-build` install from `test_dont_remove_conda`. This test uses existing fixture packages from `tests/data/test-recipes` (`another_dependent -> dependent -> dependency`) and temporarily models `dependency` as a conda runtime dependency. It asserts that removing `dependency` raises `RemoveError` and leaves conda plus the dependent fixture packages installed.

This is not the same package graph as the old `conda-build` / `pycosat` setup; it covers the related root-prefix CLI behavior without reinstalling `conda-build`.

### Checklist - did you ...

- [x] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
