### PR TITLE
Suggest using `conda self` to update if available

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -268,7 +268,8 @@ class BaseSolver:
     def _notify_conda_outdated(self, link_precs):
         if not context.notify_outdated_conda or context.quiet:
             return
-        current_conda_prefix_rec = PrefixData(context.conda_prefix).get("conda", None)
+        conda_prefix_data = PrefixData(context.conda_prefix)
+        current_conda_prefix_rec = conda_prefix_data.get("conda", None)
         if current_conda_prefix_rec:
             channel_name = current_conda_prefix_rec.channel.canonical_name
             if channel_name == UNKNOWN_CHANNEL:
@@ -296,6 +297,14 @@ class BaseSolver:
                 latest_version = conda_newer_precs[-1].version
                 # If conda comes from defaults, ensure we're giving instructions to users
                 # that should resolve release timing issues between defaults and conda-forge.
+                if conda_prefix_data.get("conda-self", None):
+                    conda_update_message = "conda self update"
+                else:
+                    conda_update_message = (
+                        f"conda update -n base -c {channel_name} conda"
+                    )
+                    if conda_prefix_data.is_frozen():
+                        conda_update_message += " --override-frozen"
                 print(
                     dedent(
                         f"""
@@ -306,11 +315,7 @@ class BaseSolver:
 
                         Please update conda by running
 
-                            $ conda update -n base -c {channel_name} conda
-
-                        Or to minimize the number of packages updated during conda update use
-
-                            conda install conda={latest_version}
+                            $ {conda_update_message}
 
                         """
                     ),

--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -295,8 +295,6 @@ class BaseSolver:
             )
             if conda_newer_precs:
                 latest_version = conda_newer_precs[-1].version
-                # If conda comes from defaults, ensure we're giving instructions to users
-                # that should resolve release timing issues between defaults and conda-forge.
                 if conda_prefix_data.get("conda-self", None):
                     conda_update_message = "conda self update"
                 else:

--- a/news/16414-suggest-conda-self-to-update
+++ b/news/16414-suggest-conda-self-to-update
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Suggest updating conda with `conda self` if conda self plugin is installed. (#16414)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -47,7 +47,7 @@ from conda.testing.helpers import (
 from conda.testing.integration import package_is_installed
 
 if TYPE_CHECKING:
-    from pytest import MonkeyPatch
+    from pytest import CaptureFixture, MonkeyPatch
     from pytest_benchmark.fixture import BenchmarkFixture
     from pytest_mock import MockerFixture
 
@@ -4061,3 +4061,87 @@ def test_no_channels_error(tmpdir, mocker: MockerFixture):
     assert "No channels are configured" in error_message
     assert "numpy" in error_message
     assert "conda config --append channels" in error_message
+
+
+def _make_conda_prefix_rec(name, version, channel="test"):
+    return PrefixRecord(
+        package_type=PackageType.NOARCH_GENERIC,
+        name=name,
+        version=version,
+        channel=channel,
+        subdir="noarch",
+        fn=f"{name}-{version}",
+        build="0",
+        build_number=0,
+        paths_data=None,
+        files=None,
+        depends=[],
+        constrains=[],
+    )
+
+
+@pytest.mark.parametrize(
+    "has_conda_self,is_frozen,expected,unexpected",
+    [
+        pytest.param(
+            True,
+            False,
+            "conda self update",
+            "conda update -n base",
+            id="has_conda_self",
+        ),
+        pytest.param(
+            True,
+            True,
+            "conda self update",
+            "--override-frozen",
+            id="has_conda_self, override-frozen",
+        ),
+        pytest.param(
+            False,
+            False,
+            "conda update -n base -c test conda",
+            "--override-frozen",
+            id="no_conda_self",
+        ),
+        pytest.param(
+            False, True, "--override-frozen", "conda self update", id="frozen"
+        ),
+    ],
+)
+def test_notify_conda_outdated_update_message(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture,
+    has_conda_self: bool,
+    is_frozen: bool,
+    expected: str,
+    unexpected: str,
+):
+    monkeypatch.setenv("CONDA_NOTIFY_OUTDATED_CONDA", "true")
+    monkeypatch.setenv("CONDA_QUIET", "false")
+    reset_context()
+
+    # Setup prefix data to return the current conda and conda-self records, and to indicate whether the environment is frozen
+    current_conda = _make_conda_prefix_rec("conda", "0.0.1")
+    newer_conda = _make_conda_prefix_rec("conda", "99.0.0")
+    conda_self = (
+        _make_conda_prefix_rec("conda-self", "1.0.0") if has_conda_self else None
+    )
+    mock_prefix_data = mocker.Mock()
+    mock_prefix_data.get.side_effect = lambda name, default=None: {
+        "conda": current_conda,
+        "conda-self": conda_self,
+    }.get(name, default)
+    mock_prefix_data.is_frozen.return_value = is_frozen
+    mocker.patch("conda.core.solve.PrefixData", return_value=mock_prefix_data)
+
+    # Setup SubdirData query to return a always newer version of conda
+    mocker.patch("conda.core.solve.SubdirData.query_all", return_value=[newer_conda])
+
+    solver = Solver(prefix="idontexist", channels=("test",))
+    solver._notify_conda_outdated(link_precs=())
+
+    err = capsys.readouterr().err
+    assert expected in err
+    assert unexpected not in err


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

With this change, the conda classic solver will suggest using `conda self` to update conda when is outdated (if conda self is installed). For example,

```
$ conda list | grep conda-self
conda-self                 0.2.0            py310h06a4308_0

$ CONDA_SOLVER=classic conda create -n test imagesize --dry-run  
Solving environment: done


==> WARNING: A newer version of conda exists. <==
  current version: 1.2.3
  latest version: 26.5.3

Please update conda by running

    $ conda self update
```

part of https://github.com/conda/conda/issues/16319

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
