### PR TITLE
Use APFS clonefile for copy-mode installs (B26)

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Disk utility functions for creating new files or directories."""
 
+import errno
 import os
 import sys
 import tempfile
 import warnings as _warnings
-from errno import EACCES, EPERM, EROFS
+from ctypes import CDLL, c_char_p, c_int, get_errno
+from errno import EACCES, ENOSYS, EPERM, EROFS, EXDEV
 from logging import getLogger
 from os.path import dirname, isdir, isfile, join, splitext
 from shutil import copyfileobj, copystat
@@ -15,7 +17,7 @@ from ... import CondaError
 from ...auxlib.ish import dals
 from ...base.constants import PACKAGE_CACHE_MAGIC_FILE
 from ...base.context import context
-from ...common.compat import on_win
+from ...common.compat import on_mac, on_win
 from ...common.constants import TRACE
 from ...common.path import ensure_pad, expand, win_path_double_escape, win_path_ok
 from ...common.path.python import is_valid_import_path
@@ -90,6 +92,20 @@ deprecated.constant(
     getLogger("conda.stdoutlog"),
     addendum="Use `conda.gateways.streams.stdoutlog` instead.",
 )
+
+_CLONEFILE_UNSUPPORTED_ERRNOS = frozenset(
+    error
+    for error in (
+        EXDEV,
+        ENOSYS,
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+    )
+    if error is not None
+)
+_CLONEFILE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
+_CLONEFILE_UNAVAILABLE = object()
+_CLONEFILE = None
 
 # in __init__.py to help with circular imports
 mkdir_p = mkdir_p
@@ -322,7 +338,61 @@ def copy(src, dst):
             log.log(TRACE, "soft linking %s => %s", src, dst)
             symlink(src_points_to, dst)
             return
+    # APFS clonefile gives copy-on-write semantics for normal copy requests.
+    # Keep this copy-scoped: clonefile does not raise hardlink refcounts, so
+    # package-cache cleanup cannot treat it as a normal cache-linked install.
+    if _clone_file(src, dst):
+        try:
+            copystat(src, dst)
+        except OSError as e:  # pragma: no cover
+            log.debug("%r", e)
+        return
     _do_copy(src, dst)
+
+
+def _clone_file(src, dst):
+    """Create a copy-on-write clone when supported.
+
+    Returns:
+        True when cloning succeeds, or False to use the normal copy fallback.
+    """
+    if not on_mac or islink(src) or lexists(dst):
+        return False
+    try:
+        src_dev = os.stat(src).st_dev
+        dst_dev = os.stat(dirname(dst) or ".").st_dev
+    except OSError:
+        return False
+    device_pair = (src_dev, dst_dev)
+    if device_pair in _CLONEFILE_UNSUPPORTED_DEVICES:
+        return False
+
+    global _CLONEFILE
+    # Resolve clonefile lazily so importing conda stays portable and cheap.
+    if _CLONEFILE is _CLONEFILE_UNAVAILABLE:
+        return False
+    if _CLONEFILE is None:
+        try:
+            clonefile = CDLL(None, use_errno=True).clonefile
+        except AttributeError:
+            _CLONEFILE = _CLONEFILE_UNAVAILABLE
+            return False
+        clonefile.argtypes = (c_char_p, c_char_p, c_int)
+        clonefile.restype = c_int
+        _CLONEFILE = clonefile
+
+    if _CLONEFILE(os.fsencode(src), os.fsencode(dst), 0) == 0:
+        log.log(TRACE, "cloning %s => %s", src, dst)
+        return True
+    errno = get_errno()
+    log.debug("clonefile failed with errno %s for %s => %s", errno, src, dst)
+    if errno in _CLONEFILE_UNSUPPORTED_ERRNOS:
+        # Cross-device and unsupported filesystem failures are stable for this
+        # source/destination pair; skip repeated clonefile probes.
+        _CLONEFILE_UNSUPPORTED_DEVICES.add(device_pair)
+    if lexists(dst):
+        rm_rf(dst)
+    return False
 
 
 def _do_copy(src, dst):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -2,20 +2,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Disk utility functions for creating new files or directories."""
 
+import errno
 import os
 import sys
 import tempfile
 import warnings as _warnings
