### PR TITLE
Fix timeout() leaving SIGALRM armed on unexpected exceptions

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -473,15 +473,19 @@ def timeout(
         def interrupt(signum, frame):
             raise TimeoutException()
 
-        signal.signal(signal.SIGALRM, interrupt)
+        previous_handler = signal.signal(signal.SIGALRM, interrupt)
         signal.alarm(timeout_secs)
 
         try:
-            ret = func(*args, **kwargs)
-            signal.alarm(0)
-            return ret
+            return func(*args, **kwargs)
         except (TimeoutException, KeyboardInterrupt):  # pragma: no cover
             return default_return
+        finally:
+            # Always cancel the alarm and restore the previous handler, even if
+            # func() raised an unexpected exception; otherwise the alarm stays
+            # armed and can later fire during unrelated code. See #15702.
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, previous_handler)
 
 
 def _load_concurrency() -> None:

--- a/news/15702-timeout-sigalrm-leak
+++ b/news/15702-timeout-sigalrm-leak
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `conda.common.io.timeout()` leaving the `SIGALRM` alarm armed (and the previous signal handler unrestored) when the wrapped callable raised an unexpected exception, which could cause the alarm to fire later during unrelated code. The alarm is now always cancelled and the previous handler restored via a `finally` block. (#15702)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -143,3 +143,40 @@ def test_deprecations(function: str, raises: type[Exception] | None) -> None:
     raises_context = pytest.raises(raises) if raises else nullcontext()
     with pytest.deprecated_call(), raises_context:
         getattr(io, function)()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="timeout() uses SIGALRM (Unix only)"
+)
+def test_timeout_returns_value():
+    assert io.timeout(5, lambda: "ok") == "ok"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="timeout() uses SIGALRM (Unix only)"
+)
+def test_timeout_cleans_up_after_unexpected_exception():
+    """
+    If the callable raises an unexpected (non-timeout) exception, timeout()
+    must still cancel the alarm and restore the previous SIGALRM handler
+    instead of leaving the alarm armed. See
+    https://github.com/conda/conda/issues/15702.
+    """
+    import signal
+
+    def sentinel(signum, frame): ...
+
+    previous = signal.signal(signal.SIGALRM, sentinel)
+    try:
+
+        def boom():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError):
+            io.timeout(5, boom)
+
+        # the alarm must be cancelled (0 seconds remaining)
+        assert signal.alarm(0) == 0
+        assert signal.getsignal(signal.SIGALRM) is sentinel
+    finally:
+        signal.signal(signal.SIGALRM, previous)


### PR DESCRIPTION
Closes #15702.

## Problem

`conda.common.io.timeout()` arms a `SIGALRM` alarm, then only cancels it (`signal.alarm(0)`) when the wrapped callable returns normally:

```python
signal.signal(signal.SIGALRM, interrupt)
signal.alarm(timeout_secs)
try:
    ret = func(*args, **kwargs)
    signal.alarm(0)          # only reached on success
    return ret
except (TimeoutException, KeyboardInterrupt):
    return default_return
```

If `func()` raises any *other* exception, the alarm stays armed and later fires during unrelated code — surfacing as a spurious `TimeoutException` far from its origin (the symptom reported in #15702). The original `SIGALRM` handler is also never restored.

## Fix

Move the cleanup into a `finally` block that always cancels the alarm and restores the previously installed handler.

## Tests

Added `test_io.py` tests: one for the normal return value, and one asserting that after the callable raises an unexpected exception the alarm is cancelled and the previous handler is restored (Unix-only, since `timeout()` uses `SIGALRM`). Verified the test fails against the current code and passes with the fix.

## Note

Verified in isolation and with `ruff`; I couldn't run the full suite locally (the test conftest pulls in extras like `flask`/`xprocess`), so I've relied on CI for the complete run.