### PR TITLE
environment.yaml validation issues should be printed to stderr

### DIFF
--- a/conda/env/env.py
+++ b/conda/env/env.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 from itertools import chain
 from typing import TYPE_CHECKING
 
 from ..base.context import context
 from ..cli import common
+from ..common.io import dashlist
 from ..common.iterators import unique
 from ..common.serialize import json, yaml
 from ..core.prefix_data import PrefixData
@@ -182,13 +184,13 @@ def validate_keys(data, kwargs):
         filename = kwargs.get("filename")
         verb = "are" if len(invalid_keys) != 1 else "is"
         plural = "s" if len(invalid_keys) != 1 else ""
+
         print(
             f"\nEnvironmentSectionNotValid: The following section{plural} on "
             f"'{filename}' {verb} invalid and will be ignored:"
+            f"{dashlist(invalid_keys)}\n",
+            file=sys.stderr,
         )
-        for key in invalid_keys:
-            print(f" - {key}")
-        print()
 
     deps = data.get("dependencies") or []
     depsplit = re.compile(r"[<>~\s=]")
@@ -201,7 +203,8 @@ def validate_keys(data, kwargs):
                 "but you do not list pip itself as one of your conda dependencies.  Conda "
                 "may not use the correct pip to install your packages, and they may end up "
                 "in the wrong place.  Please add an explicit pip dependency.  I'm adding one"
-                " for you, but still nagging you."
+                " for you, but still nagging you.",
+                file=sys.stderr,
             )
             new_data["dependencies"].insert(0, "pip")
             break

