### PR TITLE
Delete deprecated JSON serialization shims for 26.9

### DIFF
--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import os
 import sys
-from json import JSONEncoder  # noqa: TID251
 from os.path import abspath, dirname
 from typing import TYPE_CHECKING
 
@@ -224,32 +223,3 @@ def conda_signal_handler(signum: int, frame: Any):
     from .exceptions import CondaSignalInterrupt
 
     raise CondaSignalInterrupt(signum)
-
-
-def _default(self, obj):
-    from frozendict import frozendict
-
-    from .deprecations import deprecated
-
-    if isinstance(obj, frozendict):
-        deprecated.topic(
-            "26.3",
-            "26.9",
-            topic="Monkey-patching `json.JSONEncoder` to support `frozendict`",
-            addendum="Use `conda.common.serialize.json.CondaJSONEncoder` instead.",
-        )
-        return dict(obj)
-    elif hasattr(obj, "to_json"):
-        deprecated.topic(
-            "26.3",
-            "26.9",
-            topic="Monkey-patching `json.JSONEncoder` to support `obj.to_json()`",
-            addendum="Use `conda.common.serialize.json.CondaJSONEncoder` instead.",
-        )
-        return obj.to_json()
-    return _default.default(obj)
-
-
-# FUTURE: conda 26.3, remove the following monkey patching
-_default.default = JSONEncoder().default
-JSONEncoder.default = _default

--- a/conda/auxlib/entity.py
+++ b/conda/auxlib/entity.py
@@ -972,11 +972,3 @@ class DictSafeMixin:
         for k in F:
             self[k] = F[k]
 
-
-deprecated.constant(
-    "26.3",
-    "26.9",
-    "EntityEncoder",
-    json.CondaJSONEncoder,
-    addendum="Use `conda.common.serialize.json.CondaJSONEncoder` instead.",
-)

--- a/conda/auxlib/logz.py
+++ b/conda/auxlib/logz.py
@@ -51,15 +51,6 @@ def initialize_logging(level=INFO):
     attach_stderr(level)
 
 
-# ``conda.common.serialize.json`` (and transitively ``frozendict``) stays
-# off the cold-start path; the factories below materialize it only when
-# one of the three deprecated names is actually accessed.
-def _json():
-    from ..common.serialize import json
-
-    return json
-
-
 def fullname(obj):
     try:
         return obj.__module__ + "." + obj.__class__.__name__

--- a/conda/auxlib/logz.py
+++ b/conda/auxlib/logz.py
@@ -60,34 +60,6 @@ def _json():
     return json
 
 
-deprecated.constant(
-    "26.3",
-    "26.9",
-    "DumpEncoder",
-    factory=lambda: _json().CondaJSONEncoder,
-    addendum="Use `conda.common.serialize.json.CondaJSONEncoder` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
-    "_DUMPS",
-    factory=lambda: _json().CondaJSONEncoder(
-        indent=2, ensure_ascii=False, sort_keys=True
-    ).encode,
-    addendum="Use `conda.common.serialize.json.CondaJSONEncoder(sort_keys=True).encode` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
-    "jsondumps",
-    factory=lambda: _json().CondaJSONEncoder(
-        indent=2, ensure_ascii=False, sort_keys=True
-    ).encode,
-    addendum="Use `conda.common.serialize.json.CondaJSONEncoder(sort_keys=True).encode` instead.",
-)
-
-
-
 def fullname(obj):
     try:
         return obj.__module__ + "." + obj.__class__.__name__

--- a/conda/common/serialize/__init__.py
+++ b/conda/common/serialize/__init__.py
@@ -89,38 +89,3 @@ def yaml_safe_dump(object, stream=None):
     _yaml_safe().dump(object, ostream)
     if not stream:
         return ostream.getvalue()
-
-
-# Defer the ``.json`` submodule (and transitively ``frozendict``) until one
-# of the two deprecated names is actually accessed.
-def _json():
-    from . import json
-
-    return json
-
-
-deprecated.constant(
-    "26.3",
-    "26.9",
-    "EntityEncoder",
-    factory=lambda: _json().CondaJSONEncoder,
-    addendum="Use `conda.common.serialize.json.CondaJSONEncoder` instead.",
-)
-deprecated.constant(
-    "26.3",
-    "26.9",
-    "json_load",
-    factory=lambda: _json().loads,
-    addendum="Use `conda.common.serialize.json.loads(sort_keys=True)` instead.",
-)
-
-
-@deprecated(
-    "26.3",
-    "26.9",
-    addendum="Use `conda.common.serialize.json.dumps(sort_keys=True)` instead.",
-)
-def json_dump(object):
-    from .json import dumps
-
-    return dumps(object, sort_keys=True)

--- a/conda/exports.py
+++ b/conda/exports.py
@@ -27,7 +27,6 @@ from .cli.helpers import (  # noqa: F401
     add_parser_prefix,
 )
 from .common import compat  # noqa: F401
