### PR TITLE
docs: update commands concept page

### DIFF
--- a/docs/source/user-guide/concepts/conda-commands.rst
+++ b/docs/source/user-guide/concepts/conda-commands.rst
@@ -2,22 +2,90 @@
 Commands
 ========
 
-The ``conda`` command is the primary interface for managing
-installations of various packages. It can:
+The ``conda`` command is the primary command-line interface for managing
+conda environments and packages. You can use conda commands to create
+environments, install packages, update packages, remove packages, search for
+packages, and inspect your current conda configuration.
 
-* Query and search the Anaconda package index and current
-  Anaconda installation.
+Common commands
+===============
 
-* Create new conda environments.
+Some of the most commonly used conda commands include:
 
-* Install and update packages into existing conda environments.
+``conda create``
+    Creates a new conda environment.
+
+    .. code-block:: bash
+
+       $ conda create --name myenv python=3.12
+
+``conda install``
+    Installs packages into the active environment or into a specified
+    environment.
+
+    .. code-block:: bash
+
+       $ conda install numpy pandas
+
+``conda update``
+    Updates packages in an environment.
+
+    .. code-block:: bash
+
+       $ conda update numpy
+
+``conda remove``
+    Removes packages from an environment.
+
+    .. code-block:: bash
+
+       $ conda remove numpy
+
+Other commands are available for managing channels, listing environments,
+searching for packages, cleaning package caches, and viewing conda
+configuration.
 
 .. tip::
-   You can abbreviate many frequently used command options that
-   are preceded by 2 dashes (``--``) to just 1 dash and the first
-   letter of the option. So ``--name`` and ``--envs`` can be written as ``-n`` and ``-e`` respectively.
+   You can abbreviate many frequently used command options that are preceded
+   by two dashes (``--``) to one dash and the first letter of the option. For
+   example, ``--name`` and ``--envs`` can be written as ``-n`` and ``-e``.
+
+Getting help for commands
+=========================
+
+Use ``--help`` or ``-h`` to see help for conda itself or for an individual
+command.
+
+To see top-level conda help:
+
+.. code-block:: bash
+
+   $ conda --help
+
+To see help for a specific command:
+
+.. code-block:: bash
+
+   $ conda install --help
+
+or:
+
+.. code-block:: bash
+
+   $ conda install -h
 
 For full usage of each command, including abbreviations, see
 :doc:`commands <../../commands/index>`. You can see the same information at the
 command line by :doc:`viewing the command-line help
 <../tasks/view-command-line-help>`.
+
+Plugin commands
+===============
+
+Conda plugins can add their own commands or subcommands to the conda
+command-line interface. For example, a plugin may add a command for a custom
+workflow, package source, or environment management task.
+
+Plugins that add conda commands must be installed in the ``base`` environment,
+where conda itself is installed. Installing a plugin into another environment
+does not make its command available to the main ``conda`` command.

--- a/docs/source/user-guide/concepts/conda-commands.rst
+++ b/docs/source/user-guide/concepts/conda-commands.rst
@@ -87,5 +87,6 @@ command-line interface. For example, a plugin may add a command for a custom
 workflow, package source, or environment management task.
 
 Plugins that add conda commands must be installed in the ``base`` environment,
-where conda itself is installed. Installing a plugin into another environment
-does not make its command available to the main ``conda`` command.
+where conda itself is installed. You can use ``conda self install`` to install
+a plugin into the ``base`` environment. Installing a plugin into another
+environment does not make its command available to the main ``conda`` command.

--- a/news/16023-update-commands-concept-page
+++ b/news/16023-update-commands-concept-page
@@ -1,0 +1,3 @@
+### Docs
+
+* Updated the commands concept page with common conda commands, command-line help examples, and a note about plugin-provided commands.

--- a/news/16023-update-commands-concept-page
+++ b/news/16023-update-commands-concept-page
@@ -1,3 +1,4 @@
 ### Docs
 
 * Updated the commands concept page with common conda commands, command-line help examples, and a note about plugin-provided commands.
+  ([#16023](https://github.com/conda/conda/issues/16023), [#16485](https://github.com/conda/conda/pull/16485))

--- a/news/16023-update-commands-concept-page
+++ b/news/16023-update-commands-concept-page
@@ -1,4 +1,3 @@
 ### Docs
 
-* Updated the commands concept page with common conda commands, command-line help examples, and a note about plugin-provided commands.
-  ([#16023](https://github.com/conda/conda/issues/16023), [#16485](https://github.com/conda/conda/pull/16485))
+* Update the commands concept page with common conda commands, command-line help examples, and a note about plugin-provided commands. (#16023 via #16485)


### PR DESCRIPTION
### Description

Closes #16023.

This PR updates the User Guide -> Concepts -> Commands page.

Changes:
- Adds examples of common conda commands, including `conda create`, `conda install`, `conda update`, and `conda remove`.
- Adds command-line help examples using `--help` and `-h`.
- Adds a section explaining that plugins can provide additional conda commands.
- Explains that command-providing plugins must be installed in the `base` environment and can be installed with `conda self install`.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- ~[ ] Add / update necessary tests?~
- [x] Add / update outdated documentation?