### PR TITLE
Document trailing glob semantics in version specs

### DIFF
--- a/docs/source/user-guide/concepts/pkg-specs.rst
+++ b/docs/source/user-guide/concepts/pkg-specs.rst
@@ -286,7 +286,7 @@ are described in `Command-line package specifications`_.
 Internally, conda translates command-line package specifications into
 canonical match specifications.
 
-EXAMPLE: python=3.9 is translated to python 3.9*.
+EXAMPLE: python=3.9 is translated to python 3.9.*.
 
 Command-line package specifications
 -----------------------------------
@@ -311,7 +311,7 @@ Common forms include:
    * - ``numpy=1.11``
      - Match the ``1.11`` release series. This is a fuzzy version match
        and is translated internally to a version pattern such as
-       ``numpy 1.11*``.
+       ``numpy 1.11.*``.
    * - ``numpy==1.11``
      - Exact match for version 1.11. This also matches 1.11.0 and 1.11.0.0, but not 1.11.1.
         Unlike numpy=1.11, it does not match the whole 1.11 series.
@@ -365,10 +365,20 @@ parts:
 
     EXAMPLE: ``1.0|1.2`` matches version 1.0 or 1.2
 
-  * \* matches 0 or more characters in the version string. In
-    terms of regular expressions, it is the same as ``r".*"``.
+  * \* at the end of a version is a fuzzy match. ``1.4*`` means the same
+    as ``1.4.*``: any version whose leading segments are ``1.4``. Conda
+    compares whole segments here, so ``1.4*`` does not match ``1.40`` or
+    ``14.0``. Use the ``.*`` form where you can, since it shows where the
+    segments end.
 
-    EXAMPLE: 1.0|1.4* matches 1.0, 1.4 and 1.4.1b2, but not 1.2.
+    EXAMPLE: ``1.0|1.4.*`` matches 1.0, 1.4, 1.4.1b2, and 1.4rc1, but not
+    1.2, 1.40, or 14.0.
+
+  * \* anywhere else in a version is a glob. Conda replaces each \* with
+    ``.*`` and matches the result against the whole version string as a
+    regular expression.
+
+    EXAMPLE: ``1.*.3`` matches 1.2.3 and 1.22.3, but not 1.3 or 1.2.30.
 
   * <, >, <=, >=, == and != are relational operators on versions,
     which are compared using
@@ -444,11 +454,11 @@ The following are all valid match specifications for
 numpy-1.8.1-py27_0:
 
 * numpy
-* numpy 1.8*
+* numpy 1.8.*
 * numpy 1.8.1
 * numpy >=1.8
 * numpy ==1.8.1
-* numpy 1.8|1.8*
+* numpy 1.8|1.8.*
 * numpy >=1.8,<2
 * numpy >=1.8,<2|1.9
 * numpy 1.8.1 py27_0

--- a/releases/news/16619-version-glob-docs
+++ b/releases/news/16619-version-glob-docs
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Fix the description of `*` in version specs. A trailing `*` is a fuzzy match on version segments, so `1.4*` matches `1.4.1` but not `1.40`. Only a `*` elsewhere in the version acts as a regular expression glob. (#16619 via #16655)
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

When I was working on #16619 (in #16654), I happened to read this page and [CEP 29](https://conda.org/learn/ceps/cep-0029/) for a refresher. The "Package match specifications" section in the documentation described the `*` in a version as equivalent to the regex `.*`. That statement only holds true for a non-trailing glob. A trailing glob is, rather, fuzzy equality on version segments, so `1.4*` matches `1.4.1` and `1.4rc1` but not `1.40` or `14.0`. This PR rewrites that bullet into two parts; one for a trailing glob and one for a glob elsewhere in the version, and updates the examples that used the dotless form to the dotted form.

cc: @jaimergp

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~
- [ ] ~Add / update necessary tests?~
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
