### PR TITLE
Reject nested named envs from env-local conda

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -2329,7 +2329,13 @@ def determine_target_prefix(ctx: Context, args: Namespace | None = None) -> Path
     else:
         from ..core.prefix_data import PrefixData
 
-        return str(PrefixData.from_name(prefix_name).prefix_path)
+        return str(
+            PrefixData.from_name(
+                prefix_name,
+                reject_active_envs_dir=getattr(argparse_args, "func", None)
+                == "conda.cli.main_create.execute",
+            ).prefix_path
+        )
 
 
 try:

--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -140,7 +140,12 @@ class PrefixData(metaclass=PrefixDataType):
         )
 
     @classmethod
-    def from_name(cls, name: str, **kwargs) -> PrefixData:
+    def from_name(
+        cls,
+        name: str,
+        reject_active_envs_dir: bool = False,
+        **kwargs,
+    ) -> PrefixData:
         """
         Creates a PrefixData instance from an environment name.
 
@@ -148,6 +153,8 @@ class PrefixData(metaclass=PrefixDataType):
 
         Args:
             name: The name of the environment. Must not contain path separators (/, \\).
+            reject_active_envs_dir: Whether to reject the active environment's nested
+                `envs` directory if activation metadata points at another conda installation.
 
         Raises:
             CondaValueError: If `name` contains a path separator.
@@ -158,7 +165,15 @@ class PrefixData(metaclass=PrefixDataType):
             return cls(locate_prefix_by_name(name))
         except EnvironmentNameNotFound:
             cls(name).validate_name()
-            return cls(Path(first_writable_envs_dir(), name), **kwargs)
+            return cls(
+                Path(
+                    first_writable_envs_dir(
+                        reject_active_envs_dir=reject_active_envs_dir
+                    ),
+                    name,
+                ),
+                **kwargs,
+            )
 
     @classmethod
     def from_context(cls, validate: bool = False, **kwargs) -> PrefixData:

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -13,17 +13,24 @@ from shutil import copyfileobj, copystat
 
 from ... import CondaError
 from ...auxlib.ish import dals
-from ...base.constants import PACKAGE_CACHE_MAGIC_FILE
+from ...base.constants import PACKAGE_CACHE_MAGIC_FILE, PREFIX_FROZEN_FILE
 from ...base.context import context
 from ...common.compat import on_win
 from ...common.constants import TRACE
-from ...common.path import ensure_pad, expand, win_path_double_escape, win_path_ok
+from ...common.path import (
+    ensure_pad,
+    expand,
+    paths_equal,
+    win_path_double_escape,
+    win_path_ok,
+)
 from ...common.path.python import is_valid_import_path
 from ...common.serialize import json
 from ...deprecations import deprecated
 from ...exceptions import (
     BasicClobberError,
     CondaOSError,
+    CondaValueError,
     NoWritableEnvsDirError,
     maybe_raise,
 )
@@ -497,12 +504,48 @@ def create_envs_directory(envs_dir):
     return True
 
 
-def first_writable_envs_dir(create=True):
+def first_writable_envs_dir(create=True, reject_active_envs_dir=False):
     # Calling this function will *create* an envs directory if one does not already
     # exist. Any caller should intend to *use* that directory for *writing*, not just reading.
     for envs_dir in context.envs_dirs:
         if envs_dir == os.devnull:
             continue
+        if reject_active_envs_dir:
+            active_prefix = context.active_prefix
+            if (
+                active_prefix
+                and paths_equal(context.conda_prefix, active_prefix)
+                and paths_equal(envs_dir, join(active_prefix, "envs"))
+            ):
+                if activated_prefix := os.environ.get("_CONDA_ROOT"):
+                    activated_prefix = expand(activated_prefix)
+                elif conda_exe := os.environ.get("CONDA_EXE"):
+                    activated_prefix = dirname(dirname(expand(conda_exe)))
+                else:
+                    activated_prefix = None
+
+                if (
+                    activated_prefix
+                    and not paths_equal(activated_prefix, context.conda_prefix)
+                    and isfile(join(activated_prefix, PREFIX_FROZEN_FILE))
+                ):
+                    raise CondaValueError(
+                        dals(
+                            f"""
+                            Refusing to create a named environment in '{envs_dir}' because
+                            conda appears to have been invoked from the active environment's
+                            conda executable instead of the initialized base conda.
+
+                            active prefix: {active_prefix}
+                            invoked conda prefix: {context.conda_prefix}
+                            initialized conda prefix: {activated_prefix}
+
+                            Use `CONDA_EXE` or `CONDA_PYTHON_EXE -m conda` when calling
+                            conda from scripts or Makefiles. If you intentionally want this
+                            target location, pass it explicitly with `--prefix`.
+                            """
+                        )
+                    )
 
         # The magic file being used here could change in the future.  Don't write programs
         # outside this code base that rely on the presence of this file.

--- a/news/16346-env-local-conda-named-env
+++ b/news/16346-env-local-conda-named-env
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Refuse to create named environments under an active environment's nested `envs/` directory when `conda` was invoked from that active environment but activation metadata points at a different protected base conda installation. (#16346)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -3,10 +3,131 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from typing import TYPE_CHECKING
 
 import pytest
 
+from conda.base.constants import PREFIX_FROZEN_FILE
+from conda.exceptions import CondaValueError
 from conda.gateways.disk import create
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.mark.parametrize(
+    ("env_var", "path_parts"),
+    (
+        pytest.param("_CONDA_ROOT", (), id="conda-root"),
+        pytest.param("CONDA_EXE", ("bin", "conda"), id="conda-exe"),
+    ),
+)
+def test_first_writable_envs_dir_rejects_env_local_conda_nested_env(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    env_var: str,
+    path_parts: tuple[str, ...],
+) -> None:
+    base_prefix = tmp_path / "miniconda3"
+    active_prefix = base_prefix / "envs" / "default"
+    envs_dir = active_prefix / "envs"
+    frozen_file = base_prefix / PREFIX_FROZEN_FILE
+
+    mocker.patch(
+        "conda.base.context.Context.active_prefix",
+        new_callable=mocker.PropertyMock,
+        return_value=str(active_prefix),
+    )
+    mocker.patch(
+        "conda.base.context.Context.conda_prefix",
+        new_callable=mocker.PropertyMock,
+        return_value=str(active_prefix),
+    )
+    mocker.patch(
+        "conda.base.context.Context.envs_dirs",
+        new_callable=mocker.PropertyMock,
+        return_value=(str(envs_dir),),
+    )
+    monkeypatch.delenv("_CONDA_ROOT", raising=False)
+    monkeypatch.delenv("CONDA_EXE", raising=False)
+    monkeypatch.setenv(env_var, str(base_prefix.joinpath(*path_parts)))
+    frozen_file.parent.mkdir(parents=True)
+    frozen_file.touch()
+
+    with pytest.raises(
+        CondaValueError,
+        match="Refusing to create a named environment",
+    ):
+        create.first_writable_envs_dir(reject_active_envs_dir=True)
+
+    assert not envs_dir.exists()
+
+
+def test_first_writable_envs_dir_allows_unprotected_base_env_local_conda(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    base_prefix = tmp_path / "miniconda3"
+    active_prefix = base_prefix / "envs" / "default"
+    envs_dir = active_prefix / "envs"
+
+    mocker.patch(
+        "conda.base.context.Context.active_prefix",
+        new_callable=mocker.PropertyMock,
+        return_value=str(active_prefix),
+    )
+    mocker.patch(
+        "conda.base.context.Context.conda_prefix",
+        new_callable=mocker.PropertyMock,
+        return_value=str(active_prefix),
+    )
+    mocker.patch(
+        "conda.base.context.Context.envs_dirs",
+        new_callable=mocker.PropertyMock,
+        return_value=(str(envs_dir),),
+    )
+    monkeypatch.delenv("_CONDA_ROOT", raising=False)
+    monkeypatch.setenv("CONDA_EXE", str(base_prefix / "bin" / "conda"))
+
+    assert create.first_writable_envs_dir(reject_active_envs_dir=True) == str(envs_dir)
+    assert (envs_dir / ".conda_envs_dir_test").is_file()
+
+
+def test_first_writable_envs_dir_allows_safe_envs_dir_with_env_local_conda(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    base_prefix = tmp_path / "miniconda3"
+    active_prefix = base_prefix / "envs" / "default"
+    safe_envs_dir = tmp_path / "safe-envs"
+
+    mocker.patch(
+        "conda.base.context.Context.active_prefix",
+        new_callable=mocker.PropertyMock,
+        return_value=str(active_prefix),
+    )
+    mocker.patch(
+        "conda.base.context.Context.conda_prefix",
+        new_callable=mocker.PropertyMock,
+        return_value=str(active_prefix),
+    )
+    mocker.patch(
+        "conda.base.context.Context.envs_dirs",
+        new_callable=mocker.PropertyMock,
+        return_value=(str(safe_envs_dir), str(active_prefix / "envs")),
+    )
+    monkeypatch.delenv("_CONDA_ROOT", raising=False)
+    monkeypatch.setenv("CONDA_EXE", str(base_prefix / "bin" / "conda"))
+
+    assert create.first_writable_envs_dir(reject_active_envs_dir=True) == str(
+        safe_envs_dir
+    )
+    assert (safe_envs_dir / ".conda_envs_dir_test").is_file()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Fixes #16346.

Named environment creation can otherwise pick `<active-prefix>/envs` when conda is invoked from an active environment's conda executable while activation metadata points at a different protected base conda installation. This rejects that target for `conda create` and `conda env create`, while still allowing an earlier configured safe `envs_dirs` entry and leaving unfrozen base setups alone.

The error points script and Makefile callers at `CONDA_EXE`, `CONDA_PYTHON_EXE -m conda`, or an explicit `--prefix`.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
