### PR TITLE
Remove obsolete conda-pypi CI upgrade

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,11 +135,6 @@ jobs:
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
-      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
-      # This should be removed next conda release.
-      - name: Upgrade conda-pypi
-        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
-
       - name: Conda Install
         run: >
           conda install
@@ -285,11 +280,6 @@ jobs:
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
-      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
-      # This should be removed next conda release.
-      - name: Upgrade conda-pypi
-        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
-
       - name: Conda Install
         run: >
           conda install
@@ -404,11 +394,6 @@ jobs:
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
-      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
-      # This should be removed next conda release.
-      - name: Upgrade conda-pypi
-        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
-
       - name: Conda Install
         run: >
           conda install
@@ -497,11 +482,6 @@ jobs:
       # Remove once miniforge ships c-l-s >=26.4.1.
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
-
-      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
-      # This should be removed next conda release.
-      - name: Upgrade conda-pypi
-        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
 
       - name: Conda Install
         run: >
@@ -660,11 +640,6 @@ jobs:
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
 
-      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
-      # This should be removed next conda release.
-      - name: Upgrade conda-pypi
-        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
-
       - name: Conda Install
         run: >
           conda install
@@ -765,11 +740,6 @@ jobs:
       # Remove once miniforge ships c-l-s >=26.4.1.
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
-
-      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
-      # This should be removed next conda release.
-      - name: Upgrade conda-pypi
-        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
 
       - name: Conda Install
         run: >
@@ -957,11 +927,6 @@ jobs:
       # Remove once miniforge ships c-l-s >=26.4.1.
       - name: Upgrade conda-libmamba-solver
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.1"
-
-      # conda currently ships with conda-pypi 0.9.0. Pull in 0.10.1 to pull in required fixes.
-      # This should be removed next conda release.
-      - name: Upgrade conda-pypi
-        run: conda install --yes "conda-pypi>=0.10.1" -c conda-forge --override-channels
 
       - name: Conda Install
         working-directory: conda


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Removes the temporary CI upgrade added in #16210.

Conda 26.7.0 now depends on `conda-pypi >=0.10.1`, so the test environments receive the required version through their normal conda installation.

### Checklist - did you ...

- [x] ~~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~~
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
