### PR TITLE
Improve Bencher PR signal

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,10 +17,7 @@ jobs:
   track-base-branch:
     if: >-
       !github.event.repository.fork
-      && (
-        github.event.workflow_run.conclusion == 'success'
-        || github.event.workflow_run.conclusion == 'failure'
-      )
+      && contains(['success', 'failure'], github.event.workflow_run.conclusion)
       && github.event.workflow_run.event == 'push'
       && (
         github.event.workflow_run.head_branch == 'main'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -91,10 +91,7 @@ jobs:
   track-pull-request:
     if: >-
       !github.event.repository.fork
-      && (
-        github.event.workflow_run.conclusion == 'success'
-        || github.event.workflow_run.conclusion == 'failure'
-      )
+      && contains(['success', 'failure'], github.event.workflow_run.conclusion)
       && github.event.workflow_run.event == 'pull_request'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,10 @@ jobs:
   track-base-branch:
     if: >-
       !github.event.repository.fork
-      && github.event.workflow_run.conclusion == 'success'
+      && (
+        github.event.workflow_run.conclusion == 'success'
+        || github.event.workflow_run.conclusion == 'failure'
+      )
       && github.event.workflow_run.event == 'push'
       && (
         github.event.workflow_run.head_branch == 'main'
@@ -91,7 +94,10 @@ jobs:
   track-pull-request:
     if: >-
       !github.event.repository.fork
-      && github.event.workflow_run.conclusion == 'success'
+      && (
+        github.event.workflow_run.conclusion == 'success'
+        || github.event.workflow_run.conclusion == 'failure'
+      )
       && github.event.workflow_run.event == 'pull_request'
 
     runs-on: ubuntu-latest
@@ -175,11 +181,8 @@ jobs:
             --start-point-clone-thresholds \
             --start-point-reset \
             --testbed "$TESTBED" \
-            --threshold-measure latency \
-            --threshold-test t_test \
-            --threshold-max-sample-size 64 \
-            --threshold-upper-boundary 0.99 \
             --ci-only-thresholds \
+            --ci-only-on-alert \
             --err \
             --adapter python_pytest \
             --github-actions "$GH_TOKEN" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
               - 'tests/**'
               - '*.py'
               - 'recipe/**'
+              - '.github/workflows/benchmarks.yml'
               - '.github/workflows/tests.yml'
 
   # windows test suite


### PR DESCRIPTION
### Description

Bencher PR comments currently provide little signal when the benchmark artifact exists but no useful boundary can be calculated. Two things contribute to that:

- benchmark tracking only ran after the entire `Tests` workflow succeeded, so valid benchmark artifacts from otherwise-failed test runs did not help build base-branch history;
- the PR tracking command defined thresholds directly on PR branches, which made `--ci-only-thresholds` post comments even when no threshold or benchmark history had been cloned from the base branch.

This updates the benchmark tracking workflow to consume benchmark artifacts from successful or failed `Tests` runs, while still letting artifact discovery decide whether benchmark data exists. PR tracking now relies on thresholds cloned from the base branch and only starts posting PR comments when Bencher raises an alert. The Bencher check and job summary remain available for every tracked run.

The `Tests` workflow code-change filter now includes `.github/workflows/benchmarks.yml`, so benchmark workflow edits exercise the benchmark-producing job in PR CI.

### Checklist - did you ...

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~ (CI-only workflow change)
- [x] Add / update necessary tests? (validated workflow YAML and `benchmarks.yml` with `actionlint`)
- [ ] ~Add / update outdated documentation?~ (no user-facing docs)
