### PR TITLE
Fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_speed_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/2_speed_improvement.yml
@@ -30,7 +30,7 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: What oepration was taking a long time, and how long do you think it should have taken? Are there any other comparable tools you are basing this on?
+      description: What operation was taking a long time, and how long do you think it should have taken? Are there any other comparable tools you are basing this on?
       placeholder: I was trying to export an environment to a file. I was expecting it to be done within 60 seconds. Using the "conda env export --file SOME_FILE" command
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1340,7 +1340,7 @@ Following feedback from conda users about the pre-configuration of the conda cod
 
 In the future, we will rely on providers of conda distributions, such as [miniforge](https://github.com/conda-forge/miniforge) or Anaconda (including miniconda), to pre-configure their preferred channels, e.g. by running the necessary ``conda config --set channels`` command.
 
-We're also going to continue to [work on improving channel management](https://github.com/conda/conda/issues/14217) in the forseeable future and would love to get your feedback.
+We're also going to continue to [work on improving channel management](https://github.com/conda/conda/issues/14217) in the foreseeable future and would love to get your feedback.
 
 ### Enhancements
 
@@ -1488,7 +1488,7 @@ We're also going to continue to [work on improving channel management](https://g
 
 ### Other
 
-* Update `xonsh` support to accomodate deprecated import path. (#14047)
+* Update `xonsh` support to accommodate deprecated import path. (#14047)
 
 ### Contributors
 
@@ -1842,7 +1842,7 @@ command line interface related to environment management. (#13168)
 * Provide a more useful warning when attempting to rename a non-existent prefix. (#13387)
 * Add a new flag `--keep-env` to be used with `conda remove --all`. It allows users to delete all packages in the environment while retaining the environment itself. (#13419)
 * Add a Y/N prompt warning users that `conda env remove` and `conda remove --all` deletes not only the conda packages but the entirety of the specified environment. (#13440)
-* Add `--repodata-use-zst/--no-repodata-use-zst` flag to control `repodata.json.zst` check; corresponding `repodata_use_zst: true/false` for `.condarc`. Default is to check for `repodata.json.zst`. Disable if remote returns unparseable `repodata.json.zst` instead of correct data or 404. (#13504)
+* Add `--repodata-use-zst/--no-repodata-use-zst` flag to control `repodata.json.zst` check; corresponding `repodata_use_zst: true/false` for `.condarc`. Default is to check for `repodata.json.zst`. Disable if remote returns unparsable `repodata.json.zst` instead of correct data or 404. (#13504)
 
 
 ### Bug fixes
@@ -3568,7 +3568,7 @@ Please read that CEP for more information, but here is a quick synopsis. We hope
 
 ### Docs
 
-* removeed references to MD5s from docs (#9247)
+* removed references to MD5s from docs (#9247)
 * Add docs on `CONDA_DLL_SEARCH_MODIFICATION_ENABLED` (#9286)
 * document threads, spec history and configuration (#9327)
 * more documentation on channels (#9335)
@@ -5048,7 +5048,7 @@ will make sure that whenever conda is installed or changed in an environment, th
 * fix #6181 keep existing pythons pinned to minor version (4.4.0rc2) (#6363)
 * fix #6201 incorrect subdir shown for conda search when package not found (4.4.0rc2) (#6367)
 * fix #6045 help message and zsh shift (4.4.0rc3) (#6368)
-* fix noarch python package resintall (4.4.0rc3) (#6394)
+* fix noarch python package reinstall (4.4.0rc3) (#6394)
 * fix #6366 shell activation message (4.4.0rc3) (#6369)
 * fix #6429 AttributeError on 'conda remove' (4.4.0rc3) (#6434)
 * fix #6449 problems with 'conda info --envs' (#6451)
@@ -5271,7 +5271,7 @@ will make sure that whenever conda is installed or changed in an environment, th
 ### Non-User-Facing Changes
 * test conda 4.3 with requests 2.14.2 (#5281)
 * remove pycrypto as requirement on windows (#5325)
-* fix typo avaialble -> available (#5345)
+* fix typo (#5345)
 * fix test failures related to menuinst update (#5344, #5362)
 
 

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -62,7 +62,7 @@ ZSTD_MAX_SHARD_INDEX_SIZE = (
 
 # For reference, the largest shard "conda-forge/linux-64/vim" is 2608283 bytes
 # or < 2**19*5 decompressed (486155 bytes compressed); the index is 575219 bytes
-# decompressed (514039 bytes compressed) and is mostly uncompressible hash data.
+# decompressed (514039 bytes compressed) and is mostly incompressible hash data.
 
 
 class ShardFetch:

--- a/conda/_private/shards/subset.py
+++ b/conda/_private/shards/subset.py
@@ -578,7 +578,7 @@ def build_repodata_subset(
         spec_to_package_name_func: callable to convert package specs to names.
                                    Defaults to the standard spec_to_package_name.
         repodata_version: repodata format version (1 = classic, 3 = v3).
-        depth: the maximum depth of dependant packages to include in the repodata
+        depth: the maximum depth of dependent packages to include in the repodata
                subset.
     Return:
         None if there are no shards available, or a mapping of channel URL's to

--- a/conda/auxlib/entity.py
+++ b/conda/auxlib/entity.py
@@ -801,7 +801,7 @@ class Entity(metaclass=EntityType):
 
         Args:
             cls(:class:`Entity` subclass): The class to create, usually determined by call, e.g. ``PrefixRecord.from_objects(...)``.
-            *objects(tuple(object or dict)): Any combination of objects and dicts in order of decending precedence.
+            *objects(tuple(object or dict)): Any combination of objects and dicts in order of descending precedence.
             **override_fields(dict(str, object)): Any individual fields overriding possible contents from ``*objects``.
         """
         init_vars = {}

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -692,7 +692,7 @@ class Context(Configuration):
     @property
     def fetch_threads(self) -> int | None:
         """
-        If both are not overriden (0), return experimentally-determined value of 5
+        If both are not overridden (0), return experimentally-determined value of 5
         """
         if self._fetch_threads == 0 and self._default_threads == 0:
             return 5

--- a/conda/cli/main_update.py
+++ b/conda/cli/main_update.py
@@ -101,7 +101,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
             file=sys.stderr,
         )
 
-    # Ensure provided combination of command line argments are valid
+    # Ensure provided combination of command line arguments are valid
     # One of --file or packages or --update-all must be specified
     if not (
         args.file

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -43,7 +43,7 @@ class Index(UserDict):
     Channels
         represent packages available from standard sources identified with a url, mostly online,
         but can also be on a local filesystem using the ``file://`` scheme.
-        Programatically, channels are represented by :class:`conda.models.channel.Channel`, their data
+        Programmatically, channels are represented by :class:`conda.models.channel.Channel`, their data
         is fetched using :class:`conda.core.subdir_data.SubdirData`.
 
         For more information see :ref:`concepts-channels`.

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -1225,7 +1225,7 @@ def install_anaconda_prompt(target_path, conda_prefix, reverse):
     if not context.dry_run:
         create_shortcut(
             "%windir%\\System32\\cmd.exe",
-            "Anconda Prompt",
+            "Anaconda Prompt",
             "" + target_path,
             " ".join(args),
             "" + expanduser("~"),

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -1066,7 +1066,7 @@ def do_cache_action(prec, cache_action, progress_bar, download_total=1.0, *, can
         def progress_update_cache_action(pct_completed):
             if cancelled():
                 """
-                Used to cancel dowload threads when parent thread is interrupted.
+                Used to cancel download threads when parent thread is interrupted.
                 """
                 raise CancelledError()
             progress_bar.update_to(pct_completed * download_total)

--- a/conda/core/subdir_data.py
+++ b/conda/core/subdir_data.py
@@ -269,7 +269,7 @@ class SubdirData(metaclass=SubdirDataType):
         # disallow None (typing)
         self.url_w_subdir = self.channel.url(with_credentials=False) or ""
         self.url_w_credentials = self.channel.url(with_credentials=True) or ""
-        # these can be overriden by repodata.json v2
+        # these can be overridden by repodata.json v2
         self._base_url = self.url_w_subdir
         self._base_url_w_credentials = self.url_w_credentials
         # whether or not to try using the new, trimmed-down repodata

--- a/conda/gateways/disk/lock.py
+++ b/conda/gateways/disk/lock.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """
 Record locking to manage potential repodata / repodata metadata file contention
-between conda processes. Try to acquire a lock on a single byte in the metadat
+between conda processes. Try to acquire a lock on a single byte in the metadata
 file; modify both files; then release the lock.
 """
 
@@ -51,7 +51,7 @@ except ImportError:
     try:
         import fcntl
     except ImportError:  # pragma: no cover
-        # "fcntl Availibility: not Emscripten, not WASI."
+        # "fcntl Availability: not Emscripten, not WASI."
         warnings.warn("file locking not available")
 
         _lock_impl = _lock_noop  # type: ignore

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -75,7 +75,7 @@ CACHE_CONTROL_KEY = "cache_control"
 URL_KEY = "url"
 CACHE_STATE_SUFFIX = ".info.json"
 
-# show some unparseable json in error
+# show some unparsable json in error
 ERROR_SNIPPET_LENGTH = 32
 
 
@@ -648,7 +648,7 @@ class RepodataCache:
         if target is None:
             target = self.cache_path_json
         with self.lock() as state_file:
-            # "a+" creates the file if necessary, does not trunctate file.
+            # "a+" creates the file if necessary, does not truncate file.
             state_file.seek(0)
             state_file.truncate()
             stat = temp_path.stat()
@@ -670,7 +670,7 @@ class RepodataCache:
         """
         # Note this is not thread-safe.
         with self.lock() as state_file:
-            # "a+" creates the file if necessary, does not trunctate file.
+            # "a+" creates the file if necessary, does not truncate file.
             state_file.seek(0)
             state_file.truncate()
             self.state["refresh_ns"] = refresh_ns or time.time_ns()

--- a/conda/models/records.py
+++ b/conda/models/records.py
@@ -671,7 +671,7 @@ class SolvedRecord(PackageRecord):
 
 
 class PrefixRecord(SolvedRecord):
-    """Representation of a package that is installed in a local conda environmnet.
+    """Representation of a package that is installed in a local conda environment.
 
     Specialization of :class:`PackageRecord` that adds information for packages that are installed
     in a local conda environment or prefix.

--- a/conda/plugins/subcommands/doctor/health_checks/requests_ca_bundle.py
+++ b/conda/plugins/subcommands/doctor/health_checks/requests_ca_bundle.py
@@ -41,7 +41,7 @@ def requests_ca_bundle_check(prefix: str, verbose: bool) -> None:
             print(f"{OK_MARK} `REQUESTS_CA_BUNDLE` was verified.\n")
         except (OSError, RequestException) as e:
             print(
-                f"{X_MARK} The following error occured while verifying `REQUESTS_CA_BUNDLE`: {e}\n"
+                f"{X_MARK} The following error occurred while verifying `REQUESTS_CA_BUNDLE`: {e}\n"
             )
 
 

--- a/conda/resolve.py
+++ b/conda/resolve.py
@@ -890,7 +890,7 @@ class Resolve:
                                 # specifies a "soft" dependency: it must be in the
                                 # environment, but it is not _pulled_ in. The SAT
                                 # logic doesn't do a perfect job of capturing this
-                                # behavior, but keeping these packags out of the
+                                # behavior, but keeping these packages out of the
                                 # reduced index helps. Of course, if _another_
                                 # package pulls it in by dependency, that's fine.
                                 if "track_features" not in new_ms and not self._broader(

--- a/docs/source/dev-guide/deep-dives/activation.md
+++ b/docs/source/dev-guide/deep-dives/activation.md
@@ -48,7 +48,7 @@ environment variables back to the shell session (and not just temporarily in the
 process). This will be discussed in the next section.
 
 So how is initialization performed? This is the job of the `conda init` subcommand, driven by
-the `conda.cli.main_init` module, which depends direcly on the `conda.core.initialize` module. Let's
+the `conda.cli.main_init` module, which depends directly on the `conda.core.initialize` module. Let's
 see how this is implemented.
 
 `conda init` will initialize a shell permanently by writing some shell code in the relevant

--- a/docs/source/dev-guide/deep-dives/context.md
+++ b/docs/source/dev-guide/deep-dives/context.md
@@ -40,7 +40,7 @@ class MyConfiguration(Configuration):
 ```
 
 When `MyConfiguration` is instantiated, those class attributes are populated by the `.raw_data`
-dicionary that has been filled in with the values coming from the precedence chain stated
+dictionary that has been filled in with the values coming from the precedence chain stated
 above. The `raw_data` dictionary contains `RawParameter` objects, subclassed to deal with the
 specifics of their origin (YAML file, environment variable, command line flag). Each
 `ParameterLoader` object will pass the `RawParameter` object to the `.load()` method of its relevant

--- a/docs/source/dev-guide/deep-dives/install.md
+++ b/docs/source/dev-guide/deep-dives/install.md
@@ -249,7 +249,7 @@ optimization step also takes longer the bigger the index gets.
 `context.channels` returns an `IndexedSet` of `Channel` objects; essentially a list of unique
 items. The different channels in this list can have overlapping or even conflicting information
 for the same package name. For example, `defaults` and `conda-forge` will for sure contain
-packages that fullfil the `conda install numpy` request. Which one is chosen by `conda` in this
+packages that fulfil the `conda install numpy` request. Which one is chosen by `conda` in this
 case? It depends on the `context.channel_priority` setting: From the help message:
 
 > Accepts values of 'strict', 'flexible', and 'disabled'. The default value is 'flexible'. With
@@ -345,7 +345,7 @@ public methods:
 * `download_and_extract()`: essentially a forwarder to instantiate and call
   `ProgressiveFetchExtract`, responsible for deciding which `PackageRecords` need to be
   downloaded and extracted to the packages cache.
-* `execute()`: the core logic is layed out here. It involves preparing, verifying and
+* `execute()`: the core logic is laid out here. It involves preparing, verifying and
   performing the rest of the actions. Among others:
     * Unlinking packages (removing a package from the environment)
     * Linking (adding a package to the environment)

--- a/docs/source/dev-guide/deep-dives/solvers.md
+++ b/docs/source/dev-guide/deep-dives/solvers.md
@@ -207,7 +207,7 @@ Some tasks do not involve the solver at all. Let's enumerate them:
 
 These commands do not need a solver because the requested packages are expressed with a direct
 URL or path to a specific tarball. Instead of a `MatchSpec`, we already have a
-`PackageRecord`-like entity! For this to work, all the requested packages neeed to be URLs or paths.
+`PackageRecord`-like entity! For this to work, all the requested packages need to be URLs or paths.
 They can be typed in the command line or in a text file including a `@EXPLICIT` line.
 
 Since the solver is not involved, the dependencies of the explicit package(s) are not processed

--- a/docs/source/dev-guide/development-environment.md
+++ b/docs/source/dev-guide/development-environment.md
@@ -397,7 +397,7 @@ review the code before committing again.
 
 Strictly speaking using pre-commit on your local machine for commits is
 optional (if you don't install pre-commit you will still be able to commit
-normally). But once you open a PR to contribue your changes, pre-commit will
+normally). But once you open a PR to contribute your changes, pre-commit will
 be automatically run at which point any errors that occur will need to be
 addressed prior to proceeding.
 

--- a/docs/source/dev-guide/plugins/environment_specifiers.rst
+++ b/docs/source/dev-guide/plugins/environment_specifiers.rst
@@ -206,7 +206,7 @@ contain. In this example, a valid environment file is a ``.json`` file that defi
        )
 
 We can test this out by trying to create a conda environment with a new file
-that is compatible with the definied spec. Create a file ``testenv.json``
+that is compatible with the defined spec. Create a file ``testenv.json``
 
 .. code-block::
 

--- a/docs/source/dev-guide/specs/solver-state.md
+++ b/docs/source/dev-guide/specs/solver-state.md
@@ -41,7 +41,7 @@ This one group _does_ change during the solver lifetime:
 Also, two more sources that are not obvious at first. These are not labeled as a _source_, but they
 do participate in the `specs` collection:
 
-* In new environments, packages included in the `contex.create_default_packages` list. These
+* In new environments, packages included in the `context.create_default_packages` list. These
   `MatchSpec` objects are injected in each `conda create` command, so the solver will see them
   as explicitly requested by the user (`requested`).
 * Specs added by command line modifiers. The specs here present aren't new (they are already in
@@ -123,7 +123,7 @@ This is getting simplified in the libmamba refactor, as the following. It should
 If we have a history:
     * Add history specs
     * Add installed packages as unconstrained specs that satisfy any of these conditions:
-        * Part of aggresive updates
+        * Part of aggressive updates
         * Part of do_not_remove
         * Installed by pip
 Else, we add _all_ installed packages as unconstrained specs.

--- a/docs/source/dev-guide/writing-tests/index.rst
+++ b/docs/source/dev-guide/writing-tests/index.rst
@@ -85,7 +85,7 @@ collide with each other. Consider using a prefix to achieve this.
 
 The context object
 ------------------
-The context object in ``conda`` is used as a singleton. This means that everytime the ``conda``
+The context object in ``conda`` is used as a singleton. This means that every time the ``conda``
 command runs, only a single object is instantiated. This makes sense as it holds all the configuration
 for the program and re-instantiating it or making multiple copies would be inefficient.
 

--- a/docs/source/dev-guide/writing-tests/integration-tests.md
+++ b/docs/source/dev-guide/writing-tests/integration-tests.md
@@ -172,7 +172,7 @@ def test_conda_rename(
 
 ## Tests with fixtures
 
-Sometimes in integration tests, you may want to re-use the same type of environment more
+Sometimes in integration tests, you may want to reuse the same type of environment more
 than once. Copying and pasting this setup and teardown code into each individual test
 can make these tests more difficult to read and harder to maintain.
 

--- a/docs/source/dev-guide/writing-tests/windows-applocker.md
+++ b/docs/source/dev-guide/writing-tests/windows-applocker.md
@@ -13,7 +13,7 @@ AppLocker is Microsoft's application control solution that allows organizations 
 - Create rules to allow or deny applications from running based on file attributes
 - Create exceptions to rules
 
-Many enterprise environments use AppLocker to restrict script execution, which can impact environmnet activation and execution processes. Testing with AppLocker ensures `conda` works properly in these restricted environments.
+Many enterprise environments use AppLocker to restrict script execution, which can impact environment activation and execution processes. Testing with AppLocker ensures `conda` works properly in these restricted environments.
 
 ## Setting Up AppLocker for Testing
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ using conda in your own projects.
 Install  :octicon:`download;1em;sd-text-primary`
 ................................................
 
-We recommend the following conda distribtions to install conda:
+We recommend the following conda distributions to install conda:
 
 .. grid:: 2
 

--- a/docs/source/user-guide/cheatsheet.rst
+++ b/docs/source/user-guide/cheatsheet.rst
@@ -11,7 +11,7 @@ See the :download:`conda cheatsheet <conda-cheatsheet.pdf>` PDF (3 MB) for a dow
 ..
     Maintainers! When updating the following list, please make sure to
     update the filesystem symlink "conda-cheatsheet.pdf" to the latest
-    version as well, to keep the URL of the conda cheetsheet the same.
+    version as well, to keep the URL of the conda cheatsheet the same.
     Thank you!
 
 - :download:`conda 25.3.1 <cheatsheets/conda-25.3.1.pdf>` (latest)

--- a/docs/source/user-guide/configuration/settings.rst
+++ b/docs/source/user-guide/configuration/settings.rst
@@ -718,7 +718,7 @@ specific version or build overrides for virtual package installs.
 
 Conda sets virtual package version and/or build numbers in three ways:
 
-1. By passing an enviroment variable with the ``conda install`` command (highest priority)
+1. By passing an environment variable with the ``conda install`` command (highest priority)
 
    For example: ``CONDA_OVERRIDE_CUDA="12.0" conda install -c conda-forge tensorflow``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ changelog = "https://github.com/conda/conda/blob/main/CHANGELOG.md"
 documentation = "https://docs.conda.io/projects/conda/en/stable/"
 repository = "https://github.com/conda/conda"
 
+[tool.codespell]
+ignore-words-list = ["astroid", "rever", "fo", "te", "thi", "crasher", "crashers", "wile", "iTerm", "cant", "doesnt"]
+skip = "AUTHORS.md,*invalid_keys.yml,*env_metadata*,*.json,*.pdf"
+
 [tool.coverage.report]
 exclude_lines = [
   "pragma: no cover",

--- a/tests/cli/test_main_notices.py
+++ b/tests/cli/test_main_notices.py
@@ -313,7 +313,7 @@ def test_notices_appear_once_when_running_decorated_commands(
 
     This should only be once per 24 hours according to the current setting.
 
-    To ensure this test runs appropriately, we rely on using a pass-thru mock
+    To ensure this test runs appropriately, we rely on using a passthrough mock
     of the `conda.notices.fetch.get_notice_responses` function. If this function
     was called and called correctly we can assume everything is working well.
 

--- a/tests/common/test_logic.py
+++ b/tests/common/test_logic.py
@@ -12,7 +12,7 @@ from conda.testing.helpers import raises
 #    - positive integers are variables
 #    - negative integers are negations of positive variables
 #    - lowercase True and False are fixed values
-#    - None reprents an indeterminate value
+#    - None represents an indeterminate value
 # If a fixed result is not determinable, the result is None, which
 # propagates through the result.
 #

--- a/tests/core/test_envs_manager.py
+++ b/tests/core/test_envs_manager.py
@@ -151,7 +151,7 @@ def test_list_all_known_prefixes_with_none_values_error(
     mock_is_admin, mock_getpwall, mock_clean_env, mock_context, tmp_path
 ):
     """
-    Regression test for a bug first indentified in this issue: https://github.com/conda/conda/issues/12063
+    Regression test for a bug first identified in this issue: https://github.com/conda/conda/issues/12063
 
     Tests to make sure that `None` values are filtered out of the `search_dirs` variable in the
     `list_all_known_prefixes` function.

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -236,7 +236,7 @@ def test_virtual_package_solver(tmpdir, clear_cuda_version, monkeypatch):
 
 
 def test_solve_msgs_exclude_vp(tmpdir, clear_cuda_version, monkeypatch: MonkeyPatch):
-    # Sovler hints should exclude virtual packages that are not dependencies
+    # Solver hints should exclude virtual packages that are not dependencies
     specs = (
         MatchSpec("python =2.7.5"),
         MatchSpec("readline =5.0"),
@@ -674,7 +674,7 @@ def test_update_prune_2(tmpdir, request):
         final_state_1 = solver.solve_final_state(prune=True)
         pprint(convert_to_dist_str(final_state_1))
 
-        # Every dependecy of accelerate should now be absent from the solved
+        # Every dependency of accelerate should now be absent from the solved
         # packages.
         order = add_subdir_to_iter(
             (
@@ -757,7 +757,7 @@ def test_update_prune_3(tmpdir, request):
         final_state_1 = solver.solve_final_state(prune=True)
         pprint(convert_to_dist_str(final_state_1))
 
-        # Every dependecy of accelerate should now be absent from the solved packages,
+        # Every dependency of accelerate should now be absent from the solved packages,
         # but numpy should remain.
         order = add_subdir_to_iter(
             (

--- a/tests/data/recipes/run_constrained/meta.yaml
+++ b/tests/data/recipes/run_constrained/meta.yaml
@@ -9,4 +9,4 @@ requirements:
   run_constrained: "dependency>=2.0"
 
 about:
-  summary: A package with a run contrain
+  summary: A package with a run constrain

--- a/tests/fixtures_package_server.py
+++ b/tests/fixtures_package_server.py
@@ -131,7 +131,7 @@ def package_repository_base(tmp_path_factory):
     """
     Copy tests/index_data to avoid writing changes to repository.
 
-    Could be made session-scoped if we don't mind re-using the index cache
+    Could be made session-scoped if we don't mind reusing the index cache
     during tests.
     """
     # destination can't exist for shutil.copytree(); create its parent

--- a/tests/gateways/test_connection.py
+++ b/tests/gateways/test_connection.py
@@ -127,7 +127,7 @@ def test_s3_server_with_mock(
 ) -> None:
     """
     Use boto3 to fetch from a mock s3 server pointing at the test package
-    repository. This works since conda only GET's against s3 and s3 is http.
+    repository. This works since conda only GETs against s3 and s3 is http.
     """
     host, port = package_server.getsockname()
     endpoint_url = f"http://{host}:{port}"
@@ -410,7 +410,7 @@ def test_get_session_with_channel_settings_multiple(mocker):
 def test_get_session_with_channel_settings_no_handler(mocker):
     """
     Tests to make sure the get_session function works when ``channel_settings``
-    have been set on the context objet. This test does not find a matching auth
+    have been set on the context object. This test does not find a matching auth
     handler.
     """
     mocker.patch(

--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -108,7 +108,7 @@ def test_stale(tmp_path, mocker: MockerFixture):
     assert cache.timeout() == -30
 
     # lesser backdate.
-    # excercise stale paths.
+    # exercise stale paths.
     original_ttl = context.local_repodata_ttl
     try:
         cache.state["refresh_ns"] = now_ns - (31 * 10**9)  # type: ignore

--- a/tests/gateways/test_zstd.py
+++ b/tests/gateways/test_zstd.py
@@ -126,7 +126,7 @@ def test_repodata_state(
 
     assert sd._loaded is False
 
-    # shoud automatically fetch and load
+    # should automatically fetch and load
     assert len(list(sd.iter_records()))
 
     assert sd._loaded is True
@@ -168,7 +168,7 @@ def test_repodata_info_jsondecodeerror(
     sd = SubdirData(channel=test_channel)
 
     assert sd._loaded is False
-    # shoud automatically fetch and load
+    # should automatically fetch and load
     assert len(list(sd.iter_records()))
     assert sd._loaded is True
 

--- a/tests/models/test_match_spec.py
+++ b/tests/models/test_match_spec.py
@@ -379,7 +379,7 @@ def test_url_percent_encoding():
 
     assert MatchSpec(url_with).version == MatchSpec(url_without).version
 
-    # Ficticious channel that yells at you
+    # Fictitious channel that yells at you
     url_with = "https://anaconda.org/conda-forge%21/linux-64/x264-1%21164.3095-h166bdaf_2.tar.bz2"
     url_without = (
         "https://anaconda.org/conda-forge!/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2"

--- a/tests/plugins/subcommands/doctor/health_checks/test_requests_ca_bundle.py
+++ b/tests/plugins/subcommands/doctor/health_checks/test_requests_ca_bundle.py
@@ -69,6 +69,6 @@ def test_requests_ca_bundle_check_action_fails(
     requests_ca_bundle_check(env_ok.prefix, verbose=True)
     captured = capsys.readouterr()
     assert (
-        f"{X_MARK} The following error occured while verifying `REQUESTS_CA_BUNDLE`:"
+        f"{X_MARK} The following error occurred while verifying `REQUESTS_CA_BUNDLE`:"
         in captured.out
     )

--- a/tests/plugins/test_environment_export.py
+++ b/tests/plugins/test_environment_export.py
@@ -583,7 +583,7 @@ def test_compare_export_commands(
     args: list[str],
     format: str,
 ):
-    """Test that the new export commmand produces the same output as the legacy command."""
+    """Test that the new export command produces the same output as the legacy command."""
     with tmp_env("small-executable") as prefix:
         old_output, _, _ = conda_cli(*args, f"--prefix={prefix}")
         new_output, _, _ = conda_cli(

--- a/tests/plugins/test_virtual_packages.py
+++ b/tests/plugins/test_virtual_packages.py
@@ -431,13 +431,13 @@ def test_override_package_values(
             ("1.2", "1-abc-2", "version", "override", None, None),
             False,
             True,
-            id="version overriden",
+            id="version overridden",
         ),
         pytest.param(
             ("1.2", "1-abc-2", "build", "override", None, None),
             True,
             False,
-            id="build overriden",
+            id="build overridden",
         ),
         pytest.param(
             ("1.2", "1-abc-2", None, None, None, None),
@@ -493,7 +493,7 @@ def test_version_validation(virtual_package_plugin: CondaVirtualPackage):
     [
         pytest.param(
             ("1.2", "0", "version", None, None, None),
-            "overriden",
+            "overridden",
             id="`CONDA_OVERRIDE_FOO` not set, but `context.override_virtual_packages` is set",
         ),
         pytest.param(
@@ -512,7 +512,7 @@ def test_context_override(
     mocker.patch(
         "conda.base.context.Context.override_virtual_packages",
         new_callable=mocker.PropertyMock,
-        return_value=({"foo": "overriden"}),
+        return_value=({"foo": "overridden"}),
     )
     package = virtual_package_plugin.to_virtual_package()
     assert package.name == "__foo"

--- a/tests/shards/test_coverage.py
+++ b/tests/shards/test_coverage.py
@@ -241,7 +241,7 @@ class TestMiscModule:
         assert result1 == "python"
 
     def test_spec_to_package_name_invalid_returns_none(self):
-        """An unparseable spec returns None instead of raising"""
+        """An unparsable spec returns None instead of raising"""
         result = spec_to_package_name("python>= '2.7'")
         assert result is None
 

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -557,7 +557,7 @@ def test_shard_mentioned_packages_2():
 
 
 def test_shard_mentioned_packages_invalid_spec_skipped():
-    # An unparseable spec is silently skipped; valid deps are still yielded and
+    # An unparsable spec is silently skipped; valid deps are still yielded and
     # no None values appear in the output.
     shard = {
         "packages": {


### PR DESCRIPTION
This fixes typos identified and fixed with codespell. This check can be added as a pre-commit, if requested.

Please review for false positives.