### PR TITLE
Add `conda_clean_paths` plugin hook

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -96,6 +96,15 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         action="store_true",
         help="Remove log files.",
     )
+    from ..base.context import context
+
+    for clean_path in context.plugin_manager.get_clean_paths().values():
+        removal_target_options.add_argument(
+            clean_path.flag,
+            dest=clean_path.dest,
+            action="store_true",
+            help=clean_path.summary or f"Remove {clean_path.name} paths.",
+        )
 
     add_output_and_prompt_options(p)
 
@@ -369,6 +378,13 @@ def _execute(args, parser):
         # package caches
         return json_result
 
+    clean_paths = context.plugin_manager.get_clean_paths()
+    selected_clean_paths = [
+        clean_path
+        for clean_path in clean_paths.values()
+        if getattr(args, clean_path.dest, False)
+    ]
+
     if not (
         args.all
         or args.tarballs
@@ -376,12 +392,21 @@ def _execute(args, parser):
         or args.packages
         or args.tempfiles
         or args.logfiles
+        or selected_clean_paths
     ):
         from ..exceptions import ArgumentError
 
         raise ArgumentError(
             "At least one removal target must be given. See 'conda clean --help'."
         )
+
+    if selected_clean_paths:
+        target_prefix = os.fspath(context.target_prefix)
+        json_result["clean_paths"] = {}
+        for clean_path in selected_clean_paths:
+            paths = list(clean_path.find(target_prefix))
+            json_result["clean_paths"][clean_path.name] = {"files": paths}
+            rm_items(paths, **kwargs, name=f"{clean_path.name} path(s)")
 
     if args.tarballs or args.all:
         json_result["tarballs"] = tars = find_tarballs()

--- a/conda/plugins/clean_paths/__init__.py
+++ b/conda/plugins/clean_paths/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Clean path plugins for ``conda clean``."""
+
+from __future__ import annotations
+
+from . import notices
+
+plugins = [notices]
+
+__all__ = ["plugins"]

--- a/conda/plugins/clean_paths/notices.py
+++ b/conda/plugins/clean_paths/notices.py
@@ -13,13 +13,15 @@ from ..types import CondaCleanPath
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from ...common.path import PathType
 
-def find_notices_cache_paths(_target_prefix: str) -> Iterable[str]:
+
+def find_notices_cache_paths(_target_prefix: str) -> Iterable[PathType]:
     """Return cached notice files that can be removed."""
     cache_dir = get_notices_cache_dir()
     for path in cache_dir.iterdir():
         if path.is_file():
-            yield str(path)
+            yield path
 
 
 @hookimpl

--- a/conda/plugins/clean_paths/notices.py
+++ b/conda/plugins/clean_paths/notices.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Clean path plugin for cached channel notices."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...notices.cache import get_notices_cache_dir
+from .. import hookimpl
+from ..types import CondaCleanPath
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def find_notices_cache_paths(_target_prefix: str) -> Iterable[str]:
+    """Return cached notice files that can be removed."""
+    cache_dir = get_notices_cache_dir()
+    for path in cache_dir.iterdir():
+        if path.is_file():
+            yield str(path)
+
+
+@hookimpl
+def conda_clean_paths() -> Iterable[CondaCleanPath]:
+    yield CondaCleanPath(
+        name="notices-cache",
+        find=find_notices_cache_paths,
+        summary="Remove cached channel notices.",
+    )

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
     from .types import (
         CondaAuthHandler,
+        CondaCleanPath,
         CondaEnvironmentExporter,
         CondaEnvironmentSpecifier,
         CondaExceptionObserver,
@@ -822,6 +823,44 @@ class CondaSpecs:
 
         Returns:
             An iterable of :class:`~conda.plugins.types.CondaPackageExtractor` entries.
+        """
+        yield from ()
+
+    @_hookspec
+    def conda_clean_paths(self) -> Iterable[CondaCleanPath]:
+        """
+        Register clean path providers for ``conda clean``.
+
+        Each provider is exposed as a dedicated ``--<name>`` flag on
+        ``conda clean``. Providers discover file or directory paths that
+        can be removed. Conda handles user confirmation, dry-run, and
+        deletion.
+
+        **Example:**
+
+        .. code-block:: python
+
+            import os
+
+            from conda import plugins
+
+
+            def find_example_cache(target_prefix: str):
+                cache_dir = f"{target_prefix}/.example-cache"
+                if os.path.isdir(cache_dir):
+                    yield cache_dir
+
+
+            @plugins.hookimpl
+            def conda_clean_paths():
+                yield plugins.types.CondaCleanPath(
+                    name="example-cache",
+                    find=find_example_cache,
+                    summary="Remove example cache files.",
+                )
+
+        Returns:
+            An iterable of :class:`~conda.plugins.types.CondaCleanPath` entries.
         """
         yield from ()
 

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
     from ..models.records import PackageRecord
     from .types import (
         CondaAuthHandler,
+        CondaCleanPath,
         CondaEnvironmentExporter,
         CondaEnvironmentSpecifier,
         CondaExceptionObserver,
@@ -386,6 +387,11 @@ class CondaPluginManager(pluggy.PluginManager):
         self, name: Literal["exception_observers"]
     ) -> list[CondaExceptionObserver]: ...
 
