### PR TITLE
Stop using `--dev` in tests and deprecate `--dev`/`context.dev`

### DIFF
--- a/conda/activate.py
+++ b/conda/activate.py
@@ -44,6 +44,7 @@ from .common.compat import on_win
 from .common.path import path_identity as _path_identity
 from .common.path import paths_equal, unix_path_to_win, win_path_to_unix
 from .common.serialize import json
+from .deprecations import deprecated
 from .exceptions import (
     ActivateHelp,
     ArgumentError,
@@ -289,10 +290,17 @@ class _Activator(metaclass=abc.ABCMeta):
             try:
                 dev_idx = remainder_args.index("--dev")
             except ValueError:
-                context.dev = False
+                pass
             else:
                 del remainder_args[dev_idx]
                 context.dev = True
+                deprecated.topic(
+                    "27.3",
+                    "27.9",
+                    topic=f"`conda {command} --dev`",
+                    addendum="Set `PYTHONPATH` to the conda source root instead.",
+                    deprecation_type=FutureWarning,
+                )
 
         if command == "activate":
             self.stack = context.auto_stack and context.shlvl <= context.auto_stack

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -293,7 +293,6 @@ class _Activator(metaclass=abc.ABCMeta):
                 pass
             else:
                 del remainder_args[dev_idx]
-                context.dev = True
                 deprecated.topic(
                     "27.3",
                     "27.9",

--- a/conda/activate.py
+++ b/conda/activate.py
@@ -293,6 +293,7 @@ class _Activator(metaclass=abc.ABCMeta):
                 pass
             else:
                 del remainder_args[dev_idx]
+                context.dev = True
                 deprecated.topic(
                     "27.3",
                     "27.9",

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -885,6 +885,12 @@ class Context(Configuration):
         None means unset it.
         """
         if context.dev:
+            deprecated.topic(
+                "27.3",
+                "27.9",
+                topic="`conda.base.context.Context.dev`",
+                addendum="Set `PYTHONPATH` to the conda source root instead.",
+            )
             if pythonpath := os.environ.get("PYTHONPATH", ""):
                 pythonpath = os.pathsep.join((CONDA_SOURCE_ROOT, pythonpath))
             else:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 
 from frozendict import frozendict
 
+from .. import CONDA_SOURCE_ROOT
 from .. import __version__ as CONDA_VERSION
 from ..auxlib.decorators import memoizedproperty
 from ..auxlib.ish import dals
@@ -612,6 +613,11 @@ class Context(Configuration):
     def dev(self) -> bool:
         return self._dev
 
+    @dev.setter
+    def dev(self, value: bool) -> None:
+        self._dev = value
+        self._cache_.pop("_dev", None)
+
     @property
     @deprecated(
         "26.9",
@@ -892,6 +898,28 @@ class Context(Configuration):
         The vars can refer to each other if necessary since the dict is ordered.
         None means unset it.
         """
+        if self._dev:
+            deprecated.topic(
+                "27.3",
+                "27.9",
+                topic="`conda.base.context.Context.dev`",
+                addendum="Set `PYTHONPATH` to the conda source root instead.",
+            )
+            if pythonpath := os.environ.get("PYTHONPATH", ""):
+                pythonpath = os.pathsep.join((CONDA_SOURCE_ROOT, pythonpath))
+            else:
+                pythonpath = CONDA_SOURCE_ROOT
+            return {
+                "CONDA_EXE": sys.executable,
+                "_CONDA_EXE": sys.executable,
+                # do not confuse with os.path.join, we are joining paths with ; or : delimiters
+                "PYTHONPATH": pythonpath,
+                "_CE_M": "-m",
+                "_CE_CONDA": "conda",
+                "CONDA_PYTHON_EXE": sys.executable,
+                "_CONDA_ROOT": self.conda_prefix,
+            }
+
         exe = os.path.join(
             self.conda_prefix,
             BIN_DIRECTORY,

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING
 
 from frozendict import frozendict
 
-from .. import CONDA_SOURCE_ROOT
 from .. import __version__ as CONDA_VERSION
 from ..auxlib.decorators import memoizedproperty
 from ..auxlib.ish import dals
@@ -454,7 +453,7 @@ class Context(Configuration):
     )
     _debug = ParameterLoader(PrimitiveParameter(False), aliases=["debug"])
     _trace = ParameterLoader(PrimitiveParameter(False), aliases=["trace"])
-    dev = ParameterLoader(PrimitiveParameter(False))
+    _dev = ParameterLoader(PrimitiveParameter(False), aliases=("dev",))
     dry_run = ParameterLoader(PrimitiveParameter(False))
     _error_upload_url = ParameterLoader(
         PrimitiveParameter("https://conda.io/conda-post/unexpected-error"),
@@ -603,6 +602,15 @@ class Context(Configuration):
         """
         self.plugin_manager.load_settings()
         return self.plugin_manager.get_config(self.raw_data)
+
+    @property
+    @deprecated(
+        "27.3",
+        "27.9",
+        addendum="Set `PYTHONPATH` to the conda source root instead.",
+    )
+    def dev(self) -> bool:
+        return self._dev
 
     @property
     @deprecated(
@@ -884,41 +892,22 @@ class Context(Configuration):
         The vars can refer to each other if necessary since the dict is ordered.
         None means unset it.
         """
-        if context.dev:
-            deprecated.topic(
-                "27.3",
-                "27.9",
-                topic="`conda.base.context.Context.dev`",
-                addendum="Set `PYTHONPATH` to the conda source root instead.",
-            )
-            if pythonpath := os.environ.get("PYTHONPATH", ""):
-                pythonpath = os.pathsep.join((CONDA_SOURCE_ROOT, pythonpath))
-            else:
-                pythonpath = CONDA_SOURCE_ROOT
-            return {
-                "CONDA_EXE": sys.executable,
-                "_CONDA_EXE": sys.executable,
-                # do not confuse with os.path.join, we are joining paths with ; or : delimiters
-                "PYTHONPATH": pythonpath,
-                "_CE_M": "-m",
-                "_CE_CONDA": "conda",
-                "CONDA_PYTHON_EXE": sys.executable,
-                "_CONDA_ROOT": self.conda_prefix,
-            }
-        else:
-            exe = os.path.join(
-                self.conda_prefix,
-                BIN_DIRECTORY,
-                "conda.exe" if on_win else "conda",
-            )
-            return {
-                "CONDA_EXE": exe,
-                "_CONDA_EXE": exe,
-                "_CE_M": None,
-                "_CE_CONDA": None,
-                "CONDA_PYTHON_EXE": sys.executable,
-                "_CONDA_ROOT": self.conda_prefix,
-            }
+        exe = os.path.join(
+            self.conda_prefix,
+            BIN_DIRECTORY,
+            "conda.exe" if on_win else "conda",
+        )
+        return {
+            "CONDA_EXE": exe,
+            "_CONDA_EXE": exe,
+            # Shell wrappers expand `"$CONDA_EXE" $_CE_M $_CE_CONDA` (`python -m conda`
+            # when set). None unsets leftovers; keep the keys while wrappers expand them.
+            # https://github.com/conda/conda/issues/14142
+            "_CE_M": None,
+            "_CE_CONDA": None,
+            "CONDA_PYTHON_EXE": sys.executable,
+            "_CONDA_ROOT": self.conda_prefix,
+        }
 
     @memoizedproperty
     def channel_alias(self) -> Channel:
@@ -1421,7 +1410,7 @@ class Context(Configuration):
             "allow_conda_downgrades",
             "debug",
             "trace",
-            "dev",
+            "dev",  # TODO: Remove after deprecation ended
             "default_python",
             "enable_private_envs",
             "error_upload_url",  # TODO: Remove after deprecation ended

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -615,8 +615,7 @@ class Context(Configuration):
 
     @dev.setter
     def dev(self, value: bool) -> None:
-        self._dev = value
-        self._cache_.pop("_dev", None)
+        self._cache_["_dev"] = value
 
     @property
     @deprecated(
@@ -904,6 +903,7 @@ class Context(Configuration):
                 "27.9",
                 topic="`conda.base.context.Context.dev`",
                 addendum="Set `PYTHONPATH` to the conda source root instead.",
+                deprecation_type=FutureWarning,
             )
             if pythonpath := os.environ.get("PYTHONPATH", ""):
                 pythonpath = os.pathsep.join((CONDA_SOURCE_ROOT, pythonpath))

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -52,6 +52,7 @@ def epilog() -> str:
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
+    from ..deprecations import deprecated
     from .actions import NullCountAction
     from .helpers import (
         add_parser_create_install_update,
@@ -95,7 +96,12 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     add_parser_solver(solver_mode_options)
     p.add_argument(
         "--dev",
-        action=NullCountAction,
+        action=deprecated.action(
+            "27.3",
+            "27.9",
+            NullCountAction,
+            addendum="Set `PYTHONPATH` to the conda source root instead.",
+        ),
         help="Use `sys.executable -m conda` in wrapper scripts instead of CONDA_EXE. "
         "This is mainly for use during tests where we test new conda sources "
         "against old Python versions.",

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -65,6 +65,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         action="store_true",
         help=SUPPRESS,
         default=NULL,
+        dest="init_dev",
     )
 
     p.add_argument(
@@ -167,7 +168,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     else:
         selected_shells = tuple(args.shells)
 
-    if args.dev:
+    if args.init_dev:
         if len(selected_shells) != 1:
             raise ArgumentError("--dev can only handle one shell at a time right now")
         return initialize_dev(selected_shells[0])

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -22,8 +22,6 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..base.constants import COMPATIBLE_SHELLS
     from ..common.compat import on_win
     from ..common.constants import NULL
-    from ..deprecations import deprecated
-    from .actions import NullCountAction
     from .helpers import add_parser_json
 
     summary = "Initialize conda for shell interaction."
@@ -64,12 +62,7 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
 
     p.add_argument(
         "--dev",
-        action=deprecated.action(
-            "27.3",
-            "27.9",
-            NullCountAction,
-            addendum="Set `PYTHONPATH` to the conda source root instead.",
-        ),
+        action="store_true",
         help=SUPPRESS,
         default=NULL,
     )

--- a/conda/cli/main_init.py
+++ b/conda/cli/main_init.py
@@ -22,6 +22,8 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     from ..base.constants import COMPATIBLE_SHELLS
     from ..common.compat import on_win
     from ..common.constants import NULL
+    from ..deprecations import deprecated
+    from .actions import NullCountAction
     from .helpers import add_parser_json
 
     summary = "Initialize conda for shell interaction."
@@ -62,7 +64,12 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
 
     p.add_argument(
         "--dev",
-        action="store_true",
+        action=deprecated.action(
+            "27.3",
+            "27.9",
+            NullCountAction,
+            addendum="Set `PYTHONPATH` to the conda source root instead.",
+        ),
         help=SUPPRESS,
         default=NULL,
     )

--- a/conda/cli/main_install.py
+++ b/conda/cli/main_install.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
+    from ..deprecations import deprecated
     from .actions import NullCountAction
     from .helpers import (
         add_parser_create_install_update,
@@ -108,7 +109,12 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     add_parser_update_modifiers(solver_mode_options)
     p.add_argument(
         "--dev",
-        action=NullCountAction,
+        action=deprecated.action(
+            "27.3",
+            "27.9",
+            NullCountAction,
+            addendum="Set `PYTHONPATH` to the conda source root instead.",
+        ),
         help="Use `sys.executable -m conda` in wrapper scripts instead of CONDA_EXE. "
         "This is mainly for use during tests where we test new conda sources "
         "against old Python versions.",

--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser:
     from ..auxlib.ish import dals
     from ..common.constants import NULL
+    from ..deprecations import deprecated
     from .actions import NullCountAction
     from .helpers import (
         add_output_and_prompt_options,
@@ -127,7 +128,12 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
     )
     p.add_argument(
         "--dev",
-        action=NullCountAction,
+        action=deprecated.action(
+            "27.3",
+            "27.9",
+            NullCountAction,
+            addendum="Set `PYTHONPATH` to the conda source root instead.",
+        ),
         help="Use `sys.executable -m conda` in wrapper scripts instead of CONDA_EXE. "
         "This is mainly for use during tests where we test new conda sources "
         "against old Python versions.",

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -265,6 +265,9 @@ def _initialize_dev_bash(prefix, env_vars, unset_env_vars):
 
 
 def _initialize_dev_cmdexe(prefix, env_vars, unset_env_vars):
+    dev_arg = ""
+    if context._dev:
+        dev_arg = "--dev"
     condabin = Path(prefix, "condabin")
 
     yield (
@@ -279,12 +282,12 @@ def _initialize_dev_cmdexe(prefix, env_vars, unset_env_vars):
     )
 
     # initialize shell interface
-    yield f'@CALL "{condabin / "conda_hook.bat"}"'
+    yield f'@CALL "{condabin / "conda_hook.bat"}" {dev_arg}'
     yield "@IF %ERRORLEVEL% NEQ 0 @EXIT /B %ERRORLEVEL%"
 
     # optionally activate environment
     if context.auto_activate:
-        yield f'@CALL "{condabin / "conda.bat"}" activate "{prefix}"'
+        yield f'@CALL "{condabin / "conda.bat"}" activate {dev_arg} "{prefix}"'
         yield "@IF %ERRORLEVEL% NEQ 0 @EXIT /B %ERRORLEVEL%"
 
 

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -265,9 +265,6 @@ def _initialize_dev_bash(prefix, env_vars, unset_env_vars):
 
 
 def _initialize_dev_cmdexe(prefix, env_vars, unset_env_vars):
-    dev_arg = ""
-    if context.dev:
-        dev_arg = "--dev"
     condabin = Path(prefix, "condabin")
 
     yield (
@@ -282,12 +279,12 @@ def _initialize_dev_cmdexe(prefix, env_vars, unset_env_vars):
     )
 
     # initialize shell interface
-    yield f'@CALL "{condabin / "conda_hook.bat"}" {dev_arg}'
+    yield f'@CALL "{condabin / "conda_hook.bat"}"'
     yield "@IF %ERRORLEVEL% NEQ 0 @EXIT /B %ERRORLEVEL%"
 
     # optionally activate environment
     if context.auto_activate:
-        yield f'@CALL "{condabin / "conda.bat"}" activate {dev_arg} "{prefix}"'
+        yield f'@CALL "{condabin / "conda.bat"}" activate "{prefix}"'
         yield "@IF %ERRORLEVEL% NEQ 0 @EXIT /B %ERRORLEVEL%"
 
 

--- a/conda/core/initialize.py
+++ b/conda/core/initialize.py
@@ -265,9 +265,7 @@ def _initialize_dev_bash(prefix, env_vars, unset_env_vars):
 
 
 def _initialize_dev_cmdexe(prefix, env_vars, unset_env_vars):
-    dev_arg = ""
-    if context._dev:
-        dev_arg = "--dev"
+    dev_arg = "--dev"
     condabin = Path(prefix, "condabin")
 
     yield (

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1645,7 +1645,7 @@ def run_script(
             script_caller, command_args = wrap_subprocess_call(
                 context.root_prefix,
                 prefix,
-                False,
+                context._dev,
                 False,
                 ("@CALL", path),
             )
@@ -1657,7 +1657,7 @@ def run_script(
             script_caller, command_args = wrap_subprocess_call(
                 context.root_prefix,
                 prefix,
-                False,
+                context._dev,
                 False,
                 (".", path),
             )

--- a/conda/core/link.py
+++ b/conda/core/link.py
@@ -1645,7 +1645,7 @@ def run_script(
             script_caller, command_args = wrap_subprocess_call(
                 context.root_prefix,
                 prefix,
-                context.dev,
+                False,
                 False,
                 ("@CALL", path),
             )
@@ -1657,7 +1657,7 @@ def run_script(
             script_caller, command_args = wrap_subprocess_call(
                 context.root_prefix,
                 prefix,
-                context.dev,
+                False,
                 False,
                 (".", path),
             )

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -48,7 +48,7 @@ def any_subprocess(args: Sequence[str], prefix, env=None, cwd=None):
     script_caller, command_args = wrap_subprocess_call(
         context.root_prefix,
         prefix,
-        False,
+        context._dev,
         context.debug,
         args,
     )

--- a/conda/gateways/subprocess.py
+++ b/conda/gateways/subprocess.py
@@ -48,7 +48,7 @@ def any_subprocess(args: Sequence[str], prefix, env=None, cwd=None):
     script_caller, command_args = wrap_subprocess_call(
         context.root_prefix,
         prefix,
-        context.dev,
+        False,
         context.debug,
         args,
     )

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -199,9 +199,14 @@ def wrap_subprocess_call(
         multiline = True
     if on_win:
         comspec = get_comspec()  # fail early with KeyError if undefined
-        conda_bat = environ.get(
-            "CONDA_BAT", abspath(join(root_prefix, "condabin", "conda.bat"))
-        )
+        if dev_mode:
+            from . import CONDA_PACKAGE_ROOT
+
+            conda_bat = join(CONDA_PACKAGE_ROOT, "shell", "condabin", "conda.bat")
+        else:
+            conda_bat = environ.get(
+                "CONDA_BAT", abspath(join(root_prefix, "condabin", "conda.bat"))
+            )
         with Utf8NamedTemporaryFile(mode="w", suffix=".bat", delete=False) as fh:
             silencer = "" if debug_wrapper_scripts else "@"
             fh.write(f"{silencer}ECHO OFF\n")
@@ -211,6 +216,17 @@ def wrap_subprocess_call(
                 f'{silencer}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'
             )
             fh.write(f"{silencer}chcp 65001 > NUL\n")
+            if dev_mode:
+                from . import CONDA_SOURCE_ROOT
+
+                fh.write(f"{silencer}SET CONDA_DEV=1\n")
+                # In dev mode, conda is really:
+                # 'python -m conda'
+                # *with* PYTHONPATH set.
+                fh.write(f"{silencer}SET PYTHONPATH={CONDA_SOURCE_ROOT}\n")
+                fh.write(f"{silencer}SET CONDA_EXE={sys.executable}\n")
+                fh.write(f"{silencer}SET _CE_M=-m\n")
+                fh.write(f"{silencer}SET _CE_CONDA=conda\n")
             if debug_wrapper_scripts:
                 fh.write("echo *** environment before *** 1>&2\n")
                 fh.write("SET 1>&2\n")
@@ -264,16 +280,30 @@ def wrap_subprocess_call(
         if shell_path is None:
             raise Exception("No compatible shell found!")
 
-        conda_exe = [
-            environ.get("CONDA_EXE", abspath(join(root_prefix, "bin", "conda")))
-        ]
+        # During tests, we sometimes like to have a temp env with e.g. an old python in it
+        # and have it run tests against the very latest development sources. For that to
+        # work we need extra smarts here, we want it to be instead:
+        if dev_mode:
+            conda_exe = [abspath(join(root_prefix, "bin", "python")), "-m", "conda"]
+            dev_arg = "--dev"
+            dev_args = [dev_arg]
+        else:
+            conda_exe = [
+                environ.get("CONDA_EXE", abspath(join(root_prefix, "bin", "conda")))
+            ]
+            dev_arg = ""
+            dev_args = []
         with Utf8NamedTemporaryFile(mode="w", delete=False) as fh:
-            hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook")
+            if dev_mode:
+                from . import CONDA_SOURCE_ROOT
+
+                fh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + "\n")
+            hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment before ***'\n>&2 env\n")
                 fh.write(f'>&2 echo "$({hook_quoted})"\n')
             fh.write(f'eval "$({hook_quoted})"\n')
-            fh.write(f"conda activate {quote_for_shell(prefix)}\n")
+            fh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment after ***'\n>&2 env\n")
             if multiline:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -199,14 +199,9 @@ def wrap_subprocess_call(
         multiline = True
     if on_win:
         comspec = get_comspec()  # fail early with KeyError if undefined
-        if dev_mode:
-            from . import CONDA_PACKAGE_ROOT
-
-            conda_bat = join(CONDA_PACKAGE_ROOT, "shell", "condabin", "conda.bat")
-        else:
-            conda_bat = environ.get(
-                "CONDA_BAT", abspath(join(root_prefix, "condabin", "conda.bat"))
-            )
+        conda_bat = environ.get(
+            "CONDA_BAT", abspath(join(root_prefix, "condabin", "conda.bat"))
+        )
         with Utf8NamedTemporaryFile(mode="w", suffix=".bat", delete=False) as fh:
             silencer = "" if debug_wrapper_scripts else "@"
             fh.write(f"{silencer}ECHO OFF\n")
@@ -216,17 +211,6 @@ def wrap_subprocess_call(
                 f'{silencer}FOR /F "tokens=2 delims=:." %%A in (\'chcp\') do for %%B in (%%A) do set "_CONDA_OLD_CHCP=%%B"\n'
             )
             fh.write(f"{silencer}chcp 65001 > NUL\n")
-            if dev_mode:
-                from . import CONDA_SOURCE_ROOT
-
-                fh.write(f"{silencer}SET CONDA_DEV=1\n")
-                # In dev mode, conda is really:
-                # 'python -m conda'
-                # *with* PYTHONPATH set.
-                fh.write(f"{silencer}SET PYTHONPATH={CONDA_SOURCE_ROOT}\n")
-                fh.write(f"{silencer}SET CONDA_EXE={sys.executable}\n")
-                fh.write(f"{silencer}SET _CE_M=-m\n")
-                fh.write(f"{silencer}SET _CE_CONDA=conda\n")
             if debug_wrapper_scripts:
                 fh.write("echo *** environment before *** 1>&2\n")
                 fh.write("SET 1>&2\n")
@@ -280,30 +264,16 @@ def wrap_subprocess_call(
         if shell_path is None:
             raise Exception("No compatible shell found!")
 
-        # During tests, we sometimes like to have a temp env with e.g. an old python in it
-        # and have it run tests against the very latest development sources. For that to
-        # work we need extra smarts here, we want it to be instead:
-        if dev_mode:
-            conda_exe = [abspath(join(root_prefix, "bin", "python")), "-m", "conda"]
-            dev_arg = "--dev"
-            dev_args = [dev_arg]
-        else:
-            conda_exe = [
-                environ.get("CONDA_EXE", abspath(join(root_prefix, "bin", "conda")))
-            ]
-            dev_arg = ""
-            dev_args = []
+        conda_exe = [
+            environ.get("CONDA_EXE", abspath(join(root_prefix, "bin", "conda")))
+        ]
         with Utf8NamedTemporaryFile(mode="w", delete=False) as fh:
-            if dev_mode:
-                from . import CONDA_SOURCE_ROOT
-
-                fh.write(">&2 export PYTHONPATH=" + CONDA_SOURCE_ROOT + "\n")
-            hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook", *dev_args)
+            hook_quoted = quote_for_shell(*conda_exe, "shell.posix", "hook")
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment before ***'\n>&2 env\n")
                 fh.write(f'>&2 echo "$({hook_quoted})"\n')
             fh.write(f'eval "$({hook_quoted})"\n')
-            fh.write(f"conda activate {dev_arg} {quote_for_shell(prefix)}\n")
+            fh.write(f"conda activate {quote_for_shell(prefix)}\n")
             if debug_wrapper_scripts:
                 fh.write(">&2 echo '*** environment after ***'\n>&2 env\n")
             if multiline:

--- a/conda/utils.py
+++ b/conda/utils.py
@@ -185,6 +185,14 @@ def wrap_subprocess_call(
         raise TypeError("`arguments` must be iterable")
     arguments = tuple(map(str, arguments))
 
+    if dev_mode:
+        deprecated.topic(
+            "27.3",
+            "27.9",
+            topic="`conda.utils.wrap_subprocess_call(dev_mode)`",
+            addendum="Set `PYTHONPATH` to the conda source root instead.",
+        )
+
     script_caller = None
     multiline = False
     if len(arguments) == 1 and "\n" in arguments[0]:

--- a/docs/source/dev-guide/deep-dives/activation.md
+++ b/docs/source/dev-guide/deep-dives/activation.md
@@ -114,7 +114,7 @@ export _CE_CONDA=''
 export CONDA_PYTHON_EXE='/Users/username/.local/anaconda/bin/python'
 ```
 
-`_CE_M` and `_CE_CONDA` are empty here (a no-op). The shell still expands them so `python -m conda` works when they are set; conda itself will stop exporting them. For local development, set `PYTHONPATH` to the conda source root (see `dev/start`) instead of using `--dev`.
+`_CE_M` and `_CE_CONDA` are empty here (a no-op). The shell still expands them so `python -m conda` works when they are set; conda itself always unsets them. `--dev` is pending deprecation and has no effect. For local development, set `PYTHONPATH` to the conda source root (see `dev/start`).
 
 See? It only wrote some shell code to stdout, but it wasn't executed. We would need to do this to
 actually run it:

--- a/docs/source/dev-guide/deep-dives/activation.md
+++ b/docs/source/dev-guide/deep-dives/activation.md
@@ -114,6 +114,8 @@ export _CE_CONDA=''
 export CONDA_PYTHON_EXE='/Users/username/.local/anaconda/bin/python'
 ```
 
+`_CE_M` and `_CE_CONDA` are empty here (a no-op). The shell still expands them so `python -m conda` works when they are set; conda itself will stop exporting them. For local development, set `PYTHONPATH` to the conda source root (see `dev/start`) instead of using `--dev`.
+
 See? It only wrote some shell code to stdout, but it wasn't executed. We would need to do this to
 actually run it:
 

--- a/docs/source/dev-guide/deep-dives/activation.md
+++ b/docs/source/dev-guide/deep-dives/activation.md
@@ -114,7 +114,7 @@ export _CE_CONDA=''
 export CONDA_PYTHON_EXE='/Users/username/.local/anaconda/bin/python'
 ```
 
-`_CE_M` and `_CE_CONDA` are empty here (a no-op). The shell still expands them so `python -m conda` works when they are set; conda itself always unsets them. `--dev` is pending deprecation and has no effect. For local development, set `PYTHONPATH` to the conda source root (see `dev/start`).
+`_CE_M` and `_CE_CONDA` are empty here (a no-op). The shell still expands them so `python -m conda` works when they are set; conda itself will stop exporting them except when `--dev` is passed. For local development, set `PYTHONPATH` to the conda source root (see `dev/start`) instead of using `--dev`.
 
 See? It only wrote some shell code to stdout, but it wasn't executed. We would need to do this to
 actually run it:

--- a/docs/source/dev-guide/development-environment.md
+++ b/docs/source/dev-guide/development-environment.md
@@ -228,7 +228,8 @@ If you prefer to set up your development environment manually instead of using t
 
    **Option A: Set PYTHONPATH**
 
-   Set PYTHONPATH to make the conda source code available, then activate the environment:
+   Set PYTHONPATH to make the conda source code available, then activate the environment
+   (`dev/start` does this automatically):
 
    ````{tab-set}
 

--- a/news/14142-dev-mode.md
+++ b/news/14142-dev-mode.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Do not force `context.dev` off when `--dev` is absent from `conda activate` / hook, so `CONDA_EXE` is retained across stacking and reactivate. (#14142, #15696)
+
+### Deprecations
+
+* Mark `conda activate --dev`, `conda create --dev`, `conda install --dev`, `conda remove --dev`, `conda init --dev`, `conda.base.context.Context.dev`, and `conda.utils.wrap_subprocess_call(dev_mode)` as pending deprecation, to be removed in 27.9. Conda will stop exporting `_CE_M` and `_CE_CONDA` except when `--dev` is passed; shell expansion of those variables remains. Set `PYTHONPATH` to the conda source root instead. (#14142)
+
+### Docs
+
+* Note that `_CE_M` and `_CE_CONDA` in activation examples are empty no-ops. Use `PYTHONPATH` and `dev/start` for local conda development. (#14142)
+
+### Other
+
+* <news item>

--- a/news/14142-dev-mode.md
+++ b/news/14142-dev-mode.md
@@ -4,15 +4,15 @@
 
 ### Bug fixes
 
-* Do not force `context.dev` off when `--dev` is absent from `conda activate` / hook, so `CONDA_EXE` is retained across stacking and reactivate. (#14142, #15696)
+* Do not force `context.dev` off when `--dev` is absent from `conda activate` / hook, so `CONDA_EXE` is retained across stacking and reactivate. (#14142 via #16571, #15696 via #16571)
 
 ### Deprecations
 
-* Mark `conda activate --dev`, `conda create --dev`, `conda install --dev`, `conda remove --dev`, `conda init --dev`, `conda.base.context.Context.dev`, and `conda.utils.wrap_subprocess_call(dev_mode)` as pending deprecation, to be removed in 27.9. Conda will stop exporting `_CE_M` and `_CE_CONDA` except when `--dev` is passed; shell expansion of those variables remains. Set `PYTHONPATH` to the conda source root instead. (#14142)
+* Mark `conda activate --dev`, `conda create --dev`, `conda install --dev`, `conda remove --dev`, `conda init --dev`, `conda.base.context.Context.dev`, and `conda.utils.wrap_subprocess_call(dev_mode)` as pending deprecation, to be removed in 27.9. Conda will stop exporting `_CE_M` and `_CE_CONDA` except when `--dev` is passed; shell expansion of those variables remains. Set `PYTHONPATH` to the conda source root instead. (#14142 via #16571)
 
 ### Docs
 
-* Note that `_CE_M` and `_CE_CONDA` in activation examples are empty no-ops. Use `PYTHONPATH` and `dev/start` for local conda development. (#14142)
+* Note that `_CE_M` and `_CE_CONDA` in activation examples are empty no-ops. Use `PYTHONPATH` and `dev/start` for local conda development. (#14142 via #16571)
 
 ### Other
 

--- a/news/14142-dev-mode.md
+++ b/news/14142-dev-mode.md
@@ -4,11 +4,11 @@
 
 ### Bug fixes
 
-* Do not rewrite `CONDA_EXE` from `--dev` or `context.dev` on `conda activate` / hook, so `CONDA_EXE` is retained across stacking and reactivate. (#14142 via #16571, #15696 via #16571)
+* Do not force `context.dev` off when `--dev` is absent from `conda activate` / hook, so `CONDA_EXE` is retained across stacking and reactivate. (#14142 via #16571, #15696 via #16571)
 
 ### Deprecations
 
-* Mark `conda activate --dev`, `conda create --dev`, `conda install --dev`, `conda remove --dev`, `conda init --dev`, `conda.base.context.Context.dev`, and `conda.utils.wrap_subprocess_call(dev_mode)` as pending deprecation, to be removed in 27.9. Those knobs warn and have no effect. Conda always unsets `_CE_M` and `_CE_CONDA`; shell expansion of those variables remains. Set `PYTHONPATH` to the conda source root instead. (#14142 via #16571)
+* Mark `conda activate --dev`, `conda create --dev`, `conda install --dev`, `conda remove --dev`, `conda.base.context.Context.dev`, and `conda.utils.wrap_subprocess_call(dev_mode)` as pending deprecation, to be removed in 27.9. Conda will stop exporting `_CE_M` and `_CE_CONDA` except when `--dev` is passed; shell expansion of those variables remains. Set `PYTHONPATH` to the conda source root instead. (#14142 via #16571)
 
 ### Docs
 

--- a/news/14142-dev-mode.md
+++ b/news/14142-dev-mode.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Do not force `context.dev` off when `--dev` is absent from `conda activate` / hook, so `CONDA_EXE` is retained across stacking and reactivate. (#14142 via #16571, #15696 via #16571)
+* Do not force `context.dev` off when `--dev` is absent from `conda activate` / hook, so configuration-backed dev mode (`CONDA_DEV` / `dev: true`) retains `CONDA_EXE` across stacking and reactivation. (#14142 via #16571, #15696 via #16571)
 
 ### Deprecations
 

--- a/news/14142-dev-mode.md
+++ b/news/14142-dev-mode.md
@@ -4,11 +4,11 @@
 
 ### Bug fixes
 
-* Do not force `context.dev` off when `--dev` is absent from `conda activate` / hook, so `CONDA_EXE` is retained across stacking and reactivate. (#14142 via #16571, #15696 via #16571)
+* Do not rewrite `CONDA_EXE` from `--dev` or `context.dev` on `conda activate` / hook, so `CONDA_EXE` is retained across stacking and reactivate. (#14142 via #16571, #15696 via #16571)
 
 ### Deprecations
 
-* Mark `conda activate --dev`, `conda create --dev`, `conda install --dev`, `conda remove --dev`, `conda init --dev`, `conda.base.context.Context.dev`, and `conda.utils.wrap_subprocess_call(dev_mode)` as pending deprecation, to be removed in 27.9. Conda will stop exporting `_CE_M` and `_CE_CONDA` except when `--dev` is passed; shell expansion of those variables remains. Set `PYTHONPATH` to the conda source root instead. (#14142 via #16571)
+* Mark `conda activate --dev`, `conda create --dev`, `conda install --dev`, `conda remove --dev`, `conda init --dev`, `conda.base.context.Context.dev`, and `conda.utils.wrap_subprocess_call(dev_mode)` as pending deprecation, to be removed in 27.9. Those knobs warn and have no effect. Conda always unsets `_CE_M` and `_CE_CONDA`; shell expansion of those variables remains. Set `PYTHONPATH` to the conda source root instead. (#14142 via #16571)
 
 ### Docs
 

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -1065,14 +1065,16 @@ def test_context_dev_pending_deprecation() -> None:
 
 
 @pytest.mark.parametrize("conda_dev", [True, False])
-def test_conda_exe_vars_dict_unsets_ce(
-    monkeypatch: MonkeyPatch, conda_dev: bool
-) -> None:
+def test_conda_exe_vars_dict_dev(monkeypatch: MonkeyPatch, conda_dev: bool) -> None:
     monkeypatch.setenv("CONDA_DEV", str(int(conda_dev)))
     reset_context()
     assert context._dev is conda_dev
 
-    # context.dev is noop on _CE_* variables
-    exe_vars = context.conda_exe_vars_dict
-    assert exe_vars["_CE_M"] is None
-    assert exe_vars["_CE_CONDA"] is None
+    with pytest.deprecated_call() if conda_dev else nullcontext():
+        exe_vars = context.conda_exe_vars_dict
+    if conda_dev:
+        assert exe_vars["_CE_M"] == "-m"
+        assert exe_vars["_CE_CONDA"] == "conda"
+    else:
+        assert exe_vars["_CE_M"] is None
+        assert exe_vars["_CE_CONDA"] is None

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -1057,3 +1057,22 @@ def test_root_writable_false_when_magic_file_missing(
     reset_context()
 
     assert context.root_writable is False
+
+
+def test_context_dev_pending_deprecation() -> None:
+    with pytest.deprecated_call():
+        context.dev
+
+
+@pytest.mark.parametrize("conda_dev", [True, False])
+def test_conda_exe_vars_dict_unsets_ce(
+    monkeypatch: MonkeyPatch, conda_dev: bool
+) -> None:
+    monkeypatch.setenv("CONDA_DEV", str(int(conda_dev)))
+    reset_context()
+    assert context._dev == conda_dev
+
+    # context.dev is noop on _CE_* variables
+    exe_vars = context.conda_exe_vars_dict
+    assert exe_vars["_CE_M"] is None
+    assert exe_vars["_CE_CONDA"] is None

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -1070,7 +1070,7 @@ def test_conda_exe_vars_dict_unsets_ce(
 ) -> None:
     monkeypatch.setenv("CONDA_DEV", str(int(conda_dev)))
     reset_context()
-    assert context._dev == conda_dev
+    assert context._dev is conda_dev
 
     # context.dev is noop on _CE_* variables
     exe_vars = context.conda_exe_vars_dict

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import warnings
 from inspect import isclass, isfunction
 from logging import getLogger
 from typing import TYPE_CHECKING
@@ -173,7 +174,9 @@ def test_dev_flag_absent_is_not_deprecated() -> None:
     assert not args.dev
 
 
-def test_init_dev_is_not_deprecated() -> None:
-    parser = generate_parser()
-    args = parser.parse_args(["init", "--dev"])
-    assert args.dev
+def test_init_dev_is_not_deprecated(conda_cli: CondaCLIFixture) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PendingDeprecationWarning)
+        _, stderr, rc = conda_cli("init", "--dev", "--dry-run", "bash")
+
+    assert rc == 0, stderr

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -157,3 +157,19 @@ def test_sorted_commands_in_error(capsys: CaptureFixture):
         )
     else:
         pytest.fail("Did not raise")
+
+
+@pytest.mark.parametrize("command", ["create", "install", "remove", "init"])
+def test_dev_flag_pending_deprecation(command: str) -> None:
+    parser = generate_parser()
+    with pytest.warns(
+        PendingDeprecationWarning, match=r"`--dev` is pending deprecation"
+    ):
+        args = parser.parse_args([command, "--dev"])
+    assert args.dev
+
+
+def test_dev_flag_absent_is_not_deprecated() -> None:
+    parser = generate_parser()
+    args = parser.parse_args(["create", "-n", "x"])
+    assert not args.dev

--- a/tests/cli/test_conda_argparse.py
+++ b/tests/cli/test_conda_argparse.py
@@ -159,12 +159,10 @@ def test_sorted_commands_in_error(capsys: CaptureFixture):
         pytest.fail("Did not raise")
 
 
-@pytest.mark.parametrize("command", ["create", "install", "remove", "init"])
+@pytest.mark.parametrize("command", ["create", "install", "remove", "run"])
 def test_dev_flag_pending_deprecation(command: str) -> None:
     parser = generate_parser()
-    with pytest.warns(
-        PendingDeprecationWarning, match=r"`--dev` is pending deprecation"
-    ):
+    with pytest.deprecated_call():
         args = parser.parse_args([command, "--dev"])
     assert args.dev
 
@@ -173,3 +171,9 @@ def test_dev_flag_absent_is_not_deprecated() -> None:
     parser = generate_parser()
     args = parser.parse_args(["create", "-n", "x"])
     assert not args.dev
+
+
+def test_init_dev_is_not_deprecated() -> None:
+    parser = generate_parser()
+    args = parser.parse_args(["init", "--dev"])
+    assert args.dev

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -53,9 +54,29 @@ pytest_plugins = (
 @pytest.hookimpl
 def pytest_report_header(config: pytest.Config):
     # ensuring the expected development conda is being run
-    expected = Path(__file__).parent.parent / "conda" / "__init__.py"
+    source_root = Path(__file__).parent.parent
+    expected = source_root / "conda" / "__init__.py"
     assert expected.samefile(conda.__file__)
-    return f"conda.__file__: {conda.__file__}"
+
+    # shell.X hook and wrap_subprocess_call read these from CONDA_PACKAGE_ROOT
+    from conda.activate import PosixActivator
+
+    conda_sh = PosixActivator.hook_source_path
+    expected_sh = source_root / "conda" / "shell" / "etc" / "profile.d" / "conda.sh"
+    assert expected_sh.samefile(conda_sh)
+
+    conda_bat = Path(conda.CONDA_PACKAGE_ROOT, "shell", "condabin", "conda.bat")
+    expected_bat = source_root / "conda" / "shell" / "condabin" / "conda.bat"
+    assert expected_bat.samefile(conda_bat)
+
+    lines = [
+        f"conda.__file__: {conda.__file__}",
+        f"conda.sh: {conda_sh}",
+        f"conda.bat: {conda_bat}",
+        f"CONDA_EXE: {os.environ.get('CONDA_EXE')}",
+        f"CONDA_BAT: {os.environ.get('CONDA_BAT')}",
+    ]
+    return lines
 
 
 @pytest.fixture

--- a/tests/core/test_initialize.py
+++ b/tests/core/test_initialize.py
@@ -411,7 +411,6 @@ def test_make_entry_point_exe(verbose, tmp_path: Path):
 def test_install_conda_sh(verbose):
     with tempdir() as conda_prefix:
         target_path = join(conda_prefix, "etc", "profile.d", "conda.sh")
-        context.dev = False
         result = install_conda_sh(target_path, conda_prefix)
         assert result == Result.MODIFIED
 

--- a/tests/shell/__init__.py
+++ b/tests/shell/__init__.py
@@ -6,7 +6,7 @@ import os
 import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
-from os.path import dirname
+from os.path import dirname, join
 from shutil import which
 from signal import SIGINT
 from typing import TYPE_CHECKING, overload
@@ -18,7 +18,7 @@ from pexpect.popen_spawn import PopenSpawn
 from conda import CONDA_PACKAGE_ROOT, CONDA_SOURCE_ROOT
 from conda.activate import activator_map
 from conda.common.compat import on_win
-from conda.common.path import unix_path_to_win, win_path_to_unix
+from conda.common.path import BIN_DIRECTORY, unix_path_to_win, win_path_to_unix
 from conda.utils import quote_for_shell
 
 if TYPE_CHECKING:
@@ -30,17 +30,9 @@ if TYPE_CHECKING:
     T = TypeVar("T")
 
 
-# Here, by removing --dev you can try weird situations that you may want to test, upgrade paths
-# and the like? What will happen is that the conda being run and the shell scripts it's being run
-# against will be essentially random and will vary over the course of activating and deactivating
-# environments. You will have absolutely no idea what's going on as you change code or scripts and
-# encounter some different code that ends up being run (some of the time). You will go slowly mad.
-# No, you are best off keeping --dev on the end of these. For sure, if conda bundled its own tests
-# module then we could remove --dev if we detect we are being run in that way.
-dev_arg = "--dev"
-activate = f" activate {dev_arg} "
-deactivate = f" deactivate {dev_arg} "
-install = f" install {dev_arg} "
+activate = " activate "
+deactivate = " deactivate "
+install = " install "
 
 
 @dataclass
@@ -88,7 +80,7 @@ class InteractiveShellType(type):
     SHELLS: dict[str, dict] = {
         "posix": {
             "activator": "posix",
-            "init_command": f'eval "$({EXE_UNIX} -m conda shell.posix hook {dev_arg})"',
+            "init_command": f'eval "$({EXE_UNIX} -m conda shell.posix hook)"',
             "print_env_var": 'echo "$%s"',
         },
         "bash": {
@@ -99,25 +91,17 @@ class InteractiveShellType(type):
         "ash": {"base_shell": "posix"},
         "dash": {"base_shell": "posix"},
         "zsh": {"base_shell": "posix"},
-        # It should be noted here that we use the latest hook with whatever conda.exe is installed
-        # in sys.prefix (and we will activate all of those PATH entries).  We will set PYTHONPATH
-        # though, so there is that.  What I'm getting at is that this is a huge mixup and a mess.
+        # Hook from the checkout; CONDA_EXE is the conda launcher in sys.prefix.
+        # PYTHONPATH (set in InteractiveShell) makes that launcher import the checkout,
+        # matching dev/start.bat.
         "cmd.exe": {
             "activator": "cmd.exe",
-            # For non-dev-mode you'd have:
-            #            'init_command': 'set "CONDA_SHLVL=" '
-            #                            '&& @CALL {}\\shell\\condabin\\conda_hook.bat {} '
-            #                            '&& set CONDA_EXE={}'
-            #                            '&& set _CE_M='
-            #                            '&& set _CE_CONDA='
-            #                            .format(CONDA_PACKAGE_ROOT, dev_arg,
-            #                                    join(sys.prefix, "Scripts", "conda.exe")),
             "init_command": (
                 '@SET "CONDA_SHLVL=" '
-                f"&& @CALL {CONDA_PACKAGE_ROOT}\\shell\\condabin\\conda_hook.bat {dev_arg} "
-                f'&& @SET "CONDA_EXE={sys.executable}" '
-                '&& @SET "_CE_M=-m" '
-                '&& @SET "_CE_CONDA=conda"'
+                f"&& @CALL {CONDA_PACKAGE_ROOT}\\shell\\condabin\\conda_hook.bat "
+                f'&& @SET "CONDA_EXE={join(sys.prefix, BIN_DIRECTORY, "conda.exe")}" '
+                '&& @SET "_CE_M=" '
+                '&& @SET "_CE_CONDA="'
             ),
             "print_env_var": '@ECHO "%%%s%%"',
             "assert_env_var": r'"%s"\r?\n',
@@ -127,13 +111,13 @@ class InteractiveShellType(type):
             "activator": "csh",
             # "args": ("-v", "-x"),  # for debugging
             # unset conda alias before calling conda shell hook
-            "init_command": f'unalias conda;\neval "`{EXE_UNIX} -m conda shell.csh hook {dev_arg}`"',
+            "init_command": f'unalias conda;\neval "`{EXE_UNIX} -m conda shell.csh hook`"',
             "print_env_var": 'echo "$%s"',
         },
         "tcsh": {"base_shell": "csh"},
         "fish": {
             "activator": "fish",
-            "init_command": f"eval ({EXE_UNIX} -m conda shell.fish hook {dev_arg})",
+            "init_command": f"eval ({EXE_UNIX} -m conda shell.fish hook)",
             "print_env_var": "echo $%s",
         },
         # We don't know if the PowerShell executable is called
@@ -141,7 +125,7 @@ class InteractiveShellType(type):
         "powershell": {
             "activator": "powershell",
             "args": ("-NoProfile", "-NoLogo"),
-            "init_command": f"{EXE_WIN} -m conda shell.powershell hook --dev | Out-String | Invoke-Expression",
+            "init_command": f"{EXE_WIN} -m conda shell.powershell hook | Out-String | Invoke-Expression",
             "print_env_var": "$Env:%s",
             "get_env_var": r"\$Env:%s\r?\n([^\r\n]*)\r?\n",
             "exit_cmd": "exit",

--- a/tests/shell/test_cmd_exe.py
+++ b/tests/shell/test_cmd_exe.py
@@ -16,8 +16,9 @@ from conda import __version__ as CONDA_VERSION
 from conda.base.constants import WINDOWS_PROBLEMATIC_CHARS
 from conda.base.context import context, reset_context
 from conda.common.compat import on_linux, on_mac
+from conda.common.path import BIN_DIRECTORY
 
-from . import activate, deactivate, dev_arg, install
+from . import activate, deactivate, install
 
 if TYPE_CHECKING:
     from pytest import MonkeyPatch
@@ -49,11 +50,10 @@ def test_cmd_exe_basic_integration(
 ) -> None:
     prefix, charizard, _ = shell_wrapper_integration
     conda_bat = str(Path(CONDA_PACKAGE_ROOT, "shell", "condabin", "conda.bat"))
+    conda_exe = os.path.join(sys.prefix, BIN_DIRECTORY, "conda.exe")
 
     with shell.interactive() as sh:
-        sh.assert_env_var("_CE_CONDA", "conda")
-        sh.assert_env_var("_CE_M", "-m")
-        sh.assert_env_var("CONDA_EXE", escape(sys.executable))
+        sh.assert_env_var("CONDA_EXE", escape(conda_exe))
 
         # We use 'PowerShell' here because 'where conda' returns all of them and
         # shell.expect_exact does not do what you would think it does given its name.
@@ -77,9 +77,7 @@ def test_cmd_exe_basic_integration(
         sh.sendline('powershell -NoProfile -c "(Get-Command conda).Source"')
         sh.expect_exact(conda_bat)
 
-        sh.assert_env_var("_CE_CONDA", "conda")
-        sh.assert_env_var("_CE_M", "-m")
-        sh.assert_env_var("CONDA_EXE", escape(sys.executable))
+        sh.assert_env_var("CONDA_EXE", escape(conda_exe))
         sh.assert_env_var("CONDA_PREFIX", charizard, True)
         PATH2 = sh.get_env_var("PATH", "").split(os.pathsep)
         log.debug("PATH2=%s", PATH2)
@@ -88,9 +86,7 @@ def test_cmd_exe_basic_integration(
         sh.expect_exact(conda_bat)
 
         sh.sendline(f'conda {activate} "{prefix}"')
-        sh.assert_env_var("_CE_CONDA", "conda")
-        sh.assert_env_var("_CE_M", "-m")
-        sh.assert_env_var("CONDA_EXE", escape(sys.executable))
+        sh.assert_env_var("CONDA_EXE", escape(conda_exe))
         sh.assert_env_var("CONDA_SHLVL", "2")
         sh.assert_env_var("CONDA_PREFIX", prefix, True)
         sh.assert_env_var("PROMPT", rf"\({escape(prefix)}\).*")
@@ -114,7 +110,7 @@ def test_cmd_exe_basic_integration(
         sh.assert_env_var("SMALL_EXE", "small-var-cmd")
 
         # see tests/test-recipes/small-executable
-        sh.sendline(f"conda run {dev_arg} small")
+        sh.sendline("conda run small")
         sh.expect_exact("Hello!")
 
         sh.sendline(f"conda {deactivate}")
@@ -127,7 +123,6 @@ def test_cmd_exe_basic_integration(
 
 @PARAMETRIZE_CMD_EXE
 def test_cmd_exe_activate_error(shell: Shell) -> None:
-    context.dev = True
     with shell.interactive() as sh:
         sh.sendline("set")
         sh.expect(".*")
@@ -196,13 +191,11 @@ def test_legacy_activate_deactivate_cmd_exe(
     with shell.interactive() as sh:
         sh.sendline("echo off")
 
-        sh.assert_env_var("_CE_CONDA", "conda")
-
         PATH = f"{CONDA_PACKAGE_ROOT}\\shell\\Scripts;%PATH%"
 
         sh.sendline("SET PATH=" + PATH)
 
-        sh.sendline(f'activate --dev "{prefix2}"')
+        sh.sendline(f'activate "{prefix2}"')
         sh.clear()
 
         sh.assert_env_var("CONDA_SHLVL", "1")
@@ -210,20 +203,18 @@ def test_legacy_activate_deactivate_cmd_exe(
         PATH = sh.get_env_var("PATH")
         assert "charizard" in PATH
 
-        sh.assert_env_var("_CE_CONDA", "conda")
-
         sh.sendline("conda --version")
         sh.expect_exact(f"conda {CONDA_VERSION}")
 
-        sh.sendline(f'activate.bat --dev "{prefix3}"')
+        sh.sendline(f'activate.bat "{prefix3}"')
         PATH = sh.get_env_var("PATH")
         assert "venusaur" in PATH
 
-        sh.sendline("deactivate.bat --dev")
+        sh.sendline("deactivate.bat")
         PATH = sh.get_env_var("PATH")
         assert "charizard" in PATH
 
-        sh.sendline("deactivate --dev")
+        sh.sendline("deactivate")
         sh.assert_env_var("CONDA_SHLVL", "0")
 
 

--- a/tests/shell/test_posix.py
+++ b/tests/shell/test_posix.py
@@ -12,11 +12,10 @@ import pytest
 
 from conda import CONDA_PACKAGE_ROOT
 from conda import __version__ as CONDA_VERSION
-from conda.base.context import context
 from conda.common.compat import on_mac, on_win
 from conda.common.path import win_path_to_unix
 
-from . import activate, deactivate, dev_arg, install
+from . import activate, deactivate, install
 
 if TYPE_CHECKING:
     from . import InteractiveShell, Shell
@@ -133,11 +132,9 @@ def test_basic_integration(
         assert _CE_CONDA == _CE_CONDA2
 
         sh.sendline("env | sort")
-        # When CONDA_SHLVL==2 fails it usually means that conda activate failed. We that fails it is
-        # usually because you forgot to pass `--dev` to the *previous* activate so CONDA_EXE changed
-        # from python to conda, which is then found on PATH instead of using the dev sources. When it
-        # goes to use this old conda to generate the activation script for the newly activated env.
-        # it is running the old code (or at best, a mix of new code and old scripts).
+        # When CONDA_SHLVL==2 fails it usually means that conda activate failed. That often happens
+        # when CONDA_EXE flipped to a different launcher and the next activate is not using the
+        # checkout on PYTHONPATH.
         sh.assert_env_var("CONDA_SHLVL", "2")
         CONDA_PREFIX = sh.get_env_var("CONDA_PREFIX", "")
         # We get C: vs c: differences on Windows.
@@ -194,7 +191,7 @@ def test_basic_integration(
         sh.expect(is_a_function(sh))
 
         # see tests/test-recipes/small-executable
-        sh.sendline(f"conda run {dev_arg} small")
+        sh.sendline("conda run small")
         sh.expect_exact("Hello!")
 
         # regression test for #6840
@@ -228,13 +225,11 @@ def test_basic_integration(
         sh.sendline(f"conda {deactivate}")
         sh.assert_env_var("CONDA_SHLVL", "0")
 
-        # When fully deactivated, CONDA_EXE, _CE_M and _CE_CONDA must be retained
-        # because the conda shell scripts use them and if they are unset activation
-        # is not possible.
+        # When fully deactivated, CONDA_EXE must be retained because the conda shell
+        # scripts use it and if it is unset activation is not possible.
         CONDA_EXED = case(sh.get_env_var("CONDA_EXE"))
         assert CONDA_EXED, (
-            "A fully deactivated conda shell must retain CONDA_EXE (and _CE_M and _CE_CONDA in dev)\n"
-            "  as the shell scripts refer to them."
+            "A fully deactivated conda shell must retain CONDA_EXE as the shell scripts refer to it."
         )
 
         PATH0 = sh.get_env_var("PATH")
@@ -296,7 +291,6 @@ def test_bash_activate_error(
     shell_wrapper_integration: tuple[str, str, str],
     shell: Shell,
 ) -> None:
-    context.dev = True
     with shell.interactive() as sh:
         sh.sendline("export CONDA_SHLVL=unaffected")
         if on_win:
@@ -338,7 +332,7 @@ def test_legacy_activate_deactivate_bash(
         prefix2_p = sh.path_conversion(prefix2)
         prefix3_p = sh.path_conversion(prefix3)
         sh.sendline(f"export _CONDA_ROOT='{CONDA_ROOT}/shell'")
-        sh.sendline(f'. "{activate}" {dev_arg} "{prefix2_p}"')
+        sh.sendline(f'. "{activate}" "{prefix2_p}"')
         PATH0 = sh.get_env_var("PATH")
         assert "charizard" in PATH0
 
@@ -348,7 +342,7 @@ def test_legacy_activate_deactivate_bash(
         sh.sendline("conda --version")
         sh.expect_exact(f"conda {CONDA_VERSION}")
 
-        sh.sendline(f'. "{activate}" {dev_arg} "{prefix3_p}"')
+        sh.sendline(f'. "{activate}" "{prefix3_p}"')
 
         PATH1 = sh.get_env_var("PATH")
         assert "venusaur" in PATH1

--- a/tests/shell/test_powershell.py
+++ b/tests/shell/test_powershell.py
@@ -12,7 +12,7 @@ import pytest
 from conda import __version__ as CONDA_VERSION
 from conda.common.compat import on_win
 
-from . import Shell, dev_arg, install
+from . import Shell, install
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -106,7 +106,7 @@ def test_powershell_basic_integration(
 
         # see tests/test-recipes/small-executable
         log.debug("## [PowerShell integration] Checking conda run.")
-        sh.sendline(f"conda run {dev_arg} small")
+        sh.sendline("conda run small")
         sh.expect_exact("Hello!")
 
         log.debug("## [PowerShell integration] Deactivating")

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -168,7 +168,7 @@ def test_stacking(
             sh.sendline(f'conda activate "{env.prefix}"')
         sh.clear()
 
-        sh.sendline(f'conda run --prefix="{run.prefix}" --dev {which}')
+        sh.sendline(f'conda run --prefix="{run.prefix}" {which}')
         if not expected:
             sh.expect_exact(f"'conda run {which}' failed")
         else:

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2260,19 +2260,24 @@ def test_dev_flag_deprecation(
     reset_context()
     assert context._dev is conda_dev
 
-    # pickup dev_mode from context
-    with (
-        pytest.deprecated_call()
-        if conda_dev and command in ("activate", "hook")
-        else nullcontext()
-    ):
-        PosixActivator([command]).execute()
-    assert context._dev is conda_dev
+    try:
+        # pickup dev_mode from context
+        with (
+            pytest.deprecated_call()
+            if conda_dev and command in ("activate", "hook")
+            else nullcontext()
+        ):
+            PosixActivator([command]).execute()
+        assert context._dev is conda_dev
 
-    # pickup dev_mode from command line
-    with pytest.deprecated_call():
-        PosixActivator([command, "--dev"]).execute()
-    assert context._dev is True
+        # pickup dev_mode from command line
+        with pytest.deprecated_call():
+            PosixActivator([command, "--dev"]).execute()
+        assert context._dev is True
+    finally:
+        # context.dev = True plants instance __dict__; monkeypatch/reset_context do not undo it
+        context.__dict__.pop("_dev", None)
+        reset_context()
 
 
 @pytest.mark.parametrize("activator_cls", list(dict.fromkeys(activator_map.values())))

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import nullcontext
 from logging import getLogger
 from os.path import join
 from pathlib import Path
@@ -2259,14 +2260,19 @@ def test_dev_flag_deprecation(
     reset_context()
     assert context._dev is conda_dev
 
-    # calling without --dev should not be deprecated
-    PosixActivator([command]).execute()
+    # pickup dev_mode from context
+    with (
+        pytest.deprecated_call()
+        if conda_dev and command in ("activate", "hook")
+        else nullcontext()
+    ):
+        PosixActivator([command]).execute()
     assert context._dev is conda_dev
 
-    # calling with --dev should be deprecated
+    # pickup dev_mode from command line
     with pytest.deprecated_call():
         PosixActivator([command, "--dev"]).execute()
-    assert context._dev is conda_dev
+    assert context._dev is True
 
 
 @pytest.mark.parametrize("activator_cls", list(dict.fromkeys(activator_map.values())))

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2260,24 +2260,23 @@ def test_dev_flag_deprecation(
     reset_context()
     assert context._dev is conda_dev
 
-    try:
-        # pickup dev_mode from context
-        with (
-            pytest.deprecated_call()
-            if conda_dev and command in ("activate", "hook")
-            else nullcontext()
-        ):
-            PosixActivator([command]).execute()
-        assert context._dev is conda_dev
+    # pickup dev_mode from context
+    with (
+        pytest.deprecated_call()
+        if conda_dev and command in ("activate", "hook")
+        else nullcontext()
+    ):
+        PosixActivator([command]).execute()
+    assert context._dev is conda_dev
 
-        # pickup dev_mode from command line
-        with pytest.deprecated_call():
-            PosixActivator([command, "--dev"]).execute()
-        assert context._dev is True
-    finally:
-        # context.dev = True plants instance __dict__; monkeypatch/reset_context do not undo it
-        context.__dict__.pop("_dev", None)
-        reset_context()
+    # pickup dev_mode from command line
+    with pytest.deprecated_call():
+        PosixActivator([command, "--dev"]).execute()
+    assert context._dev is True
+
+    # reset_context clears the override, restoring the configured value
+    reset_context()
+    assert context._dev is conda_dev
 
 
 @pytest.mark.parametrize("activator_cls", list(dict.fromkeys(activator_map.values())))

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2249,20 +2249,24 @@ def test_activator_invalid_command_arguments(command_args, expected_error_messag
 
 
 @pytest.mark.parametrize("command", ["activate", "deactivate", "reactivate", "hook"])
-def test_dev_flag_pending_deprecation(
+@pytest.mark.parametrize("conda_dev", [False, True])
+def test_dev_flag_deprecation(
     command: str,
+    conda_dev: bool,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("CONDA_DEV", "0")
+    monkeypatch.setenv("CONDA_DEV", str(int(conda_dev)))
     reset_context()
-    assert not context._dev
+    assert context._dev is conda_dev
+
+    # calling without --dev should not be deprecated
+    PosixActivator([command]).execute()
+    assert context._dev is conda_dev
 
     # calling with --dev should be deprecated
     with pytest.deprecated_call():
         PosixActivator([command, "--dev"]).execute()
-
-    # dev flag should be unset
-    assert not context._dev
+    assert context._dev is conda_dev
 
 
 @pytest.mark.parametrize("activator_cls", list(dict.fromkeys(activator_map.values())))

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -2248,6 +2248,23 @@ def test_activator_invalid_command_arguments(command_args, expected_error_messag
         activator.execute()
 
 
+@pytest.mark.parametrize("command", ["activate", "deactivate", "reactivate", "hook"])
+def test_dev_flag_pending_deprecation(
+    command: str,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONDA_DEV", "0")
+    reset_context()
+    assert not context._dev
+
+    # calling with --dev should be deprecated
+    with pytest.deprecated_call():
+        PosixActivator([command, "--dev"]).execute()
+
+    # dev flag should be unset
+    assert not context._dev
+
+
 @pytest.mark.parametrize("activator_cls", list(dict.fromkeys(activator_map.values())))
 def test_activate_default_env(activator_cls, monkeypatch, conda_cli, tmp_path):
     # Make sure local config does not affect the test; empty string -> base

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import sys
+from contextlib import nullcontext
 from logging import getLogger
 from os import environ, pathsep
 from os.path import dirname, join
+from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING
 
@@ -16,8 +18,6 @@ from conda.activate import CmdExeActivator, PosixActivator
 from conda.common.compat import on_win
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from pytest_mock import MockerFixture
 
 SOME_PREFIX = "/some/prefix"
@@ -201,3 +201,18 @@ def test_ensure_dir_errors(mocker: MockerFixture, tmp_path: Path):
 
     with pytest.raises(CondaError, match=exc_message):
         get_test_dir()
+
+
+@pytest.mark.parametrize("dev_mode", [True, False])
+def test_wrap_subprocess_call_dev_mode_deprecation(
+    tmp_path: Path, dev_mode: bool
+) -> None:
+    with pytest.deprecated_call() if dev_mode else nullcontext():
+        script, _ = utils.wrap_subprocess_call(
+            str(tmp_path),
+            str(tmp_path),
+            dev_mode,
+            False,
+            ["echo", "ok"],
+        )
+    Path(script).unlink(missing_ok=True)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`--dev`, `context.dev`, and conda-exported `_CE_M` / `_CE_CONDA` are a 2019 test-harness protocol so a temp env can still run checkout conda as `python -m conda`. That is not how development works anymore: `dev/start` sets `PYTHONPATH` to the repo and uses the devenv `conda` launcher; pytest already has an autouse `PYTHONPATH` fixture; `conda_cli` no longer injects `--dev`. `conda run --dev` is already pending deprecation (#15641).

This PR switches tests and wrappers to that `PYTHONPATH` + real `CONDA_EXE` path, and pending-deprecates the remaining knobs. `--dev` behavior is unchanged for external callers during the comment period.

- Tests no longer pass `--dev` or rewrite `CONDA_EXE` to `python -m conda`. Shell init uses the real launcher and `PYTHONPATH`.
- `conda activate` / hook without `--dev` no longer force `context.dev = False`. That was rewriting `CONDA_EXE` to a pip stub on Windows during stacking/reactivate (#15696).
- Deprecate `conda activate --dev`, `create`/`install`/`remove`/`init --dev`, `context.dev`, and `wrap_subprocess_call(dev_mode)`.
- conda still *exports* `_CE_M=-m` / `_CE_CONDA=conda` only when `context.dev` is true. Shell expansion of `$_CE_M $_CE_CONDA` stays (empty is a no-op; conda-build still uses the slots).
- `pytest_report_header` now also asserts checkout `conda.sh` / `conda.bat` (not site-packages copies).

Xref #14142
Resolves #15696

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
