### PR TITLE
Run pyc compiler from private helper script (B23)

### DIFF
--- a/conda/_private/pyc_compiler.py
+++ b/conda/_private/pyc_compiler.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Compile explicit py/pyc path pairs for install transactions.
+
+This script is executed by the target environment's Python, which may not have
+conda installed. Keep it stdlib-only and do not import from conda.
+"""
+
+import errno
+import json  # noqa: TID251 - the target Python may not be able to import conda
+import os
+import py_compile
+import sys
+import traceback
+
+
+def main():
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        pairs = json.load(fh)
+
+    for py_full_path, pyc_full_path in pairs:
+        try:
+            pyc_dir = os.path.dirname(pyc_full_path)
+            if pyc_dir and not os.path.isdir(pyc_dir):
+                try:
+                    os.makedirs(pyc_dir)
+                except OSError as exc:
+                    if exc.errno != errno.EEXIST:
+                        raise
+            py_compile.compile(py_full_path, cfile=pyc_full_path, doraise=True)
+        except Exception:
+            traceback.print_exc()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -3,7 +3,6 @@
 """Disk utility functions for creating new files or directories."""
 
 import os
-import sys
 import tempfile
 import warnings as _warnings
 from errno import EACCES, EPERM, EROFS
@@ -405,20 +404,23 @@ def compile_multiple_pyc(
     if len(py_full_paths) == 0:
         return []
 
-    fd, filename = tempfile.mkstemp()
+    temp_files = []
     try:
-        for f in py_full_paths:
-            f = os.path.relpath(f, prefix)
-            if hasattr(f, "encode"):
-                f = f.encode(sys.getfilesystemencoding(), errors="replace")
-            os.write(fd, f + b"\n")
-        os.close(fd)
-        command = ["-Wi", "-m", "compileall", "-q", "-l", "-i", filename]
-        # if the python version in the prefix is 3.5+, we have some extra args.
-        #    -j 0 will do the compilation in parallel, with os.cpu_count() cores
-        if int(py_ver[0]) >= 3 and int(py_ver.split(".")[1]) > 5:
-            command.extend(["-j", "0"])
-        command[0:0] = [python_exe_full_path]
+        pyc_pairs = tuple(
+            (
+                os.path.relpath(py_full_path, prefix),
+                os.path.relpath(pyc_full_path, prefix),
+            )
+            for py_full_path, pyc_full_path in zip(py_full_paths, pyc_full_paths)
+        )
+        pairs_fd, pairs_filename = tempfile.mkstemp()
+        temp_files.append(pairs_filename)
+        with os.fdopen(pairs_fd, "w", encoding="utf-8") as fh:
+            json.dump(pyc_pairs, fh)
+
+        # This runs with the target prefix's Python, which may not have conda
+        # installed. Execute the stdlib-only helper by file path, not with -m.
+        command = [python_exe_full_path, "-Wi", _PYC_COMPILER_SCRIPT, pairs_filename]
         # command[0:0] = ['--cwd', prefix, '--dev', '-p', prefix, python_exe_full_path]
         log.log(TRACE, command)
         from ..subprocess import any_subprocess
@@ -430,7 +432,11 @@ def compile_multiple_pyc(
         #     stdout, stderr, rc = run_command(Commands.RUN, *command)
         stdout, stderr, rc = any_subprocess(command, prefix)
     finally:
-        os.remove(filename)
+        for filename in temp_files:
+            try:
+                os.remove(filename)
+            except FileNotFoundError:
+                pass
 
     created_pyc_paths = []
     for py_full_path, pyc_full_path in zip(py_full_paths, pyc_full_paths):
@@ -459,6 +465,11 @@ def compile_multiple_pyc(
             created_pyc_paths.append(pyc_full_path)
 
     return created_pyc_paths
+
+
+_PYC_COMPILER_SCRIPT = os.path.abspath(
+    join(dirname(dirname(dirname(__file__))), "_private", "pyc_compiler.py")
+)
 
 
 def create_package_cache_directory(pkgs_dir):

--- a/news/15969-windows-pyc-temp-script
+++ b/news/15969-windows-pyc-temp-script
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Compile noarch Python bytecode through temporary script files so Windows launcher wrappers do not receive newline-containing command arguments. (#15969)

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -2,10 +2,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import ast
+import json
+import subprocess
+import sys
 from contextlib import nullcontext
+from pathlib import Path
 
 import pytest
 
+from conda._private import pyc_compiler
+from conda.gateways import subprocess as gateway_subprocess
 from conda.gateways.disk import create
 
 
@@ -22,3 +29,113 @@ def test_deprecations(function: str, raises: type[Exception] | None) -> None:
     raises_context = pytest.raises(raises) if raises else nullcontext()
     with pytest.deprecated_call(), raises_context:
         getattr(create, function)()
+
+
+def test_compile_multiple_pyc_uses_direct_pair_compiler(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    prefix = tmp_path / "prefix"
+    source = prefix / "lib/python3.12/site-packages/demo.py"
+    target = prefix / "lib/python3.12/site-packages/__pycache__/demo.cpython-312.pyc"
+    source.parent.mkdir(parents=True)
+    source.write_text("value = 1")
+    calls = []
+
+    def fake_any_subprocess(command, command_prefix):
+        pairs = json.loads(Path(command[3]).read_text())
+        calls.append((command, command_prefix, pairs))
+        assert command[1] == "-Wi"
+        assert Path(command[2]).resolve() == Path(pyc_compiler.__file__).resolve()
+        assert "-c" not in command
+        assert all("\n" not in arg for arg in command)
+        assert "compileall" not in command
+        assert pairs == [
+            [
+                str(Path("lib/python3.12/site-packages/demo.py")),
+                str(
+                    Path(
+                        "lib/python3.12/site-packages/__pycache__/demo.cpython-312.pyc"
+                    )
+                ),
+            ]
+        ]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"pyc")
+        return "", "", 0
+
+    monkeypatch.setattr(gateway_subprocess, "any_subprocess", fake_any_subprocess)
+
+    created = create.compile_multiple_pyc(
+        "/prefix/bin/python",
+        [str(source)],
+        [str(target)],
+        str(prefix),
+        "3.12",
+    )
+
+    assert created == [str(target)]
+    assert calls == [
+        (
+            [
+                "/prefix/bin/python",
+                "-Wi",
+                calls[0][0][2],
+                calls[0][0][3],
+            ],
+            str(prefix),
+            [
+                [
+                    str(Path("lib/python3.12/site-packages/demo.py")),
+                    str(
+                        Path(
+                            "lib/python3.12/site-packages/__pycache__/"
+                            "demo.cpython-312.pyc"
+                        )
+                    ),
+                ]
+            ],
+        )
+    ]
+
+
+def test_private_pyc_compiler_compiles_pairs(tmp_path):
+    prefix = tmp_path / "prefix"
+    source = prefix / "lib/python3.12/site-packages/demo.py"
+    target = prefix / "lib/python3.12/site-packages/__pycache__/demo.cpython-312.pyc"
+    pairs_file = tmp_path / "pairs.json"
+    source.parent.mkdir(parents=True)
+    source.write_text("value = 1")
+    pairs_file.write_text(
+        json.dumps(
+            [
+                [
+                    str(source.relative_to(prefix)),
+                    str(target.relative_to(prefix)),
+                ]
+            ]
+        )
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(Path(pyc_compiler.__file__).resolve()), str(pairs_file)],
+        cwd=prefix,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert target.is_file()
+
+
+def test_private_pyc_compiler_does_not_import_conda():
+    source = Path(pyc_compiler.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imports = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.partition(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.partition(".")[0])
+
+    assert "conda" not in imports


### PR DESCRIPTION
### Description

Part of #15969 as Track B follow-up B23.

Conda currently invokes the target environment's Python as a subprocess and runs the standard-library compileall module with a temporary path list. This PR moves the compiler program into a stdlib-only private helper file and invokes that helper with the target Python.

The design was informed by [uv's bytecode compiler](https://github.com/astral-sh/uv/blob/main/crates/uv-installer/src/compile.rs), which uses multiple persistent target-Python helper processes, streams files over stdin and stdout, and applies per-file timeouts. This PR establishes only the helper-file boundary. By itself it does not add process isolation beyond conda's existing target-Python subprocess, and it does not add parallel workers.

### Measured impact

Focused compile-phase measurements on macOS:

| Case | main | B23 | Result |
| --- | ---: | ---: | ---: |
| 500 Python files | 951.56 ms | 808.42 ms | 1.18x |
| 2,000 Python files | 1.03 s | 1.22 s | 0.84x |

The result is workload-dependent and regresses the larger fixture. B24 is now independent and passes its process count directly to the target interpreter's compileall -j implementation.

B23 should remain draft unless conda intends to implement the rest of the uv-style persistent-worker protocol. As a standalone helper extraction it does not establish a speed or correctness win.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the news directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? No user-facing documentation change.
