### PR TITLE
Use FICLONE for Linux copy-mode installs (B28)

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -12,6 +12,7 @@ from errno import EACCES, EINVAL, ENOSYS, EPERM, EROFS, EXDEV
 from logging import getLogger
 from os.path import dirname, isdir, isfile, join, splitext
 from shutil import copyfileobj, copystat
+from stat import S_ISREG
 
 from ... import CondaError
 from ...auxlib.ish import dals
@@ -119,6 +120,7 @@ _FICLONE_UNSUPPORTED_ERRNOS = frozenset(
     if error is not None
 )
 _FICLONE = 0x40049409
+_FICLONE_MIN_FILE_SIZE = 64 * 1024
 _FICLONE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
 _FICLONE_UNAVAILABLE = object()
 _FICLONE_IOCTL = None
@@ -373,12 +375,12 @@ def _clone_file(src, dst):
     Returns:
         True when cloning succeeds, or False to use the normal copy fallback.
     """
+    if on_linux:
+        return _clone_file_linux(src, dst)
     if islink(src) or lexists(dst):
         return False
     if on_mac:
         return _clone_file_macos(src, dst)
-    if on_linux:
-        return _clone_file_linux(src, dst)
     return False
 
 
@@ -421,13 +423,24 @@ def _clone_file_macos(src, dst):
 
 
 def _clone_file_linux(src, dst):
-    if not isfile(src):
+    try:
+        src_stat = os.stat(src)
+    except OSError:
+        return False
+    if not S_ISREG(src_stat.st_mode):
+        return False
+    # The ioctl is slower than a buffered copy for tiny files on btrfs, so keep
+    # those on conda's normal copy path and reserve reflinks for files that can
+    # actually avoid meaningful byte-copy work.
+    if src_stat.st_size < _FICLONE_MIN_FILE_SIZE:
+        return False
+    if islink(src) or lexists(dst):
         return False
     try:
-        src_dev = os.stat(src).st_dev
         dst_dev = os.stat(dirname(dst) or ".").st_dev
     except OSError:
         return False
+    src_dev = src_stat.st_dev
     device_pair = (src_dev, dst_dev)
 
     global _FICLONE_IOCTL

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -375,12 +375,12 @@ def _clone_file(src, dst):
     Returns:
         True when cloning succeeds, or False to use the normal copy fallback.
     """
-    if on_linux:
-        return _clone_file_linux(src, dst)
     if islink(src) or lexists(dst):
         return False
     if on_mac:
         return _clone_file_macos(src, dst)
+    if on_linux:
+        return _clone_file_linux(src, dst)
     return False
 
 

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import warnings as _warnings
 from ctypes import CDLL, c_char_p, c_int, get_errno
-from errno import EACCES, ENOSYS, EPERM, EROFS, EXDEV
+from errno import EACCES, EINVAL, ENOSYS, EPERM, EROFS, EXDEV
 from logging import getLogger
 from os.path import dirname, isdir, isfile, join, splitext
 from shutil import copyfileobj, copystat
@@ -17,7 +17,7 @@ from ... import CondaError
 from ...auxlib.ish import dals
 from ...base.constants import PACKAGE_CACHE_MAGIC_FILE
 from ...base.context import context
-from ...common.compat import on_mac, on_win
+from ...common.compat import on_linux, on_mac, on_win
 from ...common.constants import TRACE
 from ...common.path import ensure_pad, expand, win_path_double_escape, win_path_ok
 from ...common.path.python import is_valid_import_path
