### PR TITLE
Fix token insertion when no platform is present in URL

### DIFF
--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -318,6 +318,8 @@ class Channel:
             base.append(self.platform)
             if self.package_filename:
                 base.append(self.package_filename)
+        elif self.package_filename:
+            base.append(self.package_filename)
         else:
             first_non_noarch = next(
                 (s for s in context.subdirs if s != "noarch"), "noarch"

--- a/news/16516-fix-add-binstar-token-notices-json
+++ b/news/16516-fix-add-binstar-token-notices-json
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `CondaHttpAuth.add_binstar_token` mangling URLs that end in `notices.json` (or any filename without a platform subdir) by correcting `Channel.url()` to preserve `package_filename` when `platform` is `None`. (#16516)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/gateways/test_connection.py
+++ b/tests/gateways/test_connection.py
@@ -66,6 +66,26 @@ def test_add_binstar_token():
         remove_binstar_token("https://api.anaconda.test")
 
 
+def test_add_binstar_token_notices_json():
+    """add_binstar_token must not drop notices.json from URLs that have no platform subdir.
+
+    Regression test for https://github.com/conda/conda/issues/16516:
+    URLs like /channel-name/notices.json have no platform component, so Channel.url()
+    previously discarded the filename and substituted a subdir from context.subdirs.
+    """
+    try:
+        set_binstar_token("https://api.anaconda.test", "tk-abacadaba-1029384756")
+
+        # URL with no platform subdir — notices.json must be preserved
+        url = "https://conda.anaconda.test/channel-name/notices.json"
+        expected = "https://conda.anaconda.test/t/tk-abacadaba-1029384756/channel-name/notices.json"
+        assert CondaHttpAuth.add_binstar_token(url) == expected, (
+            f"notices.json was dropped or URL was mangled: {CondaHttpAuth.add_binstar_token(url)}"
+        )
+    finally:
+        remove_binstar_token("https://api.anaconda.test")
+
+
 def test_local_file_adapter_404():
     session = CondaSession()
     test_path = "file:///some/location/doesnt/exist"

--- a/tests/models/test_channel.py
+++ b/tests/models/test_channel.py
@@ -1341,6 +1341,37 @@ def test_channel_mangles_urls():
         assert str(Channel(url)) == expected
 
 
+def test_url_with_credentials_preserves_filename_without_platform():
+    """Channel.url() must preserve package_filename when platform is None.
+
+    Regression test for https://github.com/conda/conda/issues/16516:
+    a URL like /channel-name/notices.json has no platform subdir, so package_filename
+    is set but platform is None.  Previously url(with_credentials=True) dropped
+    the filename and appended a subdir from context.subdirs instead.
+    """
+    # notices.json — the exact reproducer from the issue
+    channel = Channel("https://conda.anaconda.org/channel-name/notices.json")
+    assert channel.name == "channel-name"
+    assert channel.platform is None
+    assert channel.package_filename == "notices.json"
+
+    # without credentials: filename is preserved, no token injected
+    assert channel.url() == "https://conda.anaconda.org/channel-name/notices.json"
+
+    # with credentials + token: token is injected and filename is still preserved
+    channel.token = "tk-12345678-abcdefgh"
+    assert (
+        channel.url(with_credentials=True)
+        == "https://conda.anaconda.org/t/tk-12345678-abcdefgh/channel-name/notices.json"
+    )
+
+    # channeldata.json without a platform subdir behaves the same way
+    channel2 = Channel("https://conda.anaconda.org/channel-name/channeldata.json")
+    assert channel2.platform is None
+    assert channel2.package_filename == "channeldata.json"
+    assert channel2.url() == "https://conda.anaconda.org/channel-name/channeldata.json"
+
+
 def test_basic_multichannel():
     multichannel_name = "multichannel"
     channel1_name = "channel1"


### PR DESCRIPTION
### Description

This is a backport of a change made in #16516 for the `26.7.x` version branch for conda version `26.7.1`.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
