### PR TITLE
Backport `DeprecationHandler` fallback fix to 26.7.x

### DIFF
--- a/conda/deprecations.py
+++ b/conda/deprecations.py
@@ -77,13 +77,14 @@ class DeprecationHandler:
         # If self._version or version could not be represented by a simple
         # tuple[int, ...], do a more elaborate version parsing and comparison.
         # Avoid this import otherwise to reduce import time for conda activate.
-        from packaging.version import parse
+        from packaging.version import InvalidVersion, parse
 
         if self._version_object is None:
             try:
                 self._version_object = parse(self._version)  # type: ignore[arg-type]
-            except TypeError:
-                # TypeError: self._version could not be parsed
+            except (TypeError, InvalidVersion):
+                # Unparseable version (e.g. None): packaging <26 raised TypeError.
+                # packaging >=26.3 raises InvalidVersion.
                 self._version_object = parse("0.0.0.dev0+placeholder")
         return self._version_object < parse(version)
 

--- a/news/16495-packaging-26.3-deprecation-handler
+++ b/news/16495-packaging-26.3-deprecation-handler
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `DeprecationHandler` version fallback when `packaging` raises `InvalidVersion` for unparseable versions (e.g. `None` under packaging >=26.3). (#16495)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -329,7 +329,12 @@ def test_get_module() -> None:
     ],
 )
 def test_version_fallback(version: str | None) -> None:
-    """Unparseable versions fall back so conda can still run."""
+    """Unparseable versions fall back so conda can still run.
+
+    packaging <26 raised TypeError for non-strings (e.g. None). packaging >=26.3
+    raises InvalidVersion instead (pypa/packaging#1319). Invalid strings have
+    always raised InvalidVersion.
+    """
     deprecated = DeprecationHandler(version)  # type: ignore[arg-type]
     assert deprecated._version_less_than("0")
     assert deprecated._version_tuple is None

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -320,10 +320,18 @@ def test_get_module() -> None:
     assert fullname == __name__
 
 
-def test_version_fallback() -> None:
-    """Test that conda can run even if deprecations can't parse the version."""
-    deprecated = DeprecationHandler(None)  # type: ignore[arg-type]
+@pytest.mark.parametrize(
+    "version",
+    [
+        pytest.param(None, id="none"),
+        # packaging raises InvalidVersion for non-PEP 440 strings (any packaging version)
+        pytest.param("not a valid version", id="invalid-string"),
+    ],
+)
+def test_version_fallback(version: str | None) -> None:
+    """Unparseable versions fall back so conda can still run."""
+    deprecated = DeprecationHandler(version)  # type: ignore[arg-type]
     assert deprecated._version_less_than("0")
     assert deprecated._version_tuple is None
-    version: Version = deprecated._version_object  # type: ignore[assignment]
-    assert version.major == version.minor == version.micro == 0
+    version_obj: Version = deprecated._version_object  # type: ignore[assignment]
+    assert version_obj.major == version_obj.minor == version_obj.micro == 0


### PR DESCRIPTION
### Description

Backport #16495 to `26.7.x`.

`packaging` 26.3 raises `InvalidVersion` instead of `TypeError` for non-string versions such as `None`. `26.7.x` allows `packaging >=23.0`.

Catch both exceptions so `DeprecationHandler` retains its placeholder-version fallback for unparseable version values. The tests also cover invalid version strings.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ Not applicable.
