### PR TITLE
Fix `conda.common.io.IS_INTERACTIVE` deprecation

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -36,14 +36,6 @@ from .path import expand
 
 log = getLogger(__name__)
 
-deprecated.constant(
-    "26.9",
-    "27.3",
-    "IS_INTERACTIVE",
-    hasattr(sys.stdout, "isatty") and sys.stdout.isatty(),
-    addendum="Use `conda.common.terminal.is_tty()` instead.",
-)
-
 
 class DeltaSecondsFormatter(Formatter):
     """
@@ -577,6 +569,15 @@ def __getattr__(name: str):
         _load_concurrency()
         return globals()[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+deprecated.constant(
+    "26.9",
+    "27.3",
+    "IS_INTERACTIVE",
+    hasattr(sys.stdout, "isatty") and sys.stdout.isatty(),
+    addendum="Use `conda.common.terminal.is_tty()` instead.",
+)
 
 
 def get_instrumentation_record_file() -> str:

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from io import StringIO
 from logging import DEBUG, NOTSET, WARN, getLogger
 
 import pytest
 
+from conda.common import io
 from conda.common.io import (
     CaptureTarget,
     ThreadLimitedThreadPoolExecutor,
@@ -129,3 +131,15 @@ def test_thread_limited_executor_handles_thread_limit(
                 _ = [executor.submit(time.sleep, 0.1) for _ in range(jobs)]
         else:
             _ = [executor.submit(time.sleep, 0.1) for _ in range(jobs)]
+
+
+@pytest.mark.parametrize(
+    "function,raises",
+    [
+        ("IS_INTERACTIVE", TypeError),
+    ],
+)
+def test_deprecations(function: str, raises: type[Exception] | None) -> None:
+    raises_context = pytest.raises(raises) if raises else nullcontext()
+    with pytest.deprecated_call(), raises_context:
+        getattr(io, function)()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Reorder `IS_INTERACTIVE` deprecation so it doesn't get overwritten by `conda.common.io.__getattr__` implementation.

Followup to https://github.com/conda/conda/pull/15982 and https://github.com/conda/conda/pull/15881
Resolves #16401

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
