### PR TITLE
Deprecate `get_revision` in favor of `argparse.ArgumentParser.add_argument(type=int)`

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -131,6 +131,7 @@ def clone(src_arg, dst_prefix, json=False, quiet=False, index_args=None):
         )
 
 
+@deprecated("27.3", "27.9")
 def get_revision(arg, json=False):
     try:
         return int(arg)
@@ -492,9 +493,8 @@ def install_revision(args, parser):
                     prefix=prefix,
                     repodata_fn=repodata,
                 )
-            revision_idx = get_revision(args.revision)
-            with get_spinner(f"Reverting to revision {revision_idx}"):
-                unlink_link_transaction = revert_actions(prefix, revision_idx, index)
+            with get_spinner(f"Reverting to revision {args.revision}"):
+                unlink_link_transaction = revert_actions(prefix, args.revision, index)
 
     handle_txn(unlink_link_transaction, prefix, args, newenv=False)
 

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -90,6 +90,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         action="store",
         help="Revert to the specified REVISION.",
         metavar="REVISION",
+        type=int,
     )
     add_parser_frozen_env(p)
 
@@ -124,7 +125,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..base.context import context
     from ..exceptions import CondaValueError
     from .common import validate_environment_files_consistency
-    from .install import get_revision, install, install_revision
+    from .install import install, install_revision
 
     if context.force:
         print(
@@ -141,20 +142,18 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
 
     # Ensure that users do not provide incompatible arguments.
     # revision and packages can not be specified together
-    if args.revision and (args.file or args.packages):
+    if args.revision is not None and (args.file or args.packages):
         raise CondaValueError(
             "too many arguments, must supply one of command line packages, --file or --revision"
         )
 
     # Ensure provided combination of command line arguments are valid
-    if args.revision:
-        get_revision(args.revision, json=context.json)
-    elif not (args.file or args.packages):
+    if args.revision is None and not (args.file or args.packages):
         raise CondaValueError(
             "too few arguments, must supply one of command line packages, --file or --revision"
         )
 
-    if args.revision:
+    if args.revision is not None:
         install_revision(args, parser)
     else:
         install(args, parser, "install")

--- a/news/16536-deprecate-get-revision
+++ b/news/16536-deprecate-get-revision
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Mark `conda.cli.install.get_revision` as pending deprecation, to be removed in 27.9.
+* Mark `conda.cli.install.get_revision` as pending deprecation, to be removed in 27.9. (#16536)
 
 ### Docs
 

--- a/news/deprecate-get-revision
+++ b/news/deprecate-get-revision
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Parse `conda install --revision` with argparse `type=int`.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.cli.install.get_revision` as pending deprecation, to be removed in 27.9.
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_install.py
+++ b/tests/cli/test_main_install.py
@@ -160,6 +160,26 @@ def test_too_many_arguments(
     assert "too many arguments" in excinfo.value.message
 
 
+def test_install_revision_invalid(
+    conda_cli: CondaCLIFixture,
+):
+    stdout, stderr, exc = conda_cli(
+        "install",
+        "--revision",
+        "abc",
+        raises=SystemExit,
+    )
+    assert exc.value.code == 2
+    assert "invalid int value" in stderr
+
+
+def test_get_revision_pending_deprecation():
+    from conda.cli.install import get_revision
+
+    with pytest.deprecated_call():
+        assert get_revision("1") == 1
+
+
 def test_install_revision_revert(
     test_recipes_channel: Path,
     tmp_env: TmpEnvFixture,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While reviewing exceptions in https://github.com/conda/conda/pull/16535, found this helper function that is better handled by `argparse`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
