### PR TITLE
Fall back to threads when process-pool extraction is unavailable

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -870,11 +870,18 @@ class ProgressiveFetchExtract:
                         break
 
             if use_process_pool:
-                extract_executor = ProcessPoolExecutor(
-                    max_workers=EXTRACT_PROCESSES,
-                    mp_context=multiprocessing.get_context("spawn"),
-                )
-            else:
+                try:
+                    extract_executor = ProcessPoolExecutor(
+                        max_workers=EXTRACT_PROCESSES,
+                        mp_context=multiprocessing.get_context("spawn"),
+                    )
+                except (OSError, NotImplementedError):
+                    log.debug(
+                        "Process pool unavailable, falling back to thread pool.",
+                        exc_info=True,
+                    )
+                    use_process_pool = False
+            if not use_process_pool:
                 extract_executor = ThreadPoolExecutor(EXTRACT_THREADS)
 
             cancelled_flag = False

--- a/news/16512-process-pool-extraction-fallback
+++ b/news/16512-process-pool-extraction-fallback
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fall back to threaded package extraction when process synchronization
+  primitives are unavailable. (#16512)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -142,6 +142,24 @@ def test_process_extract_finishes_when_later_fetch_fails(mocker):
     bad_extract._finish_extract.assert_not_called()
 
 
+@pytest.mark.parametrize("error", (FileNotFoundError, NotImplementedError))
+def test_process_pool_unavailable_falls_back_to_threads(
+    mocker, tmp_pkgs_dir: Path, error
+):
+    process_pool = mocker.patch.object(
+        package_cache_data,
+        "ProcessPoolExecutor",
+        side_effect=error,
+    )
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 2)
+    _, conda_prec = fresh_zlib_records()
+
+    ProgressiveFetchExtract((conda_prec,)).execute()
+
+    process_pool.assert_called_once()
+    assert isfile(join(tmp_pkgs_dir, zlib_base_fn, "info", "repodata_record.json"))
+
+
 def test_ProgressiveFetchExtract_prefers_conda_v2_format(monkeypatch: MonkeyPatch):
     # force this to False, because otherwise tests fail when run with old conda-build
     # zlib is available in local "linux-64" subdir


### PR DESCRIPTION
### Description

Fixes #16512.

Requires #16514 to land first.

`ProcessPoolExecutor` creates multiprocessing synchronization primitives before package extraction begins. AWS Lambda and some other sandboxed environments do not provide those primitives.

Fall back to the existing thread pool when process-pool construction fails. Systems that support process-based extraction continue to use it.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ Not applicable.
