### PR TITLE
Retry built-in Windows package extraction (B25)

### DIFF
--- a/conda/_private/extract.py
+++ b/conda/_private/extract.py
@@ -6,19 +6,21 @@ from __future__ import annotations
 
 import os
 
-# This module is imported in each spawned extraction worker. Keep imports here
-# limited to the standard library; importing conda runtime state defeats the
-# process pool's startup benefit.
+# This module is imported in each spawned extraction worker. Keep top-level
+# imports limited to the standard library so loading the worker stays cheap.
 
 
 def extract_conda_package_archive(
     source_full_path: str | os.PathLike,
     destination_directory: str | os.PathLike,
 ) -> None:
-    """Extract a conda package archive without importing conda runtime state."""
+    """Extract a conda package archive with standard file-operation retries."""
     import conda_package_handling.api
 
-    conda_package_handling.api.extract(
+    from ..gateways.disk import exp_backoff_fn
+
+    exp_backoff_fn(
+        conda_package_handling.api.extract,
         os.fspath(source_full_path),
         dest_dir=os.fspath(destination_directory),
     )

--- a/conda/_private/extract.py
+++ b/conda/_private/extract.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 import os
 import pickle
 
-# This module is imported in each spawned extraction worker. Keep imports here
-# limited to the standard library; importing conda runtime state defeats the
-# process pool's startup benefit.
+# This module is imported in each spawned extraction worker. Keep top-level
+# imports limited to the standard library so loading the worker stays cheap.
 
 
 def extract_conda_package_archive(
@@ -18,7 +17,7 @@ def extract_conda_package_archive(
     *,
     ensure_picklable_errors: bool = False,
 ) -> None:
-    """Extract a conda package archive without importing conda runtime state.
+    """Extract a conda package archive with standard file-operation retries.
 
     Args:
         source_full_path: Package archive to extract.
@@ -28,8 +27,11 @@ def extract_conda_package_archive(
     """
     import conda_package_handling.api
 
+    from ..gateways.disk import exp_backoff_fn
+
     try:
-        conda_package_handling.api.extract(
+        exp_backoff_fn(
+            conda_package_handling.api.extract,
             os.fspath(source_full_path),
             dest_dir=os.fspath(destination_directory),
         )

--- a/news/15969-windows-extract-retry
+++ b/news/15969-windows-extract-retry
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Retry built-in Windows package extraction to tolerate transient file-handle contention. (#15969 via #16353)

--- a/tests/_private/test_extract.py
+++ b/tests/_private/test_extract.py
@@ -6,6 +6,14 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from typing import TYPE_CHECKING
+
+from conda._private.extract import extract_conda_package_archive
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 def test_extract_module_does_not_import_runtime_state() -> None:
@@ -34,3 +42,23 @@ for name in sorted(sys.modules):
         "conda._version",
     }
     assert not any(name.startswith("conda_package_handling") for name in imported)
+
+
+def test_extract_uses_standard_backoff(mocker: MockerFixture, tmp_path: Path) -> None:
+    import conda_package_handling.api
+
+    from conda.gateways import disk
+
+    source = tmp_path / "package.conda"
+    destination = tmp_path / "package"
+    extract = mocker.patch.object(conda_package_handling.api, "extract")
+    backoff = mocker.spy(disk, "exp_backoff_fn")
+
+    extract_conda_package_archive(source, destination)
+
+    backoff.assert_called_once_with(
+        extract,
+        str(source),
+        dest_dir=str(destination),
+    )
+    extract.assert_called_once_with(str(source), dest_dir=str(destination))

--- a/tests/_private/test_extract.py
+++ b/tests/_private/test_extract.py
@@ -8,10 +8,16 @@ import subprocess
 import sys
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import get_context
+from typing import TYPE_CHECKING
 
 import pytest
 
 from conda._private.extract import extract_conda_package_archive
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 class _UnpickleableError(Exception):
@@ -69,3 +75,23 @@ def test_process_extract_normalizes_unpickleable_errors(tmp_path) -> None:
             match=r"_UnpickleableError: Could not extract archive\.conda to destination",
         ):
             future.result()
+
+
+def test_extract_uses_standard_backoff(mocker: MockerFixture, tmp_path: Path) -> None:
+    import conda_package_handling.api
+
+    from conda.gateways import disk
+
+    source = tmp_path / "package.conda"
+    destination = tmp_path / "package"
+    extract = mocker.patch.object(conda_package_handling.api, "extract")
+    backoff = mocker.spy(disk, "exp_backoff_fn")
+
+    extract_conda_package_archive(source, destination)
+
+    backoff.assert_called_once_with(
+        extract,
+        str(source),
+        dest_dir=str(destination),
+    )
+    extract.assert_called_once_with(str(source), dest_dir=str(destination))


### PR DESCRIPTION
### Description

Part of conda/conda#15969 as Track B follow-up B25.

Built-in package extraction can fail transiently on Windows when antivirus, indexing, or filesystem watchers briefly hold package-cache files open. A retry can recover once the handle is released instead of failing the installation.

This PR passes built-in `.conda` and `.tar.bz2` extraction through conda's existing `exp_backoff_fn`. The retry lives in the shared extraction helper used by both the process pool and the plugin fallback.

The existing default is used without a custom attempt count. Windows retries `EACCES` and `EPERM` failures up to seven attempts, for a maximum sleep window of roughly 6.3 to 6.9 seconds. Other platforms call the extractor once without sleeping.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Measured impact

This is a reliability-focused Track B follow-up. A focused Python 3.10.20 simulation of the Windows retry branch, using the same positional and keyword arguments as package extraction, produced:

| Case | `main` | B25 |
| --- | ---: | ---: |
| No-failure call, per call | 0.05 us | 0.26 us |
| 4 transient `EACCES` failures before success | fails after 1 attempt | succeeds on attempt 5 |
| 6 transient `EACCES` failures before success | fails after 1 attempt | succeeds on attempt 7 |

The wrapper adds about 0.21 us to a successful extraction call. A seventh consecutive failure still stops after attempt 7 instead of extending the wait further.

A separate macOS spawn-process-pool benchmark used 12 tiny `.conda` packages, 3 workers, and 50 randomized runs to include worker startup and the new runtime import:

| Case | `main` median | B25 median |
| --- | ---: | ---: |
| Process-pool startup and 12 extractions | 145.6 ms | 145.0 ms |

This showed no measurable process-pool regression.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? No user-facing documentation change.
