### PR TITLE
Use constants for "json", "shards", "zst" format keys in cache state

### DIFF
--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -23,6 +23,8 @@ from conda.base.context import context
 from conda.core.subdir_data import SubdirData
 from conda.gateways.connection.session import get_session
 from conda.gateways.repodata import (
+    FORMAT_JSON,
+    FORMAT_SHARDS,
     _add_http_value_to_dict,
     conda_http_errors,
 )
@@ -673,7 +675,7 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
     cache_state = repo_cache.state
     shards_index_url = f"{sd.url_w_credentials}/{REPODATA_SHARDS_FN}"
 
-    if cache_state.should_check_format("shards"):
+    if cache_state.should_check_format(FORMAT_SHARDS):
         # look for shards index
         shards_data = None
 
@@ -690,7 +692,7 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
         if shards_data is None:
             try:
                 shards_data = _repodata_shards(shards_index_url, repo_cache)
-                cache_state.set_has_format("shards", True)
+                cache_state.set_has_format(FORMAT_SHARDS, True)
                 # this will also set state["refresh_ns"] = time.time_ns(); we could
                 # call cache.refresh() if we got a 304 instead:
                 repo_cache.save(shards_data)
@@ -698,7 +700,7 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
                 # repodata_shards converts HTTP errors to conda errors.
                 # fetch repodata.json / repodata.json.zst instead
                 if _is_http_error_most_400_codes(err.status_code):
-                    cache_state.set_has_format("shards", False)
+                    cache_state.set_has_format(FORMAT_SHARDS, False)
                 repo_cache.refresh()
             except conda.exceptions.CondaHTTPError as err:
                 # repodata_shards converts HTTP errors to conda errors.
@@ -710,33 +712,33 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
                         err._caused_by.response.status_code
                     )
                 ):
-                    cache_state.set_has_format("shards", False)
+                    cache_state.set_has_format(FORMAT_SHARDS, False)
                 repo_cache.refresh()
 
         # Use cached on-disk shards data in case re-fetch fails above or classic repodata.json is missing
         if shards_data is None and repo_cache.cache_path_shards.exists():
-            has_shards, checked = cache_state.has_format("shards")
+            has_shards, checked = cache_state.has_format(FORMAT_SHARDS)
             shards_still_ok = checked is not None and has_shards
-            classic_absent = not cache_state.should_check_format("repodata_json")
+            classic_absent = not cache_state.should_check_format(FORMAT_JSON)
             if shards_still_ok or classic_absent:
                 with repo_cache.lock("r+"):
                     shards_data = repo_cache.cache_path_shards.read_bytes()
-                cache_state.set_has_format("shards", True)
+                cache_state.set_has_format(FORMAT_SHARDS, True)
                 repo_cache.refresh()
 
         if shards_data:
             return _shards_from_bytes(shards_data, shards_index_url)
 
-    # classic known absent + shard cache exists + should_check_format("shards") marked False
+    # classic known absent + shard cache exists + should_check_format(FORMAT_SHARDS) marked False
     if (
-        not cache_state.should_check_format("repodata_json")
+        not cache_state.should_check_format(FORMAT_JSON)
         and repo_cache.cache_path_shards.exists()
     ):
         with repo_cache.lock("r+"):
             shards_data = repo_cache.cache_path_shards.read_bytes()
-        has_shards, _ = cache_state.has_format("shards")
+        has_shards, _ = cache_state.has_format(FORMAT_SHARDS)
         if not has_shards:
-            cache_state.set_has_format("shards", True)
+            cache_state.set_has_format(FORMAT_SHARDS, True)
             repo_cache.refresh()
         return _shards_from_bytes(shards_data, shards_index_url)
 
@@ -852,7 +854,7 @@ def fetch_channels(url_to_channel: dict[str, Channel]) -> dict[str, ShardBase] |
 
             # Skip classic when has_repodata_json is False until
             # CHECK_ALTERNATE_FORMAT_INTERVAL (should_check_format) expires
-            if cache.state.should_check_format("repodata_json"):
+            if cache.state.should_check_format(FORMAT_JSON):
                 futures_non_sharded[
                     executor.submit(sd.repo_fetch.fetch_latest_parsed)
                 ] = channel_url

