### PR TITLE
Delete deprecated `index` related code for 26.9

### DIFF
--- a/conda/auxlib/compat.py
+++ b/conda/auxlib/compat.py
@@ -5,13 +5,6 @@ from shlex import split
 from ..deprecations import deprecated
 
 
-@deprecated("26.3", "26.9", addendum="Use `conda.common.compat.isiterable` instead.")
-def isiterable(obj):
-    # and not a string
-    from collections.abc import Iterable
-    return not isinstance(obj, str) and isinstance(obj, Iterable)
-
-
 # shlex.split() is a poor function to use for anything general purpose (like calling subprocess).
 # It mishandles Unicode in Python 3 but all is not lost. We can escape it, then escape the escapes
 # then call shlex.split() then un-escape that.

--- a/conda/auxlib/compat.py
+++ b/conda/auxlib/compat.py
@@ -2,8 +2,6 @@ from collections import OrderedDict as odict  # noqa: F401
 import os
 from shlex import split
 
-from ..deprecations import deprecated
-
 
 # shlex.split() is a poor function to use for anything general purpose (like calling subprocess).
 # It mishandles Unicode in Python 3 but all is not lost. We can escape it, then escape the escapes

--- a/conda/core/index.py
+++ b/conda/core/index.py
@@ -10,13 +10,12 @@ from typing import TYPE_CHECKING
 
 from ..base.context import context
 from ..common.iterators import unique
-from ..deprecations import deprecated
 from ..exceptions import (
     CondaKeyError,
     InvalidSpec,
     PackagesNotFoundError,
 )
-from ..models.channel import Channel, all_channel_urls
+from ..models.channel import Channel
 from ..models.match_spec import MatchSpec
 from ..models.records import EMPTY_LINK, PackageCacheRecord, PackageRecord, PrefixRecord
 from .package_cache_data import PackageCacheData
@@ -610,35 +609,3 @@ def get_archspec_name() -> str | None:
         import archspec.cpu
 
         return str(archspec.cpu.host())
-
-
-@deprecated(
-    "26.3",
-    "26.9",
-    addendum="Use `conda.models.channel.all_channel_urls(context.channels)` instead.",
-)
-def calculate_channel_urls(
-    channel_urls: tuple[str] = (),
-    prepend: bool = True,
-    platform: str | None = None,
-    use_local: bool = False,
-) -> list[str]:
-    """
-    Calculate the full list of channel URLs to use based on the given parameters.
-
-    Args:
-        channel_urls: Initial list of channel URLs.
-        prepend: Whether to prepend default channels to the list.
-        platform: The target platform for the channels.
-        use_local: Whether to include the local channel.
-
-    Returns:
-        The calculated list of channel URLs.
-    """
-    if use_local:
-        channel_urls = ["local"] + list(channel_urls)
-    if prepend:
-        channel_urls += context.channels
-
-    subdirs = (platform, "noarch") if platform is not None else context.subdirs
-    return all_channel_urls(channel_urls, subdirs=subdirs)

--- a/news/16564-delete-index
+++ b/news/16564-delete-index
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove `isiterable` function from `conda.auxlib.compat`. (#16564)
+* Remove `calculate_channel_urls` function from `conda.core.index`. (#16564)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -3,20 +3,16 @@
 from __future__ import annotations
 
 import copy
-from contextlib import nullcontext
 from logging import getLogger
 from typing import TYPE_CHECKING
 
 import pytest
 
 import conda
-from conda.base.constants import DEFAULTS_CHANNEL_NAME
 from conda.base.context import context, non_x86_machines
 from conda.common.compat import on_linux, on_mac, on_win
-from conda.core import index
 from conda.core.index import (
     Index,
-    calculate_channel_urls,
     dist_str_in_index,
 )
 from conda.core.prefix_data import PrefixData
@@ -251,16 +247,6 @@ def test_dist_str_in_index(test_recipes_channel: Path) -> None:
     idx = Index((Channel(str(test_recipes_channel)),), prepend=False)
     assert not dist_str_in_index(idx.data, "test-1.4.0-0")
     assert dist_str_in_index(idx.data, "other_dependent-1.0-0")
-
-
-def test_calculate_channel_urls():
-    with pytest.deprecated_call():
-        urls = calculate_channel_urls(
-            channel_urls=[DEFAULTS_CHANNEL_NAME], use_local=False, prepend=True
-        )
-
-        assert "https://repo.anaconda.com/pkgs/main/noarch" in urls
-        assert len(urls) == 6 if on_win else 4
 
 
 @pytest.mark.parametrize(
@@ -541,15 +527,3 @@ class TestIndex:
             # each OS has different virtual packages
             + len(context.plugin_manager.get_virtual_package_records())
         )
-
-
-@pytest.mark.parametrize(
-    "function,raises",
-    [
-        ("calculate_channel_urls", None),
-    ],
-)
-def test_deprecations(function: str, raises: type[Exception] | None) -> None:
-    raises_context = pytest.raises(raises) if raises else nullcontext()
-    with pytest.deprecated_call(), raises_context:
-        getattr(index, function)()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

- [x] Remove `conda.core.index.calculate_channel_urls` (use `conda.models.channel.all_channel_urls(context.channels)`)
- [x] Remove `conda.auxlib.compat.isiterable` (use `conda.common.compat.isiterable`)

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
