### PR TITLE
Fix bare except clauses across multiple files

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -62,7 +62,7 @@ def is_active_prefix(prefix: str) -> bool:
 def arg2spec(arg: str, update: bool = False) -> str:
     try:
         spec = MatchSpec(arg)
-    except:
+    except Exception:
         from ..exceptions import CondaValueError
 
         raise CondaValueError(f"invalid package specification: {arg}")

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -1455,7 +1455,7 @@ def init_fish_user(
             rc_content = fh.read()
     except FileNotFoundError:
         rc_content = ""
-    except:
+    except Exception:
         raise
 
     rc_original_content = rc_content
@@ -1596,7 +1596,7 @@ def init_xonsh_user(
             rc_content = fh.read()
     except FileNotFoundError:
         rc_content = ""
-    except:
+    except Exception:
         raise
 
     rc_original_content = rc_content
@@ -1775,7 +1775,7 @@ def init_sh_user(
             rc_content = fh.read()
     except FileNotFoundError:
         rc_content = ""
-    except:
+    except Exception:
         raise
 
     rc_original_content = rc_content

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -314,7 +314,7 @@ class UnlinkLinkTransaction:
             if exceptions:
                 try:
                     maybe_raise(CondaMultiError(exceptions), context)
-                except:
+                except Exception:
                     rm_rf(self.transaction_context["temp_dir"])
                     raise
                 log.info(exceptions)

--- a/conda/core/portability.py
+++ b/conda/core/portability.py
@@ -405,7 +405,7 @@ def replace_long_shebang(mode: FileMode, data: bytes) -> bytes:
         if not isinstance(data, bytes):
             try:
                 data = bytes(data, encoding="utf-8")
-            except:
+            except Exception:
                 data = data.encode("utf-8")
 
         shebang_match = re.match(SHEBANG_REGEX, data, re.MULTILINE)

--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -55,7 +55,7 @@ def rmtree(path):
             out = check_output(
                 f'RD /S /Q "{path}" > NUL 2> NUL', shell=True, stderr=STDOUT
             )
-        except:
+        except Exception:
             try:
                 # Try to delete in Unicode
                 name = None
@@ -106,7 +106,7 @@ def rmtree(path):
     else:
         try:
             os.makedirs(".empty")
-        except:
+        except OSError:
             pass
         # yes, this looks strange.  See
         #    https://unix.stackexchange.com/a/79656/34459
@@ -259,7 +259,7 @@ def backoff_rmdir(dirpath, max_tries=MAX_TRIES):
 
     try:
         rmtree(dirpath)
-    except:
+    except OSError:
         # we don't really care about errors that much.  We'll catch remaining files
         #    with slower python logic.
         pass


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types to avoid accidentally catching `BaseException` subclasses like `KeyboardInterrupt` and `SystemExit`.

**Files changed:**
- `conda/gateways/disk/delete.py`: 3 fixes (`except Exception:`, `except OSError:`)
- `conda/cli/common.py`: 1 fix (`except Exception:`)
- `conda/core/portability.py`: 1 fix (`except Exception:`)
- `conda/core/initialize.py`: 3 fixes (`except Exception:`)
- `conda/core/link.py`: 1 fix (`except Exception:`)

This is a safe, non-breaking change — bare `except:` and `except Exception:` behave identically for all practical exception types; the difference is that bare `except:` also catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never the intent.