+    @overload
+    def get_hook_results(
+        self, name: Literal["clean_paths"]
+    ) -> list[CondaCleanPath]: ...
+
     def get_hook_results(self, name, **kwargs):
         """
         Return results of the plugin hooks with the given name and
@@ -642,6 +648,16 @@ class CondaPluginManager(pluggy.PluginManager):
     def get_health_checks(self) -> dict[str, CondaHealthCheck]:
         """Return a mapping of health check name to health check."""
         return {check.name: check for check in self.get_hook_results("health_checks")}
+
+    def get_clean_paths(self) -> dict[str, CondaCleanPath]:
+        """Return a mapping of clean path target name to clean path plugin."""
+        clean_paths = self.get_hook_results("clean_paths")
+        return {
+            clean_path.name: clean_path
+            for clean_path in sorted(
+                clean_paths, key=lambda clean_path: clean_path.name
+            )
+        }
 
     def get_reporter_backends(self) -> tuple[CondaReporterBackend, ...]:
         return tuple(self.get_hook_results("reporter_backends"))

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -40,6 +40,7 @@ from ..exceptions import (
     PluginError,
 )
 from . import (
+    clean_paths,
     environment_exporters,
     environment_specifiers,
     package_extractors,
@@ -1312,6 +1313,7 @@ def get_plugin_manager() -> CondaPluginManager:
         *virtual_packages.plugins,
         *subcommands.plugins,
         *health_checks.plugins,
+        *clean_paths.plugins,
         *post_solves.plugins,
         *reporter_backends.plugins,
         *package_extractors.plugins,

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     SinglePlatformEnvironmentExport = Callable[[Environment], str]
     MultiPlatformEnvironmentExport = Callable[[Iterable[Environment]], str]
 
-    CondaCleanPathCallable: TypeAlias = Callable[[str], Iterable[str]]
+    CondaCleanPathCallable: TypeAlias = Callable[[str], Iterable[PathType]]
 
     # Callback type for health check fixer confirmation prompts.
     # Raises CondaSystemExit if user declines, or DryRunExit in dry-run mode.
@@ -883,7 +883,8 @@ class CondaCleanPath(CondaPlugin):
     Args:
         name: Clean target identifier (e.g., ``notices-cache``).
         find: Callable that discovers removable paths:
-            ``find(target_prefix) -> paths``.
+            ``find(target_prefix) -> paths`` where each path is a
+            :data:`~conda.common.path.PathType`.
         summary: Short description of what the clean target removes
             (shown in ``conda clean --help`` as the flag help text).
     """

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
     SinglePlatformEnvironmentExport = Callable[[Environment], str]
     MultiPlatformEnvironmentExport = Callable[[Iterable[Environment]], str]
 
+    CondaCleanPathCallable: TypeAlias = Callable[[str], Iterable[str]]
+
     # Callback type for health check fixer confirmation prompts.
     # Raises CondaSystemExit if user declines, or DryRunExit in dry-run mode.
     ConfirmCallback: TypeAlias = Callable[[str], None]
@@ -864,6 +866,39 @@ class CondaPackageExtractor(CondaPlugin):
     name: str
     extensions: list[str]
     extract: PackageExtract
