### PR TITLE
Allow larger individual repodata shards

### DIFF
--- a/conda/_private/shards/cache.py
+++ b/conda/_private/shards/cache.py
@@ -15,7 +15,8 @@ from typing import TYPE_CHECKING
 import msgpack
 
 from ..zstd import capped_decompress
-from .shards import ZSTD_MAX_SHARD_SIZE
+from .misc import shard_error_context
+from .shards import ZSTD_MAX_SHARD_SIZE, ZSTD_MAX_SHARD_WINDOW_SIZE
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -154,10 +155,17 @@ class ShardCache:
 
     def retrieve(self, url) -> ShardDict | None:
         with self.conn as c:
-            row = c.execute("SELECT shard FROM shards WHERE url = ?", (url,)).fetchone()
+            row = c.execute(
+                "SELECT package, shard FROM shards WHERE url = ?", (url,)
+            ).fetchone()
             return (
                 msgpack.loads(
-                    capped_decompress(row["shard"], max_output_size=ZSTD_MAX_SHARD_SIZE)
+                    capped_decompress(
+                        row["shard"],
+                        max_output_size=ZSTD_MAX_SHARD_SIZE,
+                        max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
+                        error_context=shard_error_context(url, row["package"]),
+                    )
                 )
                 if row
                 else None
@@ -172,11 +180,16 @@ class ShardCache:
         if not urls:
             return {}  # this optimization does not save a noticeable amount of time.
 
-        query = f"SELECT url, shard FROM shards WHERE url IN ({','.join(('?',) * len(urls))}) ORDER BY url"
+        query = f"SELECT url, package, shard FROM shards WHERE url IN ({','.join(('?',) * len(urls))}) ORDER BY url"
         with self.conn as c:
             result: dict[str, ShardDict | None] = {
                 row["url"]: msgpack.loads(
-                    capped_decompress(row["shard"], max_output_size=ZSTD_MAX_SHARD_SIZE)
+                    capped_decompress(
+                        row["shard"],
+                        max_output_size=ZSTD_MAX_SHARD_SIZE,
+                        max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
+                        error_context=shard_error_context(row["url"], row["package"]),
+                    )
                 )
                 if row
                 else None

--- a/conda/_private/shards/cache.py
+++ b/conda/_private/shards/cache.py
@@ -14,8 +14,7 @@ from typing import TYPE_CHECKING
 
 import msgpack
 
-from .misc import decompress_shard
-from .shards import ZSTD_MAX_SHARD_SIZE, ZSTD_MAX_SHARD_WINDOW_SIZE
+from .decompression import decompress_shard
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -163,8 +162,6 @@ class ShardCache:
                         row["shard"],
                         url=url,
                         package=row["package"],
-                        max_output_size=ZSTD_MAX_SHARD_SIZE,
-                        max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
                     )
                 )
                 if row
@@ -188,8 +185,6 @@ class ShardCache:
                         row["shard"],
                         url=row["url"],
                         package=row["package"],
-                        max_output_size=ZSTD_MAX_SHARD_SIZE,
-                        max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
                     )
                 )
                 if row

--- a/conda/_private/shards/cache.py
+++ b/conda/_private/shards/cache.py
@@ -14,8 +14,7 @@ from typing import TYPE_CHECKING
 
 import msgpack
 
-from ..zstd import capped_decompress
-from .misc import shard_error_context
+from .misc import decompress_shard
 from .shards import ZSTD_MAX_SHARD_SIZE, ZSTD_MAX_SHARD_WINDOW_SIZE
 
 if TYPE_CHECKING:
