### PR TITLE
docs: explain RC labels with strict channel priority

### DIFF
--- a/docs/source/user-guide/tasks/manage-channels.rst
+++ b/docs/source/user-guide/tasks/manage-channels.rst
@@ -160,4 +160,33 @@ we recommend the following approach:
       with the same name exists in a higher-priority channel. This includes
       channels that supply packages not available as conda packages.
 
+Installing release candidates with strict channel priority
+==========================================================
+
+Some channel providers publish pre-release packages in label channels. Conda
+treats each label as a separate channel, so its position in the channel list
+affects package selection. With strict channel priority, if a package name is
+present in a higher-priority label channel, builds of that package in
+lower-priority channels are excluded from consideration.
+
+Prefer a package-specific pre-release label, when the channel provider offers
+one, and place it immediately before the corresponding stable channel. For
+example:
+
+.. code-block:: yaml
+
+   channel_priority: strict
+   channels:
+     - <owner>/label/<package>-rc
+     - <owner>
+
+When that label contains only builds for the package being tested, unrelated
+package names remain eligible from the stable channel. A general-purpose
+``rc`` label can contain unrelated packages and unintentionally override or
+exclude their stable builds.
+
+Label names and contents are controlled by the channel provider. Check the
+provider's documentation before adding a label, and avoid mixing labels or
+channels whose packages are not built to be compatible.
+
 .. _`default channel`: https://repo.anaconda.com/pkgs/

--- a/news/8752-strict-rc-labels
+++ b/news/8752-strict-rc-labels
@@ -1,0 +1,3 @@
+### Docs
+
+* Explain how to use package-specific pre-release label channels with strict channel priority. (#8752)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes #8752.

This change documents a different situation from the mixed `defaults` and `conda-forge` example discussed above. It covers installing a release candidate from a provider's label while continuing to install stable packages from that same provider.

Conda treats each label as a separate channel. With strict channel priority, placing a broad `rc` label first can hide stable builds of unrelated packages that are also present in that label. This can make an otherwise valid environment unsatisfiable.

The new section explains why a package-specific pre-release label is preferable when one is available, and why it should be placed immediately before the provider's stable channel.

The existing warning against mixing incompatible provider channels remains unchanged. This section is specifically about ordering label channels belonging to the same provider.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
