### PR TITLE
Add EnvironmentConfig.get_channel name-based lookup

### DIFF
--- a/conda/models/environment.py
+++ b/conda/models/environment.py
@@ -18,6 +18,7 @@ from ..core.prefix_data import PrefixData
 from ..exceptions import CondaValueError, PlatformMismatchError
 from ..history import History
 from ..misc import get_package_records_from_explicit
+from .channel import Channel
 from .match_spec import MatchSpec
 
 if TYPE_CHECKING:
@@ -75,6 +76,26 @@ class EnvironmentConfig:
     update_modifier: UpdateModifier | None = None
 
     use_only_tar_bz2: bool | None = None
+
+    def get_channel(self, name: str) -> str | None:
+        """
+        **Experimental** While experimental, expect both major and minor changes across minor releases.
+
+        Look up a configured channel by its canonical name.
+
+        ``channels`` is an ordered sequence of channel references stored exactly as
+        configured (a channel name such as ``"conda-forge"`` or a URL such as
+        ``"https://conda.anaconda.org/conda-forge"``). This resolves each entry to a
+        :class:`~conda.models.channel.Channel` and compares its
+        :attr:`~conda.models.channel.Channel.canonical_name` against ``name``.
+
+        Returns the first matching entry in configured order, preserving the original
+        configured value, or ``None`` when no configured channel resolves to ``name``.
+        """
+        for channel in self.channels:
+            if Channel.from_value(channel).canonical_name == name:
+                return channel
+        return None
 
     def _append_without_duplicates(
         self, first: Iterable[T], second: Iterable[T]

--- a/news/16351-environmentconfig-get-channel
+++ b/news/16351-environmentconfig-get-channel
@@ -1,0 +1,21 @@
+### Enhancements
+
+* Add `EnvironmentConfig.get_channel(name)`, a helper that looks up a configured
+  channel by its `canonical_name` and returns the value as stored (name or URL),
+  preserving configured order and returning `None` when there is no match. (#16351)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -612,6 +612,41 @@ def test_environment_config_channels_basic():
     assert len(env_config.channels) == 2
 
 
+def test_get_channel_matches_by_canonical_name():
+    """`get_channel` returns the configured channel whose canonical name matches."""
+    config = EnvironmentConfig(channels=("conda-forge", "defaults"))
+    assert config.get_channel("conda-forge") == "conda-forge"
+    assert config.get_channel("defaults") == "defaults"
+
+
+def test_get_channel_no_match_returns_none():
+    """`get_channel` returns None when no configured channel matches (incl. empty)."""
+    config = EnvironmentConfig(channels=("conda-forge", "defaults"))
+    assert config.get_channel("conda-pypi") is None
+    assert EnvironmentConfig().get_channel("conda-forge") is None
+
+
+def test_get_channel_returns_first_match_in_order():
+    """When several entries share a canonical name, the first configured one wins.
+
+    Both entries resolve to canonical name "conda-forge"; the URL form is listed
+    first, so it is returned as stored, confirming order is preserved.
+    """
+    config = EnvironmentConfig(
+        channels=("https://conda.anaconda.org/conda-forge", "conda-forge")
+    )
+    assert config.get_channel("conda-forge") == "https://conda.anaconda.org/conda-forge"
+
+
+def test_get_channel_matches_url_by_canonical_name():
+    """A URL-form channel is matched by its canonical name and returned verbatim."""
+    config = EnvironmentConfig(
+        channels=("defaults", "https://conda.anaconda.org/conda-forge")
+    )
+    assert config.get_channel("conda-forge") == "https://conda.anaconda.org/conda-forge"
+    assert config.get_channel("defaults") == "defaults"
+
+
 def test_from_cli_empty():
     env = Environment.from_cli(
         SimpleNamespace(name=None, packages=[], file=[]),


### PR DESCRIPTION
### Description

Adds `EnvironmentConfig.get_channel(name)`, the name-based channel lookup requested in #16351. `channels` is an ordered list stored as configured (a name or a URL), and looking one up by canonical name currently needs a manual scan. This returns the first configured channel whose `Channel.canonical_name` matches `name` (preserving order, returning the value as stored, `None` if absent), reusing conda's existing `Channel` machinery rather than reimplementing parsing.

On the API shape: @jezdez noted it needn't be `dict.get`, so I added a method on `EnvironmentConfig` (matching the existing `from_context` / `from_cli_channels` accessor style) rather than making `channels` a custom tuple subclass, which would ripple through equality, the merge dedup, and serialization. Happy to move it to a `channels`-level helper if you'd prefer.

Note: canonical-name resolution is context-dependent (channel_alias / custom_channels), so matching is by canonical identity, not string equality — documented in the docstring.

### Checklist - did you ...

- [x] Add a file to the `news` directory — `news/16351-environmentconfig-get-channel`
- [x] Add / update necessary tests? — 4 table cases in `tests/models/test_environment.py` (canonical match, no-match, order preserved, URL-form matched by canonical name)
- [ ] Add / update outdated documentation? — n/a, the method is marked experimental and documents itself

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Verified with `pytest tests/models/test_environment.py -k get_channel` (4 passed) and `ruff check`.*
