### PR TITLE
Fix conda-meta paths for wheel package records

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -12,7 +12,7 @@ import warnings
 from collections import defaultdict
 from itertools import chain
 from logging import getLogger
-from os.path import basename, dirname, isdir, join
+from os.path import dirname, isdir, join
 from pathlib import Path
 from textwrap import indent
 from traceback import format_exception_only
@@ -110,18 +110,7 @@ def make_unlink_actions(transaction_context, target_prefix, prefix_record):
         for trgt in prefix_record.files
     )
 
-    try:
-        extracted_package_dir = basename(prefix_record.extracted_package_dir)
-    except AttributeError:
-        try:
-            extracted_package_dir = basename(prefix_record.link.source)
-        except AttributeError:
-            # for backward compatibility only
-            extracted_package_dir = (
-                f"{prefix_record.name}-{prefix_record.version}-{prefix_record.build}"
-            )
-
-    meta_short_path = "{}/{}".format("conda-meta", extracted_package_dir + ".json")
+    meta_short_path = f"conda-meta/{prefix_record._get_json_fn()}"
     remove_conda_meta_actions = (
         RemoveLinkedPackageRecordAction(
             transaction_context, prefix_record, target_prefix, meta_short_path

--- a/conda/core/prefix_data.py
+++ b/conda/core/prefix_data.py
@@ -33,7 +33,7 @@ from ..base.context import context, locate_prefix_by_name
 from ..common.compat import on_mac, on_win
 from ..common.constants import NULL
 from ..common.io import time_recorder
-from ..common.path import expand, paths_equal, strip_pkg_extension
+from ..common.path import expand, paths_equal
 from ..common.serialize import json
 from ..common.url import mask_anaconda_token
 from ..common.url import remove_auth as url_remove_auth
@@ -489,16 +489,9 @@ class PrefixData(metaclass=PrefixDataType):
         return self
 
     def _get_json_fn(self, prefix_record: PrefixRecord) -> str:
-        fn = prefix_record.fn
-        # Check package extensions (dynamic) or .dist-info (pip-installed)
-        stripped, ext = strip_pkg_extension(fn)
-        if not ext and fn.endswith(".dist-info"):
-            stripped = fn[: -len(".dist-info")]
-        elif not ext:
-            raise ValueError(
-                f"Attempted to make prefix record for unknown package type: {fn}"
-            )
-        return stripped + ".json"
+        if not isinstance(prefix_record, PrefixRecord):
+            prefix_record = PrefixRecord.from_objects(prefix_record)
+        return prefix_record._get_json_fn()
 
     def insert(self, prefix_record: PrefixRecord, remove_auth: bool = True) -> None:
         if prefix_record.name in self._prefix_records:

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -708,6 +708,9 @@ class PrefixRecord(SolvedRecord):
     auth = StringField(required=False, nullable=True)
     """Authentication information."""
 
+    def _get_json_fn(self) -> str:
+        return f"{self.name}-{self.version}-{self.build}.json"
+
     def package_size(self, prefix_path: Path) -> int:
         """
         Compute the installed size of this package within a prefix.
@@ -721,9 +724,7 @@ class PrefixRecord(SolvedRecord):
         """
         total_size = 0
 
-        meta_file = (
-            prefix_path / "conda-meta" / f"{self.name}-{self.version}-{self.build}.json"
-        )
+        meta_file = prefix_path / "conda-meta" / self._get_json_fn()
         try:
             total_size += meta_file.stat().st_size
         except OSError:

--- a/conda/plugins/prefix_data_loaders/pypi/__init__.py
+++ b/conda/plugins/prefix_data_loaders/pypi/__init__.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import sys
 import traceback
 from logging import getLogger
-from os.path import basename
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -106,15 +105,7 @@ def load_site_packages(
     # also deleting the record on disk in the conda-meta/ directory.
     for conda_anchor_file in clobbered_conda_anchor_files:
         prefix_rec = records.pop(conda_python_packages[conda_anchor_file].name)
-        try:
-            extracted_package_dir = basename(prefix_rec.extracted_package_dir)
-        except AttributeError:
-            extracted_package_dir = "-".join(
-                map(str, (prefix_rec.name, prefix_rec.version, prefix_rec.build))
-            )
-        prefix_rec_json_path = (
-            prefix_path / "conda-meta" / f"{extracted_package_dir}.json"
-        )
+        prefix_rec_json_path = prefix_path / "conda-meta" / prefix_rec._get_json_fn()
         try:
             rm_rf(prefix_rec_json_path)
         except OSError:

--- a/news/16265-wheel-conda-meta-rollback
+++ b/news/16265-wheel-conda-meta-rollback
@@ -1,0 +1,11 @@
+### Enhancements
+
+### Bug fixes
+
+* Fix conda-meta JSON paths for wheel package records by deriving them from package record name, version, and build instead of the package filename or extracted package directory. (#16235, #16265)
+
+### Deprecations
+
+### Docs
+
+### Other

--- a/tests/core/test_link.py
+++ b/tests/core/test_link.py
@@ -2,7 +2,35 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from conda.core import link
-from conda.models.records import PackageRecord
+from conda.core.path_actions import RemoveLinkedPackageRecordAction
+from conda.models.records import PackageRecord, PrefixRecord
+
+
+def test_make_unlink_actions_uses_prefix_record_json_filename_for_conda_meta():
+    prefix_record = PrefixRecord(
+        name="idna",
+        version="3.10",
+        build="py3_none_any_0",
+        build_number=0,
+        channel="https://example.com/noarch",
+        subdir="noarch",
+        fn="idna-3.10-py3-none-any.whl",
+        url="https://example.com/noarch/idna-3.10-py3-none-any.whl",
+        extracted_package_dir="/pkgs/idna-3.10-py3-none-any",
+        files=(),
+    )
+
+    actions = link.make_unlink_actions({}, "/target", prefix_record)
+    remove_record_action = next(
+        action
+        for action in actions
+        if isinstance(action, RemoveLinkedPackageRecordAction)
+    )
+
+    assert (
+        remove_record_action.target_short_path
+        == "conda-meta/idna-3.10-py3_none_any_0.json"
+    )
 
 
 def test_calculate_change_report_revised_variant():

--- a/tests/core/test_prefix_data.py
+++ b/tests/core/test_prefix_data.py
@@ -16,6 +16,7 @@ import pytest
 
 from conda.base.constants import PREFIX_PINNED_FILE, PREFIX_STATE_FILE
 from conda.common.compat import on_win
+from conda.common.path.python import get_python_site_packages_short_path
 from conda.core.prefix_data import PrefixData, get_conda_anchor_files_and_records
 from conda.exceptions import CondaError, CondaValueError, CorruptedEnvironmentError
 from conda.models.enums import PackageType
@@ -290,6 +291,47 @@ def test_pip_interop(
     assert set(records) == expected_output
 
 
+def test_pypi_loader_removes_clobbered_record_json_by_prefix_record_name(
+    empty_env: Path, mocker: MockerFixture
+) -> None:
+    rm_rf = mocker.patch("conda.plugins.prefix_data_loaders.pypi.rm_rf")
+    site_packages_path = get_python_site_packages_short_path("3.11")
+    site_packages = empty_env / site_packages_path
+    site_packages.mkdir(parents=True)
+    records = {
+        "python": PrefixRecord(
+            name="python",
+            version="3.11.0",
+            build="h123_0",
+            build_number=0,
+            channel="conda-forge",
+            subdir="osx-arm64",
+            fn="python-3.11.0-h123_0.conda",
+            files=(),
+        ),
+        "pyqplot": PrefixRecord(
+            name="pyqplot",
+            version="0.7.2",
+            build="py3_none_any_0",
+            build_number=0,
+            channel="conda-pypi",
+            subdir="noarch",
+            fn="pyqplot-0.7.2-py3-none-any.whl",
+            url="https://pypi.org/pyqplot-0.7.2-py3-none-any.whl",
+            package_type=PackageType.VIRTUAL_PYTHON_WHEEL,
+            files=(f"{site_packages_path}/pyqplot-0.7.2.dist-info/RECORD",),
+            depends=("python >=3.11",),
+        ),
+    }
+
+    load_site_packages(empty_env, records)
+
+    assert "pyqplot" not in records
+    rm_rf.assert_called_once_with(
+        empty_env / "conda-meta" / "pyqplot-0.7.2-py3_none_any_0.json"
+    )
+
+
 def test_get_conda_anchor_files_and_records():
     @dataclass
     class DummyPythonRecord:
@@ -464,6 +506,35 @@ def test_no_tokens_dumped(empty_env: Path, remove_auth: bool):
         assert "/t/<TOKEN>/" in json_content
     else:
         assert "/t/some-fake-token/" in json_content
+
+
+def test_insert_wheel_style_fn_uses_name_version_build(empty_env: Path) -> None:
+    pkg_record = record(
+        name="pyqplot",
+        version="0.7.2",
+        build="py3_none_any_0",
+        build_number=0,
+        channel="conda-pypi",
+        fn="pyqplot-0.7.2-py3-none-any.whl",
+        url="https://pypi.org/pyqplot-0.7.2-py3-none-any.whl",
+        package_type=PackageType.VIRTUAL_PYTHON_WHEEL,
+    )
+
+    prefix_data = PrefixData(empty_env)
+    prefix_data.insert(pkg_record)
+
+    conda_meta_dir = empty_env / "conda-meta"
+    conda_meta_file = conda_meta_dir / "pyqplot-0.7.2-py3_none_any_0.json"
+    assert conda_meta_file.is_file()
+    assert not (conda_meta_dir / "pyqplot-0.7.2-py3-none-any.json").exists()
+
+    prefix_data.load()
+    reloaded = prefix_data.get("pyqplot")
+    assert reloaded.version == "0.7.2"
+    assert reloaded.build == "py3_none_any_0"
+
+    prefix_data.remove("pyqplot")
+    assert not conda_meta_file.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Fixes #16235.
Fixes #16265.

Conda-meta JSON paths now come from the prefix record's canonical `name-version-build` filename instead of the package filename or extracted package directory. This keeps prefix-data insert/remove, link, unlink, rollback, and package-size accounting aligned for package records whose artifact filename or extracted cache directory differs from the conda-meta filename, including wheel records from repodata v3 channels.

The filename helper now lives on `PrefixRecord`, with `PrefixData` delegating to it so existing insert/remove paths use the same rule.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
