### PR TITLE
Fix return value of `archspec.cpu.host()` mock in test

### DIFF
--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -10,6 +10,7 @@ from pprint import pprint
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
+import archspec.cpu
 import pytest
 
 from conda.auxlib.ish import dals
@@ -468,11 +469,12 @@ def test_archspec_call(
     # Remove CONDA_OVERRIDE_ARCHSPEC if it exists.
     monkeypatch.delenv("CONDA_OVERRIDE_ARCHSPEC", raising=False)
     reset_context()
-
-    with patch("archspec.cpu.host") as archspec:
+    archspec_value = archspec.cpu.host()
+    with patch("archspec.cpu.host") as patched_archspec:
+        patched_archspec.return_value = archspec_value
         with get_solver_cuda(tmpdir, specs) as solver:
             solver.solve_final_state()
-            archspec.assert_called()
+            patched_archspec.assert_called()
 
 
 def test_prune_1(tmpdir, request):


### PR DESCRIPTION
Otherwise results in illegal build string

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Needed for https://github.com/conda/conda-libmamba-solver/pull/962

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
