### PR TITLE
Deprecate conda run resolving conda from caller environment

### DIFF
--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -124,6 +124,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         args.dev,
         args.debug_wrapper_scripts,
         args.executable_call,
+        use_target_conda_executable=True,
     )
 
     # run script

--- a/conda/cli/main_run.py
+++ b/conda/cli/main_run.py
@@ -99,8 +99,9 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
 
 def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..base.context import context
-    from ..common.compat import encode_environment
+    from ..common.compat import encode_environment, on_win
     from ..core.prefix_data import PrefixData
+    from ..deprecations import deprecated
     from ..exceptions import ArgumentError
     from ..gateways.disk.delete import rm_rf
     from ..gateways.subprocess import subprocess_call
@@ -117,6 +118,25 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     if not args.executable_call:
         raise ArgumentError("No command specified. Please provide a command to run.")
 
+    if not on_win and (
+        args.executable_call[0] == "conda"
+        or args.executable_call[:2] == ["time", "conda"]
+    ):
+        deprecated.topic(
+            "27.3",
+            "27.9",
+            topic=(
+                "`conda run ... conda ...` resolving `conda` from the invoking "
+                "installation"
+            ),
+            addendum=(
+                "In 27.9, `conda` will resolve from the target environment's PATH. "
+                "Use `$CONDA_EXE` to continue using the invoking installation, or "
+                "`python -m conda` to use the target installation."
+            ),
+            deprecation_type=FutureWarning,
+        )
+
     # create run script
     script, command = wrap_subprocess_call(
         context.root_prefix,
@@ -124,7 +144,8 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         args.dev,
         args.debug_wrapper_scripts,
         args.executable_call,
-        use_target_conda_executable=True,
+        # TODO: Set to True when the deprecated behavior is removed in 27.9.
+        use_target_conda_executable=False,
     )
 
     # run script

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -298,18 +298,34 @@ def wrap_subprocess_call(
             fh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment after ***'\n>&2 env\n")
+            if not dev_mode:
+                # The POSIX hook defines `conda` as a shell function backed by
+                # the caller's CONDA_EXE. Keep shell-state commands working, but
+                # resolve normal `conda` calls from the activated PATH.
+                fh.write(
+                    r"""conda() {
+    \local cmd="${1-__missing__}"
+    case "$cmd" in
+        activate|deactivate)
+            __conda_activate "$@"
+            ;;
+        install|update|upgrade|remove|uninstall)
+            command conda "$@" || \return
+            __conda_activate reactivate
+            ;;
+        *)
+            command conda "$@"
+            ;;
+    esac
+}
+"""
+                )
             if multiline:
                 # The ' '.join() is pointless since mutliline is only True when there's 1 arg
                 # still, if that were to change this would prevent breakage.
                 fh.write("{}\n".format(" ".join(arguments)))
             else:
-                if not dev_mode and arguments and arguments[0] == "conda":
-                    # The POSIX hook defines `conda` as a shell function. `command`
-                    # skips functions and resolves the executable from the activated PATH.
-                    command_args = ("command", *arguments)
-                else:
-                    command_args = arguments
-                fh.write(f"{quote_for_shell(*command_args)}\n")
+                fh.write(f"{quote_for_shell(*arguments)}\n")
             # Capture the return code of the user's command in a variable
             # before deactivating. We don't need to unset this per se, because
             # the shell process will terminate and clean it up afterwards.

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -179,6 +179,8 @@ def wrap_subprocess_call(
     dev_mode,
     debug_wrapper_scripts,
     arguments: Sequence[str],
+    *,
+    use_target_conda_executable: bool = False,
 ):
     # Ensure arguments is a tuple of strings
     if not isiterable(arguments):
@@ -298,14 +300,19 @@ def wrap_subprocess_call(
             fh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment after ***'\n>&2 env\n")
-            if not dev_mode:
+            if use_target_conda_executable and not dev_mode:
+                from .auxlib.ish import dals
+
                 # Keep the hook's `conda()` function, but make its command
                 # runner resolve `conda` from the activated PATH.
                 fh.write(
-                    r"""__conda_exe() (
-    command conda "$@"
-)
-"""
+                    dals(
+                        r"""
+                        __conda_exe() (
+                            command conda "$@"
+                        )
+                        """
+                    )
                 )
             if multiline:
                 # The ' '.join() is pointless since mutliline is only True when there's 1 arg

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -303,7 +303,13 @@ def wrap_subprocess_call(
                 # still, if that were to change this would prevent breakage.
                 fh.write("{}\n".format(" ".join(arguments)))
             else:
-                fh.write(f"{quote_for_shell(*arguments)}\n")
+                if not dev_mode and arguments and arguments[0] == "conda":
+                    # The POSIX hook defines `conda` as a shell function. `command`
+                    # skips functions and resolves the executable from the activated PATH.
+                    command_args = ("command", *arguments)
+                else:
+                    command_args = arguments
+                fh.write(f"{quote_for_shell(*command_args)}\n")
             # Capture the return code of the user's command in a variable
             # before deactivating. We don't need to unset this per se, because
             # the shell process will terminate and clean it up afterwards.

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -304,7 +304,10 @@ def wrap_subprocess_call(
                 from .auxlib.ish import dals
 
                 # Keep the hook's `conda()` function, but make its command
-                # runner resolve `conda` from the activated PATH.
+                # runner resolve `conda` from the activated PATH. Match the
+                # subshell body used by `__conda_exe()` in `conda.sh`:
+                # https://github.com/conda/conda/blob/main/conda/shell/etc/profile.d/conda.sh
+                # `()` isolates shell-state changes, while `{}` does not.
                 fh.write(
                     dals(
                         r"""
@@ -315,7 +318,7 @@ def wrap_subprocess_call(
                     )
                 )
             if multiline:
-                # The ' '.join() is pointless since mutliline is only True when there's 1 arg
+                # The ' '.join() is pointless since multiline is only True when there's 1 arg
                 # still, if that were to change this would prevent breakage.
                 fh.write("{}\n".format(" ".join(arguments)))
             else:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -299,25 +299,12 @@ def wrap_subprocess_call(
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment after ***'\n>&2 env\n")
             if not dev_mode:
-                # The POSIX hook defines `conda` as a shell function backed by
-                # the caller's CONDA_EXE. Keep shell-state commands working, but
-                # resolve normal `conda` calls from the activated PATH.
+                # Keep the hook's `conda()` function, but make its command
+                # runner resolve `conda` from the activated PATH.
                 fh.write(
-                    r"""conda() {
-    \local cmd="${1-__missing__}"
-    case "$cmd" in
-        activate|deactivate)
-            __conda_activate "$@"
-            ;;
-        install|update|upgrade|remove|uninstall)
-            command conda "$@" || \return
-            __conda_activate reactivate
-            ;;
-        *)
-            command conda "$@"
-            ;;
-    esac
-}
+                    r"""__conda_exe() (
+    command conda "$@"
+)
 """
                 )
             if multiline:

--- a/docs/source/commands/run.rst
+++ b/docs/source/commands/run.rst
@@ -8,3 +8,26 @@
    :path: run
    :nodefault:
    :nodefaultconst:
+
+Nested ``conda`` commands
+=========================
+
+On POSIX systems, an unqualified ``conda`` command currently resolves through
+the invoking installation's shell function:
+
+.. code-block:: console
+
+   $ conda run -n target conda --version
+
+This behavior is scheduled to change. In conda 27.9, ``conda`` will instead
+resolve from the target environment's ``PATH``, like other executables.
+
+Use an explicit form to avoid relying on behavior that will change:
+
+.. code-block:: console
+
+   # Use the invoking installation
+   $ conda run -n target "$CONDA_EXE" --version
+
+   # Use the target installation
+   $ conda run -n target python -m conda --version

--- a/news/16333-conda-run-target-conda
+++ b/news/16333-conda-run-target-conda
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* Run the target environment's `conda` executable for `conda run <prefix> conda ...` on POSIX shells. (#16333)
+* Run the target environment's `conda` executable for `conda run --prefix <prefix> conda ...` on POSIX shells. (#16333)
 
 ### Deprecations
 

--- a/news/16333-conda-run-target-conda
+++ b/news/16333-conda-run-target-conda
@@ -1,0 +1,11 @@
+### Enhancements
+
+### Bug fixes
+
+* Run the target environment's `conda` executable for `conda run <prefix> conda ...` on POSIX shells. (#16333)
+
+### Deprecations
+
+### Docs
+
+### Other

--- a/news/16333-conda-run-target-conda
+++ b/news/16333-conda-run-target-conda
@@ -2,9 +2,9 @@
 
 ### Bug fixes
 
-* Run the target environment's `conda` executable for `conda run --prefix <prefix> conda ...` on POSIX shells. (#16333)
-
 ### Deprecations
+
+* Mark `conda run --prefix <prefix> conda ...` resolving `conda` from the invoking installation on POSIX as pending deprecation. In 27.9, it will resolve from the target environment's `PATH`. Use `$CONDA_EXE` to select the invoking installation or `python -m conda` to select the target installation. (#16333)
 
 ### Docs
 

--- a/tests/cli/test_main_run.py
+++ b/tests/cli/test_main_run.py
@@ -128,11 +128,11 @@ def test_conda_run_prefix_not_a_conda_env(tmp_path: Path, conda_cli: CondaCLIFix
 @pytest.mark.parametrize(
     "command",
     [
-        pytest.param(("conda", "sentinel"), id="direct"),
-        pytest.param(("time", "conda", "sentinel"), id="time"),
+        pytest.param(("conda", "--version"), id="direct"),
+        pytest.param(("time", "conda", "--version"), id="time"),
     ],
 )
-def test_run_uses_target_prefix_conda_executable(
+def test_run_warns_before_changing_conda_executable_resolution(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
     command: tuple[str, ...],
@@ -140,19 +140,24 @@ def test_run_uses_target_prefix_conda_executable(
     with tmp_env() as prefix:
         conda_exe = prefix / "bin" / "conda"
         conda_exe.parent.mkdir(parents=True, exist_ok=True)
-        conda_exe.write_text('#!/bin/sh\nprintf "target-prefix-conda %s\\n" "$1"\n')
+        conda_exe.write_text('#!/bin/sh\nprintf "target-prefix-conda\\n"\n')
         conda_exe.chmod(
             conda_exe.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
 
-        stdout, stderr, err = conda_cli(
-            "run",
-            f"--prefix={prefix}",
-            *command,
-        )
+        with pytest.warns(
+            (PendingDeprecationWarning, FutureWarning),
+            match="resolving `conda` from the invoking installation",
+        ):
+            stdout, stderr, err = conda_cli(
+                "run",
+                f"--prefix={prefix}",
+                *command,
+            )
 
         assert err == 0, f"conda run failed ({err}): {stderr}"
-        assert stdout.strip() == "target-prefix-conda sentinel"
+        assert stdout.startswith("conda ")
+        assert "target-prefix-conda" not in stdout
 
 
 @pytest.mark.skipif(on_win, reason="POSIX shell function regression test")

--- a/tests/cli/test_main_run.py
+++ b/tests/cli/test_main_run.py
@@ -155,6 +155,34 @@ def test_run_uses_target_prefix_conda_executable(
         assert stdout.strip() == "target-prefix-conda sentinel"
 
 
+@pytest.mark.skipif(on_win, reason="POSIX shell function regression test")
+def test_target_conda_executable_override_is_opt_in(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+):
+    default_script, _ = wrap_subprocess_call(
+        root_prefix=context.root_prefix,
+        prefix=str(tmp_path),
+        dev_mode=False,
+        debug_wrapper_scripts=False,
+        arguments=["echo", "test"],
+    )
+    request.addfinalizer(lambda: Path(default_script).unlink(missing_ok=True))
+
+    target_script, _ = wrap_subprocess_call(
+        root_prefix=context.root_prefix,
+        prefix=str(tmp_path),
+        dev_mode=False,
+        debug_wrapper_scripts=False,
+        arguments=["echo", "test"],
+        use_target_conda_executable=True,
+    )
+    request.addfinalizer(lambda: Path(target_script).unlink(missing_ok=True))
+
+    assert 'command conda "$@"' not in Path(default_script).read_text()
+    assert 'command conda "$@"' in Path(target_script).read_text()
+
+
 def test_multiline_run_command(
     test_recipes_channel: Path,
     tmp_env: TmpEnvFixture,

--- a/tests/cli/test_main_run.py
+++ b/tests/cli/test_main_run.py
@@ -124,6 +124,31 @@ def test_conda_run_prefix_not_a_conda_env(tmp_path: Path, conda_cli: CondaCLIFix
         conda_cli("run", f"--prefix={tmp_path}", "echo", "hello")
 
 
+@pytest.mark.skipif(on_win, reason="POSIX shell function regression test")
+def test_run_uses_target_prefix_conda_executable(
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+):
+    with tmp_env() as prefix:
+        conda_exe = prefix / "bin" / "conda"
+        conda_exe.parent.mkdir(parents=True, exist_ok=True)
+        conda_exe.write_text('#!/bin/sh\nprintf "target-prefix-conda %s\\n" "$1"\n')
+        conda_exe.chmod(
+            conda_exe.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+
+        stdout, stderr, err = conda_cli(
+            "run",
+            f"--prefix={prefix}",
+            "conda",
+            "sentinel",
+        )
+
+        assert stdout.strip() == "target-prefix-conda sentinel"
+        assert not stderr
+        assert err == 0
+
+
 def test_multiline_run_command(
     test_recipes_channel: Path,
     tmp_env: TmpEnvFixture,

--- a/tests/cli/test_main_run.py
+++ b/tests/cli/test_main_run.py
@@ -125,9 +125,17 @@ def test_conda_run_prefix_not_a_conda_env(tmp_path: Path, conda_cli: CondaCLIFix
 
 
 @pytest.mark.skipif(on_win, reason="POSIX shell function regression test")
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param(("conda", "sentinel"), id="direct"),
+        pytest.param(("time", "conda", "sentinel"), id="time"),
+    ],
+)
 def test_run_uses_target_prefix_conda_executable(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
+    command: tuple[str, ...],
 ):
     with tmp_env() as prefix:
         conda_exe = prefix / "bin" / "conda"
@@ -140,13 +148,11 @@ def test_run_uses_target_prefix_conda_executable(
         stdout, stderr, err = conda_cli(
             "run",
             f"--prefix={prefix}",
-            "conda",
-            "sentinel",
+            *command,
         )
 
+        assert err == 0, f"conda run failed ({err}): {stderr}"
         assert stdout.strip() == "target-prefix-conda sentinel"
-        assert not stderr
-        assert err == 0
 
 
 def test_multiline_run_command(


### PR DESCRIPTION
### Description

Starts the deprecation cycle for #16333.

On POSIX, `conda run` currently uses the shell hook from the invoking installation. Its `conda()` function routes nested `conda` calls through `CONDA_EXE`, so they use the invoking installation instead of the target environment.

This behavior remains the default during the deprecation cycle. It becomes deprecated in 27.3 and is scheduled to change in 27.9. At that point, an unqualified nested `conda` command will resolve from the target environment's `PATH`, like other executables.

Users can select either installation explicitly during the transition:

- `conda run -n target "$CONDA_EXE" ...` uses the invoking installation.
- `conda run -n target python -m conda ...` uses the target installation.

The target-resolution path remains scoped to `conda run` and disabled until the behavior change.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
