### PR TITLE
Limit channel notice response cache age

### DIFF
--- a/conda/notices/cache.py
+++ b/conda/notices/cache.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path
@@ -117,7 +118,11 @@ def get_notice_response_from_cache(
     """Retrieves a notice response object from cache if it exists."""
     cache_key = ChannelNoticeResponse.get_cache_key(url, cache_dir)
 
-    if os.path.isfile(cache_key):
+    if (
+        os.path.isfile(cache_key)
+        and time.time_ns() - cache_key.stat().st_mtime_ns
+        < NOTICES_DECORATOR_DISPLAY_INTERVAL_NS
+    ):
         with open(cache_key) as fp:
             data = json.load(fp)
         chn_ntc_resp = ChannelNoticeResponse(url, name, data)

--- a/news/16502-cached-notices
+++ b/news/16502-cached-notices
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Limit cached channel notice responses to 24 hours so newly published notices can be fetched. (#16502)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/notices/test_response_cache.py
+++ b/tests/notices/test_response_cache.py
@@ -5,7 +5,12 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from conda.notices.cache import is_notice_response_cache_expired
+from conda.base.constants import NOTICES_DECORATOR_DISPLAY_INTERVAL_NS
+from conda.notices.cache import (
+    get_notice_response_from_cache,
+    is_notice_response_cache_expired,
+    write_notice_response_to_cache,
+)
 from conda.notices.types import ChannelNoticeResponse
 
 
@@ -30,3 +35,22 @@ def test_notice_response_expiration_field(field):
 
     assert response.notices[0].expired_at == expires_at
     assert not is_notice_response_cache_expired(response)
+
+
+def test_notice_response_cache_max_age(notices_cache_dir, mocker):
+    url = "https://conda.example.com/notices.json"
+    expires_at = datetime.now(timezone.utc) + timedelta(days=90)
+    response = ChannelNoticeResponse(
+        url,
+        "test",
+        {"notices": [{"expires_at": expires_at.isoformat()}]},
+    )
+    write_notice_response_to_cache(response, notices_cache_dir)
+    cache_time_ns = response.get_cache_key(url, notices_cache_dir).stat().st_mtime_ns
+    now = mocker.patch("conda.notices.cache.time.time_ns")
+
+    now.return_value = cache_time_ns + NOTICES_DECORATOR_DISPLAY_INTERVAL_NS - 1
+    assert get_notice_response_from_cache(url, "test", notices_cache_dir) == response
+
+    now.return_value = cache_time_ns + NOTICES_DECORATOR_DISPLAY_INTERVAL_NS
+    assert get_notice_response_from_cache(url, "test", notices_cache_dir) is None


### PR DESCRIPTION
### Description

Closes #16502.

Limit per-channel notice response caches to the existing 24-hour notice display interval. This bounds how long older cached responses can hide newly published notices.

### Checklist - did you ...

- [x] Add a file to the `news` directory?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~