### PR TITLE
Add Windows ARM64 CI coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
             default-channel: conda-forge
     env:
       ErrorActionPreference: Stop  # powershell exit immediately on error
-      TEMP_DRIVE: ${{ matrix.runs-on == 'windows-11-arm' && 'C' || 'D' }}
+      TEMP_DRIVE: C
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       CONDA_TEST_SOLVERS: ${{ github.event_name == 'pull_request' && 'libmamba' || 'libmamba,classic' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
             default-channel: conda-forge
     env:
       ErrorActionPreference: Stop  # powershell exit immediately on error
+      TEMP_DRIVE: ${{ matrix.runs-on == 'windows-11-arm' && 'C' || 'D' }}
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       CONDA_TEST_SOLVERS: ${{ github.event_name == 'pull_request' && 'libmamba' || 'libmamba,classic' }}
@@ -106,7 +107,7 @@ jobs:
 
       - name: Set TEMP
         run: |
-          $TEMP_DIR = "${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\\Temp"
+          $TEMP_DIR = "$($env:TEMP_DRIVE):\\Temp"
           New-Item -ItemType Directory -Force -Path $TEMP_DIR | Out-Null
           echo "TEMP=$TEMP_DIR" >> $env:GITHUB_ENV
           echo "TMP=$TEMP_DIR"  >> $env:GITHUB_ENV
@@ -124,8 +125,8 @@ jobs:
           # Use faster GNU tar for all runners
           enableCrossOsArchive: true
           path: |
-            ${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\conda_pkgs_dir\*.tar.bz2
-            ${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\conda_pkgs_dir\*.conda
+            ${{ env.TEMP_DRIVE }}:\conda_pkgs_dir\*.tar.bz2
+            ${{ env.TEMP_DRIVE }}:\conda_pkgs_dir\*.conda
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
@@ -133,8 +134,8 @@ jobs:
         with:
           condarc-file: .github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
-          pkgs-dirs: ${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\conda_pkgs_dir
-          installation-dir: ${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\conda
+          pkgs-dirs: ${{ env.TEMP_DRIVE }}:\conda_pkgs_dir
+          installation-dir: ${{ env.TEMP_DRIVE }}:\conda
           # A native win-arm64 conda test environment is not available yet.
           architecture: x64
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,11 +73,12 @@ jobs:
       (!github.event.repository.fork && github.event_name == 'schedule')
       || needs.changes.outputs.code == 'true'
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         # test lower version (w/ defaults) and upper version (w/ defaults and conda-forge)
+        runs-on: [windows-latest, windows-11-arm]
         python-version: ['3.10', '3.14']
         default-channel: [defaults, conda-forge]
         test-type: [unit, integration]
@@ -87,6 +88,10 @@ jobs:
             python-version: '3.10'
           - test-type: unit
             test-group: 3
+          - runs-on: windows-11-arm
+            python-version: '3.10'
+          - runs-on: windows-11-arm
+            default-channel: conda-forge
     env:
       ErrorActionPreference: Stop  # powershell exit immediately on error
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
@@ -99,11 +104,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set TEMP to D:/Temp
+      - name: Set TEMP
         run: |
-          mkdir "D:\\Temp"
-          echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV
-          echo "TMP=D:\\Temp"  >> $env:GITHUB_ENV
+          $TEMP_DIR = "${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\\Temp"
+          New-Item -ItemType Directory -Force -Path $TEMP_DIR | Out-Null
+          echo "TEMP=$TEMP_DIR" >> $env:GITHUB_ENV
+          echo "TMP=$TEMP_DIR"  >> $env:GITHUB_ENV
 
       - name: Hash + Timestamp
         shell: bash  # use bash to run date command
@@ -118,8 +124,8 @@ jobs:
           # Use faster GNU tar for all runners
           enableCrossOsArchive: true
           path: |
-            D:\conda_pkgs_dir\*.tar.bz2
-            D:\conda_pkgs_dir\*.conda
+            ${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\conda_pkgs_dir\*.tar.bz2
+            ${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\conda_pkgs_dir\*.conda
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
@@ -127,8 +133,12 @@ jobs:
         with:
           condarc-file: .github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
-          pkgs-dirs: D:\conda_pkgs_dir
-          installation-dir: D:\conda
+          pkgs-dirs: ${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\conda_pkgs_dir
+          installation-dir: ${{ runner.arch == 'ARM64' && 'C' || 'D' }}:\conda
+          # A native win-arm64 conda test environment is not available yet.
+          architecture: x64
+        env:
+          CONDA_SUBDIR: win-64
 
       # Workaround: miniforge ships c-l-s 26.4.0 which has a sqlite locking bug.
       # Remove once miniforge ships c-l-s >=26.4.1.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,8 @@ jobs:
       # Remove once miniforge ships c-l-s >=26.4.1.
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
+        env:
+          CONDA_SUBDIR: win-64
 
       - name: Conda Install
         run: >
@@ -154,6 +156,8 @@ jobs:
           --file tests\requirements-ci.txt
           --file tests\requirements-s3.txt
           python=${{ matrix.python-version }}
+        env:
+          CONDA_SUBDIR: win-64
 
       - name: Conda Info
         # view test env info (not base)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,6 @@ jobs:
             default-channel: conda-forge
     env:
       ErrorActionPreference: Stop  # powershell exit immediately on error
-      TEMP_DRIVE: C
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
       CONDA_TEST_SOLVERS: ${{ github.event_name == 'pull_request' && 'libmamba' || 'libmamba,classic' }}
@@ -104,13 +103,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-
-      - name: Set TEMP
-        run: |
-          $TEMP_DIR = "$($env:TEMP_DRIVE):\\Temp"
-          New-Item -ItemType Directory -Force -Path $TEMP_DIR | Out-Null
-          echo "TEMP=$TEMP_DIR" >> $env:GITHUB_ENV
-          echo "TMP=$TEMP_DIR"  >> $env:GITHUB_ENV
 
       - name: Hash + Timestamp
         shell: bash  # use bash to run date command
@@ -125,8 +117,8 @@ jobs:
           # Use faster GNU tar for all runners
           enableCrossOsArchive: true
           path: |
-            ${{ env.TEMP_DRIVE }}:\conda_pkgs_dir\*.tar.bz2
-            ${{ env.TEMP_DRIVE }}:\conda_pkgs_dir\*.conda
+            ~/conda_pkgs_dir/*.tar.bz2
+            ~/conda_pkgs_dir/*.conda
           key: cache-${{ env.CACHE_KEY }}
 
       - name: Setup Miniconda
@@ -134,8 +126,6 @@ jobs:
         with:
           condarc-file: .github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
-          pkgs-dirs: ${{ env.TEMP_DRIVE }}:\conda_pkgs_dir
-          installation-dir: ${{ env.TEMP_DRIVE }}:\conda
           # A native win-arm64 conda test environment is not available yet.
           architecture: x64
         env:

--- a/news/16466-windows-arm64-ci
+++ b/news/16466-windows-arm64-ci
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Add Windows ARM64 GitHub-hosted runner coverage using win-64 emulation. (#16466)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Adds Windows ARM64 runner coverage for #16466.

The existing Windows test job now runs five jobs on `windows-11-arm`. They use x64 Miniconda and win-64 packages under Windows emulation, while keeping the existing dependency files and libmamba test configuration.

This does not test native win-arm64 Python or packages. The existing requirements cannot currently be solved for win-arm64 because conda, libmambapy, and several test dependencies are unavailable. Native testing remains follow-up work for #16466.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->