### PR TITLE
Fix quote handling in `parse_entry_point_def()` function

### DIFF
--- a/conda/common/path/python.py
+++ b/conda/common/path/python.py
@@ -57,8 +57,8 @@ def missing_pyc_files(python_major_minor_version, files):
 
 
 def parse_entry_point_def(ep_definition):
-    cmd_mod, func = ep_definition.rsplit(":", 1)
-    command, module = cmd_mod.rsplit("=", 1)
+    command, defn = ep_definition.split("=", 1)
+    module, func = defn.strip(" \t\r\n\"'").rsplit(":", 1)
     command, module, func = command.strip(), module.strip(), func.strip()
 
     # Validate command

--- a/news/16340-fix-entry-point-parsing
+++ b/news/16340-fix-entry-point-parsing
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix quote handling in parse_entry_point_def() function (#16340)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -312,6 +312,10 @@ def test_CreatePythonEntryPointAction_noarch_python(prefix: Path):
             ("command1", "some.module", "SomeClass.method"),
         ),
         (
+            'command1 = "some.module:main"',
+            ("command1", "some.module", "main"),
+        ),
+        (
             "../bin/python=some.module:main",
             (ValueError, "simple file name"),
         ),


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR fixes #16339 by patching the `parse_entry_point_def()` to handle surrounding quotes in an entry point spec.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
