### PR TITLE
Protect cache packages referenced by environment symlinks during cleanup

### DIFF
--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -182,23 +182,8 @@ def find_tarballs() -> dict[str, Any]:
 
 
 def find_pkgs() -> dict[str, Any]:
-    from ..base.context import context
-
     warnings: list[str] = []
     pkg_sizes: dict[str, dict[str, int]] = {}
-    if context.always_softlink or context.allow_softlinks:
-        warnings.append(
-            "WARNING: Skipping package cache cleanup because `always_softlink` or "
-            "`allow_softlinks` is enabled. Removing cache packages may break "
-            "environments that use symlinks."
-        )
-        return {
-            "warnings": warnings,
-            "pkg_sizes": pkg_sizes,
-            "pkgs_dirs": _get_pkgs_dirs(pkg_sizes),
-            "total_size": _get_total_size(pkg_sizes),
-        }
-
     for pkgs_dir in find_pkgs_dirs():
         # pkgs are directories in pkgs_dir
         _, pkgs, _ = next(os.walk(pkgs_dir))

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -11,6 +11,7 @@ import os
 import sys
 from logging import getLogger
 from os.path import isdir, join
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -62,8 +63,8 @@ def configure_parser(sub_parsers: _SubParsersAction, **kwargs) -> ArgumentParser
         "--packages",
         action="store_true",
         help="Remove unused packages from writable package caches. "
