### PR TITLE
Improve `cuda_version()` performance

### DIFF
--- a/conda/_private/cuda.py
+++ b/conda/_private/cuda.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Code to detect CUDA version without importing much of conda.
+
+Called as a subprocess by conda.plugins.virtual_packages.cuda.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import itertools
+import os
+import platform
+from contextlib import suppress
+
+
+def cuda_driver_version_detector_target(queue):
+    """
+    Attempt to detect the version of CUDA present in the operating system in a
+    subprocess.
+
+    On Windows and Linux, the CUDA library is installed by the NVIDIA
+    driver package, and is typically found in the standard library path,
+    rather than with the CUDA SDK (which is optional for running CUDA apps).
+
+    On macOS, the CUDA library is only installed with the CUDA SDK, and
+    might not be in the library path.
+
+    Returns: version string (e.g., '9.2') or None if CUDA is not found.
+             The result is put in the queue rather than a return value.
+    """
+    # Platform-specific libcuda location
+    system = platform.system()
+    if system == "Darwin":
+        lib_filenames = [
+            "libcuda.1.dylib",  # check library path first
+            "libcuda.dylib",
+            "/usr/local/cuda/lib/libcuda.1.dylib",
+            "/usr/local/cuda/lib/libcuda.dylib",
+        ]
+    elif system == "Linux":
+        lib_filenames = [
+            "libcuda.so",  # check library path first
+            "/usr/lib64/nvidia/libcuda.so",  # RHEL/Centos/Fedora
+            "/usr/lib/x86_64-linux-gnu/libcuda.so",  # Ubuntu
+            "/usr/lib/wsl/lib/libcuda.so",  # WSL
+        ]
+        # Also add libraries with version suffix `.1`
+        lib_filenames = list(
+            itertools.chain.from_iterable((f"{lib}.1", lib) for lib in lib_filenames)
+        )
+    elif system == "Windows":
+        bits = platform.architecture()[0].replace("bit", "")  # e.g. "64" or "32"
+        lib_filenames = [f"nvcuda{bits}.dll", "nvcuda.dll"]
+    else:
+        queue.put(None)  # CUDA not available for other operating systems
+        return
+
+    # Open library
+    if system == "Windows":
+        dll = ctypes.windll
+    else:
+        dll = ctypes.cdll
+    for lib_filename in lib_filenames:
+        with suppress(Exception):
+            libcuda = dll.LoadLibrary(lib_filename)
+            break
+    else:
+        queue.put(None)
+        return
+
+    # Empty `CUDA_VISIBLE_DEVICES` can cause `cuInit()` returns `CUDA_ERROR_NO_DEVICE`
+    # Invalid `CUDA_VISIBLE_DEVICES` can cause `cuInit()` returns `CUDA_ERROR_INVALID_DEVICE`
+    # Unset this environment variable to avoid these errors
+    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+
+    # Get CUDA version
+    try:
+        cuInit = libcuda.cuInit
+        flags = ctypes.c_uint(0)
+        ret = cuInit(flags)
+        if ret != 0:
+            queue.put(None)
+            return
+
+        cuDriverGetVersion = libcuda.cuDriverGetVersion
+        version_int = ctypes.c_int(0)
+        ret = cuDriverGetVersion(ctypes.byref(version_int))
+        if ret != 0:
+            queue.put(None)
+            return
+
+        # Convert version integer to version string
+        value = version_int.value
+        queue.put(f"{value // 1000}.{(value % 1000) // 10}")
+        return
+    except Exception:
+        queue.put(None)
+        return

