### PR TITLE
Require confirmation to replace environments with `conda env create`

### DIFF
--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -123,6 +123,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     from ..core.prefix_data import PrefixData
     from ..exceptions import ArgumentError, CondaValueError, TooManyArgumentsError
     from ..gateways.disk.delete import rm_rf
+    from ..gateways.streams import stdoutlog
     from ..reporters import confirm_yn
     from .common import (
         get_name_prefix_from_env_file,
@@ -132,6 +133,8 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
         validate_subdir_config,
     )
     from .install import install, install_clone
+
+    env_create = getattr(args, "env_create", False)
 
     # When `--clone` is present, `--file` and `packages` are not allowed
     if args.clone:
@@ -193,6 +196,14 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
             raise CondaValueError(
                 "Cannot `create --dry-run` with an existing conda environment"
             )
+        if env_create and not context.always_yes:
+            raise CondaValueError(f"prefix already exists: {prefix_data.prefix_path}")
+
+    if env_create:
+        args.yes = True
+        context._set_argparse_args(args)
+
+    if prefix_data.is_environment():
         confirm_yn(
             f"WARNING: A conda environment already exists at '{context.target_prefix}'\n\n"
             "Remove existing environment?\nThis will remove ALL directories contained within "
@@ -200,7 +211,10 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
             default="no",
             dry_run=False,
         )
-        log.info("Removing existing environment %s", context.target_prefix)
+        if env_create:
+            stdoutlog(f"Removing existing environment at '{context.target_prefix}'.")
+        else:
+            log.info("Removing existing environment %s", context.target_prefix)
         rm_rf(context.target_prefix)
     elif prefix_data.exists():
         confirm_yn(

--- a/conda/cli/main_env_create.py
+++ b/conda/cli/main_env_create.py
@@ -113,6 +113,6 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         use_local=NULL,
         packages=[],
         repodata_fns=None,
-        yes=True,
+        env_create=True,
     )
     return p

--- a/news/15071-env-create-existing-prefix
+++ b/news/15071-env-create-existing-prefix
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Require confirmation through `--yes` or `always_yes` to replace an existing environment with `conda env create`. (#15071)

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -25,6 +25,7 @@ from . import remote_support_file, support_file
 
 if TYPE_CHECKING:
     from pytest import MonkeyPatch
+    from pytest_mock import MockerFixture
 
     from conda.testing.fixtures import (
         CondaCLIFixture,
@@ -335,6 +336,94 @@ def test_protected_dirs_error_for_env_create(
             )
 
 
+def test_create_existing_env_requires_confirmation(
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+    mocker: MockerFixture,
+    tmp_env: TmpEnvFixture,
+):
+    install = mocker.patch("conda.cli.install.install")
+    monkeypatch.setenv("CONDA_ALWAYS_YES", "false")
+
+    with tmp_env() as prefix:
+        sentinel = prefix / "sentinel"
+        sentinel.touch()
+
+        _, _, exc = conda_cli(
+            "env",
+            "create",
+            f"--prefix={prefix}",
+            "--file",
+            support_file("just_vars.yml"),
+            raises=CondaValueError,
+        )
+        assert exc.match("prefix already exists")
+        install.assert_not_called()
+        assert sentinel.exists()
+
+
+@pytest.mark.parametrize(
+    ("always_yes", "confirmation"),
+    (
+        pytest.param("false", ("--yes",), id="yes"),
+        pytest.param("true", (), id="always-yes"),
+    ),
+)
+def test_create_existing_env_accepts_confirmation(
+    always_yes: str,
+    confirmation: tuple[str, ...],
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+    mocker: MockerFixture,
+    tmp_env: TmpEnvFixture,
+):
+    install = mocker.patch("conda.cli.install.install")
+    monkeypatch.setenv("CONDA_ALWAYS_YES", always_yes)
+
+    with tmp_env() as prefix:
+        sentinel = prefix / "sentinel"
+        sentinel.touch()
+
+        stdout, _, _ = conda_cli(
+            "env",
+            "create",
+            f"--prefix={prefix}",
+            "--file",
+            support_file("just_vars.yml"),
+            *confirmation,
+        )
+        install.assert_called_once()
+        assert not sentinel.exists()
+        assert f"Removing existing environment at '{prefix}'." in stdout
+
+
+def test_create_existing_env_replacement_json_output(
+    conda_cli: CondaCLIFixture,
+    monkeypatch: MonkeyPatch,
+    mocker: MockerFixture,
+    tmp_env: TmpEnvFixture,
+):
+    install = mocker.patch("conda.cli.install.install")
+    monkeypatch.setenv("CONDA_ALWAYS_YES", "false")
+
+    with tmp_env() as prefix:
+        sentinel = prefix / "sentinel"
+        sentinel.touch()
+
+        stdout, _, _ = conda_cli(
+            "env",
+            "create",
+            f"--prefix={prefix}",
+            "--file",
+            support_file("just_vars.yml"),
+            "--yes",
+            "--json",
+        )
+        install.assert_called_once()
+        assert not sentinel.exists()
+        assert "Removing existing environment" not in stdout
+
+
 def test_create_env_from_non_existent_plugin(
     conda_cli: CondaCLIFixture,
     tmp_env: TmpEnvFixture,
@@ -351,6 +440,7 @@ def test_create_env_from_non_existent_plugin(
                 f"--prefix={prefix}",
                 "--file",
                 support_file("example/environment_pinned.yml"),
+                "--yes",
             )
 
         assert (
@@ -393,6 +483,7 @@ def test_create_env_custom_platform(
             "--file",
             str(env_file),
             f"--platform={platform}",
+            "--yes",
         )
         prefix_data = PrefixData(prefix)
 


### PR DESCRIPTION
### Description

Require `conda env create` to reject an existing environment unless replacement is authorized by `--yes` or `always_yes`. This preserves the existing prefix instead of silently deleting and recreating it. When replacement is authorized, report that the existing environment is being removed.

Closes #15071.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~ Not applicable.
