### PR TITLE
Raise shell hook module budget

### DIFF
--- a/tests/cli/test_startup_benchmarks.py
+++ b/tests/cli/test_startup_benchmarks.py
@@ -231,7 +231,7 @@ _MODULE_BUDGETS: dict[str, _BudgetSpec] = {
             "with contextlib.redirect_stdout(CapturedStdout()):\n"
             "    main_sourced('shell.posix', 'hook')"
         ),
-        "max_modules": 750,
+        "max_modules": 760,
     },
 }
 


### PR DESCRIPTION
### Description

Fixes #16644.

Raise the shell hook startup module limit from 750 to 760 to accommodate the imports used by channel notice wrappers.

### Checklist - did you ...

- [x] ~~Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?~~
- [x] ~~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~~
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~
