### PR TITLE
Add `conda_package_verifiers` plugin hook

### DIFF
--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -293,6 +293,7 @@ class UnlinkLinkTransaction:
                     stp.remove_specs,
                     stp.update_specs,
                     stp.neutered_specs,
+                    package_verifiers=self._pfe._package_verifiers,
                 )
 
         self._prepared = True
@@ -405,6 +406,8 @@ class UnlinkLinkTransaction:
         remove_specs,
         update_specs,
         neutered_specs,
+        *,
+        package_verifiers=(),
     ):
         # make sure prefix directory exists
         if not isdir(target_prefix):
@@ -426,8 +429,11 @@ class UnlinkLinkTransaction:
         # NOTE: load_meta can return None
         # TODO: figure out if this filter shouldn't be an assert not None
         prefix_recs_to_unlink = tuple(lpd for lpd in prefix_recs_to_unlink if lpd)
+        # A same-device cache may contain an extraction that was not verified.
         pkg_cache_recs_to_link = tuple(
-            PackageCacheData.get_entry_to_link(prec, target_prefix)
+            PackageCacheData.get_entry_to_link(
+                prec, None if package_verifiers else target_prefix
+            )
             for prec in link_precs
         )
         if not all(pkg_cache_recs_to_link):

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -72,7 +72,7 @@ from .path_actions import CacheUrlAction, ExtractPackageAction
 if TYPE_CHECKING:
     from concurrent.futures import Future
 
-    from ..plugins.types import ProgressBarBase
+    from ..plugins.types import CondaPackageVerifier, ProgressBarBase
 
 log = getLogger(__name__)
 
@@ -149,20 +149,32 @@ class PackageCacheData(metaclass=PackageCacheType):
 
         self._urls_data = UrlsData(pkgs_dir)
 
-    def insert(self, package_cache_record):
+    def insert(
+        self,
+        package_cache_record,
+        package_verifiers: tuple[CondaPackageVerifier, ...] | None = None,
+    ):
         meta = join(
             package_cache_record.extracted_package_dir, "info", "repodata_record.json"
         )
         write_as_json_to_file(meta, PackageRecord.from_objects(package_cache_record))
 
-        self._package_cache_records[package_cache_record] = package_cache_record
+        if self.__package_cache_records is None:
+            self.load(package_verifiers)
+        self.__package_cache_records[package_cache_record] = package_cache_record
 
-    def load(self):
+    def load(
+        self,
+        package_verifiers: tuple[CondaPackageVerifier, ...] | None = None,
+    ):
         self.__package_cache_records = _package_cache_records = {}
         self._check_writable()  # called here to create the cache if it doesn't exist
         if not isdir(self.pkgs_dir):
             # no directory exists, and we didn't have permissions to create it
             return
+
+        if package_verifiers is None:
+            package_verifiers = context.plugin_manager.get_package_verifiers()
 
         pkgs_dir_contents = tuple(entry.name for entry in scandir(self.pkgs_dir))
         for base_name in self._dedupe_pkgs_dir_contents(pkgs_dir_contents):
@@ -176,7 +188,10 @@ class PackageCacheData(metaclass=PackageCacheType):
                 and context.plugin_manager.has_package_extension(full_path)
             ):
                 try:
-                    package_cache_record = self._make_single_record(base_name)
+                    package_cache_record = self._make_single_record(
+                        base_name,
+                        package_verifiers,
+                    )
                 except ValidationError as err:
                     # ValidationError: package fields are invalid
                     log.warning(
@@ -431,9 +446,16 @@ class PackageCacheData(metaclass=PackageCacheType):
         args = (f"{key}={getattr(self, key)!r}" for key in ("pkgs_dir",))
         return "{}({})".format(self.__class__.__name__, ", ".join(args))
 
-    def _make_single_record(self, package_filename):
+    def _make_single_record(
+        self,
+        package_filename,
+        package_verifiers: tuple[CondaPackageVerifier, ...] | None = None,
+    ):
         # delay-load this to help make sure libarchive can be found
         from conda_package_handling.api import InvalidArchiveError
+
+        if package_verifiers is None:
+            package_verifiers = context.plugin_manager.get_package_verifiers()
 
         package_tarball_full_path = join(self.pkgs_dir, package_filename)
         log.log(TRACE, "adding to package cache %s", package_tarball_full_path)
@@ -457,8 +479,6 @@ class PackageCacheData(metaclass=PackageCacheType):
                 e,
             )
 
-            package_verifiers = context.plugin_manager.get_package_verifiers()
-
             # try reading info/index.json
             try:
                 raw_json_record = read_index_json(extracted_package_dir)
@@ -480,7 +500,9 @@ class PackageCacheData(metaclass=PackageCacheType):
                     return None
 
                 try:
-                    if self.is_writable and not package_verifiers:
+                    if package_verifiers:
+                        return None
+                    elif self.is_writable:
                         if isdir(extracted_package_dir):
                             # We have a partially unpacked conda package directory. Best thing
                             # to do is remove it and try extracting.
@@ -639,12 +661,16 @@ class UrlsData:
 
 class ProgressiveFetchExtract:
     @staticmethod
-    def make_actions_for_record(pref_or_spec):
+    def make_actions_for_record(
+        pref_or_spec,
+        package_verifiers: tuple[CondaPackageVerifier, ...] | None = None,
+    ):
         if pref_or_spec is None:
             raise TypeError("`pref_or_spec` cannot be None.")
         # returns a cache_action and extract_action
 
-        package_verifiers = context.plugin_manager.get_package_verifiers()
+        if package_verifiers is None:
+            package_verifiers = context.plugin_manager.get_package_verifiers()
 
         # if the pref or spec has an md5 value
         # look in all caches for package cache record that is
@@ -725,6 +751,7 @@ class ProgressiveFetchExtract:
                         sha256=sha256,
                         size=size,
                         md5=md5,
+                        package_verifiers=package_verifiers,
                     )
 
                 return None, ExtractPackageAction(
@@ -735,6 +762,7 @@ class ProgressiveFetchExtract:
                     sha256=sha256,
                     size=size,
                     md5=md5,
+                    package_verifiers=package_verifiers,
                 )
 
         # there is no extracted dist that can work, so now we look for tarballs that
@@ -775,6 +803,7 @@ class ProgressiveFetchExtract:
                 sha256=pcrec_from_writable_cache.sha256 or sha256,
                 size=pcrec_from_writable_cache.size or size,
                 md5=pcrec_from_writable_cache.md5 or md5,
+                package_verifiers=package_verifiers,
             )
             return None, extract_action
 
@@ -820,6 +849,7 @@ class ProgressiveFetchExtract:
                 sha256=pcrec_from_read_only_cache.get("sha256") or sha256,
                 size=pcrec_from_read_only_cache.get("size") or size,
                 md5=pcrec_from_read_only_cache.get("md5") or md5,
+                package_verifiers=package_verifiers,
             )
             return cache_action, extract_action
 
@@ -861,6 +891,7 @@ class ProgressiveFetchExtract:
             sha256=sha256,
             size=size,
             md5=md5,
+            package_verifiers=package_verifiers,
         )
         return cache_action, extract_action
 
@@ -881,6 +912,7 @@ class ProgressiveFetchExtract:
         )
 
         self.paired_actions = {}  # Map[pref, Tuple(CacheUrlAction, ExtractPackageAction)]
+        self._package_verifiers = None
 
         self._prepared = False
         self._executed = False
@@ -889,6 +921,8 @@ class ProgressiveFetchExtract:
     def prepare(self):
         if self._prepared:
             return
+
+        self._package_verifiers = context.plugin_manager.get_package_verifiers()
 
         # Download largest first
         def by_size(prec: PackageRecord | MatchSpec):
@@ -902,7 +936,11 @@ class ProgressiveFetchExtract:
         largest_first = sorted(self.link_precs, key=by_size, reverse=True)
 
         self.paired_actions.update(
-            (prec, self.make_actions_for_record(prec)) for prec in largest_first
+            (
+                prec,
+                self.make_actions_for_record(prec, self._package_verifiers),
+            )
+            for prec in largest_first
         )
         self._prepared = True
 
@@ -927,7 +965,7 @@ class ProgressiveFetchExtract:
         if context.dry_run:
             raise RuntimeError("Cannot run .execute() in dry-run mode.")
 
-        verify_packages = bool(context.plugin_manager.get_package_verifiers())
+        verify_packages = bool(self._package_verifiers)
 
         with get_progress_bar_context_manager() as pbar_context:
             if self._executed:
@@ -1037,12 +1075,11 @@ class ProgressiveFetchExtract:
                         extract_action._prepare_extract()
                         extract_future = extract_executor.submit(
                             extract_conda_package_archive,
-                            extract_action.source_full_path,
+                            extract_action.verified_source_full_path,
                             extract_action.target_full_path,
                             ensure_picklable_errors=True,
                         )
                     except Exception as e:
