### PR TITLE
Delete deprecated code related Disk linking for 26.9

### DIFF
--- a/conda/gateways/disk/create.py
+++ b/conda/gateways/disk/create.py
@@ -8,7 +8,7 @@ import tempfile
 import warnings as _warnings
 from errno import EACCES, EPERM, EROFS
 from logging import getLogger
-from os.path import dirname, isdir, isfile, join, splitext
+from os.path import isdir, isfile, join
 from shutil import copyfileobj, copystat
 
 from ... import CondaError
@@ -17,7 +17,7 @@ from ...base.constants import PACKAGE_CACHE_MAGIC_FILE
 from ...base.context import context
 from ...common.compat import on_win
 from ...common.constants import TRACE
-from ...common.path import ensure_pad, expand, win_path_double_escape, win_path_ok
+from ...common.path import expand, win_path_ok
 from ...common.path.python import is_valid_import_path
 from ...common.serialize import json
 from ...deprecations import deprecated
@@ -168,65 +168,6 @@ def create_python_entry_point(target_full_path, python_full_path, module, func):
     return target_full_path
 
 
-@deprecated("26.3", "26.9")
-def create_application_entry_point(
-    source_full_path, target_full_path, python_full_path
-):
-    # source_full_path: where the entry point file points to
-    # target_full_path: the location of the new entry point file being created
-    if lexists(target_full_path):
-        maybe_raise(
-            BasicClobberError(
-                source_path=None,
-                target_path=target_full_path,
-                context=context,
-            ),
-            context,
-        )
-
-    entry_point = application_entry_point_template % {
-        "source_full_path": win_path_double_escape(source_full_path),
-    }
-    if not isdir(dirname(target_full_path)):
-        mkdir_p(dirname(target_full_path))
-    with open(target_full_path, "w") as fo:
-        if " " in python_full_path:
-            python_full_path = ensure_pad(python_full_path, '"')
-        fo.write(f"#!{python_full_path}\n")
-        fo.write(entry_point)
-    make_executable(target_full_path)
-
-
-@deprecated("26.3", "26.9")
-class ProgressFileWrapper:
-    def __init__(self, fileobj, progress_update_callback):
-        self.progress_file = fileobj
-        self.progress_update_callback = progress_update_callback
-        self.progress_file_size = max(1, os.fstat(fileobj.fileno()).st_size)
-        self.progress_max_pos = 0
-
-    def __getattr__(self, name):
-        return getattr(self.progress_file, name)
-
-    def __setattr__(self, name, value):
-        if name.startswith("progress_"):
-            super().__setattr__(name, value)
-        else:
-            setattr(self.progress_file, name, value)
-
-    def read(self, size=-1):
-        data = self.progress_file.read(size)
-        self.progress_update()
-        return data
-
-    def progress_update(self):
-        pos = max(self.progress_max_pos, self.progress_file.tell())
-        pos = min(pos, self.progress_file_size)
-        self.progress_max_pos = pos
-        rel_pos = pos / self.progress_file_size
-        self.progress_update_callback(rel_pos)
-
-
 @deprecated(
     "26.9",
     "27.3",
@@ -300,17 +241,6 @@ def _do_softlink(src, dst):
     else:
         log.log(TRACE, "soft linking %s => %s", src, dst)
         symlink(src, dst)
-
-
-@deprecated("26.3", "26.9")
-def create_fake_executable_softlink(src, dst):
-    if not on_win:
-        raise RuntimeError("Only runs on Windows.")
-    src_root, _ = splitext(src)
-    # TODO: this open will clobber, consider raising
-    with open(dst, "w") as f:
-        f.write(f'@echo off\ncall "{src_root}" %*\n')
-    return dst
 
 
 def copy(src, dst):

--- a/news/16314-delete-deprecated-disk-linking-code
+++ b/news/16314-delete-deprecated-disk-linking-code
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove `conda.gateways.disk.create.create_application_entry_point`, `conda.gateways.disk.create.ProgressFileWrapper`, and `conda.gateways.disk.create.create_fake_executable_softlink`, deprecated in 26.3. (#16314)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/gateways/disk/test_create.py
+++ b/tests/gateways/disk/test_create.py
@@ -12,9 +12,6 @@ from conda.gateways.disk import create
 @pytest.mark.parametrize(
     "function,raises",
     [
-        ("create_application_entry_point", TypeError),
-        ("ProgressFileWrapper", TypeError),
-        ("create_fake_executable_softlink", TypeError),
         ("extract_tarball", TypeError),
     ],
 )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

#### Disk / linking ([#15062](https://github.com/conda/conda/pull/15062))

- [x] Remove `conda.gateways.disk.create.create_application_entry_point`
- [x] Remove `conda.gateways.disk.create.ProgressFileWrapper`
- [x] Remove `conda.gateways.disk.create.create_fake_executable_softlink`

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
