### PR TITLE
fix: use IEC binary prefixes (KiB, MiB, GiB) in human_bytes()

### DIFF
--- a/conda/utils.py
+++ b/conda/utils.py
@@ -30,28 +30,28 @@ def human_bytes(n):
     """
     Return the number of bytes n in more human readable form.
 
-    Note: Uses SI prefixes (KB, MB, GB) instead of binary prefixes (KiB, MiB, GiB).
+    Uses IEC binary prefixes (KiB, MiB, GiB) for base-2 units.
 
     Examples:
         >>> human_bytes(42)
         '42 B'
         >>> human_bytes(1042)
-        '1 KB'
+        '1 KiB'
         >>> human_bytes(10004242)
-        '9.5 MB'
+        '9.5 MiB'
         >>> human_bytes(100000004242)
-        '93.13 GB'
+        '93.13 GiB'
     """
     if n < 1024:
         return "%d B" % n
     k = n / 1024
     if k < 1024:
-        return "%d KB" % round(k)
+        return "%d KiB" % round(k)
     m = k / 1024
     if m < 1024:
-        return f"{m:.1f} MB"
+        return f"{m:.1f} MiB"
     g = m / 1024
-    return f"{g:.2f} GB"
+    return f"{g:.2f} GiB"
 
 
 # ##########################################

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -737,13 +737,13 @@ def test_env_list_size(conda_cli: CondaCLIFixture):
     # regex to match: <any prefix stuff> <number> <unit> <path>
     # The path is at the end of the line.
     pattern = re.compile(
-        r"\s+(?P<size>\d+(\.\d+)?)\s+(?P<unit>B|KB|MB|GB)\s+(?P<path>.*)$"
+        r"\s+(?P<size>\d+(\.\d+)?)\s+(?P<unit>B|KiB|MiB|GiB)\s+(?P<path>.*)$"
     )
 
     for line in non_comment_lines:
         match = pattern.search(line)
         assert match, f"Line did not match size pattern: {line}"
-        assert match.group("unit") in ["B", "KB", "MB", "GB"]
+        assert match.group("unit") in ["B", "KiB", "MiB", "GiB"]
 
 
 def test_env_list_size_json(conda_cli: CondaCLIFixture):

--- a/tests/cli/test_main_info.py
+++ b/tests/cli/test_main_info.py
@@ -255,13 +255,13 @@ def test_info_envs_size(conda_cli: CondaCLIFixture):
     # regex to match: <any prefix stuff> <number> <unit> <path>
     # The path is at the end of the line.
     pattern = re.compile(
-        r"\s+(?P<size>\d+(\.\d+)?)\s+(?P<unit>B|KB|MB|GB)\s+(?P<path>.*)$"
+        r"\s+(?P<size>\d+(\.\d+)?)\s+(?P<unit>B|KiB|MiB|GiB)\s+(?P<path>.*)$"
     )
 
     for line in non_comment_lines:
         match = pattern.search(line)
         assert match, f"Line did not match size pattern: {line}"
-        assert match.group("unit") in ["B", "KB", "MB", "GB"]
+        assert match.group("unit") in ["B", "KiB", "MiB", "GiB"]
 
 
 def test_info_envs_size_json(conda_cli: CondaCLIFixture):

--- a/tests/cli/test_main_list.py
+++ b/tests/cli/test_main_list.py
@@ -347,7 +347,7 @@ def test_list_size(
         for line in package_lines:
             # Size should be the last column
             assert any(
-                line.strip().endswith(suffix) for suffix in ("B", "KB", "MB", "GB")
+                line.strip().endswith(suffix) for suffix in ("B", "KiB", "MiB", "GiB")
             )
 
 
@@ -405,4 +405,4 @@ def test_list_size_empty_paths_data(
         assert pkg_line is not None
 
         assert "0 B" not in pkg_line
-        assert pkg_line.strip().endswith(("B", "KB", "MB", "GB"))
+        assert pkg_line.strip().endswith(("B", "KiB", "MiB", "GiB"))


### PR DESCRIPTION
## Summary

Switch `human_bytes()` from non-standard KB/MB/GB prefixes to IEC standard KiB/MiB/GiB prefixes.

## Background

The `human_bytes()` function in `conda/utils.py` uses base-2 arithmetic (1024 divisions) but outputs non-standard prefixes (`KB`, `MB`, `GB`). These are neither SI (kB, MB, GB = base-10) nor IEC (KiB, MiB, GiB = base-2) standard prefixes.

Since the computation is base-2, the correct standard is IEC binary prefixes.

## Changes

- **`conda/utils.py`**: Updated `human_bytes()` to output `KiB`, `MiB`, `GiB` instead of `KB`, `MB`, `GB`. Updated docstring examples accordingly.
- **`tests/cli/test_env.py`**: Updated regex and assertion to match new IEC prefixes.
- **`tests/cli/test_main_info.py`**: Updated regex and assertion to match new IEC prefixes.
- **`tests/cli/test_main_list.py`**: Updated suffix checks to match new IEC prefixes.

## Test Plan

- [x] No behavior change — only the unit label string changes; the numeric values and rounding are identical
- [x] All existing tests should pass (assertions updated to match new output format)

Fixes #12263
