### PR TITLE
Fix NameError: name 'json' is not defined in auxlib/logz.py

### DIFF
--- a/conda/auxlib/logz.py
+++ b/conda/auxlib/logz.py
@@ -1,3 +1,4 @@
+import json
 from itertools import islice
 from logging import getLogger, INFO, Formatter, StreamHandler, DEBUG
 from sys import stderr

--- a/news/16446-missing-json-logz
+++ b/news/16446-missing-json-logz
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Fix `NameError: name 'json' is not defined` in `conda.auxlib.logz.stringify` when debug-logging an HTTP response with `Content-Type: application/json`; regression introduced by #15926. (#16446)

--- a/news/16446-missing-json-logz
+++ b/news/16446-missing-json-logz
@@ -1,3 +1,5 @@
 ### Bug fixes
 
-* Fix `NameError: name 'json' is not defined` in `conda.auxlib.logz.stringify` when debug-logging an HTTP response with `Content-Type: application/json`; regression introduced by #15926. (#16446)
+* Fix `NameError: name 'json' is not defined` in `conda.auxlib.logz.stringify`
+  when logging an HTTP response with `Content-Type: application/json`. This was
+  a regression introduced by #15926. (#16446)

--- a/news/missing-json-logz.md
+++ b/news/missing-json-logz.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-* Fix `NameError: name 'json' is not defined` in `conda.auxlib.logz.stringify` when debug-logging an HTTP response with `Content-Type: application/json`; regression introduced by #15926. (#missing-json)

--- a/news/missing-json-logz.md
+++ b/news/missing-json-logz.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Fix `NameError: name 'json' is not defined` in `conda.auxlib.logz.stringify` when debug-logging an HTTP response with `Content-Type: application/json`; regression introduced by #15926. (#missing-json)

--- a/tests/auxlib/test_logz.py
+++ b/tests/auxlib/test_logz.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+from conda.auxlib.logz import stringify
+
+
+class _FakePreparedRequest:
+    method = "GET"
+    path_url = "/api/endpoint"
+    url = "https://example.com/api/endpoint"
+    headers = {}
+    body = None
+
+
+_FakePreparedRequest.__name__ = "PreparedRequest"
+_FakePreparedRequest.__module__ = "requests.models"
+
+
+class _FakeResponse:
+    url = "https://example.com/api/endpoint"
+    status_code = 200
+    reason = "OK"
+    elapsed = timedelta(milliseconds=110)
+    request = _FakePreparedRequest()
+
+
+_FakeResponse.__name__ = "Response"
+_FakeResponse.__module__ = "requests.models"
+
+
+def test_stringify_json_response_no_truncation():
+    """Regression: json.loads/json.dumps in stringify must not raise NameError."""
+    response = _FakeResponse()
+    response.headers = {"Content-Type": "application/json"}
+    response.text = '{"key": "value"}'
+    # content_max_len > len(text) triggers the json.loads/json.dumps path
+    result = stringify(response, content_max_len=1000)
+    assert result is not None
+    assert "key" in result
+
+
+def test_stringify_json_response_truncation():
+    """The text-truncation branch (len > content_max_len) skips json.loads and works."""
+    response = _FakeResponse()
+    response.headers = {"Content-Type": "application/json"}
+    response.text = '{"key": "value"}'
+    # content_max_len < len(text) takes the direct-truncation path (no json.loads)
+    result = stringify(response, content_max_len=5)
+    assert result is not None
+    assert '{"key' in result
+
+
+def test_stringify_no_content_max_len():
+    """With content_max_len=0 (default), the response body is omitted entirely."""
+    response = _FakeResponse()
+    response.headers = {"Content-Type": "application/json"}
+    response.text = '{"key": "value"}'
+    result = stringify(response, content_max_len=0)
+    assert result is not None
+    assert "key" not in result

--- a/tests/auxlib/test_logz.py
+++ b/tests/auxlib/test_logz.py
@@ -2,63 +2,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import json
-from datetime import timedelta
+from requests import Request, Response
 
 from conda.auxlib.logz import stringify
 
 
-class _FakePreparedRequest:
-    method = "GET"
-    path_url = "/api/endpoint"
-    url = "https://example.com/api/endpoint"
-    headers = {}
-    body = None
+def test_stringify_json_response():
+    request = Request("GET", "https://example.com/api/endpoint").prepare()
+    response = Response()
+    response.request = request
+    response.url = request.url
+    response.status_code = 200
+    response.reason = "OK"
+    response.headers["Content-Type"] = "application/json"
+    response._content = b'{"key": "value"}'
 
-
-_FakePreparedRequest.__name__ = "PreparedRequest"
-_FakePreparedRequest.__module__ = "requests.models"
-
-
-class _FakeResponse:
-    url = "https://example.com/api/endpoint"
-    status_code = 200
-    reason = "OK"
-    elapsed = timedelta(milliseconds=110)
-    request = _FakePreparedRequest()
-
-
-_FakeResponse.__name__ = "Response"
-_FakeResponse.__module__ = "requests.models"
-
-
-def test_stringify_json_response_no_truncation():
-    """Regression: json.loads/json.dumps in stringify must not raise NameError."""
-    response = _FakeResponse()
-    response.headers = {"Content-Type": "application/json"}
-    response.text = '{"key": "value"}'
-    # content_max_len > len(text) triggers the json.loads/json.dumps path
     result = stringify(response, content_max_len=1000)
+
     assert result is not None
-    assert "key" in result
-
-
-def test_stringify_json_response_truncation():
-    """The text-truncation branch (len > content_max_len) skips json.loads and works."""
-    response = _FakeResponse()
-    response.headers = {"Content-Type": "application/json"}
-    response.text = '{"key": "value"}'
-    # content_max_len < len(text) takes the direct-truncation path (no json.loads)
-    result = stringify(response, content_max_len=5)
-    assert result is not None
-    assert '{"key' in result
-
-
-def test_stringify_no_content_max_len():
-    """With content_max_len=0 (default), the response body is omitted entirely."""
-    response = _FakeResponse()
-    response.headers = {"Content-Type": "application/json"}
-    response.text = '{"key": "value"}'
-    result = stringify(response, content_max_len=0)
-    assert result is not None
-    assert "key" not in result
+    assert '{"key": "value"}' in result


### PR DESCRIPTION
### Description

Fixes regression introduced by #15926. That PR removed the eager import of
`conda.common.serialize.json` from `conda/auxlib/logz.py` to keep `frozendict`
off the cold-start path. Two `json.loads` and `json.dumps` calls inside
`stringify()` were left unchanged.

Fixes missing imports by importing the standard library `json` module.

Supersedes #16264, which fixes the same regression by invoking the lazy conda
serializer.

### Checklist - did you ...

- [x] Add a file to the news directory (using the template) for the next
  release's release notes?
- [x] Add / update necessary tests?
- [] ~Add / update outdated documentation?~
