### PR TITLE
Skip CUDA detection on macOS ARM64; handle multiprocessing error

### DIFF
--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -10,6 +10,7 @@ import itertools
 import multiprocessing
 import os
 import platform
+import warnings
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
@@ -35,11 +36,28 @@ def cuda_version():
     Returns: version string (e.g., '9.2') or None if CUDA is not found.
     """
 
+    # Shortcut: CUDA is not available on macOS ARM64 (Apple Silicon)
+    system = platform.system()
+    machine = platform.machine()
+    if system == "Darwin" and machine == "arm64":
+        return NULL
+
     # Do not inherit file descriptors and handles from the parent process.
     # The `fork` start method should be considered unsafe as it can lead to
     # crashes of the subprocess. The `spawn` start method is preferred.
-    context = multiprocessing.get_context("spawn")
-    queue = context.SimpleQueue()
+    try:
+        context = multiprocessing.get_context("spawn")
+        queue = context.SimpleQueue()
+    except PermissionError as e:
+        # If we can't create multiprocessing primitives (e.g., in a sandbox),
+        # log a warning and skip CUDA detection
+        warnings.warn(
+            f"Unable to detect CUDA version due to permission error: {e}. "
+            "Assuming CUDA is not available.",
+            stacklevel=2,
+        )
+        return NULL
+
     try:
         # Spawn a subprocess to detect the CUDA version
         detector = context.Process(

--- a/news/osx-arm64-cuda-shortcut
+++ b/news/osx-arm64-cuda-shortcut
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Shortcut CUDA detection on unsupported osx-arm64 platform; warn and assume not
+  supported on `PermissionError()` as when operating in a sandbox.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/osx-arm64-cuda-shortcut
+++ b/news/osx-arm64-cuda-shortcut
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 * Shortcut CUDA detection on unsupported osx-arm64 platform; warn and assume not
-  supported on `PermissionError()` as when operating in a sandbox.
+  supported on `PermissionError()` as when operating in a sandbox. (#16388)
 
 ### Deprecations
 


### PR DESCRIPTION

### Description

While running `conda` in a sandbox, I noticed a `PermissionError` that prevents conda from running. Since cuda isn't supported on osx-arm64 at all, we can safely skip the cuda check on that platform. This should save time as well.

Would this be faster on non-osx-arm64 platforms if we moved the cuda detection subprocess into `conda/_private` so that there were fewer collateral imports?

It offends me that we need to return `auxlib.NULL` to indicate "no cuda".

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
