### PR TITLE
Invalidate context caches in `Context._override()`

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1190,10 +1190,17 @@ class Context(Configuration):
         non-data descriptors used by the context) have no ``__set__``: a
         plain ``setattr`` would shadow the descriptor permanently in
         ``__dict__`` and ``reset_context()`` could not restore it.
+
+        Caches derived from context values (``memoizedproperty`` results
+        and the registered reset callbacks, such as the ``Channel.from_value``
+        cache) are invalidated on entry and again on exit, so that values
+        computed before the override do not mask it and values computed
+        during it do not outlive it.
         """
         sentinel = object()
         previous = self.__dict__.get(key, sentinel)
         self.__dict__[key] = value
+        self._reset_cache()
         try:
             yield
         finally:
@@ -1201,6 +1208,7 @@ class Context(Configuration):
                 self.__dict__.pop(key, None)
             else:
                 self.__dict__[key] = previous
+            self._reset_cache()
 
     @memoizedproperty
     def requests_version(self) -> str:

--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -1418,7 +1418,13 @@ class Configuration(metaclass=ConfigurationType):
         # A future improvement would be to cache files that are already loaded.
         self.raw_data = {}
         self._cache_ = {}
-        self._reset_callbacks: dict[Callable, None] = {}
+        # We preserve callback registrations across re-initialisation.
+        # reset_context() re-runs __init__ on the context singleton, and
+        # callbacks registered at import time (such as Channel._reset_state)
+        # must survive it for _reset_cache() to stay a complete reset.
+        self._reset_callbacks: dict[Callable, None] = getattr(
+            self, "_reset_callbacks", {}
+        )
         self._validation_errors = defaultdict(list)
 
         self._set_search_path(search_path, **kwargs)

--- a/releases/news/16631-override-invalidates-caches
+++ b/releases/news/16631-override-invalidates-caches
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Invalidate context-derived caches on entering and exiting `Context._override()`, so that `memoizedproperty` values (such as `custom_multichannels` and `custom_channels`) and the `Channel.from_value` cache follow the temporary override, instead of masking it or leaking past it. (#16631)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -1146,7 +1146,7 @@ class TestOverrideCacheInvalidation:
         def callback():
             calls.append(True)
 
-        context.register_reset_callaback(callback)
+        context.register_reset_callback(callback)
         try:
             reset_context(())
             context._reset_cache()

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -42,7 +42,7 @@ from conda.common.serialize import yaml
 from conda.common.url import join_url, path_to_url
 from conda.exceptions import ChannelDenied, ChannelNotAllowed
 from conda.gateways.disk.permissions import make_read_only
-from conda.models.channel import Channel
+from conda.models.channel import Channel, MultiChannel
 from conda.models.match_spec import MatchSpec
 from conda.utils import on_win
 
@@ -1078,3 +1078,79 @@ def test_conda_exe_vars_dict_dev(monkeypatch: MonkeyPatch, conda_dev: bool) -> N
     else:
         assert exe_vars["_CE_M"] is None
         assert exe_vars["_CE_CONDA"] is None
+
+
+class TestOverrideCacheInvalidation:
+    """Regression tests for https://github.com/conda/conda/issues/16631"""
+
+    OVERRIDE = {
+        "custom": (
+            "https://example.invalid/subchannel-a",
+            "https://example.invalid/subchannel-b",
+        )
+    }
+
+    def _warm_caches(self):
+        # Read every cache the override must invalidate
+        assert "custom" not in context.custom_multichannels
+        assert "custom" not in context.custom_channels
+        assert not isinstance(Channel("custom"), MultiChannel)
+
+    def test_override_visible_despite_warm_caches(self):
+        reset_context(())
+        self._warm_caches()
+        with context._override("_custom_multichannels", self.OVERRIDE):
+            assert "custom" in context.custom_multichannels
+            assert [c.base_url for c in context.custom_multichannels["custom"]] == list(
+                self.OVERRIDE["custom"]
+            )
+            assert isinstance(Channel("custom"), MultiChannel)
+        self._warm_caches()
+
+    def test_override_does_not_leak_after_exception(self):
+        reset_context(())
+        with pytest.raises(RuntimeError, match="boom"):
+            with context._override("_custom_multichannels", self.OVERRIDE):
+                assert "custom" in context.custom_multichannels
+                raise RuntimeError("boom")
+        self._warm_caches()
+
+    def test_nested_overrides(self):
+        reset_context(())
+        inner = {"nested": ("https://example.invalid/nested",)}
+        with context._override("_custom_multichannels", self.OVERRIDE):
+            assert "custom" in context.custom_multichannels
+            with context._override("_custom_multichannels", inner):
+                assert "nested" in context.custom_multichannels
+                assert "custom" not in context.custom_multichannels
+            assert "custom" in context.custom_multichannels
+            assert "nested" not in context.custom_multichannels
+        self._warm_caches()
+
+    def test_reset_context_inside_override_is_preserved(self):
+        # reset_context() is supported inside _override(): the overridden
+        # attribute is stored in __dict__ and survives re-initialisation.
+        reset_context(())
+        with context._override("_custom_multichannels", self.OVERRIDE):
+            reset_context(())
+            assert "custom" in context.custom_multichannels
+            assert isinstance(Channel("custom"), MultiChannel)
+        self._warm_caches()
+
+    def test_reset_callbacks_survive_reset_context(self):
+        # Channel._reset_state is registered once at import time. It must
+        # stay registered after reset_context() re-runs Context.__init__,
+        # or _reset_cache() stops clearing the Channel.from_value cache.
+        calls = []
+
+        def callback():
+            calls.append(True)
+
+        context.register_reset_callaback(callback)
+        try:
+            reset_context(())
+            context._reset_cache()
+            assert calls
+            assert Channel._reset_state in context._reset_callbacks
+        finally:
+            context._reset_callbacks.pop(callback, None)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #16631

The `Context._override()` method now invalidates context-derived caches through `Configuration._reset_cache()` right after installing the temporary attribute, and again after restoring the original one. Values cached by `memoizedproperty`, such as `custom_multichannels` and `custom_channels`, previously stayed in `context._cache_` across the boundary of the override across both directions (this is as I mentioned in #16631, i.e., a value computed before the override masked it entirely, and a value computed during the override leaked out of it afterwards)

For `_reset_cache()` to cover the `Channel.from_value` cache too, we now make `Configuration.__init__` preserve `_reset_callbacks` across re-initialisation. `reset_context()` re-runs `__init__` on the singleton, which previously erased the `Channel._reset_state` registration made at import time.

I've verified that this change works well in conda-incubator/pytest-conda-solvers#85 downstream via an editable installation of conda and the Channel cache workaround I added there removed.

Also, I used Claude Opus 5 to review these changes, i.e., to verify that this fix would be sufficient and that we are not inadvertently doing anything that should be outside the scope of what was discussed in https://github.com/conda/conda/issues/16631#issuecomment-5539225505

Thank you!

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