-                        do_reverse(reversed(actions))
                         exceptions.append(e)
                     else:
                         extract_futures[extract_future] = (
@@ -1080,6 +1117,7 @@ class ProgressiveFetchExtract:
                             exceptions=exceptions,
                             progress_bar=progress_bar,
                             finish=True,
+                            reverse_on_error=not verify_packages,
                             cleanup=not (
                                 cache_action
                                 and cache_action.defer_cleanup
@@ -1108,11 +1146,6 @@ class ProgressiveFetchExtract:
                         cache_action, extract_action = self.paired_actions[prec_or_spec]
                         progress_bar = progress_bars[prec_or_spec]
                         actions = (cache_action, extract_action)
-                        if verify_packages and cache_action and extract_action:
-                            extract_action._verified_checksum = (
-                                cache_action._verified_checksum
-                            )
-                            cache_action._verified_checksum = None
                         if not extract_action:
                             do_cleanup(actions)
                             progress_bar.finish()
@@ -1132,7 +1165,7 @@ class ProgressiveFetchExtract:
                                 extract_action._prepare_extract()
                                 extract_future = extract_executor.submit(
                                     extract_conda_package_archive,
-                                    extract_action.source_full_path,
+                                    extract_action.verified_source_full_path,
                                     extract_action.target_full_path,
                                     ensure_picklable_errors=True,
                                 )
@@ -1190,7 +1223,8 @@ class ProgressiveFetchExtract:
                             do_cleanup(actions)
                         except Exception as e:
                             log.debug("Package extraction failed.", exc_info=e)
-                            do_reverse(reversed(actions))
+                            if not verify_packages:
+                                do_reverse(reversed(actions))
                             exceptions.append(e)
                         else:
                             progress_bar.finish()
@@ -1309,6 +1343,7 @@ def done_callback(
     exceptions: list[Exception],
     finish: bool = False,
     cleanup: bool = True,
+    reverse_on_error: bool = True,
 ):
     try:
         future.result()
@@ -1316,7 +1351,8 @@ def done_callback(
         # if it was interrupted with CTRL-C this might be BaseException and not
         # get caught here, but conda's signal handler also converts that to
         # CondaError which is just Exception.
-        do_reverse(reversed(actions))
+        if reverse_on_error:
+            do_reverse(reversed(actions))
         exceptions.append(e)
     else:
         if cleanup:

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -13,6 +13,7 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     as_completed,
 )
+from contextlib import ExitStack
 from errno import EACCES, ENOENT, EPERM, EROFS
 from functools import partial
 from itertools import chain
@@ -23,6 +24,7 @@ from pathlib import Path
 from sys import platform
 from tarfile import ReadError
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 from .. import CondaError, CondaMultiError, conda_signal_handler
 from .._private.extract import extract_conda_package_archive
@@ -448,13 +450,13 @@ class PackageCacheData(metaclass=PackageCacheType):
         except (OSError, json.JSONDecodeError, ValueError, FileNotFoundError) as e:
             # EnvironmentError: info/repodata_record.json doesn't exists
             # json.JSONDecodeError: info/repodata_record.json is partially extracted or corrupted
-            #   python 2.7 raises ValueError instead of json.JSONDecodeError
-            #   ValueError("No JSON object could be decoded")
             log.debug(
                 "unable to read %s\n  because %r",
                 join(extracted_package_dir, "info", "repodata_record.json"),
                 e,
             )
+
+            package_verifiers = context.plugin_manager.get_package_verifiers()
 
             # try reading info/index.json
             try:
@@ -462,8 +464,6 @@ class PackageCacheData(metaclass=PackageCacheType):
             except (OSError, json.JSONDecodeError, ValueError, FileNotFoundError) as e:
                 # EnvironmentError: info/index.json doesn't exist
                 # json.JSONDecodeError: info/index.json is partially extracted or corrupted
-                #   python 2.7 raises ValueError instead of json.JSONDecodeError
-                #   ValueError("No JSON object could be decoded")
                 log.debug(
                     "unable to read %s\n  because %r",
                     join(extracted_package_dir, "info", "index.json"),
@@ -479,7 +479,7 @@ class PackageCacheData(metaclass=PackageCacheType):
                     return None
 
                 try:
-                    if self.is_writable:
+                    if self.is_writable and not package_verifiers:
                         if isdir(extracted_package_dir):
                             # We have a partially unpacked conda package directory. Best thing
                             # to do is remove it and try extracting.
@@ -546,7 +546,7 @@ class PackageCacheData(metaclass=PackageCacheType):
             )
 
             # write the info/repodata_record.json file so we can short-circuit this next time
-            if self.is_writable:
+            if self.is_writable and not package_verifiers:
                 repodata_record = PackageRecord.from_objects(package_cache_record)
                 repodata_record_path = join(
                     extracted_package_dir, "info", "repodata_record.json"
@@ -644,6 +644,8 @@ class ProgressiveFetchExtract:
             raise TypeError("`pref_or_spec` cannot be None.")
         # returns a cache_action and extract_action
 
+        package_verifiers = context.plugin_manager.get_package_verifiers()
+
         # if the pref or spec has an md5 value
         # look in all caches for package cache record that is
         #   (1) already extracted, and
@@ -652,17 +654,28 @@ class ProgressiveFetchExtract:
         sha256 = pref_or_spec.get("sha256")
         size = pref_or_spec.get("size")
         md5 = pref_or_spec.get("md5")
+        if package_verifiers:
+            selected_url = pref_or_spec.get("url")
+            selected_filename = (
+                basename(urlsplit(selected_url).path)
+                if selected_url
+                else basename(pref_or_spec.fn)
+            )
 
-        extracted_pcrec = next(
-            (
-                pcrec
-                for pcrec in chain.from_iterable(
-                    PackageCacheData(pkgs_dir).query(pref_or_spec)
-                    for pkgs_dir in context.pkgs_dirs
-                )
-                if pcrec.is_extracted
-            ),
-            None,
+        extracted_pcrec = (
+            next(
+                (
+                    pcrec
+                    for pcrec in chain.from_iterable(
+                        PackageCacheData(pkgs_dir).query(pref_or_spec)
+                        for pkgs_dir in context.pkgs_dirs
+                    )
+                    if pcrec.is_extracted
+                ),
+                None,
+            )
+            if not package_verifiers
+            else None
         )
         if (
             extracted_pcrec
@@ -671,21 +684,78 @@ class ProgressiveFetchExtract:
         ):
             return None, None
 
+        if package_verifiers and (sha256 or md5):
+            exact_package_cache = None
+            for package_cache in PackageCacheData.all_caches_writable_first():
+                exact_archive = join(package_cache.pkgs_dir, selected_filename)
+                if islink(exact_archive) or not isfile(exact_archive):
+                    continue
+                if size is not None and getsize(exact_archive) != size:
+                    continue
+                if sha256 and compute_sum(exact_archive, "sha256") != sha256:
+                    continue
+                if not sha256 and md5 and compute_sum(exact_archive, "md5") != md5:
+                    continue
+                exact_package_cache = package_cache
+                break
+
+            if exact_package_cache:
+                exact_archive = join(
+                    exact_package_cache.pkgs_dir,
+                    selected_filename,
+                )
+                first_writable_cache = PackageCacheData.first_writable()
+                if exact_package_cache.pkgs_dir != first_writable_cache.pkgs_dir:
+                    cache_action = CacheUrlAction(
+                        url=path_to_url(exact_archive),
+                        target_pkgs_dir=first_writable_cache.pkgs_dir,
+                        target_package_basename=selected_filename,
+                        sha256=sha256,
+                        size=size,
+                        md5=md5,
+                        defer_cleanup=True,
+                    )
+                    return cache_action, ExtractPackageAction(
+                        source_full_path=cache_action.target_full_path,
+                        target_pkgs_dir=first_writable_cache.pkgs_dir,
+                        target_extracted_dirname=strip_pkg_extension(selected_filename)[
+                            0
+                        ],
+                        record_or_spec=pref_or_spec,
+                        sha256=sha256,
+                        size=size,
+                        md5=md5,
+                    )
+
+                return None, ExtractPackageAction(
+                    source_full_path=exact_archive,
+                    target_pkgs_dir=dirname(exact_archive),
+                    target_extracted_dirname=strip_pkg_extension(selected_filename)[0],
+                    record_or_spec=pref_or_spec,
+                    sha256=sha256,
+                    size=size,
+                    md5=md5,
+                )
+
         # there is no extracted dist that can work, so now we look for tarballs that
         #   aren't extracted
         # first we look in all writable caches, and if we find a match, we extract in place
         # otherwise, if we find a match in a non-writable cache, we link it to the first writable
         #   cache, and then extract
-        pcrec_from_writable_cache = next(
-            (
-                pcrec
-                for pcrec in chain.from_iterable(
-                    pcache.query(pref_or_spec)
-                    for pcache in PackageCacheData.writable_caches()
-                )
-                if pcrec.is_fetched
-            ),
-            None,
+        pcrec_from_writable_cache = (
+            next(
+                (
+                    pcrec
+                    for pcrec in chain.from_iterable(
+                        pcache.query(pref_or_spec)
+                        for pcache in PackageCacheData.writable_caches()
+                    )
+                    if pcrec.is_fetched
+                ),
+                None,
+            )
+            if not package_verifiers
+            else None
         )
         if (
             pcrec_from_writable_cache
@@ -708,16 +778,20 @@ class ProgressiveFetchExtract:
             )
             return None, extract_action
 
-        pcrec_from_read_only_cache = next(
-            (
-                pcrec
-                for pcrec in chain.from_iterable(
-                    pcache.query(pref_or_spec)
-                    for pcache in PackageCacheData.read_only_caches()
-                )
-                if pcrec.is_fetched
-            ),
-            None,
+        pcrec_from_read_only_cache = (
+            next(
+                (
+                    pcrec
+                    for pcrec in chain.from_iterable(
+                        pcache.query(pref_or_spec)
+                        for pcache in PackageCacheData.read_only_caches()
+                    )
+                    if pcrec.is_fetched
+                ),
+                None,
+            )
+            if not package_verifiers
+            else None
         )
 
         first_writable_cache = PackageCacheData.first_writable()
@@ -764,7 +838,11 @@ class ProgressiveFetchExtract:
         # PyPI URLs may include a #sha256=... fragment (e.g., file.whl#sha256=abc123);
         # strip the fragment before extracting the basename so the cached filename
         # ends with the real extension (needed for plugin-based extraction).
-        target_package_basename = basename(url.split("#")[0]) or pref_or_spec.fn
+        target_package_basename = (
+            basename(urlsplit(url).path) or basename(pref_or_spec.fn)
+            if package_verifiers
+            else basename(url.split("#")[0]) or pref_or_spec.fn
+        )
 
         cache_action = CacheUrlAction(
             url=url,
@@ -773,6 +851,7 @@ class ProgressiveFetchExtract:
             sha256=sha256,
             size=size,
             md5=md5,
+            defer_cleanup=bool(package_verifiers),
         )
         extract_action = ExtractPackageAction(
             source_full_path=cache_action.target_full_path,
@@ -847,6 +926,8 @@ class ProgressiveFetchExtract:
 
         if context.dry_run:
             raise RuntimeError("Cannot run .execute() in dry-run mode.")
+
+        verify_packages = bool(context.plugin_manager.get_package_verifiers())
 
         with get_progress_bar_context_manager() as pbar_context:
             if self._executed:
@@ -924,11 +1005,19 @@ class ProgressiveFetchExtract:
                 return cancelled_flag
 
             with (
+                ExitStack() as package_verifier_rollback,
                 signal_handler(conda_signal_handler),
                 time_recorder("fetch_extract_execute"),
                 ThreadPoolExecutor(context.fetch_threads) as fetch_executor,
                 extract_executor,
             ):
+                if verify_packages:
+                    for actions in self.paired_actions.values():
+                        package_verifier_rollback.callback(
+                            do_reverse,
+                            reversed(actions),
+                        )
+
                 for prec_or_spec, (
                     cache_action,
                     extract_action,
@@ -958,6 +1047,11 @@ class ProgressiveFetchExtract:
                             exceptions=exceptions,
                             progress_bar=progress_bar,
                             finish=True,
+                            cleanup=not (
+                                cache_action
+                                and cache_action.defer_cleanup
+                                and extract_action
+                            ),
                         )
                     )
                     futures.append(future)
@@ -970,6 +1064,11 @@ class ProgressiveFetchExtract:
                         cache_action, extract_action = self.paired_actions[prec_or_spec]
                         progress_bar = progress_bars[prec_or_spec]
                         actions = (cache_action, extract_action)
+                        if verify_packages and cache_action and extract_action:
+                            extract_action._verified_checksum = (
+                                cache_action._verified_checksum
+                            )
+                            cache_action._verified_checksum = None
                         if not extract_action:
                             do_cleanup(actions)
                             progress_bar.finish()
@@ -1028,12 +1127,12 @@ class ProgressiveFetchExtract:
                             if process_extract_action:
                                 process_extract_action._finish_extract()
                                 progress_bar.update_to(1.0)
+                            do_cleanup(actions)
                         except Exception as e:
                             log.debug("Package extraction failed.", exc_info=e)
                             do_reverse(reversed(actions))
                             exceptions.append(e)
                         else:
-                            do_cleanup(actions)
                             progress_bar.finish()
                             progress_bar.refresh()
 
@@ -1149,6 +1248,7 @@ def done_callback(
     progress_bar: ProgressBarBase,
     exceptions: list[Exception],
     finish: bool = False,
+    cleanup: bool = True,
 ):
     try:
         future.result()
@@ -1159,7 +1259,8 @@ def done_callback(
         do_reverse(reversed(actions))
         exceptions.append(e)
     else:
-        do_cleanup(actions)
+        if cleanup:
+            do_cleanup(actions)
         if finish:
             progress_bar.finish()
             progress_bar.refresh()

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -23,7 +23,6 @@ from logging import getLogger
 from os import scandir
 from os.path import basename, dirname, getsize, join
 from pathlib import Path
-from sys import platform
 from tarfile import ReadError
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
@@ -616,8 +615,7 @@ class UrlsData:
 
     def add_url(self, url):
         with open(self.urls_txt_path, mode="a", encoding="utf-8") as fh:
-            linefeed = "\r\n" if platform == "win32" else "\n"
-            fh.write(url + linefeed)
+            fh.write(url + "\n")
         self._urls_data.insert(0, url)
 
     @memoizemethod

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -8,10 +8,12 @@ import multiprocessing
 import os
 from collections import defaultdict
 from concurrent.futures import (
+    FIRST_COMPLETED,
     CancelledError,
     ProcessPoolExecutor,
     ThreadPoolExecutor,
     as_completed,
+    wait,
 )
 from contextlib import ExitStack
 from errno import EACCES, ENOENT, EPERM, EROFS
@@ -954,6 +956,7 @@ class ProgressiveFetchExtract:
             exceptions = []
             progress_bars = {}
             futures: list[Future] = []
+            verifier_futures = {}
             extract_futures = {}
             extract_actions = self.extract_actions
             use_process_pool = (
@@ -1017,6 +1020,38 @@ class ProgressiveFetchExtract:
                             do_reverse,
                             reversed(actions),
                         )
+                verifier_executor = (
+                    package_verifier_rollback.enter_context(
+                        ThreadPoolExecutor(EXTRACT_PROCESSES)
+                    )
+                    if verify_packages and use_process_pool
+                    else None
+                )
+
+                def finish_verification(verifier_future, *, submit_extract=True):
+                    actions, extract_action, progress_bar = verifier_futures.pop(
+                        verifier_future
+                    )
+                    try:
+                        verifier_future.result()
+                        if not submit_extract:
+                            return
+                        extract_action._prepare_extract()
+                        extract_future = extract_executor.submit(
+                            extract_conda_package_archive,
+                            extract_action.source_full_path,
+                            extract_action.target_full_path,
+                            ensure_picklable_errors=True,
+                        )
+                    except Exception as e:
+                        do_reverse(reversed(actions))
+                        exceptions.append(e)
+                    else:
+                        extract_futures[extract_future] = (
+                            actions,
+                            extract_action,
+                            progress_bar,
+                        )
 
                 for prec_or_spec, (
                     cache_action,
@@ -1057,7 +1092,18 @@ class ProgressiveFetchExtract:
                     futures.append(future)
 
                 try:
-                    for completed_future in as_completed(futures):
+                    completed = set()
+                    while futures or verifier_futures:
+                        if not completed:
+                            completed, _ = wait(
+                                (*futures, *verifier_futures),
+                                return_when=FIRST_COMPLETED,
+                            )
+                        completed_future = completed.pop()
+                        if completed_future in verifier_futures:
+                            finish_verification(completed_future)
+                            continue
+
                         futures.remove(completed_future)
                         prec_or_spec = completed_future.result()
 
@@ -1073,6 +1119,15 @@ class ProgressiveFetchExtract:
                             do_cleanup(actions)
                             progress_bar.finish()
                             progress_bar.refresh()
+                        elif verifier_executor:
+                            verifier_future = verifier_executor.submit(
+                                extract_action.verify
+                            )
+                            verifier_futures[verifier_future] = (
+                                actions,
+                                extract_action,
+                                progress_bar,
+                            )
                         elif use_process_pool:
                             try:
                                 extract_action.verify()
@@ -1104,20 +1159,27 @@ class ProgressiveFetchExtract:
                                 None,
                                 progress_bar,
                             )
+
                 except BaseException as e:
-                    # We are interested in KeyboardInterrupt delivered to
-                    # as_completed() while waiting, or any exception raised from
-                    # completed_future.result(). cancelled_flag is checked in the
-                    # progress callback to stop running transfers, shutdown() should
-                    # prevent new downloads from starting.
+                    # We are interested in KeyboardInterrupt delivered while waiting,
+                    # or any exception raised from completed_future.result().
+                    # cancelled_flag is checked in the progress callback to stop
+                    # running transfers, shutdown() should prevent new downloads from
+                    # starting.
                     cancelled_flag = True
-                    for future in futures:  # needed on top of .shutdown()
+                    for future in chain(futures, verifier_futures):
                         future.cancel()
                     # Has a Python >=3.9 cancel_futures= parameter that does not
                     # replace the above loop:
                     fetch_executor.shutdown(wait=False)
                     exceptions.append(e)
                 finally:
+                    for verifier_future in tuple(verifier_futures):
+                        finish_verification(
+                            verifier_future,
+                            submit_extract=not cancelled_flag,
+                        )
+
                     for extract_future in as_completed(extract_futures):
                         actions, process_extract_action, progress_bar = extract_futures[
                             extract_future

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -34,10 +34,12 @@ from ..common.path import (
 from ..common.serialize import json
 from ..common.url import has_platform, path_to_url
 from ..exceptions import (
+    ChecksumMismatchError,
     CondaUpgradeError,
     CondaVerificationError,
     NotWritableError,
     PaddingError,
+    PluginError,
     SafetyError,
 )
 from ..gateways.connection.download import download
@@ -1314,6 +1316,7 @@ class CacheUrlAction(PathAction):
         sha256=None,
         size=None,
         md5=None,
+        defer_cleanup=False,
     ):
         self.url = url
         self.target_pkgs_dir = target_pkgs_dir
@@ -1321,7 +1324,11 @@ class CacheUrlAction(PathAction):
         self.sha256 = sha256
         self.size = size
         self.md5 = md5
+        self.defer_cleanup = defer_cleanup
         self.hold_path = self.target_full_path + CONDA_TEMP_EXTENSION
+        self._verified_checksum = None
+        self._target_path_touched = False
+        self._pending_url = None
 
     def verify(self):
         if "::" in self.url:
@@ -1334,6 +1341,7 @@ class CacheUrlAction(PathAction):
         from .package_cache_data import PackageCacheData
 
         target_package_cache = PackageCacheData(self.target_pkgs_dir)
+        self._verified_checksum = None
 
         log.log(TRACE, "caching url %s => %s", self.url, self.target_full_path)
 
@@ -1349,6 +1357,7 @@ class CacheUrlAction(PathAction):
             else:
                 backoff_rename(self.target_full_path, self.hold_path, force=True)
 
+        self._target_path_touched = True
         if self.url.startswith("file:/"):
             source_path = url_to_path(self.url)
             self._execute_local(
@@ -1374,7 +1383,7 @@ class CacheUrlAction(PathAction):
                 self.target_package_basename
             )
             if origin_url and has_platform(origin_url, context.known_subdirs):
-                target_package_cache._urls_data.add_url(origin_url)
+                self.record_url(target_package_cache, origin_url)
         else:
             # so our tarball source isn't a package cache, but that doesn't mean it's not
             #   in another package cache somewhere
@@ -1409,9 +1418,9 @@ class CacheUrlAction(PathAction):
             )
 
             if origin_url and has_platform(origin_url, context.known_subdirs):
-                target_package_cache._urls_data.add_url(origin_url)
+                self.record_url(target_package_cache, origin_url)
             else:
-                target_package_cache._urls_data.add_url(self.url)
+                self.record_url(target_package_cache, self.url)
 
     def _execute_channel(self, target_package_cache, progress_update_callback=None):
         kwargs = {}
@@ -1427,15 +1436,36 @@ class CacheUrlAction(PathAction):
             progress_update_callback=progress_update_callback,
             **kwargs,
         )
-        target_package_cache._urls_data.add_url(self.url)
+        if self.sha256:
+            self._verified_checksum = ("sha256", self.sha256)
+        elif self.md5:
+            self._verified_checksum = ("md5", self.md5)
+        self.record_url(target_package_cache, self.url)
+
+    def record_url(self, target_package_cache, url):
+        """Record the package URL now or when the cache action is accepted."""
+        if self.defer_cleanup:
+            self._pending_url = (target_package_cache._urls_data, url)
+        else:
+            target_package_cache._urls_data.add_url(url)
 
     def reverse(self):
+        self._verified_checksum = None
+        if self._target_path_touched:
+            rm_rf(self.target_full_path)
         if lexists(self.hold_path):
             log.log(TRACE, "moving %s => %s", self.hold_path, self.target_full_path)
             backoff_rename(self.hold_path, self.target_full_path, force=True)
+        self._target_path_touched = False
+        self._pending_url = None
 
     def cleanup(self):
+        if self._pending_url is not None:
+            urls_data, url = self._pending_url
+            urls_data.add_url(url)
+            self._pending_url = None
         rm_rf(self.hold_path)
+        self._target_path_touched = False
 
     @property
     def target_full_path(self):
@@ -1464,8 +1494,79 @@ class ExtractPackageAction(PathAction):
         self.sha256 = sha256
         self.size = size
         self.md5 = md5
+        self._verified_checksum = None
+        self._target_path_touched = False
 
     def verify(self):
+        verified_checksum = self._verified_checksum
+        self._verified_checksum = None
+        verifiers = context.plugin_manager.get_package_verifiers()
+        if verifiers:
+            source_url = path_to_url(os.fspath(self.source_full_path))
+            actual_size = getsize(self.source_full_path)
+            if self.size is not None and actual_size != self.size:
+                raise ChecksumMismatchError(
+                    source_url,
+                    self.source_full_path,
+                    "size",
+                    self.size,
+                    actual_size,
+                )
+
+            if verified_checksum and verified_checksum[0] == "sha256":
+                actual_sha256 = bytes.fromhex(verified_checksum[1]).hex()
+                expected_sha256 = (
+                    bytes.fromhex(self.sha256).hex() if self.sha256 else None
+                )
+                if actual_sha256 != expected_sha256:
+                    raise ChecksumMismatchError(
+                        source_url,
+                        self.source_full_path,
+                        "sha256",
+                        self.sha256,
+                        actual_sha256,
+                    )
+            else:
+                actual_sha256 = compute_sum(self.source_full_path, "sha256")
+                if self.sha256 and actual_sha256 != self.sha256:
+                    raise ChecksumMismatchError(
+                        source_url,
+                        self.source_full_path,
+                        "sha256",
+                        self.sha256,
+                        actual_sha256,
+                    )
+
+            if not self.sha256 and self.md5:
+                actual_md5 = (
+                    verified_checksum[1]
+                    if verified_checksum and verified_checksum[0] == "md5"
+                    else compute_sum(self.source_full_path, "md5")
+                )
+                if actual_md5 != self.md5:
+                    raise ChecksumMismatchError(
+                        source_url,
+                        self.source_full_path,
+                        "md5",
+                        self.md5,
+                        actual_md5,
+                    )
+
+            for verifier in verifiers:
+                try:
+                    verifier.verify(
+                        self.record_or_spec,
+                        self.source_full_path,
+                        actual_sha256,
+                    )
+                except CondaError:
+                    raise
+                except Exception as err:
+                    raise PluginError(
+                        f"Package verifier {verifier.name!r} failed: {err}"
+                    ) from err
+            self.sha256 = actual_sha256
+
         self._verified = True
 
     def execute(self, progress_update_callback=None):
@@ -1481,6 +1582,7 @@ class ExtractPackageAction(PathAction):
             TRACE, "extracting %s => %s", self.source_full_path, self.target_full_path
         )
 
+        self._target_path_touched = True
         if lexists(self.target_full_path):
             rm_rf(self.target_full_path)
 
@@ -1546,14 +1648,16 @@ class ExtractPackageAction(PathAction):
         target_package_cache.insert(package_cache_record)
 
     def reverse(self):
-        rm_rf(self.target_full_path)
-        if lexists(self.hold_path):
-            log.log(TRACE, "moving %s => %s", self.hold_path, self.target_full_path)
+        if self._target_path_touched:
             rm_rf(self.target_full_path)
-            backoff_rename(self.hold_path, self.target_full_path)
+            if lexists(self.hold_path):
+                log.log(TRACE, "moving %s => %s", self.hold_path, self.target_full_path)
+                backoff_rename(self.hold_path, self.target_full_path)
+        self._target_path_touched = False
 
     def cleanup(self):
         rm_rf(self.hold_path)
+        self._target_path_touched = False
 
     @property
     def target_full_path(self):

--- a/conda/core/path_actions.py
+++ b/conda/core/path_actions.py
@@ -11,6 +11,8 @@ from abc import ABC, abstractmethod
 from itertools import chain
 from logging import getLogger
 from os.path import basename, dirname, getsize, isdir, isfile, join, normpath
+from shutil import copyfile
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -75,6 +77,8 @@ from .prefix_data import PrefixData
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from ..plugins.types import CondaPackageVerifier
 
 try:
     FileNotFoundError
@@ -1326,7 +1330,6 @@ class CacheUrlAction(PathAction):
         self.md5 = md5
         self.defer_cleanup = defer_cleanup
         self.hold_path = self.target_full_path + CONDA_TEMP_EXTENSION
-        self._verified_checksum = None
         self._target_path_touched = False
         self._pending_url = None
 
@@ -1341,7 +1344,6 @@ class CacheUrlAction(PathAction):
         from .package_cache_data import PackageCacheData
 
         target_package_cache = PackageCacheData(self.target_pkgs_dir)
-        self._verified_checksum = None
 
         log.log(TRACE, "caching url %s => %s", self.url, self.target_full_path)
 
@@ -1436,10 +1438,6 @@ class CacheUrlAction(PathAction):
             progress_update_callback=progress_update_callback,
             **kwargs,
         )
-        if self.sha256:
-            self._verified_checksum = ("sha256", self.sha256)
-        elif self.md5:
-            self._verified_checksum = ("md5", self.md5)
         self.record_url(target_package_cache, self.url)
 
     def record_url(self, target_package_cache, url):
@@ -1450,7 +1448,6 @@ class CacheUrlAction(PathAction):
             target_package_cache._urls_data.add_url(url)
 
     def reverse(self):
-        self._verified_checksum = None
         if self._target_path_touched:
             rm_rf(self.target_full_path)
         if lexists(self.hold_path):
@@ -1485,6 +1482,7 @@ class ExtractPackageAction(PathAction):
         sha256,
         size,
         md5,
+        package_verifiers: tuple[CondaPackageVerifier, ...] | None = None,
     ):
         self.source_full_path = source_full_path
         self.target_pkgs_dir = target_pkgs_dir
@@ -1494,16 +1492,28 @@ class ExtractPackageAction(PathAction):
         self.sha256 = sha256
         self.size = size
         self.md5 = md5
-        self._verified_checksum = None
+        self._package_verifiers = (
+            context.plugin_manager.get_package_verifiers()
+            if package_verifiers is None
+            else package_verifiers
+        )
+        self._verified_archive_dir = None
         self._target_path_touched = False
 
     def verify(self):
-        verified_checksum = self._verified_checksum
-        self._verified_checksum = None
-        verifiers = context.plugin_manager.get_package_verifiers()
+        verifiers = self._package_verifiers
         if verifiers:
+            if self._verified_archive_dir is not None:
+                self._verified_archive_dir.cleanup()
+            self._verified_archive_dir = TemporaryDirectory(
+                prefix=".conda-verify-",
+                dir=self.target_pkgs_dir,
+                ignore_cleanup_errors=True,
+            )
+            source_full_path = self.verified_source_full_path
+            copyfile(self.source_full_path, source_full_path)
             source_url = path_to_url(os.fspath(self.source_full_path))
-            actual_size = getsize(self.source_full_path)
+            actual_size = getsize(source_full_path)
             if self.size is not None and actual_size != self.size:
                 raise ChecksumMismatchError(
                     source_url,
@@ -1513,36 +1523,19 @@ class ExtractPackageAction(PathAction):
                     actual_size,
                 )
 
-            if verified_checksum and verified_checksum[0] == "sha256":
-                actual_sha256 = bytes.fromhex(verified_checksum[1]).hex()
-                expected_sha256 = (
-                    bytes.fromhex(self.sha256).hex() if self.sha256 else None
+            actual_sha256 = compute_sum(source_full_path, "sha256")
+            expected_sha256 = bytes.fromhex(self.sha256).hex() if self.sha256 else None
+            if expected_sha256 and actual_sha256 != expected_sha256:
+                raise ChecksumMismatchError(
+                    source_url,
+                    self.source_full_path,
+                    "sha256",
+                    self.sha256,
+                    actual_sha256,
                 )
-                if actual_sha256 != expected_sha256:
-                    raise ChecksumMismatchError(
-                        source_url,
-                        self.source_full_path,
-                        "sha256",
-                        self.sha256,
-                        actual_sha256,
-                    )
-            else:
-                actual_sha256 = compute_sum(self.source_full_path, "sha256")
-                if self.sha256 and actual_sha256 != self.sha256:
-                    raise ChecksumMismatchError(
-                        source_url,
-                        self.source_full_path,
-                        "sha256",
-                        self.sha256,
-                        actual_sha256,
-                    )
 
             if not self.sha256 and self.md5:
-                actual_md5 = (
-                    verified_checksum[1]
-                    if verified_checksum and verified_checksum[0] == "md5"
-                    else compute_sum(self.source_full_path, "md5")
-                )
+                actual_md5 = compute_sum(source_full_path, "md5")
                 if actual_md5 != self.md5:
                     raise ChecksumMismatchError(
                         source_url,
@@ -1556,7 +1549,7 @@ class ExtractPackageAction(PathAction):
                 try:
                     verifier.verify(
                         self.record_or_spec,
-                        self.source_full_path,
+                        source_full_path,
                         actual_sha256,
                     )
                 except CondaError:
@@ -1572,19 +1565,30 @@ class ExtractPackageAction(PathAction):
     def execute(self, progress_update_callback=None):
         self._prepare_extract()
         context.plugin_manager.extract_package(
-            self.source_full_path,
+            self.verified_source_full_path,
             self.target_full_path,
         )
         self._finish_extract()
+
+    @property
+    def verified_source_full_path(self):
+        if self._verified_archive_dir is None:
+            return self.source_full_path
+        return join(
+            self._verified_archive_dir.name,
+            basename(self.source_full_path),
+        )
 
     def _prepare_extract(self):
         log.log(
             TRACE, "extracting %s => %s", self.source_full_path, self.target_full_path
         )
 
-        self._target_path_touched = True
         if lexists(self.target_full_path):
-            rm_rf(self.target_full_path)
+            if lexists(self.hold_path):
+                rm_rf(self.hold_path)
+            backoff_rename(self.target_full_path, self.hold_path, force=True)
+        self._target_path_touched = True
 
     def _finish_extract(self):
         # I hate inline imports, but I guess it's ok since we're importing from the conda.core
@@ -1613,13 +1617,14 @@ class ExtractPackageAction(PathAction):
                 else Channel(None)
             )
             fn = basename(url)
-            sha256 = self.sha256 or compute_sum(self.source_full_path, "sha256")
-            size = getsize(self.source_full_path)
+            archive_path = self.verified_source_full_path
+            sha256 = self.sha256 or compute_sum(archive_path, "sha256")
+            size = getsize(archive_path)
             if self.size is not None and size != self.size:
                 raise RuntimeError(
                     f"Computed size ({size}) does not match expected value {self.size}"
                 )
-            md5 = self.md5 or compute_sum(self.source_full_path, "md5")
+            md5 = self.md5 or compute_sum(archive_path, "md5")
             repodata_record = PackageRecord.from_objects(
                 raw_index_json,
                 url=url,
@@ -1634,6 +1639,15 @@ class ExtractPackageAction(PathAction):
                 self.record_or_spec, raw_index_json
             )
 
+        if self._verified_archive_dir is not None:
+            backoff_rename(
+                self.verified_source_full_path,
+                self.source_full_path,
+                force=True,
+            )
+            self._verified_archive_dir.cleanup()
+            self._verified_archive_dir = None
+
         repodata_record_path = join(
             self.target_full_path, "info", "repodata_record.json"
         )
@@ -1645,9 +1659,12 @@ class ExtractPackageAction(PathAction):
             package_tarball_full_path=self.source_full_path,
             extracted_package_dir=self.target_full_path,
         )
-        target_package_cache.insert(package_cache_record)
+        target_package_cache.insert(package_cache_record, self._package_verifiers)
 
     def reverse(self):
+        if self._verified_archive_dir is not None:
+            self._verified_archive_dir.cleanup()
+            self._verified_archive_dir = None
         if self._target_path_touched:
             rm_rf(self.target_full_path)
             if lexists(self.hold_path):
@@ -1656,6 +1673,9 @@ class ExtractPackageAction(PathAction):
         self._target_path_touched = False
 
     def cleanup(self):
+        if self._verified_archive_dir is not None:
+            self._verified_archive_dir.cleanup()
+            self._verified_archive_dir = None
         rm_rf(self.hold_path)
         self._target_path_touched = False
 

--- a/conda/plugins/hookspec.py
+++ b/conda/plugins/hookspec.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         CondaExceptionObserver,
         CondaHealthCheck,
         CondaPackageExtractor,
+        CondaPackageVerifier,
         CondaPostCommand,
         CondaPostSolve,
         CondaPostTransactionAction,
@@ -831,6 +832,47 @@ class CondaSpecs:
                     default_filenames=("environment.toml",),
                     export=export_toml,
                 )
+        """
+        yield from ()
+
+    @_hookspec
+    def conda_package_verifiers(self) -> Iterable[CondaPackageVerifier]:
+        """
+        Register package verifiers that run before package extraction.
+
+        Conda validates the recorded size and strongest available package digest
+        before invoking these hooks. Every registered verifier receives the selected
+        package record or explicit match specification, the package archive path,
+        and its computed SHA-256. A verifier rejects the archive by raising
+        :class:`conda.CondaError` or a subclass. Verifiers run in name order for
+        each archive, but different archives may be verified concurrently, so
+        callbacks must be thread-safe. Conda may verify the same archive more than
+        once during a command, so callbacks must also be idempotent. Callbacks must
+        not mutate the package record, explicit match specification, or archive.
+
+        **Example:**
+
+        .. code-block:: python
+
+            from conda import plugins
+            from conda.exceptions import CondaVerificationError
+
+
+            def verify_package(record_or_spec, package_path, sha256):
+                if not is_allowed(record_or_spec, package_path, sha256):
+                    raise CondaVerificationError("Package verification failed")
+
+
+            @plugins.hookimpl
+            def conda_package_verifiers():
+                yield plugins.types.CondaPackageVerifier(
+                    name="example-verifier",
+                    verify=verify_package,
+                )
+
+        Returns:
+            An iterable of :class:`~conda.plugins.types.CondaPackageVerifier`
+            entries.
         """
         yield from ()
 

--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
         CondaExceptionObserver,
         CondaHealthCheck,
         CondaPackageExtractor,
+        CondaPackageVerifier,
         CondaPlugin,
         CondaPluginWithAliases,
         CondaPostCommand,
@@ -488,6 +489,11 @@ class CondaPluginManager(pluggy.PluginManager):
     def get_hook_results(
         self, name: Literal["package_extractors"]
     ) -> list[CondaPackageExtractor]: ...
+
+    @overload
+    def get_hook_results(
+        self, name: Literal["package_verifiers"]
+    ) -> list[CondaPackageVerifier]: ...
 
     @overload
     def get_hook_results(
@@ -1343,6 +1349,10 @@ class CondaPluginManager(pluggy.PluginManager):
             )
             for hook in self.get_hook_results("post_transaction_actions")
         ]
+
+    def get_package_verifiers(self) -> tuple[CondaPackageVerifier, ...]:
+        """Return the registered package verifier plugins."""
+        return tuple(self.get_hook_results("package_verifiers"))
 
     def get_package_extractors(self) -> dict[str, CondaPackageExtractor]:
         """

--- a/conda/plugins/types.py
+++ b/conda/plugins/types.py
@@ -51,6 +51,11 @@ if TYPE_CHECKING:
         None,
     ]
 
+    PackageVerify: TypeAlias = Callable[
+        [PackageRecord | MatchSpec, PathType, str],
+        None,
+    ]
+
     SinglePlatformEnvironmentExport = Callable[[Environment], str]
     MultiPlatformEnvironmentExport = Callable[[Iterable[Environment]], str]
 
@@ -856,6 +861,30 @@ class CondaEnvironmentExporter(CondaPlugin):
         # Set default description to name if not provided
         if self.description is None:
             self.description = self.name
+
+
+@dataclass
+class CondaPackageVerifier(CondaPlugin):
+    """
+    Return type to use when defining a conda package verifier plugin hook.
+
+    Package verifiers inspect package archives before extraction. All registered
+    verifiers must accept the package for extraction to proceed.
+
+    For details on how this is used, see
+    :meth:`~conda.plugins.hookspec.CondaSpecs.conda_package_verifiers`.
+
+    Args:
+        name: Verifier name.
+        verify: Callable that verifies a package archive. It receives the selected
+            package record or explicit match specification, the archive path, and
+            the archive's computed SHA-256. It must raise
+            :class:`conda.CondaError` or a subclass to reject the package and must
+            not mutate the record, match specification, or archive.
+    """
+
+    name: str
+    verify: PackageVerify
 
 
 @dataclass

--- a/docs/source/dev-guide/plugins/index.rst
+++ b/docs/source/dev-guide/plugins/index.rst
@@ -104,6 +104,7 @@ For examples of how to use other plugin hooks, please read their respective docu
    exception_observers
    health_checks
    package_extractors
+   package_verifiers
    post_commands
    pre_commands
    pre_transaction_actions

--- a/docs/source/dev-guide/plugins/package_verifiers.rst
+++ b/docs/source/dev-guide/plugins/package_verifiers.rst
@@ -1,0 +1,33 @@
+=================
+Package verifiers
+=================
+
+Package verifiers inspect package archives before conda extracts them. Conda
+first validates the recorded size and SHA-256, or MD5 when SHA-256 is unavailable.
+It then passes each verifier the selected package record or explicit match
+specification, the archive path, and the archive's computed SHA-256. Every
+registered verifier must accept the archive for extraction to proceed.
+
+Verifiers run in name order for each archive, but different archives may be
+verified concurrently, so callbacks must be thread-safe. Conda may verify the
+same archive more than once during a command, so callbacks must also be
+idempotent. Callbacks must not mutate the package record, explicit match
+specification, or archive. Raise
+:class:`conda.CondaError` or a subclass to reject a package with an expected error.
+:class:`conda.exceptions.CondaVerificationError` is available for a general
+verification failure. Conda reports any other exception as a failure in the named
+verifier plugin.
+
+Package verifier hooks run independently of the ``safety_checks`` setting. When at
+least one verifier is registered, conda rechecks retained package archives instead
+of reusing extracted package-cache entries without verification.
+
+A plugin can enable verification by yielding a verifier only when its own setting
+or environment variable is active. If no plugin yields a verifier, conda preserves
+its normal package-cache behavior.
+
+.. autoapiclass:: conda.plugins.types.CondaPackageVerifier
+   :members:
+   :undoc-members:
+
+.. autoapifunction:: conda.plugins.hookspec.CondaSpecs.conda_package_verifiers

--- a/docs/source/dev-guide/plugins/package_verifiers.rst
+++ b/docs/source/dev-guide/plugins/package_verifiers.rst
@@ -3,10 +3,14 @@ Package verifiers
 =================
 
 Package verifiers inspect package archives before conda extracts them. Conda
-first validates the recorded size and SHA-256, or MD5 when SHA-256 is unavailable.
-It then passes each verifier the selected package record or explicit match
-specification, the archive path, and the archive's computed SHA-256. Every
-registered verifier must accept the archive for extraction to proceed.
+copies the selected archive into a private staging directory in the package cache
+without changing its filename. It validates each recorded size and SHA-256, or MD5
+when SHA-256 is unavailable, against that staged file. Conda then passes each
+verifier the selected package record or explicit match specification, the staged
+archive path, and the archive's computed SHA-256. Conda extracts the same staged
+file and publishes those verified bytes back to the selected cache path after
+successful extraction. Every registered verifier must accept the archive for
+extraction to proceed.
 
 Verifiers run in name order for each archive, but different archives may be
 verified concurrently, so callbacks must be thread-safe. Conda may verify the
@@ -17,6 +21,9 @@ specification, or archive. Raise
 :class:`conda.exceptions.CondaVerificationError` is available for a general
 verification failure. Conda reports any other exception as a failure in the named
 verifier plugin.
+
+As with other package-cache operations, do not run another command that modifies
+the same package cache while package verification and extraction are in progress.
 
 Package verifier hooks run independently of the ``safety_checks`` setting. When at
 least one verifier is registered, conda rechecks retained package archives instead

--- a/docs/source/dev-guide/plugins/package_verifiers.rst
+++ b/docs/source/dev-guide/plugins/package_verifiers.rst
@@ -27,7 +27,9 @@ the same package cache while package verification and extraction are in progress
 
 Package verifier hooks run independently of the ``safety_checks`` setting. When at
 least one verifier is registered, conda rechecks retained package archives instead
-of reusing extracted package-cache entries without verification.
+of reusing extracted package-cache entries without verification. Conda links from
+the first writable package cache where it extracted the verified archive, even if
+another cache is on the target environment's device.
 
 A plugin can enable verification by yielding a verifier only when its own setting
 or environment variable is active. If no plugin yields a verifier, conda preserves

--- a/releases/news/16515-package-verifiers
+++ b/releases/news/16515-package-verifiers
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add a package verifier plugin hook that runs before package extraction. (#16515)

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -13,7 +13,7 @@ import pytest
 from pytest import MonkeyPatch
 
 from conda import CondaError, CondaMultiError
-from conda.base.constants import PACKAGE_CACHE_MAGIC_FILE
+from conda.base.constants import PACKAGE_CACHE_MAGIC_FILE, SafetyChecks
 from conda.base.context import context, reset_context
 from conda.common.compat import on_win
 from conda.common.path import strip_pkg_extension
@@ -28,7 +28,13 @@ from conda.core.package_cache_data import (
 from conda.core.path_actions import CacheUrlAction
 from conda.gateways.disk.create import copy
 from conda.gateways.disk.permissions import make_read_only
-from conda.gateways.disk.read import isfile, listdir, yield_lines
+from conda.gateways.disk.read import (
+    compute_sum,
+    isfile,
+    listdir,
+    read_index_json,
+    yield_lines,
+)
 from conda.models.enums import LinkType
 from conda.models.match_spec import MatchSpec
 from conda.models.records import PrefixRecord
@@ -647,6 +653,395 @@ def test_tar_bz2_in_pkg_cache_used_instead_of_conda_pkg(tmp_pkgs_dir: Path):
     # Now check urls.txt to make sure extensions are included.
     urls_text = tuple(yield_lines(join(tmp_pkgs_dir, "urls.txt")))
     assert urls_text[0] == tar_bz2_prec.url
+
+
+def test_package_verifier_does_not_reuse_complementary_format(
+    tmp_pkgs_dir: Path,
+    mocker,
+):
+    tar_bz2_prec, conda_prec = fresh_zlib_records()
+    ProgressiveFetchExtract((tar_bz2_prec,)).execute()
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(mocker.MagicMock(),),
+    )
+
+    pfe = ProgressiveFetchExtract((conda_prec,))
+    pfe.prepare()
+
+    assert len(pfe.cache_actions) == 1
+    assert pfe.cache_actions[0].target_package_basename == conda_prec.fn
+    assert pfe.extract_actions[0].sha256 == conda_prec.sha256
+
+
+def test_package_verifier_uses_exact_retained_format(
+    tmp_pkgs_dir: Path,
+    mocker,
+):
+    for filename in (zlib_tar_bz2_fn, zlib_conda_fn):
+        cache_action = CacheUrlAction(
+            f"{CONDA_PKG_REPO}/{subdir}/{filename}",
+            tmp_pkgs_dir,
+            filename,
+        )
+        cache_action.verify()
+        cache_action.execute()
+        cache_action.cleanup()
+
+    verify = mocker.stub(name="verify")
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(name="test-verifier", verify=verify),),
+    )
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
+    selected = PackageRecord.from_objects(
+        zlib_tar_bz2_prec,
+        url=f"https://mirror.example/{subdir}/{zlib_tar_bz2_fn}",
+    )
+
+    pfe = ProgressiveFetchExtract((selected,))
+    pfe.prepare()
+
+    assert not pfe.cache_actions
+    assert Path(pfe.extract_actions[0].source_full_path) == Path(
+        tmp_pkgs_dir,
+        zlib_tar_bz2_fn,
+    )
+
+    pfe.execute()
+
+    verify.assert_called_once()
+    assert verify.call_args.args[0] is selected
+
+
+@pytest.mark.parametrize("checksum", ("sha256", "md5"))
+def test_package_verifier_reuses_download_checksum(
+    checksum: str,
+    tmp_pkgs_dir: Path,
+    mocker,
+):
+    source = Path(CHANNEL_DIR_V1, subdir, zlib_tar_bz2_fn)
+    record_data = zlib_tar_bz2_prec.dump()
+    record_data["url"] = f"https://example.invalid/{subdir}/{zlib_tar_bz2_fn}"
+    if checksum == "md5":
+        record_data.pop("sha256")
+    else:
+        record_data["sha256"] = record_data["sha256"].upper()
+    selected = PackageRecord(**record_data)
+
+    def download(url, target_full_path, **kwargs):
+        copy(source, target_full_path)
+
+    download_package = mocker.patch(
+        "conda.core.path_actions.download",
+        side_effect=download,
+    )
+    compute_checksum = mocker.patch(
+        "conda.core.path_actions.compute_sum",
+        wraps=compute_sum,
+    )
+
+    def verify(record_or_spec, source_full_path, sha256):
+        assert record_or_spec is selected
+        assert sha256 == zlib_tar_bz2_prec.sha256
+        if checksum == "sha256":
+            compute_checksum.assert_not_called()
+        else:
+            compute_checksum.assert_called_once_with(source_full_path, "sha256")
+
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(name="test-verifier", verify=verify),),
+    )
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
+
+    pfe = ProgressiveFetchExtract((selected,))
+    pfe.execute()
+
+    download_package.assert_called_once()
+    assert download_package.call_args.kwargs[checksum] == getattr(selected, checksum)
+    if checksum == "sha256":
+        compute_checksum.assert_not_called()
+        extract_action = pfe.extract_actions[0]
+        extract_action._verified_checksum = ("sha256", selected.sha256)
+        extract_action.verify()
+        compute_checksum.assert_not_called()
+    else:
+        compute_checksum.assert_called_once_with(
+            str(Path(tmp_pkgs_dir, zlib_tar_bz2_fn)),
+            "sha256",
+        )
+
+
+def test_package_verifier_uses_exact_read_only_archive(
+    tmp_pkgs_dir: Path,
+    tmp_path: Path,
+    mocker,
+):
+    read_only_pkgs_dir = tmp_path / "read-only-pkgs"
+    read_only_pkgs_dir.mkdir()
+    magic_file = read_only_pkgs_dir / PACKAGE_CACHE_MAGIC_FILE
+    magic_file.touch()
+    copy(
+        join(CHANNEL_DIR_V1, subdir, zlib_tar_bz2_fn),
+        read_only_pkgs_dir / zlib_tar_bz2_fn,
+    )
+    make_read_only(magic_file)
+    mocker.patch(
+        "conda.base.context.Context.pkgs_dirs",
+        new_callable=mocker.PropertyMock,
+        return_value=(str(tmp_pkgs_dir), str(read_only_pkgs_dir)),
+    )
+    PackageCacheData.clear()
+    verify = mocker.stub(name="verify")
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(name="test-verifier", verify=verify),),
+    )
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
+
+    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe.prepare()
+
+    assert len(pfe.cache_actions) == 1
+    assert pfe.cache_actions[0].url == (read_only_pkgs_dir / zlib_tar_bz2_fn).as_uri()
+
+    pfe.execute()
+
+    verify.assert_called_once()
+    assert Path(verify.call_args.args[1]).parent == tmp_pkgs_dir
+
+
+def test_package_verifier_extracts_into_first_writable_cache(
+    tmp_pkgs_dir: Path,
+    tmp_path: Path,
+    mocker,
+):
+    ProgressiveFetchExtract((zlib_tar_bz2_prec,)).execute()
+    Path(tmp_pkgs_dir, zlib_tar_bz2_fn).unlink()
+    stale_marker = Path(tmp_pkgs_dir, zlib_base_fn, "stale")
+    stale_marker.touch()
+
+    second_pkgs_dir = tmp_path / "second-pkgs"
+    second_pkgs_dir.mkdir()
+    Path(second_pkgs_dir, PACKAGE_CACHE_MAGIC_FILE).touch()
+    copy(
+        join(CHANNEL_DIR_V1, subdir, zlib_tar_bz2_fn),
+        second_pkgs_dir / zlib_tar_bz2_fn,
+    )
+    mocker.patch(
+        "conda.base.context.Context.pkgs_dirs",
+        new_callable=mocker.PropertyMock,
+        return_value=(str(tmp_pkgs_dir), str(second_pkgs_dir)),
+    )
+    PackageCacheData.clear()
+    verify = mocker.stub(name="verify")
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(name="test-verifier", verify=verify),),
+    )
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
+
+    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe.prepare()
+
+    assert len(pfe.cache_actions) == 1
+    assert pfe.cache_actions[0].url == (second_pkgs_dir / zlib_tar_bz2_fn).as_uri()
+    assert Path(pfe.cache_actions[0].target_full_path).parent == tmp_pkgs_dir
+
+    pfe.execute()
+
+    verify.assert_called_once()
+    assert Path(verify.call_args.args[1]).parent == tmp_pkgs_dir
+    assert not stale_marker.exists()
+    entry = PackageCacheData.get_entry_to_link(zlib_tar_bz2_prec)
+    assert entry is not None
+    assert Path(entry.extracted_package_dir).parent == tmp_pkgs_dir
+
+
+def test_package_verifier_reacquires_unhashed_explicit_package(
+    tmp_pkgs_dir: Path,
+    mocker,
+):
+    requested = Path(CHANNEL_DIR_V1, "win-64", zlib_tar_bz2_fn)
+    wrong = Path(
+        CHANNEL_DIR_V1,
+        "linux-64",
+        "zlib-1.2.11-h7b6447c_3.tar.bz2",
+    )
+    copy(wrong, Path(tmp_pkgs_dir, requested.name))
+    verify = mocker.stub(name="verify")
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(name="test-verifier", verify=verify),),
+    )
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
+
+    ProgressiveFetchExtract((MatchSpec(url=requested.as_uri()),)).execute()
+
+    verify.assert_called_once()
+    assert verify.call_args.args[2] == compute_sum(requested, "sha256")
+    assert read_index_json(Path(tmp_pkgs_dir, zlib_base_fn))["subdir"] == "win-64"
+
+
+@pytest.mark.skipif(on_win, reason="creating symlinks requires extra privileges")
+def test_package_verifier_does_not_follow_cached_archive_symlink(
+    tmp_pkgs_dir: Path,
+    mocker,
+):
+    Path(tmp_pkgs_dir, zlib_tar_bz2_fn).symlink_to(
+        Path(CHANNEL_DIR_V1, subdir, zlib_tar_bz2_fn)
+    )
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(mocker.MagicMock(),),
+    )
+
+    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe.prepare()
+
+    assert len(pfe.cache_actions) == 1
+
+
+def test_package_verifier_rechecks_cached_package(tmp_pkgs_dir: Path, mocker):
+    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe.prepare()
+    pfe.execute()
+
+    archive_path = str(Path(tmp_pkgs_dir, zlib_tar_bz2_fn))
+    compute_checksum = None
+
+    def reject(*args):
+        compute_checksum.assert_called_once_with(archive_path, "sha256")
+        raise CondaError("rejected")
+
+    verify = mocker.MagicMock(side_effect=reject)
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(verify=verify),),
+    )
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
+    extract = mocker.patch.object(context.plugin_manager, "extract_package")
+    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe.prepare()
+    compute_checksum = mocker.patch(
+        "conda.core.path_actions.compute_sum",
+        wraps=compute_sum,
+    )
+
+    with pytest.raises(CondaMultiError, match="rejected"):
+        pfe.execute()
+
+    verify.assert_called_once()
+    assert verify.call_args.args[0] is zlib_tar_bz2_prec
+    assert verify.call_args.args[1] == archive_path
+    assert verify.call_args.args[2] == zlib_tar_bz2_prec.sha256
+    compute_checksum.assert_called_once_with(archive_path, "sha256")
+    extract.assert_not_called()
+    assert Path(tmp_pkgs_dir, zlib_base_fn, "info", "index.json").exists()
+
+    Path(tmp_pkgs_dir, zlib_tar_bz2_fn).unlink()
+    cache_action, extract_action = ProgressiveFetchExtract.make_actions_for_record(
+        zlib_tar_bz2_prec
+    )
+    assert cache_action is not None
+    assert extract_action is not None
+
+
+def test_package_verifier_prevents_extraction_during_cache_scan(
+    tmp_pkgs_dir: Path,
+    mocker,
+):
+    copy(
+        join(CHANNEL_DIR_V1, subdir, zlib_tar_bz2_fn),
+        join(tmp_pkgs_dir, zlib_tar_bz2_fn),
+    )
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(mocker.MagicMock(),),
+    )
+
+    record = PackageCacheData(tmp_pkgs_dir)._make_single_record(zlib_tar_bz2_fn)
+
+    assert record is not None
+    assert record.is_fetched
+    assert not record.is_extracted
+
+
+def test_package_verifier_blocks_process_extraction_when_safety_checks_disabled(
+    tmp_pkgs_dir: Path,
+    monkeypatch: MonkeyPatch,
+    mocker,
+):
+    monkeypatch.setenv("CONDA_SAFETY_CHECKS", "disabled")
+    reset_context()
+    assert context.safety_checks == SafetyChecks.disabled
+    reject = mocker.MagicMock(side_effect=CondaError("rejected"))
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(verify=reject),),
+    )
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 2)
+    extract = mocker.patch.object(
+        package_cache_data,
+        "extract_conda_package_archive",
+    )
+
+    with pytest.raises(CondaMultiError, match="rejected") as exc_info:
+        ProgressiveFetchExtract((zlib_tar_bz2_prec,)).execute()
+
+    assert len(exc_info.value.errors) == 1
+    reject.assert_called_once()
+    extract.assert_not_called()
+    assert not Path(tmp_pkgs_dir, zlib_tar_bz2_fn).exists()
+    assert not Path(tmp_pkgs_dir, zlib_base_fn).exists()
+
+
+@pytest.mark.parametrize("same_size", (False, True))
+def test_package_verifier_rejection_restores_previous_archive(
+    same_size: bool,
+    tmp_pkgs_dir: Path,
+    mocker,
+):
+    target = Path(tmp_pkgs_dir, zlib_tar_bz2_fn)
+    if same_size:
+        target.write_bytes(b"\0" * zlib_tar_bz2_prec.size)
+    else:
+        copy(
+            Path(
+                CHANNEL_DIR_V1,
+                "linux-64",
+                "zlib-1.2.11-h7b6447c_3.tar.bz2",
+            ),
+            target,
+        )
+    previous_bytes = target.read_bytes()
+    urls_path = Path(tmp_pkgs_dir, "urls.txt")
+    previous_urls = urls_path.read_bytes() if urls_path.exists() else None
+    reject = mocker.MagicMock(side_effect=CondaError("rejected"))
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(verify=reject),),
+    )
+
+    with pytest.raises(CondaMultiError, match="rejected"):
+        ProgressiveFetchExtract((zlib_tar_bz2_prec,)).execute()
+
+    reject.assert_called_once()
+    assert target.read_bytes() == previous_bytes
+    current_urls = urls_path.read_bytes() if urls_path.exists() else None
+    assert current_urls == previous_urls
 
 
 @pytest.mark.integration

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -199,10 +199,12 @@ def test_process_extract_finishes_when_later_fetch_fails(
     bad_cache = mocker.MagicMock()
     good_extract = mocker.MagicMock(
         source_full_path="/tmp/good.conda",
+        verified_source_full_path="/tmp/good.conda",
         target_full_path="/tmp/good",
     )
     bad_extract = mocker.MagicMock(
         source_full_path="/tmp/bad.conda",
+        verified_source_full_path="/tmp/bad.conda",
         target_full_path="/tmp/bad",
     )
     pfe = ProgressiveFetchExtract(())
@@ -470,12 +472,14 @@ def test_process_extract_gates_each_archive_on_concurrent_verifier(
     for record in records:
         action = mocker.MagicMock(
             source_full_path=f"/tmp/{record.name}.conda",
+            verified_source_full_path=f"/tmp/{record.name}.conda",
             target_full_path=f"/tmp/{record.name}",
         )
         action.verify.side_effect = lambda name=record.name: verify(name)
         actions[record] = (None, action)
     pfe = ProgressiveFetchExtract(())
     pfe.paired_actions = actions
+    pfe._package_verifiers = (SimpleNamespace(name="test-verifier", verify=verify),)
     pfe._prepared = True
     mocker.patch.object(pfe, "_progress_bar", return_value=mocker.MagicMock())
 
@@ -500,10 +504,12 @@ def test_process_extract_does_not_start_after_interrupt(
     record = PackageRecord(name="package", version="1", build="0", build_number=0)
     extract_action = mocker.MagicMock(
         source_full_path="/tmp/package.conda",
+        verified_source_full_path="/tmp/package.conda",
         target_full_path="/tmp/package",
     )
     pfe = ProgressiveFetchExtract(())
     pfe.paired_actions = {record: (None, extract_action)}
+    pfe._package_verifiers = (mocker.MagicMock(),)
     pfe._prepared = True
 
     mocker.patch.object(
@@ -543,6 +549,95 @@ def test_process_extract_does_not_start_after_interrupt(
     extract_action.verify.assert_called_once_with()
     extract_action._prepare_extract.assert_not_called()
     extract.assert_not_called()
+
+
+@pytest.mark.parametrize("failure", ("fetch", "verify"))
+def test_package_verifier_failure_reverses_each_action_once(
+    failure: str,
+    mocker,
+):
+    record = PackageRecord(name="package", version="1", build="0", build_number=0)
+    cache_action = mocker.MagicMock(
+        url="file:/tmp/package.conda",
+        defer_cleanup=True,
+    )
+    extract_action = mocker.MagicMock(
+        source_full_path="/tmp/package.conda",
+        verified_source_full_path="/tmp/package.conda",
+        target_full_path="/tmp/package",
+    )
+    error = RuntimeError(f"{failure} failed")
+    if failure == "fetch":
+        cache_action.execute.side_effect = error
+    else:
+        extract_action.verify.side_effect = error
+
+    pfe = ProgressiveFetchExtract(())
+    pfe.paired_actions = {record: (cache_action, extract_action)}
+    pfe._package_verifiers = (mocker.MagicMock(),)
+    pfe._prepared = True
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
+    mocker.patch.object(pfe, "_progress_bar", return_value=mocker.MagicMock())
+
+    with pytest.raises(CondaMultiError, match=f"{failure} failed"):
+        pfe.execute()
+
+    cache_action.reverse.assert_called_once_with()
+    extract_action.reverse.assert_called_once_with()
+
+
+@pytest.mark.parametrize("use_process_pool", (False, True), ids=("thread", "process"))
+def test_package_verifier_extraction_failure_restores_extracted_cache(
+    use_process_pool: bool,
+    mocker,
+    process_pool_as_threads,
+    tmp_pkgs_dir: Path,
+):
+    ProgressiveFetchExtract((zlib_tar_bz2_prec,)).execute()
+    extracted_dir = Path(tmp_pkgs_dir, zlib_base_fn)
+    marker = extracted_dir / "existing-cache-marker"
+    marker.write_text("existing")
+    archive_path = Path(tmp_pkgs_dir, zlib_tar_bz2_fn)
+    archive_bytes = archive_path.read_bytes()
+
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(
+            SimpleNamespace(name="test-verifier", verify=lambda *_args: None),
+        ),
+    )
+    mocker.patch.object(
+        package_cache_data,
+        "EXTRACT_PROCESSES",
+        2 if use_process_pool else 1,
+    )
+    if use_process_pool:
+        extract = mocker.patch.object(
+            package_cache_data,
+            "extract_conda_package_archive",
+            side_effect=RuntimeError("extraction failed"),
+        )
+    else:
+        extract = mocker.patch.object(
+            context.plugin_manager,
+            "extract_package",
+            side_effect=RuntimeError("extraction failed"),
+        )
+
+    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe.prepare()
+    extract_action = pfe.extract_actions[0]
+
+    with pytest.raises(CondaMultiError, match="extraction failed"):
+        pfe.execute()
+
+    extract.assert_called_once()
+    assert marker.read_text() == "existing"
+    assert (extracted_dir / "info" / "index.json").exists()
+    assert archive_path.read_bytes() == archive_bytes
+    assert not Path(extract_action.hold_path).exists()
+    assert not tuple(Path(tmp_pkgs_dir).glob(".conda-verify-*"))
 
 
 def test_ProgressiveFetchExtract_prefers_conda_v2_format(monkeypatch: MonkeyPatch):
@@ -842,7 +937,7 @@ def test_package_verifier_uses_exact_retained_format(
 
 
 @pytest.mark.parametrize("checksum", ("sha256", "md5"))
-def test_package_verifier_reuses_download_checksum(
+def test_package_verifier_rechecks_downloaded_archive(
     checksum: str,
     tmp_pkgs_dir: Path,
     mocker,
@@ -871,10 +966,9 @@ def test_package_verifier_reuses_download_checksum(
     def verify(record_or_spec, source_full_path, sha256):
         assert record_or_spec is selected
         assert sha256 == zlib_tar_bz2_prec.sha256
-        if checksum == "sha256":
-            compute_checksum.assert_not_called()
-        else:
-            compute_checksum.assert_called_once_with(source_full_path, "sha256")
+        compute_checksum.assert_any_call(source_full_path, "sha256")
+        if checksum == "md5":
+            compute_checksum.assert_any_call(source_full_path, "md5")
 
     mocker.patch.object(
         context.plugin_manager,
@@ -888,17 +982,15 @@ def test_package_verifier_reuses_download_checksum(
 
     download_package.assert_called_once()
     assert download_package.call_args.kwargs[checksum] == getattr(selected, checksum)
+    archive_path = Path(compute_checksum.call_args_list[0].args[0])
+    assert archive_path.name == zlib_tar_bz2_fn
+    assert archive_path.parent.parent == tmp_pkgs_dir
+    compute_checksum.assert_any_call(str(archive_path), "sha256")
     if checksum == "sha256":
-        compute_checksum.assert_not_called()
-        extract_action = pfe.extract_actions[0]
-        extract_action._verified_checksum = ("sha256", selected.sha256)
-        extract_action.verify()
-        compute_checksum.assert_not_called()
+        assert compute_checksum.call_count == 1
     else:
-        compute_checksum.assert_called_once_with(
-            str(Path(tmp_pkgs_dir, zlib_tar_bz2_fn)),
-            "sha256",
-        )
+        compute_checksum.assert_any_call(str(archive_path), "md5")
+        assert compute_checksum.call_count == 2
 
 
 def test_package_verifier_uses_exact_read_only_archive(
@@ -938,7 +1030,7 @@ def test_package_verifier_uses_exact_read_only_archive(
     pfe.execute()
 
     verify.assert_called_once()
-    assert Path(verify.call_args.args[1]).parent == tmp_pkgs_dir
+    assert Path(verify.call_args.args[1]).parent.parent == tmp_pkgs_dir
 
 
 def test_package_verifier_extracts_into_first_writable_cache(
@@ -982,7 +1074,7 @@ def test_package_verifier_extracts_into_first_writable_cache(
     pfe.execute()
 
     verify.assert_called_once()
-    assert Path(verify.call_args.args[1]).parent == tmp_pkgs_dir
+    assert Path(verify.call_args.args[1]).parent.parent == tmp_pkgs_dir
     assert not stale_marker.exists()
     entry = PackageCacheData.get_entry_to_link(zlib_tar_bz2_prec)
     assert entry is not None
@@ -1040,10 +1132,9 @@ def test_package_verifier_rechecks_cached_package(tmp_pkgs_dir: Path, mocker):
     pfe.prepare()
     pfe.execute()
 
-    archive_path = str(Path(tmp_pkgs_dir, zlib_tar_bz2_fn))
     compute_checksum = None
 
-    def reject(*args):
+    def reject(_record_or_spec, archive_path, _sha256):
         compute_checksum.assert_called_once_with(archive_path, "sha256")
         raise CondaError("rejected")
 
@@ -1051,7 +1142,7 @@ def test_package_verifier_rechecks_cached_package(tmp_pkgs_dir: Path, mocker):
     mocker.patch.object(
         context.plugin_manager,
         "get_package_verifiers",
-        return_value=(SimpleNamespace(verify=verify),),
+        return_value=(SimpleNamespace(name="test-verifier", verify=verify),),
     )
     mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
     extract = mocker.patch.object(context.plugin_manager, "extract_package")
@@ -1067,9 +1158,10 @@ def test_package_verifier_rechecks_cached_package(tmp_pkgs_dir: Path, mocker):
 
     verify.assert_called_once()
     assert verify.call_args.args[0] is zlib_tar_bz2_prec
-    assert verify.call_args.args[1] == archive_path
+    assert Path(verify.call_args.args[1]).name == zlib_tar_bz2_fn
+    assert Path(verify.call_args.args[1]).parent.parent == tmp_pkgs_dir
     assert verify.call_args.args[2] == zlib_tar_bz2_prec.sha256
-    compute_checksum.assert_called_once_with(archive_path, "sha256")
+    compute_checksum.assert_called_once_with(verify.call_args.args[1], "sha256")
     extract.assert_not_called()
     assert Path(tmp_pkgs_dir, zlib_base_fn, "info", "index.json").exists()
 
@@ -1081,7 +1173,7 @@ def test_package_verifier_rechecks_cached_package(tmp_pkgs_dir: Path, mocker):
     assert extract_action is not None
 
 
-def test_package_verifier_prevents_extraction_during_cache_scan(
+def test_package_verifier_skips_archive_extraction_during_cache_scan(
     tmp_pkgs_dir: Path,
     mocker,
 ):
@@ -1089,17 +1181,58 @@ def test_package_verifier_prevents_extraction_during_cache_scan(
         join(CHANNEL_DIR_V1, subdir, zlib_tar_bz2_fn),
         join(tmp_pkgs_dir, zlib_tar_bz2_fn),
     )
-    mocker.patch.object(
+    verify = mocker.stub(name="verify")
+    package_verifiers = (SimpleNamespace(name="test-verifier", verify=verify),)
+    get_package_verifiers = mocker.patch.object(
         context.plugin_manager,
         "get_package_verifiers",
-        return_value=(mocker.MagicMock(),),
+        side_effect=(package_verifiers, ()),
+    )
+    read_archive_metadata = mocker.patch.object(
+        package_cache_data,
+        "read_index_json_from_tarball",
     )
 
-    record = PackageCacheData(tmp_pkgs_dir)._make_single_record(zlib_tar_bz2_fn)
+    record = PackageCacheData(tmp_pkgs_dir)._make_single_record(
+        zlib_tar_bz2_fn,
+        package_verifiers,
+    )
 
-    assert record is not None
-    assert record.is_fetched
-    assert not record.is_extracted
+    assert record is None
+    read_archive_metadata.assert_not_called()
+    assert not Path(tmp_pkgs_dir, zlib_base_fn).exists()
+
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 1)
+    pfe = ProgressiveFetchExtract((zlib_tar_bz2_prec,))
+    pfe.prepare()
+    pfe.execute()
+
+    get_package_verifiers.assert_called_once()
+    verify.assert_called_once()
+    read_archive_metadata.assert_not_called()
+    assert Path(tmp_pkgs_dir, zlib_base_fn, "info", "index.json").exists()
+
+
+def test_package_verifier_cache_scan_ignores_malformed_archive(
+    tmp_pkgs_dir: Path,
+    mocker,
+):
+    archive_path = Path(tmp_pkgs_dir, zlib_tar_bz2_fn)
+    archive_path.write_bytes(b"not a package archive")
+    package_verifiers = (mocker.MagicMock(),)
+    read_archive_metadata = mocker.patch.object(
+        package_cache_data,
+        "read_index_json_from_tarball",
+    )
+
+    record = PackageCacheData(tmp_pkgs_dir)._make_single_record(
+        zlib_tar_bz2_fn,
+        package_verifiers,
+    )
+
+    assert record is None
+    read_archive_metadata.assert_not_called()
+    assert archive_path.read_bytes() == b"not a package archive"
 
 
 def test_package_verifier_blocks_process_extraction_when_safety_checks_disabled(

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from os.path import abspath, basename, dirname, join
 from pathlib import Path
-from threading import Event
+from threading import Barrier, Event, Lock
 from types import SimpleNamespace
 
 import pytest
@@ -173,7 +173,25 @@ def test_get_softlinked_package_dirs(mocker, tmp_path: Path):
     )
 
 
-def test_process_extract_finishes_when_later_fetch_fails(mocker):
+@pytest.fixture
+def process_pool_as_threads(mocker):
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 3)
+    mocker.patch.object(
+        package_cache_data,
+        "ProcessPoolExecutor",
+        side_effect=lambda **kwargs: ThreadPoolExecutor(kwargs["max_workers"]),
+    )
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_extractor",
+        return_value=SimpleNamespace(name="conda-package"),
+    )
+
+
+def test_process_extract_finishes_when_later_fetch_fails(
+    mocker,
+    process_pool_as_threads,
+):
     extracted = Event()
     good = PackageRecord(name="good", version="1", build="0", build_number=0)
     bad = PackageRecord(name="bad", version="1", build="0", build_number=0)
@@ -200,22 +218,11 @@ def test_process_extract_finishes_when_later_fetch_fails(mocker):
             raise OSError("fetch failed")
         return record
 
-    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 2)
     mocker.patch.object(package_cache_data, "do_cache_action", side_effect=cache_action)
     mocker.patch.object(
         package_cache_data,
         "extract_conda_package_archive",
         side_effect=lambda *args, **kwargs: extracted.set(),
-    )
-    mocker.patch.object(
-        package_cache_data,
-        "ProcessPoolExecutor",
-        side_effect=lambda **kwargs: ThreadPoolExecutor(kwargs["max_workers"]),
-    )
-    mocker.patch.object(
-        context.plugin_manager,
-        "get_package_extractor",
-        return_value=SimpleNamespace(name="conda-package"),
     )
     mocker.patch.object(pfe, "_progress_bar", return_value=mocker.MagicMock())
 
@@ -418,6 +425,124 @@ def test_process_extract_logs_exception_cause(mocker, tmp_pkgs_dir: Path):
     log_debug.assert_any_call("Package extraction failed.", exc_info=pool_error)
     assert exc_info.value.errors == [pool_error]
     assert pool_error.__cause__ is decode_error
+
+
+def test_process_extract_gates_each_archive_on_concurrent_verifier(
+    mocker,
+    process_pool_as_threads,
+):
+    records = tuple(
+        PackageRecord(name=name, version="1", build="0", build_number=0)
+        for name in ("accepted", "rejected-one", "rejected-two")
+    )
+    barrier = Barrier(len(records))
+    accepted_extracted = Event()
+    lock = Lock()
+    verified = set()
+
+    def verify(name):
+        barrier.wait(timeout=5)
+        with lock:
+            verified.add(name)
+        if name.startswith("rejected"):
+            assert accepted_extracted.wait(timeout=5)
+            raise CondaError(name)
+
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(SimpleNamespace(name="test-verifier", verify=verify),),
+    )
+    extracted = []
+
+    def extract(source_full_path, target_full_path, **kwargs):
+        assert target_full_path == "/tmp/accepted"
+        assert kwargs == {"ensure_picklable_errors": True}
+        extracted.append(target_full_path)
+        accepted_extracted.set()
+
+    mocker.patch.object(
+        package_cache_data,
+        "extract_conda_package_archive",
+        side_effect=extract,
+    )
+    actions = {}
+    for record in records:
+        action = mocker.MagicMock(
+            source_full_path=f"/tmp/{record.name}.conda",
+            target_full_path=f"/tmp/{record.name}",
+        )
+        action.verify.side_effect = lambda name=record.name: verify(name)
+        actions[record] = (None, action)
+    pfe = ProgressiveFetchExtract(())
+    pfe.paired_actions = actions
+    pfe._prepared = True
+    mocker.patch.object(pfe, "_progress_bar", return_value=mocker.MagicMock())
+
+    with pytest.raises(CondaMultiError) as exc_info:
+        pfe.execute()
+
+    assert {str(error) for error in exc_info.value.errors} == {
+        "rejected-one",
+        "rejected-two",
+    }
+    assert verified == {record.name for record in records}
+    assert extracted == ["/tmp/accepted"]
+    for record, (_, action) in actions.items():
+        if record.name.startswith("rejected"):
+            action._prepare_extract.assert_not_called()
+
+
+def test_process_extract_does_not_start_after_interrupt(
+    mocker,
+    process_pool_as_threads,
+):
+    record = PackageRecord(name="package", version="1", build="0", build_number=0)
+    extract_action = mocker.MagicMock(
+        source_full_path="/tmp/package.conda",
+        target_full_path="/tmp/package",
+    )
+    pfe = ProgressiveFetchExtract(())
+    pfe.paired_actions = {record: (None, extract_action)}
+    pfe._prepared = True
+
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_verifiers",
+        return_value=(mocker.MagicMock(),),
+    )
+    mocker.patch.object(pfe, "_progress_bar", return_value=mocker.MagicMock())
+    extract = mocker.patch.object(
+        package_cache_data,
+        "extract_conda_package_archive",
+    )
+    verifier_started = Event()
+    release_verifier = Event()
+
+    def verify():
+        verifier_started.set()
+        assert release_verifier.wait(timeout=5)
+
+    extract_action.verify.side_effect = verify
+    wait_calls = 0
+
+    def interrupt_after_fetch(futures, **kwargs):
+        nonlocal wait_calls
+        wait_calls += 1
+        if wait_calls == 1:
+            return {next(iter(futures))}, set()
+        assert verifier_started.wait(timeout=5)
+        release_verifier.set()
+        raise KeyboardInterrupt
+
+    mocker.patch.object(package_cache_data, "wait", side_effect=interrupt_after_fetch)
+
+    with pytest.raises(CondaMultiError):
+        pfe.execute()
+
+    extract_action.verify.assert_called_once_with()
+    extract_action._prepare_extract.assert_not_called()
+    extract.assert_not_called()
 
 
 def test_ProgressiveFetchExtract_prefers_conda_v2_format(monkeypatch: MonkeyPatch):

--- a/tests/plugins/test_package_verifiers.py
+++ b/tests/plugins/test_package_verifiers.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -78,7 +79,10 @@ def test_package_verifier_runs_before_extraction(
 
     def verify(record_or_spec, source_full_path, sha256):
         assert record_or_spec == expected_record_or_spec
-        assert source_full_path == str(package_path)
+        staged_archive = Path(source_full_path)
+        assert staged_archive.name == package_path.name
+        assert staged_archive.parent.parent == tmp_path
+        assert staged_archive.parent.name.startswith(".conda-verify-")
         assert sha256 == compute_sum(package_path, "sha256")
         events.append("verify")
 
@@ -195,7 +199,8 @@ def test_explicit_package_runs_verifier(
     verify.assert_called_once()
     record_or_spec, archive_path, sha256 = verify.call_args.args
     assert isinstance(record_or_spec, MatchSpec)
-    assert Path(archive_path).parent == tmp_pkgs_dir
+    assert Path(archive_path).name == package_path.name
+    assert Path(archive_path).parent.parent == tmp_pkgs_dir
     assert sha256 == compute_sum(package_path, "sha256")
     assert (tmp_pkgs_dir / "urls.txt").read_text().splitlines() == [
         package_path.as_uri()
@@ -393,7 +398,9 @@ def test_package_integrity_mismatch_prevents_verifier(
     verify.assert_not_called()
 
 
-def test_package_archive_is_rechecked_before_extraction(
+@pytest.mark.parametrize("checksum_name", ("sha256", "md5"))
+def test_package_archive_is_rehashed_before_verifier(
+    checksum_name: str,
     package_path: Path,
     package_record: PackageRecord,
     plugin_manager: CondaPluginManager,
@@ -402,7 +409,7 @@ def test_package_archive_is_rechecked_before_extraction(
 ) -> None:
     archive_path = tmp_path / package_path.name
     archive_path.write_bytes(package_path.read_bytes())
-    expected_sha256 = compute_sum(archive_path, "sha256")
+    expected_checksum = compute_sum(archive_path, checksum_name)
     verify = mocker.stub(name="verify")
     register_verifier(
         plugin_manager,
@@ -414,19 +421,66 @@ def test_package_archive_is_rechecked_before_extraction(
         target_pkgs_dir=tmp_path,
         target_extracted_dirname="extracted",
         record_or_spec=package_record,
-        sha256=expected_sha256,
+        sha256=expected_checksum if checksum_name == "sha256" else None,
         size=None,
-        md5=None,
+        md5=expected_checksum if checksum_name == "md5" else None,
     )
-    action._verified_checksum = ("sha256", expected_sha256)
-    action.verify()
-    archive_path.write_bytes(b"replaced after verification")
+    archive_path.write_bytes(b"x" * archive_path.stat().st_size)
 
     with pytest.raises(ChecksumMismatchError):
         do_extract_action(package_record, action, mocker.MagicMock())
 
-    verify.assert_called_once()
+    verify.assert_not_called()
     extract.assert_not_called()
+
+
+def test_extractor_uses_verified_staged_archive(
+    package_path: Path,
+    plugin_manager: CondaPluginManager,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / package_path.name
+    original_bytes = package_path.read_bytes()
+    archive_path.write_bytes(original_bytes)
+    expected_sha256 = compute_sum(archive_path, "sha256")
+    expected_md5 = compute_sum(archive_path, "md5")
+
+    def replace_cache_archive(_record_or_spec, staged_path, sha256):
+        assert Path(staged_path).name == archive_path.name
+        assert sha256 == expected_sha256
+        archive_path.write_bytes(b"replaced after verification")
+
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(
+            name="test-verifier",
+            verify=replace_cache_archive,
+        ),
+    )
+    plugin_manager.load_plugins(*package_extractors.plugins)
+    explicit_spec = MatchSpec(url=archive_path.as_uri())
+    action = ExtractPackageAction(
+        source_full_path=str(archive_path),
+        target_pkgs_dir=tmp_path,
+        target_extracted_dirname="extracted",
+        record_or_spec=explicit_spec,
+        sha256=expected_sha256,
+        size=None,
+        md5=None,
+    )
+
+    do_extract_action(explicit_spec, action, mocker.MagicMock())
+
+    assert archive_path.read_bytes() == original_bytes
+    assert (tmp_path / "extracted" / "info" / "index.json").exists()
+    repodata_record = json.loads(
+        (tmp_path / "extracted" / "info" / "repodata_record.json").read_text()
+    )
+    assert repodata_record["sha256"] == expected_sha256
+    assert repodata_record["md5"] == expected_md5
+    assert repodata_record["size"] == len(original_bytes)
+    assert not tuple(tmp_path.glob(".conda-verify-*"))
 
 
 def test_package_archive_is_hashed_once_for_verifiers(
@@ -446,7 +500,8 @@ def test_package_archive_is_hashed_once_for_verifiers(
 
     def verify(record_or_spec, source_full_path, sha256):
         assert sha256 == expected_sha256
-        compute_checksum.assert_called_once_with(str(archive_path), "sha256")
+        assert Path(source_full_path).name == archive_path.name
+        compute_checksum.assert_called_once_with(source_full_path, "sha256")
 
     register_verifier(
         plugin_manager,
@@ -464,4 +519,7 @@ def test_package_archive_is_hashed_once_for_verifiers(
 
     action.verify()
 
-    compute_checksum.assert_called_once_with(str(archive_path), "sha256")
+    staged_archive = Path(compute_checksum.call_args.args[0])
+    assert staged_archive.name == archive_path.name
+    assert staged_archive.parent.parent == tmp_path
+    compute_checksum.assert_called_once_with(str(staged_archive), "sha256")

--- a/tests/plugins/test_package_verifiers.py
+++ b/tests/plugins/test_package_verifiers.py
@@ -1,0 +1,467 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from conda import CondaError, CondaMultiError, plugins
+from conda.base.context import context, reset_context
+from conda.common.path import strip_pkg_extension
+from conda.common.url import path_to_url
+from conda.core.package_cache_data import do_extract_action
+from conda.core.path_actions import (
+    CreatePrefixRecordAction,
+    ExtractPackageAction,
+    LinkPathAction,
+    UnlinkPathAction,
+)
+from conda.exceptions import (
+    ChecksumMismatchError,
+    CondaVerificationError,
+    PluginError,
+)
+from conda.gateways.disk.read import compute_sum, read_index_json_from_tarball
+from conda.misc import get_package_records_from_explicit
+from conda.models.match_spec import MatchSpec
+from conda.models.records import PackageRecord
+from conda.plugins import package_extractors, solvers
+from conda.plugins.types import CondaPackageVerifier
+
+from .. import TEST_RECIPES_CHANNEL
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda.plugins.manager import CondaPluginManager
+    from conda.testing.fixtures import CondaCLIFixture
+
+
+@pytest.fixture
+def package_path() -> Path:
+    return TEST_RECIPES_CHANNEL / "noarch" / "small-executable-1.0-0.conda"
+
+
+@pytest.fixture
+def package_record(package_path: Path) -> PackageRecord:
+    return PackageRecord.from_objects(
+        read_index_json_from_tarball(str(package_path)),
+        fn=package_path.name,
+        url=path_to_url(str(package_path)),
+    )
+
+
+def register_verifier(
+    plugin_manager: CondaPluginManager,
+    verifier: CondaPackageVerifier,
+) -> None:
+    class VerifierPlugin:
+        @plugins.hookimpl
+        def conda_package_verifiers(self):
+            yield verifier
+
+    plugin_manager.register(VerifierPlugin())
+
+
+@pytest.mark.parametrize("explicit", (False, True))
+def test_package_verifier_runs_before_extraction(
+    explicit: bool,
+    package_path: Path,
+    package_record: PackageRecord,
+    plugin_manager: CondaPluginManager,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    events = []
+
+    def verify(record_or_spec, source_full_path, sha256):
+        assert record_or_spec == expected_record_or_spec
+        assert source_full_path == str(package_path)
+        assert sha256 == compute_sum(package_path, "sha256")
+        events.append("verify")
+
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=verify),
+    )
+    plugin_manager.load_plugins(*package_extractors.plugins)
+    expected_record_or_spec = (
+        MatchSpec(url=path_to_url(str(package_path))) if explicit else package_record
+    )
+    action = ExtractPackageAction(
+        source_full_path=str(package_path),
+        target_pkgs_dir=tmp_path,
+        target_extracted_dirname="extracted",
+        record_or_spec=expected_record_or_spec,
+        sha256=None,
+        size=None,
+        md5=None,
+    )
+    extract_package = plugin_manager.extract_package
+
+    def extract(*args):
+        events.append("extract")
+        extract_package(*args)
+
+    mocker.patch.object(plugin_manager, "extract_package", side_effect=extract)
+
+    do_extract_action(package_record, action, mocker.MagicMock())
+
+    assert events == ["verify", "extract"]
+
+
+def test_package_verifier_failure_prevents_extraction(
+    package_path: Path,
+    package_record: PackageRecord,
+    plugin_manager: CondaPluginManager,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    error = CondaVerificationError("rejected")
+
+    def reject(*args):
+        raise error
+
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=reject),
+    )
+    extract = mocker.patch.object(plugin_manager, "extract_package")
+    action = ExtractPackageAction(
+        source_full_path=str(package_path),
+        target_pkgs_dir=tmp_path,
+        target_extracted_dirname="extracted",
+        record_or_spec=package_record,
+        sha256=None,
+        size=None,
+        md5=None,
+    )
+
+    with pytest.raises(CondaVerificationError, match="rejected") as exc_info:
+        do_extract_action(package_record, action, mocker.MagicMock())
+
+    assert exc_info.value is error
+    extract.assert_not_called()
+
+
+def test_package_verifier_unexpected_error_names_plugin(
+    package_path: Path,
+    package_record: PackageRecord,
+    plugin_manager: CondaPluginManager,
+    tmp_path: Path,
+) -> None:
+    def fail(*args):
+        raise ValueError("broken verifier")
+
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=fail),
+    )
+    action = ExtractPackageAction(
+        source_full_path=str(package_path),
+        target_pkgs_dir=tmp_path,
+        target_extracted_dirname="extracted",
+        record_or_spec=package_record,
+        sha256=None,
+        size=None,
+        md5=None,
+    )
+
+    with pytest.raises(PluginError, match="test-verifier.*broken verifier") as exc_info:
+        action.verify()
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_explicit_package_runs_verifier(
+    package_path: Path,
+    plugin_manager_with_reporter_backends: CondaPluginManager,
+    mocker: MockerFixture,
+    tmp_pkgs_dir: Path,
+) -> None:
+    plugin_manager = plugin_manager_with_reporter_backends
+    verify = mocker.stub(name="verify")
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=verify),
+    )
+    plugin_manager.load_plugins(*package_extractors.plugins)
+
+    records = tuple(get_package_records_from_explicit([package_path.as_uri()]))
+
+    assert len(records) == 1
+    verify.assert_called_once()
+    record_or_spec, archive_path, sha256 = verify.call_args.args
+    assert isinstance(record_or_spec, MatchSpec)
+    assert Path(archive_path).parent == tmp_pkgs_dir
+    assert sha256 == compute_sum(package_path, "sha256")
+    assert (tmp_pkgs_dir / "urls.txt").read_text().splitlines() == [
+        package_path.as_uri()
+    ]
+
+
+def test_explicit_install_rejection_prevents_prefix_changes(
+    package_path: Path,
+    plugin_manager_with_reporter_backends: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    tmp_pkgs_dir: Path,
+) -> None:
+    plugin_manager = plugin_manager_with_reporter_backends
+    reject = mocker.MagicMock(side_effect=CondaError("rejected"))
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=reject),
+    )
+    plugin_manager.load_plugins(*package_extractors.plugins)
+    prefix = tmp_path / "prefix"
+
+    _, _, exc = conda_cli(
+        "create",
+        f"--prefix={prefix}",
+        package_path,
+        "--yes",
+        raises=CondaMultiError,
+    )
+
+    assert exc.match("rejected")
+    reject.assert_called_once()
+    assert not (prefix / "conda-meta").exists()
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("download_only", (False, True))
+def test_solved_install_rejection_prevents_prefix_changes(
+    download_only: bool,
+    parametrized_solver_fixture: str,
+    package_record: PackageRecord,
+    plugin_manager_with_reporter_backends: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    tmp_pkgs_dir: Path,
+) -> None:
+    plugin_manager = plugin_manager_with_reporter_backends
+    plugin_manager.load_plugins(solvers)
+    if parametrized_solver_fixture == "libmamba":
+        from conda_libmamba_solver import plugin as libmamba_solver_plugin
+
+        plugin_manager.load_plugins(libmamba_solver_plugin)
+    reject = mocker.MagicMock(side_effect=CondaVerificationError("rejected"))
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=reject),
+    )
+    plugin_manager.load_plugins(*package_extractors.plugins)
+    prefix = tmp_path / parametrized_solver_fixture
+
+    arguments = [
+        "create",
+        f"--prefix={prefix}",
+        "--channel",
+        str(TEST_RECIPES_CHANNEL),
+        "--override-channels",
+        package_record.name,
+        "--yes",
+    ]
+    if download_only:
+        arguments.append("--download-only")
+
+    _, _, exc = conda_cli(
+        *arguments,
+        raises=CondaMultiError,
+    )
+
+    assert exc.match("rejected")
+    reject.assert_called_once()
+    assert isinstance(reject.call_args.args[0], PackageRecord)
+    archive_path = Path(reject.call_args.args[1])
+    assert not archive_path.exists()
+    assert not Path(strip_pkg_extension(str(archive_path))[0]).exists()
+    assert not (prefix / "conda-meta").exists()
+
+
+@pytest.mark.integration
+def test_rejection_precedes_prefix_actions_when_rollback_is_disabled(
+    parametrized_solver_fixture: str,
+    package_record: PackageRecord,
+    plugin_manager_with_reporter_backends: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    tmp_pkgs_dir: Path,
+) -> None:
+    plugin_manager = plugin_manager_with_reporter_backends
+    plugin_manager.load_plugins(solvers)
+    if parametrized_solver_fixture == "libmamba":
+        from conda_libmamba_solver import plugin as libmamba_solver_plugin
+
+        plugin_manager.load_plugins(libmamba_solver_plugin)
+    plugin_manager.load_plugins(*package_extractors.plugins)
+    prefix = tmp_path / parametrized_solver_fixture
+    conda_cli(
+        "create",
+        f"--prefix={prefix}",
+        "--channel",
+        str(TEST_RECIPES_CHANNEL),
+        "--override-channels",
+        package_record.name,
+        "--yes",
+    )
+    before = {
+        path.relative_to(prefix): path.read_bytes()
+        for path in prefix.rglob("*")
+        if path.is_file()
+    }
+
+    monkeypatch.setenv("CONDA_ROLLBACK_ENABLED", "false")
+    reset_context()
+    assert not context.rollback_enabled
+    reject = mocker.MagicMock(side_effect=CondaVerificationError("rejected"))
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=reject),
+    )
+    unlink = mocker.spy(UnlinkPathAction, "execute")
+    link = mocker.spy(LinkPathAction, "execute")
+    prefix_record = mocker.spy(CreatePrefixRecordAction, "execute")
+
+    _, _, exc = conda_cli(
+        "install",
+        f"--prefix={prefix}",
+        "--channel",
+        str(TEST_RECIPES_CHANNEL),
+        "--override-channels",
+        "--force-reinstall",
+        package_record.name,
+        "--yes",
+        raises=CondaMultiError,
+    )
+
+    assert exc.match("rejected")
+    reject.assert_called_once()
+    unlink.assert_not_called()
+    link.assert_not_called()
+    prefix_record.assert_not_called()
+    assert {
+        path.relative_to(prefix): path.read_bytes()
+        for path in prefix.rglob("*")
+        if path.is_file()
+    } == before
+
+
+@pytest.mark.parametrize(
+    ("sha256", "size", "md5"),
+    (
+        pytest.param("0" * 64, None, None, id="sha256"),
+        pytest.param(None, 0, None, id="size"),
+        pytest.param(None, None, "0" * 32, id="md5-fallback"),
+    ),
+)
+def test_package_integrity_mismatch_prevents_verifier(
+    sha256: str | None,
+    size: int | None,
+    md5: str | None,
+    package_path: Path,
+    package_record: PackageRecord,
+    plugin_manager: CondaPluginManager,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    verify = mocker.stub(name="verify")
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=verify),
+    )
+    action = ExtractPackageAction(
+        source_full_path=str(package_path),
+        target_pkgs_dir=tmp_path,
+        target_extracted_dirname="extracted",
+        record_or_spec=package_record,
+        sha256=sha256,
+        size=size,
+        md5=md5,
+    )
+
+    with pytest.raises(ChecksumMismatchError):
+        action.verify()
+
+    verify.assert_not_called()
+
+
+def test_package_archive_is_rechecked_before_extraction(
+    package_path: Path,
+    package_record: PackageRecord,
+    plugin_manager: CondaPluginManager,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / package_path.name
+    archive_path.write_bytes(package_path.read_bytes())
+    expected_sha256 = compute_sum(archive_path, "sha256")
+    verify = mocker.stub(name="verify")
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=verify),
+    )
+    extract = mocker.patch.object(plugin_manager, "extract_package")
+    action = ExtractPackageAction(
+        source_full_path=str(archive_path),
+        target_pkgs_dir=tmp_path,
+        target_extracted_dirname="extracted",
+        record_or_spec=package_record,
+        sha256=expected_sha256,
+        size=None,
+        md5=None,
+    )
+    action._verified_checksum = ("sha256", expected_sha256)
+    action.verify()
+    archive_path.write_bytes(b"replaced after verification")
+
+    with pytest.raises(ChecksumMismatchError):
+        do_extract_action(package_record, action, mocker.MagicMock())
+
+    verify.assert_called_once()
+    extract.assert_not_called()
+
+
+def test_package_archive_is_hashed_once_for_verifiers(
+    package_path: Path,
+    package_record: PackageRecord,
+    plugin_manager: CondaPluginManager,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / package_path.name
+    archive_path.write_bytes(package_path.read_bytes())
+    expected_sha256 = compute_sum(archive_path, "sha256")
+    compute_checksum = mocker.patch(
+        "conda.core.path_actions.compute_sum",
+        wraps=compute_sum,
+    )
+
+    def verify(record_or_spec, source_full_path, sha256):
+        assert sha256 == expected_sha256
+        compute_checksum.assert_called_once_with(str(archive_path), "sha256")
+
+    register_verifier(
+        plugin_manager,
+        CondaPackageVerifier(name="test-verifier", verify=verify),
+    )
+    action = ExtractPackageAction(
+        source_full_path=str(archive_path),
+        target_pkgs_dir=tmp_path,
+        target_extracted_dirname="extracted",
+        record_or_spec=package_record,
+        sha256=None,
+        size=None,
+        md5=None,
+    )
+
+    action.verify()
+
+    compute_checksum.assert_called_once_with(str(archive_path), "sha256")

--- a/tests/plugins/test_package_verifiers.py
+++ b/tests/plugins/test_package_verifiers.py
@@ -12,6 +12,8 @@ from conda import CondaError, CondaMultiError, plugins
 from conda.base.context import context, reset_context
 from conda.common.path import strip_pkg_extension
 from conda.common.url import path_to_url
+from conda.core import package_cache_data
+from conda.core.link import PrefixSetup, UnlinkLinkTransaction
 from conda.core.package_cache_data import do_extract_action
 from conda.core.path_actions import (
     CreatePrefixRecordAction,
@@ -24,6 +26,7 @@ from conda.exceptions import (
     CondaVerificationError,
     PluginError,
 )
+from conda.gateways.disk.create import create_package_cache_directory
 from conda.gateways.disk.read import compute_sum, read_index_json_from_tarball
 from conda.misc import get_package_records_from_explicit
 from conda.models.match_spec import MatchSpec
@@ -205,6 +208,82 @@ def test_explicit_package_runs_verifier(
     assert (tmp_pkgs_dir / "urls.txt").read_text().splitlines() == [
         package_path.as_uri()
     ]
+
+
+@pytest.mark.parametrize("verifiers_enabled", (False, True))
+def test_transaction_links_verified_cache_before_same_device_cache(
+    verifiers_enabled: bool,
+    package_path: Path,
+    package_record: PackageRecord,
+    plugin_manager_with_reporter_backends: CondaPluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tmp_pkgs_dir: Path,
+) -> None:
+    plugin_manager = plugin_manager_with_reporter_backends
+    plugin_manager.load_plugins(*package_extractors.plugins)
+    same_device_cache = tmp_path / "same-device-cache"
+    create_package_cache_directory(str(same_device_cache))
+    monkeypatch.setattr(
+        type(context),
+        "pkgs_dirs",
+        property(lambda _: (str(tmp_pkgs_dir), str(same_device_cache))),
+    )
+    monkeypatch.setattr(
+        package_cache_data,
+        "paths_on_same_device",
+        lambda cache, _prefix: Path(cache) == same_device_cache,
+    )
+    record = PackageRecord.from_objects(
+        package_record,
+        sha256=compute_sum(package_path, "sha256"),
+        md5=compute_sum(package_path, "md5"),
+        size=package_path.stat().st_size,
+    )
+    extracted_name = strip_pkg_extension(package_path.name)[0]
+    for cache in (tmp_pkgs_dir, same_device_cache):
+        archive = cache / package_path.name
+        archive.write_bytes(package_path.read_bytes())
+        action = ExtractPackageAction(
+            source_full_path=str(archive),
+            target_pkgs_dir=str(cache),
+            target_extracted_dirname=extracted_name,
+            record_or_spec=record,
+            sha256=record.sha256,
+            size=record.size,
+            md5=record.md5,
+            package_verifiers=(),
+        )
+        action.verify()
+        action.execute()
+        action.cleanup()
+
+    assert len(tuple(package_cache_data.PackageCacheData.query_all(record))) == 2
+    verified_caches = []
+
+    def verify(_record, archive_path, sha256):
+        assert sha256 == record.sha256
+        verified_caches.append(Path(archive_path).parent.parent)
+
+    if verifiers_enabled:
+        register_verifier(
+            plugin_manager,
+            CondaPackageVerifier(name="test-verifier", verify=verify),
+        )
+    prefix = str(tmp_path / "prefix")
+    transaction = UnlinkLinkTransaction(PrefixSetup(prefix, (), (record,), (), (), ()))
+    transaction.download_and_extract()
+    # Linking must use the verifier snapshot that governed extraction.
+    monkeypatch.setattr(plugin_manager, "get_package_verifiers", lambda: ())
+
+    transaction.prepare()
+
+    assert verified_caches == ([tmp_pkgs_dir] if verifiers_enabled else [])
+    expected_cache = tmp_pkgs_dir if verifiers_enabled else same_device_cache
+    (link_group,) = transaction.prefix_action_groups[prefix].link_action_groups
+    assert Path(link_group.pkg_data.extracted_package_dir) == (
+        expected_cache / extracted_name
+    )
 
 
 def test_explicit_install_rejection_prevents_prefix_changes(

--- a/tests/plugins/test_package_verifiers.py
+++ b/tests/plugins/test_package_verifiers.py
@@ -218,17 +218,15 @@ def test_transaction_links_verified_cache_before_same_device_cache(
     plugin_manager_with_reporter_backends: CondaPluginManager,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    tmp_pkgs_dir: Path,
 ) -> None:
     plugin_manager = plugin_manager_with_reporter_backends
     plugin_manager.load_plugins(*package_extractors.plugins)
+    first_cache = tmp_path / "first-cache"
     same_device_cache = tmp_path / "same-device-cache"
-    create_package_cache_directory(str(same_device_cache))
-    monkeypatch.setattr(
-        type(context),
-        "pkgs_dirs",
-        property(lambda _: (str(tmp_pkgs_dir), str(same_device_cache))),
-    )
+    for cache in (first_cache, same_device_cache):
+        create_package_cache_directory(str(cache))
+    monkeypatch.setenv("CONDA_PKGS_DIRS", f"{first_cache},{same_device_cache}")
+    reset_context()
     monkeypatch.setattr(
         package_cache_data,
         "paths_on_same_device",
@@ -241,7 +239,7 @@ def test_transaction_links_verified_cache_before_same_device_cache(
         size=package_path.stat().st_size,
     )
     extracted_name = strip_pkg_extension(package_path.name)[0]
-    for cache in (tmp_pkgs_dir, same_device_cache):
+    for cache in (first_cache, same_device_cache):
         archive = cache / package_path.name
         archive.write_bytes(package_path.read_bytes())
         action = ExtractPackageAction(
@@ -278,8 +276,8 @@ def test_transaction_links_verified_cache_before_same_device_cache(
 
     transaction.prepare()
 
-    assert verified_caches == ([tmp_pkgs_dir] if verifiers_enabled else [])
-    expected_cache = tmp_pkgs_dir if verifiers_enabled else same_device_cache
+    assert verified_caches == ([first_cache] if verifiers_enabled else [])
+    expected_cache = first_cache if verifiers_enabled else same_device_cache
     (link_group,) = transaction.prefix_action_groups[prefix].link_action_groups
     assert Path(link_group.pkg_data.extracted_package_dir) == (
         expected_cache / extracted_name

--- a/tests/plugins/test_package_verifiers.py
+++ b/tests/plugins/test_package_verifiers.py
@@ -226,7 +226,7 @@ def test_transaction_links_verified_cache_before_same_device_cache(
     for cache in (first_cache, same_device_cache):
         create_package_cache_directory(str(cache))
     monkeypatch.setenv("CONDA_PKGS_DIRS", f"{first_cache},{same_device_cache}")
-    reset_context()
+    reset_context([])
     monkeypatch.setattr(
         package_cache_data,
         "paths_on_same_device",


### PR DESCRIPTION
### Description

Closes #16515.

Adds a `conda_package_verifiers` hook and a `CondaPackageVerifier` return type. Verifier callbacks receive the selected package record or explicit match specification, an archive path, and its computed SHA-256.

When verifiers are registered, conda copies the selected archive into a private package-cache staging directory without changing its filename. It validates the recorded size and strongest available digest against that staged file, computes its SHA-256, and invokes every registered verifier. Conda extracts the same staged file and publishes those verified bytes back to the selected cache path after successful extraction. With verifiers active, extraction and linking use the first writable package cache.

Expected `CondaError` exceptions are preserved. Other exceptions identify the verifier that raised them. Different archives may be verified concurrently, so callbacks must be thread-safe and idempotent. Callbacks must not mutate the package record, explicit match specification, or archive.

Verifier callbacks run independently of `safety_checks`. When verifiers are registered, conda does not reuse extracted-only cache entries and does not parse archive-only entries while scanning the package cache. It rechecks an exact retained archive or downloads the selected archive again. Rejected downloads are removed, and any displaced archive, extracted package, and URL metadata are restored. Existing behavior is unchanged when no verifier is registered.

### Checklist - did you ...

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
- [x] ~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