--- a/releases/news/16641-environment-yaml-validation-messages
+++ b/releases/news/16641-environment-yaml-validation-messages
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* ``environment.yaml`` should print non critical validation issues to stderr. (#16543 via #16641)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/releases/qa/6641-environment-yaml-validation-messages
+++ b/releases/qa/6641-environment-yaml-validation-messages
@@ -1,5 +1,5 @@
 ### Title
-``environment.yaml`` should print non critical validation issues to stderr. 
+``environment.yaml`` should print non critical validation issues to stderr.
 
 ### Why
 Printing the validation issues to stdout breaks the ability to build automations/parse output when json output is enabled.
@@ -39,7 +39,7 @@ You should see:
 
 For example:
 ```
- $ conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null 
+ $ conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null
 
 EnvironmentSectionNotValid: The following section on 'env.yml' is invalid and will be ignored:
   - category
@@ -68,7 +68,7 @@ You should see just the summary of action in json format:
 
 You should see just the warnings:
 ```
- $ conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null 
+ $ conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null
 
 EnvironmentSectionNotValid: The following section on 'env.yml' is invalid and will be ignored:
   - category

--- a/releases/qa/6641-environment-yaml-validation-messages
+++ b/releases/qa/6641-environment-yaml-validation-messages
@@ -39,7 +39,7 @@ You should see:
 
 For example:
 ```
- $ conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null
+ $ conda env create --quiet --json -n test --file env.yml  --dry-run
 
 EnvironmentSectionNotValid: The following section on 'env.yml' is invalid and will be ignored:
   - category

--- a/releases/qa/6641-environment-yaml-validation-messages
+++ b/releases/qa/6641-environment-yaml-validation-messages
@@ -1,0 +1,80 @@
+### Title
+``environment.yaml`` should print non critical validation issues to stderr. 
+
+### Why
+Printing the validation issues to stdout breaks the ability to build automations/parse output when json output is enabled.
+
+### Platforms
+- [x] Windows
+- [x] macOS
+- [x] Linux
+
+### Prerequisites
+Consider the ``env.yml`` file:
+
+```
+category: dev   # invalid key
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - pip:                 # conda will add pip to the dependencies
+    - numpy
+```
+
+### Steps
+1. Run the command ``conda env create --quiet --json -n test --file env.yml  --dry-run``
+
+2. Redirect stderr to /dev/null by running the command ``conda env create --quiet --json -n test --file env.yml  --dry-run 2> /dev/null``
+
+3. Or redirect stdout to /dev/null by running the command ``conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null > /dev/null``
+
+### Pass criteria
+1. Run the command ``conda env create --quiet --json -n test --file env.yml  --dry-run``
+
+You should see:
+* a warning for `EnvironmentSectionNotValid`
+* a warning a about pip-installed dependencies
+* a summary of the actions in json format
+
+For example:
+```
+ $ conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null 
+
+EnvironmentSectionNotValid: The following section on 'env.yml' is invalid and will be ignored:
+  - category
+
+Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
+
+{
+  "success": true,
+  . . .
+}
+```
+
+
+2. Redirect stderr to /dev/null by running the command ``conda env create --quiet --json -n test --file env.yml  --dry-run 2> /dev/null``
+
+You should see just the summary of action in json format:
+```
+ $ conda env create --quiet --json -n test --file env.yml  --dry-run 2> /dev/null
+{
+  "success": true,
+  . . .
+}
+```
+
+3. Or redirect stdout to /dev/null by running the command ``conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null > /dev/null``
+
+You should see just the warnings:
+```
+ $ conda env create --quiet --json -n test --file env.yml  --dry-run > /dev/null 
+
+EnvironmentSectionNotValid: The following section on 'env.yml' is invalid and will be ignored:
+  - category
+
+Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
+```
+
+### Out of scope / notes
+original issue: https://github.com/conda/conda/issues/16543

--- a/tests/env/test_create.py
+++ b/tests/env/test_create.py
@@ -505,15 +505,15 @@ def test_create_env_from_environment_yml_does_not_output_duplicate_warning(
     monkeypatch: MonkeyPatch,
 ):
     monkeypatch.setenv("CONDA_ENVIRONMENT_SPECIFIER", "environment.yml")
-    stdout, _, _ = conda_cli(
+    _, stderr, _ = conda_cli(
         "env",
         "create",
         f"--prefix={path_factory()}",
         f"--file={support_file('invalid_keys.yml')}",
     )
 
-    # EnvironmentSectionNotValid should only appear once in the output
-    assert stdout.count("EnvironmentSectionNotValid") == 1
+    # EnvironmentSectionNotValid should only appear once in stderr
+    assert stderr.count("EnvironmentSectionNotValid") == 1
 
 
 @pytest.mark.integration

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -31,7 +31,7 @@ from . import support_file
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from pytest import MonkeyPatch
+    from pytest import CaptureFixture, MonkeyPatch
 
     from conda.testing.fixtures import CondaCLIFixture, PathFactoryFixture
 
@@ -78,13 +78,32 @@ def test_with_pip():
 
 
 @pytest.mark.timeout(20)
-def test_add_pip():
+def test_add_pip(
+    capsys: CaptureFixture,
+):
+    """
+    Test that pip is added to the list of conda deps if not supplied
+    in the `dependencies` list. And ensure that the user is warned.
+    """
     e = from_file(support_file("add-pip.yml"))
     expected = {
         "conda": ["pip", "car"],
         "pip": ["foo", "baz"],
     }
+    _, stderr = capsys.readouterr()
     assert e.dependencies == expected
+    assert "Warning: you have pip-installed dependencies" in stderr
+
+
+def test_invalid_section_warning(
+    capsys: CaptureFixture,
+):
+    """
+    Test that environment validation warnings are output to stdout
+    """
+    from_file(support_file("invalid_keys.yml"))
+    _, stderr = capsys.readouterr()
+    assert "EnvironmentSectionNotValid" in stderr
 
 
 @pytest.mark.integration


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Currently, conda environmnt.yaml file validation issues that are not critical (eg. including an invalid key that will be ignored, or getting pip automatically included in the dependency list) are printed to the terminal. This breaks tools that use json output with conda for automation.

Consider the following `env.yaml`
```
category: dev   # invalid key
channels:
  - conda-forge
dependencies:
  - python
  - pip:                 # conda will add pip to the dependencies
    - numpy
```

**On the main branch**:
```
 $ conda env create --quiet --json -n test --file env.yml  --dry-run     

EnvironmentSectionNotValid: The following section on 'env.yml' is invalid and will be ignored:
 - category

Warning: you have pip-installed dependencies . . .
{
. . .
"prefix": "/home/sophia/projects/conda/devenv/Linux/x86_64/envs/devenv-3.10-miniconda/envs/test",
  "dry_run": true
}
```
Trying this with a tool like `jq`:
```
$ conda create --quiet --json -n test --file env.yml  --dry-run | jq                                                                                                                   
parse error: Invalid numeric literal at line 2, column 27
```

**With this change**:
```
 $ conda env create --quiet --json -n test --file env.yml  --dry-run     

EnvironmentSectionNotValid: The following section on 'env.yml' is invalid and will be ignored:
 - category

Warning: you have pip-installed dependencies . . .
{
. . .
"prefix": "/home/sophia/projects/conda/devenv/Linux/x86_64/envs/devenv-3.10-miniconda/envs/test",
  "dry_run": true
}
```
Trying this with a tool like `jq` the warning are still displayed (going to stderr), and the output from conda is parsable by the tool
```
 $ conda env create --quiet --json -n test --file env.yml  --dry-run  | jq

EnvironmentSectionNotValid: The following section on 'env.yml' is invalid and will be ignored:
 - category

Warning: you have pip-installed dependencies . . .
{
. . .
"prefix": "/home/sophia/projects/conda/devenv/Linux/x86_64/envs/devenv-3.10-miniconda/envs/test",
  "dry_run": true
}
```

fixes https://github.com/conda/conda/issues/16543
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
