### PR TITLE
Clarify repodata retry message

### DIFF
--- a/conda/core/solve.py
+++ b/conda/core/solve.py
@@ -508,10 +508,7 @@ class Solver(BaseSolver):
                 " with flexible solve.\n"
             )
         elif self._repodata_fn != REPODATA_FN:
-            fail_message = (
-                f"unsuccessful attempt using repodata from {self._repodata_fn}, retrying"
-                " with next repodata source.\n"
-            )
+            fail_message = "retrying with next repodata source.\n"
         else:
             fail_message = "failed\n"
 

--- a/releases/news/12008-clarify-repodata-retry
+++ b/releases/news/12008-clarify-repodata-retry
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Clarify the repodata retry message so it no longer describes the fallback as an unsuccessful attempt. (#12008 via #16599)

--- a/releases/news/12008-clarify-repodata-retry
+++ b/releases/news/12008-clarify-repodata-retry
@@ -1,3 +1,3 @@
-### Bug fixes
+### Enhancements
 
 * Clarify the repodata retry message so it no longer describes the fallback as an unsuccessful attempt. (#12008 via #16599)

--- a/tests/core/test_solve.py
+++ b/tests/core/test_solve.py
@@ -3415,6 +3415,26 @@ def test_current_repodata_fallback(tmpdir):
         raise ValueError("Didn't have expected state in solve (needed zlib record)")
 
 
+def test_current_repodata_retry_message(tmpdir, capsys: CaptureFixture):
+    if context.solver != "classic":
+        pytest.skip("retry message is specific to the classic Solver")
+
+    solver = Solver(
+        tmpdir.strpath,
+        (Channel(CHANNEL_DIR_V1),),
+        ("win-64",),
+        specs_to_add=[MatchSpec("zlib=1.2.8")],
+        repodata_fn="current_repodata.json",
+    )
+
+    with pytest.raises(ResolvePackageNotFound):
+        solver.solve_final_state()
+
+    captured = capsys.readouterr()
+    assert "retrying with next repodata source." in captured.out
+    assert "unsuccessful attempt using repodata" not in captured.out
+
+
 def test_downgrade_python_prevented_with_sane_message(tmpdir):
     specs = (MatchSpec("python=2.6"),)
     with get_solver(tmpdir, specs) as solver:


### PR DESCRIPTION
### Description

Fixes #12008

This clarifies the classic solver's repodata fallback message.

Instead of reporting an "unsuccessful attempt" before retrying, Conda now reports that it is "retrying with next repodata source." This keeps the retry visible while avoiding wording that can make a normal fallback look like an error.

This follows the discussion in #12008 to retain the retry information while making the message clearer and less alarming.

A regression test was added for the classic solver retry message.

### Checklist - did you ...

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
- [x] ~~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~~
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~