--- a/conda/gateways/repodata/__init__.py
+++ b/conda/gateways/repodata/__init__.py
@@ -75,6 +75,11 @@ CACHE_CONTROL_KEY = "cache_control"
 URL_KEY = "url"
 CACHE_STATE_SUFFIX = ".info.json"
 
+# used in cache state files *.info.json
+FORMAT_JSON = "json"
+FORMAT_SHARDS = "shards"
+FORMAT_ZST = "zst"
+
 # show some unparseable json in error
 ERROR_SNIPPET_LENGTH = 32
 
@@ -512,7 +517,7 @@ class RepodataState(UserDict):
             > CHECK_ALTERNATE_FORMAT_INTERVAL
         )
         # Always check for shards if json has not been cached:
-        if format == "shards" and not should_check:
+        if format == FORMAT_SHARDS and not should_check:
             should_check = not self.cache_path_json.exists()
         return should_check
 
@@ -745,7 +750,7 @@ class RepodataCache:
         return (max_age - (now - refresh)) / 1e9
 
     def _shards_known(self) -> bool:
-        has_shards, checked = self.state.has_format("shards")
+        has_shards, checked = self.state.has_format(FORMAT_SHARDS)
         return (checked is not None and has_shards) or self.cache_path_shards.exists()
 
 
@@ -908,7 +913,7 @@ class RepodataFetch:
         # avoid network calls if repodata_json is set to False and return "{}"
         if (
             self.repodata_fn == REPODATA_FN
-            and not cache.state.should_check_format("repodata_json")
+            and not cache.state.should_check_format(FORMAT_JSON)
             and cache.cache_path_shards.exists()
         ):
             return "{}", cache.state
@@ -927,14 +932,14 @@ class RepodataFetch:
                 # when self.repodata_fn==repodata.json, and RepodataIsEmpty error is raised:
                 # if shards are available, we can assume that repodata.json is not supported
                 if cache._shards_known():
-                    cache.state.set_has_format("repodata_json", False)
+                    cache.state.set_has_format(FORMAT_JSON, False)
 
                 # the surrounding try/except/else will cache "{}"
                 raw_repodata = None
             except UnavailableInvalidChannel:  # for noarch case
                 if self.repodata_fn == REPODATA_FN:
                     if cache._shards_known():
-                        cache.state.set_has_format("repodata_json", False)
+                        cache.state.set_has_format(FORMAT_JSON, False)
                         cache.refresh()
                 raise
             except RepodataOnDisk:

