### PR TITLE
Use native Windows copy APIs for copy-mode installs (B27)

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -437,24 +437,48 @@ def _win_copy_file(src, dst):
     if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
         return False
     if _WIN_COPYFILE is None:
-        try:
-            from ctypes import windll, wintypes
-        except ImportError:
-            _WIN_COPYFILE = _WIN_COPYFILE_UNAVAILABLE
-            return False
-        copy_file = windll.kernel32.CopyFileW
-        copy_file.restype = wintypes.BOOL
-        copy_file.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.BOOL)
-        _WIN_COPYFILE = copy_file
+        _WIN_COPYFILE = _load_win_copy_file()
+    if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
+        return False
 
-    # CopyFileW keeps Windows copy-mode installs in kernel32 instead of bouncing
-    # every file through Python's read/write loop. The target should not exist.
     if _WIN_COPYFILE(src, dst, True):
         log.log(TRACE, "windows copying %s => %s", src, dst)
         return True
     if lexists(dst):
         rm_rf(dst)
     return False
+
+
+def _load_win_copy_file():
+    """Return the best available native Windows file-copy function."""
+    try:
+        from _winapi import (
+            COPY_FILE_ALLOW_DECRYPTED_DESTINATION,
+            COPY_FILE_FAIL_IF_EXISTS,
+            CopyFile2,
+        )
+    except ImportError:
+        try:
+            from ctypes import windll, wintypes
+        except ImportError:
+            return _WIN_COPYFILE_UNAVAILABLE
+        copy_file = windll.kernel32.CopyFileW
+        copy_file.restype = wintypes.BOOL
+        copy_file.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.BOOL)
+        return copy_file
+
+    def copy_file(src, dst, fail_if_exists):
+        flags = COPY_FILE_ALLOW_DECRYPTED_DESTINATION
+        if fail_if_exists:
+            flags |= COPY_FILE_FAIL_IF_EXISTS
+        try:
+            CopyFile2(src, dst, flags)
+        except OSError as e:
+            log.debug("CopyFile2 failed for %s => %s: %r", src, dst, e)
+            return False
+        return True
+
+    return copy_file
 
 
 def create_link(src, dst, link_type=LinkType.hardlink, force=False):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -106,6 +106,8 @@ _CLONEFILE_UNSUPPORTED_ERRNOS = frozenset(
 _CLONEFILE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
 _CLONEFILE_UNAVAILABLE = object()
 _CLONEFILE = None
+_WIN_COPYFILE_UNAVAILABLE = object()
+_WIN_COPYFILE = None
 
 # in __init__.py to help with circular imports
 mkdir_p = mkdir_p
@@ -397,6 +399,13 @@ def _clone_file(src, dst):
 
 def _do_copy(src, dst):
     log.log(TRACE, "copying %s => %s", src, dst)
+    if _win_copy_file(src, dst):
+        try:
+            copystat(src, dst)
+        except OSError as e:  # pragma: no cover
+            log.debug("%r", e)
+        return
+
     # src and dst are always files. So we can bypass some checks that shutil.copy does.
     # Also shutil.copy calls shutil.copymode, which we can skip because we are explicitly
     # calling copystat.
@@ -414,6 +423,34 @@ def _do_copy(src, dst):
         # shutil.copystat gives a permission denied when using the os.setxattr function
         # on the security.selinux property.
         log.debug("%r", e)
+
+
+def _win_copy_file(src, dst):
+    if not on_win:
+        return False
+
+    global _WIN_COPYFILE
+    if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
+        return False
+    if _WIN_COPYFILE is None:
+        try:
+            from ctypes import windll, wintypes
+        except ImportError:
+            _WIN_COPYFILE = _WIN_COPYFILE_UNAVAILABLE
+            return False
+        copy_file = windll.kernel32.CopyFileW
+        copy_file.restype = wintypes.BOOL
+        copy_file.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.BOOL)
+        _WIN_COPYFILE = copy_file
+
+    # CopyFileW keeps Windows copy-mode installs in kernel32 instead of bouncing
+    # every file through Python's read/write loop. The target should not exist.
+    if _WIN_COPYFILE(src, dst, True):
+        log.log(TRACE, "windows copying %s => %s", src, dst)
+        return True
+    if lexists(dst):
+        rm_rf(dst)
+    return False
 
 
 def create_link(src, dst, link_type=LinkType.hardlink, force=False):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -429,6 +429,10 @@ def _win_copy_file(src, dst):
     if not on_win:
         return False
 
