### PR TITLE
Revert canary-release to v26.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 
       - name: Create & Upload
-        uses: conda/actions/canary-release@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
+        uses: conda/actions/canary-release@0f4ec1506e74c12799813dc66e613a39077ea864 # v26.7.0
         env:
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1
         with:


### PR DESCRIPTION
### Description

Restore canary builds by reverting `conda/actions/canary-release` from v26.8.0 to the known-good v26.7.0 pin.

v26.8.0 fails during package upload with `INPUT_CHANNEL: unbound variable`. v26.7.0 completed the previous four-platform canary build successfully.

Reverts the `canary-release` update from #16582.

Resolves #16583.