--- a/conda/_private/cuda.py
+++ b/conda/_private/cuda.py
@@ -13,9 +13,13 @@ import itertools
 import os
 import platform
 from contextlib import suppress
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from multiprocessing import SimpleQueue
 
 
-def cuda_driver_version_detector_target(queue):
+def cuda_driver_version_detector_target(queue: SimpleQueue) -> None:
     """
     Attempt to detect the version of CUDA present in the operating system in a
     subprocess.

--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -10,7 +10,9 @@ import platform
 import warnings
 from typing import TYPE_CHECKING
 
-from conda._private.cuda import cuda_driver_version_detector_target
+from conda._private.cuda import (
+    cuda_driver_version_detector_target as _cuda_driver_version_detector_target,
+)
 
 from ...auxlib import NULL
 from .. import hookimpl
@@ -58,7 +60,7 @@ def cuda_version():
 
     # Spawn a subprocess to detect the CUDA version
     detector = context.Process(
-        target=cuda_driver_version_detector_target,
+        target=_cuda_driver_version_detector_target,
         args=(queue,),
         name="CUDA driver version detector",
         daemon=True,

--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -4,15 +4,13 @@
 
 from __future__ import annotations
 
-import ctypes
 import functools
-import itertools
 import multiprocessing
-import os
 import platform
 import warnings
-from contextlib import suppress
 from typing import TYPE_CHECKING
+
+from conda._private.cuda import cuda_driver_version_detector_target
 
 from ...auxlib import NULL
 from .. import hookimpl
@@ -58,14 +56,14 @@ def cuda_version():
         )
         return NULL
 
+    # Spawn a subprocess to detect the CUDA version
+    detector = context.Process(
+        target=cuda_driver_version_detector_target,
+        args=(queue,),
+        name="CUDA driver version detector",
+        daemon=True,
+    )
     try:
-        # Spawn a subprocess to detect the CUDA version
-        detector = context.Process(
-            target=_cuda_driver_version_detector_target,
-            args=(queue,),
-            name="CUDA driver version detector",
-            daemon=True,
-        )
         detector.start()
         detector.join(timeout=60.0)
     finally:
@@ -95,88 +93,3 @@ def conda_virtual_packages() -> Iterable[CondaVirtualPackage]:
         override_entity="version",
         # empty_override=NULL,  # falsy override → skip __cuda
     )
-
-
-def _cuda_driver_version_detector_target(queue):
-    """
-    Attempt to detect the version of CUDA present in the operating system in a
-    subprocess.
-
-    On Windows and Linux, the CUDA library is installed by the NVIDIA
-    driver package, and is typically found in the standard library path,
-    rather than with the CUDA SDK (which is optional for running CUDA apps).
-
-    On macOS, the CUDA library is only installed with the CUDA SDK, and
-    might not be in the library path.
-
-    Returns: version string (e.g., '9.2') or None if CUDA is not found.
-             The result is put in the queue rather than a return value.
-    """
-    # Platform-specific libcuda location
-    system = platform.system()
-    if system == "Darwin":
-        lib_filenames = [
-            "libcuda.1.dylib",  # check library path first
-            "libcuda.dylib",
-            "/usr/local/cuda/lib/libcuda.1.dylib",
-            "/usr/local/cuda/lib/libcuda.dylib",
-        ]
-    elif system == "Linux":
-        lib_filenames = [
-            "libcuda.so",  # check library path first
-            "/usr/lib64/nvidia/libcuda.so",  # RHEL/Centos/Fedora
-            "/usr/lib/x86_64-linux-gnu/libcuda.so",  # Ubuntu
-            "/usr/lib/wsl/lib/libcuda.so",  # WSL
-        ]
-        # Also add libraries with version suffix `.1`
-        lib_filenames = list(
-            itertools.chain.from_iterable((f"{lib}.1", lib) for lib in lib_filenames)
-        )
-    elif system == "Windows":
-        bits = platform.architecture()[0].replace("bit", "")  # e.g. "64" or "32"
-        lib_filenames = [f"nvcuda{bits}.dll", "nvcuda.dll"]
-    else:
-        queue.put(None)  # CUDA not available for other operating systems
-        return
-
-    # Open library
-    if system == "Windows":
-        dll = ctypes.windll
-    else:
-        dll = ctypes.cdll
-    for lib_filename in lib_filenames:
-        with suppress(Exception):
-            libcuda = dll.LoadLibrary(lib_filename)
-            break
-    else:
-        queue.put(None)
-        return
-
-    # Empty `CUDA_VISIBLE_DEVICES` can cause `cuInit()` returns `CUDA_ERROR_NO_DEVICE`
-    # Invalid `CUDA_VISIBLE_DEVICES` can cause `cuInit()` returns `CUDA_ERROR_INVALID_DEVICE`
-    # Unset this environment variable to avoid these errors
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-
-    # Get CUDA version
-    try:
-        cuInit = libcuda.cuInit
-        flags = ctypes.c_uint(0)
-        ret = cuInit(flags)
-        if ret != 0:
-            queue.put(None)
-            return
-
-        cuDriverGetVersion = libcuda.cuDriverGetVersion
-        version_int = ctypes.c_int(0)
-        ret = cuDriverGetVersion(ctypes.byref(version_int))
-        if ret != 0:
-            queue.put(None)
-            return
-
-        # Convert version integer to version string
-        value = version_int.value
-        queue.put(f"{value // 1000}.{(value % 1000) // 10}")
-        return
-    except Exception:
-        queue.put(None)
-        return

--- a/conda/plugins/virtual_packages/cuda.py
+++ b/conda/plugins/virtual_packages/cuda.py
@@ -11,18 +11,26 @@ import warnings
 from typing import TYPE_CHECKING
 
 from conda._private.cuda import (
-    cuda_driver_version_detector_target as _cuda_driver_version_detector_target,
+    cuda_driver_version_detector_target as _private_cuda_driver_version_detector_target,
 )
 
 from ...auxlib import NULL
+from ...deprecations import deprecated
 from .. import hookimpl
 from ..types import CondaVirtualPackage
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from ...auxlib import _Null
 
-def cuda_version():
+
+@deprecated("27.3", "27.9", addendum="Use `cuda_version()` directly")
+def _cuda_driver_version_detector_target(queue) -> None:
+    _private_cuda_driver_version_detector_target(queue)
+
+
+def cuda_version() -> str | _Null:
     """
     Attempt to detect the version of CUDA present in the operating system.
 