+    # ctypes does not coerce PathLike objects for the CopyFileW wide strings.
+    src = os.fspath(src)
+    dst = os.fspath(dst)
+
     global _WIN_COPYFILE
     if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
         return False

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -106,6 +106,8 @@ _CLONEFILE_UNSUPPORTED_ERRNOS = frozenset(
 _CLONEFILE_UNSUPPORTED_DEVICES: set[tuple[int, int]] = set()
 _CLONEFILE_UNAVAILABLE = object()
 _CLONEFILE = None
+_WIN_COPYFILE_UNAVAILABLE = object()
+_WIN_COPYFILE = None
 
 # in __init__.py to help with circular imports
 mkdir_p = mkdir_p
@@ -327,6 +329,13 @@ def _clone_file(src, dst):
 
 def _do_copy(src, dst):
     log.log(TRACE, "copying %s => %s", src, dst)
+    if _win_copy_file(src, dst):
+        try:
+            copystat(src, dst)
+        except OSError as e:  # pragma: no cover
+            log.debug("%r", e)
+        return
+
     # src and dst are always files. So we can bypass some checks that shutil.copy does.
     # Also shutil.copy calls shutil.copymode, which we can skip because we are explicitly
     # calling copystat.
@@ -344,6 +353,34 @@ def _do_copy(src, dst):
         # shutil.copystat gives a permission denied when using the os.setxattr function
         # on the security.selinux property.
         log.debug("%r", e)
+
+
+def _win_copy_file(src, dst):
+    if not on_win:
+        return False
+
+    global _WIN_COPYFILE
+    if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
+        return False
+    if _WIN_COPYFILE is None:
+        try:
+            from ctypes import windll, wintypes
+        except ImportError:
+            _WIN_COPYFILE = _WIN_COPYFILE_UNAVAILABLE
+            return False
+        copy_file = windll.kernel32.CopyFileW
+        copy_file.restype = wintypes.BOOL
+        copy_file.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.BOOL)
+        _WIN_COPYFILE = copy_file
+
+    # CopyFileW keeps Windows copy-mode installs in kernel32 instead of bouncing
+    # every file through Python's read/write loop. The target should not exist.
+    if _WIN_COPYFILE(src, dst, True):
+        log.log(TRACE, "windows copying %s => %s", src, dst)
+        return True
+    if lexists(dst):
+        rm_rf(dst)
+    return False
 
 
 def create_link(src, dst, link_type=LinkType.hardlink, force=False):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -359,6 +359,10 @@ def _win_copy_file(src, dst):
     if not on_win:
         return False
 
+    # ctypes does not coerce PathLike objects for the CopyFileW wide strings.
+    src = os.fspath(src)
+    dst = os.fspath(dst)
+
     global _WIN_COPYFILE
     if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
         return False

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -367,24 +367,48 @@ def _win_copy_file(src, dst):
     if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
         return False
     if _WIN_COPYFILE is None:
-        try:
-            from ctypes import windll, wintypes
-        except ImportError:
-            _WIN_COPYFILE = _WIN_COPYFILE_UNAVAILABLE
-            return False
-        copy_file = windll.kernel32.CopyFileW
-        copy_file.restype = wintypes.BOOL
-        copy_file.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.BOOL)
-        _WIN_COPYFILE = copy_file
+        _WIN_COPYFILE = _load_win_copy_file()
+    if _WIN_COPYFILE is _WIN_COPYFILE_UNAVAILABLE:
+        return False
 
-    # CopyFileW keeps Windows copy-mode installs in kernel32 instead of bouncing
-    # every file through Python's read/write loop. The target should not exist.
     if _WIN_COPYFILE(src, dst, True):
         log.log(TRACE, "windows copying %s => %s", src, dst)
         return True
     if lexists(dst):
         rm_rf(dst)
     return False
