### PR TITLE
Fix process pool fails if parent has non-importable `__main__`

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import sys
 from collections import defaultdict
 from concurrent.futures import (
     CancelledError,
@@ -19,7 +20,6 @@ from itertools import chain
 from logging import getLogger
 from os import scandir
 from os.path import basename, dirname, getsize, join
-from sys import platform
 from tarfile import ReadError
 from typing import TYPE_CHECKING
 
@@ -89,6 +89,23 @@ EXTRACT_PROCESS_EXTENSIONS = (
     CONDA_PACKAGE_EXTENSION_V1,
     CONDA_PACKAGE_EXTENSION_V2,
 )
+
+
+def _spawn_main_is_importable() -> bool:
+    """Whether spawn workers can re-import the parent's ``__main__``.
+
+    Spawn bootstraps each worker by loading ``__main__.__file__``. Paths that
+    are not real files (e.g. ``<stdin>``) make workers exit immediately and the
+    parent sees ``BrokenProcessPool``. See #16552.
+    """
+    main_file = getattr(sys.modules.get("__main__"), "__file__", None)
+    if main_file is not None and not os.path.isfile(main_file):
+        log.debug(
+            "Process pool unavailable: __main__.__file__ %r is not a file.",
+            main_file,
+        )
+        return False
+    return True
 
 
 class PackageCacheType(type):
@@ -572,7 +589,7 @@ class UrlsData:
 
     def add_url(self, url):
         with open(self.urls_txt_path, mode="a", encoding="utf-8") as fh:
-            linefeed = "\r\n" if platform == "win32" else "\n"
+            linefeed = "\r\n" if sys.platform == "win32" else "\n"
             fh.write(url + linefeed)
         self._urls_data.insert(0, url)
 
@@ -846,7 +863,10 @@ class ProgressiveFetchExtract:
             extract_futures = {}
             extract_actions = self.extract_actions
             use_process_pool = (
-                bool(extract_actions) and EXTRACT_PROCESSES > 1 and not context.debug
+                bool(extract_actions)
+                and EXTRACT_PROCESSES > 1
+                and not context.debug
+                and _spawn_main_is_importable()
             )
             if use_process_pool:
                 # Only bypass the plugin manager when every action resolves to

--- a/news/16552-broken-process-pool-fallback
+++ b/news/16552-broken-process-pool-fallback
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Skip process-pool package extraction when ``__main__`` is not a real file
+  (e.g. stdin), falling back to threads. (#16552)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import datetime
 import json
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from os.path import abspath, basename, dirname, join
 from pathlib import Path
 from threading import Event
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from pytest import MonkeyPatch
@@ -157,6 +158,21 @@ def test_process_pool_unavailable_falls_back_to_threads(
     ProgressiveFetchExtract((conda_prec,)).execute()
 
     process_pool.assert_called_once()
+    assert isfile(join(tmp_pkgs_dir, zlib_base_fn, "info", "repodata_record.json"))
+
+
+def test_non_file_main_skips_process_pool(mocker, tmp_pkgs_dir: Path):
+    """Spawn cannot re-import a non-file __main__ (e.g. stdin) and use threads. (#16552)"""
+    fake_main = ModuleType("__main__")
+    fake_main.__file__ = "<stdin>"
+    mocker.patch.dict(sys.modules, {"__main__": fake_main})
+    process_pool = mocker.patch.object(package_cache_data, "ProcessPoolExecutor")
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 2)
+    _, conda_prec = fresh_zlib_records()
+
+    ProgressiveFetchExtract((conda_prec,)).execute()
+
+    process_pool.assert_not_called()
     assert isfile(join(tmp_pkgs_dir, zlib_base_fn, "info", "repodata_record.json"))
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