-from .common.serialize.json import CondaJSONEncoder
 from .common.toposort import _toposort  # noqa: F401
 from .core.index import (
     Index,
@@ -92,15 +91,6 @@ LinkError = LinkError
 CondaOSError = CondaOSError
 # Replacements for six exports for compatibility
 
-
-deprecated.constant(
-    "26.3",
-    "26.9",
-    "EntityEncoder",
-    CondaJSONEncoder,
-    addendum="Use `conda.common.serialize.json.CondaJSONEncoder` instead.",
-)
-del CondaJSONEncoder
 
 deprecated.constant(
     "26.9",

--- a/news/16314-remove-json-serialization-shims
+++ b/news/16314-remove-json-serialization-shims
@@ -1,0 +1,24 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove `json.JSONEncoder` monkey patching for `frozendict` and `obj.to_json()`. (#16314)
+
+* Remove `conda.auxlib.entity.EntityEncoder`, `conda.common.serialize.EntityEncoder` / `json_load` / `json_dump`, `conda.exports.EntityEncoder`. (#16314)
+
+* Remove `conda.auxlib.logz.DumpEncoder`, `_DUMPS`, `jsondumps`. (#16314)
+
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/common/test_serialize.py
+++ b/tests/common/test_serialize.py
@@ -209,7 +209,6 @@ def test_comment_round_trip():
         ("yaml_safe_load", TypeError),
         ("yaml_round_trip_dump", TypeError),
         ("yaml_safe_dump", TypeError),
-        ("json_dump", TypeError),
     ],
 )
 def test_deprecations(function: str, raises: type[Exception] | None) -> None:

--- a/tests/test_deferred_deprecations.py
+++ b/tests/test_deferred_deprecations.py
@@ -64,23 +64,3 @@ def test_deprecated_symbol_access_warns(module: str, name: str) -> None:
     mod = importlib.import_module(module)
     with pytest.deprecated_call():
         getattr(mod, name)
-
-
-@pytest.mark.parametrize(
-    "module, name",
-    [
-        ("conda.auxlib.logz", "DumpEncoder"),
-        ("conda.auxlib.logz", "_DUMPS"),
-        ("conda.auxlib.logz", "jsondumps"),
-        ("conda.common.serialize", "EntityEncoder"),
-        ("conda.common.serialize", "json_load"),
-    ],
-)
-def test_deprecated_symbol_identity_is_stable(module: str, name: str) -> None:
-    """Repeated access returns the same object (factory cached)."""
-    mod = importlib.import_module(module)
-    with pytest.deprecated_call():
-        first = getattr(mod, name)
-        second = getattr(mod, name)
-
-    assert first is second

--- a/tests/test_deferred_deprecations.py
+++ b/tests/test_deferred_deprecations.py
@@ -10,12 +10,9 @@ so the check is immune to test-order bleed-through.
 
 from __future__ import annotations
 
-import importlib
 import subprocess
 import sys
 import textwrap
-
-import pytest
 
 
 def _sys_modules_after(import_stmt: str) -> set[str]:
@@ -47,20 +44,3 @@ def test_common_serialize_does_not_pull_in_json() -> None:
     """Importing conda.common.serialize must not import .json eagerly."""
     loaded = _sys_modules_after("import conda.common.serialize")
     assert "conda.common.serialize.json" not in loaded
-
-
-@pytest.mark.parametrize(
-    "module, name",
-    [
-        ("conda.auxlib.logz", "DumpEncoder"),
-        ("conda.auxlib.logz", "_DUMPS"),
-        ("conda.auxlib.logz", "jsondumps"),
-        ("conda.common.serialize", "EntityEncoder"),
-        ("conda.common.serialize", "json_load"),
-    ],
-)
-def test_deprecated_symbol_access_warns(module: str, name: str) -> None:
-    """Accessing a canonicalized deprecated symbol still emits a warning."""
-    mod = importlib.import_module(module)
-    with pytest.deprecated_call():
-        getattr(mod, name)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -12,7 +12,6 @@ from conda import exports
 @pytest.mark.parametrize(
     "function,raises",
     [
-        ("EntityEncoder", None),
         ("input", OSError),
         ("StringIO", None),
         ("PY3", TypeError),


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Resolves part of #16314 

- [x] Remove `json` monkey-patch topics in [`conda/__init__.py`](conda/__init__.py) (`frozendict`, `obj.to_json()`)
- [x] Remove `conda.auxlib.entity.EntityEncoder`
- [x] Remove `conda.auxlib.logz.DumpEncoder`, `_DUMPS`, `jsondumps`
- [x] Remove `conda.common.serialize.EntityEncoder`, `json_load`, `json_dump`
- [x] Remove `conda.exports.EntityEncoder`

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