@@ -160,11 +159,12 @@ class ShardCache:
             ).fetchone()
             return (
                 msgpack.loads(
-                    capped_decompress(
+                    decompress_shard(
                         row["shard"],
+                        url=url,
+                        package=row["package"],
                         max_output_size=ZSTD_MAX_SHARD_SIZE,
                         max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
-                        error_context=shard_error_context(url, row["package"]),
                     )
                 )
                 if row
@@ -184,11 +184,12 @@ class ShardCache:
         with self.conn as c:
             result: dict[str, ShardDict | None] = {
                 row["url"]: msgpack.loads(
-                    capped_decompress(
+                    decompress_shard(
                         row["shard"],
+                        url=row["url"],
+                        package=row["package"],
                         max_output_size=ZSTD_MAX_SHARD_SIZE,
                         max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
-                        error_context=shard_error_context(row["url"], row["package"]),
                     )
                 )
                 if row

--- a/conda/_private/shards/decompression.py
+++ b/conda/_private/shards/decompression.py
@@ -9,15 +9,15 @@ from conda.exceptions import ChannelError
 
 from ..zstd import ZstdError, capped_decompress
 
-ZSTD_MAX_SHARD_SIZE = (
-    2**20 * 64
-)  # maximum decompressed size of an individual package shard
+# Individual package shards can exceed the original 16 MiB limit as channel
+# history grows.
+ZSTD_MAX_SHARD_SIZE = 2**20 * 64
 
-ZSTD_MAX_SHARD_WINDOW_SIZE = 2**20 * 16  # maximum zstd decoder window size
+# Bound decoder memory independently from total decompressed output.
+ZSTD_MAX_SHARD_WINDOW_SIZE = 2**20 * 16
 
-ZSTD_MAX_SHARD_INDEX_SIZE = (
-    2**23 * 16
-)  # maximum size necessary when compressed data has no size header
+# Allow shard-index frames without a decompressed-size header up to 128 MiB.
+ZSTD_MAX_SHARD_INDEX_SIZE = 2**23 * 16
 
 
 def decompress_shard(data: bytes, *, url: str, package: str) -> bytes:

--- a/conda/_private/shards/decompression.py
+++ b/conda/_private/shards/decompression.py
@@ -13,9 +13,6 @@ from ..zstd import ZstdError, capped_decompress
 # history grows.
 ZSTD_MAX_SHARD_SIZE = 2**20 * 64
 
-# Bound decoder memory independently from total decompressed output.
-ZSTD_MAX_SHARD_WINDOW_SIZE = 2**20 * 16
-
 # Allow shard-index frames without a decompressed-size header up to 128 MiB.
 ZSTD_MAX_SHARD_INDEX_SIZE = 2**23 * 16
 
@@ -26,13 +23,12 @@ def decompress_shard(data: bytes, *, url: str, package: str) -> bytes:
         return capped_decompress(
             data,
             max_output_size=ZSTD_MAX_SHARD_SIZE,
-            max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
         )
     except ZstdError as err:
         safe_url = remove_auth(mask_anaconda_token(url))
         message = (
             f"repodata shard for package {package!r} from channel {safe_url!r}: "
-            f"{err} (output limit: {ZSTD_MAX_SHARD_SIZE} bytes, "
-            f"decoder window limit: {ZSTD_MAX_SHARD_WINDOW_SIZE} bytes)"
+            f"{err} (output and decoder window limit: "
+            f"{ZSTD_MAX_SHARD_SIZE} bytes)"
         )
         raise ChannelError(message, caused_by=err) from err

--- a/conda/_private/shards/decompression.py
+++ b/conda/_private/shards/decompression.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Bounded decompression for sharded repodata."""
+
+from __future__ import annotations
+
+from conda.common.url import mask_anaconda_token, remove_auth
+from conda.exceptions import ChannelError
+
+from ..zstd import ZstdError, capped_decompress
+
+ZSTD_MAX_SHARD_SIZE = (
+    2**20 * 64
+)  # maximum decompressed size of an individual package shard
+
+ZSTD_MAX_SHARD_WINDOW_SIZE = 2**20 * 16  # maximum zstd decoder window size
+
+ZSTD_MAX_SHARD_INDEX_SIZE = (
+    2**23 * 16
+)  # maximum size necessary when compressed data has no size header
+
+
+def decompress_shard(data: bytes, *, url: str, package: str) -> bytes:
+    """Decompress an individual shard and translate errors for conda users."""
+    try:
+        return capped_decompress(
+            data,
+            max_output_size=ZSTD_MAX_SHARD_SIZE,
+            max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
+        )
+    except ZstdError as err:
+        safe_url = remove_auth(mask_anaconda_token(url))
+        message = (
+            f"repodata shard for package {package!r} from channel {safe_url!r}: "
+            f"{err} (output limit: {ZSTD_MAX_SHARD_SIZE} bytes, "
+            f"decoder window limit: {ZSTD_MAX_SHARD_WINDOW_SIZE} bytes)"
+        )
+        raise ChannelError(message, caused_by=err) from err

--- a/conda/_private/shards/misc.py
+++ b/conda/_private/shards/misc.py
@@ -20,11 +20,8 @@ from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlparse, urlunparse, uses_relative
 
 from conda.base.context import context
-from conda.common.url import mask_anaconda_token, remove_auth
-from conda.exceptions import ChannelError, InvalidMatchSpec
+from conda.exceptions import InvalidMatchSpec
 from conda.models.match_spec import MatchSpec
-
-from ..zstd import ZstdError, capped_decompress
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -42,36 +39,6 @@ log = logging.getLogger(__name__)
 _URLJOIN_SAFE_SCHEMES = frozenset(uses_relative)
 
 SHARDS_CONNECTIONS_DEFAULT = 10
-
-
-def shard_error_context(url: str, package: str) -> str:
-    """Describe a shard without exposing channel credentials."""
-    safe_url = remove_auth(mask_anaconda_token(url))
-    return f"repodata shard for package {package!r} from channel {safe_url!r}"
-
-
-def decompress_shard(
-    data: bytes,
-    *,
-    url: str,
-    package: str,
-    max_output_size: int,
-    max_window_size: int,
-) -> bytes:
-    """Decompress a shard and translate backend errors for conda users."""
-    try:
-        return capped_decompress(
-            data,
-            max_output_size=max_output_size,
-            max_window_size=max_window_size,
-        )
-    except ZstdError as err:
-        message = (
-            f"{shard_error_context(url, package)}: {err} "
-            f"(output limit: {max_output_size} bytes, "
-            f"decoder window limit: {max_window_size} bytes)"
-        )
-        raise ChannelError(message, caused_by=err) from err
 
 
 def _shards_connections() -> int:

--- a/conda/_private/shards/misc.py
+++ b/conda/_private/shards/misc.py
@@ -21,8 +21,10 @@ from urllib.parse import urljoin, urlparse, urlunparse, uses_relative
 
 from conda.base.context import context
 from conda.common.url import mask_anaconda_token, remove_auth
-from conda.exceptions import InvalidMatchSpec
+from conda.exceptions import ChannelError, InvalidMatchSpec
 from conda.models.match_spec import MatchSpec
+
+from ..zstd import ZstdError, capped_decompress
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -46,6 +48,30 @@ def shard_error_context(url: str, package: str) -> str:
     """Describe a shard without exposing channel credentials."""
     safe_url = remove_auth(mask_anaconda_token(url))
     return f"repodata shard for package {package!r} from channel {safe_url!r}"
+
+
+def decompress_shard(
+    data: bytes,
+    *,
+    url: str,
+    package: str,
+    max_output_size: int,
+    max_window_size: int,
+) -> bytes:
+    """Decompress a shard and translate backend errors for conda users."""
+    try:
+        return capped_decompress(
+            data,
+            max_output_size=max_output_size,
+            max_window_size=max_window_size,
+        )
+    except ZstdError as err:
+        message = (
+            f"{shard_error_context(url, package)}: {err} "
+            f"(output limit: {max_output_size} bytes, "
+            f"decoder window limit: {max_window_size} bytes)"
+        )
+        raise ChannelError(message, caused_by=err) from err
 
 
 def _shards_connections() -> int:

--- a/conda/_private/shards/misc.py
+++ b/conda/_private/shards/misc.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlparse, urlunparse, uses_relative
 
 from conda.base.context import context
+from conda.common.url import mask_anaconda_token, remove_auth
 from conda.exceptions import InvalidMatchSpec
 from conda.models.match_spec import MatchSpec
 
@@ -39,6 +40,12 @@ log = logging.getLogger(__name__)
 _URLJOIN_SAFE_SCHEMES = frozenset(uses_relative)
 
 SHARDS_CONNECTIONS_DEFAULT = 10
+
+
+def shard_error_context(url: str, package: str) -> str:
+    """Describe a shard without exposing channel credentials."""
+    safe_url = remove_auth(mask_anaconda_token(url))
+    return f"repodata shard for package {package!r} from channel {safe_url!r}"
 
 
 def _shards_connections() -> int:

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -30,11 +30,16 @@ from conda.models.channel import Channel
 
 from ..zstd import capped_decompress
 from . import cache
+from .decompression import (
+    ZSTD_MAX_SHARD_INDEX_SIZE,
+    ZSTD_MAX_SHARD_WINDOW_SIZE,
+    decompress_shard,
+)
+from .decompression import ZSTD_MAX_SHARD_SIZE as ZSTD_MAX_SHARD_SIZE
 from .misc import (
     _is_http_error_most_400_codes,
     _safe_urljoin_with_slash,
     _shards_connections,
-    decompress_shard,
     ensure_hex_hash,
     spec_to_package_name,
 )
@@ -50,19 +55,6 @@ if TYPE_CHECKING:
     from conda.gateways.repodata import RepodataCache
 
     from .typing import RepodataDict, ShardDict, ShardsIndexDict
-
-ZSTD_MAX_SHARD_SIZE = (
-    2**20 * 64
-)  # maximum decompressed size of an individual package shard
-
-
-ZSTD_MAX_SHARD_WINDOW_SIZE = 2**20 * 16  # maximum zstd decoder window size
-
-
-ZSTD_MAX_SHARD_INDEX_SIZE = (
-    2**23 * 16
-)  # maximum size necessary when compressed data has no size header
-
 
 # For reference, the largest shard "conda-forge/linux-64/vim" is 2608283 bytes
 # or < 2**19*5 decompressed (486155 bytes compressed); the index is 575219 bytes
@@ -185,8 +177,6 @@ class ShardFetch:
                 fetch_result.compressed_shard,
                 url=shards.url,
                 package=fetch_result.package,
-                max_output_size=ZSTD_MAX_SHARD_SIZE,
-                max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
             )
         )
         self.shard_cache.insert(fetch_result)

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -699,7 +699,6 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
                 capped_decompress(
                     shards_data,
                     max_output_size=decompression.ZSTD_MAX_SHARD_INDEX_SIZE,
-                    max_window_size=decompression.ZSTD_MAX_SHARD_WINDOW_SIZE,
                 )
             )  # type: ignore
             shards = Shards(shards_index, shards_index_url)

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -34,8 +34,8 @@ from .misc import (
     _is_http_error_most_400_codes,
     _safe_urljoin_with_slash,
     _shards_connections,
+    decompress_shard,
     ensure_hex_hash,
-    shard_error_context,
     spec_to_package_name,
 )
 
@@ -181,11 +181,12 @@ class ShardFetch:
 
         # Decompress and save record
         results[fetch_result.package] = msgpack.loads(
-            capped_decompress(
+            decompress_shard(
                 fetch_result.compressed_shard,
+                url=shards.url,
+                package=fetch_result.package,
                 max_output_size=ZSTD_MAX_SHARD_SIZE,
                 max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
-                error_context=shard_error_context(shards.url, fetch_result.package),
             )
         )
         self.shard_cache.insert(fetch_result)

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -35,6 +35,7 @@ from .misc import (
     _safe_urljoin_with_slash,
     _shards_connections,
     ensure_hex_hash,
+    shard_error_context,
     spec_to_package_name,
 )
 
@@ -51,8 +52,11 @@ if TYPE_CHECKING:
     from .typing import RepodataDict, ShardDict, ShardsIndexDict
 
 ZSTD_MAX_SHARD_SIZE = (
-    2**20 * 16
-)  # maximum size necessary when compressed data has no size header
+    2**20 * 64
+)  # maximum decompressed size of an individual package shard
+
+
+ZSTD_MAX_SHARD_WINDOW_SIZE = 2**20 * 16  # maximum zstd decoder window size
 
 
 ZSTD_MAX_SHARD_INDEX_SIZE = (
@@ -178,7 +182,10 @@ class ShardFetch:
         # Decompress and save record
         results[fetch_result.package] = msgpack.loads(
             capped_decompress(
-                fetch_result.compressed_shard, max_output_size=ZSTD_MAX_SHARD_SIZE
+                fetch_result.compressed_shard,
+                max_output_size=ZSTD_MAX_SHARD_SIZE,
+                max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
+                error_context=shard_error_context(shards.url, fetch_result.package),
             )
         )
         self.shard_cache.insert(fetch_result)
@@ -709,7 +716,9 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
             # basic parse (move into caller?)
             shards_index: ShardsIndexDict = msgpack.loads(
                 capped_decompress(
-                    shards_data, max_output_size=ZSTD_MAX_SHARD_INDEX_SIZE
+                    shards_data,
+                    max_output_size=ZSTD_MAX_SHARD_INDEX_SIZE,
+                    max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
                 )
             )  # type: ignore
             shards = Shards(shards_index, shards_index_url)

--- a/conda/_private/shards/shards.py
+++ b/conda/_private/shards/shards.py
@@ -29,13 +29,7 @@ from conda.gateways.repodata import (
 from conda.models.channel import Channel
 
 from ..zstd import capped_decompress
-from . import cache
-from .decompression import (
-    ZSTD_MAX_SHARD_INDEX_SIZE,
-    ZSTD_MAX_SHARD_WINDOW_SIZE,
-    decompress_shard,
-)
-from .decompression import ZSTD_MAX_SHARD_SIZE as ZSTD_MAX_SHARD_SIZE
+from . import cache, decompression
 from .misc import (
     _is_http_error_most_400_codes,
     _safe_urljoin_with_slash,
@@ -55,10 +49,6 @@ if TYPE_CHECKING:
     from conda.gateways.repodata import RepodataCache
 
     from .typing import RepodataDict, ShardDict, ShardsIndexDict
-
-# For reference, the largest shard "conda-forge/linux-64/vim" is 2608283 bytes
-# or < 2**19*5 decompressed (486155 bytes compressed); the index is 575219 bytes
-# decompressed (514039 bytes compressed) and is mostly uncompressible hash data.
 
 
 class ShardFetch:
@@ -173,7 +163,7 @@ class ShardFetch:
 
         # Decompress and save record
         results[fetch_result.package] = msgpack.loads(
-            decompress_shard(
+            decompression.decompress_shard(
                 fetch_result.compressed_shard,
                 url=shards.url,
                 package=fetch_result.package,
@@ -708,8 +698,8 @@ def fetch_shards_index(sd: SubdirData) -> Shards | None:
             shards_index: ShardsIndexDict = msgpack.loads(
                 capped_decompress(
                     shards_data,
-                    max_output_size=ZSTD_MAX_SHARD_INDEX_SIZE,
-                    max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
+                    max_output_size=decompression.ZSTD_MAX_SHARD_INDEX_SIZE,
+                    max_window_size=decompression.ZSTD_MAX_SHARD_WINDOW_SIZE,
                 )
             )  # type: ignore
             shards = Shards(shards_index, shards_index_url)

--- a/conda/_private/shards/subset.py
+++ b/conda/_private/shards/subset.py
@@ -67,17 +67,15 @@ from conda.base.context import context
 
 from . import cache
 from .cache import AnnotatedRawShard
+from .decompression import decompress_shard
 from .misc import (
     _shards_connections,
     combine_batches_until_none,
-    decompress_shard,
     exception_to_queue,
     filter_redundant_packages,
     spec_to_package_name,
 )
 from .shards import (
-    ZSTD_MAX_SHARD_SIZE,
-    ZSTD_MAX_SHARD_WINDOW_SIZE,
     Shards,
     batch_retrieve_from_cache,
     batch_retrieve_from_network,
@@ -730,8 +728,6 @@ def network_fetch_thread(
                 data,
                 url=node_id.channel,
                 package=node_id.package,
-                max_output_size=ZSTD_MAX_SHARD_SIZE,
-                max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
             )
         )  # type: ignore[assign]
         # This may be a QueueCache which lets the cache thread serialize access

--- a/conda/_private/shards/subset.py
+++ b/conda/_private/shards/subset.py
@@ -65,15 +65,14 @@ import msgpack
 import conda.gateways.repodata
 from conda.base.context import context
 
-from ..zstd import capped_decompress
 from . import cache
 from .cache import AnnotatedRawShard
 from .misc import (
     _shards_connections,
     combine_batches_until_none,
+    decompress_shard,
     exception_to_queue,
     filter_redundant_packages,
-    shard_error_context,
     spec_to_package_name,
 )
 from .shards import (
@@ -727,11 +726,12 @@ def network_fetch_thread(
         # msgpack.zst, insert into cache. Then put "known
         # good" shard into out queue.
         shard: ShardDict = msgpack.loads(
-            capped_decompress(
+            decompress_shard(
                 data,
+                url=node_id.channel,
+                package=node_id.package,
                 max_output_size=ZSTD_MAX_SHARD_SIZE,
                 max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
-                error_context=shard_error_context(node_id.channel, node_id.package),
             )
         )  # type: ignore[assign]
         # This may be a QueueCache which lets the cache thread serialize access

--- a/conda/_private/shards/subset.py
+++ b/conda/_private/shards/subset.py
@@ -73,10 +73,12 @@ from .misc import (
     combine_batches_until_none,
     exception_to_queue,
     filter_redundant_packages,
+    shard_error_context,
     spec_to_package_name,
 )
 from .shards import (
     ZSTD_MAX_SHARD_SIZE,
+    ZSTD_MAX_SHARD_WINDOW_SIZE,
     Shards,
     batch_retrieve_from_cache,
     batch_retrieve_from_network,
@@ -725,7 +727,12 @@ def network_fetch_thread(
         # msgpack.zst, insert into cache. Then put "known
         # good" shard into out queue.
         shard: ShardDict = msgpack.loads(
-            capped_decompress(data, max_output_size=ZSTD_MAX_SHARD_SIZE)
+            capped_decompress(
+                data,
+                max_output_size=ZSTD_MAX_SHARD_SIZE,
+                max_window_size=ZSTD_MAX_SHARD_WINDOW_SIZE,
+                error_context=shard_error_context(node_id.channel, node_id.package),
+            )
         )  # type: ignore[assign]
         # This may be a QueueCache which lets the cache thread serialize access
         # to the database:

--- a/conda/_private/zstd.py
+++ b/conda/_private/zstd.py
@@ -30,17 +30,41 @@ __all__ = [
 ]
 
 
-def capped_decompress(data: bytes, max_output_size: int) -> bytes:
+def capped_decompress(
+    data: bytes,
+    max_output_size: int,
+    max_window_size: int,
+    *,
+    error_context: str | None = None,
+) -> bytes:
     """One-shot decompress of untrusted data with output and window bounds.
 
     Replaces ``zstandard.decompress(..., max_output_size=...)`` and
     ``ZstdDecompressor(max_window_size=...)`` (window cap was only in subset.py).
     """
-    window_log_max = max(10, math.ceil(math.log2(max(max_output_size, 1))))
-    dctx = _zstd.ZstdDecompressor(
-        options={_zstd.DecompressionParameter.window_log_max: window_log_max}
-    )
-    out = dctx.decompress(data, max_length=max_output_size)
-    if not dctx.eof and not dctx.needs_input:
-        raise ZstdError(f"decompressed output exceeds {max_output_size} bytes")
-    return out
+    try:
+        decompressed_size = _zstd.get_frame_info(data).decompressed_size
+        if decompressed_size is not None and decompressed_size > max_output_size:
+            raise ZstdError(
+                f"decompressed output is {decompressed_size} bytes, "
+                f"which exceeds the {max_output_size} byte limit"
+            )
+
+        window_log_max = max(10, math.ceil(math.log2(max(max_window_size, 1))))
+        dctx = _zstd.ZstdDecompressor(
+            options={_zstd.DecompressionParameter.window_log_max: window_log_max}
+        )
+        out = dctx.decompress(data, max_length=max_output_size)
+        if not dctx.eof:
+            if dctx.needs_input:
+                raise ZstdError("compressed input ended before the end of the frame")
+            raise ZstdError(f"decompressed output exceeds {max_output_size} bytes")
+        return out
+    except ZstdError as err:
+        if error_context is None:
+            raise
+        raise ZstdError(
+            f"{error_context}: {err} "
+            f"(output limit: {max_output_size} bytes, "
+            f"decoder window limit: {max_window_size} bytes)"
+        ) from err

--- a/conda/_private/zstd.py
+++ b/conda/_private/zstd.py
@@ -34,37 +34,26 @@ def capped_decompress(
     data: bytes,
     max_output_size: int,
     max_window_size: int,
-    *,
-    error_context: str | None = None,
 ) -> bytes:
     """One-shot decompress of untrusted data with output and window bounds.
 
     Replaces ``zstandard.decompress(..., max_output_size=...)`` and
     ``ZstdDecompressor(max_window_size=...)`` (window cap was only in subset.py).
     """
-    try:
-        decompressed_size = _zstd.get_frame_info(data).decompressed_size
-        if decompressed_size is not None and decompressed_size > max_output_size:
-            raise ZstdError(
-                f"decompressed output is {decompressed_size} bytes, "
-                f"which exceeds the {max_output_size} byte limit"
-            )
-
-        window_log_max = max(10, math.ceil(math.log2(max(max_window_size, 1))))
-        dctx = _zstd.ZstdDecompressor(
-            options={_zstd.DecompressionParameter.window_log_max: window_log_max}
-        )
-        out = dctx.decompress(data, max_length=max_output_size)
-        if not dctx.eof:
-            if dctx.needs_input:
-                raise ZstdError("compressed input ended before the end of the frame")
-            raise ZstdError(f"decompressed output exceeds {max_output_size} bytes")
-        return out
-    except ZstdError as err:
-        if error_context is None:
-            raise
+    decompressed_size = _zstd.get_frame_info(data).decompressed_size
+    if decompressed_size is not None and decompressed_size > max_output_size:
         raise ZstdError(
-            f"{error_context}: {err} "
-            f"(output limit: {max_output_size} bytes, "
-            f"decoder window limit: {max_window_size} bytes)"
-        ) from err
+            f"decompressed output is {decompressed_size} bytes, "
+            f"which exceeds the {max_output_size} byte limit"
+        )
+
+    window_log_max = max(10, math.ceil(math.log2(max(max_window_size, 1))))
+    dctx = _zstd.ZstdDecompressor(
+        options={_zstd.DecompressionParameter.window_log_max: window_log_max}
+    )
+    out = dctx.decompress(data, max_length=max_output_size)
+    if not dctx.eof:
+        if dctx.needs_input:
+            raise ZstdError("compressed input ended before the end of the frame")
+        raise ZstdError(f"decompressed output exceeds {max_output_size} bytes")
+    return out

--- a/conda/_private/zstd.py
+++ b/conda/_private/zstd.py
@@ -33,7 +33,6 @@ __all__ = [
 def capped_decompress(
     data: bytes,
     max_output_size: int,
-    max_window_size: int,
 ) -> bytes:
     """One-shot decompress of untrusted data with output and window bounds.
 
@@ -47,7 +46,7 @@ def capped_decompress(
             f"which exceeds the {max_output_size} byte limit"
         )
 
-    window_log_max = max(10, math.ceil(math.log2(max(max_window_size, 1))))
+    window_log_max = max(10, math.ceil(math.log2(max(max_output_size, 1))))
     dctx = _zstd.ZstdDecompressor(
         options={_zstd.DecompressionParameter.window_log_max: window_log_max}
     )

--- a/news/16575-shard-size-limit
+++ b/news/16575-shard-size-limit
@@ -4,8 +4,7 @@
 
 ### Bug fixes
 
-* Allow individual sharded-repodata package shards up to 64 MiB while retaining
-  a 16 MiB zstd decoder-window limit. (#16575)
+* Allow individual sharded-repodata package shards up to 64 MiB. (#16575)
 
 ### Deprecations
 

--- a/news/16575-shard-size-limit
+++ b/news/16575-shard-size-limit
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Allow individual sharded-repodata package shards up to 64 MiB while retaining
+  a 16 MiB zstd decoder-window limit. (#16575)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/16575-shard-size-limit
+++ b/news/16575-shard-size-limit
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Allow individual sharded-repodata package shards up to 64 MiB. (#16575)
+* Allow individual sharded-repodata package shards up to 64 MiB after decompression. (#16575)
 
 ### Deprecations
 

--- a/tests/gateways/test_zstd.py
+++ b/tests/gateways/test_zstd.py
@@ -263,3 +263,69 @@ def test_zstd_fallback_on_invalid_zstd(
     assert not cache.state.has_format("zst")[0]
 
     assert len(json.loads(cache.cache_path_json.read_text())["packages"])
+
+
+def test_capped_decompress_uses_independent_limits():
+    original = b"x" * 4096
+    parameters = zstd._zstd.CompressionParameter
+    compressed = zstd.compress(
+        original,
+        options={
+            parameters.window_log: 11,
+            parameters.content_size_flag: 0,
+        },
+    )
+
+    assert (
+        zstd.capped_decompress(
+            compressed,
+            max_output_size=8192,
+            max_window_size=2048,
+        )
+        == original
+    )
+
+    with pytest.raises(zstd.ZstdError, match="too much memory"):
+        zstd.capped_decompress(
+            compressed,
+            max_output_size=8192,
+            max_window_size=1024,
+        )
+
+    with pytest.raises(zstd.ZstdError, match="decompressed output exceeds 4095 bytes"):
+        zstd.capped_decompress(
+            compressed,
+            max_output_size=4095,
+            max_window_size=2048,
+        )
+
+
+def test_capped_decompress_reports_declared_size():
+    compressed = zstd.compress(b"x" * 1025)
+
+    with pytest.raises(
+        zstd.ZstdError,
+        match="decompressed output is 1025 bytes, which exceeds the 1024 byte limit",
+    ):
+        zstd.capped_decompress(
+            compressed,
+            max_output_size=1024,
+            max_window_size=2048,
+        )
+
+
+def test_capped_decompress_rejects_incomplete_frame():
+    parameters = zstd._zstd.CompressionParameter
+    compressed = zstd.compress(
+        b"payload",
+        options={parameters.checksum_flag: 1},
+    )
+
+    with pytest.raises(
+        zstd.ZstdError, match="compressed input ended before the end of the frame"
+    ):
+        zstd.capped_decompress(
+            compressed[:-1],
+            max_output_size=1024,
+            max_window_size=1024,
+        )

--- a/tests/gateways/test_zstd.py
+++ b/tests/gateways/test_zstd.py
@@ -265,7 +265,7 @@ def test_zstd_fallback_on_invalid_zstd(
     assert len(json.loads(cache.cache_path_json.read_text())["packages"])
 
 
-def test_capped_decompress_uses_independent_limits():
+def test_capped_decompress_uses_output_limit_for_window():
     original = b"x" * 4096
     parameters = zstd._zstd.CompressionParameter
     compressed = zstd.compress(
@@ -280,7 +280,6 @@ def test_capped_decompress_uses_independent_limits():
         zstd.capped_decompress(
             compressed,
             max_output_size=8192,
-            max_window_size=2048,
         )
         == original
     )
@@ -288,15 +287,13 @@ def test_capped_decompress_uses_independent_limits():
     with pytest.raises(zstd.ZstdError, match="too much memory"):
         zstd.capped_decompress(
             compressed,
-            max_output_size=8192,
-            max_window_size=1024,
+            max_output_size=1024,
         )
 
     with pytest.raises(zstd.ZstdError, match="decompressed output exceeds 4095 bytes"):
         zstd.capped_decompress(
             compressed,
             max_output_size=4095,
-            max_window_size=2048,
         )
 
 
@@ -310,7 +307,6 @@ def test_capped_decompress_reports_declared_size():
         zstd.capped_decompress(
             compressed,
             max_output_size=1024,
-            max_window_size=2048,
         )
 
 
@@ -327,5 +323,4 @@ def test_capped_decompress_rejects_incomplete_frame():
         zstd.capped_decompress(
             compressed[:-1],
             max_output_size=1024,
-            max_window_size=1024,
         )

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -25,6 +25,7 @@ from requests import Request, Response
 import conda.gateways.repodata
 from conda._private import zstd
 from conda._private.shards import cache as shards_cache
+from conda._private.shards import decompression as shard_decompression
 from conda._private.shards import shards
 from conda._private.shards import subset as shards_subset
 from conda._private.shards.shards import (
@@ -766,18 +767,18 @@ def test_individual_shard_output_size_limit():
     reported_shard_size = 48_984_766
     compressed = zstd.compress(bytes(reported_shard_size))
 
-    decompressed = zstd.capped_decompress(
+    decompressed = shard_decompression.decompress_shard(
         compressed,
-        max_output_size=shards.ZSTD_MAX_SHARD_SIZE,
-        max_window_size=shards.ZSTD_MAX_SHARD_WINDOW_SIZE,
+        url="https://example.com/noarch/shards/hash",
+        package="large-package",
     )
 
     assert len(decompressed) == reported_shard_size
 
 
 def test_shards_cache_size_error_context(tmp_path: Path, monkeypatch):
-    monkeypatch.setattr(shards_cache, "ZSTD_MAX_SHARD_SIZE", 1024)
-    monkeypatch.setattr(shards_cache, "ZSTD_MAX_SHARD_WINDOW_SIZE", 2048)
+    monkeypatch.setattr(shard_decompression, "ZSTD_MAX_SHARD_SIZE", 1024)
+    monkeypatch.setattr(shard_decompression, "ZSTD_MAX_SHARD_WINDOW_SIZE", 2048)
     shard = msgpack.dumps({"payload": b"x" * 2048})
     annotated_shard = shards_cache.AnnotatedRawShard(
         "https://user:password@example.com/t/secret/channel/noarch/shards/hash",
@@ -815,7 +816,7 @@ def test_individual_shard_size_error_cli(
             patch.setenv("CONDA_REPODATA_USE_SHARDS", "true")
             patch.setenv("CONDA_TOKEN", "")
             patch.setattr(
-                shards_subset,
+                shard_decompression,
                 "ZSTD_MAX_SHARD_SIZE",
                 max_output_size,
             )
@@ -843,7 +844,8 @@ def test_individual_shard_size_error_cli(
         f"decompressed output is {shard_size} bytes, "
         f"which exceeds the {max_output_size} byte limit "
         f"(output limit: {max_output_size} bytes, "
-        f"decoder window limit: {shards.ZSTD_MAX_SHARD_WINDOW_SIZE} bytes)"
+        "decoder window limit: "
+        f"{shard_decompression.ZSTD_MAX_SHARD_WINDOW_SIZE} bytes)"
     )
     assert return_code == 1
     assert stderr.rstrip().endswith(expected)

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -39,7 +39,9 @@ from conda._private.shards.shards import (
     shard_mentioned_packages,
 )
 from conda.base.context import context, reset_context
+from conda.cli.main import main
 from conda.core.subdir_data import SubdirData
+from conda.exceptions import ChannelError
 from conda.models.channel import Channel
 
 from .conftest import (
@@ -785,7 +787,7 @@ def test_shards_cache_size_error_context(tmp_path: Path, monkeypatch):
 
     with shards_cache.ShardCache(tmp_path) as cache:
         cache.insert(annotated_shard)
-        with pytest.raises(zstd.ZstdError) as exc_info:
+        with pytest.raises(ChannelError) as exc_info:
             cache.retrieve(annotated_shard.url)
 
     message = str(exc_info.value)
@@ -796,6 +798,59 @@ def test_shards_cache_size_error_context(tmp_path: Path, monkeypatch):
     assert "decoder window limit: 2048 bytes" in message
     assert "user:password" not in message
     assert "/t/secret/" not in message
+
+
+def test_individual_shard_size_error_cli(
+    shard_factory: ShardFactory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    channel_url = shard_factory.http_server_shards("individual_shard_size_error_cli")
+    shard_size = len(msgpack.dumps(FAKE_SHARD))
+    max_output_size = shard_size - 1
+    try:
+        with monkeypatch.context() as patch:
+            patch.setenv("CONDA_PKGS_DIRS", str(tmp_path))
+            patch.setenv("CONDA_REPODATA_USE_SHARDS", "true")
+            patch.setenv("CONDA_TOKEN", "")
+            patch.setattr(
+                shards_subset,
+                "ZSTD_MAX_SHARD_SIZE",
+                max_output_size,
+            )
+            reset_context()
+            capsys.readouterr()
+
+            return_code = main(
+                "search",
+                "foo",
+                "--subdir",
+                "noarch",
+                "--override-channels",
+                "--channel",
+                channel_url,
+            )
+
+            _, stderr = capsys.readouterr()
+    finally:
+        reset_context()
+
+    shard_url = f"{channel_url}noarch/repodata_shards.msgpack.zst"
+    expected = (
+        "ChannelError: repodata shard for package 'foo' "
+        f"from channel '{shard_url}': "
+        f"decompressed output is {shard_size} bytes, "
+        f"which exceeds the {max_output_size} byte limit "
+        f"(output limit: {max_output_size} bytes, "
+        f"decoder window limit: {shards.ZSTD_MAX_SHARD_WINDOW_SIZE} bytes)"
+    )
+    assert return_code == 1
+    assert stderr.rstrip().endswith(expected)
+    assert stderr.count("ChannelError:") == 1
+    assert "Traceback" not in stderr
+    assert "ERROR REPORT" not in stderr
+    assert "An unexpected error has occurred" not in stderr
 
 
 def test_shards_cache_recovery(tmp_path: Path):

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -763,6 +763,11 @@ def test_shards_cache(tmp_path: Path):
     cache.close()
 
 
+def test_shard_size_limits():
+    assert shard_decompression.ZSTD_MAX_SHARD_SIZE == 64 * 2**20
+    assert shard_decompression.ZSTD_MAX_SHARD_INDEX_SIZE == 128 * 2**20
+
+
 def test_individual_shard_output_size_limit():
     reported_shard_size = 48_984_766
     compressed = zstd.compress(bytes(reported_shard_size))
@@ -778,7 +783,6 @@ def test_individual_shard_output_size_limit():
 
 def test_shards_cache_size_error_context(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(shard_decompression, "ZSTD_MAX_SHARD_SIZE", 1024)
-    monkeypatch.setattr(shard_decompression, "ZSTD_MAX_SHARD_WINDOW_SIZE", 2048)
     shard = msgpack.dumps({"payload": b"x" * 2048})
     annotated_shard = shards_cache.AnnotatedRawShard(
         "https://user:password@example.com/t/secret/channel/noarch/shards/hash",
@@ -795,8 +799,7 @@ def test_shards_cache_size_error_context(tmp_path: Path, monkeypatch):
     assert "package 'large-package'" in message
     assert "https://example.com/t/<TOKEN>/channel/noarch/shards/hash" in message
     assert f"decompressed output is {len(shard)} bytes" in message
-    assert "output limit: 1024 bytes" in message
-    assert "decoder window limit: 2048 bytes" in message
+    assert "output and decoder window limit: 1024 bytes" in message
     assert "user:password" not in message
     assert "/t/secret/" not in message
 
@@ -843,9 +846,7 @@ def test_individual_shard_size_error_cli(
         f"from channel '{shard_url}': "
         f"decompressed output is {shard_size} bytes, "
         f"which exceeds the {max_output_size} byte limit "
-        f"(output limit: {max_output_size} bytes, "
-        "decoder window limit: "
-        f"{shard_decompression.ZSTD_MAX_SHARD_WINDOW_SIZE} bytes)"
+        f"(output and decoder window limit: {max_output_size} bytes)"
     )
     assert return_code == 1
     assert stderr.rstrip().endswith(expected)

--- a/tests/shards/test_shards.py
+++ b/tests/shards/test_shards.py
@@ -760,6 +760,44 @@ def test_shards_cache(tmp_path: Path):
     cache.close()
 
 
+def test_individual_shard_output_size_limit():
+    reported_shard_size = 48_984_766
+    compressed = zstd.compress(bytes(reported_shard_size))
+
+    decompressed = zstd.capped_decompress(
+        compressed,
+        max_output_size=shards.ZSTD_MAX_SHARD_SIZE,
+        max_window_size=shards.ZSTD_MAX_SHARD_WINDOW_SIZE,
+    )
+
+    assert len(decompressed) == reported_shard_size
+
+
+def test_shards_cache_size_error_context(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(shards_cache, "ZSTD_MAX_SHARD_SIZE", 1024)
+    monkeypatch.setattr(shards_cache, "ZSTD_MAX_SHARD_WINDOW_SIZE", 2048)
+    shard = msgpack.dumps({"payload": b"x" * 2048})
+    annotated_shard = shards_cache.AnnotatedRawShard(
+        "https://user:password@example.com/t/secret/channel/noarch/shards/hash",
+        "large-package",
+        zstd.compress(shard),
+    )
+
+    with shards_cache.ShardCache(tmp_path) as cache:
+        cache.insert(annotated_shard)
+        with pytest.raises(zstd.ZstdError) as exc_info:
+            cache.retrieve(annotated_shard.url)
+
+    message = str(exc_info.value)
+    assert "package 'large-package'" in message
+    assert "https://example.com/t/<TOKEN>/channel/noarch/shards/hash" in message
+    assert f"decompressed output is {len(shard)} bytes" in message
+    assert "output limit: 1024 bytes" in message
+    assert "decoder window limit: 2048 bytes" in message
+    assert "user:password" not in message
+    assert "/t/secret/" not in message
+
+
 def test_shards_cache_recovery(tmp_path: Path):
     """
     Test that we can recover from a bad shards database.


### PR DESCRIPTION
### Description

Fixes #16575 by raising the decompressed output limit for individual repodata shards from 16 MiB to 64 MiB while retaining a separate 16 MiB zstd decoder-window limit.

Improve limit errors with the declared decompressed size, package name, and sanitized channel URL. Reject incomplete zstd frames instead of returning partial output.

### Checklist - did you ...

- [x] Add a file to the `news` directory?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~