### PR TITLE
docs: clarify that `--yes` forces environment creation over existing ones (#14608)

### DIFF
--- a/conda/cli/helpers.py
+++ b/conda/cli/helpers.py
@@ -241,7 +241,8 @@ def add_output_and_prompt_options(p: ArgumentParser) -> _ArgumentGroup:
         action="store_true",
         default=NULL,
         help="Sets any confirmation values to 'yes' automatically. "
-        "Users will not be asked to confirm any adding, deleting, backups, etc.",
+        "Users will not be asked to confirm any adding, deleting, backups, etc."
+        " Can also be used to force the creation of a new environment over an existing one.",
     )
     return output_and_prompt_options
 


### PR DESCRIPTION
### Description

Clarifies the `--yes` option help text to state that it can force creation of a new environment over an existing one.

Closes #14608.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] ~~Add / update necessary tests?~~ Not applicable; this is a help-text-only change.
- [x] Add / update outdated documentation?