### PR TITLE
Delete deprecated CLI helpers for 26.9

### DIFF
--- a/conda/cli/common.py
+++ b/conda/cli/common.py
@@ -22,7 +22,6 @@ from ..base.constants import (
 from ..base.context import context, env_name
 from ..common.io import swallow_broken_pipe
 from ..common.path import expand, paths_equal
-from ..deprecations import deprecated
 from ..exceptions import (
     EnvironmentFileNotFound,
     EnvironmentFileTypeMismatchError,
@@ -54,33 +53,6 @@ def is_active_prefix(prefix: str) -> bool:
     )
 
 
-@deprecated(
-    "26.3",
-    "26.9",
-    addendum="Use `spec = str(MatchSpec(arg))` instead",
-)
-def arg2spec(arg: str, update: bool = False) -> str:
-    try:
-        spec = MatchSpec(arg)
-    except:
-        from ..exceptions import CondaValueError
-
-        raise CondaValueError(f"invalid package specification: {arg}")
-
-    name = spec.name
-    if not spec._is_simple() and update:
-        from ..exceptions import CondaValueError
-
-        raise CondaValueError(
-            "version specifications not allowed with 'update'; use\n"
-            f"    conda update  {name:<{len(arg)}}  or\n"
-            f"    conda install {arg:<{len(name)}}"
-        )
-
-    return str(spec)
-
-
-@deprecated.argument("26.3", "26.9", "json")
 def specs_from_args(args: Iterable[str]) -> list[str]:
     return [str(MatchSpec(arg)) for arg in args]
 
@@ -127,7 +99,6 @@ def spec_from_line(line: str) -> str:
         return name
 
 
-@deprecated.argument("26.3", "26.9", "json")
 def specs_from_url(url: str) -> list[str]:
     from ..gateways.connection.download import TmpDownload
 

--- a/conda/cli/main_compare.py
+++ b/conda/cli/main_compare.py
@@ -8,11 +8,8 @@ Compare the packages in an environment with the packages listed in an environmen
 from __future__ import annotations
 
 import logging
-import os
 from os.path import abspath, expanduser, expandvars
 from typing import TYPE_CHECKING
-
-from ..deprecations import deprecated
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace, _SubParsersAction
@@ -60,24 +57,6 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     p.set_defaults(func="conda.cli.main_compare.execute")
 
     return p
-
-
-@deprecated(
-    "26.3",
-    "26.9",
-    addendum="Use `conda.core.prefix_data.PrefixData.map_records` instead.",
-)
-def get_packages(prefix):
-    from ..core.prefix_data import PrefixData
-    from ..exceptions import EnvironmentLocationNotFound
-
-    if not os.path.isdir(prefix):
-        raise EnvironmentLocationNotFound(prefix)
-
-    return sorted(
-        PrefixData(prefix, interoperability=True).iter_records(),
-        key=lambda x: x.name,
-    )
 
 
 def compare_packages(active_pkgs, specification_pkgs) -> tuple[int, list[str]]:

--- a/news/16314-remove-cli-helpers
+++ b/news/16314-remove-cli-helpers
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove conda.cli.common.arg2spec. Use str(MatchSpec(arg)). (#16314)
+* Remove the `json` keyword from `specs_from_args` and `specs_from_url`. (#16314)
+* Remove `conda.cli.main_compare.get_packages`. Use PrefixData.map_records. (#16314)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Resolves part of #16314 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