+
+
+@dataclass
+class CondaCleanPath(CondaPlugin):
+    """
+    Return type to use when defining a conda clean path plugin hook.
+
+    Clean path plugins register file or directory paths that ``conda clean``
+    can offer for removal. Plugins only discover paths; conda handles user
+    confirmation, dry-run, and deletion.
+
+    For details on how this is used, see
+    :meth:`~conda.plugins.hookspec.CondaSpecs.conda_clean_paths`.
+
+    Args:
+        name: Clean target identifier (e.g., ``notices-cache``).
+        find: Callable that discovers removable paths:
+            ``find(target_prefix) -> paths``.
+        summary: Short description of what the clean target removes
+            (shown in ``conda clean --help`` as the flag help text).
+    """
+
+    name: str
+    find: CondaCleanPathCallable
+    summary: str | None = None
+
+    @property
+    def flag(self) -> str:
+        return f"--{self.name}"
+
+    @property
+    def dest(self) -> str:
+        return f"clean_{self.name.replace('-', '_')}"
 
 
 @dataclass(frozen=True)

--- a/docs/source/dev-guide/plugins/clean_paths.rst
+++ b/docs/source/dev-guide/plugins/clean_paths.rst
@@ -1,0 +1,64 @@
+===========
+Clean paths
+===========
+
+``conda clean`` can be extended with the ``conda_clean_paths`` plugin hook.
+Plugins register removable file or directory paths; conda exposes each target
+as a dedicated ``conda clean --<name>`` flag, then handles listing,
+confirmation, dry-run, and removal.
+
+Plugin targets are not included in ``conda clean --all``.
+
+Basic clean path
+================
+
+A clean path requires:
+
+- **name**: Identifier for the target (also used as the CLI flag, e.g.
+  ``notices-cache`` becomes ``--notices-cache``)
+- **find**: Callable that discovers paths to remove:
+  ``find(target_prefix) -> paths``
+- **summary** (optional): Help text shown in ``conda clean --help``
+
+Each path may be a ``str`` or any other :data:`~conda.common.path.PathType`
+(e.g. ``pathlib.Path``). Plugins only discover paths; they must not remove
+files themselves.
+
+Example:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from conda.plugins import hookimpl
+   from conda.plugins.types import CondaCleanPath
+
+
+   def find_example_cache(target_prefix: str):
+       cache_dir = Path(target_prefix) / ".example-cache"
+       if cache_dir.is_dir():
+           yield cache_dir
+
+
+   @hookimpl
+   def conda_clean_paths():
+       yield CondaCleanPath(
+           name="example-cache",
+           find=find_example_cache,
+           summary="Remove example cache files.",
+       )
+
+Built-in target
+===============
+
+Conda registers a built-in ``notices-cache`` target that removes cached
+channel notice files via ``conda clean --notices-cache``.
+
+API Reference
+=============
+
+.. autoapiclass:: conda.plugins.types.CondaCleanPath
+   :members:
+   :undoc-members:
+
+.. autoapifunction:: conda.plugins.hookspec.CondaSpecs.conda_clean_paths

--- a/docs/source/dev-guide/plugins/index.rst
+++ b/docs/source/dev-guide/plugins/index.rst
@@ -98,6 +98,7 @@ For examples of how to use other plugin hooks, please read their respective docu
    :maxdepth: 1
 
    auth_handlers
+   clean_paths
    environment_exporters
    environment_specifiers
    exception_observers