@@ -106,6 +106,22 @@ _CLONEFILE_UNSUPPORTED_ERRNOS = frozenset(
 _CLONEFILE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
 _CLONEFILE_UNAVAILABLE = object()
 _CLONEFILE = None
+_FICLONE_UNSUPPORTED_ERRNOS = frozenset(
+    error
+    for error in (
+        EXDEV,
+        EINVAL,
+        ENOSYS,
+        getattr(errno, "ENOTTY", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+    )
+    if error is not None
+)
+_FICLONE = 0x40049409
+_FICLONE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
+_FICLONE_UNAVAILABLE = object()
+_FICLONE_IOCTL = None
 _WIN_COPYFILE_UNAVAILABLE = object()
 _WIN_COPYFILE = None
 
@@ -340,9 +356,8 @@ def copy(src, dst):
             log.log(TRACE, "soft linking %s => %s", src, dst)
             symlink(src_points_to, dst)
             return
-    # APFS clonefile gives copy-on-write semantics for normal copy requests.
-    # Keep this copy-scoped: clonefile does not raise hardlink refcounts, so
-    # package-cache cleanup cannot treat it as a normal cache-linked install.
+    # Copy-on-write file clones accelerate normal copy requests while preserving
+    # conda's package-cache hardlink/refcount semantics.
     if _clone_file(src, dst):
         try:
             copystat(src, dst)
@@ -358,8 +373,16 @@ def _clone_file(src, dst):
     Returns:
         True when cloning succeeds, or False to use the normal copy fallback.
     """
-    if not on_mac or islink(src) or lexists(dst):
+    if islink(src) or lexists(dst):
         return False
+    if on_mac:
+        return _clone_file_macos(src, dst)
+    if on_linux:
+        return _clone_file_linux(src, dst)
+    return False
+
+
+def _clone_file_macos(src, dst):
     try:
         src_dev = os.stat(src).st_dev
         dst_dev = os.stat(dirname(dst) or ".").st_dev
@@ -395,6 +418,46 @@ def _clone_file(src, dst):
     if lexists(dst):
         rm_rf(dst)
     return False
+
+
+def _clone_file_linux(src, dst):
+    if not isfile(src):
+        return False
+    try:
+        src_dev = os.stat(src).st_dev
+        dst_dev = os.stat(dirname(dst) or ".").st_dev
+    except OSError:
+        return False
+    device_pair = (src_dev, dst_dev)
+
+    global _FICLONE_IOCTL
+    if device_pair in _FICLONE_UNSUPPORTED_DEVICES:
+        return False
+    if _FICLONE_IOCTL is _FICLONE_UNAVAILABLE:
+        return False
+    if _FICLONE_IOCTL is None:
+        try:
+            from fcntl import ioctl
+        except ImportError:
+            _FICLONE_IOCTL = _FICLONE_UNAVAILABLE
+            return False
+        _FICLONE_IOCTL = ioctl
+
+    try:
+        with open(src, "rb") as fsrc:
+            with open(dst, "xb") as fdst:
+                _FICLONE_IOCTL(fdst.fileno(), _FICLONE, fsrc.fileno())
+        log.log(TRACE, "reflinking %s => %s", src, dst)
+        return True
+    except OSError as e:
+        log.debug("FICLONE failed with errno %s for %s => %s", e.errno, src, dst)
+        if e.errno in _FICLONE_UNSUPPORTED_ERRNOS:
+            # Filesystem support is stable for a package-cache/prefix device
+            # pair, so avoid an ioctl failure for every file in the package.
+            _FICLONE_UNSUPPORTED_DEVICES.add(device_pair)
+        if lexists(dst):
+            rm_rf(dst)
+        return False
 
 
 def _do_copy(src, dst):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -12,6 +12,7 @@ from errno import EACCES, EINVAL, ENOSYS, EPERM, EROFS, EXDEV
 from logging import getLogger
 from os.path import dirname, isdir, isfile, join
 from shutil import copyfileobj, copystat
+from stat import S_ISREG
 
 from ... import CondaError
 from ...auxlib.ish import dals
@@ -119,6 +120,7 @@ _FICLONE_UNSUPPORTED_ERRNOS = frozenset(
     if error is not None
 )
 _FICLONE = 0x40049409
+_FICLONE_MIN_FILE_SIZE = 64 * 1024
 _FICLONE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
 _FICLONE_UNAVAILABLE = object()
 _FICLONE_IOCTL = None
@@ -303,12 +305,12 @@ def _clone_file(src, dst):
     Returns:
         True when cloning succeeds, or False to use the normal copy fallback.
     """
+    if on_linux:
+        return _clone_file_linux(src, dst)
     if islink(src) or lexists(dst):
         return False
     if on_mac:
         return _clone_file_macos(src, dst)
-    if on_linux:
-        return _clone_file_linux(src, dst)
     return False
 
 
@@ -351,13 +353,24 @@ def _clone_file_macos(src, dst):
 
 
 def _clone_file_linux(src, dst):
-    if not isfile(src):
+    try:
+        src_stat = os.stat(src)
+    except OSError:
+        return False
+    if not S_ISREG(src_stat.st_mode):
+        return False
+    # The ioctl is slower than a buffered copy for tiny files on btrfs, so keep
+    # those on conda's normal copy path and reserve reflinks for files that can
+    # actually avoid meaningful byte-copy work.
+    if src_stat.st_size < _FICLONE_MIN_FILE_SIZE:
+        return False
+    if islink(src) or lexists(dst):
         return False
     try:
-        src_dev = os.stat(src).st_dev
         dst_dev = os.stat(dirname(dst) or ".").st_dev
     except OSError:
         return False
+    src_dev = src_stat.st_dev
     device_pair = (src_dev, dst_dev)
 
     global _FICLONE_IOCTL

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import warnings as _warnings
 from ctypes import CDLL, c_char_p, c_int, get_errno
-from errno import EACCES, ENOSYS, EPERM, EROFS, EXDEV
+from errno import EACCES, EINVAL, ENOSYS, EPERM, EROFS, EXDEV
 from logging import getLogger
 from os.path import dirname, isdir, isfile, join
 from shutil import copyfileobj, copystat
@@ -17,7 +17,7 @@ from ... import CondaError
 from ...auxlib.ish import dals
 from ...base.constants import PACKAGE_CACHE_MAGIC_FILE
 from ...base.context import context
-from ...common.compat import on_mac, on_win
+from ...common.compat import on_linux, on_mac, on_win
 from ...common.constants import TRACE
 from ...common.path import expand, win_path_ok
 from ...common.path.python import is_valid_import_path
@@ -106,6 +106,22 @@ _CLONEFILE_UNSUPPORTED_ERRNOS = frozenset(
 _CLONEFILE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
 _CLONEFILE_UNAVAILABLE = object()
 _CLONEFILE = None
+_FICLONE_UNSUPPORTED_ERRNOS = frozenset(
+    error
+    for error in (
+        EXDEV,
+        EINVAL,
+        ENOSYS,
+        getattr(errno, "ENOTTY", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+    )
+    if error is not None
+)
+_FICLONE = 0x40049409
+_FICLONE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
+_FICLONE_UNAVAILABLE = object()
+_FICLONE_IOCTL = None
 _WIN_COPYFILE_UNAVAILABLE = object()
 _WIN_COPYFILE = None
 
@@ -270,9 +286,8 @@ def copy(src, dst):
             log.log(TRACE, "soft linking %s => %s", src, dst)
             symlink(src_points_to, dst)
             return
-    # APFS clonefile gives copy-on-write semantics for normal copy requests.
-    # Keep this copy-scoped: clonefile does not raise hardlink refcounts, so
-    # package-cache cleanup cannot treat it as a normal cache-linked install.
+    # Copy-on-write file clones accelerate normal copy requests while preserving
+    # conda's package-cache hardlink/refcount semantics.
     if _clone_file(src, dst):
         try:
             copystat(src, dst)
@@ -288,8 +303,16 @@ def _clone_file(src, dst):
     Returns:
         True when cloning succeeds, or False to use the normal copy fallback.
     """
-    if not on_mac or islink(src) or lexists(dst):
+    if islink(src) or lexists(dst):
         return False
+    if on_mac:
+        return _clone_file_macos(src, dst)
+    if on_linux:
+        return _clone_file_linux(src, dst)
+    return False
+
+
+def _clone_file_macos(src, dst):
     try:
         src_dev = os.stat(src).st_dev
         dst_dev = os.stat(dirname(dst) or ".").st_dev
@@ -325,6 +348,46 @@ def _clone_file(src, dst):
     if lexists(dst):
         rm_rf(dst)
     return False
+
+
+def _clone_file_linux(src, dst):
+    if not isfile(src):
+        return False
+    try:
+        src_dev = os.stat(src).st_dev
+        dst_dev = os.stat(dirname(dst) or ".").st_dev
+    except OSError:
+        return False
+    device_pair = (src_dev, dst_dev)
+
+    global _FICLONE_IOCTL
+    if device_pair in _FICLONE_UNSUPPORTED_DEVICES:
+        return False
+    if _FICLONE_IOCTL is _FICLONE_UNAVAILABLE:
+        return False
+    if _FICLONE_IOCTL is None:
+        try:
+            from fcntl import ioctl
+        except ImportError:
+            _FICLONE_IOCTL = _FICLONE_UNAVAILABLE
+            return False
+        _FICLONE_IOCTL = ioctl
+
+    try:
+        with open(src, "rb") as fsrc:
+            with open(dst, "xb") as fdst:
+                _FICLONE_IOCTL(fdst.fileno(), _FICLONE, fsrc.fileno())
+        log.log(TRACE, "reflinking %s => %s", src, dst)
+        return True
+    except OSError as e:
+        log.debug("FICLONE failed with errno %s for %s => %s", e.errno, src, dst)
+        if e.errno in _FICLONE_UNSUPPORTED_ERRNOS:
+            # Filesystem support is stable for a package-cache/prefix device
+            # pair, so avoid an ioctl failure for every file in the package.
+            _FICLONE_UNSUPPORTED_DEVICES.add(device_pair)
+        if lexists(dst):
+            rm_rf(dst)
+        return False
 
 
 def _do_copy(src, dst):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -305,12 +305,12 @@ def _clone_file(src, dst):
     Returns:
         True when cloning succeeds, or False to use the normal copy fallback.
     """
-    if on_linux:
-        return _clone_file_linux(src, dst)
     if islink(src) or lexists(dst):
         return False
     if on_mac:
         return _clone_file_macos(src, dst)
+    if on_linux:
+        return _clone_file_linux(src, dst)
     return False
 
 

--- a/news/15969-linux-reflink-copy
+++ b/news/15969-linux-reflink-copy
@@ -1,0 +1,11 @@
+### Enhancements
+
+* Use Linux reflinks for copy-mode file creation during installs when the filesystem supports `FICLONE`. (#15969)
+
+### Bug fixes
+
+### Deprecations
+
+### Docs
+
+### Other

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import os
 from contextlib import nullcontext
 from shutil import copyfile
 
@@ -122,6 +123,55 @@ def test_copy_over_existing_target_skips_clonefile(
     create.copy(str(source), str(target))
 
     assert target.read_text() == "new"
+
+
+@pytest.mark.parametrize(
+    "ioctl_errno,target_names,expected_copy_calls",
+    (
+        (None, ("target",), 0),
+        (errno.ENOTTY, ("target-one", "target-two"), 2),
+    ),
+    ids=("linux-ficlone", "linux-ficlone-unsupported-cache"),
+)
+def test_copy_linux_ficlone_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    ioctl_errno,
+    target_names,
+    expected_copy_calls,
+):
+    source = tmp_path / "source"
+    source.write_text("contents")
+    ioctl_calls = []
+    copy_calls = []
+
+    def ioctl(dst_fd, request, src_fd):
+        ioctl_calls.append((dst_fd, request, src_fd))
+        if ioctl_errno is not None:
+            raise OSError(ioctl_errno, "unsupported")
+        os.lseek(src_fd, 0, os.SEEK_SET)
+        os.write(dst_fd, os.read(src_fd, 1024))
+
+    def copy_fallback(src, dst):
+        copy_calls.append((src, dst))
+        if expected_copy_calls == 0:
+            pytest.fail("copy fallback should not be used")
+        copyfile(src, dst)
+
+    monkeypatch.setattr(create, "on_mac", False)
+    monkeypatch.setattr(create, "on_linux", True)
+    monkeypatch.setattr(create, "_FICLONE_IOCTL", ioctl)
+    monkeypatch.setattr(create, "_do_copy", copy_fallback)
+    create._FICLONE_UNSUPPORTED_DEVICES.clear()
+
+    for target_name in target_names:
+        create.copy(str(source), str(tmp_path / target_name))
+
+    for target_name in target_names:
+        assert (tmp_path / target_name).read_text() == "contents"
+    assert len(ioctl_calls) == 1
+    assert all(call[1] == create._FICLONE for call in ioctl_calls)
+    assert len(copy_calls) == expected_copy_calls
 
 
 def test_copy_link_type_does_not_fall_back_to_hardlink(

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -126,22 +126,29 @@ def test_copy_over_existing_target_skips_clonefile(
 
 
 @pytest.mark.parametrize(
-    "ioctl_errno,target_names,expected_copy_calls",
+    "ioctl_errno,source_size,target_names,expected_ioctl_calls,expected_copy_calls",
     (
-        (None, ("target",), 0),
-        (errno.ENOTTY, ("target-one", "target-two"), 2),
+        (None, 64 * 1024, ("target",), 1, 0),
+        (None, 1024, ("target",), 0, 1),
+        (errno.ENOTTY, 64 * 1024, ("target-one", "target-two"), 1, 2),
     ),
-    ids=("linux-ficlone", "linux-ficlone-unsupported-cache"),
+    ids=(
+        "linux-ficlone",
+        "linux-ficlone-skips-tiny-file",
+        "linux-ficlone-unsupported-cache",
+    ),
 )
 def test_copy_linux_ficlone_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
     ioctl_errno,
+    source_size,
     target_names,
+    expected_ioctl_calls,
     expected_copy_calls,
 ):
     source = tmp_path / "source"
-    source.write_text("contents")
+    source.write_bytes(b"x" * source_size)
     ioctl_calls = []
     copy_calls = []
 
@@ -150,7 +157,7 @@ def test_copy_linux_ficlone_path(
         if ioctl_errno is not None:
             raise OSError(ioctl_errno, "unsupported")
         os.lseek(src_fd, 0, os.SEEK_SET)
-        os.write(dst_fd, os.read(src_fd, 1024))
+        os.write(dst_fd, os.read(src_fd, source_size))
 
     def copy_fallback(src, dst):
         copy_calls.append((src, dst))
@@ -168,8 +175,8 @@ def test_copy_linux_ficlone_path(
         create.copy(str(source), str(tmp_path / target_name))
 
     for target_name in target_names:
-        assert (tmp_path / target_name).read_text() == "contents"
-    assert len(ioctl_calls) == 1
+        assert (tmp_path / target_name).read_bytes() == source.read_bytes()
+    assert len(ioctl_calls) == expected_ioctl_calls
     assert all(call[1] == create._FICLONE for call in ioctl_calls)
     assert len(copy_calls) == expected_copy_calls
 

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -123,22 +123,29 @@ def test_copy_over_existing_target_skips_clonefile(
 
 
 @pytest.mark.parametrize(
-    "ioctl_errno,target_names,expected_copy_calls",
+    "ioctl_errno,source_size,target_names,expected_ioctl_calls,expected_copy_calls",
     (
-        (None, ("target",), 0),
-        (errno.ENOTTY, ("target-one", "target-two"), 2),
+        (None, 64 * 1024, ("target",), 1, 0),
+        (None, 1024, ("target",), 0, 1),
+        (errno.ENOTTY, 64 * 1024, ("target-one", "target-two"), 1, 2),
     ),
-    ids=("linux-ficlone", "linux-ficlone-unsupported-cache"),
+    ids=(
+        "linux-ficlone",
+        "linux-ficlone-skips-tiny-file",
+        "linux-ficlone-unsupported-cache",
+    ),
 )
 def test_copy_linux_ficlone_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
     ioctl_errno,
+    source_size,
     target_names,
+    expected_ioctl_calls,
     expected_copy_calls,
 ):
     source = tmp_path / "source"
-    source.write_text("contents")
+    source.write_bytes(b"x" * source_size)
     ioctl_calls = []
     copy_calls = []
 
@@ -147,7 +154,7 @@ def test_copy_linux_ficlone_path(
         if ioctl_errno is not None:
             raise OSError(ioctl_errno, "unsupported")
         os.lseek(src_fd, 0, os.SEEK_SET)
-        os.write(dst_fd, os.read(src_fd, 1024))
+        os.write(dst_fd, os.read(src_fd, source_size))
 
     def copy_fallback(src, dst):
         copy_calls.append((src, dst))
@@ -165,8 +172,8 @@ def test_copy_linux_ficlone_path(
         create.copy(str(source), str(tmp_path / target_name))
 
     for target_name in target_names:
-        assert (tmp_path / target_name).read_text() == "contents"
-    assert len(ioctl_calls) == 1
+        assert (tmp_path / target_name).read_bytes() == source.read_bytes()
+    assert len(ioctl_calls) == expected_ioctl_calls
     assert all(call[1] == create._FICLONE for call in ioctl_calls)
     assert len(copy_calls) == expected_copy_calls
 

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import os
 from contextlib import nullcontext
 from shutil import copyfile
 
@@ -119,6 +120,55 @@ def test_copy_over_existing_target_skips_clonefile(
     create.copy(str(source), str(target))
 
     assert target.read_text() == "new"
+
+
+@pytest.mark.parametrize(
+    "ioctl_errno,target_names,expected_copy_calls",
+    (
+        (None, ("target",), 0),
+        (errno.ENOTTY, ("target-one", "target-two"), 2),
+    ),
+    ids=("linux-ficlone", "linux-ficlone-unsupported-cache"),
+)
+def test_copy_linux_ficlone_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    ioctl_errno,
+    target_names,
+    expected_copy_calls,
+):
+    source = tmp_path / "source"
+    source.write_text("contents")
+    ioctl_calls = []
+    copy_calls = []
+
+    def ioctl(dst_fd, request, src_fd):
+        ioctl_calls.append((dst_fd, request, src_fd))
+        if ioctl_errno is not None:
+            raise OSError(ioctl_errno, "unsupported")
+        os.lseek(src_fd, 0, os.SEEK_SET)
+        os.write(dst_fd, os.read(src_fd, 1024))
+
+    def copy_fallback(src, dst):
+        copy_calls.append((src, dst))
+        if expected_copy_calls == 0:
+            pytest.fail("copy fallback should not be used")
+        copyfile(src, dst)
+
+    monkeypatch.setattr(create, "on_mac", False)
+    monkeypatch.setattr(create, "on_linux", True)
+    monkeypatch.setattr(create, "_FICLONE_IOCTL", ioctl)
+    monkeypatch.setattr(create, "_do_copy", copy_fallback)
+    create._FICLONE_UNSUPPORTED_DEVICES.clear()
+
+    for target_name in target_names:
+        create.copy(str(source), str(tmp_path / target_name))
+
+    for target_name in target_names:
+        assert (tmp_path / target_name).read_text() == "contents"
+    assert len(ioctl_calls) == 1
+    assert all(call[1] == create._FICLONE for call in ioctl_calls)
+    assert len(copy_calls) == expected_copy_calls
 
 
 def test_copy_link_type_does_not_fall_back_to_hardlink(


### PR DESCRIPTION
### Description

Part of conda/conda#15969 as a new Track B follow-up case (B28).

Linux filesystems such as btrfs and XFS can support copy-on-write file cloning through the `FICLONE` ioctl. This PR applies that native primitive to conda's existing copy-mode file creation path for files at or above 64 KiB, allowing compatible Linux installs to avoid eager byte copies when the package cache and target prefix live on a reflink-capable filesystem.

This PR is stacked on B27 (#16369) until that PR lands. The new Track B case here is the Linux reflink copy backend.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Measured impact

Focused copy-mode measurements on Ubuntu 24.04 arm64 with btrfs on `/dev/sdb1` and Python 3.14.6 from conda-forge, using medians of 20 randomized repeats. The benchmark compares conda's buffered copy fallback, Python 3.14's `shutil.copyfile()`, and this PR's gated `FICLONE` path. Each path also applies `copystat`.

| Case | Conda buffered copy | Python 3.14 `shutil.copyfile()` | B28 gated `FICLONE` | B28 vs conda | B28 vs `shutil` |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 file, 64 MiB | 14.47 ms | 8.62 ms | 0.060 ms | 242x | 144x |
| 512 files, 64 KiB each | 22.41 ms | 23.55 ms | 14.58 ms | 1.54x | 1.61x |
| 2,048 files, 1 KiB each | 53.34 ms | 60.68 ms | 55.71 ms | 0.96x | 1.09x |

The conda-forge Python 3.14.6 build does not expose `os.copy_file_range`, so `shutil.copyfile()` uses `sendfile` instead. After syncing writes, btrfs extent accounting showed the 64 MiB source and `FICLONE` target as fully shared. The conda buffered-copy and `shutil.copyfile()` targets were fully exclusive. `filefrag` also reported the same physical extent and the `shared` flag only for the source and `FICLONE` target.

The tiny-file case does not take the raw ioctl path. Its 0.96x result captures the clone-eligibility check before falling back to normal copy.

A separate 512-file size sweep on the same btrfs mount shows why the PR uses a 64 KiB gate. Raw `FICLONE` loses at 1-16 KiB, starts winning at 32 KiB, and is clearly ahead from 64 KiB upward.

| Bytes per file | Raw `FICLONE` speedup |
| ---: | ---: |
| 1 KiB | 0.85x |
| 4 KiB | 0.87x |
| 8 KiB | 0.91x |
| 16 KiB | 0.97x |
| 32 KiB | 1.05x |
| 64 KiB | 1.25x |
| 128 KiB | 1.59x |
| 256 KiB | 2.17x |
| 1 MiB | 6.50x |

This is a large and medium-file copy-mode win on reflink-capable filesystems, not a universal small-file win. Unsupported filesystems are cached by source and target device pair so repeated copy attempts use the normal fallback path without retrying the ioctl for every eligible file.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? No user-facing docs change.
