### PR TITLE
Fix parameter name mismatches in docstrings

### DIFF
--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -483,7 +483,7 @@ class ReducedIndex(Index):
             Add a package name or track feature from a MatchSpec to the pending set.
 
             Args:
-                spec: The MatchSpec to process.
+                *specs: The MatchSpecs to process.
             """
             for spec in map(MatchSpec, specs):
                 name = spec.get_raw_value("name")
@@ -497,10 +497,10 @@ class ReducedIndex(Index):
 
         def push_records(*records: PackageRecord) -> None:
             """
-            Process a package record to collect its dependencies and features.
+            Process package records to collect their dependencies and features.
 
             Args:
-                record: The package record to process.
+                *records: The package records to process.
             """
             for record in records:
                 try:

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -149,7 +149,7 @@ def replace_prefix(
 
     Args:
         mode: The mode of operation.
-        original_data: The original data to be updated.
+        data: The original data to be updated.
         placeholder: The placeholder to be replaced.
         new_prefix: The new prefix to be used.
         subdir: The subdirectory to be used.

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -727,13 +727,14 @@ class SubdirData(metaclass=SubdirDataType):
 
         This method deals with both cases and returns the appropriate value.
 
-        Get the base URL for the given endpoint.
+        Get the base URL for the given repodata.
 
         Args:
-            endpoint: The endpoint for which the base URL is needed.
+            repodata: The parsed repodata.json payload.
+            with_credentials: Whether to include credentials in the returned URL.
 
         Returns:
-            The base URL corresponding to the provided endpoint.
+            The base URL corresponding to the provided repodata.
         """
         maybe_base_url = repodata.get("info", {}).get("base_url")
         if maybe_base_url:  # repodata defines base_url field


### PR DESCRIPTION
### Description

Fixes several docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `conda/core/index.py` | `push_specs` | `spec` | `*specs` |
| `conda/core/index.py` | `push_records` | `record` | `*records` |
| `conda/core/portability.py` | `replace_prefix` | `original_data` | `data` |
| `conda/core/subdir_data.py` | `SubdirData._get_base_url` | stale `endpoint` | `repodata`, `with_credentials` |

Doc-only change; no behavior modified.

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes? (docs-only fix; happy to add one if required)
- [x] Add / update necessary tests? (n/a - docstring-only)
- [x] Add / update outdated documentation?