### PR TITLE
Fix package cache records when archive formats coexist

### DIFF
--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -397,6 +397,13 @@ class PackageCacheData(metaclass=PackageCacheType):
         # try reading info/repodata_record.json
         try:
             repodata_record = read_repodata_json(extracted_package_dir)
+            # Both formats share an extracted directory. Keep the archive path
+            # consistent with the saved filename and checksums.
+            if repodata_record.get("fn") in (
+                basename(extracted_package_dir) + CONDA_PACKAGE_EXTENSION_V1,
+                basename(extracted_package_dir) + CONDA_PACKAGE_EXTENSION_V2,
+            ):
+                package_tarball_full_path = join(self.pkgs_dir, repodata_record["fn"])
             package_cache_record = PackageCacheRecord.from_objects(
                 repodata_record,
                 package_tarball_full_path=package_tarball_full_path,

--- a/conda/core/package_cache_data.py
+++ b/conda/core/package_cache_data.py
@@ -430,9 +430,10 @@ class PackageCacheData(metaclass=PackageCacheType):
             repodata_record = read_repodata_json(extracted_package_dir)
             # Both formats share an extracted directory. Keep the archive path
             # consistent with the saved filename and checksums.
+            extracted_package_dir_basename = basename(extracted_package_dir)
             if repodata_record.get("fn") in (
-                basename(extracted_package_dir) + CONDA_PACKAGE_EXTENSION_V1,
-                basename(extracted_package_dir) + CONDA_PACKAGE_EXTENSION_V2,
+                extracted_package_dir_basename + CONDA_PACKAGE_EXTENSION_V1,
+                extracted_package_dir_basename + CONDA_PACKAGE_EXTENSION_V2,
             ):
                 package_tarball_full_path = join(self.pkgs_dir, repodata_record["fn"])
             package_cache_record = PackageCacheRecord.from_objects(

--- a/releases/news/16646-package-cache-archive-format
+++ b/releases/news/16646-package-cache-archive-format
@@ -1,3 +1,0 @@
-### Bug fixes
-
-* Keep cached package archive paths consistent with their recorded filenames and checksums when both archive formats are present. (#16646)

--- a/releases/news/16646-package-cache-archive-format
+++ b/releases/news/16646-package-cache-archive-format
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Keep cached package archive paths consistent with their recorded filenames and checksums when both archive formats are present. (#16646)

--- a/releases/news/9674-package-cache-archive-format
+++ b/releases/news/9674-package-cache-archive-format
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Keep cached package archive paths consistent with their recorded filenames and checksums when both archive formats are present. (#9674)

--- a/tests/core/test_package_cache_data.py
+++ b/tests/core/test_package_cache_data.py
@@ -697,6 +697,37 @@ def test_instantiating_package_cache_when_both_tar_bz2_and_conda_exist_read_only
     assert zlib_conda_fn in pkgs_dir_files
 
 
+@pytest.mark.parametrize("extracted_format", ("tar.bz2", "conda"))
+@pytest.mark.parametrize("archives", ("both", "other", "none"))
+@pytest.mark.parametrize("read_only", (False, True))
+def test_extracted_package_cache_record_matches_archive(
+    tmp_pkgs_dir: Path, extracted_format: str, archives: str, read_only: bool
+):
+    record, other = fresh_zlib_records()
+    if extracted_format == "conda":
+        record, other = other, record
+
+    pfe = ProgressiveFetchExtract((record,))
+    pfe.prepare()
+    pfe.execute()
+    copy(join(CHANNEL_DIR_V1, subdir, other.fn), tmp_pkgs_dir / other.fn)
+    if archives != "both":
+        (tmp_pkgs_dir / record.fn).unlink()
+    if archives == "none":
+        (tmp_pkgs_dir / other.fn).unlink()
+    if read_only:
+        make_read_only(tmp_pkgs_dir / PACKAGE_CACHE_MAGIC_FILE)
+
+    PackageCacheData._cache_.clear()
+    (cached,) = PackageCacheData(tmp_pkgs_dir).iter_records()
+
+    assert cached.package_tarball_full_path == str(tmp_pkgs_dir / record.fn)
+    assert cached.is_extracted
+    assert cached.is_fetched == (archives == "both")
+    for field in ("fn", "url", "md5", "sha256", "size"):
+        assert getattr(cached, field) == getattr(record, field)
+
+
 def test_instantiating_package_cache_when_unpacked_conda_exist(tmp_pkgs_dir: Path):
     """
     If .conda package exist in a writable package cache, but is unpacked,


### PR DESCRIPTION
### Description

Fixes #9674.

When `.conda` and `.tar.bz2` archives share an extracted package directory, loading the cache can pair a `.conda` archive with the saved `.tar.bz2` filename and checksums. Copying that archive using the recorded filename causes `Invalid data stream` during extraction.

Use the archive described by the saved metadata. If that archive has been removed, retain the extracted package without reporting the other archive format as fetched.

### Checklist - did you ...

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
- [x] ~~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~~
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~