--- a/conda/gateways/repodata/zstd.py
+++ b/conda/gateways/repodata/zstd.py
@@ -22,6 +22,7 @@ from ...deprecations import deprecated
 from ..connection.download import disable_ssl_verify_warning
 from ..connection.session import get_session
 from . import (
+    FORMAT_ZST,
     URL_KEY,
     RepodataOnDisk,
     RepodataState,
@@ -166,7 +167,7 @@ def request_url_zstd_state(
                 raise
 
             # zst format is not available, so fallback to .json
-            state.set_has_format("zst", False)
+            state.set_has_format(FORMAT_ZST, False)
             is_fallback = True
             response = download_repodata(
                 withext(url, ".json"),

--- a/news/16494-skip-monolithic-repodata-fallback-when-shards-only
+++ b/news/16494-skip-monolithic-repodata-fallback-when-shards-only
@@ -4,7 +4,9 @@
 
 ### Bug fixes
 
-* Skip falling back to monolithic repodata.json when the channel is shards only. Record `has_format("repodata_json")` as False when classic repodata.json 404s and shards are present. (#16452)
+* Skip falling back to monolithic repodata.json when the channel is shards only.
+  Record `has_format("json")` as False when classic `repodata.json` returns
+  `404` and shards are present. (#16452)
 
 ### Deprecations
 

--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -35,7 +35,6 @@ from conda.gateways.repodata import (
     ETAG_KEY,
     FORMAT_JSON,
     FORMAT_SHARDS,
-    FORMAT_ZST,
     CondaRepoInterface,
     RepodataCache,
     RepodataFetch,

--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -462,7 +462,7 @@ def test_get_cache_control_max_age():
 
 
 def test_classic_soft_404_records_no_repodata_json(tmp_path, mocker):
-    """Record has_repodata_json False when classic 404s and shards are known."""
+    """Record has_json False when classic 404s and shards are known."""
     channel = Channel("http://example.com/linux-64")
     mocker.patch.object(
         CondaRepoInterface,
@@ -479,11 +479,14 @@ def test_classic_soft_404_records_no_repodata_json(tmp_path, mocker):
     fetch.repo_cache.save(b"shards")
     assert not fetch.repo_cache.cache_path_json.exists()
     fetch.fetch_latest()
-    assert fetch.repo_cache.load_state().has_format(FORMAT_JSON)[0] is False
+    state = fetch.repo_cache.load_state()
+    assert state.has_format(FORMAT_JSON)[0] is False
+    assert "has_json" in state
+    assert "has_repodata_json" not in state
 
 
 def test_classic_noarch_404_records_no_repodata_json(tmp_path, mocker):
-    """Record has_repodata_json False when noarch classic 404s and shards are known."""
+    """Record has_json False when noarch classic 404s and shards are known."""
     channel = Channel("http://example.com/noarch")
     mocker.patch.object(
         CondaRepoInterface,

--- a/tests/gateways/test_repodata_gateway.py
+++ b/tests/gateways/test_repodata_gateway.py
@@ -33,6 +33,9 @@ from conda.gateways.connection import (
 )
 from conda.gateways.repodata import (
     ETAG_KEY,
+    FORMAT_JSON,
+    FORMAT_SHARDS,
+    FORMAT_ZST,
     CondaRepoInterface,
     RepodataCache,
     RepodataFetch,
@@ -473,11 +476,11 @@ def test_classic_soft_404_records_no_repodata_json(tmp_path, mocker):
         REPODATA_FN,
         repo_interface_cls=CondaRepoInterface,
     )
-    fetch.repo_cache.state.set_has_format("shards", True)
+    fetch.repo_cache.state.set_has_format(FORMAT_SHARDS, True)
     fetch.repo_cache.save(b"shards")
     assert not fetch.repo_cache.cache_path_json.exists()
     fetch.fetch_latest()
-    assert fetch.repo_cache.load_state().has_format("repodata_json")[0] is False
+    assert fetch.repo_cache.load_state().has_format(FORMAT_JSON)[0] is False
 
 
 def test_classic_noarch_404_records_no_repodata_json(tmp_path, mocker):
@@ -494,11 +497,11 @@ def test_classic_noarch_404_records_no_repodata_json(tmp_path, mocker):
         REPODATA_FN,
         repo_interface_cls=CondaRepoInterface,
     )
-    fetch.repo_cache.state.set_has_format("shards", True)
+    fetch.repo_cache.state.set_has_format(FORMAT_SHARDS, True)
     fetch.repo_cache.save(b"shards")
     with pytest.raises(UnavailableInvalidChannel):
         fetch.fetch_latest()
-    assert fetch.repo_cache.load_state().has_format("repodata_json")[0] is False
+    assert fetch.repo_cache.load_state().has_format(FORMAT_JSON)[0] is False
 
 
 def test_fetch_latest_is_skipped_when_repodata_json_False(tmp_path, mocker):
@@ -512,8 +515,8 @@ def test_fetch_latest_is_skipped_when_repodata_json_False(tmp_path, mocker):
         repo_interface_cls=CondaRepoInterface,
     )
     cache = fetch.repo_cache
-    cache.state.set_has_format("repodata_json", False)
-    cache.state.set_has_format("shards", True)
+    cache.state.set_has_format(FORMAT_JSON, False)
+    cache.state.set_has_format(FORMAT_SHARDS, True)
     cache.save(b"shards")
 
     repodata = mocker.patch.object(CondaRepoInterface, "repodata")

--- a/tests/gateways/test_repodata_shards.py
+++ b/tests/gateways/test_repodata_shards.py
@@ -6,7 +6,7 @@ Test bytes cache used for sharded repodata.
 
 from pathlib import Path
 
-from conda.gateways.repodata import RepodataCache
+from conda.gateways.repodata import FORMAT_JSON, FORMAT_SHARDS, RepodataCache
 
 
 def test_bytes_cache(tmp_path: Path):
@@ -30,8 +30,8 @@ def test_bytes_cache(tmp_path: Path):
 def test_load_state_preserves_state_without_classic_json(tmp_path: Path):
     """load_state keeps format flags when only the shard cache file exists."""
     cache = RepodataCache(tmp_path / "cache", "repodata.json")
-    cache.state.set_has_format("shards", True)
-    cache.state.set_has_format("repodata_json", False)
+    cache.state.set_has_format(FORMAT_SHARDS, True)
+    cache.state.set_has_format(FORMAT_JSON, False)
     cache.save(b"fake-shard-index")
 
     assert not cache.cache_path_json.exists()
@@ -41,5 +41,5 @@ def test_load_state_preserves_state_without_classic_json(tmp_path: Path):
     state = reloaded.load_state()
 
     # assert state is preserved after reload
-    assert state.has_format("shards")[0] is True
-    assert state.has_format("repodata_json")[0] is False
+    assert state.has_format(FORMAT_SHARDS)[0] is True
+    assert state.has_format(FORMAT_JSON)[0] is False

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -41,6 +41,7 @@ from conda._private.shards.shards import (
 from conda.base.context import context, reset_context
 from conda.core.subdir_data import SubdirData
 from conda.exceptions import UnavailableInvalidChannel
+from conda.gateways.repodata import FORMAT_JSON, FORMAT_SHARDS
 from conda.models.channel import Channel
 
 from .conftest import (
@@ -350,7 +351,7 @@ def test_fetch_shards_index_mark_unavailable(monkeypatch, tmp_path, error_code):
 
     repo_cache = subdir_data.repo_cache
     repo_cache.load_state()
-    assert repo_cache.state.should_check_format("shards")
+    assert repo_cache.state.should_check_format(FORMAT_SHARDS)
 
     fetch_shards_index(subdir_data)
 
@@ -358,7 +359,7 @@ def test_fetch_shards_index_mark_unavailable(monkeypatch, tmp_path, error_code):
     # fetch_shards_index gets a different repo_cache instance:
     repo_cache.state.update(json.loads(repo_cache.cache_path_state.read_text()))
     # Always check for shards if json has not been cached:
-    assert repo_cache.state.should_check_format("shards") == (
+    assert repo_cache.state.should_check_format(FORMAT_SHARDS) == (
         expect_should_check_shards or not repo_cache.cache_path_json.exists()
     )
     assert mock_session.get_count == 1
@@ -1548,8 +1549,8 @@ def test_cached_shards_returned(monkeypatch, tmp_path):
         },
     }
     index_bytes = zstd.compress(msgpack.dumps(fake_index))
-    cache.state.set_has_format("shards", True)
-    cache.state.set_has_format("repodata_json", False)
+    cache.state.set_has_format(FORMAT_SHARDS, True)
+    cache.state.set_has_format(FORMAT_JSON, False)
     cache.save(index_bytes)
 
     # force stale
@@ -1592,20 +1593,20 @@ def test_cached_shards_when_shards_check_skipped(monkeypatch, tmp_path):
     fake_index: ShardsIndexDict = {
         "info": {"subdir": "noarch", "base_url": "", "shards_base_url": ""},
         "version": 1,
-        "shards": {
+        FORMAT_SHARDS: {
             "foo": hashlib.sha256(b"x").digest(),
         },
     }
     index_bytes = zstd.compress(msgpack.dumps(fake_index))
-    cache.state.set_has_format("shards", False)
-    cache.state.set_has_format("repodata_json", False)
+    cache.state.set_has_format(FORMAT_SHARDS, False)
+    cache.state.set_has_format(FORMAT_JSON, False)
     cache.save(index_bytes)
     cache.save(
         "{}"
     )  # classic cache exists; with has_shards=False, shards check stays skipped
     cache.refresh()
 
-    assert cache.state.should_check_format("shards") is False
+    assert cache.state.should_check_format(FORMAT_SHARDS) is False
     found = fetch_shards_index(sd)
     assert found is not None
     assert "foo" in found  # loaded cached index
@@ -1625,7 +1626,7 @@ def test_fetch_channels_skips_classic_for_shards_only_url(
 
     # Same cache path fetch_channels will use for the shards-only URL
     only_cache = SubdirData(Channel(shards_only_url)).repo_cache
-    only_cache.state.set_has_format("repodata_json", False)
+    only_cache.state.set_has_format(FORMAT_JSON, False)
     only_cache.refresh()
 
     # mimic fetch_shards_index behavior without http calls


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

PR based off of Daniel's https://github.com/conda/conda/commit/733fdd54bc4ab8539e45f0eac202cdbad652bceb 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
