### PR TITLE
Correct deprecation schedules for 26.7

### DIFF
--- a/conda/common/io.py
+++ b/conda/common/io.py
@@ -576,8 +576,8 @@ def __getattr__(name: str):
 
 
 deprecated.constant(
-    "26.9",
     "27.3",
+    "27.9",
     "IS_INTERACTIVE",
     hasattr(sys.stdout, "isatty") and sys.stdout.isatty(),
     addendum="Use `conda.common.terminal.is_tty()` instead.",

--- a/conda/common/serialize/yaml.py
+++ b/conda/common/serialize/yaml.py
@@ -151,8 +151,8 @@ def __getattr__(name: str) -> Any:
 # access. Passing ``factory=`` defers ``_representer()`` (which imports
 # ``ruamel.yaml``) until the deprecated symbol is actually used.
 deprecated.constant(
-    "26.9",
     "27.3",
+    "27.9",
     "CondaYAMLRepresenter",
     factory=_representer,
     addendum=(

--- a/news/15867-lazy-ruamel-yaml
+++ b/news/15867-lazy-ruamel-yaml
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Mark `conda.common.serialize.yaml.CondaYAMLRepresenter` as pending deprecation (removal in 27.3). The class is still importable via a lazy module-level `__getattr__` but accessing it now emits a `PendingDeprecationWarning`. External consumers should use `conda.common.serialize.yaml.write`/`read` or subclass `ruamel.yaml.representer.RoundTripRepresenter` directly. (#15867)
+* Mark `conda.common.serialize.yaml.CondaYAMLRepresenter` as pending deprecation (removal in 27.9). The class is still importable via a lazy module-level `__getattr__` but accessing it now emits a `PendingDeprecationWarning`. External consumers should use `conda.common.serialize.yaml.write`/`read` or subclass `ruamel.yaml.representer.RoundTripRepresenter` directly. (#15867)
 
 ### Docs
 

--- a/news/15943-no-color-force-color-term-dumb
+++ b/news/15943-no-color-force-color-term-dumb
@@ -9,7 +9,7 @@
 
 ### Deprecations
 
-* Deprecate `conda.common.io.IS_INTERACTIVE` (pending removal in 27.3). Use `conda.common.terminal.is_tty()` instead. (#15943)
+* Deprecate `conda.common.io.IS_INTERACTIVE` (pending removal in 27.9). Use `conda.common.terminal.is_tty()` instead. (#15943)
 
 ### Docs
 

--- a/news/16320-solver-prep-basesolver
+++ b/news/16320-solver-prep-basesolver
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Mark `conda.exports.Solver` as pending deprecation to be removed in 27.3. Use `conda.core.solve.Solver` instead. (#16320)
+* Mark `conda.exports.Solver` as pending deprecation to be removed in 27.9. Use `conda.core.solve.Solver` instead. (#16320)
 
 ### Docs
 

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -141,7 +141,7 @@ def test_thread_limited_executor_handles_thread_limit(
 )
 def test_deprecations(function: str, raises: type[Exception] | None) -> None:
     raises_context = pytest.raises(raises) if raises else nullcontext()
-    with pytest.deprecated_call(), raises_context:
+    with pytest.deprecated_call(match=rf"{function}.*27\.9"), raises_context:
         getattr(io, function)()
 
 

--- a/tests/common/test_yaml_deferred_imports.py
+++ b/tests/common/test_yaml_deferred_imports.py
@@ -66,7 +66,7 @@ def test_yaml_error_accessible() -> None:
 
 def test_conda_yaml_representer_is_deprecated() -> None:
     """Accessing the legacy module-level class emits a deprecation warning."""
-    with pytest.deprecated_call(match="CondaYAMLRepresenter"):
+    with pytest.deprecated_call(match=r"CondaYAMLRepresenter.*27\.9"):
         cls = yaml.CondaYAMLRepresenter
 
     assert cls is not None


### PR DESCRIPTION
### Description

Correct the pending deprecation schedules for `CondaYAMLRepresenter` and `IS_INTERACTIVE`. Both first ship in 26.7, so the documented schedule places active deprecation in 27.3 and removal in 27.9.

Align the affected news fragments, including the existing `conda.exports.Solver` removal date.

Xref #16275

### Checklist - did you ...

- [x] Add or update the news fragments for the next release
- [x] Add or update necessary tests
- [x] Confirm no documentation update is needed