### PR TITLE
Add notices cache to conda info

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -208,6 +208,7 @@ def get_info_dict() -> dict[str, Any]:
     from ..common.url import mask_anaconda_token
     from ..core.index import Index
     from ..models.channel import all_channel_urls, offline_keep
+    from ..notices.cache import get_notices_cache_dir
 
     try:
         from conda_build import __version__ as conda_build_version
@@ -273,6 +274,7 @@ def get_info_dict() -> dict[str, Any]:
         virtual_pkgs=virtual_pkgs,
         solver=solver,
         tmp_dir=gettempdir(),
+        notices_cache_dir=str(get_notices_cache_dir()),
     )
     if on_win:
         from ..common._os.windows import is_admin_on_windows
@@ -378,6 +380,7 @@ def get_main_info_display(info_dict: dict[str, Any]) -> dict[str, str]:
         yield ("conda av metadata url", info_dict["av_metadata_url_base"])
         yield ("channel URLs", flatten(info_dict["channels"]))
         yield ("package cache", flatten(info_dict["pkgs_dirs"]))
+        yield ("notices cache", info_dict["notices_cache_dir"])
         yield ("envs directories", flatten(info_dict["envs_dirs"]))
         yield ("temporary directory", info_dict["tmp_dir"])
         yield ("platform", info_dict["platform"])

--- a/news/16374-notices-cache-in-conda-info
+++ b/news/16374-notices-cache-in-conda-info
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add channel notices cache directory to `conda info` output. (#16374)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -44,6 +44,7 @@ DETAIL_KEYS = {
     "conda_version",
     "envs_dirs",
     "pkgs_dirs",
+    "notices_cache_dir",
     "channels",
     "config_files",
     "offline",
@@ -148,6 +149,7 @@ def test_info_detail(conda_cli: CondaCLIFixture):
     assert "conda version" in stdout
     assert "envs directories" in stdout
     assert "package cache" in stdout
+    assert "notices cache" in stdout
     assert "channel URLs" in stdout
     assert "config file" in stdout
     assert "offline mode" in stdout
@@ -195,6 +197,7 @@ def test_info_json(conda_cli: CondaCLIFixture):
         "envs_details",
         "envs_dirs",
         "pkgs_dirs",
+        "notices_cache_dir",
         "platform",
         "python_version",
         "rc_path",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Expose the channel notices cache location in `conda info`, alongside other cache and data directories.

- Add `notices_cache_dir` to the `get_info_dict()` payload (via `get_notices_cache_dir()`).
- Show a **notices cache** line in the default `conda info` detail view, placed after **package cache**.
- Include `notices_cache_dir` in `conda info --json` output.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
