### PR TITLE
Speed up `test_update_env_no_action_json_output` (#16605)

### DIFF
--- a/releases/news/16605-speed-up-update-env-no-action-json-output
+++ b/releases/news/16605-speed-up-update-env-no-action-json-output
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Speed up `test_update_env_no_action_json_output` by using `tmp_env` with `ca-certificates` instead of creating an environment with `pip` and PyPI `click`. (#16605)

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -474,9 +474,8 @@ def test_update_env_only_pip_json_output(
 
 
 @pytest.mark.integration
-@pytest.mark.flaky(reruns=2, condition=on_win and not in_subprocess())
 def test_update_env_no_action_json_output(
-    path_factory: PathFactoryFixture,
+    tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
     request: pytest.FixtureRequest,
 ):
@@ -486,18 +485,14 @@ def test_update_env_no_action_json_output(
     """
     if context.solver == "libmamba" and on_win and forward_to_subprocess(request):
         return
-    prefix = path_factory()
-    request.applymarker(
-        pytest.mark.xfail(
-            context.solver == "libmamba",
-            reason="Known issue: https://github.com/conda/conda-libmamba-solver/issues/320",
+
+    with tmp_env("ca-certificates") as prefix:
+        create_env(ENVIRONMENT_CA_CERTIFICATES)
+        stdout, _, _ = conda_cli(
+            "env", "update", f"--prefix={prefix}", "--quiet", "--json"
         )
-    )
-    create_env(ENVIRONMENT_PIP_CLICK)
-    conda_cli("env", "create", f"--prefix={prefix}", "--json", "--yes")
-    stdout, _, _ = conda_cli("env", "update", f"--prefix={prefix}", "--quiet", "--json")
-    output = json.loads(stdout)
-    assert output["message"] == "All requested packages already installed."
+        output = json.loads(stdout)
+        assert output["message"] == "All requested packages already installed."
 
 
 @pytest.mark.integration


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Resolves #16605 

Speeds up `tests/cli/test_env.py::test_update_env_no_action_json_output` (#16605).

The test only checks that `conda env update --json` reports "All requested packages already installed." when the env already satisfies the file. It was creating a full env from `ENVIRONMENT_PIP_CLICK` (`pip` + PyPI `click`) just to set that up.

Now it uses `tmp_env("ca-certificates")` and the matching `ENVIRONMENT_CA_CERTIFICATES` yaml, so the update stays a true no-op without the pip stack. Also drops the libmamba #320 xfail and Windows flaky marker, which only applied to the old pip path.

 **~12–18s → ~1s**. 

| | before | after |
|---|---|---|
| classic | ~12s | ~1.1s |
| libmamba | ~18s | ~1.2s |

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `releases/news` directory ([using the template](https://github.com/conda/conda/blob/main/releases/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] If this change is QA-worthy, add a snippet under `releases/qa/` ([using the template](https://github.com/conda/conda/blob/main/releases/qa/TEMPLATE))?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
