### PR TITLE
Fix for missing guidance

### DIFF
--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -101,7 +101,11 @@ class CondaError(Exception):
         always the canonical type after dict coercion; callers do not need to
         handle raw dicts.
         """
-        return self._guidance
+        try:
+            return self._guidance
+        except AttributeError:
+            # Some exceptions aren't properly initialized by calling super().__init__()
+            return None
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}: {self}"
@@ -135,8 +139,8 @@ class CondaError(Exception):
             caused_by=repr(self._caused_by),
             **self._kwargs,
         )
-        if self._guidance is not None:
-            result["guidance"] = self._guidance.__json__()
+        if (guidance := self.guidance) is not None:
+            result["guidance"] = guidance.__json__()
         return result
 
 

--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -75,6 +75,12 @@ class CondaError(Exception):
     return_code: int = 1
     reportable: bool = False  # Exception may be reported to core maintainers
 
+    # Class defaults so subclasses that skip CondaError.__init__ still have
+    # safe attribute access in guidance / __str__ / dump_map.
+    _kwargs: dict[str, Any] | None = None
+    _caused_by: Any = None
+    _guidance: ErrorGuidance | None = None
+
     def __init__(
         self,
         message: str | None,
@@ -86,7 +92,6 @@ class CondaError(Exception):
         self.message = message or ""
         self._kwargs = kwargs
         self._caused_by = caused_by
-        self._guidance = None
         if guidance:
             from ._private.exception_guidance import ErrorGuidance
 
@@ -101,11 +106,7 @@ class CondaError(Exception):
         always the canonical type after dict coercion; callers do not need to
         handle raw dicts.
         """
-        try:
-            return self._guidance
-        except AttributeError:
-            # Some exceptions aren't properly initialized by calling super().__init__()
-            return None
+        return self._guidance
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}: {self}"
@@ -122,7 +123,7 @@ class CondaError(Exception):
                     "message:",
                     self.message,
                     "kwargs:",
-                    str(self._kwargs),
+                    str(self._kwargs or {}),
                     "",
                 )
             )
@@ -137,7 +138,7 @@ class CondaError(Exception):
             message=str(self),
             error=repr(self),
             caused_by=repr(self._caused_by),
-            **self._kwargs,
+            **(self._kwargs or {}),
         )
         if (guidance := self.guidance) is not None:
             result["guidance"] = guidance.__json__()

--- a/news/16534-missing-guidance
+++ b/news/16534-missing-guidance
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `AttributeError` when accessing `CondaError.guidance` on subclasses that skip `CondaError.__init__`. (#16534 via #16535)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/16534-missing-guidance
+++ b/news/16534-missing-guidance
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix `AttributeError` when accessing `CondaError.guidance` on subclasses that skip `CondaError.__init__`. (#16534 via #16535)
+* Fix `AttributeError` when accessing `CondaError.guidance`, `__str__`, or `dump_map` on subclasses that skip `CondaError.__init__`. (#16534 via #16535)
 
 ### Deprecations
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -972,11 +972,11 @@ def test_RemoveError_without_guidance() -> None:
     assert exc.guidance is None
 
 
-def test_CondaError_guidance_when_init_skipped(
+def test_CondaError_when_init_skipped(
     monkeypatch: MonkeyPatch,
     capsys: CaptureFixture,
 ) -> None:
-    """Subclasses that skip CondaError.__init__ must not raise on .guidance."""
+    """Subclasses that skip CondaError.__init__ must still print and dump."""
 
     class IncompleteCondaError(CondaError):
         def __init__(self, message: str):
@@ -984,17 +984,25 @@ def test_CondaError_guidance_when_init_skipped(
             # subclasses historically do, e.g. DependencyNeedsBuildingError).
             self.message = message
 
-        def __str__(self) -> str:
-            return self.message
-
     exc = IncompleteCondaError("boom")
     assert exc.guidance is None
+    assert str(exc) == "boom"
+    dumped = exc.dump_map()
+    assert dumped["message"] == "boom"
+    assert dumped["caused_by"] == "None"
+    assert "guidance" not in dumped
 
     monkeypatch.setenv("CONDA_JSON", "no")
     reset_context()
     print_conda_exception(exc)
     stderr = capsys.readouterr().err
     assert "IncompleteCondaError: boom" in stderr
+
+    monkeypatch.setenv("CONDA_JSON", "yes")
+    reset_context()
+    print_conda_exception(exc)
+    stdout = capsys.readouterr().out
+    assert json.loads(stdout)["exception_name"] == "IncompleteCondaError"
 
 
 def test_RemoveError_guidance_in_dump_map() -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -972,6 +972,31 @@ def test_RemoveError_without_guidance() -> None:
     assert exc.guidance is None
 
 
+def test_CondaError_guidance_when_init_skipped(
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture,
+) -> None:
+    """Subclasses that skip CondaError.__init__ must not raise on .guidance."""
+
+    class IncompleteCondaError(CondaError):
+        def __init__(self, message: str):
+            # Intentionally skip CondaError.__init__ (as some downstream
+            # subclasses historically do, e.g. DependencyNeedsBuildingError).
+            self.message = message
+
+        def __str__(self) -> str:
+            return self.message
+
+    exc = IncompleteCondaError("boom")
+    assert exc.guidance is None
+
+    monkeypatch.setenv("CONDA_JSON", "no")
+    reset_context()
+    print_conda_exception(exc)
+    stderr = capsys.readouterr().err
+    assert "IncompleteCondaError: boom" in stderr
+
+
 def test_RemoveError_guidance_in_dump_map() -> None:
     exc = RemoveError(
         "legacy message",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While using conda-build found that not all exceptions properly initialize by calling `super().__init__` so guidance is undefined in certain cases causing an `AttributeError`.

Resolves https://github.com/conda/conda/issues/16534

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
