### PR TITLE
Use CopyFileW for Windows copy-mode installs (B27)

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -106,6 +106,8 @@ _CLONEFILE_UNSUPPORTED_ERRNOS = frozenset(
 _CLONEFILE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
 _CLONEFILE_UNAVAILABLE = object()
 _CLONEFILE = None
+_WIN_COPYFILE_UNAVAILABLE = object()
+_WIN_COPYFILE = None
 
 # in __init__.py to help with circular imports
 mkdir_p = mkdir_p
@@ -392,6 +394,13 @@ def _clone_file(src, dst):
 
 def _do_copy(src, dst):
     log.log(TRACE, "copying %s => %s", src, dst)
+    if _win_copy_file(src, dst):
+        try:
+            copystat(src, dst)
+        except OSError as e:  # pragma: no cover
+            log.debug("%r", e)
+        return
+
     # src and dst are always files. So we can bypass some checks that shutil.copy does.
     # Also shutil.copy calls shutil.copymode, which we can skip because we are explicitly
     # calling copystat.
@@ -409,6 +418,34 @@ def _do_copy(src, dst):
         # shutil.copystat gives a permission denied when using the os.setxattr function
         # on the security.selinux property.
         log.debug("%r", e)
+
+
+def _win_copy_file(src, dst):
+    if not on_win:
+        return False
+
+    global _WIN_COPYFILE
+    if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
+        return False
+    if _WIN_COPYFILE is None:
+        try:
+            from ctypes import windll, wintypes
+        except ImportError:
+            _WIN_COPYFILE = _WIN_COPYFILE_UNAVAILABLE
+            return False
+        copy_file = windll.kernel32.CopyFileW
+        copy_file.restype = wintypes.BOOL
+        copy_file.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.BOOL)
+        _WIN_COPYFILE = copy_file
+
+    # CopyFileW keeps Windows copy-mode installs in kernel32 instead of bouncing
+    # every file through Python's read/write loop. The target should not exist.
+    if _WIN_COPYFILE(src, dst, True):
+        log.log(TRACE, "windows copying %s => %s", src, dst)
+        return True
+    if lexists(dst):
+        rm_rf(dst)
+    return False
 
 
 def create_link(src, dst, link_type=LinkType.hardlink, force=False):

--- a/news/15969-windows-copy-fast-path
+++ b/news/15969-windows-copy-fast-path
@@ -1,0 +1,11 @@
+### Enhancements
+
+* Use the Windows `CopyFileW` API for copy-mode file creation during installs. (#15969)
+
+### Bug fixes
+
+### Deprecations
+
+### Docs
+
+### Other

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -145,3 +145,71 @@ def test_copy_link_type_does_not_fall_back_to_hardlink(
     assert target.read_text() == "contents"
     assert target.stat().st_nlink == 1
     assert link_calls == []
+
+
+@pytest.mark.parametrize(
+    (
+        "on_win",
+        "copyfile_result",
+        "initial_target",
+        "expects_python_copy",
+        "expects_removed_target",
+    ),
+    (
+        (True, True, None, False, False),
+        (False, True, None, True, False),
+        (True, False, "partial", True, True),
+    ),
+    ids=("windows-copyfile", "non-windows-copy", "windows-copyfile-fallback"),
+)
+def test_do_copy_windows_copyfile_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    on_win,
+    copyfile_result,
+    initial_target,
+    expects_python_copy,
+    expects_removed_target,
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    if initial_target is not None:
+        target.write_text(initial_target)
+    copy_calls = []
+    python_copy_calls = []
+    removed = []
+    rm_rf = create.rm_rf
+    original_copyfileobj = create.copyfileobj
+
+    def copy_file(src, dst, fail_if_exists):
+        copy_calls.append((src, dst, fail_if_exists))
+        if copyfile_result:
+            copyfile(src, dst)
+        return copyfile_result
+
+    def copyfileobj_spy(*args, **kwargs):
+        python_copy_calls.append(args[2] if len(args) > 2 else kwargs.get("length"))
+        return original_copyfileobj(*args, **kwargs)
+
+    def remove(path):
+        removed.append(path)
+        rm_rf(path)
+
+    win_copyfile = (
+        copy_file
+        if on_win
+        else lambda *args: pytest.fail("CopyFileW should be Windows-only")
+    )
+
+    monkeypatch.setattr(create, "on_win", on_win)
+    monkeypatch.setattr(create, "_WIN_COPYFILE", win_copyfile)
+    monkeypatch.setattr(create, "copyfileobj", copyfileobj_spy)
+    monkeypatch.setattr(create, "rm_rf", remove)
+
+    create._do_copy(str(source), str(target))
+
+    assert target.read_text() == "contents"
+    assert copy_calls == ([(str(source), str(target), True)] if on_win else [])
+    assert bool(python_copy_calls) is expects_python_copy
+    assert removed == ([str(target)] if expects_removed_target else [])


### PR DESCRIPTION
### Description

Part of conda/conda#15969 as a new Track B follow-up case (B27).

Windows provides `CopyFileW` for kernel32-managed file copies. This PR routes conda's copy-mode file creation through that API on Windows, so copy-style install paths avoid Python-level read/write loops when package files need to be copied.

This draft is stacked on B26 (#16358) until that PR lands; the new Track B case here is the Windows copy backend.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Measured impact

The expected win is for Windows copy-mode installs, where conda would otherwise copy package files byte-for-byte through Python. The normal fallback path remains available when `CopyFileW` cannot complete a copy.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? No user-facing docs change.