@@ -30,10 +38,10 @@ def cuda_version():
     driver package, and is typically found in the standard library path,
     rather than with the CUDA SDK (which is optional for running CUDA apps).
 
-    On macOS, the CUDA library is only installed with the CUDA SDK, and
+    On macOS Intel, the CUDA library is only installed with the CUDA SDK, and
     might not be in the library path.
 
-    Returns: version string (e.g., '9.2') or None if CUDA is not found.
+    Returns: version string (e.g., '9.2') or NULL if CUDA is not found.
     """
 
     # Shortcut: CUDA is not available on macOS ARM64 (Apple Silicon)

--- a/news/cuda-detect-faster
+++ b/news/cuda-detect-faster
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Speed up CUDA detection by using a lighter Python subprocess.
+* Speed up CUDA detection by using a lighter Python subprocess. (#16392)
 
 ### Bug fixes
 

--- a/news/cuda-detect-faster
+++ b/news/cuda-detect-faster
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Speed up CUDA detection by using a lighter Python subprocess.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/cuda-detect-faster
+++ b/news/cuda-detect-faster
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* <news item>
+* Mark `conda.plugins.virtual_packages.cuda._cuda_driver_version_detector_target` as pending deprecation, to be removed in 27.9. Use `conda.plugins.virtual_packages.cuda.cuda_version()` instead. (#16392)
 
 ### Docs
 

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -92,6 +92,7 @@ def test_duplicated(plugin_manager):
         )
 
 
+@pytest.mark.benchmark
 def test_cuda_detection(benchmark):
     """
     Test, time cuda detection which is done in a subprocess.

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -92,9 +92,12 @@ def test_duplicated(plugin_manager):
         )
 
 
-def test_cuda_detection(clear_cuda_version):
+def test_cuda_detection(benchmark):
+    """
+    Test, time cuda detection which is done in a subprocess.
+    """
     # confirm that CUDA detection doesn't raise exception
-    version = cuda.cuda_version()
+    version = benchmark(cuda.cuda_version)
     assert version is NULL or isinstance(version, str)
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I noticed that `_cuda_driver_version_detector_target()` is a good candidate for inclusion in `conda/_private/`. Since it is called in a subprocess, we can save time by putting it somewhere that does not import most of conda inside the subprocess.

On my Linux machine it takes `.104s` with the current method and `.028s` with the improved method.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
