### PR TITLE
Show metadata for disabled plugins

### DIFF
--- a/conda/plugins/manager.py
+++ b/conda/plugins/manager.py
@@ -262,9 +262,7 @@ class CondaPluginManager(pluggy.PluginManager):
         requested_normalized_name = canonicalize_name(requested_name)
 
         for plugin, dist in self.list_plugin_distinfo():
-            canonical_name = self.get_name(plugin)
-            if canonical_name is None:
-                continue
+            canonical_name = self.get_name(plugin) or self.get_canonical_name(plugin)
 
             lookup_names = {
                 dist.project_name,

--- a/releases/news/16356-disabled-plugin-info
+++ b/releases/news/16356-disabled-plugin-info
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Show metadata for disabled plugins in `conda plugins info`. (#16356)

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -173,14 +173,19 @@ def test_get_installed_plugins(plugin_manager: CondaPluginManager):
     "name",
     ("conda-test-plugin", "conda_test_plugin", "test_plugin.success"),
 )
-def test_get_installed_plugin_info(name: str, plugin_manager: CondaPluginManager):
+@pytest.mark.parametrize("disabled", (False, True))
+def test_get_installed_plugin_info(
+    name: str, disabled: bool, plugin_manager: CondaPluginManager
+):
     assert plugin_manager.load_entrypoints("test_plugin", "success") == 1
+    if disabled:
+        plugin_manager.disable_external_plugins()
 
     assert plugin_manager.get_installed_plugin_info(name) == {
         "name": "conda-test-plugin",
         "version": "1.0",
         "canonical_name": "test_plugin.success",
-        "status": "active",
+        "status": "disabled" if disabled else "active",
         "hooks": ["solvers"],
         "summary": "A test plugin",
         "license": "",

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -109,18 +109,40 @@ def test_plugins_info(
     assert not err
 
 
-def test_plugins_info_json(
+def test_plugins_info_disabled(
     plugin_manager_with_test_plugin: CondaPluginManager,
     conda_cli: CondaCLIFixture,
 ):
-    out, err, code = conda_cli("plugins", "info", "test_plugin.success", "--json")
+    out, err, code = conda_cli("--no-plugins", "plugins", "info", "conda-test-plugin")
+
+    assert code == 0, f"conda plugins info failed ({code}): {err}"
+    assert "conda-test-plugin" in out
+    assert "disabled" in out
+    assert "test_plugin.success" in out
+    assert "solvers" in out
+    assert not err
+
+
+@pytest.mark.parametrize("no_plugins", (False, True))
+def test_plugins_info_json(
+    no_plugins: bool,
+    plugin_manager_with_test_plugin: CondaPluginManager,
+    conda_cli: CondaCLIFixture,
+):
+    out, err, code = conda_cli(
+        *(("--no-plugins",) if no_plugins else ()),
+        "plugins",
+        "info",
+        "test_plugin.success",
+        "--json",
+    )
 
     assert code == 0, f"conda plugins info --json failed ({code}): {err}"
     assert json.loads(out) == {
         "name": "conda-test-plugin",
         "version": "1.0",
         "canonical_name": "test_plugin.success",
-        "status": "active",
+        "status": "disabled" if no_plugins else "active",
         "hooks": ["solvers"],
         "summary": "A test plugin",
         "license": "",


### PR DESCRIPTION
### Description

Fix `conda --no-plugins plugins info <name>` reporting that an installed plugin does not exist. Recover its canonical name after pluggy unregisters it so text and JSON output retain the plugin metadata and show its disabled status.

Related to #16354.

### Checklist - did you ...

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
- [x] ~If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?~
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