--- a/news/16370-conda-clean-paths-plugin
+++ b/news/16370-conda-clean-paths-plugin
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add `conda_clean_paths` plugin hook so third-party plugins can register file and directory paths removed via dedicated `conda clean --<name>` flags. (#14253 via #16370)
+* Register a built-in `notices-cache` clean target for `conda clean --notices-cache`. (#16370)

--- a/news/clean-paths-plugin
+++ b/news/clean-paths-plugin
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `conda_clean_paths` plugin hook so third-party plugins can register file and directory paths removed via dedicated `conda clean --<name>` flags. (#TBD)

--- a/news/clean-paths-plugin
+++ b/news/clean-paths-plugin
@@ -1,3 +1,3 @@
 ### Enhancements
 
-* Add `conda_clean_paths` plugin hook so third-party plugins can register file and directory paths removed via dedicated `conda clean --<name>` flags. (#TBD)
+* Add `conda_clean_paths` plugin hook so third-party plugins can register file and directory paths removed via dedicated `conda clean --<name>` flags. Register a built-in `notices-cache` clean target. (#TBD)

--- a/news/clean-paths-plugin
+++ b/news/clean-paths-plugin
@@ -1,3 +1,0 @@
-### Enhancements
-
-* Add `conda_clean_paths` plugin hook so third-party plugins can register file and directory paths removed via dedicated `conda clean --<name>` flags. Register a built-in `notices-cache` clean target. (#TBD)

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -407,6 +407,36 @@ def test_clean_all_mock_lstat(
     set_log_level(WARN)  # reset verbosity
 
 
+# conda clean --example-cache
+def test_clean_plugin_paths(
+    plugin_manager,
+    conda_cli: CondaCLIFixture,
+    tmp_path: Path,
+):
+    from conda import plugins
+    from conda.plugins.types import CondaCleanPath
+
+    cache_file = tmp_path / "example-cache.txt"
+    cache_file.write_text("cached")
+
+    class CleanPathPlugin:
+        @plugins.hookimpl
+        def conda_clean_paths(self):
+            yield CondaCleanPath(
+                name="example-cache",
+                find=lambda target_prefix: [str(cache_file)],
+            )
+
+    plugin_manager.register(CleanPathPlugin())
+
+    assert cache_file.is_file()
+
+    stdout, _, _ = conda_cli("clean", "--example-cache", "--yes", "--json")
+    result = json.loads(stdout)
+    assert result["clean_paths"]["example-cache"]["files"] == [str(cache_file)]
+    assert not cache_file.exists()
+
+
 # _get_size unittest, valid file
 def test_get_size(tmp_path: Path):
     warnings: list[str] = []

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -409,7 +409,7 @@ def test_clean_all_mock_lstat(
 
 # conda clean --example-cache
 def test_clean_plugin_paths(
-    plugin_manager,
+    plugin_manager_with_reporter_backends,
     conda_cli: CondaCLIFixture,
     tmp_path: Path,
 ):
@@ -427,7 +427,7 @@ def test_clean_plugin_paths(
                 find=lambda target_prefix: [str(cache_file)],
             )
 
-    plugin_manager.register(CleanPathPlugin())
+    plugin_manager_with_reporter_backends.register(CleanPathPlugin())
 
     assert cache_file.is_file()
 

--- a/tests/plugins/clean_paths/test_notices.py
+++ b/tests/plugins/clean_paths/test_notices.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from conda.notices.cache import get_notices_cache_file
+from conda.plugins.clean_paths.notices import find_notices_cache_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda.testing.fixtures import CondaCLIFixture
+
+
+def test_find_notices_cache_paths(notices_cache_dir: Path):
+    channel_cache = notices_cache_dir / "chan.json"
+    channel_cache.write_text("{}")
+    notices_cache_file = get_notices_cache_file()
+    notices_cache_file.write_text("viewed-id\n")
+
+    paths = set(find_notices_cache_paths("/unused/prefix"))
+
+    assert paths == {str(channel_cache), str(notices_cache_file)}
+
+
+def test_clean_notices_cache(
+    clear_plugin_manager_cache,
+    notices_cache_dir: Path,
+    conda_cli: CondaCLIFixture,
+):
+    channel_cache = notices_cache_dir / "chan.json"
+    channel_cache.write_text("{}")
+    notices_cache_file = get_notices_cache_file()
+    notices_cache_file.write_text("viewed-id\n")
+
+    stdout, _, _ = conda_cli("clean", "--notices-cache", "--yes", "--json")
+    result = json.loads(stdout)
+
+    assert set(result["clean_paths"]["notices-cache"]["files"]) == {
+        str(channel_cache),
+        str(notices_cache_file),
+    }
+    assert not channel_cache.exists()
+    assert not notices_cache_file.exists()

--- a/tests/plugins/clean_paths/test_notices.py
+++ b/tests/plugins/clean_paths/test_notices.py
@@ -22,7 +22,7 @@ def test_find_notices_cache_paths(notices_cache_dir: Path):
 
     paths = set(find_notices_cache_paths("/unused/prefix"))
 
-    assert paths == {str(channel_cache), str(notices_cache_file)}
+    assert paths == {channel_cache, notices_cache_file}
 
 
 def test_clean_notices_cache(

--- a/tests/plugins/test_clean_paths.py
+++ b/tests/plugins/test_clean_paths.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+import pytest
+
+from conda import plugins
+from conda.exceptions import PluginError
+from conda.plugins.types import CondaCleanPath
+
+
+class CleanPathPlugin:
+    target_prefix = None
+
+    def find_example_paths(self, target_prefix: str):
+        CleanPathPlugin.target_prefix = target_prefix
+        return [f"{target_prefix}/example-cache"]
+
+    @plugins.hookimpl
+    def conda_clean_paths(self):
+        yield CondaCleanPath(
+            name="example-cache",
+            find=self.find_example_paths,
+            summary="Remove example cache files.",
+        )
+
+
+@pytest.fixture()
+def clean_path_plugin(plugin_manager):
+    plugin = CleanPathPlugin()
+    plugin_manager.register(plugin)
+    return plugin
+
+
+def test_clean_path_flag_and_dest():
+    clean_path = CondaCleanPath(name="example-cache", find=lambda prefix: ())
+    assert clean_path.flag == "--example-cache"
+    assert clean_path.dest == "clean_example_cache"
+
+
+def test_get_clean_paths_sorted(plugin_manager):
+    class CleanPathPlugin:
+        @plugins.hookimpl
+        def conda_clean_paths(self):
+            yield CondaCleanPath(name="zebra-cache", find=lambda prefix: ())
+            yield CondaCleanPath(name="alpha-cache", find=lambda prefix: ())
+
+    plugin_manager.register(CleanPathPlugin())
+
+    assert list(plugin_manager.get_clean_paths()) == ["alpha-cache", "zebra-cache"]
+
+
+def test_get_clean_paths(clean_path_plugin, plugin_manager):
+    clean_paths = plugin_manager.get_clean_paths()
+    assert set(clean_paths) == {"example-cache"}
+    assert clean_paths["example-cache"].summary == "Remove example cache files."
+
+
+def test_find_clean_paths(clean_path_plugin, plugin_manager):
+    clean_path = plugin_manager.get_clean_paths()["example-cache"]
+    paths = list(clean_path.find("/tmp/prefix"))
+    assert paths == ["/tmp/prefix/example-cache"]
+    assert CleanPathPlugin.target_prefix == "/tmp/prefix"
+
+
+def test_conflicting_clean_paths(plugin_manager):
+    class FirstCleanPathPlugin:
+        @plugins.hookimpl
+        def conda_clean_paths(self):
+            yield CondaCleanPath(name="example-cache", find=lambda prefix: ())
+
+    class SecondCleanPathPlugin:
+        @plugins.hookimpl
+        def conda_clean_paths(self):
+            yield CondaCleanPath(name="example-cache", find=lambda prefix: ())
+
+    plugin_manager.register(FirstCleanPathPlugin())
+    plugin_manager.register(SecondCleanPathPlugin())
+
+    with pytest.raises(
+        PluginError, match="Conflicting plugins found for `clean_paths`"
+    ):
+        plugin_manager.get_clean_paths()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Partial implementation of [#14253](https://github.com/conda/conda/issues/14253): add a `conda_clean_paths` plugin hook so components can register removable file or directory paths for `conda clean`, without refactoring existing built-in clean targets.

- Introduce `CondaCleanPath` plugin type with a `find(target_prefix) -> paths` callable; plugins discover paths only — conda handles listing, confirmation, dry-run, and removal via existing `rm_items()` / `rm_rf()`.
- Add `conda_clean_paths` hookspec, `get_clean_paths()` on the plugin manager (sorted by name), and `flag` / `dest` properties for CLI integration.
- Wire plugin targets into `conda clean`: each registered plugin gets a dedicated `--<name>` flag in the Removal Targets group (e.g. `--notices-cache`). Plugin targets are **not** included in `--all`.
- Register a built-in `notices-cache` clean path that removes cached channel notice files under the user notices cache directory.

Existing `conda clean` behavior for tarballs, packages, index cache, tempfiles, and logfiles is unchanged.

> [!WARNING]
> **Tradeoff: plugin flags prevent lazy loading.** Each clean-path plugin is registered as a dedicated `--<name>` flag at parser setup time (`configure_parser` calls `get_clean_paths()`). That means the plugin manager must be loaded and all `conda_clean_paths` hook implementations must be importable before `conda clean --help` (or any `conda clean` invocation) can run — we cannot defer loading clean-path plugins until a flag is actually selected. A `--clean-path NAME` indirection (like `conda doctor`'s positional names) would allow lazy loading but at the cost of discoverability in `--help`. This PR chooses per-plugin flags; revisit if startup cost becomes an issue.

Closes #14253 (partial — hook + first built-in target; full subcommand refactor deferred).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
