### PR TITLE
Use tmp_env and local wheel for slow test

### DIFF
--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -425,6 +425,7 @@ def test_update_env_only_pip_json_output(
     conda_cli: CondaCLIFixture,
     request: pytest.FixtureRequest,
     wheelhouse: Path,
+    monkeypatch: MonkeyPatch,
 ):
     """
     Update an environment by adding only a pip package.
@@ -437,13 +438,15 @@ def test_update_env_only_pip_json_output(
         pytest.mark.xfail(
             context.solver == "libmamba",
             reason="Known issue: https://github.com/conda/conda-libmamba-solver/issues/320",
+            run=False,
         )
     )
-
     wheel = wheelhouse / "small_python_package-1.0.0-py3-none-any.whl"
 
     # Baseline: python + pip already installed (no environment.yml create)
     with tmp_env("pip>=23") as prefix:
+        monkeypatch.setenv("PIP_DISABLE_PIP_VERSION_CHECK", "1")
+
         # Desired state: same conda deps + one local pip package
         create_env(
             yaml.write(

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -421,13 +421,14 @@ def test_update_env_json_output(
 @pytest.mark.integration
 @pytest.mark.flaky(reruns=2, condition=on_win and not in_subprocess())
 def test_update_env_only_pip_json_output(
-    path_factory: PathFactoryFixture,
+    tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
     request: pytest.FixtureRequest,
+    wheelhouse: Path,
 ):
     """
-    Update an environment by adding only a pip package
-    Check the json output
+    Update an environment by adding only a pip package.
+    Check the json output.
     """
     if context.solver == "libmamba" and on_win and forward_to_subprocess(request):
         return
@@ -438,18 +439,39 @@ def test_update_env_only_pip_json_output(
             reason="Known issue: https://github.com/conda/conda-libmamba-solver/issues/320",
         )
     )
-    prefix = path_factory()
-    create_env(ENVIRONMENT_PIP_CLICK)
-    conda_cli("env", "create", f"--prefix={prefix}", "--json", "--yes")
-    create_env(ENVIRONMENT_PIP_CLICK_ATTRS)
-    stdout, _, _ = conda_cli("env", "update", f"--prefix={prefix}", "--quiet", "--json")
-    output = json.loads(stdout)
-    assert output["success"] is True
-    # No conda actions (FETCH/LINK), only pip
-    assert list(output["actions"].keys()) == ["PIP"]
-    # Only attrs installed
-    assert len(output["actions"]["PIP"]) == 1
-    assert output["actions"]["PIP"][0].startswith("attrs")
+
+    wheel = wheelhouse / "small_python_package-1.0.0-py3-none-any.whl"
+
+    # Baseline: python + pip already installed (no environment.yml create)
+    with tmp_env("pip>=23") as prefix:
+        # Desired state: same conda deps + one local pip package
+        create_env(
+            yaml.write(
+                {
+                    "name": TEST_ENV1,
+                    "dependencies": [
+                        "pip>=23",
+                        {"pip": [str(wheel)]},
+                    ],
+                    "channels": context.channels,
+                }
+            )
+        )
+
+        stdout, _, _ = conda_cli(
+            "env",
+            "update",
+            f"--prefix={prefix}",
+            "--quiet",
+            "--json",
+        )
+        output = json.loads(stdout)
+
+        assert output["success"] is True
+        # No conda actions (FETCH/LINK), only pip
+        assert list(output["actions"].keys()) == ["PIP"]
+        assert len(output["actions"]["PIP"]) == 1
+        assert output["actions"]["PIP"][0].startswith("small-python-package")
 
 
 @pytest.mark.integration

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -459,11 +459,7 @@ def test_update_env_only_pip_json_output(
         )
 
         stdout, _, _ = conda_cli(
-            "env",
-            "update",
-            f"--prefix={prefix}",
-            "--quiet",
-            "--json",
+            "env", "update", f"--prefix={prefix}", "--quiet", "--json"
         )
         output = json.loads(stdout)
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
#16344 

use `tmp_env` and a local wheel instead of `click`. 
The improvement really is marginal. 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