-from errno import EACCES, EPERM, EROFS
+from ctypes import CDLL, c_char_p, c_int, get_errno
+from errno import EACCES, ENOSYS, EPERM, EROFS, EXDEV
 from logging import getLogger
-from os.path import isdir, isfile, join
+from os.path import dirname, isdir, isfile, join
 from shutil import copyfileobj, copystat
 
 from ... import CondaError
 from ...auxlib.ish import dals
 from ...base.constants import PACKAGE_CACHE_MAGIC_FILE
 from ...base.context import context
-from ...common.compat import on_win
+from ...common.compat import on_mac, on_win
 from ...common.constants import TRACE
 from ...common.path import expand, win_path_ok
 from ...common.path.python import is_valid_import_path
@@ -90,6 +92,20 @@ deprecated.constant(
     getLogger("conda.stdoutlog"),
     addendum="Use `conda.gateways.streams.stdoutlog` instead.",
 )
+
+_CLONEFILE_UNSUPPORTED_ERRNOS = frozenset(
+    error
+    for error in (
+        EXDEV,
+        ENOSYS,
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+    )
+    if error is not None
+)
+_CLONEFILE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
+_CLONEFILE_UNAVAILABLE = object()
+_CLONEFILE = None
 
 # in __init__.py to help with circular imports
 mkdir_p = mkdir_p
@@ -252,7 +268,61 @@ def copy(src, dst):
             log.log(TRACE, "soft linking %s => %s", src, dst)
             symlink(src_points_to, dst)
             return
+    # APFS clonefile gives copy-on-write semantics for normal copy requests.
+    # Keep this copy-scoped: clonefile does not raise hardlink refcounts, so
+    # package-cache cleanup cannot treat it as a normal cache-linked install.
+    if _clone_file(src, dst):
+        try:
+            copystat(src, dst)
+        except OSError as e:  # pragma: no cover
+            log.debug("%r", e)
+        return
     _do_copy(src, dst)
+
+
+def _clone_file(src, dst):
+    """Create a copy-on-write clone when supported.
+
+    Returns:
+        True when cloning succeeds, or False to use the normal copy fallback.
+    """
+    if not on_mac or islink(src) or lexists(dst):
+        return False
+    try:
+        src_dev = os.stat(src).st_dev
+        dst_dev = os.stat(dirname(dst) or ".").st_dev
+    except OSError:
+        return False
+    device_pair = (src_dev, dst_dev)
+    if device_pair in _CLONEFILE_UNSUPPORTED_DEVICES:
+        return False
+
+    global _CLONEFILE
+    # Resolve clonefile lazily so importing conda stays portable and cheap.
+    if _CLONEFILE is _CLONEFILE_UNAVAILABLE:
+        return False
+    if _CLONEFILE is None:
+        try:
+            clonefile = CDLL(None, use_errno=True).clonefile
+        except AttributeError:
+            _CLONEFILE = _CLONEFILE_UNAVAILABLE
+            return False
+        clonefile.argtypes = (c_char_p, c_char_p, c_int)
+        clonefile.restype = c_int
+        _CLONEFILE = clonefile
+
+    if _CLONEFILE(os.fsencode(src), os.fsencode(dst), 0) == 0:
+        log.log(TRACE, "cloning %s => %s", src, dst)
+        return True
+    errno = get_errno()
+    log.debug("clonefile failed with errno %s for %s => %s", errno, src, dst)
+    if errno in _CLONEFILE_UNSUPPORTED_ERRNOS:
+        # Cross-device and unsupported filesystem failures are stable for this
+        # source/destination pair; skip repeated clonefile probes.
+        _CLONEFILE_UNSUPPORTED_DEVICES.add(device_pair)
+    if lexists(dst):
+        rm_rf(dst)
+    return False
 
 
 def _do_copy(src, dst):

