### PR TITLE
Make `add_pip_as_python_dependency` visible and documented

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1342,6 +1342,7 @@ class Context(Configuration):
             "ssl_verify",
         ),
         "Solver Configuration": (
+            "add_pip_as_python_dependency",
             "aggressive_update_packages",
             "auto_update_conda",
             "channel_priority",
@@ -1412,7 +1413,6 @@ class Context(Configuration):
         "Hidden and Undocumented": (
             "allow_cycles",  # allow cyclical dependencies, or raise
             "allow_conda_downgrades",
-            "add_pip_as_python_dependency",
             "debug",
             "trace",
             "dev",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1454,7 +1454,8 @@ class Context(Configuration):
             ),
             add_pip_as_python_dependency=dals(
                 """
-                Add pip.This ensures pip, will always be installed any time python is installed.
+                Add pip as a dependency of python. This ensures pip will always be installed any
+                time python is installed.
                 """
             ),
             aggressive_update_packages=dals(

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1452,12 +1452,11 @@ class Context(Configuration):
                 private token to enable access to private packages and channels.
                 """
             ),
-            # add_pip_as_python_dependency=dals(
-            #     """
-            #     Add pip, wheel and setuptools as dependencies of python. This ensures pip,
-            #     wheel and setuptools will always be installed any time python is installed.
-            #     """
-            # ),
+            add_pip_as_python_dependency=dals(
+                """
+                Add pip.This ensures pip, will always be installed any time python is installed.
+                """
+            ),
             aggressive_update_packages=dals(
                 """
                 A list of packages that, if installed, are always updated to the latest possible

--- a/docs/source/user-guide/configuration/settings.rst
+++ b/docs/source/user-guide/configuration/settings.rst
@@ -290,9 +290,21 @@ to include the activated environment. The default is ``True``.
 ``add_pip_as_python_dependency``: Add pip as Python dependency
 --------------------------------------------------------------
 
-Add pip as a dependency of Python.
-This ensures that pip is always installed any time Python is installed.
+Add ``pip`` as a dependency of ``python``.
+This ensures that ``pip`` is always installed any time ``python`` is installed.
 The default is ``True``.
+
+A future conda release may change that default to ``False``
+(see https://github.com/conda/conda/issues/16404).
+The setting itself will remain supported. If you still want ``pip`` after
+the default changes, either install it explicitly::
+
+  conda create --name myenv python pip
+
+or keep the current automatic behavior by setting
+``add_pip_as_python_dependency`` to ``True``::
+
+  conda config --set add_pip_as_python_dependency True
 
 **Example:**
 

--- a/news/16545-add-pip-setting-visible
+++ b/news/16545-add-pip-setting-visible
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Move `add_pip_as_python_dependency` from hidden settings into Solver Configuration. (#16545)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Document `add_pip_as_python_dependency`, including the planned default change in #16404. (#16545)
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Make `add_pip_as_python_dependency` discoverable for #16545:
- Move the setting from Hidden and Undocumented into Solver Configuration
- Restore `conda config --describe` text 
- Document current default, planned default change (#16404), and migration paths

resolves #16545

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
