### PR TITLE
Fix channel notice response caching

### DIFF
--- a/conda/notices/cache.py
+++ b/conda/notices/cache.py
@@ -72,9 +72,9 @@ def is_notice_response_cache_expired(
             return True
         return expired_at < now
 
-    return any(
-        is_channel_notice_expired(chn.expired_at)
-        for chn in channel_notice_response.notices
+    notices = channel_notice_response.notices
+    return not notices or any(
+        is_channel_notice_expired(chn.expired_at) for chn in notices
     )
 
 

--- a/conda/notices/types.py
+++ b/conda/notices/types.py
@@ -74,7 +74,9 @@ class ChannelNoticeResponse(NamedTuple):
                     message=notice.get("message"),
                     level=self._parse_notice_level(notice.get("level")),
                     created_at=self._parse_iso_timestamp(notice.get("created_at")),
-                    expired_at=self._parse_iso_timestamp(notice.get("expired_at")),
+                    expired_at=self._parse_iso_timestamp(
+                        notice.get("expires_at", notice.get("expired_at"))
+                    ),
                     interval=notice.get("interval"),
                 )
                 for notice in notices

--- a/conda/testing/notices/helpers.py
+++ b/conda/testing/notices/helpers.py
@@ -42,7 +42,7 @@ def get_test_notices(
                 "message": message,
                 "level": level,
                 "created_at": created_at.isoformat(),
-                "expired_at": expired_at.isoformat(),
+                "expires_at": expired_at.isoformat(),
             }
             for message in messages
         ]

--- a/news/16500-notice-response-cache
+++ b/news/16500-notice-response-cache
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Refresh cached empty channel notice responses and parse CEP 6 `expires_at` timestamps. (#16500, #16501)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_notices.py
+++ b/tests/cli/test_main_notices.py
@@ -116,6 +116,8 @@ def test_main_notices_json(
 
     captured = capsys.readouterr()
     json_data = json.loads(captured.out)
+    for item in messages_json["notices"]:
+        item["expired_at"] = item.pop("expires_at")
     assert messages_json.get("notices") == json_data
 
 

--- a/tests/notices/test_response_cache.py
+++ b/tests/notices/test_response_cache.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from conda.notices.cache import is_notice_response_cache_expired
+from conda.notices.types import ChannelNoticeResponse
+
+
+def test_empty_notice_response_cache_expired():
+    response = ChannelNoticeResponse(
+        "https://conda.example.com/notices.json",
+        "test",
+        {"notices": []},
+    )
+
+    assert is_notice_response_cache_expired(response)
+
+
+@pytest.mark.parametrize("field", ("expires_at", "expired_at"))
+def test_notice_response_expiration_field(field):
+    expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    response = ChannelNoticeResponse(
+        "https://conda.example.com/notices.json",
+        "test",
+        {"notices": [{field: expires_at.isoformat()}]},
+    )
+
+    assert response.notices[0].expired_at == expires_at
+    assert not is_notice_response_cache_expired(response)


### PR DESCRIPTION
### Description

Closes #16500.
Closes #16501.

Treat cached empty channel notice responses as expired so notices published later can be fetched. Parse the CEP 6 `expires_at` field while retaining `expired_at` as an input fallback.

The internal `ChannelNotice.expired_at` field and JSON output remain unchanged. This keeps the cache boundary compatible with #16503 while it moves notice retrieval into `NoticeBus`.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~