### PR TITLE
Fix always-true skip condition in `test_dont_remove_conda_3`

### DIFF
--- a/news/16579-fix-test-dont-remove-conda-3-skip
+++ b/news/16579-fix-test-dont-remove-conda-3-skip
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Fix always-true skip condition so `test_dont_remove_conda_3` runs with solvers shipped with conda. (#16579)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2411,7 +2411,7 @@ def test_dont_remove_conda_3(
     upgrades a dependency) it could produce spurious RemoveError, blocking
     further use of conda.
     """
-    if context.solver != "libmamba" or context.solver != "classic":
+    if context.solver not in ("libmamba", "classic"):
         pytest.skip(
             "This test can only be run with solvers that come shipped with conda"
         )

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -2411,7 +2411,7 @@ def test_dont_remove_conda_3(
     upgrades a dependency) it could produce spurious RemoveError, blocking
     further use of conda.
     """
-    if context.solver not in ("libmamba", "classic"):
+    if context.solver not in ("libmamba", "classic", "rattler"):
         pytest.skip(
             "This test can only be run with solvers that come shipped with conda"
         )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I noticed that in #16116, we accidentally introduced an always True skip condition in `test_dont_remove_conda_3`. This is a classic De Morgan's law problem:

x != A or x != B (with A ≠ B) is a "tautology". A single value can't equal both "libmamba" and "classic" at once, so at least one of the two != comparisons is always true, making it always true. If it is always true, we always skip it.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
