### PR TITLE
Allow skipping install-time Python bytecode compilation (B24)

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -461,6 +461,7 @@ class Context(Configuration):
         aliases=("error_upload_url",),
     )
     force = ParameterLoader(PrimitiveParameter(False))
+    compile_pyc = ParameterLoader(PrimitiveParameter(True))
     json = ParameterLoader(PrimitiveParameter(False))
     _console = ParameterLoader(
         PrimitiveParameter(DEFAULT_CONSOLE_REPORTER_BACKEND, element_type=str),
@@ -1357,6 +1358,7 @@ class Context(Configuration):
             "allow_softlinks",
             "always_copy",
             "always_softlink",
+            "compile_pyc",
             "path_conflict",
             "rollback_enabled",
             "safety_checks",
@@ -1655,8 +1657,10 @@ class Context(Configuration):
             default_threads=dals(
                 """
                 Threads to use by default for parallel operations.  Default is None,
-                which allows operations to choose themselves.  For more specific
-                control, see the other *_threads parameters:
+                which allows operations to choose themselves.  When set, this value is
+                also used as the worker-process count for Python bytecode compilation
+                during installation.  For more specific control, see the other
+                *_threads parameters:
                     * repodata_threads - for fetching/loading repodata
                     * verify_threads - for verifying package contents in transactions
                     * execute_threads - for carrying out the unlinking and linking steps
@@ -1705,6 +1709,13 @@ class Context(Configuration):
                 Threads to use when performing the unlink/link transaction.  When not set,
                 defaults to 1.  This step is pretty strongly I/O limited, and you may not
                 see much benefit here.
+                """
+            ),
+            compile_pyc=dals(
+                """
+                Compile Python bytecode files for noarch Python packages during installation.
+                Disable this when startup-time bytecode compilation is preferable to
+                install-time compilation.
                 """
             ),
             export_platforms=dals(

--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -539,6 +539,13 @@ def add_parser_package_install_options(p: ArgumentParser) -> _ArgumentGroup:
         help="Install all packages using copies instead of hard- or soft-linking.",
     )
     package_install_options.add_argument(
+        "--no-compile-pyc",
+        action="store_false",
+        default=NULL,
+        dest="compile_pyc",
+        help="Do not compile Python bytecode files during installation.",
+    )
+    package_install_options.add_argument(
         "--shortcuts",
         action="store_true",
         help=SUPPRESS,

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -677,6 +677,9 @@ class CompileMultiPycAction(MultiPathAction):
         requested_link_type,
         file_link_actions,
     ):
+        if not context.compile_pyc:
+            return ()
+
         noarch = package_info.package_metadata and package_info.package_metadata.noarch
         if noarch is not None and noarch.type == NoarchType.python:
             noarch_py_file_re = re.compile(r"^site-packages[/\\][^\t\n\r\f\v]+\.py$")

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -415,9 +415,8 @@ def compile_multiple_pyc(
         os.close(fd)
         command = ["-Wi", "-m", "compileall", "-q", "-l", "-i", filename]
         # if the python version in the prefix is 3.5+, we have some extra args.
-        #    -j 0 will do the compilation in parallel, with os.cpu_count() cores
         if int(py_ver[0]) >= 3 and int(py_ver.split(".")[1]) > 5:
-            command.extend(["-j", "0"])
+            command.extend(["-j", str(context.default_threads or 0)])
         command[0:0] = [python_exe_full_path]
         # command[0:0] = ['--cwd', prefix, '--dev', '-p', prefix, python_exe_full_path]
         log.log(TRACE, command)

--- a/news/15969-uv-pyc-controls
+++ b/news/15969-uv-pyc-controls
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add a control to skip install-time Python bytecode compilation. (#15969 via #16352)

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -390,6 +390,21 @@ def test_threads(monkeypatch: MonkeyPatch) -> None:
         assert context.execute_threads == 3
 
 
+def test_compile_pyc(monkeypatch: MonkeyPatch) -> None:
+    assert context.compile_pyc is True
+
+    with monkeypatch.context() as m:
+        m.setenv("CONDA_COMPILE_PYC", "false")
+        reset_context()
+        assert context.compile_pyc is False
+
+    try:
+        reset_context(argparse_args=Namespace(compile_pyc=False))
+        assert context.compile_pyc is False
+    finally:
+        reset_context()
+
+
 def test_channels_empty(context_testdata: None):
     """Test when no channels provided in cli and no condarc config is present."""
     reset_context(())

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -59,6 +59,15 @@ def test_console_rejects_unknown_backend(capsys: CaptureFixture):
     assert "invalid choice: 'does-not-exist'" in capsys.readouterr().err
 
 
+def test_parse_no_compile_pyc(subtests: Subtests):
+    parser = generate_parser()
+
+    for command in ["create", "install", "update"]:
+        with subtests.test(command):
+            args = parser.parse_args([command, "--no-compile-pyc"])
+            assert args.compile_pyc is False
+
+
 def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
     stdout, stderr, err = conda_cli("config", "--show", "add_anaconda_token")
     assert stdout

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -92,6 +92,33 @@ def test_CompileMultiPycAction_generic(prefix: Path):
     assert axns == ()
 
 
+def test_CompileMultiPycAction_disabled(prefix: Path):
+    target_python_version = "%d.%d" % sys.version_info[:2]
+    sp_dir = get_python_site_packages_short_path(target_python_version)
+    transaction_context = {
+        "target_python_version": target_python_version,
+        "target_site_packages_short_path": sp_dir,
+    }
+    package_info = AttrDict(
+        package_metadata=AttrDict(noarch=AttrDict(type=NoarchType.python))
+    )
+    file_link_actions = [
+        AttrDict(
+            source_short_path="site-packages/something.py",
+            target_short_path=get_python_noarch_target_path(
+                "site-packages/something.py", sp_dir
+            ),
+        )
+    ]
+
+    with context._override("compile_pyc", False):
+        actions = CompileMultiPycAction.create_actions(
+            transaction_context, package_info, str(prefix), None, file_link_actions
+        )
+
+    assert actions == ()
+
+
 @pytest.mark.xfail(on_win, reason="pyc compilation need env on windows, see gh #8025")
 def test_CompileMultiPycAction_noarch_python(prefix: Path):
     if not softlink_supported(__file__, prefix) and on_win:

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -6,6 +6,8 @@ from contextlib import nullcontext
 
 import pytest
 
+from conda.base.context import context
+from conda.gateways import subprocess as gateway_subprocess
 from conda.gateways.disk import create
 
 
@@ -22,3 +24,38 @@ def test_deprecations(function: str, raises: type[Exception] | None) -> None:
     raises_context = pytest.raises(raises) if raises else nullcontext()
     with pytest.deprecated_call(), raises_context:
         getattr(create, function)()
+
+
+@pytest.mark.parametrize(
+    ("default_threads", "expected_processes"),
+    [(0, "0"), (2, "2")],
+)
+def test_compile_multiple_pyc_uses_default_threads(
+    monkeypatch, tmp_path, default_threads, expected_processes
+):
+    prefix = tmp_path / "prefix"
+    source = prefix / "lib/python3.12/site-packages/demo.py"
+    target = prefix / "lib/python3.12/site-packages/__pycache__/demo.cpython-312.pyc"
+    source.parent.mkdir(parents=True)
+    source.write_text("value = 1")
+    commands = []
+
+    def fake_any_subprocess(command, command_prefix):
+        commands.append(command)
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"pyc")
+        return "", "", 0
+
+    monkeypatch.setattr(gateway_subprocess, "any_subprocess", fake_any_subprocess)
+
+    with context._override("_default_threads", default_threads):
+        created = create.compile_multiple_pyc(
+            "/prefix/bin/python",
+            [str(source)],
+            [str(target)],
+            str(prefix),
+            "3.12",
+        )
+
+    assert created == [str(target)]
+    assert commands[0][-2:] == ["-j", expected_processes]


### PR DESCRIPTION
### Description

Part of #15969 as Track B follow-up B24.

Python bytecode compilation is an install-time latency versus first-import tradeoff. Conda currently compiles bytecode for noarch Python packages during installation, while uv lets users choose whether to pay that cost during installation.

This PR preserves conda's current default and adds a way to skip that work:

- `--no-compile-pyc` disables bytecode compilation for `create`, `install`, and `update` commands.
- `compile_pyc: false` disables it through configuration.

When compilation remains enabled, conda continues to invoke the target environment's Python as a subprocess. The `compileall` worker count follows `default_threads` when configured. Otherwise, conda passes `-j 0` and lets Python choose based on the available CPUs.

This implementation is independent of B23. The target interpreter owns the `compileall` worker processes. No generated command-line Python or custom compilation helper is added.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the news directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? CLI help and the configuration description cover the new control.
