### PR TITLE
Remove stale conda-verify guidance from configuration docs

### DIFF
--- a/docs/source/user-guide/configuration/settings.rst
+++ b/docs/source/user-guide/configuration/settings.rst
@@ -850,8 +850,8 @@ with the following config entry:
 ``no_verify``: Disable recipe and package verification (conda-build 3.0+)
 -------------------------------------------------------------------------
 
-By default, conda-build uses conda-verify to ensure that your recipe
-and package meet some minimum sanity checks. You can disable these:
+By default, conda-build enables optional recipe and package verification.
+You can disable it:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Describe conda-build recipe and package verification as optional without recommending `conda-verify`.

Closes #16450

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