-        "WARNING: This does not check for packages installed using "
-        "symlinks back to the package cache.",
+        "WARNING: Environments not listed by `conda info --envs` are not checked "
+        "for symlinks back to the package cache.",
     )
     removal_target_options.add_argument(
         "-t",
@@ -181,8 +182,22 @@ def find_tarballs() -> dict[str, Any]:
 
 
 def find_pkgs() -> dict[str, Any]:
+    from ..base.context import context
+
     warnings: list[str] = []
     pkg_sizes: dict[str, dict[str, int]] = {}
+    if context.always_softlink:
+        warnings.append(
+            "WARNING: Skipping package cache cleanup because `always_softlink` is "
+            "enabled. Removing cache packages may break environments that use symlinks."
+        )
+        return {
+            "warnings": warnings,
+            "pkg_sizes": pkg_sizes,
+            "pkgs_dirs": _get_pkgs_dirs(pkg_sizes),
+            "total_size": _get_total_size(pkg_sizes),
+        }
+
     for pkgs_dir in find_pkgs_dirs():
         # pkgs are directories in pkgs_dir
         _, pkgs, _ = next(os.walk(pkgs_dir))
@@ -202,6 +217,29 @@ def find_pkgs() -> dict[str, Any]:
                 pass
             else:
                 pkg_sizes.setdefault(pkgs_dir, {})[pkg] = size
+
+    if pkg_sizes:
+        from ..core.package_cache_data import get_softlinked_package_dirs
+
+        softlinked_pkgs = get_softlinked_package_dirs()
+        softlinked_pkgs_by_name: dict[str, list[Path]] = {}
+        for path in softlinked_pkgs:
+            softlinked_pkgs_by_name.setdefault(path.name.casefold(), []).append(path)
+        for pkgs_dir, pkgs in pkg_sizes.items():
+            for pkg in tuple(pkgs):
+                package_dir = Path(pkgs_dir, pkg).resolve(strict=False)
+                if package_dir in softlinked_pkgs:
+                    del pkgs[pkg]
+                    continue
+
+                for softlinked_pkg in softlinked_pkgs_by_name.get(pkg.casefold(), ()):
+                    try:
+                        matches = package_dir.samefile(softlinked_pkg)
+                    except OSError:
+                        continue
+                    if matches:
+                        del pkgs[pkg]
+                        break
 
     return {
         "warnings": warnings,

--- a/conda/cli/main_clean.py
+++ b/conda/cli/main_clean.py
@@ -186,10 +186,11 @@ def find_pkgs() -> dict[str, Any]:
 
     warnings: list[str] = []
     pkg_sizes: dict[str, dict[str, int]] = {}
-    if context.always_softlink:
+    if context.always_softlink or context.allow_softlinks:
         warnings.append(
-            "WARNING: Skipping package cache cleanup because `always_softlink` is "
-            "enabled. Removing cache packages may break environments that use symlinks."
+            "WARNING: Skipping package cache cleanup because `always_softlink` or "
+            "`allow_softlinks` is enabled. Removing cache packages may break "
+            "environments that use symlinks."
         )
         return {
             "warnings": warnings,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -111,7 +111,10 @@ def get_softlinked_package_dirs() -> set[Path]:
 
     package_dirs = set()
     for prefix in prefixes:
-        for record in PrefixData(prefix, interoperability=False).iter_records():
+        prefix_data = PrefixData(prefix, interoperability=False)
+        if not prefix_data.is_environment():
+            continue
+        for record in prefix_data.iter_records():
             link = getattr(record, "link", None)
             # Older records may have a source without recording the link type.
             if link and getattr(link, "type", LinkType.softlink) == LinkType.softlink:

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -19,6 +19,7 @@ from itertools import chain
 from logging import getLogger
 from os import scandir
 from os.path import basename, dirname, getsize, join
+from pathlib import Path
 from sys import platform
 from tarfile import ReadError
 from typing import TYPE_CHECKING
@@ -67,7 +68,6 @@ from .path_actions import CacheUrlAction, ExtractPackageAction
 
 if TYPE_CHECKING:
     from concurrent.futures import Future
-    from pathlib import Path
 
     from ..plugins.types import ProgressBarBase
 
@@ -89,6 +89,34 @@ EXTRACT_PROCESS_EXTENSIONS = (
     CONDA_PACKAGE_EXTENSION_V1,
     CONDA_PACKAGE_EXTENSION_V2,
 )
+
+
+def get_softlinked_package_dirs() -> set[Path]:
+    """Return cache directories known environments may reference through symlinks."""
+    from ..models.enums import LinkType
+    from .envs_manager import list_all_known_prefixes
+    from .prefix_data import PrefixData
+
+    prefixes = set(list_all_known_prefixes())
+    prefixes.update(
+        prefix
+        for prefix in (
+            context.root_prefix,
+            context.conda_prefix,
+            context.active_prefix,
+            context.target_prefix,
+        )
+        if prefix
+    )
+
+    package_dirs = set()
+    for prefix in prefixes:
+        for record in PrefixData(prefix, interoperability=False).iter_records():
+            link = getattr(record, "link", None)
+            # Older records may have a source without recording the link type.
+            if link and getattr(link, "type", LinkType.softlink) == LinkType.softlink:
+                package_dirs.add(Path(link.source).resolve(strict=False))
+    return package_dirs
 
 
 class PackageCacheType(type):

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -116,7 +116,7 @@ def get_softlinked_package_dirs() -> set[Path]:
             continue
         for record in prefix_data.iter_records():
             link = getattr(record, "link", None)
-            # Older records may have a source without recording the link type.
+            # A missing link type does not rule out symlinks.
             if link and getattr(link, "type", LinkType.softlink) == LinkType.softlink:
                 package_dirs.add(Path(link.source).resolve(strict=False))
     return package_dirs

--- a/releases/news/16614-clean-softlinked-packages
+++ b/releases/news/16614-clean-softlinked-packages
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Keep extracted cache packages referenced by soft-linked environments when running `conda clean --packages` or `conda clean --all`. (#16614)

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -176,63 +176,39 @@ def test_clean_and_packages(
     "softlink_env_var",
     ("CONDA_ALWAYS_SOFTLINK", "CONDA_ALLOW_SOFTLINKS"),
 )
-def test_clean_packages_skips_when_softlinking_enabled(
-    clear_cache,
-    test_recipes_channel: Path,
-    conda_cli: CondaCLIFixture,
-    tmp_env: TmpEnvFixture,
-    mocker: MockerFixture,
-    monkeypatch: pytest.MonkeyPatch,
-    clean_arg: str,
-    softlink_env_var: str,
-):
-    mocker.patch("conda.core.link.hardlink_supported", return_value=False)
-    monkeypatch.setenv(softlink_env_var, "true")
-    reset_context()
-
-    with tmp_env("small-executable") as prefix:
-        activate_script = (
-            prefix / "etc" / "conda" / "activate.d" / "small_executable.sh"
-        )
-        assert activate_script.is_symlink()
-
-        stdout, _, _ = conda_cli("clean", clean_arg, "--yes")
-
-        assert "`always_softlink` or `allow_softlinks` is enabled" in stdout
-        assert activate_script.exists()
-
-
-@pytest.mark.skipif(on_win, reason="creating symlinks may require elevated privileges")
 def test_clean_packages_preserves_known_softlinked_environment(
     clear_cache,
     test_recipes_channel: Path,
     conda_cli: CondaCLIFixture,
     tmp_env: TmpEnvFixture,
     tmp_pkgs_dir: Path,
+    mocker: MockerFixture,
     monkeypatch: pytest.MonkeyPatch,
     known_prefixes,
+    clean_arg: str,
+    softlink_env_var: str,
 ):
-    monkeypatch.setenv("CONDA_ALWAYS_SOFTLINK", "true")
+    pkg = "small-executable"
+    mocker.patch("conda.core.link.hardlink_supported", return_value=False)
+    monkeypatch.setenv(softlink_env_var, "true")
     reset_context()
 
-    with tmp_env("small-executable") as prefix:
+    with tmp_env(pkg) as prefix:
         activate_script = (
             prefix / "etc" / "conda" / "activate.d" / "small_executable.sh"
         )
         assert activate_script.is_symlink()
-        monkeypatch.delenv("CONDA_ALWAYS_SOFTLINK")
-        reset_context()
         known_prefixes.return_value = [str(prefix)]
 
-        conda_cli("clean", "--packages", "--yes")
+        conda_cli("clean", clean_arg, "--yes")
 
         assert activate_script.exists()
-        assert has_pkg("small-executable", _get_pkgs(tmp_pkgs_dir))
+        assert has_pkg(pkg, _get_pkgs(tmp_pkgs_dir))
 
-        conda_cli("remove", "--prefix", prefix, "small-executable", "--yes")
-        conda_cli("clean", "--packages", "--yes")
+        conda_cli("remove", "--prefix", prefix, pkg, "--yes")
+        conda_cli("clean", clean_arg, "--yes")
 
-        assert not has_pkg("small-executable", _get_pkgs(tmp_pkgs_dir))
+        assert not has_pkg(pkg, _get_pkgs(tmp_pkgs_dir))
 
 
 # conda clean --tarballs

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -172,15 +172,22 @@ def test_clean_and_packages(
 
 @pytest.mark.skipif(on_win, reason="creating symlinks may require elevated privileges")
 @pytest.mark.parametrize("clean_arg", ("--packages", "--all"))
-def test_clean_packages_skips_when_always_softlink(
+@pytest.mark.parametrize(
+    "softlink_env_var",
+    ("CONDA_ALWAYS_SOFTLINK", "CONDA_ALLOW_SOFTLINKS"),
+)
+def test_clean_packages_skips_when_softlinking_enabled(
     clear_cache,
     test_recipes_channel: Path,
     conda_cli: CondaCLIFixture,
     tmp_env: TmpEnvFixture,
+    mocker: MockerFixture,
     monkeypatch: pytest.MonkeyPatch,
     clean_arg: str,
+    softlink_env_var: str,
 ):
-    monkeypatch.setenv("CONDA_ALWAYS_SOFTLINK", "true")
+    mocker.patch("conda.core.link.hardlink_supported", return_value=False)
+    monkeypatch.setenv(softlink_env_var, "true")
     reset_context()
 
     with tmp_env("small-executable") as prefix:
@@ -191,7 +198,7 @@ def test_clean_packages_skips_when_always_softlink(
 
         stdout, _, _ = conda_cli("clean", clean_arg, "--yes")
 
-        assert "Skipping package cache cleanup" in stdout
+        assert "`always_softlink` or `allow_softlinks` is enabled" in stdout
         assert activate_script.exists()
 
 

--- a/tests/cli/test_main_clean.py
+++ b/tests/cli/test_main_clean.py
@@ -16,8 +16,9 @@ from conda.base.constants import (
     PACKAGE_CACHE_MAGIC_FILE,
     PARTIAL_EXTENSION,
 )
-from conda.base.context import context
-from conda.cli.main_clean import _get_size
+from conda.base.context import context, reset_context
+from conda.cli.main_clean import _get_size, find_pkgs
+from conda.common.compat import on_win
 from conda.core.subdir_data import create_cache_dir
 from conda.gateways.logging import set_log_level
 
@@ -73,6 +74,14 @@ def has_pkg(name: str, contents: Iterable[str | Path]) -> bool:
     return any(Path(content).name.startswith(f"{name}-") for content in contents)
 
 
+@pytest.fixture(autouse=True)
+def known_prefixes(mocker: MockerFixture):
+    return mocker.patch(
+        "conda.core.envs_manager.list_all_known_prefixes",
+        return_value=[],
+    )
+
+
 # conda clean --force-pkgs-dirs
 def test_clean_force_pkgs_dirs(
     clear_cache,
@@ -98,6 +107,35 @@ def test_clean_force_pkgs_dirs(
 
 
 # conda clean --packages
+def test_clean_packages_without_candidates_does_not_scan_prefixes(
+    tmp_pkgs_dir: Path,
+    mocker: MockerFixture,
+):
+    get_softlinked_package_dirs = mocker.patch(
+        "conda.core.package_cache_data.get_softlinked_package_dirs"
+    )
+
+    assert find_pkgs()["pkg_sizes"] == {}
+    get_softlinked_package_dirs.assert_not_called()
+
+
+def test_clean_packages_matches_softlinks_with_samefile(
+    tmp_pkgs_dir: Path,
+    mocker: MockerFixture,
+):
+    package_dir = tmp_pkgs_dir / "package-1.0-0"
+    (package_dir / "info").mkdir(parents=True)
+    (package_dir / "file.txt").touch()
+    mocker.patch(
+        "conda.core.package_cache_data.get_softlinked_package_dirs",
+        return_value={Path("/different/spelling/package-1.0-0")},
+    )
+    samefile = mocker.patch.object(Path, "samefile", return_value=True)
+
+    assert find_pkgs()["pkg_sizes"] == {str(tmp_pkgs_dir): {}}
+    samefile.assert_called_once()
+
+
 def test_clean_and_packages(
     clear_cache,
     test_recipes_channel: Path,
@@ -130,6 +168,64 @@ def test_clean_and_packages(
 
     # pkg is still removed
     assert not has_pkg(pkg, _get_pkgs(tmp_pkgs_dir))
+
+
+@pytest.mark.skipif(on_win, reason="creating symlinks may require elevated privileges")
+@pytest.mark.parametrize("clean_arg", ("--packages", "--all"))
+def test_clean_packages_skips_when_always_softlink(
+    clear_cache,
+    test_recipes_channel: Path,
+    conda_cli: CondaCLIFixture,
+    tmp_env: TmpEnvFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    clean_arg: str,
+):
+    monkeypatch.setenv("CONDA_ALWAYS_SOFTLINK", "true")
+    reset_context()
+
+    with tmp_env("small-executable") as prefix:
+        activate_script = (
+            prefix / "etc" / "conda" / "activate.d" / "small_executable.sh"
+        )
+        assert activate_script.is_symlink()
+
+        stdout, _, _ = conda_cli("clean", clean_arg, "--yes")
+
+        assert "Skipping package cache cleanup" in stdout
+        assert activate_script.exists()
+
+
+@pytest.mark.skipif(on_win, reason="creating symlinks may require elevated privileges")
+def test_clean_packages_preserves_known_softlinked_environment(
+    clear_cache,
+    test_recipes_channel: Path,
+    conda_cli: CondaCLIFixture,
+    tmp_env: TmpEnvFixture,
+    tmp_pkgs_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    known_prefixes,
+):
+    monkeypatch.setenv("CONDA_ALWAYS_SOFTLINK", "true")
+    reset_context()
+
+    with tmp_env("small-executable") as prefix:
+        activate_script = (
+            prefix / "etc" / "conda" / "activate.d" / "small_executable.sh"
+        )
+        assert activate_script.is_symlink()
+        monkeypatch.delenv("CONDA_ALWAYS_SOFTLINK")
+        reset_context()
+        known_prefixes.return_value = [str(prefix)]
+
+        conda_cli("clean", "--packages", "--yes")
+
+        assert activate_script.exists()
+        assert has_pkg("small-executable", _get_pkgs(tmp_pkgs_dir))
+
+        conda_cli("remove", "--prefix", prefix, "small-executable", "--yes")
+        conda_cli("clean", "--packages", "--yes")
+
+        assert not has_pkg("small-executable", _get_pkgs(tmp_pkgs_dir))
 
 
 # conda clean --tarballs

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -29,6 +29,7 @@ from conda.core.path_actions import CacheUrlAction
 from conda.gateways.disk.create import copy
 from conda.gateways.disk.permissions import make_read_only
 from conda.gateways.disk.read import isfile, listdir, yield_lines
+from conda.models.enums import LinkType
 from conda.models.match_spec import MatchSpec
 from conda.testing.helpers import CHANNEL_DIR_V1
 from conda.utils import url_path
@@ -86,6 +87,68 @@ def fresh_zlib_records():
     return (
         PackageRecord.from_objects(zlib_tar_bz2_prec),
         PackageRecord.from_objects(zlib_conda_prec),
+    )
+
+
+def test_get_softlinked_package_dirs(mocker, tmp_path: Path):
+    known_prefix = str(tmp_path / "known")
+    root_prefix = str(tmp_path / "root")
+    conda_prefix = str(tmp_path / "conda")
+    active_prefix = str(tmp_path / "active")
+    target_prefix = str(tmp_path / "target")
+    softlinked_source = tmp_path / "pkgs" / "softlinked"
+    untyped_source = tmp_path / "pkgs" / "untyped"
+    records = {
+        known_prefix: (
+            SimpleNamespace(
+                link=SimpleNamespace(
+                    source=str(softlinked_source / ".." / "softlinked"),
+                    type=LinkType.softlink,
+                )
+            ),
+            SimpleNamespace(
+                link=SimpleNamespace(
+                    source=str(tmp_path / "pkgs" / "hardlinked"),
+                    type=LinkType.hardlink,
+                )
+            ),
+            SimpleNamespace(link=SimpleNamespace(source=str(untyped_source))),
+            SimpleNamespace(link=None),
+        )
+    }
+    mocker.patch(
+        "conda.core.envs_manager.list_all_known_prefixes",
+        return_value=[known_prefix],
+    )
+    prefix_data = mocker.patch("conda.core.prefix_data.PrefixData")
+    prefix_data.side_effect = lambda prefix, **kwargs: SimpleNamespace(
+        iter_records=lambda: records.get(prefix, ())
+    )
+    mocker.patch.object(
+        package_cache_data,
+        "context",
+        SimpleNamespace(
+            root_prefix=root_prefix,
+            conda_prefix=conda_prefix,
+            active_prefix=active_prefix,
+            target_prefix=target_prefix,
+        ),
+    )
+
+    assert package_cache_data.get_softlinked_package_dirs() == {
+        softlinked_source.resolve(),
+        untyped_source.resolve(),
+    }
+    assert {call.args[0] for call in prefix_data.call_args_list} == {
+        known_prefix,
+        root_prefix,
+        conda_prefix,
+        active_prefix,
+        target_prefix,
+    }
+    assert all(
+        call.kwargs == {"interoperability": False}
+        for call in prefix_data.call_args_list
     )
 
 

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -94,10 +94,10 @@ def test_get_softlinked_package_dirs(mocker, tmp_path: Path):
     known_prefix = str(tmp_path / "known")
     root_prefix = str(tmp_path / "root")
     conda_prefix = str(tmp_path / "conda")
-    active_prefix = str(tmp_path / "active")
-    target_prefix = str(tmp_path / "target")
+    missing_target_prefix = str(tmp_path / "missing-target")
     softlinked_source = tmp_path / "pkgs" / "softlinked"
     untyped_source = tmp_path / "pkgs" / "untyped"
+    ignored_source = tmp_path / "pkgs" / "ignored"
     records = {
         known_prefix: (
             SimpleNamespace(
@@ -114,7 +114,15 @@ def test_get_softlinked_package_dirs(mocker, tmp_path: Path):
             ),
             SimpleNamespace(link=SimpleNamespace(source=str(untyped_source))),
             SimpleNamespace(link=None),
-        )
+        ),
+        missing_target_prefix: (
+            SimpleNamespace(
+                link=SimpleNamespace(
+                    source=str(ignored_source),
+                    type=LinkType.softlink,
+                )
+            ),
+        ),
     }
     mocker.patch(
         "conda.core.envs_manager.list_all_known_prefixes",
@@ -122,7 +130,8 @@ def test_get_softlinked_package_dirs(mocker, tmp_path: Path):
     )
     prefix_data = mocker.patch("conda.core.prefix_data.PrefixData")
     prefix_data.side_effect = lambda prefix, **kwargs: SimpleNamespace(
-        iter_records=lambda: records.get(prefix, ())
+        is_environment=lambda: prefix != missing_target_prefix,
+        iter_records=lambda: records.get(prefix, ()),
     )
     mocker.patch.object(
         package_cache_data,
@@ -130,8 +139,8 @@ def test_get_softlinked_package_dirs(mocker, tmp_path: Path):
         SimpleNamespace(
             root_prefix=root_prefix,
             conda_prefix=conda_prefix,
-            active_prefix=active_prefix,
-            target_prefix=target_prefix,
+            active_prefix=None,
+            target_prefix=missing_target_prefix,
         ),
     )
 
@@ -143,8 +152,7 @@ def test_get_softlinked_package_dirs(mocker, tmp_path: Path):
         known_prefix,
         root_prefix,
         conda_prefix,
-        active_prefix,
-        target_prefix,
+        missing_target_prefix,
     }
     assert all(
         call.kwargs == {"interoperability": False}

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -31,6 +31,7 @@ from conda.gateways.disk.permissions import make_read_only
 from conda.gateways.disk.read import isfile, listdir, yield_lines
 from conda.models.enums import LinkType
 from conda.models.match_spec import MatchSpec
+from conda.models.records import PrefixRecord
 from conda.testing.helpers import CHANNEL_DIR_V1
 from conda.utils import url_path
 
@@ -112,7 +113,13 @@ def test_get_softlinked_package_dirs(mocker, tmp_path: Path):
                     type=LinkType.hardlink,
                 )
             ),
-            SimpleNamespace(link=SimpleNamespace(source=str(untyped_source))),
+            PrefixRecord(
+                name="untyped",
+                version="1",
+                build="0",
+                build_number=0,
+                link={"source": str(untyped_source)},
+            ),
             SimpleNamespace(link=None),
         ),
         missing_target_prefix: (


### PR DESCRIPTION
### Description

Fixes #16614.

`conda clean --packages` uses hard-link counts to identify unused extracted packages. Symbolic links do not change those counts, so cleanup can delete cache files that environments created with `always_softlink` or `allow_softlinks` still need.

When the hard-link check finds removal candidates, conda now reads package records for every environment it can discover and keeps cache directories that those records reference through symbolic links. The scan includes registered environments, configured `envs_dirs`, and the root, conda, active, and target prefixes. It compares normalized paths first, then uses filesystem identity when different paths point to the same directory.

Cleanup still removes unreferenced cache packages when either soft-link option is enabled. Conda cannot protect an environment it cannot discover, so the `--packages` help now calls that out.

`get_softlinked_package_dirs()` lives in `conda.core.package_cache_data`. Prefix discovery stays in `conda.core.envs_manager`.

`--force-pkgs-dirs` remains the explicit option for removing complete package caches.

#16616 tracks deprecating and eventually removing package-cache soft links for future environments.

### Checklist - did you ...

- [x] Add a file to `releases/news` for the next release?
- [x] ~~If this change is QA-worthy, add a snippet under `releases/qa/`?~~
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
