### PR TITLE
Add conda plugins list subcommand

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -59,7 +59,7 @@ from .types import CondaErrorHint, CondaExceptionEvent
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from types import TracebackType
-    from typing import Any, Literal, TypeVar, cast
+    from typing import Any, Literal, TypedDict, TypeVar, cast
 
     from pluggy import HookImpl
     from requests.auth import AuthBase
@@ -98,6 +98,14 @@ if TYPE_CHECKING:
     )
 
     P = TypeVar("P", bound=CondaPluginWithAliases)
+
+    class PluginInfo(TypedDict):
+        name: str
+        version: str
+        canonical_name: str
+        status: str
+        hooks: list[str]
+
 
 log = logging.getLogger(__name__)
 
@@ -202,6 +210,35 @@ class CondaPluginManager(pluggy.PluginManager):
                 return f"{dist.project_name} {version}".strip()
 
         return self.get_name(plugin) or self.get_canonical_name(plugin)
+
+    def get_plugin_hook_names(self, plugin: object) -> list[str]:
+        """Return short hook names implemented by a registered plugin."""
+        hook_prefix = f"{self.project_name}_"
+        hook_names: list[str] = []
+        for hook_caller in self.get_hookcallers(plugin) or ():
+            hook_name = hook_caller.name
+            if hook_name.startswith(hook_prefix):
+                hook_names.append(hook_name[len(hook_prefix) :])
+
+        return sorted(hook_names)
+
+    def get_installed_plugins(self) -> list[PluginInfo]:
+        """Return metadata for installed entry-point conda plugins."""
+        installed: dict[str, PluginInfo] = {}
+        for plugin, dist in self.list_plugin_distinfo():
+            canonical_name = self.get_name(plugin)
+            if canonical_name is None or canonical_name in installed:
+                continue
+
+            installed[canonical_name] = {
+                "name": dist.project_name,
+                "version": dist.version,
+                "canonical_name": canonical_name,
+                "status": "disabled" if self.is_blocked(canonical_name) else "active",
+                "hooks": self.get_plugin_hook_names(plugin),
+            }
+
+        return sorted(installed.values(), key=lambda plugin: plugin["canonical_name"])
 
     def register(self, plugin, name: str | None = None) -> str | None:
         """

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -212,11 +212,15 @@ class CondaPluginManager(pluggy.PluginManager):
         return self.get_name(plugin) or self.get_canonical_name(plugin)
 
     def get_plugin_hook_names(self, plugin: object) -> list[str]:
-        """Return short hook names implemented by a registered plugin."""
+        """Return short hook names implemented by a plugin."""
         hook_prefix = f"{self.project_name}_"
         hook_names: list[str] = []
-        for hook_caller in self.get_hookcallers(plugin) or ():
-            hook_name = hook_caller.name
+        for name in dir(plugin):
+            hookimpl_opts = self.parse_hookimpl_opts(plugin, name)
+            if hookimpl_opts is None:
+                continue
+
+            hook_name = hookimpl_opts.get("specname") or name
             if hook_name.startswith(hook_prefix):
                 hook_names.append(hook_name[len(hook_prefix) :])
 
@@ -226,8 +230,8 @@ class CondaPluginManager(pluggy.PluginManager):
         """Return metadata for installed entry-point conda plugins."""
         installed: dict[str, PluginInfo] = {}
         for plugin, dist in self.list_plugin_distinfo():
-            canonical_name = self.get_name(plugin)
-            if canonical_name is None or canonical_name in installed:
+            canonical_name = self.get_name(plugin) or self.get_canonical_name(plugin)
+            if canonical_name in installed:
                 continue
 
             installed[canonical_name] = {

--- a/conda/plugins/subcommands/__init__.py
+++ b/conda/plugins/subcommands/__init__.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-from importlib import import_module
+from . import doctor as _doctor
+from . import plugins as _plugins
 
-from . import doctor
-
-plugins = [doctor, import_module(f"{__name__}.plugins")]
+plugins = [_doctor, _plugins]

--- a/conda/plugins/subcommands/__init__.py
+++ b/conda/plugins/subcommands/__init__.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from importlib import import_module
+
 from . import doctor
 
-plugins = [doctor]
+plugins = [doctor, import_module(f"{__name__}.plugins")]

--- a/conda/plugins/subcommands/plugins/__init__.py
+++ b/conda/plugins/subcommands/plugins/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Implementation for `conda plugins` subcommand."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING
+
+from ... import hookimpl
+from ...types import CondaSubcommand
+from . import list
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+
+SUMMARY = "Manage conda plugins."
+
+
+def configure_parser(parser: ArgumentParser) -> None:
+    subparsers = parser.add_subparsers(
+        title="subcommands",
+        dest="subcommand",
+    )
+
+    list.configure_parser(subparsers.add_parser("list", help=list.HELP))
+    parser.set_defaults(func=partial(parser.parse_args, ["--help"]))
+
+
+def execute(args: Namespace) -> int:
+    return args.func(args)
+
+
+@hookimpl
+def conda_subcommands():
+    yield CondaSubcommand(
+        name="plugins",
+        summary=SUMMARY,
+        action=execute,
+        configure_parser=configure_parser,
+    )

--- a/conda/plugins/subcommands/plugins/list.py
+++ b/conda/plugins/subcommands/plugins/list.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Implementation for `conda plugins list` subcommand."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ....base.context import context
+from ....cli.helpers import add_parser_json
+from ....common.serialize import json
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+
+
+HELP = "List installed conda plugins."
+
+
+def configure_parser(parser: ArgumentParser) -> None:
+    parser.description = HELP
+    add_parser_json(parser)
+    parser.set_defaults(func=execute)
+
+
+def execute(args: Namespace) -> int:
+    plugins = context.plugin_manager.get_installed_plugins()
+
+    if context.json:
+        print(json.dumps(plugins, indent=2))
+        return 0
+
+    if not plugins:
+        print("No plugins installed.")
+        return 0
+
+    name_width = max(len(plugin["name"]) for plugin in plugins)
+    version_width = max(len(plugin["version"]) for plugin in plugins)
+    status_width = max(len(plugin["status"]) for plugin in plugins)
+
+    header = (
+        f"{'Name':<{name_width}}  "
+        f"{'Version':<{version_width}}  "
+        f"{'Status':<{status_width}}  "
+        "Hooks"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for plugin in plugins:
+        print(
+            f"{plugin['name']:<{name_width}}  "
+            f"{plugin['version']:<{version_width}}  "
+            f"{plugin['status']:<{status_width}}  "
+            f"{', '.join(plugin['hooks'])}"
+        )
+
+    return 0

--- a/news/16354-plugins-list-subcommand
+++ b/news/16354-plugins-list-subcommand
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add a `conda plugins list` subcommand for listing installed conda plugins. (#16354)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -151,7 +151,7 @@ def test_load_entrypoints_success(plugin_manager: CondaPluginManager):
 def test_get_installed_plugins(plugin_manager: CondaPluginManager):
     assert plugin_manager.load_entrypoints("test_plugin", "success") == 1
 
-    assert plugin_manager.get_installed_plugins() == [
+    expected = [
         {
             "name": "conda-test-plugin",
             "version": "1.0",
@@ -160,6 +160,12 @@ def test_get_installed_plugins(plugin_manager: CondaPluginManager):
             "hooks": ["solvers"],
         }
     ]
+    assert plugin_manager.get_installed_plugins() == expected
+
+    plugin_manager.disable_external_plugins()
+    expected[0]["status"] = "disabled"
+
+    assert plugin_manager.get_installed_plugins() == expected
 
 
 def test_load_entrypoints_importerror(

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -148,6 +148,20 @@ def test_load_entrypoints_success(plugin_manager: CondaPluginManager):
     assert plugin_manager.list_name_plugin()[0][0] == "test_plugin.success"
 
 
+def test_get_installed_plugins(plugin_manager: CondaPluginManager):
+    assert plugin_manager.load_entrypoints("test_plugin", "success") == 1
+
+    assert plugin_manager.get_installed_plugins() == [
+        {
+            "name": "conda-test-plugin",
+            "version": "1.0",
+            "canonical_name": "test_plugin.success",
+            "status": "active",
+            "hooks": ["solvers"],
+        }
+    ]
+
+
 def test_load_entrypoints_importerror(
     plugin_manager: CondaPluginManager,
     mocker: MockerFixture,

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from conda.plugins.manager import CondaPluginManager
+    from conda.testing.fixtures import CondaCLIFixture
+
+
+@pytest.fixture
+def plugin_manager_with_plugins_command(
+    plugin_manager: CondaPluginManager,
+) -> CondaPluginManager:
+    plugin_manager.load_plugins(import_module("conda.plugins.subcommands.plugins"))
+    return plugin_manager
+
+
+@pytest.fixture
+def plugin_manager_with_test_plugin(
+    plugin_manager_with_plugins_command: CondaPluginManager,
+) -> CondaPluginManager:
+    assert (
+        plugin_manager_with_plugins_command.load_entrypoints(
+            "test_plugin",
+            "success",
+        )
+        == 1
+    )
+    return plugin_manager_with_plugins_command
+
+
+def test_plugins_help(
+    plugin_manager_with_plugins_command: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+):
+    out, err, exc = conda_cli("plugins", "--help", raises=SystemExit)
+
+    assert exc.value.code == 0
+    assert "list" in out
+    assert not err
+
+
+def test_plugins_list_help(
+    plugin_manager_with_plugins_command: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+):
+    out, err, exc = conda_cli("plugins", "list", "--help", raises=SystemExit)
+
+    assert exc.value.code == 0
+    assert "List installed conda plugins." in out
+    assert not err
+
+
+def test_plugins_list_empty(
+    plugin_manager_with_plugins_command: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+):
+    out, err, code = conda_cli("plugins", "list")
+
+    assert code == 0, f"conda plugins list failed ({code}): {err}"
+    assert out == "No plugins installed.\n"
+    assert not err
+
+
+def test_plugins_list_table(
+    plugin_manager_with_test_plugin: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+):
+    out, err, code = conda_cli("plugins", "list")
+
+    assert code == 0, f"conda plugins list failed ({code}): {err}"
+    assert "Name" in out
+    assert "Version" in out
+    assert "Status" in out
+    assert "Hooks" in out
+    assert "conda-test-plugin" in out
+    assert "active" in out
+    assert "solvers" in out
+    assert not err
+
+
+def test_plugins_list_json(
+    plugin_manager_with_test_plugin: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+):
+    out, err, code = conda_cli("plugins", "list", "--json")
+
+    assert code == 0, f"conda plugins list --json failed ({code}): {err}"
+    data = json.loads(out)
+    test_plugin = next(
+        plugin for plugin in data if plugin["name"] == "conda-test-plugin"
+    )
+
+    assert test_plugin == {
+        "name": "conda-test-plugin",
+        "version": "1.0",
+        "canonical_name": "test_plugin.success",
+        "status": "active",
+        "hooks": ["solvers"],
+    }
+    assert not err

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -85,6 +85,22 @@ def test_plugins_list_table(
     assert not err
 
 
+def test_plugins_list_disabled(
+    plugin_manager_with_test_plugin: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CONDA_NO_PLUGINS", "true")
+
+    out, err, code = conda_cli("plugins", "list")
+
+    assert code == 0, f"conda plugins list failed ({code}): {err}"
+    assert "conda-test-plugin" in out
+    assert "disabled" in out
+    assert "solvers" in out
+    assert not err
+
+
 def test_plugins_list_json(
     plugin_manager_with_test_plugin: CondaPluginManager,
     conda_cli: CondaCLIFixture,


### PR DESCRIPTION
### Description

Implements the first slice of conda/conda#16354 after moving the plugin-management epic from `conda-self` into conda. This supersedes conda/conda-self#130.

This adds a bundled `conda plugins` subcommand with an initial `conda plugins list` action. The list command reports installed entry-point plugins with their distribution name, version, active/disabled status, canonical plugin name, and registered hook groups, with `--json` support for machine-readable output.

The plugin discovery logic lives on `CondaPluginManager`, reusing conda's loaded plugin state, pluggy hook callers, and entry-point distribution metadata instead of rescanning entry points from the subcommand implementation.

Part of #16354.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
