### PR TITLE
Deprecate misspelt `register_reset_callaback` function

### DIFF
--- a/conda/common/configuration.py
+++ b/conda/common/configuration.py
@@ -46,6 +46,7 @@ from ..auxlib.exceptions import ThisShouldNeverHappenError
 from ..auxlib.type_coercion import TypeCoercionError, typify, typify_data_structure
 from ..base.constants import CMD_LINE_SOURCE, ENV_VARS_SOURCE
 from ..common.iterators import unique
+from ..deprecations import deprecated
 from .compat import isiterable, primitive_types
 from .constants import NULL
 from .serialize import yaml
@@ -1600,8 +1601,12 @@ class Configuration(metaclass=ConfigurationType):
             callback()
         return self
 
-    def register_reset_callaback(self, callback):
+    def register_reset_callback(self, callback):
         self._reset_callbacks.setdefault(callback, None)
+
+    @deprecated("27.3", "27.9", addendum="Use `register_reset_callback` instead.")
+    def register_reset_callaback(self, callback):
+        self.register_reset_callback(callback)
 
     def check_source(self, source):
         # this method ends up duplicating much of the logic of Parameter.__get__

--- a/conda/models/channel.py
+++ b/conda/models/channel.py
@@ -737,7 +737,7 @@ def get_channel_objs(ctx: Context) -> tuple[Channel, ...]:
     return tuple(Channel(chn) for chn in ctx.channels)
 
 
-context.register_reset_callaback(Channel._reset_state)
+context.register_reset_callback(Channel._reset_state)
 
 
 deprecated.constant(

--- a/releases/news/deprecate-register-reset-callaback
+++ b/releases/news/deprecate-register-reset-callaback
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda.common.configuration.Configuration.register_reset_callaback` as pending deprecation. Use the correctly spelled `register_reset_callback` instead. (#16631)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR adds `Configuration.register_reset_callback` and marks `register_reset_callaback`, which I believe is misspelt (see the extra `a`), as pending deprecation.

I found this while working on #16651, and discovered the typo is nearly a decade old. It was introduced in d79cb98.

- I searched for this in conda: https://github.com/conda/conda/issues?q=sort:updated-desc%20%22register_reset_callaback%22, and found no direct results, so I assumed no one ever raised it.
- And here is a GitHub-wide search: https://github.com/search?q=%22register_reset_callaback%22&type=code, which doesn't reveal anything particularly interesting :D It's just conda-lock which vendors conda, conda forks, and other repositories that committed their conda environments/venvs/etc.

But... as I was typing this description, I didn't find it reasonable to believe that no one else had ever found this before me, so I searched and got to know that @travishathaway did indeed do so and had raised this on Slack internally ;) And as a result, this PR is rightfully co-authored with Travis.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~
- [ ] ~Add / update necessary tests?~ Not necessary, but if #16651 gets merged first, I'll do that here.
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
