### PR TITLE
Aggregate transaction hardlink actions (B29)

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -66,6 +66,7 @@ from ..utils import get_comspec, human_bytes, wrap_subprocess_call
 from .package_cache_data import PackageCacheData
 from .path_actions import (
     AggregateCompileMultiPycAction,
+    BulkHardLinkPathAction,
     CompileMultiPycAction,
     CreatePrefixRecordAction,
     CreatePythonEntryPointAction,
@@ -558,6 +559,9 @@ class UnlinkLinkTransaction:
                     specs,
                     all_link_path_actions,
                 )
+            )
+            link_action_groups[-1] = link_ag._replace(
+                actions=cls._aggregate_link_actions(link_ag.actions)
             )
 
         prefix_record_groups = [ActionGroup("record", None, record_axns, target_prefix)]
@@ -1266,6 +1270,32 @@ class UnlinkLinkTransaction:
             *create_directory_actions,
             *file_link_actions,
         )
+
+    @staticmethod
+    def _aggregate_link_actions(actions):
+        bulkable_actions = []
+        aggregate_actions = []
+        for action in actions:
+            # Only exact LinkPathAction instances are plain file links. Subclasses
+            # such as PrefixReplaceLinkAction carry extra side effects and must
+            # stay in the normal action stream.
+            plain_link_action = type(action) is LinkPathAction
+            if plain_link_action and action.link_type == LinkType.hardlink:
+                bulkable_actions.append(action)
+                continue
+
+            if len(bulkable_actions) > 1:
+                aggregate_actions.append(BulkHardLinkPathAction(*bulkable_actions))
+            else:
+                aggregate_actions.extend(bulkable_actions)
+            bulkable_actions = []
+            aggregate_actions.append(action)
+
+        if len(bulkable_actions) > 1:
+            aggregate_actions.append(BulkHardLinkPathAction(*bulkable_actions))
+        else:
+            aggregate_actions.extend(bulkable_actions)
+        return tuple(aggregate_actions)
 
     @staticmethod
     def _make_entry_point_actions(

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1273,6 +1273,11 @@ class UnlinkLinkTransaction:
 
     @staticmethod
     def _aggregate_link_actions(actions):
+        if context.extra_safety_checks:
+            # Extra safety checks intentionally report payload corruption in
+            # conda's original per-path order, so avoid grouped verification.
+            return actions
+
         bulkable_actions = []
         aggregate_actions = []
         for action in actions:

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -42,6 +42,7 @@ from ..exceptions import (
 )
 from ..gateways.connection.download import download
 from ..gateways.disk.create import (
+    HardLinkPathExecutor,
     compile_multiple_pyc,
     copy,
     create_hard_link_or_copy,
@@ -529,6 +530,55 @@ class LinkPathAction(CreateInPrefixPathAction):
             log.log(TRACE, "reversing link creation %s", self.target_prefix)
             if not isdir(self.target_full_path):
                 rm_rf(self.target_full_path, clean_empty_parents=True)
+
+
+class BulkHardLinkPathAction(MultiPathAction):
+    def __init__(self, *link_path_actions):
+        self._link_path_actions = link_path_actions
+        self.transaction_context = link_path_actions[0].transaction_context
+        self.package_info = link_path_actions[0].package_info
+        self.target_prefix = link_path_actions[0].target_prefix
+        self.target_short_paths = tuple(
+            action.target_short_path for action in link_path_actions
+        )
+        self._execute_successful = False
+
+    @property
+    def target_full_paths(self):
+        return tuple(action.target_full_path for action in self._link_path_actions)
+
+    def verify(self):
+        for action in self._link_path_actions:
+            if action.verified:
+                continue
+            error = action.verify()
+            if error:
+                return error
+        self._verified = True
+
+    def execute(self):
+        log.log(TRACE, "bulk hard linking %d paths", len(self._link_path_actions))
+        with HardLinkPathExecutor(force=context.force) as link_executor:
+            for action in self._link_path_actions:
+                # The wrapped LinkPathAction still owns verification, rollback,
+                # cleanup, and conda-meta path data. The bulk action only reuses
+                # filesystem setup across adjacent hardlink operations.
+                link_executor.link_or_copy(
+                    action.source_full_path,
+                    action.target_full_path,
+                )
+                action._execute_successful = True
+        self._execute_successful = True
+
+    def reverse(self):
+        if any(action._execute_successful for action in self._link_path_actions):
+            log.log(TRACE, "reversing bulk hard link creation %s", self.target_prefix)
+            for action in reversed(self._link_path_actions):
+                action.reverse()
+
+    def cleanup(self):
+        for action in self._link_path_actions:
+            action.cleanup()
 
 
 class PrefixReplaceLinkAction(LinkPathAction):

--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -7,10 +7,11 @@ import os
 import sys
 import tempfile
 import warnings as _warnings
+from collections import OrderedDict
 from ctypes import CDLL, c_char_p, c_int, get_errno
 from errno import EACCES, EINVAL, ENOSYS, EPERM, EROFS, EXDEV
 from logging import getLogger
-from os.path import dirname, isdir, isfile, join, splitext
+from os.path import basename, dirname, isdir, isfile, join, splitext
 from shutil import copyfileobj, copystat
 from stat import S_ISREG
 
@@ -526,6 +527,69 @@ def _win_copy_file(src, dst):
     if lexists(dst):
         rm_rf(dst)
     return False
+
+
+class HardLinkPathExecutor:
+    def __init__(self, force=False):
+        self._force = force
+        self._dir_fds = OrderedDict()
+        # Reusing dir_fd handles avoids repeated absolute path resolution when a
+        # package links many files from the same source and target directories.
+        self._use_dir_fds = not on_win and os.link in os.supports_dir_fd and not force
+        # Windows has no dir_fd support here, but the direct link call still
+        # avoids create_link's per-file fallback scaffolding when it succeeds.
+        self._use_windows_direct = on_win and not force
+        self._windows_direct_failed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        while self._dir_fds:
+            _, fd = self._dir_fds.popitem()
+            os.close(fd)
+
+    def _get_dir_fd(self, directory):
+        directory = directory or "."
+        try:
+            fd = self._dir_fds.pop(directory)
+        except KeyError:
+            if len(self._dir_fds) >= 64:
+                _, old_fd = self._dir_fds.popitem(last=False)
+                os.close(old_fd)
+            fd = os.open(directory, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        self._dir_fds[directory] = fd
+        return fd
+
+    def link_or_copy(self, src, dst):
+        if self._use_windows_direct and not isdir(src):
+            if not self._windows_direct_failed:
+                try:
+                    log.log(TRACE, "hard linking %s => %s", src, dst)
+                    link(src, dst)
+                    return
+                except OSError as e:
+                    log.debug("%r", e)
+                    self._windows_direct_failed = True
+            # One direct Windows failure does not prove every file must be
+            # copied. Keep conda's normal hardlink-then-copy fallback per file.
+            create_link(src, dst, LinkType.hardlink, force=self._force)
+            return
+
+        if self._use_dir_fds and not isdir(src):
+            try:
+                log.log(TRACE, "hard linking %s => %s", src, dst)
+                os.link(
+                    basename(src),
+                    basename(dst),
+                    src_dir_fd=self._get_dir_fd(dirname(src)),
+                    dst_dir_fd=self._get_dir_fd(dirname(dst)),
+                )
+                return
+            except OSError as e:
+                log.debug("%r", e)
+
+        create_link(src, dst, LinkType.hardlink, force=self._force)
 
 
 def create_link(src, dst, link_type=LinkType.hardlink, force=False):

--- a/news/15969-aggregate-link-actions
+++ b/news/15969-aggregate-link-actions
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Batch simple hardlink path actions during install transaction execution. (#15969)

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
+from conda.base.context import reset_context
 from conda.core import link
 from conda.models.enums import LinkType
 from conda.models.records import PackageRecord
@@ -42,6 +43,23 @@ def test_aggregate_link_actions_keeps_link_path_subclasses_individual():
     )
 
     assert actions == (first, special, second)
+
+
+def test_aggregate_link_actions_keeps_safety_check_order(monkeypatch):
+    first = object.__new__(link.LinkPathAction)
+    first.link_type = LinkType.hardlink
+    second = object.__new__(link.LinkPathAction)
+    second.link_type = LinkType.hardlink
+
+    monkeypatch.setenv("CONDA_EXTRA_SAFETY_CHECKS", "true")
+    reset_context()
+    try:
+        actions = link.UnlinkLinkTransaction._aggregate_link_actions((first, second))
+    finally:
+        monkeypatch.delenv("CONDA_EXTRA_SAFETY_CHECKS")
+        reset_context()
+
+    assert actions == (first, second)
 
 
 def test_calculate_change_report_revised_variant():

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -2,7 +2,46 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from conda.core import link
+from conda.models.enums import LinkType
 from conda.models.records import PackageRecord
+
+
+def test_aggregate_link_actions_batches_adjacent_plain_hardlinks():
+    def plain_action(path):
+        action = object.__new__(link.LinkPathAction)
+        action.link_type = LinkType.hardlink
+        action.target_short_path = path
+        action.transaction_context = {}
+        action.package_info = object()
+        action.target_prefix = "/prefix"
+        return action
+
+    first = plain_action("bin/first")
+    second = plain_action("bin/second")
+
+    actions = link.UnlinkLinkTransaction._aggregate_link_actions((first, second))
+
+    assert len(actions) == 1
+    assert isinstance(actions[0], link.BulkHardLinkPathAction)
+
+
+def test_aggregate_link_actions_keeps_link_path_subclasses_individual():
+    class SpecialLinkPathAction(link.LinkPathAction):
+        pass
+
+    first = object.__new__(link.LinkPathAction)
+    first.link_type = LinkType.hardlink
+    special = object.__new__(SpecialLinkPathAction)
+    special.link_type = LinkType.hardlink
+    special.target_short_path = "bin/special"
+    second = object.__new__(link.LinkPathAction)
+    second.link_type = LinkType.hardlink
+
+    actions = link.UnlinkLinkTransaction._aggregate_link_actions(
+        (first, special, second)
+    )
+
+    assert actions == (first, special, second)
 
 
 def test_calculate_change_report_revised_variant():

--- a/tests/core/test_path_actions.py
+++ b/tests/core/test_path_actions.py
@@ -27,6 +27,7 @@ from conda.common.path import (
     win_path_ok,
 )
 from conda.core.path_actions import (
+    BulkHardLinkPathAction,
     CompileMultiPycAction,
     CreatePythonEntryPointAction,
     LinkPathAction,
@@ -481,6 +482,38 @@ def test_simple_LinkPathAction_copy(prefix: Path, pkgs_dir: Path):
 
     axn.reverse()
     assert not lexists(axn.target_full_path)
+
+
+def test_BulkHardLinkPathAction_hardlink(prefix: Path, pkgs_dir: Path):
+    actions = []
+    for path in ("bin/one", "bin/two"):
+        source = pkgs_dir / path
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(path)
+        (prefix / path).parent.mkdir(parents=True, exist_ok=True)
+        action = LinkPathAction(
+            {},
+            None,
+            pkgs_dir,
+            path,
+            prefix,
+            path,
+            LinkType.hardlink,
+            PathDataV1(_path=path, path_type=PathEnum.hardlink),
+        )
+        actions.append(action)
+
+    bulk = BulkHardLinkPathAction(*actions)
+    bulk.execute()
+
+    for action in actions:
+        assert isfile(action.target_full_path)
+        assert action._execute_successful
+
+    bulk.reverse()
+
+    for action in actions:
+        assert not lexists(action.target_full_path)
 
 
 def test_create_file_link_actions(tmp_path):

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -270,3 +270,104 @@ def test_do_copy_windows_copyfile_path(
     assert copy_calls == ([(str(source), str(target), True)] if on_win else [])
     assert bool(python_copy_calls) is expects_python_copy
     assert removed == ([str(target)] if expects_removed_target else [])
+
+
+def test_hard_link_path_executor_uses_dir_fds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+    source = source_dir / "file"
+    target = target_dir / "file"
+    source.write_text("contents")
+    opened = {}
+    closed = []
+    link_calls = []
+
+    def fake_open(path, flags):
+        fd = len(opened) + 10
+        opened[str(path)] = fd
+        return fd
+
+    def fake_link(src, dst, *, src_dir_fd, dst_dir_fd):
+        link_calls.append((src, dst, src_dir_fd, dst_dir_fd))
+
+    monkeypatch.setattr(create, "on_win", False)
+    monkeypatch.setattr(create.os, "open", fake_open)
+    monkeypatch.setattr(create.os, "close", lambda fd: closed.append(fd))
+    monkeypatch.setattr(create.os, "link", fake_link)
+    monkeypatch.setattr(create.os, "supports_dir_fd", {fake_link})
+    monkeypatch.setattr(
+        create,
+        "create_link",
+        lambda *args, **kwargs: pytest.fail("dir-fd link should not fall back"),
+    )
+
+    with create.HardLinkPathExecutor() as link_executor:
+        link_executor.link_or_copy(str(source), str(target))
+
+    assert link_calls == [
+        ("file", "file", opened[str(source_dir)], opened[str(target_dir)])
+    ]
+    assert sorted(closed) == sorted(opened.values())
+
+
+def test_hard_link_path_executor_uses_windows_direct_link(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.write_text("contents")
+    link_calls = []
+
+    def direct_link(src, dst):
+        link_calls.append((src, dst))
+
+    monkeypatch.setattr(create, "on_win", True)
+    monkeypatch.setattr(create, "link", direct_link)
+    monkeypatch.setattr(
+        create,
+        "create_link",
+        lambda *args, **kwargs: pytest.fail("direct Windows link should not fall back"),
+    )
+
+    with create.HardLinkPathExecutor() as link_executor:
+        link_executor.link_or_copy(str(source), str(target))
+
+    assert link_calls == [(str(source), str(target))]
+
+
+def test_hard_link_path_executor_falls_back_after_windows_direct_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    source = tmp_path / "source"
+    source_two = tmp_path / "source-two"
+    target = tmp_path / "target"
+    target_two = tmp_path / "target-two"
+    source.write_text("contents")
+    source_two.write_text("contents")
+    link_calls = []
+    fallback_calls = []
+
+    def direct_link(src, dst):
+        link_calls.append((src, dst))
+        raise OSError(errno.EPERM, "direct hardlink failed")
+
+    def create_link(src, dst, link_type, force=False):
+        fallback_calls.append((src, dst, link_type, force))
+
+    monkeypatch.setattr(create, "on_win", True)
+    monkeypatch.setattr(create, "link", direct_link)
+    monkeypatch.setattr(create, "create_link", create_link)
+
+    with create.HardLinkPathExecutor() as link_executor:
+        link_executor.link_or_copy(str(source), str(target))
+        link_executor.link_or_copy(str(source_two), str(target_two))
+
+    assert link_calls == [(str(source), str(target))]
+    assert fallback_calls == [
+        (str(source), str(target), create.LinkType.hardlink, False),
+        (str(source_two), str(target_two), create.LinkType.hardlink, False),
+    ]


### PR DESCRIPTION
### Description

Part of #15969 as Track B follow-up B29.

Install transactions often execute long runs of plain package hardlinks. This PR replaces adjacent exact LinkPathAction objects with a BulkHardLinkPathAction after transaction preparation has created compile actions and prefix records.

The wrapped actions still own verification, rollback, cleanup, and conda-meta path data. The bulk action reuses open directory file descriptors on supported platforms and uses a direct Windows hardlink attempt before conda's normal per-file fallback.

This was informed by the package-tree linking work in uv and Rattler/Pixi, but it is a narrower implementation. [Rattler groups paths by directory and executes groups through Rayon](https://github.com/conda/rattler/blob/main/crates/rattler/src/install/mod.rs); [uv walks a complete cached wheel tree with one link-state machine](https://github.com/astral-sh/uv/blob/main/crates/uv-fs/src/link.rs). This PR remains serial and only reuses hardlink setup.

This draft is stacked on B28 (#16367).

Part of the [conda-tempo Track B](https://github.com/jezdez/conda-tempo) performance work.

### Measured impact

The macOS measurements were rerun on AC power with no thermal or performance warning. A balanced ABBA warm-cache W1 comparison used eight recorded runs per branch after warming each branch:

| Workload | B28 median | B29 median | Result |
| --- | ---: | ---: | ---: |
| W1, normal hardlink install | 5.915 s | 5.919 s | neutral |

Focused 2,048-file runs can show a small action-loop win, but the direction does not hold across larger fixtures and does not survive the full transaction. There is currently no demonstrated user-visible speedup, so this remains a research draft.

Tracking issue: #15969. Full research report: https://github.com/jezdez/conda-tempo/blob/main/track-b-transaction.md

### Checklist - did you ...

- [x] Add a file to the news directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation? No user-facing documentation change.