--- a/news/15969-clone-link-apfs
+++ b/news/15969-clone-link-apfs
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Use APFS `clonefile` for copy-mode package file creation when available. (#15969)

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import errno
 from contextlib import nullcontext
+from shutil import copyfile
 
 import pytest
 
@@ -22,3 +24,124 @@ def test_deprecations(function: str, raises: type[Exception] | None) -> None:
     raises_context = pytest.raises(raises) if raises else nullcontext()
     with pytest.deprecated_call(), raises_context:
         getattr(create, function)()
+
+
+def test_copy_uses_clonefile_on_macos(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    clone_calls = []
+
+    class CloneFile:
+        argtypes = None
+        restype = None
+
+        def __call__(self, src, dst, flags):
+            clone_calls.append((src, dst, flags))
+            copyfile(src, dst)
+            return 0
+
+    class LibC:
+        clonefile = CloneFile()
+
+    monkeypatch.setattr(create, "on_mac", True)
+    monkeypatch.setattr(create, "CDLL", lambda *args, **kwargs: LibC())
+    monkeypatch.setattr(
+        create,
+        "_do_copy",
+        lambda src, dst: pytest.fail("copy fallback should not be used"),
+    )
+    create._CLONEFILE_UNSUPPORTED_DEVICES.clear()
+    monkeypatch.setattr(create, "_CLONEFILE", None)
+
+    create.copy(str(source), str(target))
+
+    assert target.read_text() == "contents"
+    assert clone_calls == [(bytes(source), bytes(target), 0)]
+
+
+def test_copy_caches_unsupported_clonefile_device_pair(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source = tmp_path / "source"
+    target_one = tmp_path / "target-one"
+    target_two = tmp_path / "target-two"
+    source.write_text("contents")
+    clone_calls = []
+    copy_calls = []
+
+    class CloneFile:
+        argtypes = None
+        restype = None
+
+        def __call__(self, src, dst, flags):
+            clone_calls.append((src, dst, flags))
+            return -1
+
+    class LibC:
+        clonefile = CloneFile()
+
+    def copy_fallback(src, dst):
+        copy_calls.append((src, dst))
+        copyfile(src, dst)
+
+    monkeypatch.setattr(create, "on_mac", True)
+    monkeypatch.setattr(create, "CDLL", lambda *args, **kwargs: LibC())
+    monkeypatch.setattr(create, "get_errno", lambda: errno.ENOTSUP)
+    monkeypatch.setattr(create, "_do_copy", copy_fallback)
+    create._CLONEFILE_UNSUPPORTED_DEVICES.clear()
+    monkeypatch.setattr(create, "_CLONEFILE", None)
+
+    create.copy(str(source), str(target_one))
+    create.copy(str(source), str(target_two))
+
+    assert target_one.read_text() == "contents"
+    assert target_two.read_text() == "contents"
+    assert len(clone_calls) == 1
+    assert copy_calls == [
+        (str(source), str(target_one)),
+        (str(source), str(target_two)),
+    ]
+
+
+def test_copy_over_existing_target_skips_clonefile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("new")
+    target.write_text("old")
+
+    monkeypatch.setattr(create, "on_mac", True)
+    monkeypatch.setattr(
+        create,
+        "CDLL",
+        lambda *args, **kwargs: pytest.fail("clonefile should not be loaded"),
+    )
+
+    create.copy(str(source), str(target))
+
+    assert target.read_text() == "new"
+
+
+def test_copy_link_type_does_not_fall_back_to_hardlink(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    link_calls = []
+
+    def copy_fallback(src, dst):
+        copyfile(src, dst)
+        return create.LinkType.copy
+
+    monkeypatch.setattr(create, "_clone_file", lambda *args: False)
+    monkeypatch.setattr(create, "link", lambda *args: link_calls.append(args))
+    monkeypatch.setattr(create, "_do_copy", copy_fallback)
+
+    create.create_link(str(source), str(target), create.LinkType.copy)
+
+    assert target.read_text() == "contents"
+    assert target.stat().st_nlink == 1
+    assert link_calls == []

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import errno
 from contextlib import nullcontext
+from shutil import copyfile
 
 import pytest
 
@@ -19,3 +21,124 @@ def test_deprecations(function: str, raises: type[Exception] | None) -> None:
     raises_context = pytest.raises(raises) if raises else nullcontext()
     with pytest.deprecated_call(), raises_context:
         getattr(create, function)()
+
+
+def test_copy_uses_clonefile_on_macos(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    clone_calls = []
+
+    class CloneFile:
+        argtypes = None
+        restype = None
+
+        def __call__(self, src, dst, flags):
+            clone_calls.append((src, dst, flags))
+            copyfile(src, dst)
+            return 0
+
+    class LibC:
+        clonefile = CloneFile()
+
+    monkeypatch.setattr(create, "on_mac", True)
+    monkeypatch.setattr(create, "CDLL", lambda *args, **kwargs: LibC())
+    monkeypatch.setattr(
+        create,
+        "_do_copy",
+        lambda src, dst: pytest.fail("copy fallback should not be used"),
+    )
+    create._CLONEFILE_UNSUPPORTED_DEVICES.clear()
+    monkeypatch.setattr(create, "_CLONEFILE", None)
+
+    create.copy(str(source), str(target))
+
+    assert target.read_text() == "contents"
+    assert clone_calls == [(bytes(source), bytes(target), 0)]
+
+
+def test_copy_caches_unsupported_clonefile_device_pair(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source = tmp_path / "source"
+    target_one = tmp_path / "target-one"
+    target_two = tmp_path / "target-two"
+    source.write_text("contents")
+    clone_calls = []
+    copy_calls = []
+
+    class CloneFile:
+        argtypes = None
+        restype = None
+
+        def __call__(self, src, dst, flags):
+            clone_calls.append((src, dst, flags))
+            return -1
+
+    class LibC:
+        clonefile = CloneFile()
+
+    def copy_fallback(src, dst):
+        copy_calls.append((src, dst))
+        copyfile(src, dst)
+
+    monkeypatch.setattr(create, "on_mac", True)
+    monkeypatch.setattr(create, "CDLL", lambda *args, **kwargs: LibC())
+    monkeypatch.setattr(create, "get_errno", lambda: errno.ENOTSUP)
+    monkeypatch.setattr(create, "_do_copy", copy_fallback)
+    create._CLONEFILE_UNSUPPORTED_DEVICES.clear()
+    monkeypatch.setattr(create, "_CLONEFILE", None)
+
+    create.copy(str(source), str(target_one))
+    create.copy(str(source), str(target_two))
+
+    assert target_one.read_text() == "contents"
+    assert target_two.read_text() == "contents"
+    assert len(clone_calls) == 1
+    assert copy_calls == [
+        (str(source), str(target_one)),
+        (str(source), str(target_two)),
+    ]
+
+
+def test_copy_over_existing_target_skips_clonefile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("new")
+    target.write_text("old")
+
+    monkeypatch.setattr(create, "on_mac", True)
+    monkeypatch.setattr(
+        create,
+        "CDLL",
+        lambda *args, **kwargs: pytest.fail("clonefile should not be loaded"),
+    )
+
+    create.copy(str(source), str(target))
+
+    assert target.read_text() == "new"
+
+
+def test_copy_link_type_does_not_fall_back_to_hardlink(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    link_calls = []
+
+    def copy_fallback(src, dst):
+        copyfile(src, dst)
+        return create.LinkType.copy
+
+    monkeypatch.setattr(create, "_clone_file", lambda *args: False)
+    monkeypatch.setattr(create, "link", lambda *args: link_calls.append(args))
+    monkeypatch.setattr(create, "_do_copy", copy_fallback)
+
+    create.create_link(str(source), str(target), create.LinkType.copy)
+
+    assert target.read_text() == "contents"
+    assert target.stat().st_nlink == 1
+    assert link_calls == []


### PR DESCRIPTION
### Description

Part of conda/conda#15969 as a new Track B follow-up case (B26).

APFS supports copy-on-write file cloning via `clonefile`. This PR applies that primitive to conda's existing copy-mode file creation path, allowing copy-style installs on compatible APFS filesystems to avoid eager byte copies.

The implementation keeps conda's existing package-cache hardlink behavior as the source of truth for standard cache-backed installs, preserving the refcount behavior used by `conda clean --packages`.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Focused measurement

Focused copy-mode file-creation measurements on macOS 26.5.2 arm64 with APFS and Python 3.10.20, using medians from 12 randomized runs against current `main` (`0cdbbf64e`):

| Case | `main` | B26 | Speedup |
| --- | ---: | ---: | ---: |
| 1 file, 64 MiB | 19.43 ms | 0.17 ms | 111x |
| 512 files, 64 KiB each | 76.86 ms | 50.77 ms | 1.51x |

These are file-creation primitive measurements, not current whole-transaction results. The stronger transaction-level APFS result is measured separately in B30 (#16376), which plans eligible package subtrees rather than only cloning individual files.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? No user-facing docs change.
