### PR TITLE
Add conda config --clear option

### DIFF
--- a/conda/cli/condarc.py
+++ b/conda/cli/condarc.py
@@ -598,6 +598,67 @@ class ConfigurationFile:
         else:
             raise CondaKeyError(key, "invalid parameter")
 
+    def clear_key(self, key: str) -> None:
+        """
+        Clear all values from a sequence configuration parameter.
+
+        The key remains explicitly configured with an empty list. This differs
+        from ``remove_key()``, which removes the key entirely and may allow a
+        value from another configuration source or a default to take effect.
+
+        Args:
+            key: Sequence configuration key name.
+
+        Raises:
+            CondaKeyError: If the key is unknown or is not a sequence parameter.
+            CouldntParseError: If the configured value is not a sequence.
+        """
+        from ..exceptions import CondaKeyError, CouldntParseError
+
+        if not self.key_exists(key):
+            raise CondaKeyError(key, "unknown parameter")
+
+        if aliased := self.context.name_for_alias(key):
+            log.warning(
+                "Key %s is an alias of %s; clearing value with latter",
+                key,
+                aliased,
+            )
+            key = aliased
+
+        first, *rest = key.split(".")
+
+        if first == "plugins" and hasattr(self.context, "plugins"):
+            if not rest:
+                raise CondaKeyError(key, "invalid parameter")
+
+            base_context = self.context.plugins
+            base_config = self.content.setdefault("plugins", {})
+            parameter_name, *rest = rest
+        else:
+            base_context = self.context
+            base_config = self.content
+            parameter_name = first
+
+        try:
+            parameter_type = base_context.describe_parameter(parameter_name)[
+                "parameter_type"
+            ]
+        except KeyError:
+            raise CondaKeyError(key, "unknown parameter")
+
+        if parameter_type != "sequence" or rest:
+            raise CondaKeyError(key, "invalid parameter")
+
+        current_value = base_config.get(parameter_name, MISSING)
+        if current_value is not MISSING and not (
+            isinstance(current_value, Sequence) and not isinstance(current_value, str)
+        ):
+            bad_type = current_value.__class__.__name__
+            raise CouldntParseError(f"key {key!r} should be a list, not {bad_type}.")
+
+        base_config[parameter_name] = []
+
     def remove_key(self, key: str) -> None:
         """
         Remove a configuration key entirely.

--- a/conda/cli/condarc.py
+++ b/conda/cli/condarc.py
@@ -618,20 +618,19 @@ class ConfigurationFile:
         if not self.key_exists(key):
             raise CondaKeyError(key, "unknown parameter")
 
+        alias_key = None
         if aliased := self.context.name_for_alias(key):
             log.warning(
                 "Key %s is an alias of %s; clearing value with latter",
                 key,
                 aliased,
             )
+            alias_key = key
             key = aliased
 
         first, *rest = key.split(".")
 
         if first == "plugins" and hasattr(self.context, "plugins"):
-            if not rest:
-                raise CondaKeyError(key, "invalid parameter")
-
             base_context = self.context.plugins
             base_config = self.content.setdefault("plugins", {})
             parameter_name, *rest = rest
@@ -656,6 +655,9 @@ class ConfigurationFile:
         ):
             bad_type = current_value.__class__.__name__
             raise CouldntParseError(f"key {key!r} should be a list, not {bad_type}.")
+
+        if alias_key is not None:
+            self.content.pop(alias_key, None)
 
         base_config[parameter_name] = []
 

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -215,6 +215,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         "--clear",
         action="append",
         help="""Clear all values from a list key.""",
+        default=[],
         metavar="KEY",
     )
     config_modifiers.add_argument(

--- a/conda/cli/main_config.py
+++ b/conda/cli/main_config.py
@@ -212,6 +212,12 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         metavar=("KEY", "VALUE"),
     )
     config_modifiers.add_argument(
+        "--clear",
+        action="append",
+        help="""Clear all values from a list key.""",
+        metavar="KEY",
+    )
+    config_modifiers.add_argument(
         "--remove-key",
         action="append",
         help="""Remove a configuration key (and all its values).""",
@@ -697,6 +703,10 @@ def execute_config(args: Namespace, parser: ArgumentParser) -> int | None:
     # Remove
     for key, item in args.remove:
         rc_config.remove_item(key, item)
+
+    # Clear
+    for key in args.clear or ():
+        rc_config.clear_key(key)
 
     # Remove Key
     for key in args.remove_key:

--- a/news/7617-config-clear
+++ b/news/7617-config-clear
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add a ``conda config --clear KEY`` option to explicitly set sequence
+  configuration parameters to an empty list. (#7617 via #PR_NUMBER)

--- a/news/7617-config-clear
+++ b/news/7617-config-clear
@@ -1,4 +1,4 @@
 ### Enhancements
 
 * Add a ``conda config --clear KEY`` option to explicitly set sequence
-  configuration parameters to an empty list. (#7617 via #PR_NUMBER)
+  configuration parameters to an empty list. (#7617 via #16499)

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -496,6 +496,58 @@ def test_add_invalid_key(conda_cli: CondaCLIFixture):
         assert _read_test_condarc(rc) == CONDARC_BASE
 
 
+def test_clear_key(conda_cli: CondaCLIFixture):
+    condarc = """\
+aggressive_update_packages:
+  - ca-certificates
+  - certifi
+"""
+    with make_temp_condarc(condarc) as rc:
+        stdout, stderr, _ = conda_cli(
+            "config",
+            "--file",
+            rc,
+            "--clear",
+            "aggressive_update_packages",
+        )
+
+        assert stdout == stderr == ""
+        assert _read_test_condarc(rc) == "aggressive_update_packages: []\n"
+
+
+def test_clear_unconfigured_key(conda_cli: CondaCLIFixture):
+    with make_temp_condarc("changeps1: true\n") as rc:
+        stdout, stderr, _ = conda_cli(
+            "config",
+            "--file",
+            rc,
+            "--clear",
+            "create_default_packages",
+        )
+
+        assert stdout == stderr == ""
+        assert _read_test_condarc(rc) == (
+            "changeps1: true\ncreate_default_packages: []\n"
+        )
+
+
+def test_clear_key_invalid_parameter(conda_cli: CondaCLIFixture):
+    with make_temp_condarc("changeps1: true\n") as rc:
+        with pytest.raises(
+            CondaKeyError,
+            match=r"'changeps1': invalid parameter",
+        ):
+            conda_cli(
+                "config",
+                "--file",
+                rc,
+                "--clear",
+                "changeps1",
+            )
+
+        assert _read_test_condarc(rc) == "changeps1: true\n"
+
+
 def test_remove_key(conda_cli: CondaCLIFixture):
     key, value = "changeps1", "false"
     with make_temp_condarc(CONDARC_BASE) as rc:

--- a/tests/cli/test_main_config.py
+++ b/tests/cli/test_main_config.py
@@ -236,6 +236,15 @@ def test_config_clear_key() -> None:
     assert config.content["channels"] == []
 
 
+def test_config_clear_key_alias() -> None:
+    config = ConfigurationFile(content={"disallow": ["openssl"]})
+
+    config.clear_key("disallow")
+
+    assert "disallow" not in config.content
+    assert config.content["disallowed_packages"] == []
+
+
 def test_config_clear_key_invalid() -> None:
     config = ConfigurationFile(content={"changeps1": True})
 

--- a/tests/cli/test_main_config.py
+++ b/tests/cli/test_main_config.py
@@ -14,7 +14,11 @@ from conda.base.context import context, reset_context
 from conda.cli.condarc import MISSING, ConfigurationFile
 from conda.cli.main_config import set_keys
 from conda.common.configuration import DEFAULT_CONDARC_FILENAME
-from conda.exceptions import CondaKeyError, EnvironmentLocationNotFound
+from conda.exceptions import (
+    CondaKeyError,
+    CouldntParseError,
+    EnvironmentLocationNotFound,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -207,6 +211,52 @@ def test_config_remove_item() -> None:
     # invalid
     with pytest.raises(CondaKeyError, match=r"'changeps1': invalid parameter"):
         config.remove_item("changeps1", None)
+
+
+def test_config_clear_key() -> None:
+    config = ConfigurationFile(
+        content={
+            "channels": ["defaults", "conda-forge"],
+            "aggressive_update_packages": ["ca-certificates", "certifi"],
+        }
+    )
+
+    config.clear_key("channels")
+    assert config.content["channels"] == []
+
+    config.clear_key("aggressive_update_packages")
+    assert config.content["aggressive_update_packages"] == []
+
+    # Clearing an undefined sequence explicitly creates an empty list.
+    config.clear_key("create_default_packages")
+    assert config.content["create_default_packages"] == []
+
+    # Clearing an already-empty sequence is idempotent.
+    config.clear_key("channels")
+    assert config.content["channels"] == []
+
+
+def test_config_clear_key_invalid() -> None:
+    config = ConfigurationFile(content={"changeps1": True})
+
+    with pytest.raises(CondaKeyError, match=r"'unknown': unknown parameter"):
+        config.clear_key("unknown")
+
+    with pytest.raises(CondaKeyError, match=r"'changeps1': invalid parameter"):
+        config.clear_key("changeps1")
+
+    with pytest.raises(CondaKeyError, match=r"'proxy_servers': invalid parameter"):
+        config.clear_key("proxy_servers")
+
+
+def test_config_clear_key_invalid_value_type() -> None:
+    config = ConfigurationFile(content={"channels": "defaults"})
+
+    with pytest.raises(
+        CouldntParseError,
+        match=r"key 'channels' should be a list, not str",
+    ):
+        config.clear_key("channels")
 
 
 def test_config_remove_key() -> None:

--- a/tests/plugins/test_settings.py
+++ b/tests/plugins/test_settings.py
@@ -253,6 +253,37 @@ def test_conda_config_with_sequence_settings(
     assert not err
 
 
+def test_conda_config_clear_sequence_setting(
+    condarc_plugin_manager, tmp_path, conda_cli
+):
+    """Ensure that sequence plugin settings can be explicitly cleared."""
+    condarc = tmp_path / "condarc"
+
+    out, err, _ = conda_cli(
+        "config",
+        "--file",
+        condarc,
+        "--add",
+        f"plugins.{SEQ_PARAMETER_NAME}",
+        "value_one",
+    )
+
+    assert not out
+    assert not err
+
+    out, err, _ = conda_cli(
+        "config",
+        "--file",
+        condarc,
+        "--clear",
+        f"plugins.{SEQ_PARAMETER_NAME}",
+    )
+
+    assert not out
+    assert not err
+    assert "plugins:\n  seq_parameter: []\n" in condarc.read_text()
+
+
 def test_conda_config_with_map_settings(condarc_plugin_manager, tmp_path, conda_cli):
     """
     Ensure that sequence parameter types work correctly as a plugin setting


### PR DESCRIPTION
### Description

Adds a `conda config --clear KEY` option that explicitly writes an empty list for sequence configuration parameters.

This is different from `--remove-key`, which removes the key entirely and may allow values from another configuration source or default values to take effect.

Closes #7617

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~~Add / update outdated documentation?~~

### Testing

- `python -m pytest tests/cli/test_main_config.py tests/cli/test_config.py -q`
- `python -m pre_commit run --files conda/cli/condarc.py conda/cli/main_config.py tests/cli/test_config.py tests/cli/test_main_config.py news/7617-config-clear`