### PR TITLE
Docs: Fix plantuml download failures by using conda-forge

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,10 +17,6 @@ build:
     pre_build:
       # Install conda so we can run conda commands (e.g., see configuration.rst)
       - python -m pip install --no-deps --no-cache-dir --editable .
-  apt_packages:
-    # Needed for the UML graph Sphinx extension
-    - graphviz
-    - default-jre
 
 conda:
   environment: docs/environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - frozendict>=2.4.7
   - linkify-it-py==2.1.0
   - myst-parser==5.1.0
+  - plantuml==1.2026.6
   - pluggy==1.6.0
   - pylint==4.0.6
   - requests>=2.28.0,<3

--- a/docs/source/_extensions/conda_umls.py
+++ b/docs/source/_extensions/conda_umls.py
@@ -3,16 +3,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import fileinput
 import os
-import shutil
 import sys
 
-import requests  # noqa: TID253
 from pylint.pyreverse.main import Run
 
 here = os.path.dirname(__file__)
-plantuml_jarfile_url = (
-    "https://sourceforge.net/projects/plantuml/files/plantuml.jar/download"
-)
 
 
 # files and folders to ignore during generating the UML files
@@ -100,33 +95,8 @@ def generate_pumls(app=None, config=None):
         sys.stdout.write("Done generating PlantUML files.\n")
 
 
-def download_plantuml(app, config):
-    if os.path.exists(config.plantuml_jarfile_path):
-        sys.stdout.write(
-            f"PlantUML jar file already downloaded. "
-            f"To update run `make clean` or manually "
-            f"delete {config.plantuml_jarfile_path}.\n"
-        )
-    else:
-        parent = os.path.dirname(config.plantuml_jarfile_path)
-        if not os.path.isdir(parent):
-            os.makedirs(parent, exist_ok=True)
-        with requests.get(plantuml_jarfile_url, stream=True) as response:
-            sys.stdout.write(
-                f"Downloading PlantUML jar file to {config.plantuml_jarfile_path}..."
-            )
-            sys.stdout.flush()
-            response.raise_for_status()
-            response.raw.decode_content = True
-            with open(config.plantuml_jarfile_path, "wb") as jarfile:
-                shutil.copyfileobj(response.raw, jarfile)
-                sys.stdout.write("done.\n")
-
-
 def setup(app):
     if "AUTOBUILD" not in os.environ:
-        app.add_config_value("plantuml_jarfile_path", None, rebuild="")
-        app.connect("config-inited", download_plantuml)
         app.connect("config-inited", generate_pumls)
 
     return {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,8 +122,9 @@ html_context = {
 # -- sphinxcontrib.plantuml ------------------------------------------------
 
 plantuml_output_format = "svg_img"
-plantuml_jarfile_path = Path(__file__).parent.parent / "_build" / "plantuml.jar"
-plantuml = f"java -Djava.awt.headless=true -jar {plantuml_jarfile_path}"
+plantuml = (
+    f"java -Djava.awt.headless=true -jar {Path(sys.prefix) / 'lib' / 'plantuml.jar'}"
+)
 
 
 # -- For sphinx.ext.intersphinx --------------------------------------------

--- a/news/16492-plantuml-conda-forge
+++ b/news/16492-plantuml-conda-forge
@@ -12,7 +12,7 @@
 
 ### Docs
 
-* Install PlantUML from conda-forge instead of downloading the jar from SourceForge during docs builds.
+* Install PlantUML from conda-forge instead of downloading the jar from SourceForge during docs builds. (#16492)
 
 ### Other
 

--- a/news/plantuml-conda-forge
+++ b/news/plantuml-conda-forge
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Install PlantUML from conda-forge instead of downloading the jar from SourceForge during docs builds.
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

We have been getting docs build failures on readthedocs since last week due to plantuml download failures from sourceforge.

For example, see https://app.readthedocs.com/projects/continuumio-conda/builds/4282850/

This PR updates to use conda-forge to install PlantUML, rather than downloading a jar file at doc build time.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
