### PR TITLE
Document and validate --console accepted values

### DIFF
--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -198,6 +198,7 @@ def add_parser_prefix_to_group(m: _MutuallyExclusiveGroup) -> None:
 
 
 def add_parser_json(p: ArgumentParser) -> _ArgumentGroup:
+    from ..base.context import context
     from ..common.constants import NULL
 
     output_and_prompt_options = p.add_argument_group(
@@ -212,6 +213,10 @@ def add_parser_json(p: ArgumentParser) -> _ArgumentGroup:
     output_and_prompt_options.add_argument(
         "--console",
         default=NULL,
+        action=LazyChoicesAction,
+        choices_func=lambda: sorted(
+            backend.name for backend in context.plugin_manager.get_reporter_backends()
+        ),
         help="Select the backend to use for normal output rendering.",
     )
     add_parser_verbose(output_and_prompt_options)

--- a/news/16418-console-choices
+++ b/news/16418-console-choices
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Document the accepted values of the `--console` flag in its `--help` output by listing the available reporter backends (e.g. `classic`, `json`), which are discovered dynamically so plugin-provided backends are included too. (#16418)
+*
 
 ### Deprecations
 

--- a/news/16418-console-choices
+++ b/news/16418-console-choices
@@ -1,0 +1,19 @@
+### Enhancements
+
+* `--console` now validates its value against the available reporter backends and rejects unknown ones with a clear error, instead of silently accepting any string. (#16418)
+
+### Bug fixes
+
+* Document the accepted values of the `--console` flag in its `--help` output by listing the available reporter backends (e.g. `classic`, `json`), which are discovered dynamically so plugin-provided backends are included too. (#16418)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -46,6 +46,19 @@ def test_parse_clobber(subtests: Subtests):
             assert args.clobber
 
 
+def test_console_accepts_known_backend():
+    p = generate_parser()
+    args = p.parse_args(["clean", "--console", "classic", "--all"])
+    assert args.console == "classic"
+
+
+def test_console_rejects_unknown_backend(capsys: CaptureFixture):
+    p = generate_parser()
+    with pytest.raises(SystemExit):
+        p.parse_args(["clean", "--console", "does-not-exist", "--all"])
+    assert "invalid choice: 'does-not-exist'" in capsys.readouterr().err
+
+
 def test_cli_args_as_strings(conda_cli: CondaCLIFixture):
     stdout, stderr, err = conda_cli("config", "--show", "add_anaconda_token")
     assert stdout


### PR DESCRIPTION
Closes #16418.

## Problem

The `--console` flag's `--help` only shows:

```
--console CONSOLE   Select the backend to use for normal output rendering.
```

There is no indication of which values are accepted or what each backend does, so users can't tell what to pass. On top of that, the flag silently accepts any string — an unknown backend just falls back to the default at runtime rather than being reported.

## Change

Attach the existing `LazyChoicesAction` to `--console`, with choices sourced from `context.plugin_manager.get_reporter_backends()`. This mirrors how `--solver` already works:

- `--help` now renders `--console {classic,json}`, listing the available reporter backends.
- An unknown value is rejected with the standard argparse-style error, e.g. `argument --console: invalid choice: 'bogus' (choose from 'classic', 'json')`.
- Choices are evaluated lazily, so backends contributed by plugins are included automatically rather than hard-coded.

Added two parser-level tests (`test_console_accepts_known_backend`, `test_console_rejects_unknown_backend`) and a `news/` entry.

## Testing note

Verified at the parser level (`generate_parser().parse_args(...)`): the two new tests pass, and `ruff check` / `ruff format` are clean. I wasn't able to bring up the full dev environment locally (the test conftest pulls in `xprocess` and a couple of other extras, and `menuinst` isn't installable on my host), so I've relied on CI to run the complete suite. The change is confined to argument parsing (no channel/solve/config behaviour), so the dev-container isolation the guide recommends shouldn't affect these tests — happy to adjust if CI surfaces anything.