### PR TITLE
Report package extraction errors from process workers

### DIFF
--- a/conda/_private/extract.py
+++ b/conda/_private/extract.py
@@ -18,7 +18,14 @@ def extract_conda_package_archive(
     *,
     ensure_picklable_errors: bool = False,
 ) -> None:
-    """Extract a conda package archive without importing conda runtime state."""
+    """Extract a conda package archive without importing conda runtime state.
+
+    Args:
+        source_full_path: Package archive to extract.
+        destination_directory: Directory to extract into.
+        ensure_picklable_errors: Replace exceptions that cannot survive a pickle
+            round trip with a plain ``RuntimeError``.
+    """
     import conda_package_handling.api
 
     try:

--- a/conda/_private/extract.py
+++ b/conda/_private/extract.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import pickle
 
 # This module is imported in each spawned extraction worker. Keep imports here
 # limited to the standard library; importing conda runtime state defeats the
@@ -14,11 +15,24 @@ import os
 def extract_conda_package_archive(
     source_full_path: str | os.PathLike,
     destination_directory: str | os.PathLike,
+    *,
+    ensure_picklable_errors: bool = False,
 ) -> None:
     """Extract a conda package archive without importing conda runtime state."""
     import conda_package_handling.api
 
-    conda_package_handling.api.extract(
-        os.fspath(source_full_path),
-        dest_dir=os.fspath(destination_directory),
-    )
+    try:
+        conda_package_handling.api.extract(
+            os.fspath(source_full_path),
+            dest_dir=os.fspath(destination_directory),
+        )
+    except Exception as error:
+        if not ensure_picklable_errors:
+            raise
+        try:
+            # Some exceptions can be serialized but not reconstructed.
+            pickle.loads(pickle.dumps(error))
+        except Exception:
+            error_type = f"{type(error).__module__}.{type(error).__qualname__}"
+            raise RuntimeError(f"{error_type}: {error}") from None
+        raise

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -952,6 +952,7 @@ class ProgressiveFetchExtract:
                                     extract_conda_package_archive,
                                     extract_action.source_full_path,
                                     extract_action.target_full_path,
+                                    ensure_picklable_errors=True,
                                 )
                             except Exception as e:
                                 do_reverse(reversed(actions))
@@ -998,6 +999,7 @@ class ProgressiveFetchExtract:
                                 process_extract_action._finish_extract()
                                 progress_bar.update_to(1.0)
                         except Exception as e:
+                            log.debug("Package extraction failed.", exc_info=e)
                             do_reverse(reversed(actions))
                             exceptions.append(e)
                         else:

--- a/news/16552-process-extraction-errors
+++ b/news/16552-process-extraction-errors
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Report extraction errors from process workers when they cannot cross the process boundary, and include process-pool failure causes in debug logs. (#16552)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/_private/test_extract.py
+++ b/tests/_private/test_extract.py
@@ -6,6 +6,22 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from concurrent.futures import ProcessPoolExecutor
+from multiprocessing import get_context
+
+import pytest
+
+from conda._private.extract import extract_conda_package_archive
+
+
+class _UnpickleableError(Exception):
+    def __init__(self, package_location: str, extract_location: str) -> None:
+        super().__init__(f"Could not extract {package_location} to {extract_location}")
+
+
+class _UnpickleableErrorPath:
+    def __fspath__(self) -> str:
+        raise _UnpickleableError("archive.conda", "destination")
 
 
 def test_extract_module_does_not_import_runtime_state() -> None:
@@ -34,3 +50,22 @@ for name in sorted(sys.modules):
         "conda._version",
     }
     assert not any(name.startswith("conda_package_handling") for name in imported)
+
+
+def test_process_extract_normalizes_unpickleable_errors(tmp_path) -> None:
+    with ProcessPoolExecutor(
+        max_workers=1,
+        mp_context=get_context("spawn"),
+    ) as executor:
+        future = executor.submit(
+            extract_conda_package_archive,
+            _UnpickleableErrorPath(),
+            tmp_path,
+            ensure_picklable_errors=True,
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"_UnpickleableError: Could not extract archive\.conda to destination",
+        ):
+            future.result()

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from os.path import abspath, basename, dirname, join
 from pathlib import Path
 from threading import Event
@@ -120,7 +121,7 @@ def test_process_extract_finishes_when_later_fetch_fails(mocker):
     mocker.patch.object(
         package_cache_data,
         "extract_conda_package_archive",
-        side_effect=lambda *args: extracted.set(),
+        side_effect=lambda *args, **kwargs: extracted.set(),
     )
     mocker.patch.object(
         package_cache_data,
@@ -158,6 +159,37 @@ def test_process_pool_unavailable_falls_back_to_threads(
 
     process_pool.assert_called_once()
     assert isfile(join(tmp_pkgs_dir, zlib_base_fn, "info", "repodata_record.json"))
+
+
+def test_process_extract_logs_exception_cause(mocker, tmp_pkgs_dir: Path):
+    decode_error = TypeError("cannot deserialize extraction error")
+    pool_error = BrokenProcessPool("worker result unavailable")
+    pool_error.__cause__ = decode_error
+    log_debug = mocker.patch.object(package_cache_data.log, "debug")
+    mocker.patch.object(package_cache_data, "EXTRACT_PROCESSES", 2)
+    mocker.patch.object(
+        package_cache_data,
+        "extract_conda_package_archive",
+        side_effect=pool_error,
+    )
+    mocker.patch.object(
+        package_cache_data,
+        "ProcessPoolExecutor",
+        side_effect=lambda **kwargs: ThreadPoolExecutor(kwargs["max_workers"]),
+    )
+    mocker.patch.object(
+        context.plugin_manager,
+        "get_package_extractor",
+        return_value=SimpleNamespace(name="conda-package"),
+    )
+    _, conda_prec = fresh_zlib_records()
+
+    with pytest.raises(CondaMultiError) as exc_info:
+        ProgressiveFetchExtract((conda_prec,)).execute()
+
+    log_debug.assert_any_call("Package extraction failed.", exc_info=pool_error)
+    assert exc_info.value.errors == [pool_error]
+    assert pool_error.__cause__ is decode_error
 
 
 def test_ProgressiveFetchExtract_prefers_conda_v2_format(monkeypatch: MonkeyPatch):


### PR DESCRIPTION
### Description

Addresses #16552.

Some package extraction exceptions can be serialized by a spawned worker but cannot be reconstructed in the parent process. `ProcessPoolExecutor` then reports `BrokenProcessPool`, hiding the original extraction error.

Check extraction exceptions inside the worker and replace only those that cannot cross the process boundary with a pickle-safe `RuntimeError` retaining the original qualified type and message. Direct and threaded extraction paths remain unchanged.

Also retain process-pool failure causes in debug logs so unrelated worker and result-channel failures remain diagnosable.

This is a defensive conda-side workaround. The root fix for the currently affected exception classes is conda/conda-package-handling#349.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ Not applicable.