### PR TITLE
Allow doctor --fix to override frozen environments

### DIFF
--- a/conda/plugins/subcommands/doctor/__init__.py
+++ b/conda/plugins/subcommands/doctor/__init__.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from ....base.context import context
 from ....cli.helpers import (
     add_output_and_prompt_options,
+    add_parser_frozen_env,
     add_parser_help,
     add_parser_prefix,
 )
@@ -31,6 +32,7 @@ log = logging.getLogger(__name__)
 def configure_parser(parser: ArgumentParser):
     add_parser_help(parser)
     add_parser_prefix(parser)
+    add_parser_frozen_env(parser)
     add_output_and_prompt_options(parser)  # includes --verbose, --dry-run, --yes
     parser.add_argument(
         "checks",

--- a/news/16336-doctor-override-frozen
+++ b/news/16336-doctor-override-frozen
@@ -1,0 +1,11 @@
+### Enhancements
+
+### Bug fixes
+
+* Allow `conda doctor --fix --override-frozen` to run fixers against frozen environments. (#16336)
+
+### Deprecations
+
+### Docs
+
+### Other

--- a/tests/plugins/subcommands/doctor/test_cli.py
+++ b/tests/plugins/subcommands/doctor/test_cli.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
-
-import pytest
 
 from conda.base.context import context
 from conda.exceptions import EnvironmentLocationNotFound
@@ -37,18 +34,14 @@ def test_conda_doctor_happy_path_verbose(conda_cli: CondaCLIFixture):
 
 def test_conda_doctor_happy_path_show_help(conda_cli: CondaCLIFixture):
     """Make sure that we are able to run ``conda doctor`` command with the --help flag"""
-    with pytest.raises(SystemExit, match="0"):  # 0 is the return code ¯\_(ツ)_/¯
-        conda_cli("doctor", "--help")
+    out, err, exc = conda_cli("doctor", "--help", raises=SystemExit)
 
-
-def test_conda_doctor_help_shows_override_frozen(conda_cli: CondaCLIFixture):
-    with pytest.raises(SystemExit, match="0"):
-        conda_cli("doctor", "--help")
-
-    out, err = conda_cli.capsys.readouterr()
-
+    assert "conda doctor" in out
     assert "--override-frozen" in out
+    assert "--list" in out
+    assert "--fix, --heal" in out
     assert not err
+    assert exc.value.code == 0
 
 
 def test_conda_doctor_with_test_environment(
@@ -58,7 +51,7 @@ def test_conda_doctor_with_test_environment(
     """Make sure that we are able to call ``conda doctor`` command for a specific environment"""
 
     with tmp_env() as prefix:
-        out, err, code = conda_cli("doctor", "--prefix", prefix)
+        out, err, code = conda_cli("doctor", f"--prefix={prefix}")
 
         assert "There are no packages with missing files." in out
         assert not err  # no error message
@@ -68,15 +61,14 @@ def test_conda_doctor_with_test_environment(
 def test_conda_doctor_with_non_existent_environment(conda_cli: CondaCLIFixture):
     """Make sure that ``conda doctor`` detects a non existent environment path"""
     # with pytest.raises(EnvironmentLocationNotFound):
-    out, err, exception = conda_cli(
+    out, err, exc = conda_cli(
         "doctor",
-        "--prefix",
-        Path("non/existent/path"),
+        "--prefix=non/existent/path",
         raises=EnvironmentLocationNotFound,
     )
     assert not out
     assert not err  # no error message
-    assert exception
+    assert exc
 
 
 def test_conda_doctor_list(conda_cli: CondaCLIFixture):
@@ -95,7 +87,7 @@ def test_conda_doctor_specific_check(
 ):
     """Make sure we can run a specific health check by id."""
     with tmp_env() as prefix:
-        out, err, code = conda_cli("doctor", "missing-files", "--prefix", prefix)
+        out, err, code = conda_cli("doctor", "missing-files", f"--prefix={prefix}")
 
         assert "There are no packages with missing files." in out
         # Should NOT run other checks like altered files
@@ -113,13 +105,7 @@ def test_conda_doctor_fix_dry_run(
 ):
     """Make sure --fix --dry-run doesn't make actual changes."""
     with tmp_env() as prefix:
-        out, err, code = conda_cli(
-            "doctor",
-            "--fix",
-            "--dry-run",
-            "--prefix",
-            prefix,
-        )
+        out, err, code = conda_cli("doctor", "--fix", "--dry-run", f"--prefix={prefix}")
         # Dry run triggers DryRunExit which results in exit code 1
         # The important thing is that no actual changes are made
         assert "Running fixes" in out
@@ -137,8 +123,7 @@ def test_conda_doctor_fix_yes(
             "doctor",
             "--fix",
             "--yes",
-            "--prefix",
-            prefix,
+            f"--prefix={prefix}",
         )
         # Should complete without prompting
         assert not err
@@ -170,8 +155,7 @@ def test_conda_doctor_fix_accepts_override_frozen(
         "missing-files",
         "--fix",
         "--yes",
-        "--prefix",
-        env_missing_files.prefix,
+        f"--prefix={env_missing_files.prefix}",
         "--override-frozen",
     )
 

--- a/tests/plugins/subcommands/doctor/test_cli.py
+++ b/tests/plugins/subcommands/doctor/test_cli.py
@@ -7,10 +7,14 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from conda.base.context import context
 from conda.exceptions import EnvironmentLocationNotFound
 
 if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
     from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+    from tests.plugins.subcommands.conftest import EnvFixture
 
 
 def test_conda_doctor_happy_path(conda_cli: CondaCLIFixture):
@@ -35,6 +39,16 @@ def test_conda_doctor_happy_path_show_help(conda_cli: CondaCLIFixture):
     """Make sure that we are able to run ``conda doctor`` command with the --help flag"""
     with pytest.raises(SystemExit, match="0"):  # 0 is the return code ¯\_(ツ)_/¯
         conda_cli("doctor", "--help")
+
+
+def test_conda_doctor_help_shows_override_frozen(conda_cli: CondaCLIFixture):
+    with pytest.raises(SystemExit, match="0"):
+        conda_cli("doctor", "--help")
+
+    out, err = conda_cli.capsys.readouterr()
+
+    assert "--override-frozen" in out
+    assert not err
 
 
 def test_conda_doctor_with_test_environment(
@@ -129,3 +143,39 @@ def test_conda_doctor_fix_yes(
         # Should complete without prompting
         assert not err
         assert not code
+
+
+def test_conda_doctor_fix_accepts_override_frozen(
+    conda_cli: CondaCLIFixture,
+    env_missing_files: EnvFixture,
+    mocker: MockerFixture,
+):
+    """Make sure --fix can bypass frozen environment protection."""
+    (env_missing_files.prefix / "conda-meta" / "history").touch()
+    (env_missing_files.prefix / "conda-meta" / "frozen").touch()
+
+    def reinstall_packages(args, specs, force_reinstall=False):
+        assert context.protect_frozen_envs is False
+        assert specs == [env_missing_files.package]
+        assert force_reinstall is True
+        return 0
+
+    mock_reinstall = mocker.patch(
+        "conda.plugins.subcommands.doctor.health_checks.missing_files.reinstall_packages",
+        side_effect=reinstall_packages,
+    )
+
+    out, err, code = conda_cli(
+        "doctor",
+        "missing-files",
+        "--fix",
+        "--yes",
+        "--prefix",
+        env_missing_files.prefix,
+        "--override-frozen",
+    )
+
+    assert "Running fixes" in out
+    assert not err
+    assert code == 0
+    mock_reinstall.assert_called_once()

--- a/tests/plugins/test_health_checks.py
+++ b/tests/plugins/test_health_checks.py
@@ -3,6 +3,7 @@
 import pytest
 
 from conda import plugins
+from conda.base.context import context
 from conda.exceptions import CondaSystemExit
 from conda.plugins.subcommands import doctor
 from conda.plugins.types import CondaHealthCheck
@@ -95,3 +96,44 @@ def test_fix_user_cancels_no_warning(health_check_plugin_with_fixer, conda_cli, 
     assert "Error running fix" not in err
     # The warning would contain "Exiting" from CondaSystemExit
     assert "Exiting" not in err
+
+
+class HealthCheckPluginWithContextAwareFixer:
+    """Health check plugin with a fixer that records frozen-env protection."""
+
+    def __init__(self):
+        self.fixer_calls = []
+
+    def health_check_action(self, prefix, verbose):
+        pass
+
+    def health_check_fixer(self, prefix, args, confirm):
+        self.fixer_calls.append((args.protect_frozen_envs, context.protect_frozen_envs))
+        return 0
+
+    @plugins.hookimpl
+    def conda_health_checks(self):
+        yield CondaHealthCheck(
+            name="test-context-aware-fixer",
+            action=self.health_check_action,
+            fixer=self.health_check_fixer,
+        )
+
+
+@pytest.fixture()
+def health_check_plugin_with_context_aware_fixer(plugin_manager_with_doctor_command):
+    health_check_plugin = HealthCheckPluginWithContextAwareFixer()
+    plugin_manager_with_doctor_command.register(health_check_plugin)
+    return health_check_plugin
+
+
+def test_fix_override_frozen_reaches_plugin_fixer(
+    health_check_plugin_with_context_aware_fixer,
+    conda_cli,
+):
+    out, err, code = conda_cli("doctor", "--fix", "--yes", "--override-frozen")
+
+    assert "Running fixes" in out
+    assert not err
+    assert code == 0
+    assert health_check_plugin_with_context_aware_fixer.fixer_calls == [(False, False)]


### PR DESCRIPTION
### Description

Fixes #16336.

`conda doctor --fix` now accepts the shared `--override-frozen` option used by other mutating commands. This lets doctor fixers run against frozen target environments when the user explicitly opts out of frozen-environment protection.

The regression coverage includes the built-in missing-files fixer path and a plugin-style health-check fixer, matching the way `conda-self` registers its base-protection fixer.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