+
+
+def _load_win_copy_file():
+    """Return the best available native Windows file-copy function."""
+    try:
+        from _winapi import (
+            COPY_FILE_ALLOW_DECRYPTED_DESTINATION,
+            COPY_FILE_FAIL_IF_EXISTS,
+            CopyFile2,
+        )
+    except ImportError:
+        try:
+            from ctypes import windll, wintypes
+        except ImportError:
+            return _WIN_COPYFILE_UNAVAILABLE
+        copy_file = windll.kernel32.CopyFileW
+        copy_file.restype = wintypes.BOOL
+        copy_file.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.BOOL)
+        return copy_file
+
+    def copy_file(src, dst, fail_if_exists):
+        flags = COPY_FILE_ALLOW_DECRYPTED_DESTINATION
+        if fail_if_exists:
+            flags |= COPY_FILE_FAIL_IF_EXISTS
+        try:
+            CopyFile2(src, dst, flags)
+        except OSError as e:
+            log.debug("CopyFile2 failed for %s => %s: %r", src, dst, e)
+            return False
+        return True
+
+    return copy_file
 
 
 def create_link(src, dst, link_type=LinkType.hardlink, force=False):

--- a/news/15969-windows-copy-fast-path
+++ b/news/15969-windows-copy-fast-path
@@ -1,0 +1,11 @@
+### Enhancements
+
+* Use the Windows `CopyFileW` API for copy-mode file creation during installs. (#15969)
+
+### Bug fixes
+
+### Deprecations
+
+### Docs
+
+### Other

--- a/news/15969-windows-copy-fast-path
+++ b/news/15969-windows-copy-fast-path
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Use the Windows `CopyFileW` API for copy-mode file creation during installs. (#15969)
+* Use native Windows copy APIs for copy-mode file creation during installs. (#15969)
 
 ### Bug fixes
 

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -213,3 +213,65 @@ def test_do_copy_windows_copyfile_path(
     assert copy_calls == ([(str(source), str(target), True)] if on_win else [])
     assert bool(python_copy_calls) is expects_python_copy
     assert removed == ([str(target)] if expects_removed_target else [])
+
+
+def test_win_copy_file_prefers_copyfile2(
+    mocker,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+
+    def copy_file2(src, dst, flags):
+        copyfile(src, dst)
+
+    winapi = mocker.Mock()
+    winapi.COPY_FILE_ALLOW_DECRYPTED_DESTINATION = 1
+    winapi.COPY_FILE_FAIL_IF_EXISTS = 2
+    winapi.CopyFile2.side_effect = copy_file2
+    mocker.patch.dict("sys.modules", {"_winapi": winapi})
+    monkeypatch.setattr(create, "on_win", True)
+    monkeypatch.setattr(create, "_WIN_COPYFILE", None)
+
+    assert create._win_copy_file(source, target)
+    assert target.read_text() == "contents"
+    winapi.CopyFile2.assert_called_once_with(str(source), str(target), 3)
+
+
+def test_win_copy_file_falls_back_to_copyfilew(
+    mocker,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+
+    def copy_file_w(src, dst, fail_if_exists):
+        copyfile(src, dst)
+        return True
+
+    copy_file_w = mocker.Mock(side_effect=copy_file_w)
+    windll = mocker.Mock()
+    windll.kernel32.CopyFileW = copy_file_w
+    mocker.patch.dict("sys.modules", {"_winapi": None})
+    mocker.patch("ctypes.windll", windll, create=True)
+    monkeypatch.setattr(create, "on_win", True)
+    monkeypatch.setattr(create, "_WIN_COPYFILE", None)
+
+    assert create._win_copy_file(source, target)
+    assert target.read_text() == "contents"
+    copy_file_w.assert_called_once_with(str(source), str(target), True)
+
+
+@pytest.mark.skipif(not create.on_win, reason="requires Windows")
+def test_win_copy_file_native(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    monkeypatch.setattr(create, "_WIN_COPYFILE", None)
+
+    assert create._win_copy_file(source, target)
+    assert target.read_text() == "contents"

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -207,7 +207,7 @@ def test_do_copy_windows_copyfile_path(
     monkeypatch.setattr(create, "copyfileobj", copyfileobj_spy)
     monkeypatch.setattr(create, "rm_rf", remove)
 
-    create._do_copy(str(source), str(target))
+    create._do_copy(source, target)
 
     assert target.read_text() == "contents"
     assert copy_calls == ([(str(source), str(target), True)] if on_win else [])

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -145,3 +145,71 @@ def test_copy_link_type_does_not_fall_back_to_hardlink(
     assert target.read_text() == "contents"
     assert target.stat().st_nlink == 1
     assert link_calls == []
+
+
+@pytest.mark.parametrize(
+    (
+        "on_win",
+        "copyfile_result",
+        "initial_target",
+        "expects_python_copy",
+        "expects_removed_target",
+    ),
+    (
+        (True, True, None, False, False),
+        (False, True, None, True, False),
+        (True, False, "partial", True, True),
+    ),
+    ids=("windows-copyfile", "non-windows-copy", "windows-copyfile-fallback"),
+)
+def test_do_copy_windows_copyfile_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    on_win,
+    copyfile_result,
+    initial_target,
+    expects_python_copy,
+    expects_removed_target,
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    if initial_target is not None:
+        target.write_text(initial_target)
+    copy_calls = []
+    python_copy_calls = []
+    removed = []
+    rm_rf = create.rm_rf
+    original_copyfileobj = create.copyfileobj
+
+    def copy_file(src, dst, fail_if_exists):
+        copy_calls.append((src, dst, fail_if_exists))
+        if copyfile_result:
+            copyfile(src, dst)
+        return copyfile_result
+
+    def copyfileobj_spy(*args, **kwargs):
+        python_copy_calls.append(args[2] if len(args) > 2 else kwargs.get("length"))
+        return original_copyfileobj(*args, **kwargs)
+
+    def remove(path):
+        removed.append(path)
+        rm_rf(path)
+
+    win_copyfile = (
+        copy_file
+        if on_win
+        else lambda *args: pytest.fail("CopyFileW should be Windows-only")
+    )
+
+    monkeypatch.setattr(create, "on_win", on_win)
+    monkeypatch.setattr(create, "_WIN_COPYFILE", win_copyfile)
+    monkeypatch.setattr(create, "copyfileobj", copyfileobj_spy)
+    monkeypatch.setattr(create, "rm_rf", remove)
+
+    create._do_copy(str(source), str(target))
+
+    assert target.read_text() == "contents"
+    assert copy_calls == ([(str(source), str(target), True)] if on_win else [])
+    assert bool(python_copy_calls) is expects_python_copy
+    assert removed == ([str(target)] if expects_removed_target else [])

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -142,3 +142,71 @@ def test_copy_link_type_does_not_fall_back_to_hardlink(
     assert target.read_text() == "contents"
     assert target.stat().st_nlink == 1
     assert link_calls == []
+
+
+@pytest.mark.parametrize(
+    (
+        "on_win",
+        "copyfile_result",
+        "initial_target",
+        "expects_python_copy",
+        "expects_removed_target",
+    ),
+    (
+        (True, True, None, False, False),
+        (False, True, None, True, False),
+        (True, False, "partial", True, True),
+    ),
+    ids=("windows-copyfile", "non-windows-copy", "windows-copyfile-fallback"),
+)
+def test_do_copy_windows_copyfile_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    on_win,
+    copyfile_result,
+    initial_target,
+    expects_python_copy,
+    expects_removed_target,
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    if initial_target is not None:
+        target.write_text(initial_target)
+    copy_calls = []
+    python_copy_calls = []
+    removed = []
+    rm_rf = create.rm_rf
+    original_copyfileobj = create.copyfileobj
+
+    def copy_file(src, dst, fail_if_exists):
+        copy_calls.append((src, dst, fail_if_exists))
+        if copyfile_result:
+            copyfile(src, dst)
+        return copyfile_result
+
+    def copyfileobj_spy(*args, **kwargs):
+        python_copy_calls.append(args[2] if len(args) > 2 else kwargs.get("length"))
+        return original_copyfileobj(*args, **kwargs)
+
+    def remove(path):
+        removed.append(path)
+        rm_rf(path)
+
+    win_copyfile = (
+        copy_file
+        if on_win
+        else lambda *args: pytest.fail("CopyFileW should be Windows-only")
+    )
+
+    monkeypatch.setattr(create, "on_win", on_win)
+    monkeypatch.setattr(create, "_WIN_COPYFILE", win_copyfile)
+    monkeypatch.setattr(create, "copyfileobj", copyfileobj_spy)
+    monkeypatch.setattr(create, "rm_rf", remove)
+
+    create._do_copy(str(source), str(target))
+
+    assert target.read_text() == "contents"
+    assert copy_calls == ([(str(source), str(target), True)] if on_win else [])
+    assert bool(python_copy_calls) is expects_python_copy
+    assert removed == ([str(target)] if expects_removed_target else [])

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -210,3 +210,65 @@ def test_do_copy_windows_copyfile_path(
     assert copy_calls == ([(str(source), str(target), True)] if on_win else [])
     assert bool(python_copy_calls) is expects_python_copy
     assert removed == ([str(target)] if expects_removed_target else [])
+
+
+def test_win_copy_file_prefers_copyfile2(
+    mocker,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+
+    def copy_file2(src, dst, flags):
+        copyfile(src, dst)
+
+    winapi = mocker.Mock()
+    winapi.COPY_FILE_ALLOW_DECRYPTED_DESTINATION = 1
+    winapi.COPY_FILE_FAIL_IF_EXISTS = 2
+    winapi.CopyFile2.side_effect = copy_file2
+    mocker.patch.dict("sys.modules", {"_winapi": winapi})
+    monkeypatch.setattr(create, "on_win", True)
+    monkeypatch.setattr(create, "_WIN_COPYFILE", None)
+
+    assert create._win_copy_file(source, target)
+    assert target.read_text() == "contents"
+    winapi.CopyFile2.assert_called_once_with(str(source), str(target), 3)
+
+
+def test_win_copy_file_falls_back_to_copyfilew(
+    mocker,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+
+    def copy_file_w(src, dst, fail_if_exists):
+        copyfile(src, dst)
+        return True
+
+    copy_file_w = mocker.Mock(side_effect=copy_file_w)
+    windll = mocker.Mock()
+    windll.kernel32.CopyFileW = copy_file_w
+    mocker.patch.dict("sys.modules", {"_winapi": None})
+    mocker.patch("ctypes.windll", windll, create=True)
+    monkeypatch.setattr(create, "on_win", True)
+    monkeypatch.setattr(create, "_WIN_COPYFILE", None)
+
+    assert create._win_copy_file(source, target)
+    assert target.read_text() == "contents"
+    copy_file_w.assert_called_once_with(str(source), str(target), True)
+
+
+@pytest.mark.skipif(not create.on_win, reason="requires Windows")
+def test_win_copy_file_native(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    monkeypatch.setattr(create, "_WIN_COPYFILE", None)
+
+    assert create._win_copy_file(source, target)
+    assert target.read_text() == "contents"

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -204,7 +204,7 @@ def test_do_copy_windows_copyfile_path(
     monkeypatch.setattr(create, "copyfileobj", copyfileobj_spy)
     monkeypatch.setattr(create, "rm_rf", remove)
 
-    create._do_copy(str(source), str(target))
+    create._do_copy(source, target)
 
     assert target.read_text() == "contents"
     assert copy_calls == ([(str(source), str(target), True)] if on_win else [])


### PR DESCRIPTION
### Description

Part of conda/conda#15969 as Track B follow-up B27.

Windows exposes `CopyFile2` through CPython `_winapi` on Python 3.12 and newer. This PR uses that wrapper for copy-mode file creation with the same compatibility flag as `shutil.copy2`. Python 3.10 and 3.11 retain a cached `CopyFileW` fallback. Both paths avoid bouncing file data through Python read and write loops.

This PR is stacked on B26 (#16368) until that PR lands. The new Track B case here is the Windows copy backend.

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Measured impact

Focused Windows NTFS copy-mode benchmark on Garak, a Windows 11 ARM64 VM running in Parallels on macOS, using Python 3.13.13 from the repository `dev/start.bat` base environment. The table reports medians from 20 balanced repeats of conda Python copy, `CopyFileW`, and `_winapi.CopyFile2`. Each path applies `copystat`.

| Case | Python copy | `CopyFileW` | `CopyFile2` | `CopyFile2` speedup |
|---|---:|---:|---:|---:|
| 1 copy-mode file, 64 MiB | 44.02 ms | 15.11 ms | 16.18 ms | 2.72x |
| 512 copy-mode files, 64 KiB each | 1.897 s | 187.67 ms | 186.35 ms | 10.18x |
| 2,048 copy-mode files, 1 KiB each | 8.311 s | 951.91 ms | 944.57 ms | 8.80x |

Follow-up 80-repeat probes on the same Parallels VM did not reproduce the 7.1% single-file difference. With one shared destination and API time isolated, the paired median put `CopyFile2` 0.5% faster than `CopyFileW`. Repeating the original destination and `copystat` shape put `CopyFile2` 0.9% slower. The flag variants were also equivalent. Treat the native APIs as performance parity within about 1% on this fixture. `CopyFile2` preserves the material win over the Python loop while using the CPython-provided wrapper where available.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for inclusion in the next release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? No user-facing docs change.

