### PR TITLE
Add concurrency limits to benchmark tracking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch || github.run_id }}
+  cancel-in-progress: true
+
 env:
   BENCHMARK_RESULTS: benchmark_results.json
   BENCHMARK_RESULTS_ARTIFACT: benchmark-results


### PR DESCRIPTION
### Description

Add workflow-level concurrency to benchmark tracking so newer runs supersede obsolete work from the same pull request or branch.

Use the workflow run ID as a fallback when GitHub provides neither context.

Part of conda/infrastructure#706

### Checklist - did you ...

- [x] ~~Add a file to the `news` directory?~~
- [x] ~~Add / update necessary tests?~~
- [x] ~~Add / update outdated documentation?~~