### PR TITLE
Show installer metadata in `conda info`

### DIFF
--- a/conda/cli/main_info.py
+++ b/conda/cli/main_info.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
 log = getLogger(__name__)
 
+INSTALLER_INFO_FIELDS = ("name", "version", "platform", "type")
+
 
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..common.constants import NULL
@@ -122,6 +124,29 @@ def get_user_site() -> list[str]:  # pragma: no cover
     except OSError as e:
         log.debug("Error accessing user site directory.\n%r", e)
     return site_dirs
+
+
+def get_installer_info(prefix: str) -> dict[str, str] | None:
+    """Read Constructor installer metadata from a prefix."""
+    from ..common.serialize.json import JSONDecodeError, read
+
+    path = join(prefix, ".installer.info")
+    try:
+        data = read(path=path)
+    except FileNotFoundError:
+        return None
+    except (JSONDecodeError, OSError, UnicodeDecodeError) as err:
+        log.debug("Unable to read installer metadata from %s: %s", path, err)
+        return None
+
+    if not isinstance(data, dict) or any(
+        not isinstance(data.get(field), str) or not data[field]
+        for field in INSTALLER_INFO_FIELDS
+    ):
+        log.debug("Ignoring invalid installer metadata in %s", path)
+        return None
+
+    return {field: data[field] for field in INSTALLER_INFO_FIELDS}
 
 
 IGNORE_FIELDS: set[str] = {"files", "auth", "preferred_env", "priority"}
@@ -276,6 +301,8 @@ def get_info_dict() -> dict[str, Any]:
         tmp_dir=gettempdir(),
         notices_cache_dir=str(get_notices_cache_dir()),
     )
+    if installer := get_installer_info(context.root_prefix):
+        info_dict["installer"] = installer
     if on_win:
         from ..common._os.windows import is_admin_on_windows
 
@@ -376,6 +403,12 @@ def get_main_info_display(info_dict: dict[str, Any]) -> dict[str, str]:
         )
         writable = "writable" if info_dict["root_writable"] else "read only"
         yield ("base environment", f"{info_dict['root_prefix']}  ({writable})")
+        if installer := info_dict.get("installer"):
+            yield (
+                "distribution",
+                f"{installer['name']} {installer['version']} "
+                f"({installer['type']}, {installer['platform']})",
+            )
         yield ("conda av data dir", info_dict["av_data_dir"])
         yield ("conda av metadata url", info_dict["av_metadata_url_base"])
         yield ("channel URLs", flatten(info_dict["channels"]))

--- a/news/16432-installer-info
+++ b/news/16432-installer-info
@@ -1,0 +1,11 @@
+### Enhancements
+
+* Show Constructor installer metadata in `conda info`. (#16432)
+
+### Bug fixes
+
+### Deprecations
+
+### Docs
+
+### Other

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -15,7 +15,7 @@ import pytest
 
 from conda.base.constants import PREFIX_FROZEN_FILE
 from conda.base.context import context
-from conda.cli.main_info import iter_info_components
+from conda.cli.main_info import get_installer_info, iter_info_components
 from conda.common.path import paths_equal
 from conda.core.envs_manager import list_all_known_prefixes
 from conda.core.prefix_data import PrefixData
@@ -162,6 +162,60 @@ def test_info_detail(conda_cli: CondaCLIFixture):
     assert DETAIL_KEYS <= set(parsed.keys())
     assert not stderr
     assert not err
+
+
+def test_info_installer(
+    conda_cli: CondaCLIFixture,
+    mocker: MockerFixture,
+) -> None:
+    installer = {
+        "name": "Miniconda3",
+        "version": "26.7.0",
+        "platform": "linux-64",
+        "type": "sh",
+    }
+    mocker.patch("conda.cli.main_info.get_installer_info", return_value=installer)
+
+    stdout, stderr, err = conda_cli("info")
+    assert "distribution : Miniconda3 26.7.0 (sh, linux-64)" in stdout
+    assert not stderr
+    assert not err
+
+    stdout, stderr, err = conda_cli("info", "--json")
+    assert json.loads(stdout)["installer"] == installer
+    assert not stderr
+    assert not err
+
+
+def test_get_installer_info(tmp_path: Path) -> None:
+    installer = {
+        "name": "Miniconda3",
+        "version": "26.7.0",
+        "platform": "linux-64",
+        "type": "sh",
+    }
+    Path(tmp_path, ".installer.info").write_text(json.dumps(installer))
+
+    assert get_installer_info(str(tmp_path)) == installer
+
+
+def test_get_installer_info_missing(tmp_path: Path) -> None:
+    assert get_installer_info(str(tmp_path)) is None
+
+
+@pytest.mark.parametrize(
+    "contents",
+    (
+        "not json",
+        "[]",
+        '{"name": "Miniconda3"}',
+        '{"name": "Miniconda3", "version": 1, "platform": "linux-64", "type": "sh"}',
+    ),
+)
+def test_get_installer_info_invalid(tmp_path: Path, contents: str) -> None:
+    Path(tmp_path, ".installer.info").write_text(contents)
+
+    assert get_installer_info(str(tmp_path)) is None
 
 
 # conda info --all [--json]


### PR DESCRIPTION
### Description

Read Constructor's `$ROOT_PREFIX/.installer.info` metadata when it is present.

Normal `conda info` output gains one concise distribution line. JSON output gains a nested `installer` object with the installer name, version, platform, and type. Missing or malformed metadata leaves existing output unchanged.

Closes #16432.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~