### PR TITLE
Add QA scenario for conda config --clear

### DIFF
--- a/releases/qa/7617-config-clear
+++ b/releases/qa/7617-config-clear
@@ -13,22 +13,22 @@ Verify that `conda config --clear KEY` explicitly leaves a sequence configuratio
 None.
 
 ### Steps
-1. Create a temporary condarc file with the following contents:
+1. Create a file named `condarc.yaml` in a temporary directory with the following contents:
 
        aggressive_update_packages:
-         - ca-certificates
-         - certifi
+         - python
+         - pip
 
-2. Run `conda config --file <path-to-condarc> --show aggressive_update_packages`.
-3. Confirm that both `ca-certificates` and `certifi` are shown.
-4. Run `conda config --file <path-to-condarc> --clear aggressive_update_packages`.
-5. Inspect the condarc file.
-6. Run `conda config --file <path-to-condarc> --show aggressive_update_packages`.
+2. Run `conda config --file "<temporary-directory>/condarc.yaml" --show aggressive_update_packages`.
+3. Confirm that both `python` and `pip` are shown.
+4. Run `conda config --file "<temporary-directory>/condarc.yaml" --clear aggressive_update_packages`.
+5. Inspect `<temporary-directory>/condarc.yaml`.
+6. Run `conda config --file "<temporary-directory>/condarc.yaml" --show aggressive_update_packages`.
 
 ### Pass criteria
 - The `--clear` command exits successfully without an error.
 - The condarc file contains `aggressive_update_packages: []`.
-- `conda config --show aggressive_update_packages` reports an empty value for the key.
+- `conda config --file "<temporary-directory>/condarc.yaml" --show aggressive_update_packages` reports an empty value for the key.
 - The `aggressive_update_packages` key remains present in the condarc file rather than being removed.
 
 ### Out of scope / notes

--- a/releases/qa/7617-config-clear
+++ b/releases/qa/7617-config-clear
@@ -1,0 +1,35 @@
+### Title
+Clear a sequence configuration key with `conda config --clear`
+
+### Why
+Verify that `conda config --clear KEY` explicitly leaves a sequence configuration key set to an empty list instead of removing the key entirely.
+
+### Platforms
+- [x] Windows
+- [x] macOS
+- [x] Linux
+
+### Prerequisites
+None.
+
+### Steps
+1. Create a temporary condarc file with the following contents:
+
+       aggressive_update_packages:
+         - ca-certificates
+         - certifi
+
+2. Run `conda config --file <path-to-condarc> --show aggressive_update_packages`.
+3. Confirm that both `ca-certificates` and `certifi` are shown.
+4. Run `conda config --file <path-to-condarc> --clear aggressive_update_packages`.
+5. Inspect the condarc file.
+6. Run `conda config --file <path-to-condarc> --show aggressive_update_packages`.
+
+### Pass criteria
+- The `--clear` command exits successfully without an error.
+- The condarc file contains `aggressive_update_packages: []`.
+- `conda config --show aggressive_update_packages` reports an empty value for the key.
+- The `aggressive_update_packages` key remains present in the condarc file rather than being removed.
+
+### Out of scope / notes
+Automated tests cover invalid keys, scalar parameters, aliases, plugin sequence settings, and repeated clearing. This scenario only verifies the primary user-facing CLI behavior.


### PR DESCRIPTION
### Description

Adds the manual QA scenario requested in #16621 for `conda config --clear KEY`.

The scenario verifies that clearing a sequence configuration key leaves it explicitly configured as an empty list instead of removing the key entirely.

References #7617
Related to #16499