### PR TITLE
Fix benchmark workflow syntax and Check permissions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
   track-base-branch:
     if: >-
       !github.event.repository.fork
-      && contains(['success', 'failure'], github.event.workflow_run.conclusion)
+      && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
       && github.event.workflow_run.event == 'push'
       && (
         github.event.workflow_run.head_branch == 'main'
@@ -91,7 +91,7 @@ jobs:
   track-pull-request:
     if: >-
       !github.event.repository.fork
-      && contains(['success', 'failure'], github.event.workflow_run.conclusion)
+      && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
       && github.event.workflow_run.event == 'pull_request'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -97,6 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+      checks: write
       pull-requests: write
 
     env:


### PR DESCRIPTION
### Description

Backport #16468 to replace the invalid `contains(['success', 'failure'], ...)` expressions on `26.7.x`. GitHub currently rejects the workflow before any jobs start.

Add `checks: write` to the PR reporting job so Bencher can publish GitHub Checks.

Related to #16586.

### Checklist - did you ...

- [ ] ~Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?~
- [ ] ~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~
