### PR TITLE
Fix invalid benchmarks workflow syntax

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
   track-base-branch:
     if: >-
       !github.event.repository.fork
-      && contains(['success', 'failure'], github.event.workflow_run.conclusion)
+      && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
       && github.event.workflow_run.event == 'push'
       && (
         github.event.workflow_run.head_branch == 'main'
@@ -91,7 +91,7 @@ jobs:
   track-pull-request:
     if: >-
       !github.event.repository.fork
-      && contains(['success', 'failure'], github.event.workflow_run.conclusion)
+      && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
       && github.event.workflow_run.event == 'pull_request'
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
I noticed that the CI run failed after a recent merge to main
https://github.com/conda/conda/actions/runs/30579515768, and it looks like they have all been failing (https://github.com/conda/conda/actions/workflows/benchmarks.yml) since https://github.com/conda/conda/pull/16317. 

The `contains` syntax was fine, but the bare array literals are not valid syntax. We could have also done `contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)`, but I think in this case just listing out both conditions is more consistent with the other workflows.

I'll also open a separate PR to add actionslint to prevent this in the future, but it requires some infrastructure changes first.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
