### PR TITLE
Speed up `PrefixGraph` topological sorting (#16331)

### DIFF
--- a/conda/models/prefix_graph.py
+++ b/conda/models/prefix_graph.py
@@ -228,23 +228,41 @@ class PrefixGraph:
         if not graph:
             return
 
-        while True:
-            no_parent_nodes = dict.fromkeys(
-                sorted(
-                    (node for node, parents in graph.items() if len(parents) == 0),
-                    key=lambda x: x.name,
-                )
-            )
-            if not no_parent_nodes:
-                break
+        node_positions = {node: position for position, node in enumerate(graph)}
+        parents_by_node = {node: set(parents) for node, parents in graph.items()}
+        children_by_node = {node: [] for node in graph}
+        for node, parents in parents_by_node.items():
+            for parent in parents:
+                if parent in children_by_node:
+                    children_by_node[parent].append(node)
 
-            for node in no_parent_nodes:
+        def sort_key(node):
+            return node.name, node_positions[node]
+
+        no_parent_nodes = sorted(
+            (node for node, parents in parents_by_node.items() if not parents),
+            key=sort_key,
+        )
+        while no_parent_nodes:
+            nodes = no_parent_nodes
+            no_parent_nodes = []
+
+            for node in nodes:
                 yield node
-                graph.pop(node, None)
+                graph.pop(node)
+                parents_by_node.pop(node)
 
-            for parents in graph.values():
-                for node in no_parent_nodes:
-                    parents.pop(node, None)
+                for child in children_by_node[node]:
+                    child_parents = parents_by_node.get(child)
+                    if child_parents is None:
+                        continue
+
+                    child_parents.discard(node)
+                    graph[child].pop(node, None)
+                    if not child_parents:
+                        no_parent_nodes.append(child)
+
+            no_parent_nodes.sort(key=sort_key)
 
         if len(graph) != 0:
             raise CyclicalDependencyError(tuple(graph))
@@ -255,7 +273,7 @@ class PrefixGraph:
         for k, v in graph.items():
             v.pop(k, None)
 
-        # disconnected nodes go first
+        # Disconnected nodes go first. Remove them before the main sort.
         nodes_that_are_parents = {
             node for parents in graph.values() for node in parents
         }
@@ -268,6 +286,8 @@ class PrefixGraph:
             ),
             key=lambda x: x.name,
         )
+        for node in disconnected_nodes:
+            graph.pop(node, None)
         yield from disconnected_nodes
 
         t = cls._toposort_raise_on_cycles(graph)

--- a/news/16331-prefix-graph-toposort
+++ b/news/16331-prefix-graph-toposort
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Speed up transaction planning against very large existing environments by avoiding repeated full-graph scans during prefix graph sorting. (#16331)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_prefix_graph.py
+++ b/tests/models/test_prefix_graph.py
@@ -14,7 +14,12 @@ from conda.exceptions import CyclicalDependencyError
 from conda.models.match_spec import MatchSpec
 from conda.models.prefix_graph import GeneralGraph, PrefixGraph
 from conda.models.records import PackageRecord
-from conda.testing.helpers import add_subdir_to_iter, get_solver_4, get_solver_5
+from conda.testing.helpers import (
+    add_subdir_to_iter,
+    get_solver_4,
+    get_solver_5,
+    record,
+)
 
 pytestmark = pytest.mark.usefixtures("parametrized_solver_fixture")
 
@@ -796,6 +801,65 @@ def test_sort_without_prep(tmpdir, mocker, monkeypatch: MonkeyPatch):
         records, specs = get_windows_conda_build_record_set(tmpdir)
         with pytest.raises(CyclicalDependencyError):
             graph = PrefixGraph(records, specs)
+
+
+def test_prefix_graph_sorts_disconnected_nodes_then_each_dependency_level_by_name():
+    records = (
+        record("app", depends=("lib-z", "lib-a")),
+        record("lib-z", depends=("base",)),
+        record("independent"),
+        record("lib-a", depends=("base",)),
+        record("base"),
+    )
+
+    graph = PrefixGraph(records)
+
+    assert tuple(record.name for record in graph.records) == (
+        "independent",
+        "base",
+        "lib-a",
+        "lib-z",
+        "app",
+    )
+
+
+def test_prefix_graph_keeps_dependency_levels_separate():
+    # A child exposed during one level must wait until the next level.
+    records = (
+        record("m-root"),
+        record("z-root"),
+        record("a-child", depends=("m-root",)),
+        record("z-leaf", depends=("z-root",)),
+    )
+
+    graph = PrefixGraph(records)
+
+    assert tuple(record.name for record in graph.records) == (
+        "m-root",
+        "z-root",
+        "a-child",
+        "z-leaf",
+    )
+
+
+def test_prefix_graph_handles_cycle_after_acyclic_nodes():
+    records = (
+        record("cycle-child", depends=("cycle-a",)),
+        record("leaf", depends=("base",)),
+        record("cycle-b", depends=("cycle-a",)),
+        record("base"),
+        record("cycle-a", depends=("cycle-b",)),
+    )
+
+    graph = PrefixGraph(records)
+
+    assert tuple(record.name for record in graph.records) == (
+        "base",
+        "leaf",
+        "cycle-a",
+        "cycle-b",
+        "cycle-child",
+    )
 
 
 def test_deep_cyclical_dependency(tmpdir):


### PR DESCRIPTION
### Description

Part of #15969 as Track B follow-up B21. This remains independent of the name-index change merged in #15971 and only changes PrefixGraph._toposort_raise_on_cycles().

This replaces the repeated full-graph parent scans in PrefixGraph._toposort_raise_on_cycles() with a single reverse child-adjacency pass and queue. The implementation preserves conda's deterministic per-level package-name ordering, and when cycles are allowed it keeps _topo_sort_handle_cycles() seeing the same remaining graph shape before breaking a cycle.

I checked stdlib graphlib.TopologicalSorter as an alternative. It is much faster than the original repeated-scan path, but slower than the custom queue in the focused topo benchmark, so this PR keeps the custom implementation.

Focused synthetic topo timings on Windows, using a chain-like graph where each node depends on the previous three nodes:

| Records | Original repeated scan | graphlib | This PR |
|---:|---:|---:|---:|
| 1k | 0.0581 s | 0.0034 s | 0.0015 s |
| 2k | 0.2366 s | 0.0075 s | 0.0032 s |
| 5k | 1.5360 s | 0.0178 s | 0.0072 s |
| 10k | skipped | 0.0374 s | 0.0155 s |
| 50k | skipped | 0.2211 s | 0.0897 s |

The end-to-end Windows W3 signal was measured on the dedicated win-64 host in the branch combination where this bottleneck is visible (#15971 plus conda-libmamba-solver#921):

| Probe | #15971 + conda-libmamba-solver#921 | + this PR |
|---|---:|---:|
| W3 realistic, 5k records | 9.25 s | 8.018 s |
| W3 realistic, 10k records | 27.64 s | 13.736 s |
| W3 realistic, 50k records | 574.61 s | 64.459 s |

The preceding profile, prototype artifact, and branch confirmations are recorded in the [Track B report](https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md#windows-x86_64-checkpoint-2026-07-01).

### Checklist - did you ...

- [x] Add a file to the news directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
